### PR TITLE
feat: fill in AttachedRoutes in Gateways' Listeners status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
 - `Gateway` do not have their `Ready` status condition set anymore.
   This aligns with Gateway API and its conformance test suite.
   [#246](https://github.com/Kong/gateway-operator/pull/246)
+- `Gateway`s' listeners now have their `attachedRoutes` count filled in in status.
+  [#251](https://github.com/Kong/gateway-operator/pull/251)
 
 ### Fixes
 

--- a/config/samples/gateway-httproute-allowedroutes.yaml
+++ b/config/samples/gateway-httproute-allowedroutes.yaml
@@ -1,0 +1,141 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+spec:
+  ports:
+    - protocol: TCP
+      name: http
+      port: 80
+      targetPort: http
+  selector:
+    app: echo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: echo
+  name: echo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo
+  template:
+    metadata:
+      labels:
+        app: echo
+    spec:
+      containers:
+        - name: echo
+          image: registry.k8s.io/e2e-test-images/agnhost:2.40
+          command:
+            - /agnhost
+            - netexec
+            - --http-port=8080
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          resources:
+            requests:
+              cpu: 10m
+---
+kind: GatewayConfiguration
+apiVersion: gateway-operator.konghq.com/v1beta1
+metadata:
+  name: kong
+  namespace: default
+spec:
+  dataPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        spec:
+          containers:
+          - name: proxy
+            # renovate: datasource=docker versioning=docker
+            image: kong/kong-gateway:3.6
+            readinessProbe:
+              initialDelaySeconds: 1
+              periodSeconds: 1
+  controlPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        spec:
+          containers:
+          - name: controller
+            # renovate: datasource=docker versioning=docker
+            image: kong/kubernetes-ingress-controller:3.1.5
+            readinessProbe:
+              initialDelaySeconds: 1
+              periodSeconds: 1
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: kong
+spec:
+  controllerName: konghq.com/gateway-operator
+  parametersRef:
+    group: gateway-operator.konghq.com
+    kind: GatewayConfiguration
+    name: kong
+    namespace: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: kong
+  namespace: default
+spec:
+  gatewayClassName: kong
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      kinds:
+      - kind: HTTPRoute
+      namespaces:
+        from: Selector
+        selector:
+          matchLabels:
+            # This label is added automatically as of K8s 1.22 to all namespaces
+            kubernetes.io/metadata.name: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-echo
+  namespace: default
+  annotations:
+    konghq.com/strip-path: "true"
+spec:
+  parentRefs:
+  - name: kong
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /echo
+    backendRefs:
+    - name: echo
+      kind: Service
+      port: 80

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -172,8 +172,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	acceptedCondition, _ := k8sutils.GetCondition(k8sutils.ConditionType(gatewayv1.GatewayConditionAccepted), gwConditionAware)
 	// If the static Gateway API conditions (Accepted, ResolvedRefs, Conflicted) changed, we need to update the Gateway status
 	if gatewayStatusNeedsUpdate(oldGwConditionsAware, gwConditionAware) {
-		_, err := patch.ApplyGatewayStatusPatchIfNotEmpty(ctx, r.Client, logger, &gateway, oldGateway) // requeue will be triggered by the update of the gateway status
-		if err != nil {
+		 // Requeue will be triggered by the update of the gateway status.
+		if _, err := patch.ApplyGatewayStatusPatchIfNotEmpty(ctx, r.Client, logger, &gateway, oldGateway); err != nil {
 			return ctrl.Result{}, err
 		}
 		if acceptedCondition.Status == metav1.ConditionTrue {

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -92,7 +92,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// watch HTTPRoutes so that Gateway listener status can be updated.
 		Watches(
 			&gatewayv1beta1.HTTPRoute{},
-			handler.EnqueueRequestsFromMapFunc(r.listHTTPRoutesForGateway)).
+			handler.EnqueueRequestsFromMapFunc(r.listGatewaysAttachedByHTTPRoute)).
 		// watch Namespaces so that managed routes have correct status reflected in Gateway's
 		// status in status.listeners.attachedRoutes
 		// This is required to properly support Gateway's listeners.allowedRoutes.namespaces.selector.
@@ -172,7 +172,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	acceptedCondition, _ := k8sutils.GetCondition(k8sutils.ConditionType(gatewayv1.GatewayConditionAccepted), gwConditionAware)
 	// If the static Gateway API conditions (Accepted, ResolvedRefs, Conflicted) changed, we need to update the Gateway status
 	if gatewayStatusNeedsUpdate(oldGwConditionsAware, gwConditionAware) {
-		 // Requeue will be triggered by the update of the gateway status.
+		// Requeue will be triggered by the update of the gateway status.
 		if _, err := patch.ApplyGatewayStatusPatchIfNotEmpty(ctx, r.Client, logger, &gateway, oldGateway); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -88,8 +88,17 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&gatewayv1beta1.ReferenceGrant{},
 			handler.EnqueueRequestsFromMapFunc(r.listReferenceGrantsForGateway),
-			builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantHasGatewayFrom)),
-		).
+			builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantHasGatewayFrom))).
+		// watch HTTPRoutes so that Gateway listener status can be updated.
+		Watches(
+			&gatewayv1beta1.HTTPRoute{},
+			handler.EnqueueRequestsFromMapFunc(r.listHTTPRoutesForGateway)).
+		// watch Namespaces so that managed routes have correct status reflected in Gateway's
+		// status in status.listeners.attachedRoutes
+		// This is required to properly support Gateway's listeners.allowedRoutes.namespaces.selector.
+		Watches(
+			&corev1.Namespace{},
+			handler.EnqueueRequestsFromMapFunc(r.listManagedGatewaysInNamespace)).
 		Complete(r)
 }
 
@@ -152,7 +161,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	log.Trace(logger, "resource is supported, ensuring that it gets marked as accepted", gateway)
 	gwConditionAware.initListenersStatus()
 	gwConditionAware.setConflicted()
-	gwConditionAware.setAccepted()
+	if err = gwConditionAware.setAcceptedAndAttachedRoutes(ctx, r.Client); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	gwConditionAware.initProgrammedAndListenersStatus()
 	if err := gwConditionAware.setResolvedRefsAndSupportedKinds(ctx, r.Client); err != nil {
 		return ctrl.Result{}, err
@@ -160,7 +172,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	acceptedCondition, _ := k8sutils.GetCondition(k8sutils.ConditionType(gatewayv1.GatewayConditionAccepted), gwConditionAware)
 	// If the static Gateway API conditions (Accepted, ResolvedRefs, Conflicted) changed, we need to update the Gateway status
 	if gatewayStatusNeedsUpdate(oldGwConditionsAware, gwConditionAware) {
-		if err := r.patchStatus(ctx, &gateway, oldGateway); err != nil { // requeue will be triggered by the update of the dataplane status
+		_, err := patch.ApplyGatewayStatusPatchIfNotEmpty(ctx, r.Client, logger, &gateway, oldGateway) // requeue will be triggered by the update of the gateway status
+		if err != nil {
 			return ctrl.Result{}, err
 		}
 		if acceptedCondition.Status == metav1.ConditionTrue {
@@ -346,7 +359,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			gatewayConditionsAndListenersAware(&gateway))
 	}
 
-	gwConditionAware.setProgrammedAndListenersConditions()
+	gwConditionAware.setProgrammed()
 	res, err := patch.ApplyGatewayStatusPatchIfNotEmpty(ctx, r.Client, logger, &gateway, oldGateway)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -596,8 +596,7 @@ func (g *gatewayConditionsAndListenersAwareT) setAcceptedAndAttachedRoutes(ctx c
 			ObservedGeneration: g.Generation,
 		}
 
-		_, protocolSupported := supportedRoutesByProtocol()[listener.Protocol]
-		if !protocolSupported {
+		if _, protocolSupported := supportedRoutesByProtocol()[listener.Protocol]; !protocolSupported {
 			acceptedCondition.Status = metav1.ConditionFalse
 			acceptedCondition.Reason = string(gatewayv1.ListenerReasonUnsupportedProtocol)
 		}

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -23,17 +23,6 @@ import (
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 )
 
-// func init() {
-// 	if err := gatewayv1.Install(scheme.Scheme); err != nil {
-// 		fmt.Println("error while adding gatewayv1 scheme")
-// 		os.Exit(1)
-// 	}
-// 	if err := gatewayv1beta1.Install(scheme.Scheme); err != nil {
-// 		fmt.Println("error while adding gatewayv1 scheme")
-// 		os.Exit(1)
-// 	}
-// }
-
 func TestParseKongProxyListenEnv(t *testing.T) {
 	testcases := []struct {
 		Name            string

--- a/controller/gateway/controller_watch.go
+++ b/controller/gateway/controller_watch.go
@@ -268,9 +268,9 @@ func (r *Reconciler) listManagedGatewaysInNamespace(ctx context.Context, obj cli
 	return recs
 }
 
-// listHTTPRoutesForGateway is a watch predicate which finds all Gateways mentioned
+// listGatewaysAttachedByHTTPRoute is a watch predicate which finds all Gateways mentioned
 // in HTTPRoutes' Parents field.
-func (r *Reconciler) listHTTPRoutesForGateway(ctx context.Context, obj client.Object) []reconcile.Request {
+func (r *Reconciler) listGatewaysAttachedByHTTPRoute(ctx context.Context, obj client.Object) []reconcile.Request {
 	logger := log.FromContext(ctx)
 
 	httpRoute, ok := obj.(*gatewayv1beta1.HTTPRoute)

--- a/controller/gateway/controller_watch.go
+++ b/controller/gateway/controller_watch.go
@@ -287,7 +287,7 @@ func (r *Reconciler) listHTTPRoutesForGateway(ctx context.Context, obj client.Ob
 		logger.Error(err, "Failed to list gateways in watch", "HTTPRoute", httpRoute.Name)
 		return nil
 	}
-	recs := []reconcile.Request{}
+	var recs []reconcile.Request
 	for _, gateway := range gateways.Items {
 		for _, parentRef := range httpRoute.Spec.ParentRefs {
 			if parentRef.Group != nil && string(*parentRef.Group) == gatewayv1.GroupName &&

--- a/controller/pkg/patch/patch.go
+++ b/controller/pkg/patch/patch.go
@@ -68,7 +68,8 @@ func ApplyGatewayStatusPatchIfNotEmpty(ctx context.Context,
 	cl client.Client,
 	logger logr.Logger,
 	existingGateway *gatewayv1.Gateway,
-	oldExistingGateway *gatewayv1.Gateway) (res op.CreatedUpdatedOrNoop, err error) {
+	oldExistingGateway *gatewayv1.Gateway,
+) (res op.CreatedUpdatedOrNoop, err error) {
 	// Check if the patch to be applied is empty.
 	patch := client.MergeFrom(oldExistingGateway)
 	b, err := patch.Data(existingGateway)
@@ -81,7 +82,7 @@ func ApplyGatewayStatusPatchIfNotEmpty(ctx context.Context,
 		return op.Noop, nil
 	}
 
-	if err := cl.Status().Patch(ctx, existingGateway, client.MergeFrom(oldExistingGateway)); err != nil {
+	if err := cl.Status().Patch(ctx, existingGateway, patch); err != nil {
 		return op.Noop, fmt.Errorf("failed patching gateway %s/%s: %w", existingGateway.Namespace, existingGateway.Name, err)
 	}
 	log.Debug(logger, "Resource modified", existingGateway)

--- a/internal/types/gatewaytypes.go
+++ b/internal/types/gatewaytypes.go
@@ -7,5 +7,26 @@ import (
 type (
 	Gateway              = gatewayv1.Gateway
 	GatewayAddress       = gatewayv1.GatewayAddress
+	GatewaySpec          = gatewayv1.GatewaySpec
 	GatewayStatusAddress = gatewayv1.GatewayStatusAddress
+	Listener             = gatewayv1.Listener
+	HTTPRoute            = gatewayv1.HTTPRoute
+	HTTPRouteSpec        = gatewayv1.HTTPRouteSpec
+	HTTPRouteList        = gatewayv1.HTTPRouteList
+	ParentReference      = gatewayv1.ParentReference
+	CommonRouteSpec      = gatewayv1.CommonRouteSpec
+	Kind                 = gatewayv1.Kind
+	Group                = gatewayv1.Group
+	AllowedRoutes        = gatewayv1.AllowedRoutes
+	RouteGroupKind       = gatewayv1.RouteGroupKind
+	RouteNamespaces      = gatewayv1.RouteNamespaces
+	ObjectName           = gatewayv1.ObjectName
+)
+
+const (
+	HTTPProtocolType = gatewayv1.HTTPProtocolType
+
+	NamespacesFromAll      = gatewayv1.NamespacesFromAll
+	NamespacesFromSame     = gatewayv1.NamespacesFromSame
+	NamespacesFromSelector = gatewayv1.NamespacesFromSelector
 )

--- a/pkg/utils/gateway/ownerrefs.go
+++ b/pkg/utils/gateway/ownerrefs.go
@@ -110,7 +110,7 @@ func ListHTTPRoutesForGateway(
 		return nil, fmt.Errorf("can't list HTTPRoutes for gateway: %w", err)
 	}
 
-	httpRoutes := make([]gwtypes.HTTPRoute, 0)
+	var httpRoutes []gwtypes.HTTPRoute
 	for _, httpRoute := range httpRoutesList.Items {
 		if !lo.ContainsBy(httpRoute.Spec.ParentRefs, func(parentRef gwtypes.ParentReference) bool {
 			gwGVK := gateway.GroupVersionKind()

--- a/pkg/utils/gateway/ownerrefs.go
+++ b/pkg/utils/gateway/ownerrefs.go
@@ -97,7 +97,7 @@ func ListHTTPRoutesForGateway(
 	opts ...client.ListOption,
 ) ([]gwtypes.HTTPRoute, error) {
 	if gateway.Namespace == "" {
-		return nil, fmt.Errorf("can't list HTTPRoutes for gateway: gateway resource was missing namespace")
+		return nil, fmt.Errorf("can't list HTTPRoutes for gateway: Gateway %s was missing namespace", gateway.Name)
 	}
 
 	var httpRoutesList gwtypes.HTTPRouteList

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -24,6 +24,7 @@ var skippedTests = []string{
 	// gateway
 	tests.GatewayInvalidTLSConfiguration.ShortName,
 	tests.GatewayModifyListeners.ShortName,
+	// TODO: https://github.com/Kong/gateway-operator/issues/56
 	tests.GatewayWithAttachedRoutes.ShortName,
 
 	// httproute


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for setting the correct `attachedRoutes` count in `Gateway`'s listeners status.

**Which issue this PR fixes**

Part of #56

**Special notes for your reviewer**:

`TestGatewayConformance/GatewayWithAttachedRoutes/Gateway_listener_should_have_AttachedRoutes_set_even_when_Gateway_has_unresolved_refs` fails because for some reason `HTTPRoute`'s status flips back and forth between 

```
[
    {
        "parents": [
            {
                "conditions": [
                    {
                        "lastTransitionTime": "2024-05-09T12:16:14Z",
                        "message": "",
                        "observedGeneration": 1,
                        "reason": "Accepted",
                        "status": "True",
                        "type": "Accepted"
                    },
                    {
                        "lastTransitionTime": "2024-05-09T12:16:14Z",
                        "message": "",
                        "observedGeneration": 1,
                        "reason": "BackendNotFound",
                        "status": "False",
                        "type": "ResolvedRefs"
                    },
                    {
                        "lastTransitionTime": "2024-05-09T12:16:14Z",
                        "message": "",
                        "observedGeneration": 1,
                        "reason": "Unknown",
                        "status": "Unknown",
                        "type": "Programmed"
                    }
                ],
                "controllerName": "konghq.com/gateway-operator-integration-tests",
                "parentRef": {
                    "group": "gateway.networking.k8s.io",
                    "kind": "Gateway",
                    "name": "unresolved-gateway-with-one-attached-unresolved-route",
                    "namespace": "gateway-conformance-infra",
                    "sectionName": "tls"
                }
            }
        ]
    }
]
```

and

```
[
    {
        "parents": []
    }
]
```

Which I couldn't reproduce outside of conformance tests with manifests from https://github.com/kubernetes-sigs/gateway-api/blob/8b7639171b5ae5007c8a7abd1796f02a053313cf/conformance/tests/gateway-with-attached-routes.yaml#L90-L132

Below, I attach the dump of logs and resources as retrieved from the cluster during the conformance tests run. It seems that we do not set the `ResolvedRefs` condition on the `Gateway` properly when the tls secret that's referenced by the listener does not exist. That should be resolved separately when working on HTTPS/TLS routes

```
    helpers.go:716: 2024-05-21T18:56:23.89174+02:00: Programmed condition set to Status True with Reason Programmed, expected Status False
    helpers.go:716: 2024-05-21T18:56:23.891786+02:00: Programmed was not in conditions list [[{Conflicted False 1 2024-05-21 18:56:23 +0200 CEST NoConflicts } {Accepted True 1 2024-05-21 18:56:23 +0200 CEST Accepted } {Programmed True 1 2024-05-21 18:56:23 +0200 CEST Programmed } {ResolvedRefs False 1 2024-05-21 18:56:23 +0200 CEST InvalidCertificateRef Referenced secret gateway-conformance-infra/does-not-exist does not exist.}]]
    helpers.go:716: 2024-05-21T18:56:23.891848+02:00: Expected Conditions to be [{Programmed False 0 0001-01-01 00:00:00 +0000 UTC  } {ResolvedRefs False 0 0001-01-01 00:00:00 +0000 UTC  }], got [{Conflicted False 1 2024-05-21 18:56:23 +0200 CEST NoConflicts } {Accepted True 1 2024-05-21 18:56:23 +0200 CEST Accepted } {Programmed True 1 2024-05-21 18:56:23 +0200 CEST Programmed } {ResolvedRefs False 1 2024-05-21 18:56:23 +0200 CEST InvalidCertificateRef Referenced secret gateway-conformance-infra/does-not-exist does not exist.}]
    gateway-with-attached-routes.go:119:
                Error Trace:    /Users/patryk.malek@konghq.com/.gvm/pkgsets/go1.22.3/global/pkg/mod/sigs.k8s.io/gateway-api@v1.1.0/conformance/utils/kubernetes/helpers.go:718
                                                        /Users/patryk.malek@konghq.com/.gvm/pkgsets/go1.22.3/global/pkg/mod/sigs.k8s.io/gateway-api@v1.1.0/conformance/tests/gateway-with-attached-routes.go:119
                Error:          Received unexpected error:
                                error fetching Gateway: client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline
                Test:           TestGatewayConformance/GatewayWithAttachedRoutes/Gateway_listener_should_have_AttachedRoutes_set_even_when_Gateway_has_unresolved_refs
                Messages:       error waiting for Gateway status to have listeners matching expectations
```

```
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  creationTimestamp: "2024-05-21T17:34:45Z"
  generation: 1
  name: http-route-4
  namespace: gateway-conformance-infra
  resourceVersion: "416722"
  uid: 7041ffee-3393-4936-8a15-c72edfb3620a
spec:
  parentRefs:
  - group: gateway.networking.k8s.io
    kind: Gateway
    name: unresolved-gateway-with-one-attached-unresolved-route
    namespace: gateway-conformance-infra
    sectionName: tls
  rules:
  - backendRefs:
    - group: ""
      kind: Service
      name: does-not-exist
      port: 8080
      weight: 1
    matches:
    - path:
        type: PathPrefix
        value: /
status:
  parents: []
---
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  creationTimestamp: "2024-05-21T17:34:45Z"
  finalizers:
  - gateway-operator.konghq.com/cleanup-controlplanes
  - gateway-operator.konghq.com/cleanup-dataplanes
  - gateway-operator.konghq.com/cleanup-network-policies
  generation: 1
  name: unresolved-gateway-with-one-attached-unresolved-route
  namespace: gateway-conformance-infra
  resourceVersion: "421522"
  uid: 4c7fa789-101e-4719-97fd-911d7ef4fd1f
spec:
  gatewayClassName: 2279a556-36e6-4fb5-a928-c67c0454263d
  listeners:
  - allowedRoutes:
      kinds:
      - group: gateway.networking.k8s.io
        kind: HTTPRoute
      namespaces:
        from: Selector
        selector:
          matchLabels:
            kubernetes.io/metadata.name: gateway-conformance-infra
    name: tls
    port: 443
    protocol: HTTPS
    tls:
      certificateRefs:
      - group: ""
        kind: Secret
        name: does-not-exist
      mode: Terminate
status:
  addresses:
  - type: IPAddress
    value: 172.18.128.6
  conditions:
  - lastTransitionTime: "2024-05-21T17:35:41Z"
    message: All listeners are accepted.
    observedGeneration: 1
    reason: Accepted
    status: "True"
    type: Accepted
  - lastTransitionTime: "2024-05-21T17:35:41Z"
    message: ""
    observedGeneration: 1
    reason: Programmed
    status: "True"
    type: Programmed
  - lastTransitionTime: "2024-05-21T17:35:41Z"
    message: ""
    observedGeneration: 1
    reason: Ready
    status: "True"
    type: DataPlaneReady
  - lastTransitionTime: "2024-05-21T17:35:41Z"
    message: ""
    observedGeneration: 1
    reason: Ready
    status: "True"
    type: ControlPlaneReady
  - lastTransitionTime: "2024-05-21T17:35:41Z"
    message: ""
    observedGeneration: 1
    reason: Ready
    status: "True"
    type: GatewayService
  listeners:
  - attachedRoutes: 1
    conditions:
    - lastTransitionTime: "2024-05-21T17:35:41Z"
      message: ""
      observedGeneration: 1
      reason: NoConflicts
      status: "False"
      type: Conflicted
    - lastTransitionTime: "2024-05-21T17:35:41Z"
      message: ""
      observedGeneration: 1
      reason: Accepted
      status: "True"
      type: Accepted
    - lastTransitionTime: "2024-05-21T17:35:41Z"
      message: ""
      observedGeneration: 1
      reason: Programmed
      status: "True"
      type: Programmed
    - lastTransitionTime: "2024-05-21T17:35:41Z"
      message: Referenced secret gateway-conformance-infra/does-not-exist does not
        exist.
      observedGeneration: 1
      reason: InvalidCertificateRef
      status: "False"
      type: ResolvedRefs
    name: tls
    supportedKinds:
    - group: gateway.networking.k8s.io
      kind: HTTPRoute
```

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
