### PR TITLE
chore: add patch versions to KIC images in samples

### DIFF
--- a/config/samples/aigateway.yaml
+++ b/config/samples/aigateway.yaml
@@ -100,7 +100,7 @@ spec:
         spec:
           containers:
           - name: controller
-            image: kong/kubernetes-ingress-controller:3.1
+            image: kong/kubernetes-ingress-controller:3.1.5
             env:
             - name: CONTROLLER_LOG_LEVEL
               value: debug

--- a/config/samples/controlplane.yaml
+++ b/config/samples/controlplane.yaml
@@ -14,7 +14,7 @@ spec:
         containers:
         - name: controller
           # renovate: datasource=docker depName=kong/kubernetes-ingress-controller packageName=kong/kubernetes-ingress-controller versioning=docker
-          image: kong/kubernetes-ingress-controller:3.1
+          image: kong/kubernetes-ingress-controller:3.1.5
           readinessProbe:
             initialDelaySeconds: 1
             periodSeconds: 3

--- a/config/samples/gateway-httproute.yaml
+++ b/config/samples/gateway-httproute.yaml
@@ -143,7 +143,7 @@ spec:
           containers:
           - name: controller
             # renovate: datasource=docker depName=kong/kubernetes-ingress-controller packageName=kong/kubernetes-ingress-controller versioning=docker
-            image: kong/kubernetes-ingress-controller:3.1
+            image: kong/kubernetes-ingress-controller:3.1.5
             readinessProbe:
               initialDelaySeconds: 1
               periodSeconds: 1


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR should make renovate trigger patch updates for KIC (`ControlPlane`s)