### PR TITLE
ci: use renovate for Gateway and KIC versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/---release.md
+++ b/.github/ISSUE_TEMPLATE/---release.md
@@ -49,10 +49,14 @@ If the troubleshooting section does not contain the answer to the problem you en
 
 ## Verify default hardcoded versions
 
-The package [internal/consts][consts-pkg] contains a list of default versions for the operator. These versions should be updated to match the new release. The example consts to look for:
+> **NOTE**: These versions should be automatically updated via Renovate.
+> As part of the release workflow please verify that this is indeed the case and the automation still works.
+
+The packages [internal/consts][consts-pkg] and [pkg/versions][versions-pkg] contains a list of default versions for the operator.
+These versions should be updated to match the new release. The example consts to look for:
 
 - `DefaultDataPlaneTag`
-- `DefaultControlPlaneTag`
+- `DefaultControlPlaneVersion`
 - `WebhookCertificateConfigBaseImage`
 
 ## GitHub PAT
@@ -88,5 +92,6 @@ Steps:
 
 [releases]: https://github.com/Kong/gateway-operator/releases
 [release-action]: https://github.com/Kong/gateway-operator/actions/workflows/release.yaml
-[consts-pkg]: https://github.com/Kong/gateway-operator/blob/main/internal/consts/consts.go
+[consts-pkg]: https://github.com/Kong/gateway-operator/blob/main/pkg/consts/consts.go
+[versions-pkg]: https://github.com/Kong/gateway-operator/blob/main/internal/versions/
 [kgo-prs]: https://github.com/Kong/gateway-operator/pulls

--- a/internal/versions/controlplane.go
+++ b/internal/versions/controlplane.go
@@ -6,7 +6,6 @@ import (
 
 const (
 	// DefaultControlPlaneVersion is the default version of the ControlPlane to use.
-	// TODO: automatically update this via renovate https://github.com/Kong/gateway-operator/issues/121
 	//
 	// NOTE: This needs to be a full semver version (i.e. it needs to include
 	// the minor and the patch version). The reason for this is that it's used in the
@@ -14,7 +13,7 @@ const (
 	// and those tests create KIC's URLs for things like roles or CRDs.
 	// Since KIC only defines the full tags in its repo (as expected) we cannot use
 	// a partial version here, as it would not match KIC's tag.
-	DefaultControlPlaneVersion = "3.1.3"
+	DefaultControlPlaneVersion = "3.1.3" // renovate: datasource=docker depName=kong/kubernetes-ingress-controller
 )
 
 // minimumControlPlaneVersion indicates the bare minimum version of the

--- a/pkg/consts/dataplane.go
+++ b/pkg/consts/dataplane.go
@@ -87,7 +87,7 @@ const (
 	// DefaultDataPlaneTag is the base container image tag that can be used
 	// by default for a DataPlane resource if all other attempts to dynamically
 	// decide an image tag fail.
-	DefaultDataPlaneTag = "3.6" // TODO: automatically update this via renovate https://github.com/Kong/gateway-operator/issues/121
+	DefaultDataPlaneTag = "3.6" // renovate: datasource=docker depName=kong/kong-gateway
 
 	// DefaultDataPlaneImage is the default container image that can be used if
 	// all other attempts to dynamically decide the default image fail.

--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,18 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.+\"(?<currentValue>.*?)\""
       ]
+    },
+    {
+      "description": "Match versions in pkg/consts/dataplane.go that are properly annotated with `# renovate: datasource={} versioning={}.`",
+      "customType": "regex",
+      "datasourceTemplate": "docker",
+      "fileMatch": [
+        "^pkg/consts/dataplane\\.go$",
+        "^internal/versions/controlplane\\.go$"
+      ],
+      "matchStrings": [
+        ".+\\s+=\\s+\"(?<currentValue>.+)\"\\s+//\\s+renovate:\\s+datasource=(?<datasource>.*)\\s+(?<depName>.+?)"
+      ]
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Add renovate to manage default KIC and Gateway versions.

**Which issue this PR fixes**

Fixes #121

