### PR TITLE
readme: Add test status badge + license/twitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![][kong-logo]][kong-url]
 
 ![Test status badge](https://github.com/Kong/kong-operator/workflows/Test/badge.svg)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/Kong/kong-operator/blob/master/LICENSE)
+[![Twitter](https://img.shields.io/twitter/follow/thekonginc.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=thekonginc)
 
 **Kong Operator** is a Kubernetes [operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) which manages [Kong Ingress Controller](https://github.com/Kong/kubernetes-ingress-controller/) instances.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Kong Operator
 [![][kong-logo]][kong-url]
 
+![Test status badge](https://github.com/Kong/kong-operator/workflows/Test/badge.svg)
+
 **Kong Operator** is a Kubernetes [operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) which manages [Kong Ingress Controller](https://github.com/Kong/kubernetes-ingress-controller/) instances.
 
 With Kong Operator running in your cluster, you can spin up multiple instances of Kong, each of them configured by a `Kong` custom resource ([example][kong-cr-example]). See the [Quick Start][quick-start] section below to get up and running.


### PR DESCRIPTION
Adds a status badge for CI tests implemented in #20 .

Also adds license and twitter buttons, same as Kong core.