### PR TITLE
tests(conformance): enable `HTTPRouteResponseHeaderModification`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -180,7 +180,7 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.30.0
 	k8s.io/component-base v0.30.1 // indirect

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -1,7 +1,6 @@
 package conformance
 
 import (
-	"fmt"
 	"path"
 	"testing"
 
@@ -14,6 +13,7 @@ import (
 	conformancev1 "sigs.k8s.io/gateway-api/conformance/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/tests"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
 
 	"github.com/kong/gateway-operator/internal/metadata"
 	testutils "github.com/kong/gateway-operator/pkg/utils/test"
@@ -55,17 +55,20 @@ func TestGatewayConformance(t *testing.T) {
 	// There are no explicit conformance tests for GatewayClass, but we can
 	// still run the conformance test suite setup to ensure that the
 	// GatewayClass gets accepted.
-	t.Log("starting the gateway conformance test suite")
+	t.Log("configuring the Gateway API conformance test suite")
 	const reportFileName = "kong-gateway-operator.yaml" // TODO: https://github.com/Kong/gateway-operator/issues/268
 
 	opts := conformance.DefaultOptions(t)
 	opts.ReportOutputPath = "../../" + reportFileName
 	opts.Client = clients.MgrClient
 	opts.GatewayClassName = gwc.Name
-	opts.BaseManifests = fmt.Sprintf("%s/conformance/base/manifests.yaml", testutils.GatewayRawRepoURL)
+	opts.BaseManifests = testutils.GatewayRawRepoURL + "/conformance/base/manifests.yaml"
 	opts.SkipTests = skippedTests
 	opts.ConformanceProfiles = sets.New(
 		suite.GatewayHTTPConformanceProfileName,
+	)
+	opts.SupportedFeatures = sets.New(
+		features.SupportHTTPRouteResponseHeaderModification,
 	)
 	opts.Implementation = conformancev1.Implementation{
 		Organization: metadata.Organization,
@@ -77,6 +80,6 @@ func TestGatewayConformance(t *testing.T) {
 		},
 	}
 
-	t.Log("starting the gateway conformance test suite")
+	t.Log("running the Gateway API conformance test suite")
 	conformance.RunConformanceWithOptions(t, opts)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable `HTTPRouteResponseHeaderModification` and do some small opportunistic improvements.

Report generated locally

```yml
apiVersion: gateway.networking.k8s.io/v1alpha1
date: "2024-05-20T22:08:30+02:00"
gatewayAPIChannel: experimental
gatewayAPIVersion: v1.1.0
implementation:
  contact:
  - github.com/kong/gateway-operator/issues/new/choose
  organization: Kong
  project: gateway-operator
  url: github.com/kong/gateway-operator
  version: v1.2.2-41-g293bfed
kind: ConformanceReport
mode: default
profiles:
- core:
    result: partial
    skippedTests:
    - GatewayInvalidTLSConfiguration
    - GatewayModifyListeners
    - GatewayWithAttachedRoutes
    - HTTPRouteHTTPSListener
    - HTTPRouteHeaderMatching
    - HTTPRouteHostnameIntersection
    - HTTPRouteInvalidBackendRefUnknownKind
    - HTTPRouteListenerHostnameMatching
    - HTTPRouteObservedGenerationBump
    statistics:
      Failed: 0
      Passed: 24
      Skipped: 9
  extended:
    result: success
    statistics:
      Failed: 0
      Passed: 1
      Skipped: 0
    supportedFeatures:
    - HTTPRouteResponseHeaderModification
    unsupportedFeatures:
    - GatewayHTTPListenerIsolation
    - GatewayPort8080
    - GatewayStaticAddresses
    - HTTPRouteBackendRequestHeaderModification
    - HTTPRouteBackendTimeout
    - HTTPRouteHostRewrite
    - HTTPRouteMethodMatching
    - HTTPRouteParentRefPort
    - HTTPRoutePathRedirect
    - HTTPRoutePathRewrite
    - HTTPRoutePortRedirect
    - HTTPRouteQueryParamMatching
    - HTTPRouteRequestMirror
    - HTTPRouteRequestMultipleMirrors
    - HTTPRouteRequestTimeout
    - HTTPRouteSchemeRedirect
  name: GATEWAY-HTTP
  summary: Core tests partially succeeded with 9 test skips. Extended tests succeeded.

```

**Which issue this PR fixes**

Closes https://github.com/Kong/gateway-operator/issues/60
