### PR TITLE
fix: cluster-wide resources do not use `ownerRef`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@
   `CONTROLLER_ADMISSION_WEBHOOK_LISTEN` environment variable and ensure that
   relevant webhook resources are not created/deleted.
   [#326](https://github.com/Kong/gateway-operator/pull/326)
+- The `OwnerReferences` on cluster-wide resources to indicate their owner are now
+  replaced by a proper set of labels to identify `kind`, `namespace`, and
+  `name` of the owning object.
+  [#259](https://github.com/Kong/gateway-operator/pull/259)
 
 ### Fixes
 

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -404,7 +404,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		log.Trace(logger, "deployment for ControlPlane not ready yet", controlplaneDeployment)
 		// Set Ready to false for controlplane as the underlying deployment is not ready.
 		k8sutils.SetCondition(
-			k8sutils.NewCondition(k8sutils.ReadyType, metav1.ConditionFalse, k8sutils.WaitingToBecomeReadyReason, k8sutils.WaitingToBecomeReadyMessage),
+			k8sutils.NewCondition(consts.ReadyType, metav1.ConditionFalse, consts.WaitingToBecomeReadyReason, consts.WaitingToBecomeReadyMessage),
 			cp,
 		)
 

--- a/controller/controlplane/controller_conditions.go
+++ b/controller/controlplane/controller_conditions.go
@@ -1,6 +1,6 @@
 package controlplane
 
-import k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
+import "github.com/kong/gateway-operator/pkg/consts"
 
 // -----------------------------------------------------------------------------
 // ControlPlane - Status Condition Types
@@ -10,7 +10,7 @@ const (
 	// ConditionTypeProvisioned is a condition type indicating whether or
 	// not all Deployments (or Daemonsets) for the ControlPlane have been provisioned
 	// successfully.
-	ConditionTypeProvisioned k8sutils.ConditionType = "Provisioned"
+	ConditionTypeProvisioned consts.ConditionType = "Provisioned"
 )
 
 // -----------------------------------------------------------------------------
@@ -23,13 +23,13 @@ type ConditionReason string
 const (
 	// ConditionReasonPodsNotReady is a reason which indicates why a ControlPlane
 	// has not yet reached a fully Provisioned status.
-	ConditionReasonPodsNotReady k8sutils.ConditionReason = "PodsNotReady"
+	ConditionReasonPodsNotReady consts.ConditionReason = "PodsNotReady"
 
 	// ConditionReasonPodsReady is a reason which indicates how a ControlPlane
 	// reached fully Provisioned status.
-	ConditionReasonPodsReady k8sutils.ConditionReason = "PodsReady"
+	ConditionReasonPodsReady consts.ConditionReason = "PodsReady"
 
 	// ControlPlaneConditionsReasonNoDataPlane is a reason which indicates that no DataPlane
 	// has been provisioned.
-	ConditionReasonNoDataPlane k8sutils.ConditionReason = "NoDataPlane"
+	ConditionReasonNoDataPlane consts.ConditionReason = "NoDataPlane"
 )

--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -40,9 +40,9 @@ const numReplicasWhenNoDataPlane = 0
 // -----------------------------------------------------------------------------
 
 func (r *Reconciler) ensureIsMarkedScheduled(
-	controlplane *operatorv1beta1.ControlPlane,
+	cp *operatorv1beta1.ControlPlane,
 ) bool {
-	_, present := k8sutils.GetCondition(ConditionTypeProvisioned, controlplane)
+	_, present := k8sutils.GetCondition(ConditionTypeProvisioned, cp)
 	if !present {
 		condition := k8sutils.NewCondition(
 			ConditionTypeProvisioned,
@@ -51,7 +51,7 @@ func (r *Reconciler) ensureIsMarkedScheduled(
 			"ControlPlane resource is scheduled for provisioning",
 		)
 
-		k8sutils.SetCondition(condition, controlplane)
+		k8sutils.SetCondition(condition, cp)
 		return true
 	}
 
@@ -62,11 +62,11 @@ func (r *Reconciler) ensureIsMarkedScheduled(
 // to carry on with the controlplane deployments reconciliation.
 // Information about the missing dataplane is stored in the controlplane status.
 func (r *Reconciler) ensureDataPlaneStatus(
-	controlplane *operatorv1beta1.ControlPlane,
+	cp *operatorv1beta1.ControlPlane,
 	dataplane *operatorv1beta1.DataPlane,
 ) (dataplaneIsSet bool) {
-	dataplaneIsSet = controlplane.Spec.DataPlane != nil && *controlplane.Spec.DataPlane == dataplane.Name
-	condition, present := k8sutils.GetCondition(ConditionTypeProvisioned, controlplane)
+	dataplaneIsSet = cp.Spec.DataPlane != nil && *cp.Spec.DataPlane == dataplane.Name
+	condition, present := k8sutils.GetCondition(ConditionTypeProvisioned, cp)
 
 	newCondition := k8sutils.NewCondition(
 		ConditionTypeProvisioned,
@@ -83,7 +83,7 @@ func (r *Reconciler) ensureDataPlaneStatus(
 		)
 	}
 	if !present || condition.Status != newCondition.Status || condition.Reason != newCondition.Reason {
-		k8sutils.SetCondition(newCondition, controlplane)
+		k8sutils.SetCondition(newCondition, cp)
 	}
 	return dataplaneIsSet
 }
@@ -94,16 +94,16 @@ func (r *Reconciler) ensureDataPlaneStatus(
 
 func (r *Reconciler) ensureDataPlaneConfiguration(
 	ctx context.Context,
-	controlplane *operatorv1beta1.ControlPlane,
+	cp *operatorv1beta1.ControlPlane,
 	dataplaneServiceName string,
 ) error {
 	changed := setControlPlaneEnvOnDataPlaneChange(
-		&controlplane.Spec.ControlPlaneOptions,
-		controlplane.Namespace,
+		&cp.Spec.ControlPlaneOptions,
+		cp.Namespace,
 		dataplaneServiceName,
 	)
 	if changed {
-		if err := r.Client.Update(ctx, controlplane); err != nil {
+		if err := r.Client.Update(ctx, cp); err != nil {
 			return fmt.Errorf("failed updating ControlPlane's DataPlane: %w", err)
 		}
 		return nil
@@ -247,13 +247,13 @@ func (r *Reconciler) ensureDeployment(
 
 func (r *Reconciler) ensureServiceAccount(
 	ctx context.Context,
-	controlplane *operatorv1beta1.ControlPlane,
+	cp *operatorv1beta1.ControlPlane,
 ) (createdOrModified bool, sa *corev1.ServiceAccount, err error) {
 	serviceAccounts, err := k8sutils.ListServiceAccountsForOwner(
 		ctx,
 		r.Client,
-		controlplane.Namespace,
-		controlplane.UID,
+		cp.Namespace,
+		cp.UID,
 		client.MatchingLabels{
 			consts.GatewayOperatorManagedByLabel: consts.ControlPlaneManagedLabelValue,
 		},
@@ -270,8 +270,8 @@ func (r *Reconciler) ensureServiceAccount(
 		return false, nil, errors.New("number of serviceAccounts reduced")
 	}
 
-	generatedServiceAccount := k8sresources.GenerateNewServiceAccountForControlPlane(controlplane.Namespace, controlplane.Name)
-	k8sutils.SetOwnerForObject(generatedServiceAccount, controlplane)
+	generatedServiceAccount := k8sresources.GenerateNewServiceAccountForControlPlane(cp.Namespace, cp.Name)
+	k8sutils.SetOwnerForObject(generatedServiceAccount, cp)
 
 	if count == 1 {
 		var updated bool
@@ -291,15 +291,12 @@ func (r *Reconciler) ensureServiceAccount(
 
 func (r *Reconciler) ensureClusterRole(
 	ctx context.Context,
-	controlplane *operatorv1beta1.ControlPlane,
+	cp *operatorv1beta1.ControlPlane,
 ) (createdOrUpdated bool, cr *rbacv1.ClusterRole, err error) {
-	clusterRoles, err := k8sutils.ListClusterRolesForOwner(
+	clusterRoles, err := k8sutils.ListClusterRoles(
 		ctx,
 		r.Client,
-		controlplane.UID,
-		client.MatchingLabels{
-			consts.GatewayOperatorManagedByLabel: consts.ControlPlaneManagedLabelValue,
-		},
+		client.MatchingLabels(k8sutils.GetManagedByLabelSet(cp)),
 	)
 	if err != nil {
 		return false, nil, err
@@ -313,12 +310,12 @@ func (r *Reconciler) ensureClusterRole(
 		return false, nil, errors.New("number of clusterRoles reduced")
 	}
 
-	controlplaneContainer := k8sutils.GetPodContainerByName(&controlplane.Spec.Deployment.PodTemplateSpec.Spec, consts.ControlPlaneControllerContainerName)
-	generated, err := k8sresources.GenerateNewClusterRoleForControlPlane(controlplane.Name, controlplaneContainer.Image, r.DevelopmentMode)
+	controlplaneContainer := k8sutils.GetPodContainerByName(&cp.Spec.Deployment.PodTemplateSpec.Spec, consts.ControlPlaneControllerContainerName)
+	generated, err := k8sresources.GenerateNewClusterRoleForControlPlane(cp.Name, controlplaneContainer.Image, r.DevelopmentMode)
 	if err != nil {
 		return false, nil, err
 	}
-	k8sutils.SetOwnerForObject(generated, controlplane)
+	k8sutils.SetOwnerForObjectThroughLabels(generated, cp)
 
 	if count == 1 {
 		var (
@@ -346,19 +343,16 @@ func (r *Reconciler) ensureClusterRole(
 
 func (r *Reconciler) ensureClusterRoleBinding(
 	ctx context.Context,
-	controlplane *operatorv1beta1.ControlPlane,
+	cp *operatorv1beta1.ControlPlane,
 	serviceAccountName string,
 	clusterRoleName string,
 ) (createdOrUpdate bool, crb *rbacv1.ClusterRoleBinding, err error) {
 	logger := log.GetLogger(ctx, "controlplane.ensureClusterRoleBinding", r.DevelopmentMode)
 
-	clusterRoleBindings, err := k8sutils.ListClusterRoleBindingsForOwner(
+	clusterRoleBindings, err := k8sutils.ListClusterRoleBindings(
 		ctx,
 		r.Client,
-		controlplane.UID,
-		client.MatchingLabels{
-			consts.GatewayOperatorManagedByLabel: consts.ControlPlaneManagedLabelValue,
-		},
+		client.MatchingLabels(k8sutils.GetManagedByLabelSet(cp)),
 	)
 	if err != nil {
 		return false, nil, err
@@ -372,8 +366,8 @@ func (r *Reconciler) ensureClusterRoleBinding(
 		return false, nil, errors.New("number of clusterRoleBindings reduced")
 	}
 
-	generated := k8sresources.GenerateNewClusterRoleBindingForControlPlane(controlplane.Namespace, controlplane.Name, serviceAccountName, clusterRoleName)
-	k8sutils.SetOwnerForObject(generated, controlplane)
+	generated := k8sresources.GenerateNewClusterRoleBindingForControlPlane(cp.Namespace, cp.Name, serviceAccountName, clusterRoleName)
+	k8sutils.SetOwnerForObjectThroughLabels(generated, cp)
 
 	if count == 1 {
 		existing := &clusterRoleBindings[0]
@@ -397,7 +391,7 @@ func (r *Reconciler) ensureClusterRoleBinding(
 		)
 		updated, existing.ObjectMeta = k8sutils.EnsureObjectMetaIsUpdated(existing.ObjectMeta, generated.ObjectMeta)
 
-		if !k8sresources.ClusterRoleBindingContainsServiceAccount(existing, controlplane.Namespace, serviceAccountName) {
+		if !k8sresources.ClusterRoleBindingContainsServiceAccount(existing, cp.Namespace, serviceAccountName) {
 			existing.Subjects = generated.Subjects
 			updatedServiceAccount = true
 		}
@@ -419,7 +413,7 @@ func (r *Reconciler) ensureClusterRoleBinding(
 // ControlPlane and the DataPlane.
 func (r *Reconciler) ensureAdminMTLSCertificateSecret(
 	ctx context.Context,
-	controlplane *operatorv1beta1.ControlPlane,
+	cp *operatorv1beta1.ControlPlane,
 ) (
 	op.Result,
 	*corev1.Secret,
@@ -436,8 +430,8 @@ func (r *Reconciler) ensureAdminMTLSCertificateSecret(
 	// this subject is arbitrary. data planes only care that client certificates are signed by the trusted CA, and will
 	// accept a certificate with any subject
 	return secrets.EnsureCertificate(ctx,
-		controlplane,
-		fmt.Sprintf("%s.%s", controlplane.Name, controlplane.Namespace),
+		cp,
+		fmt.Sprintf("%s.%s", cp.Name, cp.Namespace),
 		k8stypes.NamespacedName{
 			Namespace: r.ClusterCASecretNamespace,
 			Name:      r.ClusterCASecretName,
@@ -504,14 +498,11 @@ func (r *Reconciler) ensureAdmissionWebhookCertificateSecret(
 // returns nil if all of owned ClusterRoles successfully deleted (ok if no owned CRs or NotFound on deleting CRs).
 func (r *Reconciler) ensureOwnedClusterRolesDeleted(
 	ctx context.Context,
-	controlplane *operatorv1beta1.ControlPlane,
+	cp *operatorv1beta1.ControlPlane,
 ) (deletions bool, err error) {
-	clusterRoles, err := k8sutils.ListClusterRolesForOwner(
+	clusterRoles, err := k8sutils.ListClusterRoles(
 		ctx, r.Client,
-		controlplane.UID,
-		client.MatchingLabels{
-			consts.GatewayOperatorManagedByLabel: consts.ControlPlaneManagedLabelValue,
-		},
+		client.MatchingLabels(k8sutils.GetManagedByLabelSet(cp)),
 	)
 	if err != nil {
 		return false, err
@@ -537,14 +528,11 @@ func (r *Reconciler) ensureOwnedClusterRolesDeleted(
 // returns nil if all of owned ClusterRoleBindings successfully deleted (ok if no owned CRBs or NotFound on deleting CRBs).
 func (r *Reconciler) ensureOwnedClusterRoleBindingsDeleted(
 	ctx context.Context,
-	controlplane *operatorv1beta1.ControlPlane,
+	cp *operatorv1beta1.ControlPlane,
 ) (deletions bool, err error) {
-	clusterRoleBindings, err := k8sutils.ListClusterRoleBindingsForOwner(
+	clusterRoleBindings, err := k8sutils.ListClusterRoleBindings(
 		ctx, r.Client,
-		controlplane.UID,
-		client.MatchingLabels{
-			consts.GatewayOperatorManagedByLabel: consts.ControlPlaneManagedLabelValue,
-		},
+		client.MatchingLabels(k8sutils.GetManagedByLabelSet(cp)),
 	)
 	if err != nil {
 		return false, err
@@ -566,13 +554,10 @@ func (r *Reconciler) ensureOwnedClusterRoleBindingsDeleted(
 }
 
 func (r *Reconciler) ensureOwnedValidatingWebhookConfigurationDeleted(ctx context.Context, cp *operatorv1beta1.ControlPlane) (deletions bool, err error) {
-	validatingWebhookConfigurations, err := k8sutils.ListValidatingWebhookConfigurationsForOwner(
+	validatingWebhookConfigurations, err := k8sutils.ListValidatingWebhookConfigurations(
 		ctx,
 		r.Client,
-		cp.UID,
-		client.MatchingLabels{
-			consts.GatewayOperatorManagedByLabel: consts.ControlPlaneManagedLabelValue,
-		},
+		client.MatchingLabels(k8sutils.GetManagedByLabelSet(cp)),
 	)
 	if err != nil {
 		return false, fmt.Errorf("failed listing webhook configurations for owner: %w", err)
@@ -596,20 +581,20 @@ func (r *Reconciler) ensureAdmissionWebhookService(
 	ctx context.Context,
 	logger logr.Logger,
 	cl client.Client,
-	controlPlane *operatorv1beta1.ControlPlane,
+	cp *operatorv1beta1.ControlPlane,
 ) (op.Result, *corev1.Service, error) {
-	matchingLabels := k8sresources.GetManagedLabelForOwner(controlPlane)
+	matchingLabels := k8sresources.GetManagedLabelForOwner(cp)
 	matchingLabels[consts.ControlPlaneServiceLabel] = consts.ControlPlaneServiceKindWebhook
 
 	services, err := k8sutils.ListServicesForOwner(
 		ctx,
 		cl,
-		controlPlane.Namespace,
-		controlPlane.UID,
+		cp.Namespace,
+		cp.UID,
 		matchingLabels,
 	)
 	if err != nil {
-		return op.Noop, nil, fmt.Errorf("failed listing admission webhook Services for ControlPlane %s/%s: %w", controlPlane.Namespace, controlPlane.Name, err)
+		return op.Noop, nil, fmt.Errorf("failed listing admission webhook Services for ControlPlane %s/%s: %w", cp.Namespace, cp.Name, err)
 	}
 
 	if !isAdmissionWebhookEnabled(ctx, cl, logger, controlPlane) {
@@ -633,7 +618,7 @@ func (r *Reconciler) ensureAdmissionWebhookService(
 		return op.Noop, nil, errors.New("number of ControlPlane admission webhook Services reduced")
 	}
 
-	generatedService, err := k8sresources.GenerateNewAdmissionWebhookServiceForControlPlane(controlPlane)
+	generatedService, err := k8sresources.GenerateNewAdmissionWebhookServiceForControlPlane(cp)
 	if err != nil {
 		return op.Noop, nil, err
 	}
@@ -676,13 +661,10 @@ func (r *Reconciler) ensureValidatingWebhookConfiguration(
 ) (op.Result, error) {
 	logger := log.GetLogger(ctx, "controlplane.ensureValidatingWebhookConfiguration", r.DevelopmentMode)
 
-	validatingWebhookConfigurations, err := k8sutils.ListValidatingWebhookConfigurationsForOwner(
+	validatingWebhookConfigurations, err := k8sutils.ListValidatingWebhookConfigurations(
 		ctx,
 		r.Client,
-		cp.UID,
-		client.MatchingLabels{
-			consts.GatewayOperatorManagedByLabel: consts.ControlPlaneManagedLabelValue,
-		},
+		client.MatchingLabels(k8sutils.GetManagedByLabelSet(cp)),
 	)
 	if err != nil {
 		return op.Noop, err
@@ -733,7 +715,7 @@ func (r *Reconciler) ensureValidatingWebhookConfiguration(
 	if err != nil {
 		return op.Noop, fmt.Errorf("failed generating ControlPlane's ValidatingWebhookConfiguration: %w", err)
 	}
-	k8sutils.SetOwnerForObject(generatedWebhookConfiguration, cp)
+	k8sutils.SetOwnerForObjectThroughLabels(generatedWebhookConfiguration, cp)
 
 	if count == 1 {
 		var updated bool

--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -293,10 +293,7 @@ func (r *Reconciler) ensureClusterRole(
 	ctx context.Context,
 	cp *operatorv1beta1.ControlPlane,
 ) (createdOrUpdated bool, cr *rbacv1.ClusterRole, err error) {
-	managedByLabelSet, err := k8sutils.GetManagedByLabelSet(cp)
-	if err != nil {
-		return false, nil, err
-	}
+	managedByLabelSet := k8sutils.GetManagedByLabelSet(cp)
 	clusterRoles, err := k8sutils.ListClusterRoles(
 		ctx,
 		r.Client,
@@ -319,10 +316,7 @@ func (r *Reconciler) ensureClusterRole(
 	if err != nil {
 		return false, nil, err
 	}
-	err = k8sutils.SetOwnerForObjectThroughLabels(generated, cp)
-	if err != nil {
-		return false, nil, err
-	}
+	k8sutils.SetOwnerForObjectThroughLabels(generated, cp)
 
 	if count == 1 {
 		var (
@@ -356,10 +350,8 @@ func (r *Reconciler) ensureClusterRoleBinding(
 ) (createdOrUpdate bool, crb *rbacv1.ClusterRoleBinding, err error) {
 	logger := log.GetLogger(ctx, "controlplane.ensureClusterRoleBinding", r.DevelopmentMode)
 
-	managedByLabelSet, err := k8sutils.GetManagedByLabelSet(cp)
-	if err != nil {
-		return false, nil, err
-	}
+	managedByLabelSet := k8sutils.GetManagedByLabelSet(cp)
+
 	clusterRoleBindings, err := k8sutils.ListClusterRoleBindings(
 		ctx,
 		r.Client,
@@ -378,10 +370,7 @@ func (r *Reconciler) ensureClusterRoleBinding(
 	}
 
 	generated := k8sresources.GenerateNewClusterRoleBindingForControlPlane(cp.Namespace, cp.Name, serviceAccountName, clusterRoleName)
-	err = k8sutils.SetOwnerForObjectThroughLabels(generated, cp)
-	if err != nil {
-		return false, nil, err
-	}
+	k8sutils.SetOwnerForObjectThroughLabels(generated, cp)
 
 	if count == 1 {
 		existing := &clusterRoleBindings[0]
@@ -514,10 +503,8 @@ func (r *Reconciler) ensureOwnedClusterRolesDeleted(
 	ctx context.Context,
 	cp *operatorv1beta1.ControlPlane,
 ) (deletions bool, err error) {
-	managedByLabelSet, err := k8sutils.GetManagedByLabelSet(cp)
-	if err != nil {
-		return false, err
-	}
+	managedByLabelSet := k8sutils.GetManagedByLabelSet(cp)
+
 	clusterRoles, err := k8sutils.ListClusterRoles(
 		ctx, r.Client,
 		client.MatchingLabels(managedByLabelSet),
@@ -548,10 +535,8 @@ func (r *Reconciler) ensureOwnedClusterRoleBindingsDeleted(
 	ctx context.Context,
 	cp *operatorv1beta1.ControlPlane,
 ) (deletions bool, err error) {
-	managedByLabelSet, err := k8sutils.GetManagedByLabelSet(cp)
-	if err != nil {
-		return false, err
-	}
+	managedByLabelSet := k8sutils.GetManagedByLabelSet(cp)
+
 	clusterRoleBindings, err := k8sutils.ListClusterRoleBindings(
 		ctx, r.Client,
 		client.MatchingLabels(managedByLabelSet),
@@ -577,10 +562,8 @@ func (r *Reconciler) ensureOwnedClusterRoleBindingsDeleted(
 
 func (r *Reconciler) ensureOwnedValidatingWebhookConfigurationDeleted(ctx context.Context,
 	cp *operatorv1beta1.ControlPlane) (deletions bool, err error) {
-	managedByLabelSet, err := k8sutils.GetManagedByLabelSet(cp)
-	if err != nil {
-		return false, err
-	}
+	managedByLabelSet := k8sutils.GetManagedByLabelSet(cp)
+
 	validatingWebhookConfigurations, err := k8sutils.ListValidatingWebhookConfigurations(
 		ctx,
 		r.Client,
@@ -624,7 +607,7 @@ func (r *Reconciler) ensureAdmissionWebhookService(
 		return op.Noop, nil, fmt.Errorf("failed listing admission webhook Services for ControlPlane %s/%s: %w", cp.Namespace, cp.Name, err)
 	}
 
-	if !isAdmissionWebhookEnabled(ctx, cl, logger, controlPlane) {
+	if !isAdmissionWebhookEnabled(ctx, cl, logger, cp) {
 		for _, svc := range services {
 			svc := svc
 			if err := cl.Delete(ctx, &svc); err != nil && !k8serrors.IsNotFound(err) {
@@ -688,10 +671,8 @@ func (r *Reconciler) ensureValidatingWebhookConfiguration(
 ) (op.Result, error) {
 	logger := log.GetLogger(ctx, "controlplane.ensureValidatingWebhookConfiguration", r.DevelopmentMode)
 
-	managedByLabelSet, err := k8sutils.GetManagedByLabelSet(cp)
-	if err != nil {
-		return op.Noop, err
-	}
+	managedByLabelSet := k8sutils.GetManagedByLabelSet(cp)
+
 	validatingWebhookConfigurations, err := k8sutils.ListValidatingWebhookConfigurations(
 		ctx,
 		r.Client,
@@ -746,10 +727,7 @@ func (r *Reconciler) ensureValidatingWebhookConfiguration(
 	if err != nil {
 		return op.Noop, fmt.Errorf("failed generating ControlPlane's ValidatingWebhookConfiguration: %w", err)
 	}
-	err = k8sutils.SetOwnerForObjectThroughLabels(generatedWebhookConfiguration, cp)
-	if err != nil {
-		return op.Noop, err
-	}
+	k8sutils.SetOwnerForObjectThroughLabels(generatedWebhookConfiguration, cp)
 
 	if count == 1 {
 		var updated bool

--- a/controller/controlplane/controller_reconciler_utils_test.go
+++ b/controller/controlplane/controller_reconciler_utils_test.go
@@ -35,6 +35,9 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 		{
 			name: "creating validating webhook configuration",
 			cp: &operatorv1beta1.ControlPlane{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "ControlPlane",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cp",
 				},
@@ -98,6 +101,9 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 		{
 			name: "updating validating webhook configuration enforces ObjectMeta",
 			cp: &operatorv1beta1.ControlPlane{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "ControlPlane",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cp",
 				},

--- a/controller/controlplane/controller_test.go
+++ b/controller/controlplane/controller_test.go
@@ -139,7 +139,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 				Status: operatorv1beta1.DataPlaneStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:   string(k8sutils.ReadyType),
+							Type:   string(consts.ReadyType),
 							Status: metav1.ConditionTrue,
 						},
 					},
@@ -321,7 +321,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 				Status: operatorv1beta1.DataPlaneStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:   string(k8sutils.ReadyType),
+							Type:   string(consts.ReadyType),
 							Status: metav1.ConditionTrue,
 						},
 					},

--- a/controller/controlplane/controlplane_controller_reconciler_utils_test.go
+++ b/controller/controlplane/controlplane_controller_reconciler_utils_test.go
@@ -72,7 +72,8 @@ func TestEnsureClusterRole(t *testing.T) {
 		},
 	}
 
-	k8sutils.SetOwnerForObjectThroughLabels(clusterRole, &controlplane)
+	err = k8sutils.SetOwnerForObjectThroughLabels(clusterRole, &controlplane)
+	assert.NoError(t, err)
 
 	testCases := []struct {
 		Name                string
@@ -111,7 +112,8 @@ func TestEnsureClusterRole(t *testing.T) {
 		}
 
 		if tc.existingClusterRole != nil {
-			k8sutils.SetOwnerForObjectThroughLabels(tc.existingClusterRole, &tc.controlplane)
+			err = k8sutils.SetOwnerForObjectThroughLabels(tc.existingClusterRole, &tc.controlplane)
+			assert.NoError(t, err)
 			ObjectsToAdd = append(ObjectsToAdd, tc.existingClusterRole)
 		}
 
@@ -249,7 +251,8 @@ func TestEnsureClusterRoleBinding(t *testing.T) {
 			controlPlane,
 		}
 		for _, crb := range tc.existingCRBs {
-			k8sutils.SetOwnerForObjectThroughLabels(crb, controlPlane)
+			err := k8sutils.SetOwnerForObjectThroughLabels(crb, controlPlane)
+			assert.NoError(t, err)
 			objectsToAdd = append(objectsToAdd, crb)
 		}
 

--- a/controller/controlplane/controlplane_controller_reconciler_utils_test.go
+++ b/controller/controlplane/controlplane_controller_reconciler_utils_test.go
@@ -72,8 +72,7 @@ func TestEnsureClusterRole(t *testing.T) {
 		},
 	}
 
-	err = k8sutils.SetOwnerForObjectThroughLabels(clusterRole, &controlplane)
-	assert.NoError(t, err)
+	k8sutils.SetOwnerForObjectThroughLabels(clusterRole, &controlplane)
 
 	testCases := []struct {
 		Name                string
@@ -112,8 +111,7 @@ func TestEnsureClusterRole(t *testing.T) {
 		}
 
 		if tc.existingClusterRole != nil {
-			err = k8sutils.SetOwnerForObjectThroughLabels(tc.existingClusterRole, &tc.controlplane)
-			assert.NoError(t, err)
+			k8sutils.SetOwnerForObjectThroughLabels(tc.existingClusterRole, &tc.controlplane)
 			ObjectsToAdd = append(ObjectsToAdd, tc.existingClusterRole)
 		}
 
@@ -251,8 +249,7 @@ func TestEnsureClusterRoleBinding(t *testing.T) {
 			controlPlane,
 		}
 		for _, crb := range tc.existingCRBs {
-			err := k8sutils.SetOwnerForObjectThroughLabels(crb, controlPlane)
-			assert.NoError(t, err)
+			k8sutils.SetOwnerForObjectThroughLabels(crb, controlPlane)
 			objectsToAdd = append(objectsToAdd, crb)
 		}
 

--- a/controller/controlplane/status_conditions_test.go
+++ b/controller/controlplane/status_conditions_test.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	operatorv1beta1 "github.com/kong/gateway-operator/api/v1beta1"
+	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 )
 
@@ -57,7 +58,7 @@ func TestMarkAsProvisioned(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				dp := tc.controlplane()
 				markAsProvisioned(dp)
-				cond, ok := k8sutils.GetCondition(k8sutils.ConditionType(tc.expectedCondition.Type), dp)
+				cond, ok := k8sutils.GetCondition(consts.ConditionType(tc.expectedCondition.Type), dp)
 				require.True(t, ok)
 				assert.Equal(t, cond.Reason, tc.expectedCondition.Reason)
 				assert.Equal(t, cond.Status, tc.expectedCondition.Status)

--- a/controller/dataplane/bluegreen_controller.go
+++ b/controller/dataplane/bluegreen_controller.go
@@ -313,7 +313,7 @@ func (r *BlueGreenReconciler) ensureDataPlaneLiveReadyStatus(
 	logger logr.Logger,
 	dataplane *operatorv1beta1.DataPlane,
 ) (ctrl.Result, error) {
-	c, ok := k8sutils.GetCondition(k8sutils.ReadyType, dataplane)
+	c, ok := k8sutils.GetCondition(consts.ReadyType, dataplane)
 	if !ok {
 		// No Ready condition yet, it will be set by the DataPlane controller.
 		return ctrl.Result{}, nil
@@ -339,7 +339,7 @@ func shouldDelegateToDataPlaneController(
 	// - any other reason for rollout status condition "RolledOut" should not trigger
 	//   the delegation because that either means that we're waiting for the promotion,
 	//   we're in the process of promotion or the promotion failed.
-	cReady, okReady := k8sutils.GetCondition(k8sutils.ReadyType, dataplane)
+	cReady, okReady := k8sutils.GetCondition(consts.ReadyType, dataplane)
 	cRolledOut, okRolledOut := k8sutils.GetCondition(consts.DataPlaneConditionTypeRolledOut, dataplane.Status.RolloutStatus)
 	if okReady && okRolledOut &&
 		cReady.ObservedGeneration == cRolledOut.ObservedGeneration &&
@@ -492,7 +492,7 @@ func (r *BlueGreenReconciler) ensureDeploymentForDataPlane(
 	// If we're running the exact same Generation as "live" version is then:
 	// - the rollout resource plan is set to ScaleDownOnPromotionScaleUpOnRollout
 	//   then  scale down the Deployment to 0 replicas.
-	cReady, okReady := k8sutils.GetCondition(k8sutils.ReadyType, dataplane)
+	cReady, okReady := k8sutils.GetCondition(consts.ReadyType, dataplane)
 	cRolledOut, okRolledOut := k8sutils.GetCondition(consts.DataPlaneConditionTypeRolledOut, dataplane.Status.RolloutStatus)
 	if okReady && okRolledOut && cReady.ObservedGeneration == cRolledOut.ObservedGeneration {
 		dPlan := dataplane.Spec.Deployment.Rollout.Strategy.BlueGreen.Resources.Plan.Deployment
@@ -600,7 +600,7 @@ func (r *BlueGreenReconciler) ensureRolledOutCondition(
 	logger logr.Logger,
 	dataplane *operatorv1beta1.DataPlane,
 	status metav1.ConditionStatus,
-	reason k8sutils.ConditionReason,
+	reason consts.ConditionReason,
 	message string,
 ) error {
 	c, ok := k8sutils.GetCondition(consts.DataPlaneConditionTypeRolledOut, dataplane.Status.RolloutStatus)

--- a/controller/dataplane/bluegreen_controller_test.go
+++ b/controller/dataplane/bluegreen_controller_test.go
@@ -313,11 +313,11 @@ func TestDataPlaneBlueGreenReconciler_Reconcile(t *testing.T) {
 
 				t.Logf("DataPlane status should have the Ready status condition set to false")
 				require.Len(t, dp.Status.Conditions, 1)
-				require.EqualValues(t, dp.Status.Conditions[0].Type, k8sutils.ReadyType)
+				require.EqualValues(t, dp.Status.Conditions[0].Type, consts.ReadyType)
 				require.Equal(t, dp.Status.Conditions[0].Status, metav1.ConditionFalse,
 					"DataPlane's Ready status condition should be set to false when live Deployment has no Ready replicas",
 				)
-				require.EqualValues(t, dp.Status.Conditions[0].Reason, k8sutils.WaitingToBecomeReadyReason)
+				require.EqualValues(t, dp.Status.Conditions[0].Reason, consts.WaitingToBecomeReadyReason)
 
 				t.Logf("DataPlane rollout status should have the Ready status condition set to true")
 				require.NotNil(t, dp.Status.RolloutStatus)

--- a/controller/dataplane/controller_conditions.go
+++ b/controller/dataplane/controller_conditions.go
@@ -1,6 +1,6 @@
 package dataplane
 
-import k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
+import "github.com/kong/gateway-operator/pkg/consts"
 
 // -----------------------------------------------------------------------------
 // DataPlane - Status Condition Reasons
@@ -9,5 +9,5 @@ import k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 const (
 	// DataPlaneConditionValidationFailed is a reason which indicates validation of
 	// a dataplane is failed.
-	DataPlaneConditionValidationFailed k8sutils.ConditionReason = "ValidationFailed"
+	DataPlaneConditionValidationFailed consts.ConditionReason = "ValidationFailed"
 )

--- a/controller/dataplane/controller_reconciler_utils.go
+++ b/controller/dataplane/controller_reconciler_utils.go
@@ -15,6 +15,7 @@ import (
 	operatorv1beta1 "github.com/kong/gateway-operator/api/v1beta1"
 	"github.com/kong/gateway-operator/controller/pkg/address"
 	"github.com/kong/gateway-operator/controller/pkg/log"
+	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 )
 
@@ -90,10 +91,10 @@ func (r *Reconciler) ensureDataPlaneIsMarkedNotReady(
 	ctx context.Context,
 	log logr.Logger,
 	dataplane *operatorv1beta1.DataPlane,
-	reason k8sutils.ConditionReason, message string,
+	reason consts.ConditionReason, message string,
 ) error {
 	notReadyCondition := metav1.Condition{
-		Type:               string(k8sutils.ReadyType),
+		Type:               string(consts.ReadyType),
 		Status:             metav1.ConditionFalse,
 		Reason:             string(reason),
 		Message:            message,
@@ -105,7 +106,7 @@ func (r *Reconciler) ensureDataPlaneIsMarkedNotReady(
 	shouldUpdate := false
 	for i, condition := range dataplane.Status.Conditions {
 		// update the condition if condition has type `Ready`, and the condition is not the same.
-		if condition.Type == string(k8sutils.ReadyType) {
+		if condition.Type == string(consts.ReadyType) {
 			conditionFound = true
 			// update the slice if the condition is not the same as we expected.
 			if !isSameDataPlaneCondition(notReadyCondition, condition) {

--- a/controller/dataplane/controller_test.go
+++ b/controller/dataplane/controller_test.go
@@ -112,7 +112,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 				Status: operatorv1beta1.DataPlaneStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:   string(k8sutils.ReadyType),
+							Type:   string(consts.ReadyType),
 							Status: metav1.ConditionTrue,
 						},
 					},
@@ -230,7 +230,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 					Service: "svc-proxy-to-delete",
 					Conditions: []metav1.Condition{
 						{
-							Type:   string(k8sutils.ReadyType),
+							Type:   string(consts.ReadyType),
 							Status: metav1.ConditionTrue,
 						},
 					},
@@ -320,7 +320,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 				Status: operatorv1beta1.DataPlaneStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:   string(k8sutils.ReadyType),
+							Type:   string(consts.ReadyType),
 							Status: metav1.ConditionTrue,
 						},
 					},
@@ -438,7 +438,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 				Status: operatorv1beta1.DataPlaneStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:   string(k8sutils.ReadyType),
+							Type:   string(consts.ReadyType),
 							Status: metav1.ConditionTrue,
 						},
 					},
@@ -689,7 +689,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 				nn := types.NamespacedName{Namespace: "default", Name: "dataplane-kong"}
 				err = reconciler.Client.Get(ctx, nn, dp)
 				require.NoError(t, err)
-				c, ok := k8sutils.GetCondition(k8sutils.ReadyType, dp)
+				c, ok := k8sutils.GetCondition(consts.ReadyType, dp)
 				require.True(t, ok, "DataPlane should have a Ready condition set")
 				assert.Equal(t, c.Status, metav1.ConditionFalse, "DataPlane shouldn't be ready just yet")
 				assert.EqualValues(t, 0, dp.Status.ReadyReplicas)
@@ -706,7 +706,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 
 				err = reconciler.Client.Get(ctx, nn, dp)
 				require.NoError(t, err)
-				c, ok = k8sutils.GetCondition(k8sutils.ReadyType, dp)
+				c, ok = k8sutils.GetCondition(consts.ReadyType, dp)
 				require.True(t, ok, "DataPlane should have a Ready condition set")
 				assert.Equal(t, c.Status, metav1.ConditionTrue, "DataPlane should be ready at this point")
 				assert.EqualValues(t, 1, dp.Status.ReadyReplicas)
@@ -854,7 +854,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 				nn := types.NamespacedName{Namespace: "default", Name: "dataplane-kong"}
 				err = reconciler.Client.Get(ctx, nn, dp)
 				require.NoError(t, err)
-				c, ok := k8sutils.GetCondition(k8sutils.ReadyType, dp)
+				c, ok := k8sutils.GetCondition(consts.ReadyType, dp)
 				require.True(t, ok, "DataPlane should have a Ready condition set")
 				assert.Equal(t, c.Status, metav1.ConditionFalse, "DataPlane shouldn't be ready just yet")
 				assert.EqualValues(t, 0, dp.Status.ReadyReplicas)
@@ -871,7 +871,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 
 				err = reconciler.Client.Get(ctx, nn, dp)
 				require.NoError(t, err)
-				c, ok = k8sutils.GetCondition(k8sutils.ReadyType, dp)
+				c, ok = k8sutils.GetCondition(consts.ReadyType, dp)
 				require.True(t, ok, "DataPlane should have a Ready condition set")
 				assert.Equal(t, c.Status, metav1.ConditionTrue, "DataPlane should be ready at this point")
 				assert.Equal(t, c.ObservedGeneration, dp.Generation, "DataPlane Ready condition should have the same generation as the DataPlane")
@@ -894,7 +894,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 				require.NoError(t, err)
 
 				require.NoError(t, reconciler.Client.Get(ctx, nn, dp))
-				c, ok = k8sutils.GetCondition(k8sutils.ReadyType, dp)
+				c, ok = k8sutils.GetCondition(consts.ReadyType, dp)
 				require.True(t, ok, "DataPlane should have a Ready condition set")
 				assert.Equal(t, c.Status, metav1.ConditionTrue, "DataPlane should be ready at this point")
 				assert.Equal(t, c.ObservedGeneration, dp.Generation, "DataPlane Ready condition should have the same generation as the DataPlane")

--- a/controller/dataplane/controller_utils.go
+++ b/controller/dataplane/controller_utils.go
@@ -143,10 +143,10 @@ func ensureDataPlaneReadyStatus(
 		// Set Ready to false for dataplane as the underlying deployment is not ready.
 		k8sutils.SetCondition(
 			k8sutils.NewConditionWithGeneration(
-				k8sutils.ReadyType,
+				consts.ReadyType,
 				metav1.ConditionFalse,
-				k8sutils.WaitingToBecomeReadyReason,
-				k8sutils.WaitingToBecomeReadyMessage,
+				consts.WaitingToBecomeReadyReason,
+				consts.WaitingToBecomeReadyMessage,
 				generation,
 			),
 			dataplane,
@@ -177,10 +177,10 @@ func ensureDataPlaneReadyStatus(
 		// Set Ready to false for dataplane as the underlying deployment is not ready.
 		k8sutils.SetCondition(
 			k8sutils.NewConditionWithGeneration(
-				k8sutils.ReadyType,
+				consts.ReadyType,
 				metav1.ConditionFalse,
-				k8sutils.WaitingToBecomeReadyReason,
-				fmt.Sprintf("%s: Deployment %s is not ready yet", k8sutils.WaitingToBecomeReadyMessage, deployment.Name),
+				consts.WaitingToBecomeReadyReason,
+				fmt.Sprintf("%s: Deployment %s is not ready yet", consts.WaitingToBecomeReadyMessage, deployment.Name),
 				generation,
 			),
 			dataplane,
@@ -204,10 +204,10 @@ func ensureDataPlaneReadyStatus(
 		// Set Ready to false for dataplane as the Service is not ready yet.
 		k8sutils.SetCondition(
 			k8sutils.NewConditionWithGeneration(
-				k8sutils.ReadyType,
+				consts.ReadyType,
 				metav1.ConditionFalse,
-				k8sutils.WaitingToBecomeReadyReason,
-				k8sutils.WaitingToBecomeReadyMessage,
+				consts.WaitingToBecomeReadyReason,
+				consts.WaitingToBecomeReadyMessage,
 				generation,
 			),
 			dataplane,
@@ -233,10 +233,10 @@ func ensureDataPlaneReadyStatus(
 		// Set Ready to false for dataplane as the Service is not ready yet.
 		k8sutils.SetCondition(
 			k8sutils.NewConditionWithGeneration(
-				k8sutils.ReadyType,
+				consts.ReadyType,
 				metav1.ConditionFalse,
-				k8sutils.WaitingToBecomeReadyReason,
-				fmt.Sprintf("%s: ingress Service %s is not ready yet", k8sutils.WaitingToBecomeReadyMessage, ingressService.Name),
+				consts.WaitingToBecomeReadyReason,
+				fmt.Sprintf("%s: ingress Service %s is not ready yet", consts.WaitingToBecomeReadyMessage, ingressService.Name),
 				generation,
 			),
 			dataplane,

--- a/controller/dataplane/controller_utils_test.go
+++ b/controller/dataplane/controller_utils_test.go
@@ -103,10 +103,10 @@ func TestEnsureDataPlaneReadyStatus(t *testing.T) {
 			expectedDataPlaneStatus: operatorv1beta1.DataPlaneStatus{
 				Conditions: []metav1.Condition{
 					k8sutils.NewConditionWithGeneration(
-						k8sutils.ReadyType,
+						consts.ReadyType,
 						metav1.ConditionFalse,
-						k8sutils.WaitingToBecomeReadyReason,
-						fmt.Sprintf("%s: Deployment %s is not ready yet", k8sutils.WaitingToBecomeReadyMessage, "dataplane-deployment-1"),
+						consts.WaitingToBecomeReadyReason,
+						fmt.Sprintf("%s: Deployment %s is not ready yet", consts.WaitingToBecomeReadyMessage, "dataplane-deployment-1"),
 						102,
 					),
 				},
@@ -229,10 +229,10 @@ func TestEnsureDataPlaneReadyStatus(t *testing.T) {
 			expectedDataPlaneStatus: operatorv1beta1.DataPlaneStatus{
 				Conditions: []metav1.Condition{
 					k8sutils.NewConditionWithGeneration(
-						k8sutils.ReadyType,
+						consts.ReadyType,
 						metav1.ConditionFalse,
-						k8sutils.WaitingToBecomeReadyReason,
-						fmt.Sprintf("%s: ingress Service %s is not ready yet", k8sutils.WaitingToBecomeReadyMessage, "dataplane-service-1"),
+						consts.WaitingToBecomeReadyReason,
+						fmt.Sprintf("%s: ingress Service %s is not ready yet", consts.WaitingToBecomeReadyMessage, "dataplane-service-1"),
 						102,
 					),
 				},
@@ -359,7 +359,7 @@ func TestEnsureDataPlaneReadyStatus(t *testing.T) {
 			expectedDataPlaneStatus: operatorv1beta1.DataPlaneStatus{
 				Conditions: []metav1.Condition{
 					k8sutils.NewConditionWithGeneration(
-						k8sutils.ReadyType,
+						consts.ReadyType,
 						metav1.ConditionTrue,
 						"Ready",
 						"",

--- a/controller/gateway/controller_conditions.go
+++ b/controller/gateway/controller_conditions.go
@@ -1,7 +1,7 @@
 package gateway
 
 import (
-	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
+	consts "github.com/kong/gateway-operator/pkg/consts"
 )
 
 // -----------------------------------------------------------------------------
@@ -10,13 +10,13 @@ import (
 
 const (
 	// GatewayServiceType the Gateway service condition type
-	GatewayServiceType k8sutils.ConditionType = "GatewayService"
+	GatewayServiceType consts.ConditionType = "GatewayService"
 
 	// ControlPlaneReadyType the ControlPlane is deployed and Ready
-	ControlPlaneReadyType k8sutils.ConditionType = "ControlPlaneReady"
+	ControlPlaneReadyType consts.ConditionType = "ControlPlaneReady"
 
 	// DataPlaneReadyType the DataPlane is deployed and Ready
-	DataPlaneReadyType k8sutils.ConditionType = "DataPlaneReady"
+	DataPlaneReadyType consts.ConditionType = "DataPlaneReady"
 )
 
 // -----------------------------------------------------------------------------
@@ -26,10 +26,10 @@ const (
 const (
 	// GatewayReasonServiceError must be used with the GatewayService condition
 	// to express that the Gateway Service is not properly configured.
-	GatewayReasonServiceError k8sutils.ConditionReason = "GatewayServiceError"
+	GatewayReasonServiceError consts.ConditionReason = "GatewayServiceError"
 
 	// ListenerReasonTooManyTLSSecrets must be used with the ResolvedRefs condition
 	// to express that more than one TLS secret has been set in the listener
 	// TLS configuration.
-	ListenerReasonTooManyTLSSecrets k8sutils.ConditionReason = "TooManyTLSSecrets"
+	ListenerReasonTooManyTLSSecrets consts.ConditionReason = "TooManyTLSSecrets"
 )

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -545,7 +545,7 @@ func (g *gatewayConditionsAndListenersAwareT) initProgrammedAndListenersStatus()
 	k8sutils.InitProgrammed(g)
 	for i := range g.Spec.Listeners {
 		lStatus := listenerConditionsAware(&g.Status.Listeners[i])
-		_, ok := k8sutils.GetCondition(k8sutils.ConditionType(gatewayv1.ListenerConditionProgrammed), lStatus)
+		_, ok := k8sutils.GetCondition(consts.ConditionType(gatewayv1.ListenerConditionProgrammed), lStatus)
 		if !ok {
 			k8sutils.SetCondition(metav1.Condition{
 				Type:               string(gatewayv1.ListenerConditionProgrammed),
@@ -780,7 +780,7 @@ func (g *gatewayConditionsAndListenersAwareT) setProgrammed() {
 			LastTransitionTime: metav1.Now(),
 		}
 		listenerStatus := listenerConditionsAware(listener)
-		rCond, ok := k8sutils.GetCondition(k8sutils.ConditionType(gatewayv1.ListenerConditionResolvedRefs), listenerStatus)
+		rCond, ok := k8sutils.GetCondition(consts.ConditionType(gatewayv1.ListenerConditionResolvedRefs), listenerStatus)
 		if ok && rCond.Status == metav1.ConditionFalse {
 			programmedCondition.Status = metav1.ConditionFalse
 			programmedCondition.Reason = string(gatewayv1.ListenerReasonPending)
@@ -1050,8 +1050,8 @@ func parseKongListenEnv(str string) (kongListenConfig, error) {
 }
 
 func gatewayStatusNeedsUpdate(oldGateway, newGateway gatewayConditionsAndListenersAwareT) bool {
-	oldCondAccepted, okOld := k8sutils.GetCondition(k8sutils.ConditionType(gatewayv1.GatewayConditionAccepted), oldGateway)
-	newCondAccepted, _ := k8sutils.GetCondition(k8sutils.ConditionType(gatewayv1.GatewayConditionAccepted), newGateway)
+	oldCondAccepted, okOld := k8sutils.GetCondition(consts.ConditionType(gatewayv1.GatewayConditionAccepted), oldGateway)
+	newCondAccepted, _ := k8sutils.GetCondition(consts.ConditionType(gatewayv1.GatewayConditionAccepted), newGateway)
 
 	if !okOld || !areConditionsEqual(oldCondAccepted, newCondAccepted) {
 		return true

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -503,7 +503,7 @@ func TestSetAcceptedOnGateway(t *testing.T) {
 			}
 
 			k8sutils.SetAcceptedConditionOnGateway(gateway)
-			acceptedCondition, found := k8sutils.GetCondition(k8sutils.ConditionType(gatewayv1.GatewayConditionAccepted), gateway)
+			acceptedCondition, found := k8sutils.GetCondition(consts.ConditionType(gatewayv1.GatewayConditionAccepted), gateway)
 			require.True(t, found)
 			// force the lastTransitionTime to be equal to properly compare the two conditions
 			tc.expectedAcceptedCondition.LastTransitionTime = acceptedCondition.LastTransitionTime

--- a/controller/gateway/controller_test.go
+++ b/controller/gateway/controller_test.go
@@ -102,7 +102,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 					},
 					Status: operatorv1beta1.DataPlaneStatus{
 						Conditions: []metav1.Condition{
-							k8sutils.NewCondition(k8sutils.ReadyType, metav1.ConditionTrue, k8sutils.ResourceReadyReason, ""),
+							k8sutils.NewCondition(consts.ReadyType, metav1.ConditionTrue, consts.ResourceReadyReason, ""),
 						},
 					},
 				},
@@ -119,7 +119,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 					},
 					Status: operatorv1beta1.ControlPlaneStatus{
 						Conditions: []metav1.Condition{
-							k8sutils.NewCondition(k8sutils.ReadyType, metav1.ConditionTrue, k8sutils.ResourceReadyReason, ""),
+							k8sutils.NewCondition(consts.ReadyType, metav1.ConditionTrue, consts.ResourceReadyReason, ""),
 						},
 					},
 				},
@@ -185,7 +185,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 				condition, found := k8sutils.GetCondition(GatewayServiceType, gatewayConditionsAndListenersAware(&currentGateway))
 				require.True(t, found)
 				require.Equal(t, condition.Status, metav1.ConditionFalse)
-				require.Equal(t, k8sutils.ConditionReason(condition.Reason), GatewayReasonServiceError)
+				require.Equal(t, consts.ConditionReason(condition.Reason), GatewayReasonServiceError)
 				require.Len(t, currentGateway.Status.Addresses, 0)
 
 				t.Log("adding a ClusterIP to the dataplane service")
@@ -204,7 +204,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 				condition, found = k8sutils.GetCondition(GatewayServiceType, gatewayConditionsAndListenersAware(&currentGateway))
 				require.True(t, found)
 				require.Equal(t, condition.Status, metav1.ConditionTrue)
-				require.Equal(t, k8sutils.ConditionReason(condition.Reason), k8sutils.ResourceReadyReason)
+				require.Equal(t, consts.ConditionReason(condition.Reason), consts.ResourceReadyReason)
 				require.Equal(t,
 					[]gwtypes.GatewayStatusAddress{
 						{
@@ -238,7 +238,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 				condition, found = k8sutils.GetCondition(GatewayServiceType, gatewayConditionsAndListenersAware(&currentGateway))
 				require.True(t, found)
 				require.Equal(t, condition.Status, metav1.ConditionTrue)
-				require.Equal(t, k8sutils.ConditionReason(condition.Reason), k8sutils.ResourceReadyReason)
+				require.Equal(t, consts.ConditionReason(condition.Reason), consts.ResourceReadyReason)
 				require.Equal(t,
 					[]gwtypes.GatewayStatusAddress{
 						{
@@ -271,7 +271,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 				condition, found = k8sutils.GetCondition(GatewayServiceType, gatewayConditionsAndListenersAware(&currentGateway))
 				require.True(t, found)
 				require.Equal(t, condition.Status, metav1.ConditionTrue)
-				require.Equal(t, k8sutils.ConditionReason(condition.Reason), k8sutils.ResourceReadyReason)
+				require.Equal(t, consts.ConditionReason(condition.Reason), consts.ResourceReadyReason)
 				require.Equal(t, currentGateway.Status.Addresses, []gwtypes.GatewayStatusAddress{
 					{
 						Type:  lo.ToPtr(gatewayv1.HostnameAddressType),
@@ -293,7 +293,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 				condition, found = k8sutils.GetCondition(GatewayServiceType, gatewayConditionsAndListenersAware(&currentGateway))
 				require.True(t, found)
 				require.Equal(t, condition.Status, metav1.ConditionFalse)
-				require.Equal(t, k8sutils.ConditionReason(condition.Reason), GatewayReasonServiceError)
+				require.Equal(t, consts.ConditionReason(condition.Reason), GatewayReasonServiceError)
 				require.Len(t, currentGateway.Status.Addresses, 0)
 			},
 		},

--- a/internal/utils/gatewayclass/decorator.go
+++ b/internal/utils/gatewayclass/decorator.go
@@ -4,6 +4,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/pkg/vars"
 )
@@ -43,7 +44,7 @@ func DecorateGatewayClass(gwc *gatewayv1.GatewayClass) *Decorator {
 
 // IsAccepted returns true if the GatewayClass has been accepted by the operator.
 func (gwc *Decorator) IsAccepted() bool {
-	if cond, ok := k8sutils.GetCondition(k8sutils.ConditionType(gatewayv1.GatewayClassConditionStatusAccepted), gwc); ok {
+	if cond, ok := k8sutils.GetCondition(consts.ConditionType(gatewayv1.GatewayClassConditionStatusAccepted), gwc); ok {
 		return cond.Reason == string(gatewayv1.GatewayClassReasonAccepted) &&
 			cond.ObservedGeneration == gwc.Generation && cond.Status == metav1.ConditionTrue
 	}

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -76,9 +76,6 @@ const (
 
 	// CertPurposeLabel indicates the purpose of a certificate.
 	CertPurposeLabel = OperatorLabelPrefix + "cert-purpose"
-
-	// OwnerIDLabel indicates a resource's owner ID when references are not available.
-	OwnerIDLabel = OperatorLabelPrefix + "owner-id"
 )
 
 // -----------------------------------------------------------------------------

--- a/pkg/consts/dataplane_bluegreen_conditions.go
+++ b/pkg/consts/dataplane_bluegreen_conditions.go
@@ -1,11 +1,9 @@
 package consts
 
-import k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
-
 const (
 	// DataPlaneConditionTypeRolledOut is a condition type indicating whether or
 	// not, DataPlane's rollout has been successful or not.
-	DataPlaneConditionTypeRolledOut k8sutils.ConditionType = "RolledOut"
+	DataPlaneConditionTypeRolledOut ConditionType = "RolledOut"
 )
 
 const (
@@ -14,32 +12,32 @@ const (
 	// If this Reason is present and no automated rollout is disabled, user can
 	// use the preview services and deployment to inspect the state of those
 	// make a judgement call if the promotion should happen.
-	DataPlaneConditionReasonRolloutAwaitingPromotion k8sutils.ConditionReason = "AwaitingPromotion"
+	DataPlaneConditionReasonRolloutAwaitingPromotion ConditionReason = "AwaitingPromotion"
 
 	// DataPlaneConditionReasonRolloutFailed is a reason which indicates a DataPlane
 	// has failed to roll out. This may be caused for example by a Deployment or
 	// a Service failing to get created during a rollout.
-	DataPlaneConditionReasonRolloutFailed k8sutils.ConditionReason = "Failed"
+	DataPlaneConditionReasonRolloutFailed ConditionReason = "Failed"
 
 	// DataPlaneConditionReasonRolloutProgressing is a reason which indicates a DataPlane's
 	// new version is being rolled out.
-	DataPlaneConditionReasonRolloutProgressing k8sutils.ConditionReason = "Progressing"
+	DataPlaneConditionReasonRolloutProgressing ConditionReason = "Progressing"
 
 	// DataPlaneConditionReasonRolloutWaitingForChange is a reason which indicates a DataPlane
 	// is waiting for a change to trigger new version to be made available before promotion.
-	DataPlaneConditionReasonRolloutWaitingForChange k8sutils.ConditionReason = "WaitingForChange"
+	DataPlaneConditionReasonRolloutWaitingForChange ConditionReason = "WaitingForChange"
 
 	// DataPlaneConditionReasonRolloutPromotionInProgress is a reason which
 	// indicates that a promotion is in progress.
-	DataPlaneConditionReasonRolloutPromotionInProgress k8sutils.ConditionReason = "PromotionInProgress"
+	DataPlaneConditionReasonRolloutPromotionInProgress ConditionReason = "PromotionInProgress"
 
 	// DataPlaneConditionReasonRolloutPromotionFailed is a reason which indicates
 	// a DataPlane has failed to promote. This may be caused for example by
 	// a failure in updating a live Service.
-	DataPlaneConditionReasonRolloutPromotionFailed k8sutils.ConditionReason = "PromotionFailed"
+	DataPlaneConditionReasonRolloutPromotionFailed ConditionReason = "PromotionFailed"
 
 	// DataPlaneConditionReasonRolloutPromotionDone is a reason which indicates that a promotion is done.
-	DataPlaneConditionReasonRolloutPromotionDone k8sutils.ConditionReason = "PromotionDone"
+	DataPlaneConditionReasonRolloutPromotionDone ConditionReason = "PromotionDone"
 )
 
 const (

--- a/pkg/consts/status.go
+++ b/pkg/consts/status.go
@@ -1,0 +1,39 @@
+package consts
+
+// ConditionType literal that defines the different types of condition
+type ConditionType string
+
+// CoditionReason literal to enumerate a specific condition reason
+type ConditionReason string
+
+const (
+	// ReadyType indicates if the resource has all the dependent conditions Ready
+	ReadyType ConditionType = "Ready"
+
+	// DependenciesNotReadyReason is a generic reason describing that the other Conditions are not true
+	DependenciesNotReadyReason ConditionReason = "DependenciesNotReady"
+
+	// ResourceReadyReason indicates the resource is ready
+	ResourceReadyReason ConditionReason = ConditionReason("Ready")
+
+	// WaitingToBecomeReadyReason generic message for dependent resources waiting to be ready
+	WaitingToBecomeReadyReason ConditionReason = "WaitingToBecomeReady"
+
+	// ResourceCreatedOrUpdatedReason generic message for missing or outdated resources
+	ResourceCreatedOrUpdatedReason ConditionReason = "ResourceCreatedOrUpdated"
+
+	// UnableToProvisionReason generic message for unexpected errors
+	UnableToProvisionReason ConditionReason = "UnableToProvision"
+
+	// DependenciesNotReadyMessage indicates the other conditions are not yet ready
+	DependenciesNotReadyMessage = "There are other conditions that are not yet ready"
+
+	// WaitingToBecomeReadyMessage indicates the target resource is not ready
+	WaitingToBecomeReadyMessage = "Waiting for the resource to become ready"
+
+	// ResourceCreatedMessage indicates a missing resource was provisioned
+	ResourceCreatedMessage = "Resource has been created"
+
+	// ResourceUpdatedMessage indicates a resource was updated
+	ResourceUpdatedMessage = "Resource has been updated"
+)

--- a/pkg/utils/kubernetes/lists.go
+++ b/pkg/utils/kubernetes/lists.go
@@ -152,13 +152,11 @@ func ListServiceAccountsForOwner(
 	return serviceAccounts, nil
 }
 
-// ListClusterRolesForOwner is a helper function to map a list of ClusterRoles
-// by list options and reduce by OwnerReference UID to efficiently
-// list only the objects owned by the provided UID.
-func ListClusterRolesForOwner(
+// ListClusterRoles is a helper function to map a list of ClusterRoles
+// by list options.
+func ListClusterRoles(
 	ctx context.Context,
 	c client.Client,
-	uid types.UID,
 	listOpts ...client.ListOption,
 ) ([]rbacv1.ClusterRole, error) {
 	clusterRoleList := &rbacv1.ClusterRoleList{}
@@ -172,24 +170,14 @@ func ListClusterRolesForOwner(
 		return nil, err
 	}
 
-	clusterRoles := make([]rbacv1.ClusterRole, 0)
-	for _, clusterRole := range clusterRoleList.Items {
-		clusterRole := clusterRole
-		if IsOwnedByRefUID(&clusterRole, uid) {
-			clusterRoles = append(clusterRoles, clusterRole)
-		}
-	}
-
-	return clusterRoles, nil
+	return clusterRoleList.Items, nil
 }
 
-// ListClusterRoleBindingsForOwner is a helper function to map a list of ClusterRoleBindings
-// by list options and reduce by OwnerReference UID to efficiently
-// list only the objects owned by the provided UID.
-func ListClusterRoleBindingsForOwner(
+// ListClusterRoleBindings is a helper function to map a list of ClusterRoleBindings
+// by list options.
+func ListClusterRoleBindings(
 	ctx context.Context,
 	c client.Client,
-	uid types.UID,
 	listOpts ...client.ListOption,
 ) ([]rbacv1.ClusterRoleBinding, error) {
 	clusterRoleBindingList := &rbacv1.ClusterRoleBindingList{}
@@ -203,15 +191,7 @@ func ListClusterRoleBindingsForOwner(
 		return nil, err
 	}
 
-	clusterRoleBindings := make([]rbacv1.ClusterRoleBinding, 0)
-	for _, clusterRoleBinding := range clusterRoleBindingList.Items {
-		clusterRoleBinding := clusterRoleBinding
-		if IsOwnedByRefUID(&clusterRoleBinding, uid) {
-			clusterRoleBindings = append(clusterRoleBindings, clusterRoleBinding)
-		}
-	}
-
-	return clusterRoleBindings, nil
+	return clusterRoleBindingList.Items, nil
 }
 
 // ListSecretsForOwner is a helper function to map a list of Secrets
@@ -244,12 +224,11 @@ func ListSecretsForOwner(ctx context.Context,
 	return secrets, nil
 }
 
-// ListValidatingWebhookConfigurationsForOwner is a helper function to map a list of ValidatingWebhookConfiguration
-// by list options and reduce by OwnerReference UID to efficiently list only the objects owned by the provided UID.
-func ListValidatingWebhookConfigurationsForOwner(
+// ListValidatingWebhookConfigurations is a helper function to map a list of ValidatingWebhookConfiguration
+// by list options.
+func ListValidatingWebhookConfigurations(
 	ctx context.Context,
 	c client.Client,
-	uid types.UID,
 	listOpts ...client.ListOption,
 ) ([]admregv1.ValidatingWebhookConfiguration, error) {
 	cfgList := &admregv1.ValidatingWebhookConfigurationList{}
@@ -262,13 +241,5 @@ func ListValidatingWebhookConfigurationsForOwner(
 		return nil, err
 	}
 
-	var webhookConfigurations []admregv1.ValidatingWebhookConfiguration
-	for _, cfg := range cfgList.Items {
-		cfg := cfg
-		if IsOwnedByRefUID(&cfg, uid) {
-			webhookConfigurations = append(webhookConfigurations, cfg)
-		}
-	}
-
-	return webhookConfigurations, nil
+	return cfgList.Items, nil
 }

--- a/pkg/utils/kubernetes/lists.go
+++ b/pkg/utils/kubernetes/lists.go
@@ -12,8 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ListDeploymentsForOwner is a helper function to map a list of Deployments
-// by list options and reduce by OwnerReference UID and namespace to efficiently
+// ListDeploymentsForOwner which gets a list of Deployments using the provided
+// list options and reduce by OwnerReference UID and namespace to efficiently
 // list only the objects owned by the provided UID.
 func ListDeploymentsForOwner(
 	ctx context.Context,
@@ -47,8 +47,8 @@ func ListDeploymentsForOwner(
 	return deployments, nil
 }
 
-// ListHPAsForOwner is a helper function to map a list of HorizontalPodAutoscalers
-// by list options and reduce by OwnerReference UID and namespace to efficiently
+// ListHPAsForOwner is a helper function which gets a list of HorizontalPodAutoscalers
+// using the provided list options and reduce by OwnerReference UID and namespace to efficiently
 // list only the objects owned by the provided UID.
 func ListHPAsForOwner(
 	ctx context.Context,
@@ -82,8 +82,8 @@ func ListHPAsForOwner(
 	return hpas, nil
 }
 
-// ListServicesForOwner is a helper function to map a list of Services
-// by list options and reduce by OwnerReference UID and namespace to efficiently
+// ListServicesForOwner is a helper function which gets a list of Services
+// using the provided list options and reduce by OwnerReference UID and namespace to efficiently
 // list only the objects owned by the provided UID.
 func ListServicesForOwner(
 	ctx context.Context,
@@ -117,8 +117,8 @@ func ListServicesForOwner(
 	return services, nil
 }
 
-// ListServiceAccountsForOwner is a helper function to map a list of ServiceAccounts
-// by list options and reduce by OwnerReference UID and namespace to efficiently
+// ListServiceAccountsForOwner is a helper function which gets a list of ServiceAccounts
+// using the provided list options and reduce by OwnerReference UID and namespace to efficiently
 // list only the objects owned by the provided UID.
 func ListServiceAccountsForOwner(
 	ctx context.Context,
@@ -152,8 +152,8 @@ func ListServiceAccountsForOwner(
 	return serviceAccounts, nil
 }
 
-// ListClusterRoles is a helper function to map a list of ClusterRoles
-// by list options.
+// ListClusterRoles is a helper function which gets a list of ClusterRoles
+// using the provided list options.
 func ListClusterRoles(
 	ctx context.Context,
 	c client.Client,
@@ -173,8 +173,8 @@ func ListClusterRoles(
 	return clusterRoleList.Items, nil
 }
 
-// ListClusterRoleBindings is a helper function to map a list of ClusterRoleBindings
-// by list options.
+// ListClusterRoleBindings is a helper function which gets a list of ClusterRoleBindings
+// using the provided list options.
 func ListClusterRoleBindings(
 	ctx context.Context,
 	c client.Client,
@@ -194,8 +194,8 @@ func ListClusterRoleBindings(
 	return clusterRoleBindingList.Items, nil
 }
 
-// ListSecretsForOwner is a helper function to map a list of Secrets
-// by list options and reduce by OwnerReference UID to efficiently
+// ListSecretsForOwner is a helper function which gets a list of Secrets
+// using the provided list options and reduce by OwnerReference UID to efficiently
 // list only the objects owned by the provided UID.
 func ListSecretsForOwner(ctx context.Context,
 	c client.Client,
@@ -224,8 +224,8 @@ func ListSecretsForOwner(ctx context.Context,
 	return secrets, nil
 }
 
-// ListValidatingWebhookConfigurations is a helper function to map a list of ValidatingWebhookConfiguration
-// by list options.
+// ListValidatingWebhookConfigurations is a helper function that gets a list of ValidatingWebhookConfiguration
+// using the provided list options.
 func ListValidatingWebhookConfigurations(
 	ctx context.Context,
 	c client.Client,

--- a/pkg/utils/kubernetes/lists_test.go
+++ b/pkg/utils/kubernetes/lists_test.go
@@ -8,9 +8,10 @@ import (
 	admregv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 )
 
@@ -19,7 +20,6 @@ func TestListValidatingWebhookConfigurationsForOwner(t *testing.T) {
 	testCases := []struct {
 		name          string
 		objects       []runtime.Object
-		ownerUID      types.UID
 		expectedCount int
 	}{
 		{
@@ -27,48 +27,42 @@ func TestListValidatingWebhookConfigurationsForOwner(t *testing.T) {
 			expectedCount: 0,
 		},
 		{
-			name:     "multiple objects, one owned by uid, one not",
-			ownerUID: types.UID("owner"),
+			name: "multiple objects, one owned by uid, one not",
 			objects: []runtime.Object{
 				&admregv1.ValidatingWebhookConfiguration{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "owned",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								UID: "owner",
-							},
+						Labels: map[string]string{
+							consts.GatewayOperatorManagedByNameLabel: "owner",
 						},
 					},
 				},
 				&admregv1.ValidatingWebhookConfiguration{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "not-owned",
+						Labels: map[string]string{
+							consts.GatewayOperatorManagedByNameLabel: "not-owned",
+						},
 					},
 				},
 			},
 			expectedCount: 1,
 		},
 		{
-			name:     "multiple objects, one owned by uid, one by another",
-			ownerUID: types.UID("owner"),
+			name: "multiple objects, one owned by uid, one by another",
 			objects: []runtime.Object{
 				&admregv1.ValidatingWebhookConfiguration{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "owned",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								UID: "owner",
-							},
+						Labels: map[string]string{
+							consts.GatewayOperatorManagedByNameLabel: "owner",
 						},
 					},
 				},
 				&admregv1.ValidatingWebhookConfiguration{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "not-owned",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								UID: "another-owner",
-							},
+						Labels: map[string]string{
+							consts.GatewayOperatorManagedByNameLabel: "another-owner",
 						},
 					},
 				},
@@ -79,8 +73,13 @@ func TestListValidatingWebhookConfigurationsForOwner(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			client := fake.NewFakeClient(tc.objects...)
-			ownedCfgs, err := k8sutils.ListValidatingWebhookConfigurationsForOwner(ctx, client, tc.ownerUID)
+			c := fake.NewFakeClient(tc.objects...)
+			ownedCfgs, err := k8sutils.ListValidatingWebhookConfigurations(ctx,
+				c,
+				client.MatchingLabels{
+					consts.GatewayOperatorManagedByNameLabel: "owner",
+				},
+			)
 			require.NoError(t, err)
 			require.Len(t, ownedCfgs, tc.expectedCount)
 		})

--- a/pkg/utils/kubernetes/ownerrefs.go
+++ b/pkg/utils/kubernetes/ownerrefs.go
@@ -5,6 +5,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/gateway-operator/pkg/consts"
 )
 
 // -----------------------------------------------------------------------------
@@ -35,6 +37,24 @@ func SetOwnerForObject(obj, owner client.Object) {
 	}
 	if !foundOwnerRef {
 		obj.SetOwnerReferences(append(obj.GetOwnerReferences(), GenerateOwnerReferenceForObject(owner)))
+	}
+}
+
+// SetOwnerForObjectThroughLabels sets the owner of the provided object through a label.
+func SetOwnerForObjectThroughLabels(obj, owner client.Object) {
+	labels := obj.GetLabels()
+	for k, v := range GetManagedByLabelSet(owner) {
+		labels[k] = v
+	}
+	obj.SetLabels(labels)
+}
+
+// GetManagedByLabelSet returns a map of labels with the managing object's metadata.
+func GetManagedByLabelSet(obj client.Object) map[string]string {
+	return map[string]string{
+		consts.GatewayOperatorManagedByLabel:          obj.GetObjectKind().GroupVersionKind().GroupKind().String(),
+		consts.GatewayOperatorManagedByNamespaceLabel: obj.GetNamespace(),
+		consts.GatewayOperatorManagedByNameLabel:      obj.GetName(),
 	}
 }
 

--- a/pkg/utils/kubernetes/owners.go
+++ b/pkg/utils/kubernetes/owners.go
@@ -42,8 +42,8 @@ func SetOwnerForObject(obj, owner client.Object) {
 	}
 }
 
-// managingObjectT is an interface that is used to represent a managing object.
-// managingObjects can be of type Gateway, ControlPlane, or DataPlane.
+// managingObjectT is type constraint that is used to represent a managing object.
+// Currently it can be one of: Gateway, ControlPlane, or DataPlane.
 type managingObjectT interface {
 	client.Object
 

--- a/pkg/utils/kubernetes/owners_test.go
+++ b/pkg/utils/kubernetes/owners_test.go
@@ -1,0 +1,43 @@
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1beta1 "github.com/kong/gateway-operator/api/v1beta1"
+	"github.com/kong/gateway-operator/pkg/consts"
+)
+
+func TestGetManagedByLabelSet(t *testing.T) {
+	testCases := []struct {
+		name     string
+		object   *operatorv1beta1.ControlPlane
+		expected map[string]string
+	}{
+		{
+			name: "Complete set of labels for a ControlPlane object",
+			object: &operatorv1beta1.ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test-namespace",
+				},
+			},
+			expected: map[string]string{
+				consts.GatewayOperatorManagedByLabel:          consts.ControlPlaneManagedLabelValue,
+				consts.GatewayOperatorManagedByNamespaceLabel: "test-namespace",
+				consts.GatewayOperatorManagedByNameLabel:      "test",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := GetManagedByLabelSet(tc.object)
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("Unexpected result. Got: %v, want: %v", result, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/utils/kubernetes/status.go
+++ b/pkg/utils/kubernetes/status.go
@@ -5,44 +5,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-)
 
-// ConditionType literal that defines the different types of condition
-type ConditionType string
-
-// CoditionReason literal to enumerate a specific condition reason
-type ConditionReason string
-
-const (
-	// ReadyType indicates if the resource has all the dependent conditions Ready
-	ReadyType ConditionType = "Ready"
-
-	// DependenciesNotReadyReason is a generic reason describing that the other Conditions are not true
-	DependenciesNotReadyReason ConditionReason = "DependenciesNotReady"
-
-	// ResourceReadyReason indicates the resource is ready
-	ResourceReadyReason ConditionReason = ConditionReason("Ready")
-
-	// WaitingToBecomeReadyReason generic message for dependent resources waiting to be ready
-	WaitingToBecomeReadyReason ConditionReason = "WaitingToBecomeReady"
-
-	// ResourceCreatedOrUpdatedReason generic message for missing or outdated resources
-	ResourceCreatedOrUpdatedReason ConditionReason = "ResourceCreatedOrUpdated"
-
-	// UnableToProvisionReason generic message for unexpected errors
-	UnableToProvisionReason ConditionReason = "UnableToProvision"
-
-	// DependenciesNotReadyMessage indicates the other conditions are not yet ready
-	DependenciesNotReadyMessage = "There are other conditions that are not yet ready"
-
-	// WaitingToBecomeReadyMessage indicates the target resource is not ready
-	WaitingToBecomeReadyMessage = "Waiting for the resource to become ready"
-
-	// ResourceCreatedMessage indicates a missing resource was provisioned
-	ResourceCreatedMessage = "Resource has been created"
-
-	// ResourceUpdatedMessage indicates a resource was updated
-	ResourceUpdatedMessage = "Resource has been updated"
+	"github.com/kong/gateway-operator/pkg/consts"
 )
 
 // ConditionsAndListenerConditionsAndGenerationAware is a CRD type that has Conditions, Generation, and Listener
@@ -92,7 +56,7 @@ func SetCondition(condition metav1.Condition, resource ConditionsAware) {
 }
 
 // GetCondition returns the condition with the given type, if it exists. If the condition does not exists it returns false.
-func GetCondition(cType ConditionType, resource ConditionsAware) (metav1.Condition, bool) {
+func GetCondition(cType consts.ConditionType, resource ConditionsAware) (metav1.Condition, bool) {
 	for _, condition := range resource.GetConditions() {
 		if condition.Type == string(cType) {
 			return condition, true
@@ -102,7 +66,7 @@ func GetCondition(cType ConditionType, resource ConditionsAware) (metav1.Conditi
 }
 
 // IsConditionTrue returns a true value whether the condition is ConditionTrue, false otherwise
-func IsConditionTrue(cType ConditionType, resource ConditionsAware) bool {
+func IsConditionTrue(cType consts.ConditionType, resource ConditionsAware) bool {
 	for _, condition := range resource.GetConditions() {
 		if condition.Type == string(cType) {
 			return condition.Status == metav1.ConditionTrue
@@ -114,12 +78,12 @@ func IsConditionTrue(cType ConditionType, resource ConditionsAware) bool {
 // InitReady initializes the Ready status to False if Ready condition is not
 // yet set on the resource.
 func InitReady(resource ConditionsAndGenerationAware) bool {
-	_, ok := GetCondition(ReadyType, resource)
+	_, ok := GetCondition(consts.ReadyType, resource)
 	if ok {
 		return false
 	}
 	SetCondition(
-		NewConditionWithGeneration(ReadyType, metav1.ConditionFalse, DependenciesNotReadyReason, DependenciesNotReadyMessage, resource.GetGeneration()),
+		NewConditionWithGeneration(consts.ReadyType, metav1.ConditionFalse, consts.DependenciesNotReadyReason, consts.DependenciesNotReadyMessage, resource.GetGeneration()),
 		resource,
 	)
 	return true
@@ -127,25 +91,25 @@ func InitReady(resource ConditionsAndGenerationAware) bool {
 
 // InitProgrammed initializes the Programmed status to False
 func InitProgrammed(resource ConditionsAware) {
-	SetCondition(NewCondition(ConditionType(gatewayv1.GatewayConditionProgrammed), metav1.ConditionFalse, ConditionReason(gatewayv1.GatewayReasonPending), DependenciesNotReadyMessage), resource)
+	SetCondition(NewCondition(consts.ConditionType(gatewayv1.GatewayConditionProgrammed), metav1.ConditionFalse, consts.ConditionReason(gatewayv1.GatewayReasonPending), consts.DependenciesNotReadyMessage), resource)
 }
 
 // SetReadyWithGeneration sets the Ready status to True if all the other conditions are True.
 // It uses the provided generation to set the ObservedGeneration field.
 func SetReadyWithGeneration(resource ConditionsAndGenerationAware, generation int64) {
 	ready := metav1.Condition{
-		Type:               string(ReadyType),
+		Type:               string(consts.ReadyType),
 		LastTransitionTime: metav1.Now(),
 		ObservedGeneration: generation,
 	}
 
 	if areAllConditionsHaveTrueStatus(resource) {
 		ready.Status = metav1.ConditionTrue
-		ready.Reason = string(ResourceReadyReason)
+		ready.Reason = string(consts.ResourceReadyReason)
 	} else {
 		ready.Status = metav1.ConditionFalse
-		ready.Reason = string(DependenciesNotReadyReason)
-		ready.Message = DependenciesNotReadyMessage
+		ready.Reason = string(consts.DependenciesNotReadyReason)
+		ready.Message = consts.DependenciesNotReadyMessage
 	}
 	SetCondition(ready, resource)
 }
@@ -168,8 +132,8 @@ func SetProgrammed(resource ConditionsAndGenerationAware) {
 		programmed.Reason = string(gatewayv1.GatewayReasonProgrammed)
 	} else {
 		programmed.Status = metav1.ConditionFalse
-		programmed.Reason = string(DependenciesNotReadyReason)
-		programmed.Message = DependenciesNotReadyMessage
+		programmed.Reason = string(consts.DependenciesNotReadyReason)
+		programmed.Message = consts.DependenciesNotReadyMessage
 	}
 	SetCondition(programmed, resource)
 }
@@ -225,7 +189,7 @@ func areAllConditionsHaveTrueStatus(resource ConditionsAware) bool {
 		if condition.Type == string(gatewayv1.GatewayConditionProgrammed) {
 			continue
 		}
-		if condition.Type != string(ReadyType) && condition.Status != metav1.ConditionTrue {
+		if condition.Type != string(consts.ReadyType) && condition.Status != metav1.ConditionTrue {
 			return false
 		}
 	}
@@ -247,7 +211,7 @@ func IsAccepted(resource ConditionsAware) bool {
 // that all its conditions are in the True state.
 func IsReady(resource ConditionsAware) bool {
 	for _, condition := range resource.GetConditions() {
-		if condition.Type == string(ReadyType) {
+		if condition.Type == string(consts.ReadyType) {
 			return condition.Status == metav1.ConditionTrue
 		}
 	}
@@ -265,7 +229,7 @@ func IsProgrammed(resource ConditionsAware) bool {
 }
 
 // NewCondition convenience method for creating conditions
-func NewCondition(cType ConditionType, status metav1.ConditionStatus, reason ConditionReason, message string) metav1.Condition {
+func NewCondition(cType consts.ConditionType, status metav1.ConditionStatus, reason consts.ConditionReason, message string) metav1.Condition {
 	return metav1.Condition{
 		Type:               string(cType),
 		Reason:             string(reason),
@@ -276,7 +240,7 @@ func NewCondition(cType ConditionType, status metav1.ConditionStatus, reason Con
 }
 
 // NewConditionWithGeneration convenience method for creating conditions with ObservedGeneration set.
-func NewConditionWithGeneration(cType ConditionType, status metav1.ConditionStatus, reason ConditionReason, message string, observedGeneration int64) metav1.Condition {
+func NewConditionWithGeneration(cType consts.ConditionType, status metav1.ConditionStatus, reason consts.ConditionReason, message string, observedGeneration int64) metav1.Condition {
 	c := NewCondition(cType, status, reason, message)
 	c.ObservedGeneration = observedGeneration
 	return c
@@ -290,7 +254,7 @@ func NeedsUpdate(current, updated ConditionsAware) bool {
 	}
 
 	for _, c := range current.GetConditions() {
-		u, exists := GetCondition(ConditionType(c.Type), updated)
+		u, exists := GetCondition(consts.ConditionType(c.Type), updated)
 		if !exists {
 			return true
 		}

--- a/pkg/utils/kubernetes/status_test.go
+++ b/pkg/utils/kubernetes/status_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/gateway-operator/pkg/consts"
 )
 
 type TestResource struct {
@@ -72,7 +74,7 @@ func TestGetCondition(t *testing.T) {
 			resource := &TestResource{
 				Conditions: tt.conditions,
 			}
-			current, exists := GetCondition(ConditionType(tt.condition), resource)
+			current, exists := GetCondition(consts.ConditionType(tt.condition), resource)
 			assert.Equal(t, current, tt.expected)
 			assert.Equal(t, exists, tt.expectedFound)
 		})
@@ -333,7 +335,7 @@ func TestIsValidCondition(t *testing.T) {
 	} {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			current := IsConditionTrue(ConditionType(tt.input), resource)
+			current := IsConditionTrue(consts.ConditionType(tt.input), resource)
 			assert.Equal(t, current, tt.expected)
 		})
 	}
@@ -354,7 +356,7 @@ func TestIsReady(t *testing.T) {
 			"true",
 			[]metav1.Condition{
 				{
-					Type:   string(ReadyType),
+					Type:   string(consts.ReadyType),
 					Status: metav1.ConditionTrue,
 				},
 			},
@@ -378,7 +380,7 @@ func TestIsReady(t *testing.T) {
 					Status: metav1.ConditionTrue,
 				},
 				{
-					Type:   string(ReadyType),
+					Type:   string(consts.ReadyType),
 					Status: metav1.ConditionFalse,
 				},
 			},
@@ -411,7 +413,7 @@ func TestSetReady(t *testing.T) {
 			"override_no_other_conditions",
 			[]metav1.Condition{
 				{
-					Type:   string(ReadyType),
+					Type:   string(consts.ReadyType),
 					Status: metav1.ConditionFalse,
 				},
 			},
@@ -455,7 +457,7 @@ func TestSetReady(t *testing.T) {
 					Status: metav1.ConditionTrue,
 				},
 				{
-					Type:   string(ReadyType),
+					Type:   string(consts.ReadyType),
 					Status: metav1.ConditionFalse,
 				},
 			},
@@ -469,7 +471,7 @@ func TestSetReady(t *testing.T) {
 					Status: metav1.ConditionFalse,
 				},
 				{
-					Type:   string(ReadyType),
+					Type:   string(consts.ReadyType),
 					Status: metav1.ConditionTrue,
 				},
 			},
@@ -483,7 +485,7 @@ func TestSetReady(t *testing.T) {
 					Status: metav1.ConditionUnknown,
 				},
 				{
-					Type:   string(ReadyType),
+					Type:   string(consts.ReadyType),
 					Status: metav1.ConditionTrue,
 				},
 			},
@@ -507,9 +509,9 @@ func TestInitReady(t *testing.T) {
 	InitReady(resource)
 	conditions := resource.GetConditions()
 	assert.Equal(t, 1, len(conditions))
-	assert.Equal(t, string(ReadyType), conditions[0].Type)
-	assert.Equal(t, string(DependenciesNotReadyReason), conditions[0].Reason)
-	assert.Equal(t, DependenciesNotReadyMessage, conditions[0].Message)
+	assert.Equal(t, string(consts.ReadyType), conditions[0].Type)
+	assert.Equal(t, string(consts.DependenciesNotReadyReason), conditions[0].Reason)
+	assert.Equal(t, consts.DependenciesNotReadyMessage, conditions[0].Message)
 	assert.NotEmpty(t, conditions[0].LastTransitionTime)
 }
 

--- a/pkg/utils/test/asserts.go
+++ b/pkg/utils/test/asserts.go
@@ -41,8 +41,7 @@ func MustListControlPlaneDeployments(t *testing.T, ctx context.Context, controlp
 // MustListControlPlaneClusterRoles is a helper function for tests that
 // conveniently lists all clusterroles owned by a given controlplane.
 func MustListControlPlaneClusterRoles(t *testing.T, ctx context.Context, controlplane *operatorv1beta1.ControlPlane, clients K8sClients) []rbacv1.ClusterRole {
-	managedByLabelSet, err := k8sutils.GetManagedByLabelSet(controlplane)
-	require.NoError(t, err)
+	managedByLabelSet := k8sutils.GetManagedByLabelSet(controlplane)
 	clusterRoles, err := k8sutils.ListClusterRoles(
 		ctx,
 		clients.MgrClient,
@@ -55,8 +54,7 @@ func MustListControlPlaneClusterRoles(t *testing.T, ctx context.Context, control
 // MustListControlPlaneClusterRoleBindings is a helper function for tests that
 // conveniently lists all clusterrolebindings owned by a given controlplane.
 func MustListControlPlaneClusterRoleBindings(t *testing.T, ctx context.Context, controlplane *operatorv1beta1.ControlPlane, clients K8sClients) []rbacv1.ClusterRoleBinding {
-	managedByLabelSet, err := k8sutils.GetManagedByLabelSet(controlplane)
-	require.NoError(t, err)
+	managedByLabelSet := k8sutils.GetManagedByLabelSet(controlplane)
 	clusterRoleBindings, err := k8sutils.ListClusterRoleBindings(
 		ctx,
 		clients.MgrClient,

--- a/pkg/utils/test/asserts.go
+++ b/pkg/utils/test/asserts.go
@@ -41,13 +41,10 @@ func MustListControlPlaneDeployments(t *testing.T, ctx context.Context, controlp
 // MustListControlPlaneClusterRoles is a helper function for tests that
 // conveniently lists all clusterroles owned by a given controlplane.
 func MustListControlPlaneClusterRoles(t *testing.T, ctx context.Context, controlplane *operatorv1beta1.ControlPlane, clients K8sClients) []rbacv1.ClusterRole {
-	clusterRoles, err := k8sutils.ListClusterRolesForOwner(
+	clusterRoles, err := k8sutils.ListClusterRoles(
 		ctx,
 		clients.MgrClient,
-		controlplane.UID,
-		client.MatchingLabels{
-			consts.GatewayOperatorManagedByLabel: consts.ControlPlaneManagedLabelValue,
-		},
+		client.MatchingLabels(k8sutils.GetManagedByLabelSet(controlplane)),
 	)
 	require.NoError(t, err)
 	return clusterRoles
@@ -56,13 +53,10 @@ func MustListControlPlaneClusterRoles(t *testing.T, ctx context.Context, control
 // MustListControlPlaneClusterRoleBindings is a helper function for tests that
 // conveniently lists all clusterrolebindings owned by a given controlplane.
 func MustListControlPlaneClusterRoleBindings(t *testing.T, ctx context.Context, controlplane *operatorv1beta1.ControlPlane, clients K8sClients) []rbacv1.ClusterRoleBinding {
-	clusterRoleBindings, err := k8sutils.ListClusterRoleBindingsForOwner(
+	clusterRoleBindings, err := k8sutils.ListClusterRoleBindings(
 		ctx,
 		clients.MgrClient,
-		controlplane.UID,
-		client.MatchingLabels{
-			consts.GatewayOperatorManagedByLabel: consts.ControlPlaneManagedLabelValue,
-		},
+		client.MatchingLabels(k8sutils.GetManagedByLabelSet(controlplane)),
 	)
 	require.NoError(t, err)
 	return clusterRoleBindings

--- a/pkg/utils/test/asserts.go
+++ b/pkg/utils/test/asserts.go
@@ -41,10 +41,12 @@ func MustListControlPlaneDeployments(t *testing.T, ctx context.Context, controlp
 // MustListControlPlaneClusterRoles is a helper function for tests that
 // conveniently lists all clusterroles owned by a given controlplane.
 func MustListControlPlaneClusterRoles(t *testing.T, ctx context.Context, controlplane *operatorv1beta1.ControlPlane, clients K8sClients) []rbacv1.ClusterRole {
+	managedByLabelSet, err := k8sutils.GetManagedByLabelSet(controlplane)
+	require.NoError(t, err)
 	clusterRoles, err := k8sutils.ListClusterRoles(
 		ctx,
 		clients.MgrClient,
-		client.MatchingLabels(k8sutils.GetManagedByLabelSet(controlplane)),
+		client.MatchingLabels(managedByLabelSet),
 	)
 	require.NoError(t, err)
 	return clusterRoles
@@ -53,10 +55,12 @@ func MustListControlPlaneClusterRoles(t *testing.T, ctx context.Context, control
 // MustListControlPlaneClusterRoleBindings is a helper function for tests that
 // conveniently lists all clusterrolebindings owned by a given controlplane.
 func MustListControlPlaneClusterRoleBindings(t *testing.T, ctx context.Context, controlplane *operatorv1beta1.ControlPlane, clients K8sClients) []rbacv1.ClusterRoleBinding {
+	managedByLabelSet, err := k8sutils.GetManagedByLabelSet(controlplane)
+	require.NoError(t, err)
 	clusterRoleBindings, err := k8sutils.ListClusterRoleBindings(
 		ctx,
 		clients.MgrClient,
-		client.MatchingLabels(k8sutils.GetManagedByLabelSet(controlplane)),
+		client.MatchingLabels(managedByLabelSet),
 	)
 	require.NoError(t, err)
 	return clusterRoleBindings

--- a/pkg/utils/test/predicates.go
+++ b/pkg/utils/test/predicates.go
@@ -306,7 +306,9 @@ func ControlPlaneHasAdmissionWebhookCertificateSecret(t *testing.T, ctx context.
 // that can be used to check if a ControlPlane has an admission webhook configuration.
 func ControlPlaneHasAdmissionWebhookConfiguration(t *testing.T, ctx context.Context, cp *operatorv1beta1.ControlPlane, clients K8sClients) func() bool {
 	return func() bool {
-		configs, err := k8sutils.ListValidatingWebhookConfigurations(ctx, clients.MgrClient, client.MatchingLabels(k8sutils.GetManagedByLabelSet(cp)))
+		managedByLabelSet, err := k8sutils.GetManagedByLabelSet(cp)
+		require.NoError(t, err)
+		configs, err := k8sutils.ListValidatingWebhookConfigurations(ctx, clients.MgrClient, client.MatchingLabels(managedByLabelSet))
 		require.NoError(t, err)
 		t.Logf("%d validating webhook configurations", len(configs))
 		return len(configs) > 0

--- a/pkg/utils/test/predicates.go
+++ b/pkg/utils/test/predicates.go
@@ -101,7 +101,7 @@ func ControlPlaneIsScheduled(t *testing.T, ctx context.Context, controlPlane typ
 func DataPlaneIsReady(t *testing.T, ctx context.Context, dataplane types.NamespacedName, operatorClient *clientset.Clientset) func() bool {
 	return DataPlanePredicate(t, ctx, dataplane, func(c *operatorv1beta1.DataPlane) bool {
 		for _, condition := range c.Status.Conditions {
-			if condition.Type == string(k8sutils.ReadyType) && condition.Status == metav1.ConditionTrue {
+			if condition.Type == string(consts.ReadyType) && condition.Status == metav1.ConditionTrue {
 				return true
 			}
 		}
@@ -146,7 +146,7 @@ func ControlPlaneIsProvisioned(t *testing.T, ctx context.Context, controlPlane t
 func ControlPlaneIsNotReady(t *testing.T, ctx context.Context, controlplane types.NamespacedName, clients K8sClients) func() bool {
 	return controlPlanePredicate(t, ctx, controlplane, func(c *operatorv1beta1.ControlPlane) bool {
 		for _, condition := range c.Status.Conditions {
-			if condition.Type == string(k8sutils.ReadyType) &&
+			if condition.Type == string(consts.ReadyType) &&
 				condition.Status == metav1.ConditionFalse {
 				return true
 			}
@@ -161,7 +161,7 @@ func ControlPlaneIsNotReady(t *testing.T, ctx context.Context, controlplane type
 func ControlPlaneIsReady(t *testing.T, ctx context.Context, controlplane types.NamespacedName, clients K8sClients) func() bool {
 	return controlPlanePredicate(t, ctx, controlplane, func(c *operatorv1beta1.ControlPlane) bool {
 		for _, condition := range c.Status.Conditions {
-			if condition.Type == string(k8sutils.ReadyType) &&
+			if condition.Type == string(consts.ReadyType) &&
 				condition.Status == metav1.ConditionTrue {
 				return true
 			}
@@ -306,10 +306,10 @@ func ControlPlaneHasAdmissionWebhookCertificateSecret(t *testing.T, ctx context.
 // that can be used to check if a ControlPlane has an admission webhook configuration.
 func ControlPlaneHasAdmissionWebhookConfiguration(t *testing.T, ctx context.Context, cp *operatorv1beta1.ControlPlane, clients K8sClients) func() bool {
 	return func() bool {
-		services, err := k8sutils.ListValidatingWebhookConfigurationsForOwner(ctx, clients.MgrClient, cp.UID)
+		configs, err := k8sutils.ListValidatingWebhookConfigurations(ctx, clients.MgrClient, client.MatchingLabels(k8sutils.GetManagedByLabelSet(cp)))
 		require.NoError(t, err)
-		t.Logf("%d validating webhook configurations", len(services))
-		return len(services) > 0
+		t.Logf("%d validating webhook configurations", len(configs))
+		return len(configs) > 0
 	}
 }
 
@@ -661,7 +661,7 @@ func GatewayDataPlaneIsReady(t *testing.T, ctx context.Context, gateway *gwtypes
 				return false
 			}
 			for _, condition := range dataplanes[0].Status.Conditions {
-				if condition.Type == string(k8sutils.ReadyType) &&
+				if condition.Type == string(consts.ReadyType) &&
 					condition.Status == metav1.ConditionTrue {
 					return true
 				}

--- a/pkg/utils/test/predicates.go
+++ b/pkg/utils/test/predicates.go
@@ -306,8 +306,7 @@ func ControlPlaneHasAdmissionWebhookCertificateSecret(t *testing.T, ctx context.
 // that can be used to check if a ControlPlane has an admission webhook configuration.
 func ControlPlaneHasAdmissionWebhookConfiguration(t *testing.T, ctx context.Context, cp *operatorv1beta1.ControlPlane, clients K8sClients) func() bool {
 	return func() bool {
-		managedByLabelSet, err := k8sutils.GetManagedByLabelSet(cp)
-		require.NoError(t, err)
+		managedByLabelSet := k8sutils.GetManagedByLabelSet(cp)
 		configs, err := k8sutils.ListValidatingWebhookConfigurations(ctx, clients.MgrClient, client.MatchingLabels(managedByLabelSet))
 		require.NoError(t, err)
 		t.Logf("%d validating webhook configurations", len(configs))

--- a/test/e2e/test_helm_install_upgrade.go
+++ b/test/e2e/test_helm_install_upgrade.go
@@ -451,7 +451,9 @@ func gatewayDataPlaneDeploymentIsNotPatched(gatewayLabelSelector string) func(co
 			c.Errorf("failed to list DataPlanes for Gateway %q: %v", client.ObjectKeyFromObject(gw), err)
 			c.FailNow()
 		}
-		require.Len(c, dataplanes, 1)
+		if !assert.Len(c, dataplanes, 1) {
+			return
+		}
 		dp := &dataplanes[0]
 		if dp.Generation != 1 {
 			c.Errorf("DataPlane %q got patched but it shouldn't: %v", client.ObjectKeyFromObject(dp), err)
@@ -468,7 +470,9 @@ func clusterWideResourcesAreProperlyManaged(gatewayLabelSelector string) func(ct
 			c.Errorf("failed to list ControlPlanes for Gateway %q: %v", client.ObjectKeyFromObject(gw), err)
 			c.FailNow()
 		}
-		require.Len(c, controlplanes, 1)
+		if !assert.Len(c, controlplanes, 1) {
+			return
+		}
 		cp := &controlplanes[0]
 
 		managedByLabelSet := k8sutils.GetManagedByLabelSet(cp)
@@ -478,23 +482,23 @@ func clusterWideResourcesAreProperlyManaged(gatewayLabelSelector string) func(ct
 			cl,
 			client.MatchingLabels(managedByLabelSet),
 		)
-		require.NoError(c, err)
-		require.Len(c, clusterRoles, 1)
+		assert.NoError(c, err)
+		assert.Len(c, clusterRoles, 1)
 
 		clusterRoleBindings, err := k8sutils.ListClusterRoleBindings(
 			ctx,
 			cl,
 			client.MatchingLabels(managedByLabelSet),
 		)
-		require.NoError(c, err)
-		require.Len(c, clusterRoleBindings, 1)
+		assert.NoError(c, err)
+		assert.Len(c, clusterRoleBindings, 1)
 
 		validatingWebhookConfigurations, err := k8sutils.ListValidatingWebhookConfigurations(
 			ctx,
 			cl,
 			client.MatchingLabels(managedByLabelSet),
 		)
-		require.NoError(c, err)
-		require.Len(c, validatingWebhookConfigurations, 1)
+		assert.NoError(c, err)
+		assert.Len(c, validatingWebhookConfigurations, 1)
 	}
 }

--- a/test/integration/test_controlplane.go
+++ b/test/integration/test_controlplane.go
@@ -256,6 +256,10 @@ func TestControlPlaneEssentials(t *testing.T) {
 	controlplane, err = controlplaneClient.Create(GetCtx(), controlplane, metav1.CreateOptions{})
 	require.NoError(t, err)
 	cleaner.Add(controlplane)
+	controlplane.TypeMeta = metav1.TypeMeta{
+		APIVersion: operatorv1beta1.SchemeGroupVersion.String(),
+		Kind:       "ControlPlane",
+	}
 
 	t.Log("verifying controlplane gets marked scheduled")
 	require.Eventually(t, testutils.ControlPlaneIsScheduled(t, GetCtx(), controlplaneName, GetClients().OperatorClient), testutils.ControlPlaneCondDeadline, testutils.ControlPlaneCondTick)

--- a/test/integration/test_dataplane.go
+++ b/test/integration/test_dataplane.go
@@ -376,9 +376,9 @@ func TestDataPlaneUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		isNotReady := dataPlaneConditionPredicate(t, &metav1.Condition{
-			Type:               string(k8sutils.ReadyType),
+			Type:               string(consts.ReadyType),
 			Status:             metav1.ConditionFalse,
-			Reason:             string(k8sutils.WaitingToBecomeReadyReason),
+			Reason:             string(consts.WaitingToBecomeReadyReason),
 			ObservedGeneration: dataplane.Generation,
 		})
 		require.Eventually(t,
@@ -414,9 +414,9 @@ func TestDataPlaneUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		isReady := dataPlaneConditionPredicate(t, &metav1.Condition{
-			Type:               string(k8sutils.ReadyType),
+			Type:               string(consts.ReadyType),
 			Status:             metav1.ConditionTrue,
-			Reason:             string(k8sutils.ResourceReadyReason),
+			Reason:             string(consts.ResourceReadyReason),
 			ObservedGeneration: dataplane.Generation,
 		})
 		require.Eventually(t,
@@ -451,9 +451,9 @@ func TestDataPlaneUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		isReady := dataPlaneConditionPredicate(t, &metav1.Condition{
-			Type:               string(k8sutils.ReadyType),
+			Type:               string(consts.ReadyType),
 			Status:             metav1.ConditionTrue,
-			Reason:             string(k8sutils.ResourceReadyReason),
+			Reason:             string(consts.ResourceReadyReason),
 			ObservedGeneration: dataplane.Generation,
 		})
 		require.Eventually(t,
@@ -488,9 +488,9 @@ func TestDataPlaneUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		isReady := dataPlaneConditionPredicate(t, &metav1.Condition{
-			Type:               string(k8sutils.ReadyType),
+			Type:               string(consts.ReadyType),
 			Status:             metav1.ConditionTrue,
-			Reason:             string(k8sutils.ResourceReadyReason),
+			Reason:             string(consts.ResourceReadyReason),
 			ObservedGeneration: dataplane.Generation,
 		})
 		require.Eventually(t,

--- a/test/integration/test_ingress.go
+++ b/test/integration/test_ingress.go
@@ -27,7 +27,6 @@ import (
 	gwtypes "github.com/kong/gateway-operator/internal/types"
 	"github.com/kong/gateway-operator/pkg/consts"
 	gatewayutils "github.com/kong/gateway-operator/pkg/utils/gateway"
-	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	testutils "github.com/kong/gateway-operator/pkg/utils/test"
 	"github.com/kong/gateway-operator/pkg/vars"
 	"github.com/kong/gateway-operator/test/helpers"
@@ -95,7 +94,7 @@ func TestIngressEssentials(t *testing.T) {
 		}
 		if len(dataplanes) == 1 {
 			for _, condition := range dataplanes[0].Status.Conditions {
-				if condition.Type == string(k8sutils.ReadyType) && condition.Status == metav1.ConditionTrue {
+				if condition.Type == string(consts.ReadyType) && condition.Status == metav1.ConditionTrue {
 					dataplane = &dataplanes[0]
 					return true
 				}

--- a/test/integration/test_validating.go
+++ b/test/integration/test_validating.go
@@ -13,7 +13,6 @@ import (
 
 	operatorv1beta1 "github.com/kong/gateway-operator/api/v1beta1"
 	"github.com/kong/gateway-operator/pkg/consts"
-	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers"
 )
 
@@ -235,7 +234,7 @@ func testDataPlaneReconcileValidation(t *testing.T, namespace *corev1.Namespace)
 
 						var cond metav1.Condition
 						for _, condition := range dataplane.Status.Conditions {
-							if condition.Type == string(k8sutils.ReadyType) {
+							if condition.Type == string(consts.ReadyType) {
 								cond = condition
 								break
 							}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #72 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
