### PR TITLE
tests: fix flaky HTTPRoute creation

### DIFF
--- a/test/integration/test_gateway.go
+++ b/test/integration/test_gateway.go
@@ -312,31 +312,31 @@ func TestGatewayMultiple(t *testing.T) {
 	httpRouteOne := createHTTPRoute(gatewayOne, service, pathOne)
 	require.EventuallyWithT(t,
 		func(c *assert.CollectT) {
-			var err error
-			httpRouteOne, err = gatewayV1Client.HTTPRoutes(namespace.Name).Create(GetCtx(), httpRouteOne, metav1.CreateOptions{})
+			result, err := gatewayV1Client.HTTPRoutes(namespace.Name).Create(GetCtx(), httpRouteOne, metav1.CreateOptions{})
 			if err != nil {
 				t.Logf("failed to deploy httproute: %v", err)
 				c.Errorf("failed to deploy httproute: %v", err)
+				return
 			}
+			cleaner.Add(result)
 		},
 		30*time.Second, time.Second,
 	)
-	cleaner.Add(httpRouteOne)
 
 	const pathTwo = "/path-test-two"
 	httpRouteTwo := createHTTPRoute(gatewayTwo, service, pathTwo)
 	require.EventuallyWithT(t,
 		func(c *assert.CollectT) {
-			var err error
-			httpRouteTwo, err = gatewayV1Client.HTTPRoutes(namespace.Name).Create(GetCtx(), httpRouteTwo, metav1.CreateOptions{})
+			result, err := gatewayV1Client.HTTPRoutes(namespace.Name).Create(GetCtx(), httpRouteTwo, metav1.CreateOptions{})
 			if err != nil {
 				t.Logf("failed to deploy httproute: %v", err)
 				c.Errorf("failed to deploy httproute: %v", err)
+				return
 			}
+			cleaner.Add(result)
 		},
 		30*time.Second, time.Second,
 	)
-	cleaner.Add(httpRouteTwo)
 
 	t.Log("verifying connectivity to the HTTPRoute")
 

--- a/test/integration/test_httproute.go
+++ b/test/integration/test_httproute.go
@@ -159,15 +159,16 @@ func TestHTTPRouteV1Beta1(t *testing.T) {
 	t.Logf("creating httproute %s/%s to access deployment %s via kong", httpRoute.Namespace, httpRoute.Name, deployment.Name)
 	require.EventuallyWithT(t,
 		func(c *assert.CollectT) {
-			httpRoute, err = GetClients().GatewayClient.GatewayV1().HTTPRoutes(namespace.Name).Create(GetCtx(), httpRoute, metav1.CreateOptions{})
+			result, err := GetClients().GatewayClient.GatewayV1().HTTPRoutes(namespace.Name).Create(GetCtx(), httpRoute, metav1.CreateOptions{})
 			if err != nil {
 				t.Logf("failed to deploy httproute: %v", err)
 				c.Errorf("failed to deploy httproute: %v", err)
+				return
 			}
+			cleaner.Add(result)
 		},
 		testutils.DefaultIngressWait, testutils.WaitIngressTick,
 	)
-	cleaner.Add(httpRoute)
 
 	t.Log("verifying connectivity to the HTTPRoute")
 	const (


### PR DESCRIPTION
Previous attempt in https://github.com/Kong/gateway-operator/pull/13 failed to account for the fact that if first call to `Create()` fails like so:

```
    test_httproute.go:164: failed to deploy httproute: admission webhook "httproutes.validation.ingress-controller.konghq.com" denied the request: Unable to validate HTTPRoute schema: making HTTP request: Post "https://10-244-227-242.dataplane-admin-9900d552-f1b5-41f1-bf65-ac46c3b727f9-9hlfz6624j.2e004961-3189-40ae-b0c4-d9c476a6fe9c.svc:8444/schemas/routes/validate": dial tcp 10.244.227.242:8444: connect: connection refused
```

then the variable set as result will be overwritten with an empty value and all the subsequent invocations will also fail with the following message:

```
    test_httproute.go:164: failed to deploy httproute: HTTPRoute.gateway.networking.k8s.io "" is invalid: [metadata.name: Required value: name or generateName is required, <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]
```

This PR should fix that issue by not reusing the same variable as an argument and return value.