### PR TITLE
tests(fix): conformance tests pass

### DIFF
--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -309,7 +309,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil // requeue will be triggered by the update of the controlplane status
 	}
 
-	// if the controlplane wasnt't ready before this reconciliation loop and now is ready, log this event
+	// if the controlplane wasn't ready before this reconciliation loop and now is ready, log this event
 	if !k8sutils.IsConditionTrue(ControlPlaneReadyType, oldGwConditionsAware) {
 		log.Debug(logger, "controlplane is ready", gateway)
 	}

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
@@ -78,7 +79,9 @@ func TestMain(m *testing.M) {
 	// Gateway API conformance tests do not create resources like NetworkPolicy
 	// that would allow e.g. cross namespace traffic.
 	// Related upstream discussion: https://github.com/kubernetes-sigs/gateway-api/discussions/2137
-	env, err = testutils.BuildEnvironment(ctx, existingCluster)
+	env, err = testutils.BuildEnvironment(ctx, existingCluster, func(b *environments.Builder, t clusters.Type) {
+		b.WithAddons(metallb.New())
+	})
 	exitOnErr(err)
 
 	fmt.Printf("INFO: waiting for cluster %s and all addons to become ready\n", env.Cluster().Name())


### PR DESCRIPTION
**What this PR does / why we need it**:

Followup for 

- https://github.com/Kong/gateway-operator/pull/265

This PR contains several fixes that make `make tests.conformance` pass and generate a report.

> **Please check on your machine too** we don't run them in CI currently.

Fixes 
- adds metallb to a testing stack (without its gateway stuck, because it can't create a Service of type LoadBalanceer successfully)
- adjustment for configuring and starting a test suite that uses the newest, streamlined API of GWAPI
- some tests have to be disabled 
   - https://github.com/Kong/gateway-operator/issues/269
   - https://github.com/Kong/gateway-operator/issues/270
   - https://github.com/Kong/gateway-operator/issues/271
   - https://github.com/Kong/gateway-operator/issues/273
   - https://github.com/Kong/gateway-operator/issues/274
   
Generated report

```yml
apiVersion: gateway.networking.k8s.io/v1alpha1
date: "2024-05-20T14:18:35+02:00"
gatewayAPIChannel: experimental
gatewayAPIVersion: v1.1.0
implementation:
  contact:
  - github.com/kong/gateway-operator/issues/new/choose
  organization: Kong
  project: gateway-operator
  url: github.com/kong/gateway-operator
  version: v1.2.2-39-g8f28499
kind: ConformanceReport
mode: default
profiles:
- core:
    result: partial
    skippedTests:
    - GatewayInvalidTLSConfiguration
    - GatewayModifyListeners
    - GatewayWithAttachedRoutes
    - HTTPRouteHTTPSListener
    - HTTPRouteHeaderMatching
    - HTTPRouteHostnameIntersection
    - HTTPRouteInvalidBackendRefUnknownKind
    - HTTPRouteListenerHostnameMatching
    - HTTPRouteObservedGenerationBump
    statistics:
      Failed: 0
      Passed: 24
      Skipped: 9
  name: GATEWAY-HTTP
  summary: Core tests partially succeeded with 9 test skips.
```

**Which issue this PR fixes**

Closes https://github.com/Kong/gateway-operator/issues/264