### PR TITLE
ci(olm): implement community-operators config validation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,8 @@ jobs:
     - name: 'Check out the repo'
       uses: actions/checkout@v2
 
+    - uses: satackey/action-docker-layer-caching@v0.0.4
+
     # This step performs the validation. Errors can be found in the stderr of `docker build`.
     - name: 'Test the OLM configuration by building the Docker image'
       uses: docker/build-push-action@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,21 @@ name: Test
 on: [push]
 
 jobs:
+  validate-olm:
+    runs-on: ubuntu-latest
+    steps:
+    - name: 'Check out the repo'
+      uses: actions/checkout@v2
+
+    # This step performs the validation. Errors can be found in the stderr of `docker build`.
+    - name: 'Test the OLM configuration by building the Docker image'
+      uses: docker/build-push-action@v1
+      with:
+        repository: olm-registry
+        tags: ci
+        dockerfile: test/olm-validation/Dockerfile.olm
+        push: false
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/test/olm-validation/Dockerfile.olm
+++ b/test/olm-validation/Dockerfile.olm
@@ -1,0 +1,8 @@
+# This Dockerfile mimics the verification part of
+# https://github.com/operator-framework/community-operators/blob/master/upstream.Dockerfile .
+# Building this Dockerfile successfully is an approximation of the test run on PRs
+# to https://github.com/operator-framework/community-operators/ .
+
+FROM quay.io/operator-framework/upstream-registry-builder:v1.13.3 as builder
+COPY olm manifests/kong
+RUN ./bin/initializer -o ./bundles.db


### PR DESCRIPTION
closes #22

This PR implements a validation of the contents of `olm/` equivalent to the automatic validation performed by https://github.com/operator-framework/community-operators/ .

`community-operators` implement the check as an intermediate step of building their registry Docker image; here we mimic that approach in the simplest way I was able to come up with.