### PR TITLE
ci: add GITHUB_TOKEN in integration tests checking provisioning failed, to prevent rate limiting when querying GitHub API

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -319,6 +319,7 @@ jobs:
       env:
         KONG_CONTROLLER_OUT: stdout
         GOTESTSUM_JUNITFILE: integration-tests-provision-dataplane-fail.xml
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     
     - name: upload diagnostics
       if: always()


### PR DESCRIPTION
**What this PR does / why we need it**:

Same thing as in #252 but for `integration-tests-provision-fail` job on CI.

Prevents: https://github.com/Kong/gateway-operator/actions/runs/9017932716/job/24777420987?pr=251

```
INFO: no existing cluster found, deploying using Kubernetes In Docker (KIND)
ERROR: failed to deploy addon cert-manager: couldn't fetch latest jetstack/cert-manager release: GET https://api.github.com/repos/jetstack/cert-manager/releases/latest: 403 API rate limit exceeded for 13.88.99.128. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 51m29s]
 stack trace:
goroutine 1 [running]:
runtime/debug.Stack()
	/opt/hostedtoolcache/go/1.22.2/x[64](https://github.com/Kong/gateway-operator/actions/runs/9017932716/job/24777420987?pr=251#step:5:65)/src/runtime/debug/stack.go:24 +0x67
github.com/kong/gateway-operator/test/integration.TestMain.func1()
	/home/runner/work/gateway-operator/gateway-operator/test/integration/suite.go:111 +0x7b
panic({0x47ea040?, 0xc000d52a60?})
	/opt/hostedtoolcache/go/1.22.2/x64/src/runtime/panic.go:770 +0x132
github.com/kong/gateway-operator/test/integration.exitOnErr({0x5[65](https://github.com/Kong/gateway-operator/actions/runs/9017932716/job/24777420987?pr=251#step:5:66)2040, 0xc000d27b60})
	/home/runner/work/gateway-operator/gateway-operator/test/integration/suite.go:208 +0x14d
github.com/kong/gateway-operator/test/integration.TestMain(0xc000c7fa40, 0xc00006b330)
	/home/runner/work/gateway-operator/gateway-operator/test/integration/suite.go:138 +0x47f
github.com/kong/gateway-operator/test/integration_test.TestMain(0xc000c7fa40)
	/home/runner/work/gateway-operator/gateway-operator/test/integration/run_integration_test.go:28 +0x216
main.main()
	_testmain.go:85 +0x2f5

FAIL	github.com/kong/gateway-operator/test/integration	43.509s
```
