### PR TITLE
chore(ci): update changelog with 1.2.3 and fix release pipeline on main

### DIFF
--- a/.github/workflows/__release-workflow.yaml
+++ b/.github/workflows/__release-workflow.yaml
@@ -230,6 +230,7 @@ jobs:
           echo ${VERSION} > VERSION
 
       - uses: jdx/mise-action@v2
+        if: ${{ (inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main') }}
         with:
           install: false
 
@@ -261,7 +262,7 @@ jobs:
           # NOTE: If the base branch set for workflow is not main (it's a release branch)
           # then create a commit message which will not trigger the release workflow
           # (via release-bot.yaml) but which will only update VERSION and config/.
-          MSG: "${{ inputs.base != 'main' && matrix.base == 'main' && format('chore( {0} ): [main] {1}', inputs.release-type, env.VERSION) || format('chore( {0} ): [bot] {1}', inputs.release-type, env.VERSION) }}"
+          MSG: "${{ inputs.base != 'main' && matrix.base == 'main' && format('chore({0}): [main] {1}', inputs.release-type, env.VERSION) || format('chore({0}): [bot] {1}', inputs.release-type, env.VERSION) }}"
         run: |
           echo "MSG=${MSG}" >> $GITHUB_ENV
 
@@ -272,6 +273,7 @@ jobs:
         with:
           token: ${{ secrets.gh-pat }}
           path: .
+          branch: release/${{ needs.semver.outputs.fullversion }}/pr-${{ matrix.base }}
           base: ${{ matrix.base }}
           add-paths: |
             VERSION

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,5 @@
 name: release
-run-name: "Release ${{ format('{0} (type: {1}) (branch: {2})', inputs.tag, inputs.release-type, inputs.base) }} "
+run-name: "Release ${{ format('{0} (type: {1}) (branch: {2})', inputs.tag, inputs.release_type, github.ref_name) }} "
 
 on:
   workflow_dispatch:
@@ -7,11 +7,6 @@ on:
       tag:
         description: The version to release (e.g. v1.2.3)
         required: true
-      base:
-        description: The base branch from which to release and against which to create a release PR.
-        type: string
-        default: 'main'
-        required: false
       latest:
         description: Whether to tag this build latest
         type: boolean
@@ -38,6 +33,6 @@ jobs:
       image-name: ${{ vars.DOCKERHUB_IMAGE_NAME }}
       latest: ${{ inputs.latest }}
       tag: ${{ inputs.tag }}
-      base: ${{ inputs.base }}
+      base: ${{ github.ref_name }}
       release-type: ${{ inputs.release_type }}
       regenerate-manifests: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,11 @@
   `apis` -> `api` and `controllers` -> `controller`.
   [#84](https://github.com/Kong/gateway-operator/pull/84)
 
-## [v1.2.2]
+## [v1.2.3]
 
 ### Fixes
 
-> Release date: 2024-04-22
+> Release date: 2024-04-23
 
 - Fixes an issue where managed `Gateway`s controller wasn't able to reduce
   the created `DataPlane` objects when too many have been created.
@@ -46,6 +46,12 @@
   controller. This allows running KGO without `ControlPlane` CRD with its controller
   disabled.
   [#103](https://github.com/Kong/gateway-operator/pull/103)
+
+## [v1.2.2]
+
+> Release date: 2024-04-23
+
+### **NOTE: Retracted**
 
 ## [v1.2.1]
 
@@ -629,6 +635,7 @@ leftovers from previous operator deployments in the cluster. The user needs to d
 (clusterrole, clusterrolebinding, validatingWebhookConfiguration) before
 re-installing the operator through the bundle.
 
+[v1.2.3]: https://github.com/Kong/gateway-operator-archive/compare/v1.2.2..v1.2.3
 [v1.2.2]: https://github.com/Kong/gateway-operator-archive/compare/v1.2.1..v1.2.2
 [v1.2.1]: https://github.com/Kong/gateway-operator-archive/compare/v1.2.0..v1.2.1
 [v1.2.0]: https://github.com/Kong/gateway-operator-archive/compare/v1.1.0..v1.2.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow up on broken 1.2.2 which was retracted. Details in https://github.com/Kong/gateway-operator/pull/206