### PR TITLE
chore(*) release v0.2.3

### DIFF
--- a/olm/0.2.0/kong.v0.2.0.clusterserviceversion.yaml
+++ b/olm/0.2.0/kong.v0.2.0.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[{"image":{"repository":"kong","tag":"2.0.0","pullPolicy":"Always"},"proxy":{"type":"NodePort"},"env":{"prefix":"/kong_prefix/"},"resources":{"limits":{"cpu":"500m","memory":"2G"},"requests":{"cpu":"100m","memory":"512Mi"}},"ingressController":{"enabled":true,"installCRDs":false}}]'
+    alm-examples: '[{"apiVersion":"charts.helm.k8s.io/v1alpha1","kind":"Kong","metadata":{"name":"example-kong"},"spec":{"image":{"repository":"kong","tag":"2.0.0","pullPolicy":"Always"},"proxy":{"type":"NodePort"},"env":{"prefix":"/kong_prefix/"},"resources":{"limits":{"cpu":"500m","memory":"2G"},"requests":{"cpu":"100m","memory":"512Mi"}},"ingressController":{"enabled":true,"installCRDs":false}}}]'
     capabilities: Basic Install
     categories: Networking
     certified: 'false'
@@ -158,4 +158,3 @@ spec:
   provider:
     name: Kong Inc
   version: 0.2.0
-  replaces: 0.1.0

--- a/olm/0.2.2/kong.v0.2.2.clusterserviceversion.yaml
+++ b/olm/0.2.2/kong.v0.2.2.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[{"image":{"repository":"kong","tag":"2.0.0","pullPolicy":"Always"},"proxy":{"type":"NodePort"},"env":{"prefix":"/kong_prefix/"},"resources":{"limits":{"cpu":"500m","memory":"2G"},"requests":{"cpu":"100m","memory":"512Mi"}},"ingressController":{"enabled":true,"installCRDs":false}}]'
+    alm-examples: '[{"apiVersion":"charts.helm.k8s.io/v1alpha1","kind":"Kong","metadata":{"name":"example-kong"},"spec":{"image":{"repository":"kong","tag":"2.0.0","pullPolicy":"Always"},"proxy":{"type":"NodePort"},"env":{"prefix":"/kong_prefix/"},"resources":{"limits":{"cpu":"500m","memory":"2G"},"requests":{"cpu":"100m","memory":"512Mi"}},"ingressController":{"enabled":true,"installCRDs":false}}}]'
     capabilities: Basic Install
     categories: Networking
     certified: 'false'
@@ -158,4 +158,3 @@ spec:
   provider:
     name: Kong Inc
   version: 0.2.2
-  replaces: 0.2.1

--- a/olm/0.2.3/kong.v0.2.3.clusterserviceversion.yaml
+++ b/olm/0.2.3/kong.v0.2.3.clusterserviceversion.yaml
@@ -6,12 +6,12 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: 'false'
-    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.1
+    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.3
     createdAt: '2020-04-10T17:26:45Z'
     description: Install and manage Kong clusters.
     repository: https://github.com/kong/kong-operator
     support: Harry Bagdi
-  name: kong.v0.2.1
+  name: kong.v0.2.3
   namespace: placeholder
 spec:
   customresourcedefinitions:
@@ -123,7 +123,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kong-operator
-                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.1
+                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.3
                 imagePullPolicy: Always
                 name: kong-operator
               serviceAccountName: kong-operator
@@ -154,7 +154,10 @@ spec:
   maintainers:
   - email: harry@konghq.com
     name: Harry
+  - email: traines@konghq.com
+    name: Travis
   maturity: alpha
   provider:
     name: Kong Inc
-  version: 0.2.1
+  version: 0.2.3
+  replaces: 0.1.0

--- a/olm/0.2.3/kongs.charts.helm.k8s.io.crd.yaml
+++ b/olm/0.2.3/kongs.charts.helm.k8s.io.crd.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongs.charts.helm.k8s.io
+spec:
+  group: charts.helm.k8s.io
+  names:
+    kind: Kong
+    listKind: KongList
+    plural: kongs
+    singular: kong
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/olm/kong.package.yaml
+++ b/olm/kong.package.yaml
@@ -1,4 +1,4 @@
 channels:
-- currentCSV: kong.v0.2.2
+- currentCSV: kong.v0.2.3
   name: alpha
 packageName: kong


### PR DESCRIPTION
Release v0.2.3:
* Add Travis as a maintainer.
* Remove replace information from intermediate release CSVs (it's
  necessary to go straight from v0.1.0 to something in
  community-operators, since 0.1.0 is currently the only version there).
* Correct issues with the ALM examples.

@hbagdi per https://github.com/operator-framework/community-operators/pull/1559#issuecomment-614660034 you'll need to commit the change and sign off the change in community-operators. https://github.com/rainest/community-operators/commit/398481c4c4c9b56b695350bbf52ac8f54f8a1a6b.diff is the changeset pending merger of this PR and uploading images.