### PR TITLE
fix(conformance): fix panic for `make test.conformance`

### DIFF
--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -172,7 +172,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 	// If the Gateway is not accepted, do not move on in the reconciliation logic.
 	if acceptedCondition.Status == metav1.ConditionFalse {
-		// TODO: clean up Dataplane and Controlplane https://github.com/Kong/gateway-operator/issues/1511
+		// TODO: clean up Dataplane and Controlplane https://github.com/Kong/gateway-operator/issues/126
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/utils/test/clients.go
+++ b/pkg/utils/test/clients.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kubernetesclient "k8s.io/client-go/kubernetes"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -38,6 +39,10 @@ func NewK8sClients(env environments.Environment) (K8sClients, error) {
 	}
 	clients.MgrClient, err = ctrlruntimeclient.New(env.Cluster().Config(), ctrlruntimeclient.Options{})
 	if err != nil {
+		return clients, err
+	}
+
+	if err := apiextensionsv1.AddToScheme(clients.MgrClient.Scheme()); err != nil {
 		return clients, err
 	}
 	if err := gatewayv1.Install(clients.MgrClient.Scheme()); err != nil {

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -1,7 +1,6 @@
 package conformance
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"path"
@@ -15,6 +14,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	conformancev1 "sigs.k8s.io/gateway-api/conformance/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/tests"
+	"sigs.k8s.io/gateway-api/conformance/utils/flags"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
 
 	"github.com/kong/gateway-operator/internal/metadata"
@@ -31,11 +31,6 @@ var skippedTests = []string{
 	// httproute
 	tests.HTTPRouteHeaderMatching.ShortName,
 }
-
-var (
-	shouldCleanup = flag.Bool("cleanup", true, "indicates whether or not the base test resources such as Gateways should be cleaned up after the run.")
-	showDebug     = flag.Bool("debug", false, "indicates whether to execute the conformance tests in debug mode.")
-)
 
 func TestGatewayConformance(t *testing.T) {
 	t.Parallel()
@@ -64,8 +59,8 @@ func TestGatewayConformance(t *testing.T) {
 		suite.ConformanceOptions{
 			Client:               clients.MgrClient,
 			GatewayClassName:     gwc.Name,
-			Debug:                *showDebug,
-			CleanupBaseResources: *shouldCleanup,
+			Debug:                *flags.ShowDebug,
+			CleanupBaseResources: *flags.CleanupBaseResources,
 			BaseManifests:        conformanceTestsBaseManifests,
 			SkipTests:            skippedTests,
 			ConformanceProfiles: sets.New(
@@ -85,7 +80,7 @@ func TestGatewayConformance(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("starting the gateway conformance test suite")
-	cSuite.Setup(t, nil)
+	cSuite.Setup(t, tests.ConformanceTests)
 
 	// To work with individual tests only, you can disable the normal Run call and construct a slice containing a
 	// single test only, e.g.:

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/gateway-api/conformance/utils/flags"
 	gwapiv1 "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/typed/apis/v1"
 
 	"github.com/kong/gateway-operator/config"
@@ -126,7 +127,7 @@ func TestMain(m *testing.M) {
 	// for the operator to handle Gateway finalizers.
 	// If we don't do it then we'll be left with Gateways that have a deleted
 	// timestamp and finalizers set but no operator running which could handle those.
-	if *shouldCleanup {
+	if *flags.CleanupBaseResources {
 		exitOnErr(waitForConformanceGatewaysToCleanup(ctx, clients.GatewayClient.GatewayV1()))
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

After 

- https://github.com/Kong/gateway-operator/pull/263

executing `make conformance.tests` 

results in panic

```log
GOTESTSUM_FORMAT=standard-verbose \
                /Users/jakub.warczarek@konghq.com/Documents/work/gateway-operator/bin/installs/gotestsum/1.11.0/bin/gotestsum --  \
                -timeout "20m" \
                -race \
                -parallel 10 \
                ./test/conformance/...
/var/folders/v4/66lp8jy17r1_jx_2x0fv278w0000gn/T/go-build1021724069/b001/conformance.test flag redefined: debug
panic: /var/folders/v4/66lp8jy17r1_jx_2x0fv278w0000gn/T/go-build1021724069/b001/conformance.test flag redefined: debug

goroutine 1 [running]:
flag.(*FlagSet).Var(0xc000200150, {0x1064362c8, 0xc00012d12f}, {0x10555ea10, 0x5}, {0x105618608, 0x41})
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/flag/flag.go:1028 +0x418
flag.(*FlagSet).BoolVar(...)
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/flag/flag.go:749
flag.(*FlagSet).Bool(0xc000200150, {0x10555ea10, 0x5}, 0x0, {0x105618608, 0x41})
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/flag/flag.go:762 +0x7c
flag.Bool(...)
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/flag/flag.go:769
github.com/kong/gateway-operator/test/conformance.init()
        /Users/jakub.warczarek@konghq.com/Documents/work/gateway-operator/test/conformance/conformance_test.go:37 +0x28c
FAIL    github.com/kong/gateway-operator/test/conformance       1.211s

=== Failed
=== FAIL: test/conformance  (0.00s)
/var/folders/v4/66lp8jy17r1_jx_2x0fv278w0000gn/T/go-build1021724069/b001/conformance.test flag redefined: debug
panic: /var/folders/v4/66lp8jy17r1_jx_2x0fv278w0000gn/T/go-build1021724069/b001/conformance.test flag redefined: debug

goroutine 1 [running]:
flag.(*FlagSet).Var(0xc000200150, {0x1064362c8, 0xc00012d12f}, {0x10555ea10, 0x5}, {0x105618608, 0x41})
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/flag/flag.go:1028 +0x418
flag.(*FlagSet).BoolVar(...)
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/flag/flag.go:749
flag.(*FlagSet).Bool(0xc000200150, {0x10555ea10, 0x5}, 0x0, {0x105618608, 0x41})
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/flag/flag.go:762 +0x7c
flag.Bool(...)
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/flag/flag.go:769
github.com/kong/gateway-operator/test/conformance.init()
        /Users/jakub.warczarek@konghq.com/Documents/work/gateway-operator/test/conformance/conformance_test.go:37 +0x28c
FAIL    github.com/kong/gateway-operator/test/conformance       1.211s

DONE 0 tests, 1 failure in 6.622s
make[1]: *** [_test.conformance] Error 1
make: *** [test.conformance] Error 2
```

this PR brings it back to the state that they run, but fail

```log
...
suite.go:348: 2024-05-16T17:59:21.406228+02:00: Test Setup: Ensuring Gateways and Pods from base manifests are ready
    helpers.go:217: 2024-05-16T17:59:21.417088+02:00: Gateway gateway-conformance-infra/all-namespaces expected observedGeneration to be updated to 1 for all conditions, only 3/4 were updated. stale conditions are: Programmed (generation 0)
    helpers.go:217: 2024-05-16T17:59:22.421528+02:00: Gateway gateway-conformance-infra/all-namespaces expected observedGeneration to be updated to 1 for all conditions, only 3/4 were updated. stale conditions are: Programmed (generation 0)
    helpers.go:217: 2024-05-16T17:59:23.41769+02:00: Gateway gateway-conformance-infra/all-namespaces expected observedGeneration to be updated to 1 for all conditions, only 3/4 were updated. stale conditions are: Programmed (generation 0)
    helpers.go:217: 2024-05-16T17:59:24.42362+02:00: Gateway gateway-conformance-infra/all-namespaces expected observedGeneration to be updated to 1 for all conditions, only 3/4 were updated. stale conditions are: Programmed (generation 0)
    helpers.go:217: 2024-05-16T17:59:25.418414+02:00: Gateway gateway-conformance-infra/all-namespaces expected observedGeneration to be updated to 1 for all conditions, only 3/4 were updated. stale conditions are: Programmed (generation 0)
    helpers.go:217: 2024-05-16T17:59:26.423449+02:00: Gateway gateway-conformance-infra/all-namespaces expected observedGeneration to be updated to 1 for all conditions, only 3/4 were updated. stale conditions are: Programmed (generation 0)
    ....
```

Fixing this failure will be handled in a separate PR. 


**Which issue this PR fixes**

Part of https://github.com/Kong/gateway-operator/issues/264

