### PR TITLE
tests(conformance): run conformance against expressions and traditional_compatible router flavors

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -177,6 +177,12 @@ jobs:
 
   conformance-tests:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - router-flavor: traditional_compatible
+        - router-flavor: expressions
     steps:
     - name: checkout repository
       uses: actions/checkout@v4
@@ -196,7 +202,8 @@ jobs:
     - name: run conformance tests
       run: make test.conformance
       env:
-        GOTESTSUM_JUNITFILE: "conformance-tests.xml"
+        GOTESTSUM_JUNITFILE: conformance-tests-${{ matrix.router-flavor }}.xml
+        TEST_KONG_ROUTER_FLAVOR: ${{ matrix.router-flavor }}
 
     - name: upload diagnostics
       if: ${{ always() }}
@@ -211,7 +218,13 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: tests-report
-        path: conformance-tests.xml
+        path: conformance-tests-${{ matrix.router-flavor }}.xml
+
+    - name: collect conformance report
+      uses: actions/upload-artifact@v4
+      with:
+        name: conformance-report-${{ matrix.router-flavor }}
+        path: kong-gateway-operator*.yaml
 
   integration-tests:
     runs-on: ubuntu-latest

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -30,7 +30,6 @@ var skippedTestsForExpressionsRouter = []string{
 	tests.GatewayInvalidTLSConfiguration.ShortName,
 
 	// httproute
-	tests.HTTPRouteHeaderMatching.ShortName,
 	tests.HTTPRouteInvalidBackendRefUnknownKind.ShortName,
 
 	// TODO: remove the skip https://github.com/Kong/gateway-operator/issues/295

--- a/test/conformance/router_flavor.go
+++ b/test/conformance/router_flavor.go
@@ -1,0 +1,41 @@
+package conformance
+
+import (
+	"os"
+	"testing"
+)
+
+// RouterFlavor represents the flavor of the Kong router.
+// ref: https://docs.konghq.com/gateway/latest/reference/configuration/#router_flavor
+type RouterFlavor string
+
+const (
+	// RouterFlavorTraditionalCompatible is the traditional compatible router flavor.
+	RouterFlavorTraditionalCompatible RouterFlavor = "traditional_compatible"
+	// RouterFlavorExpressions is the expressions router flavor.
+	RouterFlavorExpressions RouterFlavor = "expressions"
+)
+
+// KongRouterFlavor returns router mode of Kong in tests. Currently supports:
+// - `traditional`
+// - `traditional_compatible`.
+// - `expressions` (experimental, only for testing expression route related tests).
+func KongRouterFlavor(t *testing.T) RouterFlavor {
+	rf := os.Getenv("TEST_KONG_ROUTER_FLAVOR")
+	switch {
+	case rf == "":
+		return RouterFlavorTraditionalCompatible
+	case rf == string(RouterFlavorTraditionalCompatible):
+		return RouterFlavorTraditionalCompatible
+	case rf == string(RouterFlavorExpressions):
+		return RouterFlavorExpressions
+	case rf == "traditional":
+		t.Logf("Kong router flavor 'traditional' is deprecated, please use 'traditional_compatible' instead")
+		t.FailNow()
+		return ""
+	default:
+		t.Errorf("unsupported Kong router flavor: %s", rf)
+		t.FailNow()
+		return ""
+	}
+}

--- a/test/conformance/router_flavor.go
+++ b/test/conformance/router_flavor.go
@@ -17,9 +17,8 @@ const (
 )
 
 // KongRouterFlavor returns router mode of Kong in tests. Currently supports:
-// - `traditional`
-// - `traditional_compatible`.
-// - `expressions` (experimental, only for testing expression route related tests).
+// - `traditional_compatible`
+// - `expressions`
 func KongRouterFlavor(t *testing.T) RouterFlavor {
 	rf := os.Getenv("TEST_KONG_ROUTER_FLAVOR")
 	switch {


### PR DESCRIPTION
**What this PR does / why we need it**:

Run conformance against `expressions` and `traditional_compatible` Kong router flavors.

This PR will cause 2 reports to be produced instead of 1 which aligns with what KIC does.

**Which issue this PR fixes**

Fixes #57 but also for expressions router flavor because KIC itself doesn't support `HTTPRouteHeaderMatching`.
