### PR TITLE
chore(*) release v0.2.2

### DIFF
--- a/olm/0.2.1/kong.v0.2.1.clusterserviceversion.yaml
+++ b/olm/0.2.1/kong.v0.2.1.clusterserviceversion.yaml
@@ -6,12 +6,12 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: 'false'
-    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.0
+    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.1
     createdAt: '2020-04-10T17:26:45Z'
     description: Install and manage Kong clusters.
     repository: https://github.com/kong/kong-operator
     support: Harry Bagdi
-  name: kong.v0.2.0
+  name: kong.v0.2.1
   namespace: placeholder
 spec:
   customresourcedefinitions:
@@ -123,7 +123,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kong-operator
-                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.0
+                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.1
                 imagePullPolicy: Always
                 name: kong-operator
               serviceAccountName: kong-operator
@@ -157,4 +157,5 @@ spec:
   maturity: alpha
   provider:
     name: Kong Inc
-  version: 0.2.0
+  version: 0.2.1
+  replaces: 0.2.0

--- a/olm/0.2.2/kong.v0.2.2.clusterserviceversion.yaml
+++ b/olm/0.2.2/kong.v0.2.2.clusterserviceversion.yaml
@@ -6,12 +6,12 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: 'false'
-    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.0
+    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.2
     createdAt: '2020-04-10T17:26:45Z'
     description: Install and manage Kong clusters.
     repository: https://github.com/kong/kong-operator
     support: Harry Bagdi
-  name: kong.v0.2.0
+  name: kong.v0.2.2
   namespace: placeholder
 spec:
   customresourcedefinitions:
@@ -123,7 +123,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kong-operator
-                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.0
+                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.2
                 imagePullPolicy: Always
                 name: kong-operator
               serviceAccountName: kong-operator
@@ -157,5 +157,5 @@ spec:
   maturity: alpha
   provider:
     name: Kong Inc
-  version: 0.2.0
-  replaces: 0.1.0
+  version: 0.2.2
+  replaces: 0.2.1

--- a/olm/0.2.2/kongs.charts.helm.k8s.io.crd.yaml
+++ b/olm/0.2.2/kongs.charts.helm.k8s.io.crd.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongs.charts.helm.k8s.io
+spec:
+  group: charts.helm.k8s.io
+  names:
+    kind: Kong
+    listKind: KongList
+    plural: kongs
+    singular: kong
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/olm/kong.package.yaml
+++ b/olm/kong.package.yaml
@@ -1,4 +1,4 @@
 channels:
-- currentCSV: kong.v0.2.1
+- currentCSV: kong.v0.2.2
   name: alpha
 packageName: kong


### PR DESCRIPTION
Release v0.2.2. This fixes version information in OLM for previous releases, and adds replace information.