### PR TITLE
release(0.4.0): fix csv apiVersion

### DIFF
--- a/olm/0.4.0/kong.v0.4.0.clusterserviceversion.yaml
+++ b/olm/0.4.0/kong.v0.4.0.clusterserviceversion.yaml
@@ -1,4 +1,4 @@
-apiVersion: operators.coreos.com/v3alpha1
+apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:


### PR DESCRIPTION
Fixup of #37 
Fixes the mistakenly changed `apiVersion` of the `ClusterServiceVersion` CR. There is no such apiVersion as v3alpha1.