### PR TITLE
Release 0.3.0

### DIFF
--- a/helm-charts/kong/CHANGELOG.md
+++ b/helm-charts/kong/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## 1.7.0
+
+### Improvements
+
+* Added support for
+  [CRD-only](https://github.com/Kong/charts/blob/1.7.0/charts/kong/README.md#crds-only)
+  and [controller-only releases](https://github.com/Kong/charts/blob/next/charts/kong/README.md#standalone-controller-nodes).
+  ([#136](https://github.com/Kong/charts/pull/136))
+
+### Documentation
+
+* Added a set of [example
+  values.yamls](https://github.com/Kong/charts/tree/master/charts/kong/example-values)
+  for various configurations of Kong and Kong Enterprise.
+  ([#134](https://github.com/Kong/charts/pull/134))
+
+## 1.6.1
+
+This release contains no changes other than the version. This is to address an
+issue with our release automation.
+
+## 1.6.0
+
+### Improvements
+
+* Updated default controller version to 0.9.0.
+  ([#132](https://github.com/Kong/charts/pull/132))
+* Updated default Enterprise versions to 2.0.4.1 and 1.5.0.2.
+  ([#130](https://github.com/Kong/charts/pull/130))
+* Added ability to override chart lifecycle.
+  ([#116](https://github.com/Kong/charts/pull/116))
+* Added ability to apply user-defined labels to pods.
+  ([#121](https://github.com/Kong/charts/pull/121))
+* Filtered serviceMonitor to disable metrics collection from non-proxy
+  services. 
+  ([#112](https://github.com/Kong/charts/pull/112))
+* Set admin API to listen on localhost only if possible.
+  ([#125](https://github.com/Kong/charts/pull/125))
+* Add `auth_type` and `ssl` settings to `smtp` block. 
+  ([#127](https://github.com/Kong/charts/pull/127))
+* Remove UID from default securityContext.
+  ([#138](https://github.com/Kong/charts/pull/138))
+
+### Documentation
+
+* Corrected invalid default serviceMonitor.interval value.
+  ([#110](https://github.com/Kong/charts/pull/110))
+* Removed duplicate `installCRDs` documentation.
+  ([#115](https://github.com/Kong/charts/pull/115))
+* Simplified example license Secret creation command.
+  ([#131](https://github.com/Kong/charts/pull/131))
+
 ## 1.5.0
 
 ### Improvements

--- a/helm-charts/kong/Chart.yaml
+++ b/helm-charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.5.0
+version: 1.7.0
 appVersion: 2.0

--- a/helm-charts/kong/ci/default-values.yaml
+++ b/helm-charts/kong/ci/default-values.yaml
@@ -1,3 +1,9 @@
 # install chart with default values
 proxy:
   type: NodePort
+
+env:
+  anonymous_reports: "off"
+ingressController:
+  env:
+    anonymous_reports: "false"

--- a/helm-charts/kong/ci/single-image-default.yaml
+++ b/helm-charts/kong/ci/single-image-default.yaml
@@ -1,0 +1,15 @@
+# install chart with default values
+# use single image strings instead of repository/tag
+
+image:
+  single: kong:2.0
+proxy:
+  type: NodePort
+
+env:
+  anonymous_reports: "off"
+ingressController:
+  env:
+    anonymous_reports: "false"
+  image:
+    single: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:0.8.1

--- a/helm-charts/kong/ci/test1-values.yaml
+++ b/helm-charts/kong/ci/test1-values.yaml
@@ -12,11 +12,16 @@ ingressController:
     enabled: true
 # - environment variables can be injected into ingress controller container
   env:
+    anonymous_reports: "false"
     kong_admin_header: "foo:bar"
 # - annotations can be injected for service account
   serviceAccount:
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME
+# - pod labels can be added to the deployment template
+podLabels:
+  app: kong
+  environment: test
 # - podSecurityPolicies are enabled
 podSecurityPolicy:
   enabled: true
@@ -35,3 +40,5 @@ proxy:
     hosts: ["test.com", "test2.com"]
     annotations: {}
     path: /
+env:
+  anonymous_reports: "off"

--- a/helm-charts/kong/ci/test2-values.yaml
+++ b/helm-charts/kong/ci/test2-values.yaml
@@ -2,6 +2,8 @@
 # - ingressController deploys with a database
 ingressController:
   enabled: true
+  env:
+    anonymous_reports: "false"
 postgresql:
   enabled: true
   postgresqlUsername: kong
@@ -9,6 +11,7 @@ postgresql:
   service:
     port: 5432
 env:
+  anonymous_reports: "off"
   database: "postgres"
 # - ingress resources are created without hosts
 admin:

--- a/helm-charts/kong/ci/test3-values.yaml
+++ b/helm-charts/kong/ci/test3-values.yaml
@@ -4,6 +4,7 @@ ingressController:
   enabled: false
 # - disable DB for kong
 env:
+  anonymous_reports: "off"
   database: "off"
 postgresql:
   enabled: false

--- a/helm-charts/kong/ci/test4-values.yaml
+++ b/helm-charts/kong/ci/test4-values.yaml
@@ -3,6 +3,8 @@
 # - disable ingress controller
 ingressController:
   enabled: false
+  env:
+    anonymous_reports: "false"
 # - use legacy admin listen config
 admin:
   enabled: true
@@ -12,6 +14,7 @@ admin:
 
 # - disable DB for kong
 env:
+  anonymous_reports: "off"
   database: "off"
 postgresql:
   enabled: false

--- a/helm-charts/kong/crds/custom-resource-definitions.yaml
+++ b/helm-charts/kong/crds/custom-resource-definitions.yaml
@@ -110,6 +110,19 @@ spec:
           type: boolean
         config:
           type: object
+        configFrom:
+          type: object
+          properties:
+            secretKeyRef:
+              required:
+              - name
+              - key
+              type: object
+              properties:
+                name:
+                  type: string
+                key:
+                  type: string
         run_on:
           type: string
           enum:
@@ -171,6 +184,22 @@ spec:
           type: boolean
         config:
           type: object
+        configFrom:
+          type: object
+          properties:
+            secretKeyRef:
+              required:
+              - name
+              - namespace
+              - key
+              type: object
+              properties:
+                namespace:
+                  type: string
+                name:
+                  type: string
+                key:
+                  type: string
         run_on:
           type: string
           enum:

--- a/helm-charts/kong/example-values/README.md
+++ b/helm-charts/kong/example-values/README.md
@@ -1,0 +1,35 @@
+# Example values.yaml configurations
+
+The YAML files in this directory provide basic example configurations for
+common Kong deployment scenarios on Kubernetes. All examples assume Helm 3 and
+disable legacy CRD templates (`ingressController.installCRDs: false`; you must
+change this value to `true` if you use Helm 2).
+
+* [minimal-kong-controller.yaml](minimal-kong-controller.yaml) installs Kong
+  open source with the ingress controller in DB-less mode.
+
+* [minimal-kong-standalone.yaml](minimal-kong-standalone.yaml) installs Kong
+  open source and Postgres with no controller.
+
+* [minimal-k4k8s-enterprise.yaml](minimal-k4k8s-enterprise.yaml) installs Kong
+  for Kubernetes Enterprise with the ingress controller in DB-less mode.
+
+* [minimal-k4k8s-with-kong-enterprise.yaml](minimal-k4k8s-with-kong-enterprise.yaml)
+  installs Kong for Kubernetes with Kong Enterprise with the ingress controller
+  and PostgreSQL. It does not enable Enterprise features other than Kong
+  Manager, and does not expose it or the Admin API via a TLS-secured ingress.
+
+* [full-k4k8s-with-kong-enterprise.yaml](full-k4k8s-with-kong-enterprise.yaml)
+  installs Kong for Kubernetes with Kong Enterprise with the ingress controller
+  in PostgreSQL. It enables all Enterprise services.
+
+All Enterprise examples require some level of additional user configuration to
+install properly. Read the comments at the top of each file for instructions.
+
+Examples are designed for use with Helm 3, and disable Helm 2 CRD installation.
+If you use Helm 2, you will need to enable it:
+
+```
+helm install kong/kong -f /path/to/values.yaml \
+  --set ingressController.installCRDs=true
+```

--- a/helm-charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/helm-charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -1,0 +1,207 @@
+# Kong for Kubernetes with Kong Enterprise with Enterprise features enabled and
+# exposed via TLS-enabled Ingresses. Before installing:
+# * Several settings (search for the string "CHANGEME") require user-provided
+#   Secrets. These Secrets must be created before installation.
+# * Ingresses reference example "<service>.kong.CHANGEME.example" hostnames. These must
+#   be changed to an actual hostname that resolve to your proxy.
+# * Ensure that your session configurations create cookies that are usable
+#   across your services. The admin session configuration must create cookies
+#   that are sent to both the admin API and Kong Manager, and any Dev Portal
+#   instances with authentication must create cookies that are sent to both
+#   the Portal and Portal API.
+
+image:
+  repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
+  tag: 1.5.0.2-alpine
+  pullSecrets:
+    # CHANGEME: https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-docker-registry-access
+    - kong-enterprise-edition-docker
+
+env:
+  prefix: /kong_prefix/
+  database: postgres
+
+  password:
+    valueFrom:
+      secretKeyRef:
+        name: kong-enterprise-superuser-password #CHANGEME
+        key: password #CHANGEME
+
+admin:
+  enabled: true
+  annotations:
+    konghq.com/protocol: "https"
+
+  tls:
+    enabled: true
+    servicePort: 8444
+    containerPort: 8444
+    parameters:
+    - http2
+
+  ingress:
+    enabled: true
+    tls: CHANGEME-admin-tls-secret
+    hostname: admin.kong.CHANGEME.example
+    annotations:
+      kubernetes.io/ingress.class: "kong"
+    path: /
+
+proxy:
+  enabled: true
+  type: LoadBalancer
+  annotations: {}
+
+  http:
+    enabled: true
+    servicePort: 80
+    containerPort: 8000
+    parameters: []
+
+  tls:
+    enabled: true
+    servicePort: 443
+    containerPort: 8443
+    parameters:
+    - http2
+
+  stream: {}
+
+  ingress:
+    enabled: false
+    hosts: []
+    annotations: {}
+    path: /
+
+  externalIPs: []
+
+enterprise:
+  enabled: true
+  # CHANGEME: https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-license
+  license_secret: kong-enterprise-license
+  vitals:
+    enabled: true
+  portal:
+    enabled: true
+  rbac:
+    enabled: true
+    admin_gui_auth: basic-auth
+    session_conf_secret: kong-session-config
+    admin_gui_auth_conf_secret: CHANGEME-admin-gui-auth-conf-secret
+  smtp:
+    enabled: false
+    portal_emails_from: none@example.com
+    portal_emails_reply_to: none@example.com
+    admin_emails_from: none@example.com
+    admin_emails_reply_to: none@example.com
+    smtp_admin_emails: none@example.com
+    smtp_host: smtp.example.com
+    smtp_port: 587
+    smtp_auth_type: nil
+    smtp_ssl: nil
+    smtp_starttls: true
+    auth:
+      smtp_username: ''  # e.g. postmaster@example.com
+      smtp_password_secret: CHANGEME-smtp-password
+
+manager:
+  enabled: true
+  type: NodePort
+  annotations:
+    konghq.com/protocol: "https"
+
+  http:
+    enabled: false
+
+  tls:
+    enabled: true
+    servicePort: 8445
+    containerPort: 8445
+    parameters:
+    - http2
+
+  ingress:
+    enabled: true
+    tls: CHANGEME-manager-tls-secret
+    hostname: manager.kong.CHANGEME.example
+    annotations: {}
+    path: /
+
+  externalIPs: []
+
+portal:
+  enabled: true
+  type: NodePort
+  annotations:
+    konghq.com/protocol: "https"
+
+  http:
+    enabled: true
+    servicePort: 8003
+    containerPort: 8003
+    parameters: []
+
+  tls:
+    enabled: true
+    servicePort: 8446
+    containerPort: 8446
+    parameters:
+    - http2
+
+  ingress:
+    enabled: true
+    tls: CHANGEME-portal-tls-secret
+    hostname: portal.kong.CHANGEME.example
+    annotations:
+      kubernetes.io/ingress.class: "kong"
+    path: /
+
+  externalIPs: []
+
+portalapi:
+  enabled: true
+  type: NodePort
+  annotations:
+    konghq.com/protocol: "https"
+
+  http:
+
+  http:
+    enabled: true
+    servicePort: 8004
+    containerPort: 8004
+    parameters: []
+
+  tls:
+    enabled: true
+    servicePort: 8447
+    containerPort: 8447
+    parameters:
+    - http2
+
+  ingress:
+    enabled: true
+    tls: CHANGEME-portalapi-tls-secret
+    hostname: portalapi.kong.CHANGEME.example
+    annotations:
+      kubernetes.io/ingress.class: "kong"
+    path: /
+
+  externalIPs: []
+
+postgresql:
+  enabled: true
+  postgresqlUsername: kong
+  postgresqlDatabase: kong
+  service:
+    port: 5432
+
+ingressController:
+  enabled: true
+  installCRDs: false
+  env:
+    kong_admin_token:
+      valueFrom:
+        secretKeyRef:
+          name: kong-enterprise-superuser-password #CHANGEME
+          key: password #CHANGEME

--- a/helm-charts/kong/example-values/minimal-k4k8s-enterprise.yaml
+++ b/helm-charts/kong/example-values/minimal-k4k8s-enterprise.yaml
@@ -1,0 +1,22 @@
+# Basic values.yaml for Kong for Kubernetes Enterprise
+# Several settings (search for the string "CHANGEME") require user-provided
+# Secrets. These Secrets must be created before installation.
+
+image:
+  repository: kong-docker-kong-enterprise-k8s.bintray.io/kong-enterprise-k8s
+  tag: 2.0.4.1-centos
+  pullSecrets:
+    # CHANGEME: https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-docker-registry-access
+    - kong-enterprise-k8s-docker
+
+enterprise:
+  enabled: true
+  # CHANGEME: https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-license
+  license_secret: kong-enterprise-license
+
+env:
+  database: "off"
+
+ingressController:
+  enabled: true
+  installCRDs: false

--- a/helm-charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/helm-charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -1,0 +1,55 @@
+# Basic values.yaml for Kong for Kubernetes with Kong Enterprise
+# Several settings (search for the string "CHANGEME") require user-provided
+# Secrets. These Secrets must be created before installation.
+#
+# This installation does not create an Ingress or LoadBalancer Service for
+# the Admin API or Kong Manager. They require port-forwards to access without
+# further configuration to add them:
+# kubectl port-forward deploy/your-deployment-kong 8001:8001 8002:8002
+
+image:
+  repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
+  tag: 1.5.0.2-alpine
+  pullSecrets:
+    # CHANGEME: https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-docker-registry-access
+    - kong-enterprise-edition-docker
+
+admin:
+  enabled: true
+  http:
+    enabled: true
+    servicePort: 8001
+    containerPort: 8001
+
+enterprise:
+  enabled: true
+  # CHANGEME: https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-license
+  license_secret: kong-enterprise-license
+  vitals:
+    enabled: false
+  portal:
+    enabled: false
+  rbac:
+    enabled: false
+  smtp:
+    enabled: false
+
+env:
+  prefix: /kong_prefix/
+  database: postgres
+  password:
+    valueFrom:
+      secretKeyRef:
+        name: kong-enterprise-superuser-password #CHANGEME
+        key: password #CHANGEME
+
+postgresql:
+  enabled: true
+  postgresqlUsername: kong
+  postgresqlDatabase: kong
+  service:
+    port: 5432
+
+ingressController:
+  enabled: true
+  installCRDs: false

--- a/helm-charts/kong/example-values/minimal-kong-controller.yaml
+++ b/helm-charts/kong/example-values/minimal-kong-controller.yaml
@@ -1,0 +1,13 @@
+# Basic values.yaml configuration for Kong for Kubernetes (with the ingress controller)
+
+image:
+  repository: kong
+  tag: "2.0"
+
+env:
+  prefix: /kong_prefix/
+  database: "off"
+
+ingressController:
+  enabled: true
+  installCRDs: false

--- a/helm-charts/kong/example-values/minimal-kong-standalone.yaml
+++ b/helm-charts/kong/example-values/minimal-kong-standalone.yaml
@@ -1,0 +1,31 @@
+# Basic configuration for Kong without the ingress controller, using the Postgres subchart
+# This installation does not create an Ingress or LoadBalancer Service for
+# the Admin API. It requires port-forwards to access without further
+# configuration to add them, e.g.:
+# kubectl port-forward deploy/your-deployment-kong 8001:8001
+
+image:
+  repository: kong
+  tag: "2.0"
+
+env:
+  prefix: /kong_prefix/
+  database: postgres
+
+admin:
+  enabled: true
+  http:
+    enabled: true
+    servicePort: 8001
+    containerPort: 8001
+
+postgresql:
+  enabled: true
+  postgresqlUsername: kong
+  postgresqlDatabase: kong
+  service:
+    port: 5432
+
+ingressController:
+  enabled: false
+  installCRDs: false

--- a/helm-charts/kong/requirements.lock
+++ b/helm-charts/kong/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 8.6.8
-digest: sha256:f23a14b925ecc1110dcdb4e9f05f6c5bab48d830241a29054a999618c72510be
-generated: "2020-04-10T14:20:04.080225001-07:00"
+digest: sha256:8a3bbab2075144edbd954b95b2c779a61dcc55ec6a858f24b01b1e0031b72c19
+generated: "2020-03-20T13:08:19.76868615-07:00"

--- a/helm-charts/kong/templates/config-custom-server-blocks.yaml
+++ b/helm-charts/kong/templates/config-custom-server-blocks.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.kong.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -28,3 +29,4 @@ data:
             stub_status;
         }
     }
+{{- end }}

--- a/helm-charts/kong/templates/config-dbless.yaml
+++ b/helm-charts/kong/templates/config-dbless.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.kong.enabled }}
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
 {{- if not .Values.dblessConfig.configMap }}
 apiVersion: v1
@@ -9,5 +10,6 @@ metadata:
 data:
   kong.yml: |
 {{ .Values.dblessConfig.config | toYaml | indent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm-charts/kong/templates/custom-resource-definitions.yaml
+++ b/helm-charts/kong/templates/custom-resource-definitions.yaml
@@ -1,4 +1,9 @@
-{{- if and .Values.ingressController.enabled .Values.ingressController.installCRDs -}}
+{{/*
+This handles two cases where we should render this template. These map to the two top-level or clauses:
+- This is a controller-managed Helm 2 install. The controller is enabled and installCRDs is enabled.
+- This is a CRD-only install. Neither the controller nor Kong are enabled (the "not or") and installCRDs is enabled.
+*/}}
+{{- if (or (and .Values.ingressController.enabled .Values.ingressController.installCRDs) (and (not (or .Values.deployment.kong.enabled .Values.ingressController.enabled )) .Values.ingressController.installCRDs)) -}}
 {{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
 {{ $.Files.Get $path }}
 ---

--- a/helm-charts/kong/templates/deployment.yaml
+++ b/helm-charts/kong/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.deployment.kong.enabled .Values.ingressController.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -36,6 +37,9 @@ spec:
       labels:
         {{- include "kong.metaLabels" . | nindent 8 }}
         app.kubernetes.io/component: app
+        {{- if .Values.podLabels }}
+        {{ toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
@@ -50,25 +54,30 @@ spec:
       {{- end }}
       {{- end }}
       {{- if not (eq .Values.env.database "off") }}
+      {{- if .Values.deployment.kong.enabled }}
       initContainers:
       {{- include "kong.wait-for-db" . | nindent 6 }}
+      {{ end }}
       {{ end }}
       containers:
       {{- if .Values.ingressController.enabled }}
       {{- include "kong.controller-container" . | nindent 6 }}
       {{ end }}
+      {{- if .Values.deployment.kong.enabled }}
       - name: "proxy"
+        {{- if .Values.image.unifiedRepoTag }}
+        image: "{{ .Values.image.unifiedRepoTag }}"
+        {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}
         lifecycle:
-          preStop:
-            exec:
-              command: [ "/bin/sh", "-c", "kong quit" ]
+          {{- toYaml .Values.lifecycle | nindent 10 }}
         ports:
         {{/* TODO: remove legacy admin port template */}}
-        {{- if .Values.admin.containerPort }}
+        {{- if (and .Values.admin.containerPort .Values.admin.enabled) }}
         - name: admin
           containerPort: {{ .Values.admin.containerPort }}
           {{- if .Values.admin.hostPort }}
@@ -76,7 +85,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.admin.http.enabled }}
+        {{- if (and .Values.admin.http.enabled .Values.admin.enabled) }}
         - name: admin
           containerPort: {{ .Values.admin.http.containerPort }}
           {{- if .Values.admin.http.hostPort }}
@@ -84,7 +93,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.admin.tls.enabled }}
+        {{- if (and .Values.admin.tls.enabled .Values.admin.enabled) }}
         - name: admin-tls
           containerPort: {{ .Values.admin.tls.containerPort }}
           {{- if .Values.admin.tls.hostPort }}
@@ -92,7 +101,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.proxy.http.enabled }}
+        {{- if (and .Values.proxy.http.enabled .Values.proxy.enabled) }}
         - name: proxy
           containerPort: {{ .Values.proxy.http.containerPort }}
           {{- if .Values.proxy.http.hostPort }}
@@ -100,7 +109,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.proxy.tls.enabled }}
+        {{- if (and .Values.proxy.tls.enabled .Values.proxy.enabled)}}
         - name: proxy-tls
           containerPort: {{ .Values.proxy.tls.containerPort }}
           {{- if .Values.proxy.tls.hostPort }}
@@ -116,7 +125,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.status.http.enabled }}
+        {{- if (and .Values.status.http.enabled .Values.status.enabled)}}
         - name: status
           containerPort: {{ .Values.status.http.containerPort }}
           {{- if .Values.status.http.hostPort }}
@@ -124,7 +133,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.status.tls.enabled }}
+        {{- if (and .Values.status.tls.enabled .Values.status.enabled) }}
         - name: status-tls
           containerPort: {{ .Values.status.tls.containerPort }}
           {{- if .Values.status.tls.hostPort }}
@@ -141,7 +150,7 @@ spec:
           protocol: TCP
         {{- end }}
         {{- if .Values.enterprise.enabled }}
-        {{- if .Values.manager.http.enabled }}
+        {{- if (and .Values.manager.http.enabled .Values.manager.enabled) }}
         - name: manager
           containerPort: {{ .Values.manager.http.containerPort }}
           {{- if .Values.manager.http.hostPort }}
@@ -149,7 +158,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.manager.tls.enabled }}
+        {{- if (and .Values.manager.tls.enabled .Values.manager.enabled) }}
         - name: manager-tls
           containerPort: {{ .Values.manager.tls.containerPort }}
           {{- if .Values.manager.tls.hostPort }}
@@ -157,7 +166,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.portal.http.enabled }}
+        {{- if (and .Values.portal.http.enabled .Values.portal.enabled) }}
         - name: portal
           containerPort: {{ .Values.portal.http.containerPort }}
           {{- if .Values.portal.http.hostPort }}
@@ -165,7 +174,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.portal.tls.enabled }}
+        {{- if (and .Values.portal.tls.enabled .Values.portal.enabled) }}
         - name: portal-tls
           containerPort: {{ .Values.portal.tls.containerPort }}
           {{- if .Values.portal.tls.hostPort }}
@@ -173,7 +182,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.portalapi.http.enabled }}
+        {{- if (and .Values.portalapi.http.enabled .Values.portalapi.enabled) }}
         - name: portalapi
           containerPort: {{ .Values.portalapi.http.containerPort }}
           {{- if .Values.portalapi.http.hostPort }}
@@ -181,13 +190,14 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.portalapi.tls.enabled }}
+        {{- if (and .Values.portalapi.tls.enabled .Values.portalapi.enabled) }}
         - name: portalapi-tls
           containerPort: {{ .Values.portalapi.tls.containerPort }}
           {{- if .Values.portalapi.tls.hostPort }}
           hostPort: {{ .Values.portalapi.tls.hostPort }}
           {{- end}}
           protocol: TCP
+        {{- end }}
         {{- end }}
         {{- end }}
         volumeMounts:
@@ -212,3 +222,4 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
       volumes:
       {{- include "kong.volumes" . | nindent 8 -}}
+{{- end }}

--- a/helm-charts/kong/templates/ingress-admin.yaml
+++ b/helm-charts/kong/templates/ingress-admin.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Values.admin.ingress.enabled -}}
 {{- if .Values.admin.containerPort -}} {{/* TODO: remove legacy admin handling */}}
 {{- $serviceName := include "kong.fullname" . -}}
@@ -61,5 +62,6 @@ spec:
     - {{ $hostname }}
     secretName: {{ $tls }}
   {{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm-charts/kong/templates/ingress-manager.yaml
+++ b/helm-charts/kong/templates/ingress-manager.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Values.enterprise.enabled }}
 {{- if .Values.manager.ingress.enabled -}}
 {{- $serviceName := include "kong.fullname" . -}}
@@ -30,5 +31,6 @@ spec:
     - {{ $hostname }}
     secretName: {{ $tls }}
   {{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm-charts/kong/templates/ingress-portal-api.yaml
+++ b/helm-charts/kong/templates/ingress-portal-api.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Values.enterprise.enabled }}
 {{- if .Values.portalapi.ingress.enabled -}}
 {{- $serviceName := include "kong.fullname" . -}}
@@ -30,5 +31,6 @@ spec:
     - {{ $hostname }}
     secretName: {{ $tls }}
   {{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm-charts/kong/templates/ingress-portal.yaml
+++ b/helm-charts/kong/templates/ingress-portal.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Values.enterprise.enabled }}
 {{- if .Values.portal.ingress.enabled -}}
 {{- $serviceName := include "kong.fullname" . -}}
@@ -30,5 +31,6 @@ spec:
     - {{ $hostname }}
     secretName: {{ $tls }}
   {{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm-charts/kong/templates/ingress-proxy.yaml
+++ b/helm-charts/kong/templates/ingress-proxy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Values.proxy.ingress.enabled -}}
 {{- $serviceName := include "kong.fullname" . -}}
 {{- $servicePort := include "kong.ingress.servicePort" .Values.proxy -}}
@@ -37,4 +38,5 @@ spec:
   tls:
 {{ toYaml .Values.proxy.ingress.tls | indent 4 }}
   {{- end -}}
+{{- end -}}
 {{- end -}}

--- a/helm-charts/kong/templates/migrations-post-upgrade.yaml
+++ b/helm-charts/kong/templates/migrations-post-upgrade.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.kong.enabled }}
 {{- if (and (or (.Values.runMigrations) (.Values.migrations.postUpgrade)) (not (eq .Values.env.database "off"))) }}
 # Why is this Job duplicated and not using only helm hooks?
 # See: https://github.com/helm/charts/pull/7362
@@ -38,7 +39,11 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-post-upgrade-migrations
+        {{- if .Values.image.unifiedRepoTag }}
+        image: "{{ .Values.image.unifiedRepoTag }}"
+        {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}
@@ -50,4 +55,5 @@ spec:
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
+{{- end }}
 {{- end }}

--- a/helm-charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/helm-charts/kong/templates/migrations-pre-upgrade.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.kong.enabled }}
 {{- if (and (or (.Values.runMigrations) (.Values.migrations.preUpgrade)) (not (eq .Values.env.database "off"))) }}
 # Why is this Job duplicated and not using only helm hooks?
 # See: https://github.com/helm/charts/pull/7362
@@ -38,7 +39,11 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-upgrade-migrations
+        {{- if .Values.image.unifiedRepoTag }}
+        image: "{{ .Values.image.unifiedRepoTag }}"
+        {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}
@@ -50,4 +55,5 @@ spec:
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
+{{- end }}
 {{- end }}

--- a/helm-charts/kong/templates/migrations.yaml
+++ b/helm-charts/kong/templates/migrations.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Release.IsInstall -}}
 {{/* .migrations.init isn't normally exposed in values.yaml. In testing,
 however, adding it with value "false" didn't actually disable this job. Not
@@ -38,7 +39,11 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-migrations
+        {{- if .Values.image.unifiedRepoTag }}
+        image: "{{ .Values.image.unifiedRepoTag }}"
+        {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}
@@ -50,5 +55,6 @@ spec:
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm-charts/kong/templates/psp.yaml
+++ b/helm-charts/kong/templates/psp.yaml
@@ -6,25 +6,7 @@ metadata:
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
 spec:
-  privileged: false
-  fsGroup:
-    rule: RunAsAny
-  runAsUser:
-    rule: RunAsAny
-  runAsGroup:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-    - 'configMap'
-    - 'secret'
-    - 'emptyDir'
-  allowPrivilegeEscalation: false
-  hostNetwork: false
-  hostIPC: false
-  hostPID: false
+{{ .Values.podSecurityPolicy.spec | toYaml | indent 2 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/helm-charts/kong/templates/service-kong-admin.yaml
+++ b/helm-charts/kong/templates/service-kong-admin.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Values.admin.containerPort -}} {{/* TODO: remove legacy admin handling */}}
 {{- if .Values.admin.enabled -}}
 apiVersion: v1
@@ -84,5 +85,6 @@ spec:
   {{- end }}
   selector:
     {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm-charts/kong/templates/service-kong-manager.yaml
+++ b/helm-charts/kong/templates/service-kong-manager.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Values.enterprise.enabled }}
 {{- if and .Values.manager.enabled (or .Values.manager.http.enabled .Values.manager.tls.enabled) -}}
 apiVersion: v1
@@ -48,5 +49,6 @@ spec:
   {{- end }}
   selector:
     {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm-charts/kong/templates/service-kong-portal-api.yaml
+++ b/helm-charts/kong/templates/service-kong-portal-api.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Values.enterprise.enabled }}
 {{- if and .Values.portalapi.enabled (or .Values.portalapi.http.enabled .Values.portalapi.tls.enabled) -}}
 apiVersion: v1
@@ -48,5 +49,6 @@ spec:
   {{- end }}
   selector:
     {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm-charts/kong/templates/service-kong-portal.yaml
+++ b/helm-charts/kong/templates/service-kong-portal.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Values.enterprise.enabled }}
 {{- if and .Values.portal.enabled (or .Values.portal.http.enabled .Values.portal.tls.enabled) -}}
 apiVersion: v1
@@ -48,5 +49,6 @@ spec:
   {{- end }}
   selector:
     {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm-charts/kong/templates/service-kong-proxy.yaml
+++ b/helm-charts/kong/templates/service-kong-proxy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.kong.enabled }}
 {{- if and .Values.proxy.enabled (or .Values.proxy.http.enabled .Values.proxy.tls.enabled) -}}
 apiVersion: v1
 kind: Service
@@ -8,6 +9,7 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
   labels:
+    enable-metrics: "true"
     {{- include "kong.metaLabels" . | nindent 4 }}
 spec:
   type: {{ .Values.proxy.type }}
@@ -63,4 +65,5 @@ spec:
   {{- end }}
   selector:
     {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/helm-charts/kong/templates/servicemonitor.yaml
+++ b/helm-charts/kong/templates/servicemonitor.yaml
@@ -24,5 +24,6 @@ spec:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
+      enable-metrics: "true"
       {{- include "kong.metaLabels" . | nindent 6 }}
 {{- end }}

--- a/helm-charts/kong/values.yaml
+++ b/helm-charts/kong/values.yaml
@@ -2,11 +2,23 @@
 # Declare variables to be passed into your templates.
 #
 # Sections:
+# - Deployment parameters
 # - Kong parameters
 # - Ingress Controller parameters
 # - Postgres sub-chart parameters
 # - Miscellaneous parameters
 # - Kong Enterprise parameters
+
+# -----------------------------------------------------------------------------
+# Deployment parameters
+# -----------------------------------------------------------------------------
+
+deployment:
+  kong:
+    # Enable or disable Kong itself
+    # Setting this to false with ingressController.enabled=true will create a
+    # controller-only release.
+    enabled: true
 
 # -----------------------------------------------------------------------------
 # Kong parameters
@@ -36,10 +48,10 @@ image:
   tag: "2.0"
   # kong-enterprise-k8s image (Kong OSS + Enterprise plugins)
   # repository: kong-docker-kong-enterprise-k8s.bintray.io/kong-enterprise-k8s
-  # tag: "2.0.2.0-alpine"
+  # tag: "2.0.4.1-alpine"
   # kong-enterprise image
   # repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  # tag: "1.5.0.0-alpine"
+  # tag: "1.5.0.2-alpine"
 
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
@@ -260,7 +272,7 @@ ingressController:
   enabled: true
   image:
     repository: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller
-    tag: 0.8.0
+    tag: 0.9.0
   args: []
 
   # Specify Kong Ingress Controller configuration via environment variables
@@ -397,6 +409,13 @@ livenessProbe:
   successThreshold: 1
   failureThreshold: 3
 
+# Proxy container lifecycle hooks
+# Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+lifecycle:
+  preStop:
+    exec:
+      command: ["/bin/sh", "-c", "/bin/sleep 15 && kong quit"]
+
 # Affinity for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 # affinity: {}
@@ -411,6 +430,9 @@ nodeSelector: {}
 
 # Annotation to be added to Kong pods
 podAnnotations: {}
+
+# Labels to be added to Kong pods
+podLabels: {}
 
 # Kong pod count
 replicaCount: 1
@@ -443,13 +465,35 @@ podDisruptionBudget:
 
 podSecurityPolicy:
   enabled: false
+  spec:
+    privileged: false
+    fsGroup:
+      rule: RunAsAny
+    runAsUser:
+      rule: RunAsAny
+    runAsGroup:
+      rule: RunAsAny
+    seLinux:
+      rule: RunAsAny
+    supplementalGroups:
+      rule: RunAsAny
+    volumes:
+      - 'configMap'
+      - 'secret'
+      - 'emptyDir'
+    allowPrivilegeEscalation: false
+    hostNetwork: false
+    hostIPC: false
+    hostPID: false
+    # Make the root filesystem read-only. This is not compatible with Kong Enterprise <1.5.
+    # If you use Kong Enterprise <1.5, this must be set to false.
+    readOnlyRootFilesystem: true
 
 
 priorityClassName: ""
 
 # securityContext for Kong pods.
-securityContext:
-  runAsUser: 1000
+securityContext: {}
 
 serviceMonitor:
   # Specifies whether ServiceMonitor for Prometheus operator should be created
@@ -472,7 +516,7 @@ enterprise:
   # Kong Enterprise license secret name
   # This secret must contain a single 'license' key, containing your base64-encoded license data
   # The license secret is required for all Kong Enterprise deployments
-  license_secret: you-must-create-a-kong-license-secret
+  license_secret: kong-enterprise-license
   vitals:
     enabled: true
   portal:
@@ -483,10 +527,10 @@ enterprise:
     # If RBAC is enabled, this Secret must contain an admin_gui_session_conf key
     # The key value must be a secret configuration, following the example at
     # https://docs.konghq.com/enterprise/latest/kong-manager/authentication/sessions
-    session_conf_secret: you-must-create-an-rbac-session-conf-secret
+    session_conf_secret: kong-session-config
     # If admin_gui_auth is not set to basic-auth, provide a secret name which
     # has an admin_gui_auth_conf key containing the plugin config JSON
-    admin_gui_auth_conf_secret: you-must-create-an-admin-gui-auth-conf-secret
+    admin_gui_auth_conf_secret: CHANGEME-admin-gui-auth-conf-secret
   # For configuring emails and SMTP, please read through:
   # https://docs.konghq.com/enterprise/latest/developer-portal/configuration/smtp
   # https://docs.konghq.com/enterprise/latest/kong-manager/networking/email
@@ -499,6 +543,8 @@ enterprise:
     smtp_admin_emails: none@example.com
     smtp_host: smtp.example.com
     smtp_port: 587
+    smtp_auth_type: nil
+    smtp_ssl: nil
     smtp_starttls: true
     auth:
       # If your SMTP server does not require authentication, this section can
@@ -506,7 +552,7 @@ enterprise:
       # string, you must create a Secret with an smtp_password key containing
       # your SMTP password and specify its name here.
       smtp_username: ''  # e.g. postmaster@example.com
-      smtp_password_secret: you-must-create-an-smtp-password
+      smtp_password_secret: CHANGEME-smtp-password
 
 manager:
   # Enable creating a Kubernetes service for Kong Manager

--- a/olm/0.3.0/kong.v0.3.0.clusterserviceversion.yaml
+++ b/olm/0.3.0/kong.v0.3.0.clusterserviceversion.yaml
@@ -1,0 +1,171 @@
+apiVersion: operators.coreos.com/v3alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"charts.helm.k8s.io/v1alpha1","kind":"Kong","metadata":{"name":"example-kong"},"spec":{"proxy":{"type":"NodePort"},"env":{"prefix":"/kong_prefix/"},"resources":{"limits":{"cpu":"500m","memory":"2G"},"requests":{"cpu":"100m","memory":"512Mi"}},"ingressController":{"enabled":true,"installCRDs":false}}}]'
+    capabilities: Basic Install
+    categories: Networking
+    certified: 'false'
+    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.3.0
+    createdAt: '2020-04-10T17:26:45Z'
+    description: Install and manage Kong clusters.
+    repository: https://github.com/kong/kong-operator
+    support: Harry Bagdi
+  name: kong.v0.3.0
+  namespace: placeholder
+spec:
+  customresourcedefinitions:
+    owned:
+    - description: A Kong cluster configuration. Mirrors the settings in the Helm chart's values.yaml
+      displayName: Kong
+      kind: Kong
+      name: kongs.charts.helm.k8s.io
+      version: v1alpha1
+  description: >
+    Kong is a popular open-source cloud-native API gateway.
+
+    The Kong Operator manages [Kong](https://konghq.com/kong/) and [Kong Enterprise](https://konghq.com/products/kong-enterprise/) clusters.
+    It includes an [ingress controller](https://github.com/Kong/kubernetes-ingress-controller) to configure Kong's gateway using Kubernetes resources.
+
+    The operator manages Kong using the [Kong Helm chart](https://github.com/Kong/charts/blob/master/charts/kong/README.md).
+    Its `Kong` custom resource contains a [values.yaml](https://github.com/Kong/charts/blob/master/charts/kong/values.yaml).
+
+  displayName: Kong Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAI4AAACACAMAAADqKaFKAAAAnFBMVEUAAAAANFoAUnIANl0ANFkANFkAOWEANFkANFkAOl8ANFoANFoAOF0AQGMANFoANVoANFkANVoANFkANFkANVoANlwANFkANVoANVoANVoANFoANloAN1sANlsAQ2oANFoANFoANVoAOF0ANFkANVoANVoANFoANVoANlsAQGIANVkANVkANVkANVoANVkANVoANlsANVoANFoANFnuMUUSAAAAM3RSTlMA0AUt+lIYkbMT9u8hDOJ23KOM5loz84Bk68A5J0kJ17qHHMStbJVOQg/MPp57qXBUmslOI9JhAAAEs0lEQVR42szZ226qUBSF4eESFVQqFs/nc7Vat+14/3fbCSVGUVirCWvid+vNTID8mVPYok41hZdR/SHXVbyIcUiS4REvYeAw4mxRPFXjVXuGgnkL3ig1UahywDuNKQpU6TGpj8L0+YR7QCF8l08FZRSgOWeKegfipg2mE09Gy2E66WSoNjXCMeT8o4ZoMg5DaogmY0kN0WSs6tQQTcaJGqLJKFNDNhkuNUSTsaeGbDI+qSGajA7/bAd7xpVbfeqdIOedOm1IcpnNVZDkl5gp8CFqFb7SwwK6moR1YE2/drXb7eJCXjQhbcKSCu/Uu4h8MdNawQoV8F5YRaRdSNdbTPqc/c45YhZnDAu8Bh9s4p8CZmnBgm8+sURk0pAep+xkfcd7R3icRfaLMZAdZ8oUw2ZcU8lx1JxpSj4iruA4W6ZzrzWVGscbMsN7dk3re+SsxkyDrJq+dZGzicNMzvEatQejKmJyu9WwmVbTb4WY5G41PyByErirlKi3UE9qOjwif4O/rFNeYPmk4oc0sk3WdOPDgiXNONP7mn7BhmadhhqTm4fb+4AVNRoLvLimFg8pq5DGRgoRd+Ehydoipb8PzBTs6dBcC/aoGSJ9mvuALYfFBr/ONNaz9g6Xrhvb7IfG3qqwoRveLArVNyYIL8HTXryHaz4vmRvKwEns4RWasJSH5cMejhbNXZAndeaNM0zuFMlTS3689dODiFrTWLiy+B/wRXunSDm15GD8v3YzW0oYCKJoJwyLYqIgpFgECQoquJT0//+bD1CWVePkzk0n55WXLDOd26eHefDZdwqN5rkh4XZdUdpWGk/Z4tT1tA783KoyTfegtHnOqU0Hlw1AafM0IOoFLfQOWkGX315JZmnEc62imHoaEDIwdL5DmBw8DQgZ02VmfGbvopPDTOOZkevlXuMZ8b2OOwpBYKOAYJ5umO3FDg/5YP7mi0ugWgBg9oOC+c1cPYBqwTwUypJf2suja3xynRGP3LS94hTYp9bh3c+vWLXQH2++7x2oEqoFsXRak5Vv2bFqYeofv7141cLWP/5el4xqoesfc6/Nqpau2viW5lQLziyYL4NqgfWP507OrA921TJSMysRXrWcUm5yxzsTu2pZOrUyP+90u2rBT5fv6D4Y1ULUP7pBsKuWUs0UW/nFqFpe1M7OtAAOa1D/SJ7Eo6ZqWSdqxnnZhX3qJV5zhjPItVXLTu0koeDyTqsWR9xAJ0Aw1vGqpdVT4bxq0Vg2wsOrFqK34+FVS+tSb0epFi7p9ZMQi6sGxspDoarmjFtbtGpZSFzsPAuQqSMdNqtaSiESwFVOj4hI1dIVQuY912gLONWyFSLNTvA7tZ2vyUUU8pjJhU19ZzyO3DCKKB4CB1O4D8kgrkemIvltnS43XrUcRSiJlyaERKK3l8vg5RxS+cuUWGl0L5eICHlkv2+YME4iFAi5FLLcMMAvcXljhysvcerABxfSjogAXwxUL/GnDKhaChBO571/feYwKmbyMnQBLue1dsH/DIdDkAj4CpsqphcUkGCwysepG8u8cw9ugY/qK4sQDSexXCouxx0NWTxPJcAWlU9eQPcNDeIEKW/48vmo4LYSYlT5ORf5AWrXrLl1P4wQAAAAAElFTkSuQmCC
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - roles
+          - clusterrolebindings
+          - rolebindings
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - '*'
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - charts.helm.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: kong-operator
+      deployments:
+      - name: kong-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: kong-operator
+          template:
+            metadata:
+              labels:
+                name: kong-operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: kong-operator
+                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.3.0
+                imagePullPolicy: Always
+                name: kong-operator
+              serviceAccountName: kong-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - kong
+  - ingress
+  - proxy
+  - microservices
+  links:
+  - name: Kong
+    url: https://konghq.com/kong
+  - name: Helm Chart Source
+    url: https://github.com/kong/charts/tree/master/charts/kong
+  - name: Configuration Options
+    url: https://github.com/kong/charts/tree/master/charts/kong#configuration
+  - name: Kong Operator
+    url: https://github.com/kong/kong-operator
+  maintainers:
+  - email: harry@konghq.com
+    name: Harry
+  - email: traines@konghq.com
+    name: Travis
+  maturity: alpha
+  provider:
+    name: Kong Inc
+  version: 0.3.0
+  replaces: kong.v0.2.6

--- a/olm/0.3.0/kongs.charts.helm.k8s.io.crd.yaml
+++ b/olm/0.3.0/kongs.charts.helm.k8s.io.crd.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongs.charts.helm.k8s.io
+spec:
+  group: charts.helm.k8s.io
+  names:
+    kind: Kong
+    listKind: KongList
+    plural: kongs
+    singular: kong
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/olm/kong.package.yaml
+++ b/olm/kong.package.yaml
@@ -1,4 +1,4 @@
 channels:
-- currentCSV: kong.v0.2.6
+- currentCSV: kong.v0.3.0
   name: alpha
 packageName: kong


### PR DESCRIPTION
This releases 0.3.0 of the Kong Operator, which updates the Helm chart to 1.7.0. Corresponding certified operator release is available at the current tip of https://github.com/Kong/kong-operator/tree/fork/operatorhub