### PR TITLE
tests(conformance): enable `HTTPRouteObservedGenerationBump`

### DIFF
--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -34,7 +34,6 @@ var skippedTests = []string{
 	tests.HTTPRouteHostnameIntersection.ShortName,
 	tests.HTTPRouteInvalidBackendRefUnknownKind.ShortName,
 	tests.HTTPRouteListenerHostnameMatching.ShortName,
-	tests.HTTPRouteObservedGenerationBump.ShortName,
 
 	// TODO: remove the skip https://github.com/Kong/gateway-operator/issues/295
 	// This test is flaky.


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable HTTPRouteObservedGenerationBump

**Which issue this PR fixes**

Fixes #274 

