### PR TITLE
fix: ensure that Gateway managed DataPlanes are reduced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
 
+## Unreleased
+
+### Fixes
+
+- Fixes an issue where managed `Gateway`s controller wasn't able to reduce
+  the created `DataPlane` objects when too many have been created.
+  [#43](https://github.com/Kong/gateway-operator/pull/43)
+
 ## [v1.2.1]
 
 > Release date: 2024-03-19

--- a/pkg/utils/kubernetes/reduce/filters.go
+++ b/pkg/utils/kubernetes/reduce/filters.go
@@ -10,6 +10,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 
+	operatorv1beta1 "github.com/kong/gateway-operator/apis/v1beta1"
 	"github.com/kong/gateway-operator/pkg/consts"
 )
 
@@ -329,4 +330,25 @@ func filterValidatingWebhookConfigurations(webhookConfigurations []admregv1.Vali
 	}
 
 	return append(webhookConfigurations[:best], webhookConfigurations[best+1:]...)
+}
+
+// -----------------------------------------------------------------------------
+// Filter functions - DataPlanes
+// -----------------------------------------------------------------------------
+
+// filterDataPlanes filters out the DataPlanes to be kept and returns all the DataPlanes
+// to be deleted. The oldest DataPlane is kept.
+func filterDataPlanes(dataplanes []operatorv1beta1.DataPlane) []operatorv1beta1.DataPlane {
+	if len(dataplanes) < 2 {
+		return []operatorv1beta1.DataPlane{}
+	}
+
+	best := 0
+	for i, dataplane := range dataplanes {
+		if dataplane.CreationTimestamp.Before(&dataplanes[best].CreationTimestamp) {
+			best = i
+		}
+	}
+
+	return append(dataplanes[:best], dataplanes[best+1:]...)
 }

--- a/pkg/utils/kubernetes/reduce/reduce.go
+++ b/pkg/utils/kubernetes/reduce/reduce.go
@@ -12,6 +12,8 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1beta1 "github.com/kong/gateway-operator/apis/v1beta1"
 )
 
 // PreDeleteHook is a function that can be executed before deleting an object.
@@ -171,6 +173,20 @@ func ReduceValidatingWebhookConfigurations(ctx context.Context, k8sClient client
 	for _, webhookConfiguration := range filteredWebhookConfigurations {
 		webhookConfiguration := webhookConfiguration
 		if err := k8sClient.Delete(ctx, &webhookConfiguration); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// +kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=dataplanes,verbs=delete
+
+// ReduceDataPlanes detects the best DataPlane in the set and deletes all the others.
+func ReduceDataPlanes(ctx context.Context, k8sClient client.Client, dataplanes []operatorv1beta1.DataPlane) error {
+	filteredDataPlanes := filterDataPlanes(dataplanes)
+	for _, dataplane := range filteredDataPlanes {
+		dataplane := dataplane
+		if err := k8sClient.Delete(ctx, &dataplane); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
### Problem statement

It seems that there was one step that was missed in reduction of resources, namely `Gateway`'s managed `DataPlane`s.

When for some reason there was more than 1 `DataPlane` owned by 1 `Gateway` at any point in time KGO never removed those: https://github.com/Kong/gateway-operator/blob/2255cece26fdaf750bc099d458af4ebd7642f147/controllers/gateway/controller.go#L384-L391.

This PR introduced the `DataPlane` reduction step which will remove the newest `DataPlane` which exists when there's more than 1 of those per Gateway.


### Which issue does this PR solve

Fixes #29


---


This change has also the following effect on integration tests runtime:

Before: https://github.com/Kong/gateway-operator/actions/runs/8359101231

<img width="328" alt="image" src="https://github.com/Kong/gateway-operator/assets/739996/39787138-edf0-4304-970a-faddd2ada690">


After: https://github.com/Kong/gateway-operator/actions/runs/8362324992?pr=43

<img width="337" alt="image" src="https://github.com/Kong/gateway-operator/assets/739996/f3571b2b-f9bb-41ee-b801-1bdef5c607e3">
