### PR TITLE
tests: run GatewayWithAttachedRoutes from Gateway API conformance suite

### DIFF
--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -780,6 +780,12 @@ func (g *gatewayConditionsAndListenersAwareT) setProgrammed() {
 			LastTransitionTime: metav1.Now(),
 		}
 		listenerStatus := listenerConditionsAware(listener)
+		rCond, ok := k8sutils.GetCondition(k8sutils.ConditionType(gatewayv1.ListenerConditionResolvedRefs), listenerStatus)
+		if ok && rCond.Status == metav1.ConditionFalse {
+			programmedCondition.Status = metav1.ConditionFalse
+			programmedCondition.Reason = string(gatewayv1.ListenerReasonPending)
+			programmedCondition.Message = "Listener references are not resolved yet."
+		}
 		k8sutils.SetCondition(programmedCondition, listenerStatus)
 	}
 }

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -24,8 +24,6 @@ var skippedTests = []string{
 	// gateway
 	tests.GatewayInvalidTLSConfiguration.ShortName,
 	tests.GatewayModifyListeners.ShortName,
-	// TODO: https://github.com/Kong/gateway-operator/issues/56
-	tests.GatewayWithAttachedRoutes.ShortName,
 
 	// httproute
 	tests.HTTPRouteHeaderMatching.ShortName,


### PR DESCRIPTION
**What this PR does / why we need it**:

This concludes the implementation of support for setting `AttachedRoutes` in listeners status.

This PR also fixes the errors when running the tests on Darwin:

```
ld: warning: '/private/var/folders/0m/_63w01516tgf3cftmp9h7ylm0000gn/T/go-link-1798743752/000014.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
```

**Which issue this PR fixes**

Fixes #56 

**Special notes for your reviewer**:

Running conformance suite, I've observed errors which I've captured in https://github.com/Kong/kubernetes-ingress-controller/issues/6067.
