### PR TITLE
chore(refactor): get rid of duplicated helper for TLS certs, and improve existing ones

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -128,10 +128,6 @@ issues:
         - revive
       text: "exported: exported"
     # Test cases are self-explanatory, thus no need a docstring.
-    - path: test/helpers/certificate
-      linters:
-        - revive
-      text: "exported: exported"
     - path: test/integration
       linters:
         - revive

--- a/test/helpers/certs.go
+++ b/test/helpers/certs.go
@@ -5,14 +5,10 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"fmt"
-	"io"
 	"math/big"
-	"net"
 	"testing"
 	"time"
 
@@ -151,66 +147,4 @@ func TLSSecretData(t *testing.T, ca Cert, c Cert) map[string][]byte {
 		"tls.crt": c.CertPEM.Bytes(),
 		"tls.key": c.KeyPEM.Bytes(),
 	}
-}
-
-// -----------------------------------------------------------------------------
-// TLS Certificate test helper functions and types
-// -----------------------------------------------------------------------------
-
-const (
-	rsaBits  = 2048
-	validFor = 365 * 24 * time.Hour
-)
-
-// generateRSACert generates a basic self signed certificate valid for a year
-func generateRSACert(hosts []string, keyOut, certOut io.Writer) error {
-	priv, err := rsa.GenerateKey(rand.Reader, rsaBits)
-	if err != nil {
-		return fmt.Errorf("failed to generate key: %w", err)
-	}
-	notBefore := time.Now()
-	notAfter := notBefore.Add(validFor)
-
-	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
-	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
-	if err != nil {
-		return fmt.Errorf("failed to generate serial number: %w", err)
-	}
-
-	template := x509.Certificate{
-		SerialNumber: serialNumber,
-		Subject: pkix.Name{
-			CommonName:   "default",
-			Organization: []string{"Acme Co"},
-		},
-		NotBefore: notBefore,
-		NotAfter:  notAfter,
-
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		BasicConstraintsValid: true,
-	}
-
-	for _, h := range hosts {
-		if ip := net.ParseIP(h); ip != nil {
-			template.IPAddresses = append(template.IPAddresses, ip)
-		} else {
-			template.DNSNames = append(template.DNSNames, h)
-		}
-	}
-
-	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
-	if err != nil {
-		return fmt.Errorf("failed to create certificate: %w", err)
-	}
-
-	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
-		return fmt.Errorf("failed creating cert: %w", err)
-	}
-
-	if err := pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)}); err != nil {
-		return fmt.Errorf("failed creating key: %w", err)
-	}
-
-	return nil
 }

--- a/test/helpers/generators.go
+++ b/test/helpers/generators.go
@@ -1,7 +1,6 @@
 package helpers
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/google/uuid"
@@ -189,26 +188,4 @@ func GenerateHTTPRoute(namespace string, gatewayName, serviceName string, opts .
 	}
 
 	return httpRoute
-}
-
-// MustGenerateTLSSecret generates a TLS secret to be used in tests
-func MustGenerateTLSSecret(t *testing.T, namespace, secretName string, hosts []string) *corev1.Secret {
-	t.Helper()
-
-	var serverKey, serverCert bytes.Buffer
-	require.NoError(t, generateRSACert(hosts, &serverKey, &serverCert), "failed to generate RSA certificate")
-
-	data := map[string][]byte{
-		corev1.TLSCertKey:       serverCert.Bytes(),
-		corev1.TLSPrivateKeyKey: serverKey.Bytes(),
-	}
-
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      secretName,
-		},
-		Type: corev1.SecretTypeTLS,
-		Data: data,
-	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Generating a cert needed in 
- https://github.com/Kong/gateway-operator/pull/88

can be achieved without adding a new helper. This PR removes the helper introduced in https://github.com/Kong/gateway-operator/pull/88 and uses the old one. 

Moreover, it improves a little bit existing one helpers. 

**Which issue this PR fixes**

It's a bigger initiative of dealing with certs consistently across our projects. 
