### PR TITLE
chore: move and publish CRD checker

### DIFF
--- a/pkg/utils/kubernetes/crd.go
+++ b/pkg/utils/kubernetes/crd.go
@@ -1,0 +1,54 @@
+package kubernetes
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CRDChecker verifies whether the resource type defined by GVR is supported by the k8s apiserver.
+type CRDChecker struct {
+	Client client.Client
+}
+
+// CRDExists returns true if the apiserver supports the specified group/version/resource.
+func (c CRDChecker) CRDExists(gvr schema.GroupVersionResource) (bool, error) {
+	_, err := c.Client.RESTMapper().KindFor(gvr)
+
+	if meta.IsNoMatchError(err) {
+		return false, nil
+	}
+
+	if errD := (&discovery.ErrGroupDiscoveryFailed{}); errors.As(err, &errD) {
+		for _, e := range errD.Groups {
+
+			// If this is an API StatusError:
+			if errS := (&k8serrors.StatusError{}); errors.As(e, &errS) {
+				switch errS.ErrStatus.Code {
+				case 404:
+					// If it's a 404 status code then we're sure that it's just
+					// a missing CRD. Don't report an error, just false.
+					return false, nil
+				default:
+					return false, fmt.Errorf("unexpected API error status code when looking up CRD (%v): %w", gvr, err)
+				}
+			}
+
+			// It is a network error.
+			if errU := (&url.Error{}); errors.As(e, &errU) {
+				return false, fmt.Errorf("unexpected network error when looking up CRD (%v): %w", gvr, err)
+			}
+		}
+
+		// Otherwise it's a different error, report a missing CRD.
+		return false, err
+	}
+
+	return true, nil
+}

--- a/pkg/utils/kubernetes/crd_test.go
+++ b/pkg/utils/kubernetes/crd_test.go
@@ -1,4 +1,4 @@
-package manager
+package kubernetes
 
 import (
 	"testing"
@@ -94,9 +94,7 @@ func TestCRDChecker(t *testing.T) {
 				WithRESTMapper(tc.restMapper()).
 				Build()
 
-			checker := crdChecker{
-				client: fakeClient,
-			}
+			checker := CRDChecker{Client: fakeClient}
 			ok, err := checker.CRDExists(tc.CRD)
 
 			if tc.expectedErr != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

We have some features that require CRD availability and _do not_ use Reconcilers. These features should check that their required CRDs are available before attempting to interact with them.

To support this, move the manager's CRD checker utility into the `kubernetes` utils package and publish it.

**Which issue this PR fixes**

Related to https://github.com/Kong/gateway-operator-enterprise/issues/118

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] ~the `CHANGELOG.md` release notes have been updated to reflect significant changes~ Nothing user-facing
