### PR TITLE
docs: update kong gateway operator links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # Deprecation Notice
 
-**Use of this operator for new Kong installations is discouraged in favor of the [kubectl](https://docs.konghq.com/gateway/2.7.x/install-and-run/kubernetes/) and [Helm](https://docs.konghq.com/gateway/2.7.x/install-and-run/helm/) installation methods. This operator is being deprecated in favor of a replacement based on Golang (instead of Helm). During the version `v0.x.x` lifecycle of this tool we decided that Helm did not suite our needs for a robust feature-rich operator. Security updates for this repository will be continued for the time being; but new features and other requests will not be prioritized. You can track the progress of the successor operator [here](https://github.com/kong/operator) and we highly encourage feature requests and discussions on the new operator repository to let us know your use cases and needs.**
+**Use of this operator for new Kong installations is discouraged in favor of the [kubectl](https://docs.konghq.com/gateway/2.7.x/install-and-run/kubernetes/) and [Helm](https://docs.konghq.com/gateway/2.7.x/install-and-run/helm/) installation methods. This operator is being deprecated in favor of a replacement based on Golang (instead of Helm). During the version `v0.x.x` lifecycle of this tool we decided that Helm did not suite our needs for a robust feature-rich operator. Security updates for this repository will be continued for the time being; but new features and other requests will not be prioritized. You can track the progress of the successor operator [here](https://incubator.konghq.com/p/gateway-operator/) and we highly encourage feature requests and discussions on the [new operator repository](https://github.com/Kong/gateway-operator-docs) to let us know your use cases and needs.**
 
 ---
 


### PR DESCRIPTION
The existing link - https://github.com/kong/operator - looks dead to people who not have access. This PR changes that to publicly accessible incubator and -docs links.