### PR TITLE
chore(refactor): get rid of golang.org/x/exp

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -93,6 +93,11 @@ linters-settings:
   gomodguard:
     blocked:
       modules:
+      - golang.org/x/exp:
+         recommendations:
+          - maps
+          - slices
+          - github.com/samber/lo
       - github.com/pkg/errors:
           recommendations:
           - fmt

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/kr/pretty v0.3.1
 	github.com/samber/lo v1.39.0
 	github.com/stretchr/testify v1.9.0
-	golang.org/x/exp v0.0.0-20231226003508-02704c960a9b
 	k8s.io/api v0.29.4
 	k8s.io/apimachinery v0.29.4
 	k8s.io/client-go v0.29.4
@@ -52,6 +51,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	go4.org/netipx v0.0.0-20230728184502-ec4c8b891b28 // indirect
+	golang.org/x/exp v0.0.0-20231226003508-02704c960a9b // indirect
 	golang.org/x/mod v0.16.0 // indirect
 	golang.org/x/tools v0.17.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240314234333-6e1732d8331c // indirect

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"reflect"
 
-	"golang.org/x/exp/maps"
+	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -58,7 +58,7 @@ func SetupControllersShim(mgr manager.Manager, c *Config) ([]ControllerDef, erro
 		return []ControllerDef{}, err
 	}
 
-	return maps.Values(controllers), nil
+	return lo.Values(controllers), nil
 }
 
 // -----------------------------------------------------------------------------

--- a/pkg/utils/kubernetes/metadata.go
+++ b/pkg/utils/kubernetes/metadata.go
@@ -2,10 +2,10 @@ package kubernetes
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Functionalities provided by `golang.org/x/exp` are now available in stdlib and `github.com/samber/lo` so this PR removes redundant dependency `golang.org/x/exp` and implements protection from accidentally pulling it again. 