### PR TITLE
fix: update ingress example in README.md to v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ With Kong Operator running in your cluster, you can spin up multiple instances o
     1. Create an Ingress:
         ```
         kubectl create -f - <<EOF
-        apiVersion: extensions/v1beta1
+        apiVersion: networking.k8s.io/v1
         kind: Ingress
         metadata:
           name: demo
@@ -70,9 +70,12 @@ With Kong Operator running in your cluster, you can spin up multiple instances o
           - http:
               paths:
               - path: /foo
+                pathType: Prefix
                 backend:
-                  serviceName: echo
-                  servicePort: 8080
+                  service:
+                    name: echo
+                    port:
+                      number: 8080
         EOF
         ```
 1. See that Kong works and relays requests to the application!


### PR DESCRIPTION
I noticed while testing `v0.9.0` that our `Ingress` example in the main `README.md` quickstart guide was out of date (and would break on `v1.22.x`). This patch just updates it to a `v1` resource, and I manually tested that it all works.