### PR TITLE
chore: fix renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,7 +43,7 @@
         "^internal/versions/controlplane\\.go$"
       ],
       "matchStrings": [
-        ".+\\s+=\\s+\"(?<currentValue>.+)\"\\s+//\\s+renovate:\\s+datasource=(?<datasource>.*)\\s+depName=(?<depName>.+?)"
+        ".+\\s+=\\s+\"(?<currentValue>.+)\"\\s+//\\s+renovate:\\s+datasource=(?<datasource>.*)\\s+depName=(?<depName>.+)"
       ]
     }
   ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the following config (by making the `.+` greedy)

```
           {
             "deps": [
               {
                 "depName": "k",
                 "currentValue": "3.1.3",
                 "datasource": "docker",
                 "replaceString": "\tDefaultControlPlaneVersion = \"3.1.3\" // renovate: datasource=docker depName=k",
                 "updates": [],
                 "packageName": "k",
                 "versioning": "docker",
                 "warnings": [
                   {"topic": "k", "message": "Failed to look up docker package k"}
                 ]
               }
             ],
             "matchStrings": [
               ".+\\s+=\\s+\"(?<currentValue>.+)\"\\s+//\\s+renovate:\\s+datasource=(?<datasource>.*)\\s+depName=(?<depName>.+?)"
             ],
             "datasourceTemplate": "docker",
             "packageFile": "internal/versions/controlplane.go"
           },
           {
             "deps": [
               {
                 "depName": "k",
                 "currentValue": "3.6",
                 "datasource": "docker",
                 "replaceString": "\tDefaultDataPlaneTag = \"3.6\" // renovate: datasource=docker depName=k",
                 "updates": [],
                 "packageName": "k",
                 "versioning": "docker",
                 "warnings": [
                   {"topic": "k", "message": "Failed to look up docker package k"}
                 ]
               }
             ],
             "matchStrings": [
               ".+\\s+=\\s+\"(?<currentValue>.+)\"\\s+//\\s+renovate:\\s+datasource=(?<datasource>.*)\\s+depName=(?<depName>.+?)"
             ],
             "datasourceTemplate": "docker",
             "packageFile": "pkg/consts/dataplane.go"
           }
         ]
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
