### PR TITLE
tests(conformance): enable `HTTPRouteInvalidBackendRefUnknownKind`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -224,7 +224,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: conformance-report-${{ matrix.router-flavor }}
-        path: kong-gateway-operator*.yaml
+        path: standard-*-report.yaml
 
   integration-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable `HTTPRouteInvalidBackendRefUnknownKind`

**Which issue this PR fixes**

Fixes #271 

**Special notes for your reviewer**:

~Blocked by https://github.com/Kong/kubernetes-ingress-controller/pull/6104~

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
