### PR TITLE
ci: add GITHUB_TOKEN in e2e tests to prevent rate limiting when querying GitHub API

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -369,6 +369,7 @@ jobs:
       env:
         KONG_TEST_GATEWAY_OPERATOR_IMAGE_LOAD: gateway-operator:e2e-${{ github.sha }}
         GOTESTSUM_JUNITFILE: "e2e-tests.xml"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: upload diagnostics
       if: always()


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoid https://github.com/Kong/gateway-operator/actions/runs/9017365379/job/24775726082

```
    test_helm_install_upgrade.go:47: 
        	Error Trace:	/home/runner/work/gateway-operator/gateway-operator/test/e2e/environment.go:183
        	            				/home/runner/work/gateway-operator/gateway-operator/test/e2e/test_helm_install_upgrade.go:47
        	Error:      	Received unexpected error:
        	            	failed to deploy addon cert-manager: couldn't fetch latest jetstack/cert-manager release: GET https://api.github.com/repos/jetstack/cert-manager/releases/latest: 403 API rate limit exceeded for 4.236.120.25. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 36m19s]
        	Test:       	TestE2E/TestHelmUpgrade
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
