### PR TITLE
Release Kong Operator 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.8.0
+
+### Breaking changes
+
+* Chart 2.1 includes 2.0 changes. 2.0 ends support for Helm 2 and removes
+  support for all deprecated configuration in 1.14. Please review the [2.0
+  upgrade guide for details](https://github.com/Kong/charts/blob/kong-2.1.0/charts/kong/UPGRADE.md#200).
+* Bintray, the Docker registry previously used for several Kong images, is
+  discontinuing service. Affected images have moved to Docker Hub. The latest
+  defaults reflect this, but existing your existing Kong custom resources may
+  still reference the old repositories. Review your CRs to see if they contain
+  `bintray.io`, and if so, replace those repositories with the repositories in
+  the [2.1 values.yaml](https://github.com/Kong/charts/blob/kong-2.1.0/charts/kong/values.yaml).
+
+### Improvements
+
+* Updated Helm chart to 2.1.
+* Updated existing OLM CSVs to use the Docker Hub repo for the operator image.
+
 ## 0.7.0
 
 ### Breaking changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,8 @@ _For maintainers only_. These instructions require certain privileges (pushing t
 1. Ensure that `HEAD` of `main` defines the release candidate of the operator:
     - set the right version in `build/Dockerfile`,
     - update the Helm chart vendored in this repo (in a clean working copy, run `./hack/update-kong-chart.sh kong-vA.B.C` where `kong-vA.B.C` is an existing tag in the charts repository)
-    - ensure that `deploy/` manifests point to the new (nonexistent yet) operator image tag.
+    - update the  `deploy/operator/deployment.yaml` manifest to point to the new (nonexistent yet) operator image tag.
+    - update the `deploy/crds/charts_v1alpha1_kong_cr.yaml` to the latest default values.yaml.
 1. Define an OperatorHub release spec:
     - Create `/olm/X.Y.Z/` with the CSV and CRD manifests, similarly to [#37](https://github.com/Kong/kong-operator/pull/37) and [#39](https://github.com/Kong/kong-operator/pull/39). Pay particular attention to the following:
        - Always define [`skipRange`](https://docs.openshift.com/container-platform/4.2/operators/understanding_olm/olm-understanding-olm.html#olm-upgrades-replacing-multiple_olm-understanding-olm) to specify a range of versions which support a direct update to the version you're releasing,

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,11 +1,11 @@
-FROM quay.io/operator-framework/helm-operator:v0.16.0
+FROM quay.io/operator-framework/helm-operator:v0.17.2
 
 ADD LICENSE /licenses/LICENSE
 
 LABEL name="kong-operator" \
       maintainer="harry@konghq.com" \
       vendor="Kong Inc" \
-      version="v0.7.0" \
+      version="v0.8.0" \
       summary="kong-operator installs and manages Kong in your k8s environemnt" \
       description="kong-operator installs and manages Kong in your k8s environemnt"
 

--- a/deploy/crds/charts_v1alpha1_kong_cr.yaml
+++ b/deploy/crds/charts_v1alpha1_kong_cr.yaml
@@ -3,30 +3,63 @@ kind: Kong
 metadata:
   name: example-kong
 spec:
-  # Default values copied from <project_dir>/helm-charts/kong/values.yaml
-
   # Default values for Kong's Helm Chart.
   # Declare variables to be passed into your templates.
   #
   # Sections:
+  # - Deployment parameters
   # - Kong parameters
   # - Ingress Controller parameters
   # - Postgres sub-chart parameters
   # - Miscellaneous parameters
   # - Kong Enterprise parameters
-
+  
+  # -----------------------------------------------------------------------------
+  # Deployment parameters
+  # -----------------------------------------------------------------------------
+  
+  deployment:
+    kong:
+      # Enable or disable Kong itself
+      # Setting this to false with ingressController.enabled=true will create a
+      # controller-only release.
+      enabled: true
+      # Use a DaemonSet controller instead of a Deployment controller
+      daemonset: false
+    ## Optionally specify any extra sidecar containers to be included in the deployment
+    ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core
+    # sidecarContainers:
+    #   - name: sidecar
+    #     image: sidecar:latest
+    # initContainers:
+    # - name: initcon
+    #   image: initcon:latest
+    # userDefinedVolumes:
+    # - name: "volumeName"
+    #   emptyDir: {}
+    # userDefinedVolumeMounts:
+    # - name: "volumeName"
+    #   mountPath: "/opt/user/dir/mount"
+  
+  # Override namepsace for Kong chart resources. By default, the chart creates resources in the release namespace.
+  # This may not be desirable when using this chart as a dependency.
+  # namespace: "example"
+  
   # -----------------------------------------------------------------------------
   # Kong parameters
   # -----------------------------------------------------------------------------
-
-  # Specify Kong configurations
-  # Kong configurations guide https://docs.konghq.com/latest/configuration
+  
+  # Specify Kong configuration
+  # This chart takes all entries defined under `.env` and transforms them into into `KONG_*`
+  # environment variables for Kong containers.
+  # Their names here should match the names used in https://github.com/Kong/kong/blob/master/kong.conf.default
+  # See https://docs.konghq.com/latest/configuration also for additional details
   # Values here take precedence over values from other sections of values.yaml,
   # e.g. setting pg_user here will override the value normally set when postgresql.enabled
   # is set below. In general, you should not set values here if they are set elsewhere.
   env:
     database: "off"
-    nginx_worker_processes: "1"
+    nginx_worker_processes: "2"
     proxy_access_log: /dev/stdout
     admin_access_log: /dev/stdout
     admin_gui_access_log: /dev/stdout
@@ -36,13 +69,15 @@ spec:
     admin_gui_error_log: /dev/stderr
     portal_api_error_log: /dev/stderr
     prefix: /kong_prefix/
-
+  
   # Specify Kong's Docker image and repository details here
   image:
     repository: kong
-    # repository: kong-docker-kong-enterprise-k8s.bintray.io/kong-enterprise-k8s
-    # repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-    tag: "2.0"
+    tag: "2.4"
+    # Kong Enterprise
+    # repository: kong/kong-gateway
+    # tag: "2.3.3.2-alpine"
+  
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -51,7 +86,7 @@ spec:
     ##
     # pullSecrets:
     #   - myRegistrKeySecretName
-
+  
   # Specify Kong admin API service and listener configuration
   admin:
     # Enable creating a Kubernetes service for the admin API
@@ -59,11 +94,12 @@ spec:
     # Enterprise users that wish to use Kong Manager with the controller should enable this
     enabled: false
     type: NodePort
-    # If you want to specify annotations for the admin service, uncomment the following
-    # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+    # To specify annotations or labels for the admin service, add them to the respective
+    # "annotations" or "labels" dictionaries below.
     annotations: {}
     #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
-
+    labels: {}
+  
     http:
       # Enable plaintext HTTP listen for the admin API
       # Disabling this and using a TLS listen only is recommended for most configuration
@@ -74,7 +110,7 @@ spec:
       # nodePort: 32080
       # Additional listen parameters, e.g. "reuseport", "backlog=16384"
       parameters: []
-
+  
     tls:
       # Enable HTTPS listen for the admin API
       enabled: true
@@ -88,7 +124,7 @@ spec:
       # Additional listen parameters, e.g. "reuseport", "backlog=16384"
       parameters:
       - http2
-
+  
     # Kong admin ingress settings. Useful if you want to expose the Admin
     # API of Kong outside the k8s cluster.
     ingress:
@@ -102,17 +138,63 @@ spec:
       annotations: {}
       # Ingress path.
       path: /
-
-  # Specify Kong proxy service and listener configuration
+  
+  # Specify Kong status listener configuration
+  # This listen is internal-only. It cannot be exposed through a service or ingress.
+  status:
+    enabled: true
+    http:
+      # Enable plaintext HTTP listen for the status listen
+      enabled: true
+      containerPort: 8100
+      parameters: []
+  
+    tls:
+      # Enable HTTPS listen for the status listen
+      # Kong versions prior to 2.1 do not support TLS status listens.
+      # This setting must remain false on those versions
+      enabled: false
+      containerPort: 8543
+      parameters: []
+  
+  # Specify Kong cluster service and listener configuration
+  #
+  # The cluster service *must* use TLS. It does not support the "http" block
+  # available on other services.
+  #
+  # The cluster service cannot be exposed through an Ingress, as it must perform
+  # TLS client validation directly and is not compatible with TLS-terminating
+  # proxies. If you need to expose it externally, you must use "type:
+  # LoadBalancer" and use a TCP-only load balancer (check your Kubernetes
+  # provider's documentation, as the configuration required for this varies).
+  cluster:
+    enabled: false
+    # To specify annotations or labels for the cluster service, add them to the respective
+    # "annotations" or "labels" dictionaries below.
+    annotations: {}
+    #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+    labels: {}
+  
+    tls:
+      enabled: false
+      servicePort: 8005
+      containerPort: 8005
+      parameters: []
+  
+    type: ClusterIP
+  
+  # Specify Kong proxy service configuration
   proxy:
     # Enable creating a Kubernetes service for the proxy
     enabled: true
     type: LoadBalancer
-    # If you want to specify annotations for the proxy service, uncomment the following
-    # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+    # To specify annotations or labels for the proxy service, add them to the respective
+    # "annotations" or "labels" dictionaries below.
     annotations: {}
     #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
-
+    labels:
+      enable-metrics: "true"
+  
     http:
       # Enable plaintext HTTP listen for the proxy
       enabled: true
@@ -122,7 +204,7 @@ spec:
       # nodePort: 32080
       # Additional listen parameters, e.g. "reuseport", "backlog=16384"
       parameters: []
-
+  
     tls:
       # Enable HTTPS listen for the proxy
       enabled: true
@@ -136,30 +218,41 @@ spec:
       # Additional listen parameters, e.g. "reuseport", "backlog=16384"
       parameters:
       - http2
-
+  
+    # Define stream (TCP) listen
+    # To enable, remove "{}", uncomment the section below, and select your desired
+    # ports and parameters. Listens are dynamically named after their servicePort,
+    # e.g. "stream-9000" for the below.
+    stream: {}
+      #   # Set the container (internal) and service (external) ports for this listen.
+      #   # These values should normally be the same. If your environment requires they
+      #   # differ, note that Kong will match routes based on the containerPort only.
+      # - containerPort: 9000
+      #   servicePort: 9000
+      #   # Optionally set a static nodePort if the service type is NodePort
+      #   # nodePort: 32080
+      #   # Additional listen parameters, e.g. "ssl", "reuseport", "backlog=16384"
+      #   # "ssl" is required for SNI-based routes. It is not supported on versions <2.0
+      #   parameters: []
+  
     # Kong proxy ingress settings.
     # Note: You need this only if you are using another Ingress Controller
     # to expose Kong outside the k8s cluster.
     ingress:
       # Enable/disable exposure using ingress.
       enabled: false
-      hosts: []
-      # TLS section. Unlike other ingresses, this follows the format at
-      # https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-      # tls:
-      # - hosts:
-      #   - 1.example.com
-      #   secretName: example1-com-tls-secret
-      # - hosts:
-      #   - 2.example.net
-      #   secretName: example2-net-tls-secret
+      # Ingress hostname
+      # TLS secret name.
+      # tls: kong-admin.example.com-tls
+      hostname:
       # Map of ingress annotations.
       annotations: {}
       # Ingress path.
       path: /
-
-    externalIPs: []
-
+  
+    # Optionally specify a static load balancer IP.
+    # loadBalancerIP:
+  
   # Custom Kong plugins can be loaded into Kong by mounting the plugin code
   # into the file-system of Kong container.
   # The plugin code should be present in ConfigMap or Secret inside the same
@@ -189,10 +282,32 @@ spec:
   # - kong-proxy-tls
   # - kong-admin-tls
   secretVolumes: []
-
-  # Set runMigrations to run Kong migrations
-  runMigrations: true
-
+  
+  # Enable/disable migration jobs, and set annotations for them
+  migrations:
+    # Enable pre-upgrade migrations (run "kong migrations up")
+    preUpgrade: true
+    # Enable post-upgrade migrations (run "kong migrations finish")
+    postUpgrade: true
+    # Annotations to apply to migrations job pods
+    # By default, these disable service mesh sidecar injection for Istio and Kuma,
+    # as the sidecar containers do not terminate and prevent the jobs from completing
+    annotations:
+      sidecar.istio.io/inject: false
+    # Additional annotations to apply to migration jobs
+    # This is helpful in certain non-Helm installation situations such as GitOps
+    # where additional control is required around this job creation.
+    jobAnnotations: {}
+    resources: {}
+    # Example reasonable setting for "resources":
+    # resources:
+    #   limits:
+    #     cpu: 100m
+    #     memory: 256Mi
+    #   requests:
+    #     cpu: 50m
+    #     memory: 128Mi
+  
   # Kong's configuration for DB-less mode
   # Note: Use this section only if you are deploying Kong in DB-less mode
   # and not as an Ingress Controller.
@@ -210,44 +325,55 @@ spec:
         #   - name: example
         #     paths:
         #     - "/example"
-
+  
   # -----------------------------------------------------------------------------
   # Ingress Controller parameters
   # -----------------------------------------------------------------------------
-
+  
   # Kong Ingress Controller's primary purpose is to satisfy Ingress resources
   # created in k8s.  It uses CRDs for more fine grained control over routing and
   # for Kong specific configuration.
   ingressController:
     enabled: true
     image:
-      repository: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller
-      tag: 0.8.0
+      repository: kong/kubernetes-ingress-controller
+      tag: "1.2"
     args: []
-
+  
     # Specify Kong Ingress Controller configuration via environment variables
-    env: {}
-
+    env:
+      # The controller disables TLS verification by default because Kong
+      # generates self-signed certificates by default. Set this to false once you
+      # have installed CA-signed certificates.
+      kong_admin_tls_skip_verify: true
+      # If using Kong Enterprise with RBAC enabled, uncomment the section below
+      # and specify the secret/key containing your admin token.
+      # kong_admin_token:
+      #   valueFrom:
+      #     secretKeyRef:
+      #        name: CHANGEME-admin-token-secret
+      #        key: CHANGEME-admin-token-key
+  
     admissionWebhook:
       enabled: false
       failurePolicy: Fail
       port: 8080
-
+  
     ingressClass: kong
-
+  
     rbac:
       # Specifies whether RBAC resources should be created
       create: true
-
+  
     serviceAccount:
       # Specifies whether a ServiceAccount should be created
       create: true
       # The name of the ServiceAccount to use.
       # If not set and create is true, a name is generated using the fullname template
       name:
-
-    installCRDs: false
-
+      # The annotations for service account
+      annotations: {}
+  
     # general properties
     livenessProbe:
       httpGet:
@@ -270,106 +396,145 @@ spec:
       successThreshold: 1
       failureThreshold: 3
     resources: {}
-
+    # Example reasonable setting for "resources":
+    # resources:
+    #   limits:
+    #     cpu: 100m
+    #     memory: 256Mi
+    #   requests:
+    #     cpu: 50m
+    #     memory: 128Mi
+  
   # -----------------------------------------------------------------------------
   # Postgres sub-chart parameters
   # -----------------------------------------------------------------------------
-
+  
   # Kong can run without a database or use either Postgres or Cassandra
   # as a backend datatstore for it's configuration.
   # By default, this chart installs Kong without a database.
-
+  
   # If you would like to use a database, there are two options:
   # - (recommended) Deploy and maintain a database and pass the connection
   #   details to Kong via the `env` section.
   # - You can use the below `postgresql` sub-chart to deploy a database
   #   along-with Kong as part of a single Helm release.
-
+  
   # PostgreSQL chart documentation:
-  # https://github.com/helm/charts/blob/master/stable/postgresql/README.md
-
+  # https://github.com/bitnami/charts/blob/master/bitnami/postgresql/README.md
+  
   postgresql:
     enabled: false
     # postgresqlUsername: kong
     # postgresqlDatabase: kong
     # service:
     #   port: 5432
-
+  
   # -----------------------------------------------------------------------------
   # Miscellaneous parameters
   # -----------------------------------------------------------------------------
-
+  
   waitImage:
-    repository: busybox
-    tag: latest
+    # Wait for the database to come online before starting Kong or running migrations
+    # If Kong is to access the database through a service mesh that injects a sidecar to
+    # Kong's container, this must be disabled. Otherwise there'll be a deadlock:
+    # InitContainer waiting for DB access that requires the sidecar, and the sidecar
+    # waiting for InitContainers to finish.
+    enabled: true
+    # Optionally specify an image that provides bash for pre-migration database
+    # checks. If none is specified, the chart uses the Kong image. The official
+    # Kong images provide bash
+    # repository: bash
+    # tag: 5
     pullPolicy: IfNotPresent
-
+  
   # update strategy
   updateStrategy: {}
     # type: RollingUpdate
     # rollingUpdate:
     #   maxSurge: "100%"
     #   maxUnavailable: "0%"
-
+  
   # If you want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   resources: {}
     # limits:
     #  cpu: 100m
-    #  memory: 128Mi
+    #  memory: 256Mi
     # requests:
     #  cpu: 100m
-    #  memory: 128Mi
-
+    #  memory: 256Mi
+  
   # readinessProbe for Kong pods
   # If using Kong Enterprise with RBAC, you must add a Kong-Admin-Token header
   readinessProbe:
     httpGet:
       path: "/status"
-      port: metrics
+      port: status
       scheme: HTTP
     initialDelaySeconds: 5
     timeoutSeconds: 5
     periodSeconds: 10
     successThreshold: 1
     failureThreshold: 3
-
+  
   # livenessProbe for Kong pods
   livenessProbe:
     httpGet:
       path: "/status"
-      port: metrics
+      port: status
       scheme: HTTP
     initialDelaySeconds: 5
     timeoutSeconds: 5
     periodSeconds: 10
     successThreshold: 1
     failureThreshold: 3
-
+  
+  # Proxy container lifecycle hooks
+  # Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  lifecycle:
+    preStop:
+      exec:
+        # Note kong quit has a default timeout of 10 seconds
+        command: ["/bin/sh", "-c", "/bin/sleep 15 && kong quit"]
+  
+  # Sets the termination grace period for pods spawned by the Kubernetes Deployment.
+  # Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution
+  terminationGracePeriodSeconds: 30
+  
   # Affinity for pod assignment
   # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   # affinity: {}
-
+  
+  # Topology spread constraints for pod assignment (requires Kubernetes >= 1.19)
+  # Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  # topologySpreadConstraints: []
+  
   # Tolerations for pod assignment
   # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
-
+  
   # Node labels for pod assignment
   # Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
-
+  
   # Annotation to be added to Kong pods
   podAnnotations: {}
-
-  # Kong pod count
+  
+  # Labels to be added to Kong pods
+  podLabels: {}
+  
+  # Kong pod count.
+  # It has no effect when autoscaling.enabled is set to true
   replicaCount: 1
-
+  
   # Annotations to be added to Kong deployment
   deploymentAnnotations:
     kuma.io/gateway: enabled
     traffic.sidecar.istio.io/includeInboundPorts: ""
-
+  
   # Enable autoscaling using HorizontalPodAutoscaler
+  # When configuring an HPA, you must set resource requests on all containers via
+  # "resources" and, if using the controller, "ingressController.resources" in values.yaml
   autoscaling:
     enabled: false
     minReplicas: 2
@@ -384,35 +549,61 @@ spec:
           target:
             type: Utilization
             averageUtilization: 80
-
+  
   # Kong Pod Disruption Budget
   podDisruptionBudget:
     enabled: false
     maxUnavailable: "50%"
-
+  
   podSecurityPolicy:
     enabled: false
-
-
+    spec:
+      privileged: false
+      fsGroup:
+        rule: RunAsAny
+      runAsUser:
+        rule: RunAsAny
+      runAsGroup:
+        rule: RunAsAny
+      seLinux:
+        rule: RunAsAny
+      supplementalGroups:
+        rule: RunAsAny
+      volumes:
+        - 'configMap'
+        - 'secret'
+        - 'emptyDir'
+      allowPrivilegeEscalation: false
+      hostNetwork: false
+      hostIPC: false
+      hostPID: false
+      # Make the root filesystem read-only. This is not compatible with Kong Enterprise <1.5.
+      # If you use Kong Enterprise <1.5, this must be set to false.
+      readOnlyRootFilesystem: true
+  
+  
   priorityClassName: ""
-
+  
   # securityContext for Kong pods.
-  securityContext:
-    runAsUser: 1000
-
+  securityContext: {}
+  
   serviceMonitor:
     # Specifies whether ServiceMonitor for Prometheus operator should be created
+    # If you wish to gather metrics from a Kong instance with the proxy disabled (such as a hybrid control plane), see:
+    # https://github.com/Kong/charts/blob/main/charts/kong/README.md#prometheus-operator-integration
     enabled: false
     # interval: 10s
     # Specifies namespace, where ServiceMonitor should be installed
     # namespace: monitoring
     # labels:
     #   foo: bar
-
+    # targetLabels:
+    #   - foo
+  
   # -----------------------------------------------------------------------------
   # Kong Enterprise parameters
   # -----------------------------------------------------------------------------
-
+  
   # Toggle Kong Enterprise features on or off
   # RBAC and SMTP configuration have additional options that must all be set together
   # Other settings should be added to the "env" settings below
@@ -420,8 +611,9 @@ spec:
     enabled: false
     # Kong Enterprise license secret name
     # This secret must contain a single 'license' key, containing your base64-encoded license data
-    # The license secret is required for all Kong Enterprise deployments
-    license_secret: you-must-create-a-kong-license-secret
+    # The license secret is required to unlock all Enterprise features. If you omit it,
+    # Kong will run in free mode, with some Enterprise features disabled.
+    # license_secret: kong-enterprise-license
     vitals:
       enabled: true
     portal:
@@ -432,10 +624,10 @@ spec:
       # If RBAC is enabled, this Secret must contain an admin_gui_session_conf key
       # The key value must be a secret configuration, following the example at
       # https://docs.konghq.com/enterprise/latest/kong-manager/authentication/sessions
-      session_conf_secret: you-must-create-an-rbac-session-conf-secret
+      session_conf_secret: kong-session-config
       # If admin_gui_auth is not set to basic-auth, provide a secret name which
       # has an admin_gui_auth_conf key containing the plugin config JSON
-      admin_gui_auth_conf_secret: you-must-create-an-admin-gui-auth-conf-secret
+      admin_gui_auth_conf_secret: CHANGEME-admin-gui-auth-conf-secret
     # For configuring emails and SMTP, please read through:
     # https://docs.konghq.com/enterprise/latest/developer-portal/configuration/smtp
     # https://docs.konghq.com/enterprise/latest/kong-manager/networking/email
@@ -448,6 +640,8 @@ spec:
       smtp_admin_emails: none@example.com
       smtp_host: smtp.example.com
       smtp_port: 587
+      smtp_auth_type: ''
+      smtp_ssl: nil
       smtp_starttls: true
       auth:
         # If your SMTP server does not require authentication, this section can
@@ -455,17 +649,18 @@ spec:
         # string, you must create a Secret with an smtp_password key containing
         # your SMTP password and specify its name here.
         smtp_username: ''  # e.g. postmaster@example.com
-        smtp_password_secret: you-must-create-an-smtp-password
-
+        smtp_password_secret: CHANGEME-smtp-password
+  
   manager:
     # Enable creating a Kubernetes service for Kong Manager
     enabled: true
     type: NodePort
-    # If you want to specify annotations for the Manager service, uncomment the following
-    # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+    # To specify annotations or labels for the Manager service, add them to the respective
+    # "annotations" or "labels" dictionaries below.
     annotations: {}
     #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
-
+    labels: {}
+  
     http:
       # Enable plaintext HTTP listen for Kong Manager
       enabled: true
@@ -475,7 +670,7 @@ spec:
       # nodePort: 32080
       # Additional listen parameters, e.g. "reuseport", "backlog=16384"
       parameters: []
-
+  
     tls:
       # Enable HTTPS listen for Kong Manager
       enabled: true
@@ -486,7 +681,7 @@ spec:
       # Additional listen parameters, e.g. "reuseport", "backlog=16384"
       parameters:
       - http2
-
+  
     ingress:
       # Enable/disable exposure using ingress.
       enabled: false
@@ -498,18 +693,17 @@ spec:
       annotations: {}
       # Ingress path.
       path: /
-
-    externalIPs: []
-
+  
   portal:
     # Enable creating a Kubernetes service for the Developer Portal
     enabled: true
     type: NodePort
-    # If you want to specify annotations for the Portal service, uncomment the following
-    # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+    # To specify annotations or labels for the Portal service, add them to the respective
+    # "annotations" or "labels" dictionaries below.
     annotations: {}
     #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
-
+    labels: {}
+  
     http:
       # Enable plaintext HTTP listen for the Developer Portal
       enabled: true
@@ -519,7 +713,7 @@ spec:
       # nodePort: 32080
       # Additional listen parameters, e.g. "reuseport", "backlog=16384"
       parameters: []
-
+  
     tls:
       # Enable HTTPS listen for the Developer Portal
       enabled: true
@@ -530,7 +724,7 @@ spec:
       # Additional listen parameters, e.g. "reuseport", "backlog=16384"
       parameters:
       - http2
-
+  
     ingress:
       # Enable/disable exposure using ingress.
       enabled: false
@@ -542,18 +736,17 @@ spec:
       annotations: {}
       # Ingress path.
       path: /
-
-    externalIPs: []
-
+  
   portalapi:
     # Enable creating a Kubernetes service for the Developer Portal API
     enabled: true
     type: NodePort
-    # If you want to specify annotations for the Portal API service, uncomment the following
-    # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+    # To specify annotations or labels for the Portal API service, add them to the respective
+    # "annotations" or "labels" dictionaries below.
     annotations: {}
     #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
-
+    labels: {}
+  
     http:
       # Enable plaintext HTTP listen for the Developer Portal API
       enabled: true
@@ -563,7 +756,7 @@ spec:
       # nodePort: 32080
       # Additional listen parameters, e.g. "reuseport", "backlog=16384"
       parameters: []
-
+  
     tls:
       # Enable HTTPS listen for the Developer Portal API
       enabled: true
@@ -574,7 +767,7 @@ spec:
       # Additional listen parameters, e.g. "reuseport", "backlog=16384"
       parameters:
       - http2
-
+  
     ingress:
       # Enable/disable exposure using ingress.
       enabled: false
@@ -586,5 +779,32 @@ spec:
       annotations: {}
       # Ingress path.
       path: /
-
-    externalIPs: []
+  
+  clustertelemetry:
+    enabled: false
+    # To specify annotations or labels for the cluster telemetry service, add them to the respective
+    # "annotations" or "labels" dictionaries below.
+    annotations: {}
+    #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+    labels: {}
+  
+    tls:
+      enabled: false
+      servicePort: 8006
+      containerPort: 8006
+      parameters: []
+  
+    type: ClusterIP
+  
+  extraConfigMaps: []
+  # extraConfigMaps:
+  # - name: my-config-map
+  #   mountPath: /mount/to/my/location
+  #   subPath: my-subpath # Optional, if you wish to mount a single key and not the entire ConfigMap
+  
+  extraSecrets: []
+  # extraSecrets:
+  # - name: my-secret
+  #   mountPath: /mount/to/my/location
+  #   subPath: my-subpath # Optional, if you wish to mount a single key and not the entire ConfigMap
+  

--- a/deploy/operator/deployment.yaml
+++ b/deploy/operator/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: kong-operator
           # Replace this with the built image name
-          image: kong-docker-kong-operator.bintray.io/kong-operator:v0.7.0
+          image: kong/kong-operator:v0.8.0
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/helm-charts/kong/CHANGELOG.md
+++ b/helm-charts/kong/CHANGELOG.md
@@ -1,5 +1,159 @@
 # Changelog
 
+## 2.1.0
+
+### Improvements
+
+* Added support for user-defined volumes, volume mounts, and init containers.
+  ([#317](https://github.com/Kong/charts/pull/317))
+* Tolerations are now applied to migration Job Pods also.
+  ([#341](https://github.com/Kong/charts/pull/341))
+* Added support for using a DaemonSet instead of Deployment.
+  ([#347](https://github.com/Kong/charts/pull/347))
+* Updated default image versions and completed migration off Bintray
+  repositories.
+  ([#349](https://github.com/Kong/charts/pull/349))
+* PDB ignores migration Job Pods.
+  ([#352](https://github.com/Kong/charts/pull/352))
+
+### Documentation
+
+* Clarified service monitor usage information.
+  ([#345](https://github.com/Kong/charts/pull/345))
+
+## 2.0.0
+
+### Breaking changes
+
+* Helm 2 is no longer supported. You **must** [migrate your Kong chart releases
+  to Helm 3](https://helm.sh/docs/topics/v2_v3_migration/) before updating to
+  this release.
+* Deprecated [Portal auth settings](https://github.com/Kong/charts/blob/kong-1.15.0/charts/kong/UPGRADE.md#removal-of-dedicated-portal-authentication-configuration-parameters)
+  are no longer supported.
+* The deprecated [`runMigrations` setting](https://github.com/Kong/charts/blob/kong-1.15.0/charts/kong/UPGRADE.md#changes-to-migration-job-configuration)
+  is no longer supported.
+* Deprecated [admin API Service configuration](https://github.com/Kong/charts/blob/kong-1.15.0/charts/kong/UPGRADE.md#changes-to-kong-service-configuration)
+  is no longer supported.
+* Deprecated [multi-host proxy configuration](https://github.com/Kong/charts/blob/kong-1.15.0/charts/kong/UPGRADE.md#removal-of-multi-host-proxy-ingress)
+  is no longer supported.
+
+`helm upgrade` with the previous version (1.15.0) will print a warning message
+if you still use any of the removed values.yaml configuration. If you do not
+see any warnings after the upgrade completes, you are already using the modern
+equivalents of these settings and can proceed with upgrading to 2.0.0-rc1.
+
+### Improvements
+
+* Admission webhook certificates persist after their initial creation. This
+  prevents an unnecessary restart of Kong Pods on upgrades that do not actually
+  modify the deployment.
+  ([#256](https://github.com/Kong/charts/pull/256))
+* `ingressController.installCRDs` now defaults to `false`, simplifying
+  installation on Helm 3. Installs now default to using Helm 3's CRD management
+  system, and do not require changes to values or install flags to install
+  successfully.
+  ([#305](https://github.com/Kong/charts/pull/305))
+* Added support for Pod `topologySpreadConstraints`.
+  ([#308](https://github.com/Kong/charts/pull/308))
+* Kong Ingress Controller image now pulled from Docker Hub (due to Bintray being
+  discontinued). Changed the default Docker image repository for the ingress
+  controller.
+
+### Fixed
+
+* Generated admission webhook certificates now include SANs for compatibility
+  with Go 1.15 controller builds.
+  ([#312](https://github.com/Kong/charts/pull/312)).
+
+### Documentation
+
+* Clarified use of `terminationGracePeriodSeconds`.
+  ([#302](https://github.com/Kong/charts/pull/302))
+
+## 1.15.0
+
+1.15.0 is an interim release before the planned release of 2.0.0. There were
+several feature changes we wanted to release prior to the removal of deprecated
+functionality for 2.0. The original planned deprecations covered in the [1.14.0
+changelog](#1140) are still planned for 2.0.0.
+
+### Improvements
+
+* The default Kong version is now 2.3 and the default Kong Enterprise version
+  is now 2.3.2.0.
+* Added configurable `terminationGracePeriodSeconds` for the pre-stop lifecycle
+  hook.
+  ([#271](https://github.com/Kong/charts/pull/271)).
+* Initial migration database wait init containers no longer have a default
+  image configuration in values.yaml. When no image is specified, the chart
+  will use the Kong image. The standard Kong images include bash, and can run
+  the database wait script without downloading a separate image. Configuring a
+  wait image is now only necessary if you use a custom Kong image that lacks
+  bash.
+  ([#285](https://github.com/Kong/charts/pull/285)).
+* Init containers for database availability and migration completeness can now
+  be disabled. They cause compatibility issues with many service meshes.
+  ([#285](https://github.com/Kong/charts/pull/285)).
+* Removed the default migration Job annotation that disabled Kuma's mesh proxy.
+  The latest version of Kuma no longer prevents Jobs from completing.
+  ([#285](https://github.com/Kong/charts/pull/285)).
+* Services now support user-configurable labels, and the Prometheus
+  ServiceMonitor label is included on the proxy Service by default. Users that
+  disable the proxy Service and add this label to another Service to collect
+  metrics.
+  ([#290](https://github.com/Kong/charts/pull/290)).
+* Migration Jobs now allow resource quota configuration. Init containers
+  inherit their resource quotas from their associated Kong container.
+  ([#294](https://github.com/Kong/charts/pull/294)).
+
+### Fixed
+
+* The database readiness wait script ConfigMap and associated mounts are no
+  longer created if that feature is not in use.
+  ([#285](https://github.com/Kong/charts/pull/285)).
+* Removed a duplicated field from CRDs.
+  ([#281](https://github.com/Kong/charts/pull/281)).
+
+## 1.14.5
+
+### Fixed
+
+* Removed `http2` from default status listen TLS parameters. It only supports a
+  limited subset of the extra listen parameters, and does not allow `http2`.
+
+## 1.14.4
+
+### Fixed
+
+* Status listens now include parameters in the default values.yaml. The absence
+  of these defaults caused a template rendering error when the TLS listen was
+  enabled.
+
+### Documentation
+
+* Updated status listen comments to reflect TLS listen availability on Kong
+  2.1+.
+
+## 1.14.3
+
+### Fixed
+
+* Fix issues with legacy proxy Ingress object template.
+
+## 1.14.2
+
+### Fixed
+
+* Corrected invalid default value for `enterprise.smtp.smtp_auth`.
+
+## 1.14.1
+
+### Fixed
+
+* Moved several Kong container settings into the appropriate template block.
+  Previously these were rendered whether or not the Kong container was enabled,
+  which unintentionally applied them to the controller container.
+
 ## 1.14.0
 
 ### Breaking changes

--- a/helm-charts/kong/Chart.yaml
+++ b/helm-charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.14.0
-appVersion: 2.2
+version: 2.1.0
+appVersion: "2.4"

--- a/helm-charts/kong/FAQs.md
+++ b/helm-charts/kong/FAQs.md
@@ -85,3 +85,25 @@ This occurs if a `RELEASE-NAME-kong-init-migrations` Job is left over from a
 previous `helm install` or `helm upgrade`. Deleting it with
 `kubectl delete job RELEASE-NAME-kong-init-migrations` will allow the upgrade
 to proceed. Chart versions greater than 1.5.0 delete the job automatically.
+
+#### DB-backed instances do not start when deployed within a service mesh
+
+Service meshes, such as Istio and Kuma, if deployed in a mode that injects
+a sidecar to Kong, don't make the mesh available to `InitContainer`s,
+because the sidecar starts _after_ all `InitContainer`s finish.
+
+By default, this chart uses init containers to ensure that the database is
+online and has migrations applied before starting Kong. This provides for a
+smoother startup, but isn't compatible with service mesh sidecar requirements
+if Kong is to access the database through the mesh.
+
+Setting `waitImage.enabled=false` in values.yaml disables these init containers
+and resolves this issue. However, during the initial install, your Kong
+Deployment will enter the CrashLoopBackOff state while waiting for migrations
+to complete. It will eventually exit this state and enter Running as long as
+there are no issues finishing migrations, usually within 2 minutes.
+
+If your Deployment is stuck in CrashLoopBackoff for longer, check the init
+migrations Job logs to see if it is unable to connect to the database or unable
+to complete migrations for some other reason. Resolve any issues you find,
+delete the release, and attempt to install again.

--- a/helm-charts/kong/UPGRADE.md
+++ b/helm-charts/kong/UPGRADE.md
@@ -17,6 +17,8 @@ upgrading from a previous version.
 ## Table of contents
 
 - [Upgrade considerations for all versions](#upgrade-considerations-for-all-versions)
+- [2.1.0](#210)
+- [2.0.0](#200)
 - [1.14.0](#1140)
 - [1.11.0](#1110)
 - [1.10.0](#1100)
@@ -55,6 +57,56 @@ text ending with `field is immutable`. This is typically due to a bug with the
 `init-migrations` job, which was not removed automatically prior to 1.5.0.
 If you encounter this error, deleting any existing `init-migrations` jobs will
 clear it.
+
+## 2.1.0
+
+### Migration off Bintray
+
+Bintray, the Docker registry previously used for several images used by this
+chart, is [sunsetting May 1,
+2021](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/).
+
+The chart default `values.yaml` now uses the new Docker Hub repositories for all
+affected images. You should check your release `values.yaml` files to confirm that
+they do not still reference Bintray repositories. If they do, update them to
+use the Docker Hub repositories now in the default `values.yaml`.
+
+## 2.0.0
+
+### Support for Helm 2 dropped
+
+2.0.0 takes advantage of template functionality that is only available in Helm
+3 and reworks values defaults to target Helm 3 CRD handling, and requires Helm
+3 as such. If you are not already using Helm 3, you must migrate to it before
+updating to 2.0.0 or later:
+
+https://helm.sh/docs/topics/v2_v3_migration/
+
+If desired, you can migrate your Kong chart releases without migrating charts'
+releases.
+
+### Support for deprecated 1.x features removed
+
+Several previous 1.x chart releases reworked sections of values.yaml while
+maintaining support for the older version of those settings. 2.x drops support
+for the older versions of these settings entirely:
+
+* [Portal auth settings](#removal-of-dedicated-portal-authentication-configuration-parameters)
+* [The `runMigrations` setting](#changes-to-migration-job-configuration)
+* [Single-stack admin API Service configuration](#changes-to-kong-service-configuration)
+* [Multi-host proxy configuration](#removal-of-multi-host-proxy-ingress)
+
+Each deprecated setting is accompanied by a warning that appears at the end of
+`helm upgrade` output on a 1.x release:
+
+```
+WARNING: You are currently using legacy ...
+```
+
+If you do not see any such warnings when upgrading a release using chart
+1.15.0, you are not using deprecated configuration and are ready to upgrade to
+2.0.0. If you do see these warnings, follow the linked instructions to migrate
+to the current settings format.
 
 ## 1.14.0
 

--- a/helm-charts/kong/ci/single-image-default.yaml
+++ b/helm-charts/kong/ci/single-image-default.yaml
@@ -2,7 +2,7 @@
 # use single image strings instead of repository/tag
 
 image:
-  single: kong:2.0
+  unifiedRepoTag: kong:2.4
 proxy:
   type: NodePort
 
@@ -12,5 +12,5 @@ ingressController:
   env:
     anonymous_reports: "false"
   image:
-    single: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:0.8.1
+    unifiedRepoTag: kong/kubernetes-ingress-controller:1.2.0
   installCRDs: false

--- a/helm-charts/kong/ci/test3-values.yaml
+++ b/helm-charts/kong/ci/test3-values.yaml
@@ -28,3 +28,24 @@ dblessConfig:
             message: "dbless-config"
 proxy:
   type: NodePort
+deployment:
+  initContainers:
+    - name: "bash"
+      image: "bash:latest"
+      command: ["/bin/sh", "-c", "true"]
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "64Mi"
+        requests:
+          cpu: "100m"
+          memory: "64Mi"
+      volumeMounts:
+      - name: "tmpdir"
+        mountPath: "/opt/tmp"
+  userDefinedVolumes:
+  - name: "tmpdir"
+    emptyDir: {}
+  userDefinedVolumeMounts:
+  - name: "tmpdir"
+    mountPath: "/opt/tmp"

--- a/helm-charts/kong/ci/test4-values.yaml
+++ b/helm-charts/kong/ci/test4-values.yaml
@@ -1,20 +1,10 @@
 # CI test for testing dbless deployment without ingress controllers using legacy admin listen and stream listens
-# TODO: remove legacy admin listen behavior at a future date
 # - disable ingress controller
 ingressController:
   enabled: false
   installCRDs: false
   env:
     anonymous_reports: "false"
-# - use legacy admin listen config
-admin:
-  enabled: true
-  useTLS: true
-  servicePort: 8444
-  containerPort: 8444
-  ingress:
-    enabled: true
-    hostname: admin.kong.example
 
 # - disable DB for kong
 env:
@@ -52,6 +42,3 @@ proxy:
     - ssl
   ingress:
     enabled: true
-    hosts:
-    - foo.kong.example
-    - bar.kong.example

--- a/helm-charts/kong/ci/test5-values.yaml
+++ b/helm-charts/kong/ci/test5-values.yaml
@@ -1,6 +1,11 @@
 # This tests the following unrelated aspects of Ingress Controller
 # - ingressController deploys with a database
-# - stream listens work
+# - TODO remove this test when https://github.com/Kong/charts/issues/295 is solved
+#   and its associated wait-for-db workaround is removed.
+#   This test is similar to test2-values.yaml, but lacks a stream listen.
+#   wait-for-db will _not_ create a socket file. This test ensures the workaround
+#   does not interfere with startup when there is no file to remove.
+
 ingressController:
   enabled: true
   installCRDs: false
@@ -29,15 +34,6 @@ proxy:
     hostname: proxy.kong.example
     annotations: {}
     path: /
-# - add stream listens
-  stream:
-  - containerPort: 9000
-    servicePort: 9000
-    parameters: []
-  - containerPort: 9001
-    servicePort: 9001
-    parameters:
-    - ssl
 
 # - PDB is enabled
 podDisruptionBudget:

--- a/helm-charts/kong/crds/custom-resource-definitions.yaml
+++ b/helm-charts/kong/crds/custom-resource-definitions.yaml
@@ -375,8 +375,6 @@ spec:
     type: date
     description: Age
     JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/helm-charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/helm-charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -11,11 +11,8 @@
 #   the Portal and Portal API.
 
 image:
-  repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  tag: 2.2.1.0-alpine
-  pullSecrets:
-    # CHANGEME: https://github.com/Kong/charts/blob/main/charts/kong/README.md#kong-enterprise-docker-registry-access
-    - kong-enterprise-edition-docker
+  repository: kong/kong-gateway
+  tag: "2.3.3.2-alpine"
 
 env:
   prefix: /kong_prefix/
@@ -96,7 +93,7 @@ enterprise:
     smtp_admin_emails: none@example.com
     smtp_host: smtp.example.com
     smtp_port: 587
-    smtp_auth_type: nil
+    smtp_auth_type: ''
     smtp_ssl: nil
     smtp_starttls: true
     auth:

--- a/helm-charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/helm-charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -8,11 +8,8 @@
 # kubectl port-forward deploy/your-deployment-kong 8001:8001 8002:8002
 
 image:
-  repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  tag: 2.2.1.0-alpine
-  pullSecrets:
-    # CHANGEME: https://github.com/Kong/charts/blob/main/charts/kong/README.md#kong-enterprise-docker-registry-access
-    - kong-enterprise-edition-docker
+  repository: kong/kong-gateway
+  tag: "2.3.3.2-alpine"
 
 admin:
   enabled: true
@@ -33,6 +30,12 @@ enterprise:
     enabled: false
   smtp:
     enabled: false
+
+portal:
+  enabled: false
+
+portalapi:
+  enabled: false
 
 env:
   prefix: /kong_prefix/

--- a/helm-charts/kong/example-values/minimal-kong-controller.yaml
+++ b/helm-charts/kong/example-values/minimal-kong-controller.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: kong
-  tag: "2.2"
+  tag: "2.3"
 
 env:
   prefix: /kong_prefix/

--- a/helm-charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
+++ b/helm-charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
@@ -1,15 +1,10 @@
-# WARNING: this deployment example is currently in beta. It is not suited for production.
 # Basic values.yaml for Kong for Kubernetes with Kong Enterprise (DB-less)
 # Several settings (search for the string "CHANGEME") require user-provided
 # Secrets. These Secrets must be created before installation.
 
 image:
-  repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  tag: 2.2.1.0-alpine
-
-  pullSecrets:
-    # CHANGEME: https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-docker-registry-access
-    - kong-enterprise-edition-docker
+  repository: kong/kong-gateway
+  tag: "2.3.3.2-alpine"
 
 enterprise:
   enabled: true
@@ -22,6 +17,14 @@ enterprise:
   rbac:
     enabled: false
 
+manager:
+  enabled: false
+
+portal:
+  enabled: false
+
+portalapi:
+  enabled: false
 
 env:
   database: "off"

--- a/helm-charts/kong/example-values/minimal-kong-hybrid-control.yaml
+++ b/helm-charts/kong/example-values/minimal-kong-hybrid-control.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: kong
-  tag: "2.2"
+  tag: "2.3"
 
 env:
   prefix: /kong_prefix/

--- a/helm-charts/kong/example-values/minimal-kong-hybrid-data.yaml
+++ b/helm-charts/kong/example-values/minimal-kong-hybrid-data.yaml
@@ -11,7 +11,7 @@
 
 image:
   repository: kong
-  tag: "2.2"
+  tag: "2.3"
 
 env:
   prefix: /kong_prefix/
@@ -27,13 +27,6 @@ admin:
 
 secretVolumes:
 - kong-cluster-cert
-
-postgresql:
-  enabled: true
-  postgresqlUsername: kong
-  postgresqlDatabase: kong
-  service:
-    port: 5432
 
 ingressController:
   enabled: false

--- a/helm-charts/kong/example-values/minimal-kong-standalone.yaml
+++ b/helm-charts/kong/example-values/minimal-kong-standalone.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: kong
-  tag: "2.2"
+  tag: "2.3"
 
 env:
   prefix: /kong_prefix/

--- a/helm-charts/kong/templates/NOTES.txt
+++ b/helm-charts/kong/templates/NOTES.txt
@@ -13,24 +13,4 @@ Kong: https://bit.ly/k4k8s-get-started
 
 {{ $warnings := list -}}
 
-{{- if and (.Values.enterprise.portal.enabled) (or (.Values.enterprise.portal.portal_auth) (.Values.enterprise.portal.session_conf_secret)) -}}
-{{/* Legacy Portal auth handling */}}
-{{- $warnings = append $warnings "You are currently using legacy Portal authentication configuration in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#removal-of-dedicated-portal-authentication-configuration-parameters" -}}
-{{- end -}}
-
-{{- if .Values.admin.containerPort -}}
-{{/* Legacy admin API listen */}}
-{{- $warnings = append $warnings "You are currently using legacy admin API configuration in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#changes-to-kong-service-configuration" -}}
-{{- end -}}
-
-{{- if .Values.runMigrations -}}
-{{/* Legacy migration toggle */}}
-{{- $warnings = append $warnings "You are currently using the legacy runMigrations setting in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#changes-to-migration-job-configuration" -}}
-{{- end -}}
-
-{{ if (hasKey .Values "proxy.ingress.hosts") -}}
-{{/* Legacy proxy ingress */}}
-{{- $warnings = append $warnings "You are currently using legacy proxy Ingress configuration in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#removal-of-multi-host-proxy-ingress" -}}
-{{- end -}}
-
 {{- include "kong.deprecation-warnings" $warnings -}}

--- a/helm-charts/kong/templates/admission-webhook.yaml
+++ b/helm-charts/kong/templates/admission-webhook.yaml
@@ -1,7 +1,20 @@
-{{- if .Values.ingressController.admissionWebhook.enabled }}
-{{- $cn := printf "%s.%s.svc" ( include "kong.service.validationWebhook" . ) ( include "kong.namespace" . ) }}
+{{- if .Values.ingressController.admissionWebhook.enabled -}}
+{{- $cn := printf "%s.%s.svc" ( include "kong.service.validationWebhook" . ) ( include "kong.namespace" . ) -}}
 {{- $ca := genCA "kong-admission-ca" 3650 -}}
-{{- $cert := genSignedCert $cn nil nil 3650 $ca -}}
+{{- $cert := genSignedCert $cn nil (list $cn) 3650 $ca -}}
+{{- $certCert := $cert.Cert -}}
+{{- $certKey := $cert.Key -}}
+{{- $caCert := $ca.Cert -}}
+{{- $caKey := $ca.Key -}}
+
+{{- $caSecret := (lookup "v1" "Secret" (include "kong.namespace" .) (printf "%s-validation-webhook-ca-keypair" (include "kong.fullname" .))) -}}
+{{- $certSecret := (lookup "v1" "Secret" (include "kong.namespace" .) (printf "%s-validation-webhook-keypair" (include "kong.fullname" .))) -}}
+{{- if $certSecret -}}
+{{- $certCert = (b64dec (get $certSecret.data "tls.crt")) -}}
+{{- $certKey = (b64dec (get $certSecret.data "tls.key")) -}}
+{{- $caCert = (b64dec (get $caSecret.data "tls.crt")) -}}
+{{- $caKey = (b64dec (get $caSecret.data "tls.key")) -}}
+{{- end -}}
 kind: ValidatingWebhookConfiguration
 {{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
 apiVersion: admissionregistration.k8s.io/v1
@@ -30,7 +43,7 @@ webhooks:
     - kongconsumers
     - kongplugins
   clientConfig:
-    caBundle: {{ b64enc $ca.Cert }}
+    caBundle: {{ b64enc $caCert }}
     service:
       name: {{ template "kong.service.validationWebhook" . }}
       namespace: {{ template "kong.namespace" . }}
@@ -55,12 +68,24 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
+  name: {{ template "kong.fullname" . }}-validation-webhook-ca-keypair
+  namespace:  {{ template "kong.namespace" . }}
+  labels:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+    tls.crt: {{ b64enc $caCert  }}
+    tls.key: {{ b64enc $caKey  }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
   name: {{ template "kong.fullname" . }}-validation-webhook-keypair
   namespace:  {{ template "kong.namespace" . }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ b64enc $cert.Cert }}
-  tls.key: {{ b64enc $cert.Key }}
+  tls.crt: {{ b64enc $certCert }}
+  tls.key: {{ b64enc $certKey }}
 {{ end }}

--- a/helm-charts/kong/templates/custom-resource-definitions.yaml
+++ b/helm-charts/kong/templates/custom-resource-definitions.yaml
@@ -1,9 +1,40 @@
-{{/*
-This handles two cases where we should render this template. These map to the two top-level or clauses:
-- This is a controller-managed Helm 2 install. The controller is enabled and installCRDs is enabled.
-- This is a CRD-only install. Neither the controller nor Kong are enabled (the "not or") and installCRDs is enabled.
-*/}}
-{{- if (or (and .Values.ingressController.enabled .Values.ingressController.installCRDs) (and (not (or .Values.deployment.kong.enabled .Values.ingressController.enabled )) .Values.ingressController.installCRDs)) -}}
+{{- $installCRDs := false -}}
+{{- if .Values.ingressController.installCRDs -}}
+  {{- if .Values.ingressController.enabled -}}
+    {{/* Managed CRD installation is enabled, and the controller is enabled.
+    */}}
+    {{- $installCRDs = true -}}
+  {{- else if (not .Values.deployment.kong.enabled) -}}
+    {{/* Managed CRD installation is enabled, and neither the controller nor Kong or enabled.
+         This is a CRD-only release.
+    */}}
+    {{- $installCRDs = true -}}
+  {{- end -}}
+{{- else -}}
+  {{/* Legacy default handling. CRD installation is _not_ enabled, but CRDs are already present
+       and are managed by this release. This release previously relied on the <2.0 default
+       .Values.ingressController.installCRDs=true. The default change would delete CRDs on upgrade,
+       which would cascade delete all associated CRs. This unexpected loss of configuration is bad,
+       so this clause pretends the default didn't change if you have an existing release that relied
+       on it
+  */}}
+  {{- $kongPluginCRD := false -}}
+  {{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" -}}
+    {{- $kongPluginCRD = (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "kongplugins.configuration.konghq.com") -}}
+  {{- else -}}
+    {{/* TODO: remove the v1beta1 path when we no longer support k8s <1.16 */}}
+    {{- $kongPluginCRD = (lookup "apiextensions.k8s.io/v1beta1" "CustomResourceDefinition" "" "kongplugins.configuration.konghq.com") -}}
+  {{- end -}}
+  {{- if $kongPluginCRD -}}
+    {{- if (hasKey $kongPluginCRD.metadata "annotations") -}}
+      {{- if (eq .Release.Name (get $kongPluginCRD.metadata.annotations "meta.helm.sh/release-name")) -}}
+        {{- $installCRDs = true -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if $installCRDs -}}
 {{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
 {{ $.Files.Get $path }}
 ---

--- a/helm-charts/kong/templates/deployment.yaml
+++ b/helm-charts/kong/templates/deployment.yaml
@@ -1,6 +1,10 @@
 {{- if or .Values.deployment.kong.enabled .Values.ingressController.enabled }}
 apiVersion: apps/v1
+{{- if .Values.deployment.daemonset }}
+kind: DaemonSet
+{{- else }}
 kind: Deployment
+{{- end }}
 metadata:
   name: {{ template "kong.fullname" . }}
   namespace:  {{ template "kong.namespace" . }}
@@ -15,22 +19,25 @@ metadata:
   {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
+  {{- if not .Values.deployment.daemonset }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   {{- end }}
   selector:
     matchLabels:
       {{- include "kong.selectorLabels" . | nindent 6 }}
   {{- if .Values.updateStrategy }}
+  {{- if .Values.deployment.daemonset }}
+  updateStrategy:
+  {{- else }}
   strategy:
+  {{- end }}
 {{ toYaml .Values.updateStrategy | indent 4 }}
   {{- end }}
 
   template:
     metadata:
       annotations:
-        {{- if .Values.ingressController.admissionWebhook.enabled }}
-        checksum/admission-webhook.yaml: {{ include (print $.Template.BasePath "/admission-webhook.yaml") . | sha256sum }}
-        {{- end }}
         {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off" )) }}
         {{- if .Values.dblessConfig.config }}
         checksum/dbless.config: {{ toYaml .Values.dblessConfig.config | sha256sum }}
@@ -60,12 +67,15 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if not (eq .Values.env.database "off") }}
-      {{- if .Values.deployment.kong.enabled }}
+      {{- if (or (and (not (eq .Values.env.database "off")) .Values.waitImage.enabled) .Values.deployment.initContainers) }}
       initContainers:
-      {{- include "kong.wait-for-db" . | nindent 6 }}
-      {{ end }}
-      {{ end }}
+        {{- if .Values.deployment.initContainers }}
+        {{- toYaml .Values.deployment.initContainers | nindent 6 }}
+        {{- end }}
+        {{- if (and (not (eq .Values.env.database "off")) .Values.waitImage.enabled) }}
+        {{- include "kong.wait-for-db" . | nindent 6 }}
+        {{- end }}
+      {{- end }}
       containers:
       {{- if .Values.ingressController.enabled }}
       {{- include "kong.controller-container" . | nindent 6 }}
@@ -75,26 +85,13 @@ spec:
       {{- end }}
       {{- if .Values.deployment.kong.enabled }}
       - name: "proxy"
-        {{- if .Values.image.unifiedRepoTag }}
-        image: "{{ .Values.image.unifiedRepoTag }}"
-        {{- else }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- end }}
+        image: {{ include "kong.getRepoTag" .Values.image }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}
         lifecycle:
           {{- toYaml .Values.lifecycle | nindent 10 }}
         ports:
-        {{/* TODO: remove legacy admin port template */}}
-        {{- if (and .Values.admin.containerPort .Values.admin.enabled) }}
-        - name: admin
-          containerPort: {{ .Values.admin.containerPort }}
-          {{- if .Values.admin.hostPort }}
-          hostPort: {{ .Values.admin.hostPort }}
-          {{- end}}
-          protocol: TCP
-        {{- end }}
         {{- if (and .Values.admin.http.enabled .Values.admin.enabled) }}
         - name: admin
           containerPort: {{ .Values.admin.http.containerPort }}
@@ -222,18 +219,23 @@ spec:
           protocol: TCP
         {{- end }}
         {{- end }}
-        {{- end }}
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 10 }}
+        {{- include "kong.userDefinedVolumeMounts" . | nindent 10 }}
         readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 10 }}
         livenessProbe:
 {{ toYaml .Values.livenessProbe | indent 10 }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        {{- end }} {{/* End of Kong container spec */}}
     {{- if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.topologySpreadConstraints | indent 8 }}
     {{- end }}
       securityContext:
       {{- include "kong.podsecuritycontext" . | nindent 8 }}
@@ -241,8 +243,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       volumes:
       {{- include "kong.volumes" . | nindent 8 -}}
+      {{- include "kong.userDefinedVolumes" . | nindent 8 -}}
 {{- end }}

--- a/helm-charts/kong/templates/migrations-post-upgrade.yaml
+++ b/helm-charts/kong/templates/migrations-post-upgrade.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.kong.enabled }}
-{{- if (and (or (.Values.runMigrations) (.Values.migrations.postUpgrade)) (not (eq .Values.env.database "off"))) }}
+{{- if (and .Values.migrations.postUpgrade (not (eq .Values.env.database "off"))) }}
 # Why is this Job duplicated and not using only helm hooks?
 # See: https://github.com/helm/charts/pull/7362
 apiVersion: batch/v1
@@ -39,28 +39,30 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if (and (.Values.postgresql.enabled) .Values.waitImage.enabled) }}
       initContainers:
-      {{- if (eq .Values.env.database "postgres") }}
       {{- include "kong.wait-for-postgres" . | nindent 6 }}
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-post-upgrade-migrations
-        {{- if .Values.image.unifiedRepoTag }}
-        image: "{{ .Values.image.unifiedRepoTag }}"
-        {{- else }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- end }}
+        image: {{ include "kong.getRepoTag" .Values.image }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}
         command: [ "/bin/sh", "-c", "kong migrations finish" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
+        resources:
+        {{- toYaml .Values.migrations.resources | nindent 10 }}
       securityContext:
       {{- include "kong.podsecuritycontext" . | nindent 8 }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
       {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+      {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
       volumes:

--- a/helm-charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/helm-charts/kong/templates/migrations-pre-upgrade.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.kong.enabled }}
-{{- if (and (or (.Values.runMigrations) (.Values.migrations.preUpgrade)) (not (eq .Values.env.database "off"))) }}
+{{- if (and .Values.migrations.preUpgrade (not (eq .Values.env.database "off"))) }}
 # Why is this Job duplicated and not using only helm hooks?
 # See: https://github.com/helm/charts/pull/7362
 apiVersion: batch/v1
@@ -39,28 +39,30 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if (and (.Values.postgresql.enabled) .Values.waitImage.enabled) }}
       initContainers:
-      {{- if (eq .Values.env.database "postgres") }}
       {{- include "kong.wait-for-postgres" . | nindent 6 }}
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-upgrade-migrations
-        {{- if .Values.image.unifiedRepoTag }}
-        image: "{{ .Values.image.unifiedRepoTag }}"
-        {{- else }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- end }}
+        image: {{ include "kong.getRepoTag" .Values.image }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}
         command: [ "/bin/sh", "-c", "kong migrations up" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
+        resources:
+        {{- toYaml .Values.migrations.resources| nindent 10 }}
       securityContext:
       {{- include "kong.podsecuritycontext" . | nindent 8 }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
       {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+      {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
       volumes:

--- a/helm-charts/kong/templates/migrations.yaml
+++ b/helm-charts/kong/templates/migrations.yaml
@@ -9,8 +9,6 @@
 {{- $runInit := true -}}
 {{- if (hasKey .Values.migrations "init") -}}
   {{- $runInit = .Values.migrations.init -}}
-{{- else if (hasKey .Values "runMigrations") -}}
-  {{- $runInit = .Values.runMigrations -}}
 {{- end -}}
 
 {{- if (and ($runInit) (not (eq .Values.env.database "off"))) }}
@@ -22,6 +20,7 @@ metadata:
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
     app.kubernetes.io/component: init-migrations
+  annotations:
   {{- range $key, $value := .Values.migrations.jobAnnotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
@@ -48,28 +47,30 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if (and (.Values.postgresql.enabled) .Values.waitImage.enabled) }}
       initContainers:
-      {{- if (eq .Values.env.database "postgres") }}
       {{- include "kong.wait-for-postgres" . | nindent 6 }}
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-migrations
-        {{- if .Values.image.unifiedRepoTag }}
-        image: "{{ .Values.image.unifiedRepoTag }}"
-        {{- else }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- end }}
+        image: {{ include "kong.getRepoTag" .Values.image }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}
         command: [ "/bin/sh", "-c", "kong migrations bootstrap" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
+        resources:
+        {{- toYaml .Values.migrations.resources | nindent 10 }}
       securityContext:
       {{- include "kong.podsecuritycontext" . | nindent 8 }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
       {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+      {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
       volumes:

--- a/helm-charts/kong/templates/pdb.yaml
+++ b/helm-charts/kong/templates/pdb.yaml
@@ -16,4 +16,5 @@ spec:
   selector:
     matchLabels:
       {{- include "kong.metaLabels" . | nindent 6 }}
+      app.kubernetes.io/component: app
 {{- end }}

--- a/helm-charts/kong/templates/service-kong-admin.yaml
+++ b/helm-charts/kong/templates/service-kong-admin.yaml
@@ -1,83 +1,3 @@
-{{- if .Values.admin.containerPort -}} {{/* TODO: remove legacy admin handling */}}
-{{- if .Values.deployment.kong.enabled }}
-{{- if .Values.admin.enabled -}}
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ template "kong.fullname" . }}-admin
-  namespace: {{ template "kong.namespace" . }}
-  {{- if .Values.admin.annotations }}
-  annotations:
-  {{- range $key, $value := .Values.admin.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
-  {{- end }}
-  labels:
-    {{- include "kong.metaLabels" . | nindent 4 }}
-spec:
-  type: {{ .Values.admin.type }}
-  {{- if eq .Values.admin.type "LoadBalancer" }}
-  {{- if .Values.admin.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.admin.loadBalancerIP }}
-  {{- end }}
-  {{- if .Values.admin.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges:
-  {{- range $cidr := .Values.admin.loadBalancerSourceRanges }}
-  - {{ $cidr }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  ports:
-  - name: kong-admin
-    port: {{ .Values.admin.servicePort }}
-    targetPort: {{ .Values.admin.containerPort }}
-  {{- if (and (eq .Values.admin.type "NodePort") (not (empty .Values.admin.nodePort))) }}
-    nodePort: {{ .Values.admin.nodePort }}
-  {{- end }}
-    protocol: TCP
-  selector:
-    {{- include "kong.selectorLabels" . | nindent 4 }}
-{{- end -}}
-{{- end }}
----
-{{ if .Values.admin.ingress.enabled -}}
-{{- $serviceName := include "kong.fullname" . -}}
-{{- $servicePort := .Values.admin.servicePort -}}
-{{- $path := .Values.admin.ingress.path -}}
-{{- $tls := .Values.admin.ingress.tls -}}
-{{- $hostname := .Values.admin.ingress.hostname -}}
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: {{ template "kong.fullname" . }}-admin
-  namespace: {{ template "kong.namespace" . }}
-  labels:
-    {{- include "kong.metaLabels" . | nindent 4 }}
-  {{- if .Values.admin.ingress.annotations }}
-  annotations:
-  {{- range $key, $value := .Values.admin.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
-  {{- end }}
-spec:
-  rules:
-  - host: {{ $hostname }}
-    http:
-      paths:
-        - path: {{ $path }}
-          backend:
-            serviceName: {{ $serviceName }}-admin
-            servicePort: {{ $servicePort }}
-  {{- if $tls }}
-  tls:
-  - hosts:
-    - {{ $hostname }}
-    secretName: {{ $tls }}
-  {{- end -}}
-{{- end -}}
-
-{{- else -}} {{/* Modern admin handler */}}
-
 {{- if .Values.deployment.kong.enabled }}
 {{- if and .Values.admin.enabled (or .Values.admin.http.enabled .Values.admin.tls.enabled) -}}
 {{- $serviceConfig := dict -}}
@@ -91,7 +11,6 @@ spec:
 {{ if .Values.admin.ingress.enabled }}
 ---
 {{ include "kong.ingress" $serviceConfig }}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm-charts/kong/templates/service-kong-proxy.yaml
+++ b/helm-charts/kong/templates/service-kong-proxy.yaml
@@ -4,50 +4,13 @@
 {{- $serviceConfig := merge $serviceConfig .Values.proxy -}}
 {{- $_ := set $serviceConfig "fullName" (include "kong.fullname" .) -}}
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
-{{/* Only the proxy should have metrics enabled, but our labels generation is neither configurable nor flexible.
-     Pending a broader need for something more flexible, using string manipulation.
-*/}}
-{{- $_ := set $serviceConfig "metaLabels" (printf "%s\n%s" (include "kong.metaLabels" .) "enable-metrics: \"true\"") -}}
+{{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}
 {{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels" .) -}}
 {{- $_ := set $serviceConfig "serviceName" "proxy" -}}
 {{- include "kong.service" $serviceConfig }}
 {{ if .Values.proxy.ingress.enabled }}
 ---
-{{ if (not (hasKey .Values.proxy.ingress "hosts"))  -}}
 {{ include "kong.ingress" $serviceConfig }}
-{{ else -}} {{/* TODO remove legacy proxy ingress handling */}}
-{{- $serviceName := include "kong.fullname" . -}}
-{{- $servicePort := include "kong.ingress.servicePort" .Values.proxy -}}
-{{- $path := .Values.proxy.ingress.path -}}
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: {{ template "kong.fullname" . }}-proxy
-  namespace: {{ template "kong.namespace" . }}
-  labels:
-    {{- include "kong.metaLabels" . | nindent 4 }}
-  {{- if .Values.proxy.ingress.annotations }}
-  annotations:
-  {{- range $key, $value := .Values.proxy.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
-  {{- end }}
-spec:
-  rules:
-    {{- range $host := .Values.proxy.ingress.hosts }}
-    - host: {{ $host | quote }}
-      http:
-        paths:
-          - path: {{ $path }}
-            backend:
-              serviceName: {{ $serviceName }}-proxy
-              servicePort: {{ $servicePort }}
-    {{- end -}}
-    {{- end -}}
-  {{- if .Values.proxy.ingress.tls }}
-  tls:
-  {{ toYaml .Values.proxy.ingress.tls | indent 4 }}
-  {{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm-charts/kong/templates/wait-for-postgres-script.yaml
+++ b/helm-charts/kong/templates/wait-for-postgres-script.yaml
@@ -1,3 +1,4 @@
+{{ if (and (.Values.postgresql.enabled) .Values.waitImage.enabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,4 +12,4 @@ data:
       do echo "waiting for db - trying ${KONG_PG_HOST}:${KONG_PG_PORT}"
       sleep 2
     done
-
+{{ end }}

--- a/helm-charts/kong/values.yaml
+++ b/helm-charts/kong/values.yaml
@@ -19,11 +19,22 @@ deployment:
     # Setting this to false with ingressController.enabled=true will create a
     # controller-only release.
     enabled: true
+    # Use a DaemonSet controller instead of a Deployment controller
+    daemonset: false
   ## Optionally specify any extra sidecar containers to be included in the deployment
   ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core
   # sidecarContainers:
   #   - name: sidecar
   #     image: sidecar:latest
+  # initContainers:
+  # - name: initcon
+  #   image: initcon:latest
+  # userDefinedVolumes:
+  # - name: "volumeName"
+  #   emptyDir: {}
+  # userDefinedVolumeMounts:
+  # - name: "volumeName"
+  #   mountPath: "/opt/user/dir/mount"
 
 # Override namepsace for Kong chart resources. By default, the chart creates resources in the release namespace.
 # This may not be desirable when using this chart as a dependency.
@@ -57,10 +68,10 @@ env:
 # Specify Kong's Docker image and repository details here
 image:
   repository: kong
-  tag: "2.2"
+  tag: "2.4"
   # Kong Enterprise
-  # repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  # tag: "2.2.1.0-alpine"
+  # repository: kong/kong-gateway
+  # tag: "2.3.3.2-alpine"
 
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
@@ -78,10 +89,11 @@ admin:
   # Enterprise users that wish to use Kong Manager with the controller should enable this
   enabled: false
   type: NodePort
-  # If you want to specify annotations for the admin service, uncomment the following
-  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  # To specify annotations or labels for the admin service, add them to the respective
+  # "annotations" or "labels" dictionaries below.
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+  labels: {}
 
   http:
     # Enable plaintext HTTP listen for the admin API
@@ -130,12 +142,15 @@ status:
     # Enable plaintext HTTP listen for the status listen
     enabled: true
     containerPort: 8100
+    parameters: []
 
   tls:
     # Enable HTTPS listen for the status listen
-    # Kong does not currently support HTTPS status listens, so this should remain false
+    # Kong versions prior to 2.1 do not support TLS status listens.
+    # This setting must remain false on those versions
     enabled: false
     containerPort: 8543
+    parameters: []
 
 # Specify Kong cluster service and listener configuration
 #
@@ -149,10 +164,11 @@ status:
 # provider's documentation, as the configuration required for this varies).
 cluster:
   enabled: false
-  # If you want to specify annotations for the cluster service, uncomment the following
-  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  # To specify annotations or labels for the cluster service, add them to the respective
+  # "annotations" or "labels" dictionaries below.
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+  labels: {}
 
   tls:
     enabled: false
@@ -167,10 +183,12 @@ proxy:
   # Enable creating a Kubernetes service for the proxy
   enabled: true
   type: LoadBalancer
-  # If you want to specify annotations for the proxy service, uncomment the following
-  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  # To specify annotations or labels for the proxy service, add them to the respective
+  # "annotations" or "labels" dictionaries below.
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+  labels:
+    enable-metrics: "true"
 
   http:
     # Enable plaintext HTTP listen for the proxy
@@ -271,11 +289,19 @@ migrations:
   # as the sidecar containers do not terminate and prevent the jobs from completing
   annotations:
     sidecar.istio.io/inject: false
-    kuma.io/sidecar-injection: "disabled"
   # Additional annotations to apply to migration jobs
   # This is helpful in certain non-Helm installation situations such as GitOps
   # where additional control is required around this job creation.
   jobAnnotations: {}
+  resources: {}
+  # Example reasonable setting for "resources":
+  # resources:
+  #   limits:
+  #     cpu: 100m
+  #     memory: 256Mi
+  #   requests:
+  #     cpu: 50m
+  #     memory: 128Mi
 
 # Kong's configuration for DB-less mode
 # Note: Use this section only if you are deploying Kong in DB-less mode
@@ -305,8 +331,8 @@ dblessConfig:
 ingressController:
   enabled: true
   image:
-    repository: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller
-    tag: "1.1"
+    repository: kong/kubernetes-ingress-controller
+    tag: "1.2"
   args: []
 
   # Specify Kong Ingress Controller configuration via environment variables
@@ -342,8 +368,6 @@ ingressController:
     name:
     # The annotations for service account
     annotations: {}
-
-  installCRDs: true
 
   # general properties
   livenessProbe:
@@ -405,8 +429,17 @@ postgresql:
 # -----------------------------------------------------------------------------
 
 waitImage:
-  repository: bash
-  tag: 5
+  # Wait for the database to come online before starting Kong or running migrations
+  # If Kong is to access the database through a service mesh that injects a sidecar to
+  # Kong's container, this must be disabled. Otherwise there'll be a deadlock:
+  # InitContainer waiting for DB access that requires the sidecar, and the sidecar
+  # waiting for InitContainers to finish.
+  enabled: true
+  # Optionally specify an image that provides bash for pre-migration database
+  # checks. If none is specified, the chart uses the Kong image. The official
+  # Kong images provide bash
+  # repository: bash
+  # tag: 5
   pullPolicy: IfNotPresent
 
 # update strategy
@@ -456,11 +489,20 @@ livenessProbe:
 lifecycle:
   preStop:
     exec:
+      # Note kong quit has a default timeout of 10 seconds
       command: ["/bin/sh", "-c", "/bin/sleep 15 && kong quit"]
+
+# Sets the termination grace period for pods spawned by the Kubernetes Deployment.
+# Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution
+terminationGracePeriodSeconds: 30
 
 # Affinity for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 # affinity: {}
+
+# Topology spread constraints for pod assignment (requires Kubernetes >= 1.19)
+# Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+# topologySpreadConstraints: []
 
 # Tolerations for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
@@ -542,6 +584,8 @@ securityContext: {}
 
 serviceMonitor:
   # Specifies whether ServiceMonitor for Prometheus operator should be created
+  # If you wish to gather metrics from a Kong instance with the proxy disabled (such as a hybrid control plane), see:
+  # https://github.com/Kong/charts/blob/main/charts/kong/README.md#prometheus-operator-integration
   enabled: false
   # interval: 10s
   # Specifies namespace, where ServiceMonitor should be installed
@@ -562,8 +606,9 @@ enterprise:
   enabled: false
   # Kong Enterprise license secret name
   # This secret must contain a single 'license' key, containing your base64-encoded license data
-  # The license secret is required for all Kong Enterprise deployments
-  license_secret: kong-enterprise-license
+  # The license secret is required to unlock all Enterprise features. If you omit it,
+  # Kong will run in free mode, with some Enterprise features disabled.
+  # license_secret: kong-enterprise-license
   vitals:
     enabled: true
   portal:
@@ -590,7 +635,7 @@ enterprise:
     smtp_admin_emails: none@example.com
     smtp_host: smtp.example.com
     smtp_port: 587
-    smtp_auth_type: nil
+    smtp_auth_type: ''
     smtp_ssl: nil
     smtp_starttls: true
     auth:
@@ -605,10 +650,11 @@ manager:
   # Enable creating a Kubernetes service for Kong Manager
   enabled: true
   type: NodePort
-  # If you want to specify annotations for the Manager service, uncomment the following
-  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  # To specify annotations or labels for the Manager service, add them to the respective
+  # "annotations" or "labels" dictionaries below.
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+  labels: {}
 
   http:
     # Enable plaintext HTTP listen for Kong Manager
@@ -647,10 +693,11 @@ portal:
   # Enable creating a Kubernetes service for the Developer Portal
   enabled: true
   type: NodePort
-  # If you want to specify annotations for the Portal service, uncomment the following
-  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  # To specify annotations or labels for the Portal service, add them to the respective
+  # "annotations" or "labels" dictionaries below.
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+  labels: {}
 
   http:
     # Enable plaintext HTTP listen for the Developer Portal
@@ -689,10 +736,11 @@ portalapi:
   # Enable creating a Kubernetes service for the Developer Portal API
   enabled: true
   type: NodePort
-  # If you want to specify annotations for the Portal API service, uncomment the following
-  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  # To specify annotations or labels for the Portal API service, add them to the respective
+  # "annotations" or "labels" dictionaries below.
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+  labels: {}
 
   http:
     # Enable plaintext HTTP listen for the Developer Portal API
@@ -729,10 +777,11 @@ portalapi:
 
 clustertelemetry:
   enabled: false
-  # If you want to specify annotations for the cluster telemetry service, uncomment the following
-  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  # To specify annotations or labels for the cluster telemetry service, add them to the respective
+  # "annotations" or "labels" dictionaries below.
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+  labels: {}
 
   tls:
     enabled: false

--- a/olm/0.1.0/kong.v0.1.0.clusterserviceversion.yaml
+++ b/olm/0.1.0/kong.v0.1.0.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: 'false'
-    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.1.0
+    containerImage: kong/kong-operator:v0.1.0
     createdAt: '2019-05-03T12:00:00Z'
     description: Install and manage Kong clusters.
     repository: https://github.com/kong/kong-operator
@@ -123,7 +123,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kong-operator
-                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.1.0
+                image: kong/kong-operator:v0.1.0
                 imagePullPolicy: Always
                 name: kong-operator
               serviceAccountName: kong-operator

--- a/olm/0.2.0/kong.v0.2.0.clusterserviceversion.yaml
+++ b/olm/0.2.0/kong.v0.2.0.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: 'false'
-    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.0
+    containerImage: kong/kong-operator:v0.2.0
     createdAt: '2020-04-10T17:26:45Z'
     description: Install and manage Kong clusters.
     repository: https://github.com/kong/kong-operator
@@ -123,7 +123,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kong-operator
-                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.0
+                image: kong/kong-operator:v0.2.0
                 imagePullPolicy: Always
                 name: kong-operator
               serviceAccountName: kong-operator

--- a/olm/0.2.1/kong.v0.2.1.clusterserviceversion.yaml
+++ b/olm/0.2.1/kong.v0.2.1.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: 'false'
-    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.1
+    containerImage: kong/kong-operator:v0.2.1
     createdAt: '2020-04-10T17:26:45Z'
     description: Install and manage Kong clusters.
     repository: https://github.com/kong/kong-operator
@@ -123,7 +123,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kong-operator
-                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.1
+                image: kong/kong-operator:v0.2.1
                 imagePullPolicy: Always
                 name: kong-operator
               serviceAccountName: kong-operator

--- a/olm/0.2.2/kong.v0.2.2.clusterserviceversion.yaml
+++ b/olm/0.2.2/kong.v0.2.2.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: 'false'
-    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.2
+    containerImage: kong/kong-operator:v0.2.2
     createdAt: '2020-04-10T17:26:45Z'
     description: Install and manage Kong clusters.
     repository: https://github.com/kong/kong-operator
@@ -123,7 +123,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kong-operator
-                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.2
+                image: kong/kong-operator:v0.2.2
                 imagePullPolicy: Always
                 name: kong-operator
               serviceAccountName: kong-operator

--- a/olm/0.2.3/kong.v0.2.3.clusterserviceversion.yaml
+++ b/olm/0.2.3/kong.v0.2.3.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: 'false'
-    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.3
+    containerImage: kong/kong-operator:v0.2.3
     createdAt: '2020-04-10T17:26:45Z'
     description: Install and manage Kong clusters.
     repository: https://github.com/kong/kong-operator
@@ -123,7 +123,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kong-operator
-                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.3
+                image: kong/kong-operator:v0.2.3
                 imagePullPolicy: Always
                 name: kong-operator
               serviceAccountName: kong-operator

--- a/olm/0.2.4/kong.v0.2.4.clusterserviceversion.yaml
+++ b/olm/0.2.4/kong.v0.2.4.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: 'false'
-    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.4
+    containerImage: kong/kong-operator:v0.2.4
     createdAt: '2020-04-10T17:26:45Z'
     description: Install and manage Kong clusters.
     repository: https://github.com/kong/kong-operator
@@ -123,7 +123,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kong-operator
-                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.4
+                image: kong/kong-operator:v0.2.4
                 imagePullPolicy: Always
                 name: kong-operator
               serviceAccountName: kong-operator

--- a/olm/0.2.5/kong.v0.2.5.clusterserviceversion.yaml
+++ b/olm/0.2.5/kong.v0.2.5.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: 'false'
-    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.5
+    containerImage: kong/kong-operator:v0.2.5
     createdAt: '2020-04-10T17:26:45Z'
     description: Install and manage Kong clusters.
     repository: https://github.com/kong/kong-operator
@@ -123,7 +123,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kong-operator
-                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.5
+                image: kong/kong-operator:v0.2.5
                 imagePullPolicy: Always
                 name: kong-operator
               serviceAccountName: kong-operator

--- a/olm/0.2.6/kong.v0.2.6.clusterserviceversion.yaml
+++ b/olm/0.2.6/kong.v0.2.6.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: 'false'
-    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.6
+    containerImage: kong/kong-operator:v0.2.6
     createdAt: '2020-04-10T17:26:45Z'
     description: Install and manage Kong clusters.
     repository: https://github.com/kong/kong-operator
@@ -131,7 +131,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kong-operator
-                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.6
+                image: kong/kong-operator:v0.2.6
                 imagePullPolicy: Always
                 name: kong-operator
               serviceAccountName: kong-operator

--- a/olm/0.3.0/kong.v0.3.0.clusterserviceversion.yaml
+++ b/olm/0.3.0/kong.v0.3.0.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: 'false'
-    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.3.0
+    containerImage: kong/kong-operator:v0.3.0
     createdAt: '2020-04-10T17:26:45Z'
     description: Install and manage Kong clusters.
     repository: https://github.com/kong/kong-operator
@@ -131,7 +131,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kong-operator
-                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.3.0
+                image: kong/kong-operator:v0.3.0
                 imagePullPolicy: Always
                 name: kong-operator
               serviceAccountName: kong-operator

--- a/olm/0.4.0/kong.v0.4.0.clusterserviceversion.yaml
+++ b/olm/0.4.0/kong.v0.4.0.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: 'false'
-    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.4.0
+    containerImage: kong/kong-operator:v0.4.0
     createdAt: '2020-08-05T16:07:00Z'
     description: The world’s most popular open source API gateway. Built for multi-cloud and hybrid, optimized for microservices and distributed architectures.
     olm.skipRanges: '>=0.2.6 <0.4.0'
@@ -147,7 +147,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kong-operator
-                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.4.0
+                image: kong/kong-operator:v0.4.0
                 imagePullPolicy: Always
                 name: kong-operator
               serviceAccountName: kong-operator

--- a/olm/0.5.0/kong.v0.5.0.clusterserviceversion.yaml
+++ b/olm/0.5.0/kong.v0.5.0.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: 'false'
-    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.5.0
+    containerImage: kong/kong-operator:v0.5.0
     createdAt: '2020-08-05T16:07:00Z'
     description: The world’s most popular open source API gateway. Built for multi-cloud and hybrid, optimized for microservices and distributed architectures.
     olm.skipRanges: '>=0.4.0 <0.5.0'
@@ -147,7 +147,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kong-operator
-                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.5.0
+                image: kong/kong-operator:v0.5.0
                 imagePullPolicy: Always
                 name: kong-operator
               serviceAccountName: kong-operator

--- a/olm/0.6.0/kong.v0.6.0.clusterserviceversion.yaml
+++ b/olm/0.6.0/kong.v0.6.0.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: 'false'
-    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.6.0
+    containerImage: kong/kong-operator:v0.6.0
     createdAt: '2020-08-05T16:07:00Z'
     description: The world’s most popular open source API gateway. Built for multi-cloud and hybrid, optimized for microservices and distributed architectures.
     olm.skipRanges: '>=0.5.0 <0.6.0'
@@ -147,7 +147,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kong-operator
-                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.6.0
+                image: kong/kong-operator:v0.6.0
                 imagePullPolicy: Always
                 name: kong-operator
               serviceAccountName: kong-operator

--- a/olm/0.7.0/kong.v0.7.0.clusterserviceversion.yaml
+++ b/olm/0.7.0/kong.v0.7.0.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: 'false'
-    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.7.0
+    containerImage: kong/kong-operator:v0.7.0
     createdAt: '2020-08-05T16:07:00Z'
     description: The world’s most popular open source API gateway. Built for multi-cloud and hybrid, optimized for microservices and distributed architectures.
     olm.skipRanges: '>=0.5.0 <0.7.0'
@@ -147,7 +147,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kong-operator
-                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.7.0
+                image: kong/kong-operator:v0.7.0
                 imagePullPolicy: Always
                 name: kong-operator
               serviceAccountName: kong-operator

--- a/olm/0.8.0/kong.v0.8.0.clusterserviceversion.yaml
+++ b/olm/0.8.0/kong.v0.8.0.clusterserviceversion.yaml
@@ -1,0 +1,189 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"charts.helm.k8s.io/v1alpha1","kind":"Kong","metadata":{"name":"example-kong"},"spec":{"proxy":{"type":"NodePort"},"env":{"prefix":"/kong_prefix/"},"resources":{"limits":{"cpu":"500m","memory":"2G"},"requests":{"cpu":"100m","memory":"512Mi"}},"ingressController":{"enabled":true,"installCRDs":false}}}]'
+    capabilities: Basic Install
+    categories: Networking
+    certified: 'false'
+    containerImage: kong/kong-operator:v0.8.0
+    createdAt: '2020-08-05T16:07:00Z'
+    description: The world’s most popular open source API gateway. Built for multi-cloud and hybrid, optimized for microservices and distributed architectures.
+    olm.skipRanges: '>=0.5.0 <0.8.0'
+    repository: https://github.com/kong/kong-operator
+    support: Harry Bagdi
+  name: kong.v0.8.0
+  namespace: placeholder
+spec:
+  customresourcedefinitions:
+    owned:
+    - description: Defines a Kong cluster (equivalent to a Helm release). Uses the same settings as the Helm chart's values.yaml
+      displayName: Kong
+      kind: Kong
+      name: kongs.charts.helm.k8s.io
+      version: v1alpha1
+  description: |
+    Kong is a popular open-source cloud-native API gateway. Kong Operator is a Kubernetes operator which manages [Kong](https://konghq.com/kong/) and [Kong Enterprise](https://konghq.com/products/kong-enterprise/) clusters.
+
+    Kong Operator can deploy Kong in various configurations, for example:
+    * as a [Kubernetes ingress controller](https://github.com/Kong/kubernetes-ingress-controller), enabling you to expose Kubernetes `Service`s via Kong,
+    * a standalone Kong gateway (without the ingress controller; either DB-enabled or DB-less)
+    * a standalone Ingress Controller (configuring an external instance of Kong)
+
+    Those configurations are further described in the [_Deployment Options_](https://github.com/Kong/kong-operator/blob/v0.8.0/helm-charts/kong/README.md#deployment-options) section of documentation.
+
+    ### Quick Start
+
+    The [Quick Start guide](https://github.com/Kong/kong-operator/blob/v0.8.0/README.md#quick-start) uses Kong Operator to deploy
+    our recommended Kong setup for Kubernetes users (Kong DB-less with Ingress Controller), which includes an instance of Kong
+    serving as a proxy to an example Kubernetes service.
+
+    ### Documentation
+
+    The primary documentation site for Kong Operator is located [in its GitHub repository](https://github.com/Kong/kong-operator/blob/v0.8.0/README.md).
+
+    Kong Operator provides the same configuration flexibility as the Kong Helm chart.
+    Refer to the [Helm chart documentation](https://github.com/Kong/kong-operator/blob/v0.8.0/helm-charts/kong/README.md),
+    the [Configuration](https://github.com/Kong/kong-operator/blob/v0.8.0/README.md#configuration) section of Kong Operator docs, and the example `Kong` resource below.
+
+  displayName: Kong Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAI4AAACACAMAAADqKaFKAAAAnFBMVEUAAAAANFoAUnIANl0ANFkANFkAOWEANFkANFkAOl8ANFoANFoAOF0AQGMANFoANVoANFkANVoANFkANFkANVoANlwANFkANVoANVoANVoANFoANloAN1sANlsAQ2oANFoANFoANVoAOF0ANFkANVoANVoANFoANVoANlsAQGIANVkANVkANVkANVoANVkANVoANlsANVoANFoANFnuMUUSAAAAM3RSTlMA0AUt+lIYkbMT9u8hDOJ23KOM5loz84Bk68A5J0kJ17qHHMStbJVOQg/MPp57qXBUmslOI9JhAAAEs0lEQVR42szZ226qUBSF4eESFVQqFs/nc7Vat+14/3fbCSVGUVirCWvid+vNTID8mVPYok41hZdR/SHXVbyIcUiS4REvYeAw4mxRPFXjVXuGgnkL3ig1UahywDuNKQpU6TGpj8L0+YR7QCF8l08FZRSgOWeKegfipg2mE09Gy2E66WSoNjXCMeT8o4ZoMg5DaogmY0kN0WSs6tQQTcaJGqLJKFNDNhkuNUSTsaeGbDI+qSGajA7/bAd7xpVbfeqdIOedOm1IcpnNVZDkl5gp8CFqFb7SwwK6moR1YE2/drXb7eJCXjQhbcKSCu/Uu4h8MdNawQoV8F5YRaRdSNdbTPqc/c45YhZnDAu8Bh9s4p8CZmnBgm8+sURk0pAep+xkfcd7R3icRfaLMZAdZ8oUw2ZcU8lx1JxpSj4iruA4W6ZzrzWVGscbMsN7dk3re+SsxkyDrJq+dZGzicNMzvEatQejKmJyu9WwmVbTb4WY5G41PyByErirlKi3UE9qOjwif4O/rFNeYPmk4oc0sk3WdOPDgiXNONP7mn7BhmadhhqTm4fb+4AVNRoLvLimFg8pq5DGRgoRd+Ehydoipb8PzBTs6dBcC/aoGSJ9mvuALYfFBr/ONNaz9g6Xrhvb7IfG3qqwoRveLArVNyYIL8HTXryHaz4vmRvKwEns4RWasJSH5cMejhbNXZAndeaNM0zuFMlTS3689dODiFrTWLiy+B/wRXunSDm15GD8v3YzW0oYCKJoJwyLYqIgpFgECQoquJT0//+bD1CWVePkzk0n55WXLDOd26eHefDZdwqN5rkh4XZdUdpWGk/Z4tT1tA783KoyTfegtHnOqU0Hlw1AafM0IOoFLfQOWkGX315JZmnEc62imHoaEDIwdL5DmBw8DQgZ02VmfGbvopPDTOOZkevlXuMZ8b2OOwpBYKOAYJ5umO3FDg/5YP7mi0ugWgBg9oOC+c1cPYBqwTwUypJf2suja3xynRGP3LS94hTYp9bh3c+vWLXQH2++7x2oEqoFsXRak5Vv2bFqYeofv7141cLWP/5el4xqoesfc6/Nqpau2viW5lQLziyYL4NqgfWP507OrA921TJSMysRXrWcUm5yxzsTu2pZOrUyP+90u2rBT5fv6D4Y1ULUP7pBsKuWUs0UW/nFqFpe1M7OtAAOa1D/SJ7Eo6ZqWSdqxnnZhX3qJV5zhjPItVXLTu0koeDyTqsWR9xAJ0Aw1vGqpdVT4bxq0Vg2wsOrFqK34+FVS+tSb0epFi7p9ZMQi6sGxspDoarmjFtbtGpZSFzsPAuQqSMdNqtaSiESwFVOj4hI1dIVQuY912gLONWyFSLNTvA7tZ2vyUUU8pjJhU19ZzyO3DCKKB4CB1O4D8kgrkemIvltnS43XrUcRSiJlyaERKK3l8vg5RxS+cuUWGl0L5eICHlkv2+YME4iFAi5FLLcMMAvcXljhysvcerABxfSjogAXwxUL/GnDKhaChBO571/feYwKmbyMnQBLue1dsH/DIdDkAj4CpsqphcUkGCwysepG8u8cw9ugY/qK4sQDSexXCouxx0NWTxPJcAWlU9eQPcNDeIEKW/48vmo4LYSYlT5ORf5AWrXrLl1P4wQAAAAAElFTkSuQmCC
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - roles
+          - clusterrolebindings
+          - rolebindings
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - '*'
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - charts.helm.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: kong-operator
+      deployments:
+      - name: kong-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: kong-operator
+          template:
+            metadata:
+              labels:
+                name: kong-operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: kong-operator
+                image: kong/kong-operator:v0.8.0
+                imagePullPolicy: Always
+                name: kong-operator
+              serviceAccountName: kong-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - kong
+  - ingress
+  - proxy
+  - microservices
+  links:
+  - name: Kong Website
+    url: https://konghq.com/kong
+  - name: Kong Operator Documentation
+    url: https://github.com/Kong/kong-operator/blob/v0.8.0/README.md
+  - name: Quick Start Guide
+    url: https://github.com/Kong/kong-operator/blob/v0.8.0/README.md#quick-start
+  - name: Helm Chart Source
+    url: https://github.com/kong/kong-operator/tree/v0.8.0/helm-charts/kong/
+  maintainers:
+  - email: harry@konghq.com
+    name: Harry
+  - email: michal.flendrich@konghq.com
+    name: Michal
+  - email: traines@konghq.com
+    name: Travis
+  maturity: alpha
+  provider:
+    name: Kong Inc.
+  version: 0.8.0
+  replaces: kong.v0.7.0

--- a/olm/0.8.0/kongs.charts.helm.k8s.io.crd.yaml
+++ b/olm/0.8.0/kongs.charts.helm.k8s.io.crd.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongs.charts.helm.k8s.io
+spec:
+  group: charts.helm.k8s.io
+  names:
+    kind: Kong
+    listKind: KongList
+    plural: kongs
+    singular: kong
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true


### PR DESCRIPTION
0.8.0 updates the chart to 2.1.0.

This release also includes retroactive updates to the existing CSVs. This is a non-standard step to account for the demise of Bintray.

Release steps in CONTRIBUTING still reference the old image location. This section needs additional revision, since the changes to our Docker Hub permissions (removal of personal accounts from the org) preclude manual updates in general. We'll need to move to pushing images from CI. However, as the end of Bintray is imminent, I'm deferring that and will push 0.8.0's image manually still using a temporary local login to one of the bot accounts.

The original attempt to release this with SDK 0.16.0 [failed](https://github.com/Kong/kong-operator/runs/2451946050), as 0.16.0 used an older version of Helm 3 that didn't implement lookup. 0.17.2 is a conservative upgrade to do as little as possible to get to a post-Bintray world quickly; we are actually [quite behind upstream](https://sdk.operatorframework.io/docs/upgrading-sdk-version/). Later versions look like they'd require some level of work on the operator metadata (SDK 1.x.y very much so, but even the later 0.x.y suggest they'd need some level of manual work).

I don't think the loss of Helm 2 to 3 migration tools in 0.18 affects the operator, since it was already using a Helm 3-based version and the skip versions for 0.7 even didn't go far back in the past enough to use a Helm 2-based SDK version. Less sure if the K8S v1beta1 CRD removal would cause issues, but we [do still use the old version upstream](https://github.com/Kong/kubernetes-ingress-controller/issues/801), even though newer K8S versions upgrade the CRD declarations automatically.