### PR TITLE
fix: permission to manage HorizontalPodAutoscaler

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -6,10 +6,12 @@ rules:
   # to manage HorizontalPodAutoscaler
 - apiGroups:
   - "autoscaling"
-- resources:
+  resources:
   - horizontalpodautoscalers
-- verbs:
-  - '*'
+  verbs:
+  - get
+  - create
+  - delete
   # to create Ingress rules for Kong
 - apiGroups:
   - "extensions"

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -3,6 +3,13 @@ kind: ClusterRole
 metadata:
   name: kong-operator
 rules:
+  # to manage HorizontalPodAutoscaler
+- apiGroups:
+  - "autoscaling"
+- resources:
+  - horizontalpodautoscalers
+- verbs:
+  - '*'
   # to create Ingress rules for Kong
 - apiGroups:
   - "extensions"


### PR DESCRIPTION
This change fixes an error when HPA is enabled (autoscaling.enabled=true)

Without changes I get an error

```
Unable to continue with install: could not get information about the resource: 
horizontalpodautoscalers.autoscaling "konnect-dp-kong" is forbidden:
User "system:serviceaccount:openshift-operators:kong-operator" cannot get 
resource "horizontalpodautoscalers" in API group "autoscaling" in the namespace "kong"
```

Environment:
OpenShift version 4.8.2
Kong Operator 0.8.0 installed from https://operatorhub.io/