### PR TITLE
chore: `gotestsum` version specified in mise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ GOTESTSUM = $(PROJECT_DIR)/bin/installs/gotestsum/$(GOTESTSUM_VERSION)/bin/gotes
 .PHONY: gotestsum
 gotestsum: mise yq ## Download gotestsum locally if necessary.
 	@$(MISE) plugin install --yes -q gotestsum https://github.com/pmalek/mise-gotestsum.git
-	@$(MISE) install -q gotestsum
+	@$(MISE) install -q gotestsum@$(GOTESTSUM_VERSION)
 
 CRD_REF_DOCS_VERSION = $(shell $(YQ) -r '.crd-ref-docs' < $(TOOLS_VERSIONS_FILE))
 CRD_REF_DOCS = $(PROJECT_DIR)/bin/crd-ref-docs


### PR DESCRIPTION
**What this PR does / why we need it**:

All the make targets using `gotestsum` fail as its version is not specified in the make target, and `gotestsum` published a new release [yesterday](https://github.com/gotestyourself/gotestsum/releases/tag/v1.12.0). We try to use gotestsum v1.12.0, but the downloaded version is v1.11.0.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
