### PR TITLE
chore(ci): fix dir exclusion and add gocritic to golangci-lint, fix reported issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,9 +1,5 @@
 run:
   timeout: 5m
-  skip-dirs:
-  - pkg/clientset
-  - config/
-  - third_party/
 linters:
   enable:
   - asciicheck
@@ -17,6 +13,7 @@ linters:
   - forbidigo
   - gci
   - gofmt
+  - gocritic
   - goimports
   - gomodguard
   - gosec
@@ -113,6 +110,10 @@ linters-settings:
 issues:
   max-same-issues: 0
   fix: true
+  exclude-dirs:
+    - pkg/clientset
+    - config/
+    - third_party/
   include:
     - EXC0012
   exclude-rules:

--- a/controller/controlplane/status_conditions.go
+++ b/controller/controlplane/status_conditions.go
@@ -10,17 +10,17 @@ import (
 // markAsProvisioned marks the provided resource as ready by the means of Provisioned
 // Status Condition.
 func markAsProvisioned[T *operatorv1beta1.ControlPlane](resource T) {
-	switch resource := any(resource).(type) {
-	case *operatorv1beta1.ControlPlane:
+	cp, ok := any(resource).(*operatorv1beta1.ControlPlane)
+	if ok {
 		k8sutils.SetCondition(
 			k8sutils.NewConditionWithGeneration(
 				ConditionTypeProvisioned,
 				metav1.ConditionTrue,
 				ConditionReasonPodsReady,
 				"pods for all Deployments are ready",
-				resource.Generation,
+				cp.Generation,
 			),
-			resource,
+			cp,
 		)
 	}
 }

--- a/controller/dataplane/owned_deployment.go
+++ b/controller/dataplane/owned_deployment.go
@@ -307,7 +307,7 @@ func reconcileDataPlaneDeployment(
 		// some custom comparison rules are needed for some PodTemplateSpec sub-attributes, in particular
 		// resources and affinity.
 		opts := []cmp.Option{
-			cmp.Comparer(func(a, b corev1.ResourceRequirements) bool { return k8sresources.ResourceRequirementsEqual(a, b) }),
+			cmp.Comparer(k8sresources.ResourceRequirementsEqual),
 		}
 
 		// ensure that PodTemplateSpec is up to date

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -668,9 +668,7 @@ func deploymentOptionsDeepEqual(o1, o2 *operatorv1beta1.DeploymentOptions, envVa
 	}
 
 	opts := []cmp.Option{
-		cmp.Comparer(func(a, b corev1.ResourceRequirements) bool {
-			return k8sresources.ResourceRequirementsEqual(a, b)
-		}),
+		cmp.Comparer(k8sresources.ResourceRequirementsEqual),
 		cmp.Comparer(func(a, b []corev1.EnvVar) bool {
 			// Throw out env vars that we ignore.
 			a = lo.Filter(a, func(e corev1.EnvVar, _ int) bool {

--- a/modules/admission/validator.go
+++ b/modules/admission/validator.go
@@ -22,21 +22,18 @@ func (v *validator) ValidateControlPlane(ctx context.Context, controlPlane opera
 
 // ValidateDataPlane validates the DataPlane resource.
 func (v *validator) ValidateDataPlane(ctx context.Context, dataPlane, old operatorv1beta1.DataPlane, operation admissionv1.Operation) error {
-	//nolint:exhaustive
 	switch operation {
 	case admissionv1.Update, admissionv1.Create:
 		if err := v.dataplaneValidator.Validate(&dataPlane); err != nil {
 			return err
 		}
-	}
-
-	//nolint:exhaustive
-	switch operation {
-	case admissionv1.Update:
-		if err := v.dataplaneValidator.ValidateUpdate(&dataPlane, &old); err != nil {
-			return err
+		if operation == admissionv1.Update {
+			if err := v.dataplaneValidator.ValidateUpdate(&dataPlane, &old); err != nil {
+				return err
+			}
 		}
+		return nil
+	default:
+		return nil
 	}
-
-	return nil
 }

--- a/pkg/utils/kubernetes/compare/comparators.go
+++ b/pkg/utils/kubernetes/compare/comparators.go
@@ -26,9 +26,7 @@ func ControlPlaneDeploymentOptionsDeepEqual(o1, o2 *operatorv1beta1.ControlPlane
 	}
 
 	opts := []cmp.Option{
-		cmp.Comparer(func(a, b corev1.ResourceRequirements) bool {
-			return resources.ResourceRequirementsEqual(a, b)
-		}),
+		cmp.Comparer(resources.ResourceRequirementsEqual),
 		cmp.Comparer(func(a, b []corev1.EnvVar) bool {
 			// Throw out env vars that we ignore.
 			a = lo.Filter(a, func(e corev1.EnvVar, _ int) bool {

--- a/pkg/utils/kubernetes/metadata.go
+++ b/pkg/utils/kubernetes/metadata.go
@@ -72,7 +72,7 @@ func TrimGenerateName(name string) string {
 		name = name[:62]
 	}
 	if !strings.HasSuffix(name, "-") {
-		name = name + "-"
+		name += "-"
 	}
 	return name
 }

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -28,7 +28,7 @@ var skippedTests = []string{
 	tests.GatewayModifyListeners.ShortName,
 	tests.GatewayWithAttachedRoutes.ShortName,
 
-	//httproute
+	// httproute
 	tests.HTTPRouteHeaderMatching.ShortName,
 }
 
@@ -96,7 +96,7 @@ func TestGatewayConformance(t *testing.T) {
 	// To work with individual tests only, you can disable the normal Run call and construct a slice containing a
 	// single test only, e.g.:
 	//
-	//cSuite.Run(t, []suite.ConformanceTest{tests.HTTPRouteRedirectPortAndScheme})
+	// cSuite.Run(t, []suite.ConformanceTest{tests.HTTPRouteRedirectPortAndScheme})
 	require.NoError(t, cSuite.Run(t, tests.ConformanceTests))
 
 	// In the future we'll likely change the file name as https://github.com/kubernetes-sigs/gateway-api/issues/2740 will be implemented.


### PR DESCRIPTION
**What this PR does / why we need it**:

```
make lint
```

reports

```log
WARN [config_reader] The configuration option `run.skip-dirs` is deprecated, please use `issues.exclude-dirs`. 
```

this PR fixes it.

Moreover I spotted that `gocritic` is not enable for this repository, enabling it reported some quite easy-to-fix and nice to have improved issues. See

```go
pkg/utils/kubernetes/metadata.go:75:3: assignOp: replace `name = name + "-"` with `name += "-"` (gocritic)
                name = name + "-"
                ^
test/conformance/suite_test.go:129:2: exitAfterDefer: os.Exit will exit, and `defer cleaner()` will not run (gocritic)
        os.Exit(code)
        ^
pkg/utils/kubernetes/compare/comparators.go:29:16: unlambda: replace `func(a, b corev1.ResourceRequirements) bool {
        return resources.ResourceRequirementsEqual(a, b)
}` with `resources.ResourceRequirementsEqual` (gocritic)
                cmp.Comparer(func(a, b corev1.ResourceRequirements) bool {
                             ^
test/integration/suite.go:189:2: exitAfterDefer: os.Exit will exit, and `defer cleaner()` will not run (gocritic)
        os.Exit(code)
        ^
modules/admission/validator.go:34:2: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
        switch operation {
        ^
controller/dataplane/owned_deployment.go:310:17: unlambda: replace `func(a, b corev1.ResourceRequirements) bool { return k8sresources.ResourceRequirementsEqual(a, b) }` with `k8sresources.ResourceRequirementsEqual` (gocritic)
                        cmp.Comparer(func(a, b corev1.ResourceRequirements) bool { return k8sresources.ResourceRequirementsEqual(a, b) }),
                                     ^
controller/gateway/controller.go:671:16: unlambda: replace `func(a, b corev1.ResourceRequirements) bool {
        return k8sresources.ResourceRequirementsEqual(a, b)
}` with `k8sresources.ResourceRequirementsEqual` (gocritic)
                cmp.Comparer(func(a, b corev1.ResourceRequirements) bool {
                             ^
controller/controlplane/controller_reconciler_utils.go:129:9: elseif: can replace 'else {if cond {}}' with 'else if cond {}' (gocritic)
        } else {
               ^
controller/controlplane/controller_reconciler_utils.go:211:17: unlambda: replace `func(a, b corev1.ResourceRequirements) bool { return k8sresources.ResourceRequirementsEqual(a, b) }` with `k8sresources.ResourceRequirementsEqual` (gocritic)
                        cmp.Comparer(func(a, b corev1.ResourceRequirements) bool { return k8sresources.ResourceRequirementsEqual(a, b) }),
                                     ^
controller/controlplane/status_conditions.go:13:2: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
        switch resource := any(resource).(type) {
```

This PR resolves all of them.
