### PR TITLE
fix: fix kustomization ClusterRoleBinding roleRef

### DIFF
--- a/config/crd/dataplane/kustomization.yaml
+++ b/config/crd/dataplane/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../bases/gateway-operator.konghq.com_dataplanes.yaml

--- a/config/rbac/role/kustomization.yaml
+++ b/config/rbac/role/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namePrefix: gateway-operator-
-
 resources:
 - role.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

1.2.0 introduce a change in `ClusterRoleBinding` `roleRef` which causes the following errors when users try to upgrade using `default` kustomization:

```
The ClusterRoleBinding "gateway-operator-manager-rolebinding" is invalid: roleRef: Invalid value: rbac.RoleRef{APIGroup:"rbac.authorization.k8s.io", Kind:"ClusterRole", Name:"gateway-operator-gateway-operator-manager-role"}: cannot change roleRef
```

This PR fixes that by removing the unnecessary prefix.

Additionally this PR adds a kustomization which contains only the `DataPlane` CRD to workaround the breaking changes from 1.2 in `ControlPlane` and `GatewayConfiguration` CRDs.
