### PR TITLE
chore(build): use build-platform instead of emulation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,11 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
 # Ignore build and test binaries.
 bin/
-testbin/
+config/
+docs/
+scripts/
+logo/
+*Dockerfile
+Dockerfile*
+test/
+*.md

--- a/.github/workflows/__build-workflow.yaml
+++ b/.github/workflows/__build-workflow.yaml
@@ -159,11 +159,6 @@ jobs:
           username: ${{ inputs.username }}
           password: ${{ secrets.dockerhub-token }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: ${{ matrix.arch }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -197,7 +192,7 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
             ${{ env.TAGS_STANDARD }}${{ env.TAGS_SUPPLEMENTAL }}
-          flavor: latest=${{ inputs.latest }},suffix=-${{ matrix.arch  }}
+          flavor: latest=${{ inputs.latest }},suffix=-${{ matrix.arch }}
 
       - uses: docker/setup-buildx-action@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Builder
 # ------------------------------------------------------------------------------
 
-FROM golang:1.22.2 as builder
+FROM --platform=$BUILDPLATFORM golang:1.22.2 as builder
 
 WORKDIR /workspace
 ARG GOPATH

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -2,7 +2,7 @@
 # Debug image
 # ------------------------------------------------------------------------------
 
-FROM golang:1.22.2 as debug
+FROM --platform=$BUILDPLATFORM golang:1.22.2 as debug
 
 ARG GOPATH
 ARG GOCACHE


### PR DESCRIPTION
**What this PR does / why we need it**:

Same thing as https://github.com/Kong/kubernetes-ingress-controller/pull/5788/files but for KGO.

Example: https://github.com/Kong/gateway-operator/actions/runs/8817901181
