### PR TITLE
chore: remove Gateway's Ready status condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@
   `apis` -> `api` and `controllers` -> `controller`.
   [#84](https://github.com/Kong/gateway-operator/pull/84)
 
+### Changes
+
+- `Gateway` do not have their `Ready` status condition set anymore.
+  This aligns with Gateway API and its conformance test suite.
+  [#246](https://github.com/Kong/gateway-operator/pull/246)
+
 ### Fixes
 
 - Fix enforcing up to date `ControlPlane`'s `ValidatingWebhookConfiguration`

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -147,7 +147,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	gwConditionAware.initListenersStatus()
 	gwConditionAware.setConflicted()
 	gwConditionAware.setAccepted()
-	gwConditionAware.initReadyAndProgrammed()
+	gwConditionAware.initProgrammedAndListenersStatus()
 	if err := gwConditionAware.setResolvedRefsAndSupportedKinds(ctx, r.Client); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -340,7 +340,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			gatewayConditionsAndListenersAware(&gateway))
 	}
 
-	gwConditionAware.setReadyAndProgrammed()
+	gwConditionAware.setProgrammedAndListenersConditions()
 	res, err := patch.ApplyGatewayStatusPatchIfNotEmpty(ctx, r.Client, logger, &gateway, oldGateway)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -535,12 +535,11 @@ func supportedRoutesByProtocol() map[gatewayv1.ProtocolType]map[gatewayv1.Kind]s
 	}
 }
 
-// initReadyAndProgrammed initializes the gateway Programmed and Ready conditions
-// by setting the underlying Gateway Programmed and Ready status to false.
-// Furthermore, it sets the supportedKinds and initializes the readiness to false with reason
-// Pending for each Gateway listener.
-func (g *gatewayConditionsAndListenersAwareT) initReadyAndProgrammed() {
-	k8sutils.InitReady(g)
+// initProgrammedAndListenersStatus initializes the gateway Programmed condition
+// by setting the underlying Gateway Programmed status to false.
+// It also sets the listeners Programmed condition by setting the underlying
+// Listener Programmed status to false.
+func (g *gatewayConditionsAndListenersAwareT) initProgrammedAndListenersStatus() {
 	k8sutils.InitProgrammed(g)
 	for i := range g.Spec.Listeners {
 		lStatus := listenerConditionsAware(&g.Status.Listeners[i])
@@ -634,12 +633,11 @@ func (g *gatewayConditionsAndListenersAwareT) setConflicted() {
 	}
 }
 
-// setReadyAndProgrammed sets the gateway Programmed and Ready conditions by
-// setting the underlying Gateway Programmed and Ready status to true.
-// Furthermore, it sets the supportedKinds and initializes the readiness to true with reason
-// Ready or false with reason Invalid for each Gateway listener.
-func (g *gatewayConditionsAndListenersAwareT) setReadyAndProgrammed() {
-	k8sutils.SetReady(g)
+// setProgrammedAndListenersConditions sets the gateway Programmed condition by setting the underlying
+// Gateway Programmed status to true.
+// It also sets the listeners Programmed condition by setting the underlying
+// Listener Programmed status to true.
+func (g *gatewayConditionsAndListenersAwareT) setProgrammedAndListenersConditions() {
 	k8sutils.SetProgrammed(g)
 
 	for i := range g.Spec.Listeners {

--- a/controller/gateway/controller_test.go
+++ b/controller/gateway/controller_test.go
@@ -181,7 +181,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 
 				var currentGateway gwtypes.Gateway
 				require.NoError(t, reconciler.Client.Get(ctx, gatewayReq.NamespacedName, &currentGateway))
-				require.False(t, k8sutils.IsReady(gatewayConditionsAndListenersAware(&currentGateway)))
+				require.False(t, k8sutils.IsProgrammed(gatewayConditionsAndListenersAware(&currentGateway)))
 				condition, found := k8sutils.GetCondition(GatewayServiceType, gatewayConditionsAndListenersAware(&currentGateway))
 				require.True(t, found)
 				require.Equal(t, condition.Status, metav1.ConditionFalse)
@@ -200,7 +200,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 				require.NoError(t, err, "reconciliation returned an error")
 				// the dataplane service now has a clusterIP assigned, the gateway must be ready
 				require.NoError(t, reconciler.Client.Get(ctx, gatewayReq.NamespacedName, &currentGateway))
-				require.True(t, k8sutils.IsReady(gatewayConditionsAndListenersAware(&currentGateway)))
+				require.True(t, k8sutils.IsProgrammed(gatewayConditionsAndListenersAware(&currentGateway)))
 				condition, found = k8sutils.GetCondition(GatewayServiceType, gatewayConditionsAndListenersAware(&currentGateway))
 				require.True(t, found)
 				require.Equal(t, condition.Status, metav1.ConditionTrue)
@@ -234,7 +234,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 				_, err = reconciler.Reconcile(ctx, gatewayReq)
 				require.NoError(t, err, "reconciliation returned an error")
 				require.NoError(t, reconciler.Client.Get(ctx, gatewayReq.NamespacedName, &currentGateway))
-				require.True(t, k8sutils.IsReady(gatewayConditionsAndListenersAware(&currentGateway)))
+				require.True(t, k8sutils.IsProgrammed(gatewayConditionsAndListenersAware(&currentGateway)))
 				condition, found = k8sutils.GetCondition(GatewayServiceType, gatewayConditionsAndListenersAware(&currentGateway))
 				require.True(t, found)
 				require.Equal(t, condition.Status, metav1.ConditionTrue)
@@ -267,7 +267,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 				_, err = reconciler.Reconcile(ctx, gatewayReq)
 				require.NoError(t, err, "reconciliation returned an error")
 				require.NoError(t, reconciler.Client.Get(ctx, gatewayReq.NamespacedName, &currentGateway))
-				require.True(t, k8sutils.IsReady(gatewayConditionsAndListenersAware(&currentGateway)))
+				require.True(t, k8sutils.IsProgrammed(gatewayConditionsAndListenersAware(&currentGateway)))
 				condition, found = k8sutils.GetCondition(GatewayServiceType, gatewayConditionsAndListenersAware(&currentGateway))
 				require.True(t, found)
 				require.Equal(t, condition.Status, metav1.ConditionTrue)
@@ -289,7 +289,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 				require.NoError(t, reconciler.Client.Get(ctx, gatewayReq.NamespacedName, &currentGateway))
 				// the dataplane service has no clusterIP assigned, the gateway must be not ready
 				// and no addresses must be assigned
-				require.False(t, k8sutils.IsReady(gatewayConditionsAndListenersAware(&currentGateway)))
+				require.False(t, k8sutils.IsProgrammed(gatewayConditionsAndListenersAware(&currentGateway)))
 				condition, found = k8sutils.GetCondition(GatewayServiceType, gatewayConditionsAndListenersAware(&currentGateway))
 				require.True(t, found)
 				require.Equal(t, condition.Status, metav1.ConditionFalse)


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove setting `Ready` condition on `Gateway`.

**Which issue this PR fixes**

Fixes #208

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
