### PR TITLE
chore(ci): update release workflow

### DIFF
--- a/.github/workflows/__build-workflow.yaml
+++ b/.github/workflows/__build-workflow.yaml
@@ -137,7 +137,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Configure Git for private repositories (temporary until making KGO public)
+      - name: Configure Git for private repositories (this is needed by repositories that include this workflow and have other private dependencies)
         run: git config --global url."https://${{ secrets.gh-pat }}@github.com".insteadOf "https://github.com"
 
       - name: Checkout KGO submodule
@@ -273,7 +273,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Configure Git for private repositories (temporary until making KGO public)
+      - name: Configure Git for private repositories (this is needed by repositories that include this workflow and have other private dependencies)
         run: git config --global url."https://${{ secrets.gh-pat }}@github.com".insteadOf "https://github.com"
 
       - name: Checkout KGO submodule

--- a/.github/workflows/__release-workflow.yaml
+++ b/.github/workflows/__release-workflow.yaml
@@ -107,7 +107,6 @@ jobs:
 
   test-integration-current-kubernetes:
     runs-on: ubuntu-latest
-    needs: build-push-images
     strategy:
       fail-fast: true
       matrix:
@@ -131,6 +130,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+
+      - uses: jdx/mise-action@v2
+        with:
+          install: false
 
       - name: integration tests
         run: make test.integration
@@ -159,6 +162,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+
+      - uses: jdx/mise-action@v2
+        with:
+          install: false
 
       - name: E2E Tests
         run: make test.e2e
@@ -202,6 +209,10 @@ jobs:
         run: |
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
           echo ${VERSION} > VERSION
+
+      - uses: jdx/mise-action@v2
+        with:
+          install: false
 
       # Generated manifests are part of the release PR.
       - name: Generate manifests

--- a/.github/workflows/__release-workflow.yaml
+++ b/.github/workflows/__release-workflow.yaml
@@ -120,7 +120,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure Git for private repositories (temporary until making KGO public)
+      - name: Configure Git for private repositories (this is needed by repositories that include this workflow and have other private dependencies)
         run: git config --global url."https://${{ secrets.gh-pat }}@github.com".insteadOf "https://github.com"
 
       - name: Checkout KGO submodule
@@ -152,7 +152,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure Git for private repositories (temporary until making KGO public)
+      - name: Configure Git for private repositories (this is needed by repositories that include this workflow and have other private dependencies)
         run: git config --global url."https://${{ secrets.gh-pat }}@github.com".insteadOf "https://github.com"
 
       - name: Checkout KGO submodule
@@ -191,7 +191,7 @@ jobs:
           fetch-depth: 0
           ref: main
 
-      - name: Configure Git for private repositories (temporary until making KGO public)
+      - name: Configure Git for private repositories (this is needed by repositories that include this workflow and have other private dependencies)
         run: git config --global url."https://${{ secrets.gh-pat }}@github.com".insteadOf "https://github.com"
 
       - name: Checkout KGO submodule


### PR DESCRIPTION
**What this PR does / why we need it**:

- add `mise` installation steps where it manages the tools used in workflows
- ~do not set credentials to checkout KGO as private submodule (from EE): not needed anymore~
  - this is needed because the workflow is reused
- do not require build-push-images for integration tests in release pipeline (those can be run in parallel with the build stage)
- ~do not set `PAT_GITHUB` as env when building the docker image.~
  - this is needed by EE's Dockerfile

