### PR TITLE
fix: change admissionWebhook.failurePolicy value to Ignore

### DIFF
--- a/helm-charts/kong/values.yaml
+++ b/helm-charts/kong/values.yaml
@@ -431,7 +431,7 @@ ingressController:
 
   admissionWebhook:
     enabled: false
-    failurePolicy: Fail
+    failurePolicy: Ignore
     port: 8080
     certificate:
       provided: false


### PR DESCRIPTION
Ports changes made to admission failure policy in [Kong/charts/pull/612](https://github.com/Kong/charts/pull/612) to kong operator helm charts.