### PR TITLE
define the olm 0.4.0 release

### DIFF
--- a/olm/0.4.0/kong.v0.4.0.clusterserviceversion.yaml
+++ b/olm/0.4.0/kong.v0.4.0.clusterserviceversion.yaml
@@ -1,0 +1,171 @@
+apiVersion: operators.coreos.com/v3alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"charts.helm.k8s.io/v1alpha1","kind":"Kong","metadata":{"name":"example-kong"},"spec":{"proxy":{"type":"NodePort"},"env":{"prefix":"/kong_prefix/"},"resources":{"limits":{"cpu":"500m","memory":"2G"},"requests":{"cpu":"100m","memory":"512Mi"}},"ingressController":{"enabled":true,"installCRDs":false}}}]'
+    capabilities: Basic Install
+    categories: Networking
+    certified: 'false'
+    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.3.0
+    createdAt: '2020-04-10T17:26:45Z'
+    description: Install and manage Kong clusters.
+    repository: https://github.com/kong/kong-operator
+    support: Harry Bagdi
+  name: kong.v0.3.0
+  namespace: placeholder
+spec:
+  customresourcedefinitions:
+    owned:
+    - description: A Kong cluster configuration. Mirrors the settings in the Helm chart's values.yaml
+      displayName: Kong
+      kind: Kong
+      name: kongs.charts.helm.k8s.io
+      version: v1alpha1
+  description: >
+    Kong is a popular open-source cloud-native API gateway.
+
+    The Kong Operator manages [Kong](https://konghq.com/kong/) and [Kong Enterprise](https://konghq.com/products/kong-enterprise/) clusters.
+    It includes an [ingress controller](https://github.com/Kong/kubernetes-ingress-controller) to configure Kong's gateway using Kubernetes resources.
+
+    The operator manages Kong using the [Kong Helm chart](https://github.com/Kong/charts/blob/master/charts/kong/README.md).
+    Its `Kong` custom resource contains a [values.yaml](https://github.com/Kong/charts/blob/master/charts/kong/values.yaml).
+
+  displayName: Kong Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAI4AAACACAMAAADqKaFKAAAAnFBMVEUAAAAANFoAUnIANl0ANFkANFkAOWEANFkANFkAOl8ANFoANFoAOF0AQGMANFoANVoANFkANVoANFkANFkANVoANlwANFkANVoANVoANVoANFoANloAN1sANlsAQ2oANFoANFoANVoAOF0ANFkANVoANVoANFoANVoANlsAQGIANVkANVkANVkANVoANVkANVoANlsANVoANFoANFnuMUUSAAAAM3RSTlMA0AUt+lIYkbMT9u8hDOJ23KOM5loz84Bk68A5J0kJ17qHHMStbJVOQg/MPp57qXBUmslOI9JhAAAEs0lEQVR42szZ226qUBSF4eESFVQqFs/nc7Vat+14/3fbCSVGUVirCWvid+vNTID8mVPYok41hZdR/SHXVbyIcUiS4REvYeAw4mxRPFXjVXuGgnkL3ig1UahywDuNKQpU6TGpj8L0+YR7QCF8l08FZRSgOWeKegfipg2mE09Gy2E66WSoNjXCMeT8o4ZoMg5DaogmY0kN0WSs6tQQTcaJGqLJKFNDNhkuNUSTsaeGbDI+qSGajA7/bAd7xpVbfeqdIOedOm1IcpnNVZDkl5gp8CFqFb7SwwK6moR1YE2/drXb7eJCXjQhbcKSCu/Uu4h8MdNawQoV8F5YRaRdSNdbTPqc/c45YhZnDAu8Bh9s4p8CZmnBgm8+sURk0pAep+xkfcd7R3icRfaLMZAdZ8oUw2ZcU8lx1JxpSj4iruA4W6ZzrzWVGscbMsN7dk3re+SsxkyDrJq+dZGzicNMzvEatQejKmJyu9WwmVbTb4WY5G41PyByErirlKi3UE9qOjwif4O/rFNeYPmk4oc0sk3WdOPDgiXNONP7mn7BhmadhhqTm4fb+4AVNRoLvLimFg8pq5DGRgoRd+Ehydoipb8PzBTs6dBcC/aoGSJ9mvuALYfFBr/ONNaz9g6Xrhvb7IfG3qqwoRveLArVNyYIL8HTXryHaz4vmRvKwEns4RWasJSH5cMejhbNXZAndeaNM0zuFMlTS3689dODiFrTWLiy+B/wRXunSDm15GD8v3YzW0oYCKJoJwyLYqIgpFgECQoquJT0//+bD1CWVePkzk0n55WXLDOd26eHefDZdwqN5rkh4XZdUdpWGk/Z4tT1tA783KoyTfegtHnOqU0Hlw1AafM0IOoFLfQOWkGX315JZmnEc62imHoaEDIwdL5DmBw8DQgZ02VmfGbvopPDTOOZkevlXuMZ8b2OOwpBYKOAYJ5umO3FDg/5YP7mi0ugWgBg9oOC+c1cPYBqwTwUypJf2suja3xynRGP3LS94hTYp9bh3c+vWLXQH2++7x2oEqoFsXRak5Vv2bFqYeofv7141cLWP/5el4xqoesfc6/Nqpau2viW5lQLziyYL4NqgfWP507OrA921TJSMysRXrWcUm5yxzsTu2pZOrUyP+90u2rBT5fv6D4Y1ULUP7pBsKuWUs0UW/nFqFpe1M7OtAAOa1D/SJ7Eo6ZqWSdqxnnZhX3qJV5zhjPItVXLTu0koeDyTqsWR9xAJ0Aw1vGqpdVT4bxq0Vg2wsOrFqK34+FVS+tSb0epFi7p9ZMQi6sGxspDoarmjFtbtGpZSFzsPAuQqSMdNqtaSiESwFVOj4hI1dIVQuY912gLONWyFSLNTvA7tZ2vyUUU8pjJhU19ZzyO3DCKKB4CB1O4D8kgrkemIvltnS43XrUcRSiJlyaERKK3l8vg5RxS+cuUWGl0L5eICHlkv2+YME4iFAi5FLLcMMAvcXljhysvcerABxfSjogAXwxUL/GnDKhaChBO571/feYwKmbyMnQBLue1dsH/DIdDkAj4CpsqphcUkGCwysepG8u8cw9ugY/qK4sQDSexXCouxx0NWTxPJcAWlU9eQPcNDeIEKW/48vmo4LYSYlT5ORf5AWrXrLl1P4wQAAAAAElFTkSuQmCC
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - roles
+          - clusterrolebindings
+          - rolebindings
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - '*'
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - charts.helm.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: kong-operator
+      deployments:
+      - name: kong-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: kong-operator
+          template:
+            metadata:
+              labels:
+                name: kong-operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: kong-operator
+                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.3.0
+                imagePullPolicy: Always
+                name: kong-operator
+              serviceAccountName: kong-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - kong
+  - ingress
+  - proxy
+  - microservices
+  links:
+  - name: Kong
+    url: https://konghq.com/kong
+  - name: Helm Chart Source
+    url: https://github.com/kong/charts/tree/master/charts/kong
+  - name: Configuration Options
+    url: https://github.com/kong/charts/tree/master/charts/kong#configuration
+  - name: Kong Operator
+    url: https://github.com/kong/kong-operator
+  maintainers:
+  - email: harry@konghq.com
+    name: Harry
+  - email: traines@konghq.com
+    name: Travis
+  maturity: alpha
+  provider:
+    name: Kong Inc
+  version: 0.3.0
+  replaces: kong.v0.2.6

--- a/olm/0.4.0/kong.v0.4.0.clusterserviceversion.yaml
+++ b/olm/0.4.0/kong.v0.4.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Networking
     certified: 'false'
     containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.4.0
-    createdAt: '2020-08-14T11:43:45Z'
+    createdAt: '2020-08-05T16:07:00Z'
     description: The world’s most popular open source API gateway. Built for multi-cloud and hybrid, optimized for microservices and distributed architectures.
     olm.skipRanges: '>=0.2.6 <0.4.0'
     repository: https://github.com/kong/kong-operator

--- a/olm/0.4.0/kong.v0.4.0.clusterserviceversion.yaml
+++ b/olm/0.4.0/kong.v0.4.0.clusterserviceversion.yaml
@@ -174,7 +174,7 @@ spec:
   - name: Quick Start Guide
     url: https://github.com/Kong/kong-operator/blob/v0.4.0/README.md#quick-start
   - name: Helm Chart Source
-    url: https://github.com/kong/kong-operator/tree/v0.4.0/charts/kong/
+    url: https://github.com/kong/kong-operator/tree/v0.4.0/helm-charts/kong/
   maintainers:
   - email: harry@konghq.com
     name: Harry

--- a/olm/0.4.0/kong.v0.4.0.clusterserviceversion.yaml
+++ b/olm/0.4.0/kong.v0.4.0.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   customresourcedefinitions:
     owned:
-    - description: Defines a Kong cluster (equivalent to a Helm release).
+    - description: Defines a Kong cluster (equivalent to a Helm release). Uses the same settings as the Helm chart's values.yaml
       displayName: Kong
       kind: Kong
       name: kongs.charts.helm.k8s.io

--- a/olm/0.4.0/kong.v0.4.0.clusterserviceversion.yaml
+++ b/olm/0.4.0/kong.v0.4.0.clusterserviceversion.yaml
@@ -43,7 +43,7 @@ spec:
     The primary documentation site for Kong Operator is located [in its GitHub repository](https://github.com/Kong/kong-operator/blob/v0.4.0/README.md).
 
     Kong Operator provides the same configuration flexibility as the Kong Helm chart.
-    Refer to the [documentation of the Helm chart](https://github.com/Kong/kong-operator/blob/v0.4.0/helm-charts/kong/README.md) used by this version of Kong Operator,
+    Refer to the [Helm chart documentation](https://github.com/Kong/kong-operator/blob/v0.4.0/helm-charts/kong/README.md),
     the [Configuration](https://github.com/Kong/kong-operator/blob/v0.4.0/README.md#configuration) section of Kong Operator docs, and the example `Kong` resource below.
 
   displayName: Kong Operator

--- a/olm/0.4.0/kong.v0.4.0.clusterserviceversion.yaml
+++ b/olm/0.4.0/kong.v0.4.0.clusterserviceversion.yaml
@@ -6,29 +6,45 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: 'false'
-    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.3.0
-    createdAt: '2020-04-10T17:26:45Z'
-    description: Install and manage Kong clusters.
+    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.4.0
+    createdAt: '2020-08-14T11:43:45Z'
+    description: The world’s most popular open source API gateway. Built for multi-cloud and hybrid, optimized for microservices and distributed architectures.
+    olm.skipRanges: '>=0.2.6 <0.4.0'
     repository: https://github.com/kong/kong-operator
     support: Harry Bagdi
-  name: kong.v0.3.0
+  name: kong.v0.4.0
   namespace: placeholder
 spec:
   customresourcedefinitions:
     owned:
-    - description: A Kong cluster configuration. Mirrors the settings in the Helm chart's values.yaml
+    - description: Defines a Kong cluster (equivalent to a Helm release).
       displayName: Kong
       kind: Kong
       name: kongs.charts.helm.k8s.io
       version: v1alpha1
-  description: >
-    Kong is a popular open-source cloud-native API gateway.
+  description: |
+    Kong is a popular open-source cloud-native API gateway. Kong Operator is a Kubernetes operator which manages [Kong](https://konghq.com/kong/) and [Kong Enterprise](https://konghq.com/products/kong-enterprise/) clusters.
 
-    The Kong Operator manages [Kong](https://konghq.com/kong/) and [Kong Enterprise](https://konghq.com/products/kong-enterprise/) clusters.
-    It includes an [ingress controller](https://github.com/Kong/kubernetes-ingress-controller) to configure Kong's gateway using Kubernetes resources.
+    Kong Operator can deploy Kong in various configurations, for example:
+    * as a [Kubernetes ingress controller](https://github.com/Kong/kubernetes-ingress-controller), enabling you to expose Kubernetes `Service`s via Kong,
+    * a standalone Kong gateway (without the ingress controller; either DB-enabled or DB-less)
+    * a standalone Ingress Controller (configuring an external instance of Kong)
 
-    The operator manages Kong using the [Kong Helm chart](https://github.com/Kong/charts/blob/master/charts/kong/README.md).
-    Its `Kong` custom resource contains a [values.yaml](https://github.com/Kong/charts/blob/master/charts/kong/values.yaml).
+    Those configurations are further described in the [_Deployment Options_](https://github.com/Kong/charts/blob/v0.4.0/charts/kong/README.md#deployment-options) section of documentation.
+
+    ### Quick Start
+
+    The [Quick Start guide](https://github.com/Kong/kong-operator/blob/v0.4.0/README.md#quick-start) uses Kong Operator to deploy
+    our recommended Kong setup for Kubernetes users (Kong DB-less with Ingress Controller), which includes an instance of Kong
+    serving as a proxy to an example Kubernetes service.
+
+    ### Documentation
+
+    The primary documentation site for Kong Operator is located [in its GitHub repository](https://github.com/Kong/kong-operator/blob/v0.4.0/README.md).
+
+    Kong Operator provides the same configuration flexibility as the Kong Helm chart.
+    Refer to the [documentation of the Helm chart](https://github.com/Kong/kong-operator/blob/v0.4.0/helm-charts/kong/README.md) used by this version of Kong Operator,
+    the [Configuration](https://github.com/Kong/kong-operator/blob/v0.4.0/README.md#configuration) section of Kong Operator docs, and the example `Kong` resource below.
 
   displayName: Kong Operator
   icon:
@@ -131,7 +147,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kong-operator
-                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.3.0
+                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.4.0
                 imagePullPolicy: Always
                 name: kong-operator
               serviceAccountName: kong-operator
@@ -151,21 +167,23 @@ spec:
   - proxy
   - microservices
   links:
-  - name: Kong
+  - name: Kong Website
     url: https://konghq.com/kong
+  - name: Kong Operator Documentation
+    url: https://github.com/Kong/kong-operator/blob/v0.4.0/README.md
+  - name: Quick Start Guide
+    url: https://github.com/Kong/kong-operator/blob/v0.4.0/README.md#quick-start
   - name: Helm Chart Source
-    url: https://github.com/kong/charts/tree/master/charts/kong
-  - name: Configuration Options
-    url: https://github.com/kong/charts/tree/master/charts/kong#configuration
-  - name: Kong Operator
-    url: https://github.com/kong/kong-operator
+    url: https://github.com/kong/kong-operator/tree/v0.4.0/charts/kong/
   maintainers:
   - email: harry@konghq.com
     name: Harry
+  - email: michal.flendrich@konghq.com
+    name: Michal
   - email: traines@konghq.com
     name: Travis
   maturity: alpha
   provider:
-    name: Kong Inc
-  version: 0.3.0
-  replaces: kong.v0.2.6
+    name: Kong Inc.
+  version: 0.4.0
+  replaces: kong.v0.3.0

--- a/olm/0.4.0/kongs.charts.helm.k8s.io.crd.yaml
+++ b/olm/0.4.0/kongs.charts.helm.k8s.io.crd.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongs.charts.helm.k8s.io
+spec:
+  group: charts.helm.k8s.io
+  names:
+    kind: Kong
+    listKind: KongList
+    plural: kongs
+    singular: kong
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true


### PR DESCRIPTION
This PR defines the 0.4.0 version:
- using (nonexistent yet) v0.4.0 images (to be pushed to bintray after this is merged into master and tagged `v0.4.0`)
- with a `skipRange` of `>=0.2.6 <0.4.0`
- making the OperatorHub description more detailed, linking to the quick start guide and operator documentation

Note to reviewer: I recommend reviewing commit by commit - to see the difference between v0.3.0 and v0.4.0.