### PR TITLE
fix(ci): fix release CI to work with release branches

### DIFF
--- a/.github/workflows/__release-workflow.yaml
+++ b/.github/workflows/__release-workflow.yaml
@@ -178,6 +178,11 @@ jobs:
           KONG_LICENSE_DATA: ${{ secrets.kong-license-data }}
           KONG_TEST_GATEWAY_OPERATOR_IMAGE_OVERRIDE: ${{ needs.build-push-images.outputs.full_tag }}
 
+  # NOTE: This job's steps are run when:
+  # - input.base is 'main': then 1 PR is created targeting 'main'
+  # - input.base is not 'main': then 2 PRs will be created:
+  #   - 1 PR targeting 'main' to update VERSION and config/
+  #   - 1 PR targeting the release branch to update VERSION and config/ and trigger the release workflow
   create-release-pr:
     runs-on: ubuntu-latest
     needs:
@@ -185,29 +190,39 @@ jobs:
       - build-push-images
       - test-integration-current-kubernetes
       - test-e2e-current-kubernetes
+    strategy:
+      matrix:
+        base:
+          - ${{ inputs.base }}
+          - main
     steps:
       # Use the branch set via inputs as a base for the release.
       # If anything needs to be fixed before the release, it should be done on the base branch
       # before the release workflow is triggered.
       - name: Checkout repository
+        if: ${{ (inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main') }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ inputs.base }}
+          ref: ${{ matrix.base }}
 
       - name: Configure Git for private repositories (this is needed by repositories that include this workflow and have other private dependencies)
+        if: ${{ (inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main') }}
         run: git config --global url."https://${{ secrets.gh-pat }}@github.com".insteadOf "https://github.com"
 
       - name: Checkout KGO submodule
+        if: ${{ (inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main') }}
         run: git submodule update --init
 
       - name: Setup golang
+        if: ${{ (inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main') }}
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       # The bumped version file is included in the release PR.
       - name: Ensure version is set
+        if: ${{ (inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main') }}
         env:
           VERSION: ${{ needs.semver.outputs.fullversion }}
         run: |
@@ -220,7 +235,7 @@ jobs:
 
       # Generated manifests are part of the release PR.
       - name: Generate manifests
-        if: ${{ inputs.regenerate-manifests }}
+        if: ${{ inputs.regenerate-manifests && ((inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main')) }}
         run: make manifests
 
       # The generated bundle is part of the release PR.
@@ -228,10 +243,11 @@ jobs:
       # If anything needs to be fixed before the release, it should be done on the base branch
       # before the release workflow is triggered.
       - name: Generate bundle
-        if: ${{ inputs.regenerate-bundle }}
+        if: ${{ inputs.regenerate-bundle && ((inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main')) }}
         run: make bundle
 
       - name: GPG sign the commits
+        if: ${{ (inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main') }}
         uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4
         with:
           gpg_private_key: ${{ secrets.gpg-private-key }}
@@ -239,24 +255,31 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
+      - name: Commit message
+        if: ${{ (inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main') }}
+        env:
+          # NOTE: If the base branch set for workflow is not main (it's a release branch)
+          # then create a commit message which will not trigger the release workflow
+          # (via release-bot.yaml) but which will only update VERSION and config/.
+          MSG: "${{ inputs.base != 'main' && matrix.base == 'main' && format('chore( {0} ): [main] {1}', inputs.release-type, env.VERSION) || format('chore( {0} ): [bot] {1}', inputs.release-type, env.VERSION) }}"
+        run: |
+          echo "MSG=${MSG}" >> $GITHUB_ENV
+
       # PRs to the base branch will update the version file and manifests
-      # NOTE: This will not update the VERSION and config on the main branch when a release
-      # on release branch is made.
-      # This could be improved to trigger PRs for both main and release branch but
-      # using a different commit message to not cause the release-bot.yaml to trigger.
       - name: Create a release PR
         uses: peter-evans/create-pull-request@9153d834b60caba6d51c9b9510b087acf9f33f83
+        if: ${{ (inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main') }}
         with:
           token: ${{ secrets.gh-pat }}
           path: .
-          base: ${{ inputs.base }}
+          base: ${{ matrix.base }}
           add-paths: |
             VERSION
             config
-          commit-message: "chore(${{ inputs.release-type }}): [bot] ${{ env.VERSION }}"
+          commit-message: "${{ env.MSG }}"
           committer: Kong's Team k8s bot <team-k8s+github-bot@konghq.com>
           author: Kong's Team k8s bot <team-k8s+github-bot@konghq.com>
           signoff: true
           delete-branch: true
-          title: "chore(${{ inputs.release-type }}): [bot] ${{ env.VERSION }}"
-          body: "chore(${{ inputs.release-type }}): [bot] ${{ env.VERSION }}"
+          title: "${{ env.MSG }}"
+          body: "${{ env.MSG }}"

--- a/.github/workflows/__release-workflow.yaml
+++ b/.github/workflows/__release-workflow.yaml
@@ -1,5 +1,5 @@
 name: Reusable release
-run-name: "Release ${{ format('{0} (type: {1})', inputs.tag, inputs.release-type) }} "
+run-name: "Release ${{ format('{0} (type: {1}) (branch: {2})', inputs.tag, inputs.release-type, inputs.base) }} "
 
 on:
   workflow_call:
@@ -28,6 +28,11 @@ on:
         description: The version to release (e.g. v1.2.3)
         type: string
         required: true
+      base:
+        description: The base branch from which to release and against which to create a release PR.
+        type: string
+        default: 'main'
+        required: false
       latest:
         description: Whether to mark this release latest
         type: boolean
@@ -181,15 +186,14 @@ jobs:
       - test-integration-current-kubernetes
       - test-e2e-current-kubernetes
     steps:
-      # Use the main branch as a base for the release.
-      # Any changes made on the branch that the workflow was triggered on will not be included
-      # in the release PR. If anything needs to be fixed before a release, it should be
-      # done on the main branch.
+      # Use the branch set via inputs as a base for the release.
+      # If anything needs to be fixed before the release, it should be done on the base branch
+      # before the release workflow is triggered.
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: main
+          ref: ${{ inputs.base }}
 
       - name: Configure Git for private repositories (this is needed by repositories that include this workflow and have other private dependencies)
         run: git config --global url."https://${{ secrets.gh-pat }}@github.com".insteadOf "https://github.com"
@@ -221,7 +225,8 @@ jobs:
 
       # The generated bundle is part of the release PR.
       # This is done locally in this job, to avoid including unintended changes.
-      # If anything needs to be fixed before a release, it should be done on the main branch.
+      # If anything needs to be fixed before the release, it should be done on the base branch
+      # before the release workflow is triggered.
       - name: Generate bundle
         if: ${{ inputs.regenerate-bundle }}
         run: make bundle
@@ -234,12 +239,17 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
-      # PRs to the main branch will update the version file and manifests
+      # PRs to the base branch will update the version file and manifests
+      # NOTE: This will not update the VERSION and config on the main branch when a release
+      # on release branch is made.
+      # This could be improved to trigger PRs for both main and release branch but
+      # using a different commit message to not cause the release-bot.yaml to trigger.
       - name: Create a release PR
         uses: peter-evans/create-pull-request@9153d834b60caba6d51c9b9510b087acf9f33f83
         with:
           token: ${{ secrets.gh-pat }}
           path: .
+          base: ${{ inputs.base }}
           add-paths: |
             VERSION
             config

--- a/.github/workflows/release-bot.yaml
+++ b/.github/workflows/release-bot.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'release/*'
 
 jobs:
   look_for_release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,5 @@
 name: release
-run-name: "Release ${{ format('{0} (type: {1})', inputs.tag, inputs.release_type) }} "
+run-name: "Release ${{ format('{0} (type: {1}) (branch: {2})', inputs.tag, inputs.release-type, inputs.base) }} "
 
 on:
   workflow_dispatch:
@@ -7,6 +7,11 @@ on:
       tag:
         description: The version to release (e.g. v1.2.3)
         required: true
+      base:
+        description: The base branch from which to release and against which to create a release PR.
+        type: string
+        default: 'main'
+        required: false
       latest:
         description: Whether to tag this build latest
         type: boolean
@@ -33,5 +38,6 @@ jobs:
       image-name: ${{ vars.DOCKERHUB_IMAGE_NAME }}
       latest: ${{ inputs.latest }}
       tag: ${{ inputs.tag }}
+      base: ${{ inputs.base }}
       release-type: ${{ inputs.release_type }}
       regenerate-manifests: true

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,11 @@ go 1.22
 
 toolchain go1.22.0
 
-retract (
-	// 1.2.2 was released on main branch with a breaking change that was not
-	// intended to be released in 1.2.x:
-	// https://github.com/Kong/gateway-operator/commit/3876430e09e61edce58bd8464989e33236bd1872
-	// This retraction is to prevent it from being used and from breaking builds of dependent projects.
-	v1.2.2
-)
+// 1.2.2 was released on main branch with a breaking change that was not
+// intended to be released in 1.2.x:
+// https://github.com/Kong/gateway-operator/commit/3876430e09e61edce58bd8464989e33236bd1872
+// This retraction is to prevent it from being used and from breaking builds of dependent projects.
+retract v1.2.2
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,14 @@ go 1.22
 
 toolchain go1.22.0
 
+retract (
+	// 1.2.2 was released on main branch with a breaking change that was not
+	// intended to be released in 1.2.x:
+	// https://github.com/Kong/gateway-operator/commit/3876430e09e61edce58bd8464989e33236bd1872
+	// This retraction is to prevent it from being used and from breaking builds of dependent projects.
+	v1.2.2
+)
+
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/cert-manager/cert-manager v1.14.4


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes the release pipeline to make it work with release branches.

Up until now the `.github/workflows/release-bot.yaml` was only triggered on `main` and `.github/workflows/__release-workflow.yaml` was only creating release PRs against `main`. That caused 1.2.2 to be released on `main` which we did not want (due to that branch already including a breaking change which we did not want to include in 1.2.x).

This change makes the release workflow to accept a base branch argument so that we can release from release branches.

Ideally the `VERSION` and manifests would also get an update on `main` but that can be done separately.

This also retracts the 1.2.2 tag since it was not created on a desired SHA. Deleting and re-pushing the tag does not help because golang's proxy caches modules indefinitely (https://sum.golang.org/#faq-retract-version) hence the `retract` clause added in `go.mod`.