### PR TITLE
ci: Emit an artifact with the docker operator image

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,29 @@ jobs:
         dockerfile: test/olm-validation/Dockerfile.olm
         push: false
 
-  test:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: 'Check out the repo'
+      uses: actions/checkout@v2
+
+    - name: 'Build: docker build'
+      uses: docker/build-push-action@v1
+      with:
+        repository: kong-operator
+        tags: ci
+        dockerfile: build/Dockerfile
+        push: false
+
+    - run: docker save kong-operator:ci > kong-operator-ci.tar
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: operator-image
+        path: kong-operator-ci.tar
+
+  test-k8s:
+    needs: build
     runs-on: ubuntu-latest
     steps:
     - name: 'Check out the repo'
@@ -39,12 +61,15 @@ jobs:
         sudo curl -L https://storage.googleapis.com/kubernetes-release/release/v1.18.4/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl
         kubectl wait --for=condition=Available deploy -n container-registry registry --timeout=120s
 
-    - name: 'Build: docker build and push'
-      uses: docker/build-push-action@v1
+    - uses: actions/download-artifact@v2
       with:
-        repository: localhost:32000/kong-operator
-        tags: ci
-        dockerfile: build/Dockerfile
+        name: operator-image
+
+    - name: 'Arrange: Push the Kong Operator image to the local registry'
+      run: |
+        docker load < kong-operator-ci.tar
+        docker tag kong-operator:ci localhost:32000/kong-operator:ci
+        docker push localhost:32000/kong-operator:ci
 
     - name: 'Arrange: Set up Kong Operator'
       run: |


### PR DESCRIPTION
This PR splits the `test` job into two: `build` and `test-k8s`.

- `build` builds the docker image, saves it to a tarball, and writes an artifact
- `test-k8s` loads the operator image from the artifact into the local registry and performs the test on it

The artifact generated by the `build` step is releasable.