### PR TITLE
[backport: 1.2.x] fix: make creating DataPlanes index conditional on enabling the ControlPlane controller (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
   autoscaling with `GatewayConfiguration` as the generated `DataPlane` deployment
   will no longer be rejected.
   [#79](https://github.com/Kong/gateway-operator/pull/79)
+- Make creating a `DataPlane` index conditional based on enabling the `ControlPlane`
+  controller. This allows running KGO without `ControlPlane` CRD with its controller
+  disabled.
+  [#103](https://github.com/Kong/gateway-operator/pull/103)
 
 ## [v1.2.1]
 

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/url"
@@ -93,8 +94,13 @@ func (c *ControllerDef) MaybeSetupWithManager(mgr ctrl.Manager) error {
 	return c.Controller.SetupWithManager(mgr)
 }
 
-func setupIndexes(mgr manager.Manager) error {
-	return index.IndexDataPlaneNameOnControlPlane(mgr.GetCache())
+func setupIndexes(ctx context.Context, mgr manager.Manager, cfg Config) error {
+	if cfg.ControlPlaneControllerEnabled || cfg.GatewayControllerEnabled {
+		if err := index.DataPlaneNameOnControlPlane(ctx, mgr.GetCache()); err != nil {
+			return fmt.Errorf("failed to setup index for DataPlane names on ControlPlane: %w", err)
+		}
+	}
+	return nil
 }
 
 // SetupControllers returns a list of ControllerDefs based on config.

--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -186,7 +186,7 @@ func Run(
 		return fmt.Errorf("unable to start manager: %w", err)
 	}
 
-	if err := setupIndexes(mgr); err != nil {
+	if err := setupIndexes(context.Background(), mgr, cfg); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport #103 to release/1.2.x branch.


**Special notes for your reviewer**:

This mainly is to branch off of `main` and not include #84 in 1.2.2

Changelog will be handled in `main`.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
