### PR TITLE
chore(ci): add renovate config for .tools_versions.yaml

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,10 +18,20 @@
       "description": "Match dependencies in config/samples/.*.yaml that are properly annotated with `# renovate: datasource={} versioning={}.`",
       "customType": "regex",
       "fileMatch": [
-        "^config/samples/.*.yaml$"
+        "^config/samples/.*\\.yaml$"
       ],
       "matchStrings": [
         "#\\s+renovate:\\s+datasource=(?<datasource>.*)\\s+versioning=(?<versioning>.*?)\\n.+image:\\s+(?<depName>.+?):(?<currentValue>.+)"
+      ]
+    },
+    {
+      "description": "Match dependencies in .tools_verisons.yaml that are properly annotated with `# renovate: datasource={} depName={}.`",
+      "customType": "regex",
+      "fileMatch": [
+        "\\.tools_versions\\.yaml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.+\"(?<currentValue>.*?)\""
       ]
     }
   ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Extend renovate config with regex manager  for `.tools_versions.yaml`.

Inspired by https://github.com/Kong/kubernetes-ingress-controller/blob/713765d1e1edae3e2974597c7ef071d090b29a88/renovate.json#L28-L37