### PR TITLE
feat: detect when ControlPlane's admission webhook is disabled and ensure relevant resources do not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ## Unreleased
 
+> Release date: TBA
+
 ### Added
 
 - Add `ExternalTrafficPolicy` to `DataPlane`'s `ServiceOptions`
@@ -40,6 +42,10 @@
   [#246](https://github.com/Kong/gateway-operator/pull/246)
 - `Gateway`s' listeners now have their `attachedRoutes` count filled in in status.
   [#251](https://github.com/Kong/gateway-operator/pull/251)
+- Detect when `ControlPlane` has its admission webhook disabled via
+  `CONTROLLER_ADMISSION_WEBHOOK_LISTEN` environment variable and ensure that
+  relevant webhook resources are not created/deleted.
+  [#326](https://github.com/Kong/gateway-operator/pull/326)
 
 ### Fixes
 

--- a/config/samples/gateway-with-disabled-controlplane-admission-webhook.yaml
+++ b/config/samples/gateway-with-disabled-controlplane-admission-webhook.yaml
@@ -1,0 +1,111 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+spec:
+  ports:
+    - protocol: TCP
+      name: http
+      port: 80
+      targetPort: http
+  selector:
+    app: echo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: echo
+  name: echo
+spec:
+  selector:
+    matchLabels:
+      app: echo
+  template:
+    metadata:
+      labels:
+        app: echo
+    spec:
+      containers:
+        - name: echo
+          image: registry.k8s.io/e2e-test-images/agnhost:2.40
+          command:
+            - /agnhost
+            - netexec
+            - --http-port=8080
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+---
+kind: GatewayConfiguration
+apiVersion: gateway-operator.konghq.com/v1beta1
+metadata:
+  name: kong
+  namespace: default
+spec:
+  dataPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        spec:
+          containers:
+          - name: proxy
+            # renovate: datasource=docker versioning=docker
+            image: kong/kong-gateway:3.7
+            readinessProbe:
+              initialDelaySeconds: 1
+              periodSeconds: 1
+  controlPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        spec:
+          containers:
+          - name: controller
+            # renovate: datasource=docker versioning=docker
+            image: kong/kubernetes-ingress-controller:3.1.6
+            readinessProbe:
+              initialDelaySeconds: 1
+              periodSeconds: 1
+            env:
+            - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
+              value: "off"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: kong
+spec:
+  controllerName: konghq.com/gateway-operator
+  parametersRef:
+    group: gateway-operator.konghq.com
+    kind: GatewayConfiguration
+    name: kong
+    namespace: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: kong
+  namespace: default
+spec:
+  gatewayClassName: kong
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -482,7 +482,7 @@ func (r *Reconciler) ensureWebhookResources(
 	}
 
 	log.Trace(logger, "ensuring admission webhook service", cp)
-	res, admissionWebhookService, err := r.ensureAdmissionWebhookService(ctx, logger, r.Client, cp)
+	res, admissionWebhookService, err := r.ensureAdmissionWebhookService(ctx, r.Client, cp, webhookEnabled)
 	if err != nil {
 		return "", res, fmt.Errorf("failed to ensure admission webhook service: %w", err)
 	}
@@ -496,7 +496,7 @@ func (r *Reconciler) ensureWebhookResources(
 	}
 
 	log.Trace(logger, "ensuring admission webhook certificate", cp)
-	res, admissionWebhookCertificateSecret, err := r.ensureAdmissionWebhookCertificateSecret(ctx, logger, cp, admissionWebhookService)
+	res, admissionWebhookCertificateSecret, err := r.ensureAdmissionWebhookCertificateSecret(ctx, cp, admissionWebhookService, webhookEnabled)
 	if err != nil {
 		return "", res, err
 	}
@@ -510,7 +510,7 @@ func (r *Reconciler) ensureWebhookResources(
 	}
 
 	log.Trace(logger, "ensuring admission webhook configuration", cp)
-	res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, admissionWebhookCertificateSecret, admissionWebhookService)
+	res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, admissionWebhookCertificateSecret, admissionWebhookService, webhookEnabled)
 	if err != nil {
 		return "", res, err
 	}

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -482,7 +482,7 @@ func (r *Reconciler) ensureWebhookResources(
 	}
 
 	log.Trace(logger, "ensuring admission webhook service", cp)
-	res, admissionWebhookService, err := r.ensureAdmissionWebhookService(ctx, r.Client, cp, webhookEnabled)
+	res, admissionWebhookService, err := r.ensureAdmissionWebhookService(ctx, logger, r.Client, cp)
 	if err != nil {
 		return "", res, fmt.Errorf("failed to ensure admission webhook service: %w", err)
 	}
@@ -496,7 +496,7 @@ func (r *Reconciler) ensureWebhookResources(
 	}
 
 	log.Trace(logger, "ensuring admission webhook certificate", cp)
-	res, admissionWebhookCertificateSecret, err := r.ensureAdmissionWebhookCertificateSecret(ctx, cp, admissionWebhookService, webhookEnabled)
+	res, admissionWebhookCertificateSecret, err := r.ensureAdmissionWebhookCertificateSecret(ctx, logger, cp, admissionWebhookService)
 	if err != nil {
 		return "", res, err
 	}
@@ -510,7 +510,7 @@ func (r *Reconciler) ensureWebhookResources(
 	}
 
 	log.Trace(logger, "ensuring admission webhook configuration", cp)
-	res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, admissionWebhookCertificateSecret, admissionWebhookService, webhookEnabled)
+	res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, admissionWebhookCertificateSecret, admissionWebhookService)
 	if err != nil {
 		return "", res, err
 	}

--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -452,9 +452,9 @@ func (r *Reconciler) ensureAdminMTLSCertificateSecret(
 // ControlPlane's admission webhook.
 func (r *Reconciler) ensureAdmissionWebhookCertificateSecret(
 	ctx context.Context,
-	logger logr.Logger,
 	cp *operatorv1beta1.ControlPlane,
 	admissionWebhookService *corev1.Service,
+	webhookEnabled bool,
 ) (
 	op.Result,
 	*corev1.Secret,
@@ -468,7 +468,7 @@ func (r *Reconciler) ensureAdmissionWebhookCertificateSecret(
 	matchingLabels := client.MatchingLabels{
 		consts.SecretUsedByServiceLabel: consts.ControlPlaneServiceKindWebhook,
 	}
-	if !isAdmissionWebhookEnabled(ctx, r.Client, logger, cp) {
+	if !webhookEnabled {
 		labels := k8sresources.GetManagedLabelForOwner(cp)
 		labels[consts.SecretUsedByServiceLabel] = consts.ControlPlaneServiceKindWebhook
 		secrets, err := k8sutils.ListSecretsForOwner(ctx, r.Client, cp.GetUID(), matchingLabels)
@@ -594,9 +594,9 @@ func (r *Reconciler) ensureOwnedValidatingWebhookConfigurationDeleted(ctx contex
 
 func (r *Reconciler) ensureAdmissionWebhookService(
 	ctx context.Context,
-	logger logr.Logger,
 	cl client.Client,
 	controlPlane *operatorv1beta1.ControlPlane,
+	webhookEnabled bool,
 ) (op.Result, *corev1.Service, error) {
 	matchingLabels := k8sresources.GetManagedLabelForOwner(controlPlane)
 	matchingLabels[consts.ControlPlaneServiceLabel] = consts.ControlPlaneServiceKindWebhook
@@ -612,7 +612,7 @@ func (r *Reconciler) ensureAdmissionWebhookService(
 		return op.Noop, nil, fmt.Errorf("failed listing admission webhook Services for ControlPlane %s/%s: %w", controlPlane.Namespace, controlPlane.Name, err)
 	}
 
-	if !isAdmissionWebhookEnabled(ctx, cl, logger, controlPlane) {
+	if !webhookEnabled {
 		for _, svc := range services {
 			svc := svc
 			if err := cl.Delete(ctx, &svc); err != nil && !k8serrors.IsNotFound(err) {
@@ -673,6 +673,7 @@ func (r *Reconciler) ensureValidatingWebhookConfiguration(
 	cp *operatorv1beta1.ControlPlane,
 	certSecret *corev1.Secret,
 	webhookService *corev1.Service,
+	webhookEnabled bool,
 ) (op.Result, error) {
 	logger := log.GetLogger(ctx, "controlplane.ensureValidatingWebhookConfiguration", r.DevelopmentMode)
 
@@ -696,7 +697,7 @@ func (r *Reconciler) ensureValidatingWebhookConfiguration(
 		return op.Noop, errors.New("number of validatingWebhookConfigurations reduced")
 	}
 
-	if !isAdmissionWebhookEnabled(ctx, r.Client, logger, cp) {
+	if !webhookEnabled {
 		for _, webhookConfiguration := range validatingWebhookConfigurations {
 			if err := r.Client.Delete(ctx, &webhookConfiguration); err != nil && !k8serrors.IsNotFound(err) {
 				return op.Noop, fmt.Errorf("failed deleting ControlPlane admission webhook ValidatingWebhookConfiguration %s: %w", webhookConfiguration.Name, err)

--- a/controller/controlplane/controller_reconciler_utils_test.go
+++ b/controller/controlplane/controller_reconciler_utils_test.go
@@ -83,14 +83,14 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 					},
 				}
 
-				res, err := r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc, true)
+				res, err := r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
 				require.NoError(t, err)
 				require.Equal(t, op.Created, res)
 
 				require.NoError(t, r.Client.List(ctx, &webhooks))
 				require.Len(t, webhooks.Items, 1)
 
-				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc, true)
+				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
 				require.NoError(t, err)
 				require.Equal(t, op.Noop, res)
 			},
@@ -146,14 +146,14 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 					},
 				}
 
-				res, err := r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc, true)
+				res, err := r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
 				require.NoError(t, err)
 				require.Equal(t, res, op.Created)
 
 				require.NoError(t, r.Client.List(ctx, &webhooks))
 				require.Len(t, webhooks.Items, 1, "webhook configuration should be created")
 
-				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc, true)
+				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
 				require.NoError(t, err)
 				require.Equal(t, res, op.Noop)
 
@@ -165,7 +165,7 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 				}
 
 				t.Log("running ensureValidatingWebhookConfiguration to enforce ObjectMeta")
-				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc, true)
+				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
 				require.NoError(t, err)
 				require.Equal(t, res, op.Updated)
 

--- a/controller/controlplane/controller_reconciler_utils_test.go
+++ b/controller/controlplane/controller_reconciler_utils_test.go
@@ -83,14 +83,14 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 					},
 				}
 
-				res, err := r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
+				res, err := r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc, true)
 				require.NoError(t, err)
 				require.Equal(t, op.Created, res)
 
 				require.NoError(t, r.Client.List(ctx, &webhooks))
 				require.Len(t, webhooks.Items, 1)
 
-				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
+				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc, true)
 				require.NoError(t, err)
 				require.Equal(t, op.Noop, res)
 			},
@@ -146,14 +146,14 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 					},
 				}
 
-				res, err := r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
+				res, err := r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc, true)
 				require.NoError(t, err)
 				require.Equal(t, res, op.Created)
 
 				require.NoError(t, r.Client.List(ctx, &webhooks))
 				require.Len(t, webhooks.Items, 1, "webhook configuration should be created")
 
-				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
+				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc, true)
 				require.NoError(t, err)
 				require.Equal(t, res, op.Noop)
 
@@ -165,7 +165,7 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 				}
 
 				t.Log("running ensureValidatingWebhookConfiguration to enforce ObjectMeta")
-				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
+				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc, true)
 				require.NoError(t, err)
 				require.Equal(t, res, op.Updated)
 

--- a/controller/controlplane/controller_reconciler_utils_test.go
+++ b/controller/controlplane/controller_reconciler_utils_test.go
@@ -19,7 +19,11 @@ import (
 )
 
 func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
-	const webhookSvcName = "webhook-svc"
+	webhookSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "webhook-svc",
+		},
+	}
 
 	testCases := []struct {
 		name    string
@@ -41,7 +45,20 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 							PodTemplateSpec: &corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									Containers: []corev1.Container{
-										resources.GenerateControlPlaneContainer(consts.DefaultControlPlaneImage),
+										func() corev1.Container {
+											c := resources.GenerateControlPlaneContainer(
+												resources.GenerateContainerForControlPlaneParams{
+													Image:                          consts.DefaultControlPlaneImage,
+													AdmissionWebhookCertSecretName: "cert-secret",
+												})
+											// Envs are set elsewhere so fill in the CONTROLLER_ADMISSION_WEBHOOK_LISTEN
+											// here so that the webhook is enabled.
+											c.Env = append(c.Env, corev1.EnvVar{
+												Name:  "CONTROLLER_ADMISSION_WEBHOOK_LISTEN",
+												Value: "0.0.0.0:8080",
+											})
+											return c
+										}(),
 									},
 								},
 							},
@@ -59,23 +76,23 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 
 				certSecret := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "cert-cecret",
+						Name: "cert-secret",
 					},
 					Data: map[string][]byte{
 						"ca.crt": []byte("ca"), // dummy
 					},
 				}
 
-				res, err := r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvcName)
+				res, err := r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
 				require.NoError(t, err)
-				require.Equal(t, res, op.Created)
+				require.Equal(t, op.Created, res)
 
 				require.NoError(t, r.Client.List(ctx, &webhooks))
 				require.Len(t, webhooks.Items, 1)
 
-				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvcName)
+				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
 				require.NoError(t, err)
-				require.Equal(t, res, op.Noop)
+				require.Equal(t, op.Noop, res)
 			},
 		},
 		{
@@ -91,7 +108,20 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 							PodTemplateSpec: &corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									Containers: []corev1.Container{
-										resources.GenerateControlPlaneContainer(consts.DefaultControlPlaneImage),
+										func() corev1.Container {
+											c := resources.GenerateControlPlaneContainer(
+												resources.GenerateContainerForControlPlaneParams{
+													Image:                          consts.DefaultControlPlaneImage,
+													AdmissionWebhookCertSecretName: "cert-secret",
+												})
+											// Envs are set elsewhere so fill in the CONTROLLER_ADMISSION_WEBHOOK_LISTEN
+											// here so that the webhook is enabled.
+											c.Env = append(c.Env, corev1.EnvVar{
+												Name:  "CONTROLLER_ADMISSION_WEBHOOK_LISTEN",
+												Value: "0.0.0.0:8080",
+											})
+											return c
+										}(),
 									},
 								},
 							},
@@ -109,21 +139,21 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 
 				certSecret := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "cert-cecret",
+						Name: "cert-secret",
 					},
 					Data: map[string][]byte{
 						"ca.crt": []byte("ca"), // dummy
 					},
 				}
 
-				res, err := r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvcName)
+				res, err := r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
 				require.NoError(t, err)
 				require.Equal(t, res, op.Created)
 
 				require.NoError(t, r.Client.List(ctx, &webhooks))
 				require.Len(t, webhooks.Items, 1, "webhook configuration should be created")
 
-				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvcName)
+				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
 				require.NoError(t, err)
 				require.Equal(t, res, op.Noop)
 
@@ -135,7 +165,7 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 				}
 
 				t.Log("running ensureValidatingWebhookConfiguration to enforce ObjectMeta")
-				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvcName)
+				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
 				require.NoError(t, err)
 				require.Equal(t, res, op.Updated)
 

--- a/controller/controlplane/controller_reconciler_utils_test.go
+++ b/controller/controlplane/controller_reconciler_utils_test.go
@@ -49,7 +49,7 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 											c := resources.GenerateControlPlaneContainer(
 												resources.GenerateContainerForControlPlaneParams{
 													Image:                          consts.DefaultControlPlaneImage,
-													AdmissionWebhookCertSecretName: "cert-secret",
+													AdmissionWebhookCertSecretName: lo.ToPtr("cert-secret"),
 												})
 											// Envs are set elsewhere so fill in the CONTROLLER_ADMISSION_WEBHOOK_LISTEN
 											// here so that the webhook is enabled.
@@ -112,7 +112,7 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 											c := resources.GenerateControlPlaneContainer(
 												resources.GenerateContainerForControlPlaneParams{
 													Image:                          consts.DefaultControlPlaneImage,
-													AdmissionWebhookCertSecretName: "cert-secret",
+													AdmissionWebhookCertSecretName: lo.ToPtr("cert-secret"),
 												})
 											// Envs are set elsewhere so fill in the CONTROLLER_ADMISSION_WEBHOOK_LISTEN
 											// here so that the webhook is enabled.

--- a/controller/controlplane/controller_utils_test.go
+++ b/controller/controlplane/controller_utils_test.go
@@ -527,7 +527,6 @@ func TestSetControlPlaneDefaults(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			changed := controlplane.SetDefaults(
 				tc.spec,
-				map[string]struct{}{},
 				controlplane.DefaultsArgs{
 					Namespace:                   tc.namespace,
 					DataPlaneIngressServiceName: tc.dataplaneIngressServiceName,

--- a/controller/dataplane/bluegreen_controller.go
+++ b/controller/dataplane/bluegreen_controller.go
@@ -484,7 +484,7 @@ func (r *BlueGreenReconciler) ensureDeploymentForDataPlane(
 	logger logr.Logger,
 	dataplane *operatorv1beta1.DataPlane,
 	certSecret *corev1.Secret,
-) (*appsv1.Deployment, op.CreatedUpdatedOrNoop, error) {
+) (*appsv1.Deployment, op.Result, error) {
 	deploymentOpts := []k8sresources.DeploymentOpt{
 		labelSelectorFromDataPlaneRolloutStatusSelectorDeploymentOpt(dataplane),
 	}
@@ -747,7 +747,7 @@ func (r *BlueGreenReconciler) ensurePreviewAdminAPIService(
 	ctx context.Context,
 	logger logr.Logger,
 	dataplane *operatorv1beta1.DataPlane,
-) (op.CreatedUpdatedOrNoop, *corev1.Service, error) {
+) (op.Result, *corev1.Service, error) {
 	additionalServiceLabels := map[string]string{
 		consts.DataPlaneServiceStateLabel: consts.DataPlaneStateLabelValuePreview,
 	}
@@ -768,6 +768,7 @@ func (r *BlueGreenReconciler) ensurePreviewAdminAPIService(
 		log.Debug(logger, "preview admin service modified", dataplane, "service", svc.Name, "reason", res)
 	case op.Noop:
 		log.Trace(logger, "no need for preview Admin API service update", dataplane)
+	case op.Deleted:
 	}
 	return res, svc, nil // dataplane admin service creation/update will trigger reconciliation
 }
@@ -778,7 +779,7 @@ func (r *BlueGreenReconciler) ensurePreviewIngressService(
 	ctx context.Context,
 	logger logr.Logger,
 	dataplane *operatorv1beta1.DataPlane,
-) (op.CreatedUpdatedOrNoop, *corev1.Service, error) {
+) (op.Result, *corev1.Service, error) {
 	additionalServiceLabels := map[string]string{
 		consts.DataPlaneServiceStateLabel: consts.DataPlaneStateLabelValuePreview,
 	}
@@ -800,6 +801,7 @@ func (r *BlueGreenReconciler) ensurePreviewIngressService(
 		log.Debug(logger, "preview ingress service modified", dataplane, "service", svc.Name, "reason", res)
 	case op.Noop:
 		log.Trace(logger, "no need for preview ingress service update", dataplane)
+	case op.Deleted:
 	}
 
 	return res, svc, nil

--- a/controller/dataplane/bluegreen_controller_test.go
+++ b/controller/dataplane/bluegreen_controller_test.go
@@ -448,7 +448,7 @@ func TestEnsurePreviewIngressService(t *testing.T) {
 		name                     string
 		dataplane                *operatorv1beta1.DataPlane
 		existingServiceModifier  func(*testing.T, context.Context, client.Client, *corev1.Service)
-		expectedCreatedOrUpdated op.CreatedUpdatedOrNoop
+		expectedCreatedOrUpdated op.Result
 		expectedService          *corev1.Service
 		// expectedErrorMessage is empty if we expect no error, otherwise returned error must contain it.
 		expectedErrorMessage string

--- a/controller/dataplane/controller.go
+++ b/controller/dataplane/controller.go
@@ -108,6 +108,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		log.Debug(logger, "DataPlane admin service modified", dataplane, "service", dataplaneAdminService.Name, "reason", res)
 		return ctrl.Result{}, nil // dataplane admin service creation/update will trigger reconciliation
 	case op.Noop:
+	case op.Deleted: // This should not happen.
 	}
 
 	log.Trace(logger, "exposing DataPlane deployment via service", dataplane)

--- a/controller/dataplane/owned_deployment.go
+++ b/controller/dataplane/owned_deployment.go
@@ -90,7 +90,7 @@ func (d *DeploymentBuilder) BuildAndDeploy(
 	ctx context.Context,
 	dataplane *operatorv1beta1.DataPlane,
 	developmentMode bool,
-) (*appsv1.Deployment, op.CreatedUpdatedOrNoop, error) {
+) (*appsv1.Deployment, op.Result, error) {
 	// run any preparatory callbacks
 	beforeDeploymentCallbacks := NewCallbackRunner(d.client)
 	cbErrors := beforeDeploymentCallbacks.For(dataplane).Runs(d.beforeCallbacks).Do(ctx, nil)
@@ -294,7 +294,7 @@ func reconcileDataPlaneDeployment(
 	dataplane *operatorv1beta1.DataPlane,
 	existing *appsv1.Deployment,
 	desired *appsv1.Deployment,
-) (res op.CreatedUpdatedOrNoop, deploy *appsv1.Deployment, err error) {
+) (res op.Result, deploy *appsv1.Deployment, err error) {
 	if existing != nil {
 		var updated bool
 		original := existing.DeepCopy()

--- a/controller/dataplane/owned_resources.go
+++ b/controller/dataplane/owned_resources.go
@@ -36,7 +36,7 @@ func ensureDataPlaneCertificate(
 	dataplane *operatorv1beta1.DataPlane,
 	clusterCASecretNN types.NamespacedName,
 	adminServiceNN types.NamespacedName,
-) (op.CreatedUpdatedOrNoop, *corev1.Secret, error) {
+) (op.Result, *corev1.Secret, error) {
 	usages := []certificatesv1.KeyUsage{
 		certificatesv1.UsageKeyEncipherment,
 		certificatesv1.UsageDigitalSignature, certificatesv1.UsageServerAuth,
@@ -57,7 +57,7 @@ func ensureHPAForDataPlane(
 	log logr.Logger,
 	dataplane *operatorv1beta1.DataPlane,
 	deploymentName string,
-) (res op.CreatedUpdatedOrNoop, hpa *autoscalingv2.HorizontalPodAutoscaler, err error) {
+) (res op.Result, hpa *autoscalingv2.HorizontalPodAutoscaler, err error) {
 	matchingLabels := k8sresources.GetManagedLabelForOwner(dataplane)
 	hpas, err := k8sutils.ListHPAsForOwner(
 		ctx,
@@ -141,7 +141,7 @@ func ensureAdminServiceForDataPlane(
 	dataPlane *operatorv1beta1.DataPlane,
 	additionalServiceLabels client.MatchingLabels,
 	opts ...k8sresources.ServiceOpt,
-) (res op.CreatedUpdatedOrNoop, svc *corev1.Service, err error) {
+) (res op.Result, svc *corev1.Service, err error) {
 	// TODO: https://github.com/Kong/gateway-operator/issues/156.
 	// Use only new labels after several minor version of soak time.
 
@@ -252,7 +252,7 @@ func ensureIngressServiceForDataPlane(
 	dataPlane *operatorv1beta1.DataPlane,
 	additionalServiceLabels client.MatchingLabels,
 	opts ...k8sresources.ServiceOpt,
-) (op.CreatedUpdatedOrNoop, *corev1.Service, error) {
+) (op.Result, *corev1.Service, error) {
 	// TODO: https://github.com/Kong/gateway-operator/issues/156.
 	// Use only new labels after several minor version of soak time.
 

--- a/controller/dataplane/owned_resources_test.go
+++ b/controller/dataplane/owned_resources_test.go
@@ -28,7 +28,7 @@ func TestEnsureIngressServiceForDataPlane(t *testing.T) {
 		dataplane                *operatorv1beta1.DataPlane
 		additionalLabels         map[string]string
 		existingServiceModifier  func(*testing.T, context.Context, client.Client, *corev1.Service)
-		expectedCreatedOrUpdated op.CreatedUpdatedOrNoop
+		expectedCreatedOrUpdated op.Result
 		expectedServiceType      corev1.ServiceType
 		expectedServicePorts     []corev1.ServicePort
 		expectedAnnotations      map[string]string

--- a/controller/gateway/controller_test.go
+++ b/controller/gateway/controller_test.go
@@ -320,7 +320,6 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 					controlPlane := gatewaySubResource.(*operatorv1beta1.ControlPlane)
 					_ = controlplane.SetDefaults(
 						&controlPlane.Spec.ControlPlaneOptions,
-						map[string]struct{}{},
 						controlplane.DefaultsArgs{
 							Namespace:                   "test-namespace",
 							DataPlaneIngressServiceName: "test-ingress-service",

--- a/controller/pkg/controlplane/controlplane.go
+++ b/controller/pkg/controlplane/controlplane.go
@@ -35,7 +35,6 @@ type DefaultsArgs struct {
 // and returns true if env field is changed.
 func SetDefaults(
 	spec *operatorv1beta1.ControlPlaneOptions,
-	dontOverride map[string]struct{},
 	args DefaultsArgs,
 ) bool {
 	changed := false
@@ -57,6 +56,10 @@ func SetDefaults(
 		container = &corev1.Container{
 			Name: consts.ControlPlaneControllerContainerName,
 		}
+	}
+	dontOverride := make(map[string]struct{})
+	for _, envVar := range container.Env {
+		dontOverride[envVar.Name] = struct{}{}
 	}
 
 	const podNamespaceEnvVarName = "POD_NAMESPACE"

--- a/controller/pkg/op/operation_result.go
+++ b/controller/pkg/op/operation_result.go
@@ -1,16 +1,18 @@
 package op
 
-// CreatedUpdatedOrNoop represents a result of an operation that can either:
+// Result represents a result of an operation that can either:
 // - create a resource
 // - update a resource
 // - do nothing
-type CreatedUpdatedOrNoop string
+type Result string
 
 const (
 	// Created indicates that an operation resulted in creation of a resource.
-	Created CreatedUpdatedOrNoop = "created"
+	Created Result = "created"
 	// Updated indicates that an operation resulted in an update of a resource.
-	Updated CreatedUpdatedOrNoop = "updated"
+	Updated Result = "updated"
+	// Deleted indicates that an operation resulted in a delete of a resource.
+	Deleted Result = "deleted"
 	// Noop indicated that an operation did not perform any actions.
-	Noop CreatedUpdatedOrNoop = "noop"
+	Noop Result = "noop"
 )

--- a/controller/pkg/patch/patch.go
+++ b/controller/pkg/patch/patch.go
@@ -34,7 +34,7 @@ func ApplyPatchIfNonEmpty[
 	oldExistingResource ResourceT,
 	owner OwnerT,
 	updated bool,
-) (res op.CreatedUpdatedOrNoop, deploy ResourceT, err error) {
+) (res op.Result, deploy ResourceT, err error) {
 	kind := existingResource.GetObjectKind().GroupVersionKind().Kind
 
 	if !updated {
@@ -69,7 +69,7 @@ func ApplyGatewayStatusPatchIfNotEmpty(ctx context.Context,
 	logger logr.Logger,
 	existingGateway *gatewayv1.Gateway,
 	oldExistingGateway *gatewayv1.Gateway,
-) (res op.CreatedUpdatedOrNoop, err error) {
+) (res op.Result, err error) {
 	// Check if the patch to be applied is empty.
 	patch := client.MergeFrom(oldExistingGateway)
 	b, err := patch.Data(existingGateway)

--- a/controller/pkg/patch/patch_test.go
+++ b/controller/pkg/patch/patch_test.go
@@ -34,7 +34,7 @@ func TestApplyPatchIfNonEmpty(t *testing.T) {
 		assertHPAFunc   func(t *testing.T, hpa *autoscalingv2.HorizontalPodAutoscaler)
 		updated         bool
 		wantErr         bool
-		wantResult      op.CreatedUpdatedOrNoop
+		wantResult      op.Result
 	}{
 		{
 			name: "when no changes are needed no patch is being made",

--- a/controller/pkg/secrets/cert.go
+++ b/controller/pkg/secrets/cert.go
@@ -164,7 +164,7 @@ func EnsureCertificate[
 	usages []certificatesv1.KeyUsage,
 	cl client.Client,
 	additionalMatchingLabels client.MatchingLabels,
-) (op.CreatedUpdatedOrNoop, *corev1.Secret, error) {
+) (op.Result, *corev1.Secret, error) {
 	setCALogger(ctrlruntimelog.Log)
 
 	// TODO: https://github.com/Kong/gateway-operator-archive/pull/156.
@@ -313,7 +313,7 @@ func generateTLSDataSecret(
 	mtlsCASecret types.NamespacedName,
 	usages []certificatesv1.KeyUsage,
 	k8sClient client.Client,
-) (op.CreatedUpdatedOrNoop, *corev1.Secret, error) {
+) (op.Result, *corev1.Secret, error) {
 	template := x509.CertificateRequest{
 		Subject: pkix.Name{
 			CommonName:   subject,

--- a/controller/pkg/secrets/cert_test.go
+++ b/controller/pkg/secrets/cert_test.go
@@ -230,7 +230,7 @@ func TestMaybeCreateCertificateSecret(t *testing.T) {
 		subject                  string
 		mtlsCASecretNN           NN
 		additionalMatchingLabels client.MatchingLabels
-		expectedResult           op.CreatedUpdatedOrNoop
+		expectedResult           op.Result
 		expectedError            error
 		objectList               client.ObjectList
 	}{

--- a/pkg/consts/controlplane.go
+++ b/pkg/consts/controlplane.go
@@ -49,6 +49,8 @@ const (
 // -----------------------------------------------------------------------------
 
 const (
+	// ControlPlaneAdmissionWebhookPortName is the name of the port on which the control plane admission webhook listens.
+	ControlPlaneAdmissionWebhookPortName = "webhook"
 	// ControlPlaneAdmissionWebhookListenPort is the port on which the control plane admission webhook listens.
 	ControlPlaneAdmissionWebhookListenPort = 8080
 	// ControlPlaneAdmissionWebhookEnvVarValue is the default value for the admission webhook env var.

--- a/pkg/utils/kubernetes/resources/deployments.go
+++ b/pkg/utils/kubernetes/resources/deployments.go
@@ -96,7 +96,7 @@ func GenerateNewDeploymentForControlPlane(params GenerateNewDeploymentForControl
 					Containers: []corev1.Container{
 						GenerateControlPlaneContainer(GenerateContainerForControlPlaneParams{
 							Image:                          params.ControlPlaneImage,
-							AdmissionWebhookCertSecretName: params.AdmissionWebhookCertSecretName,
+							AdmissionWebhookCertSecretName: lo.ToPtr(params.AdmissionWebhookCertSecretName),
 						}),
 					},
 				},
@@ -131,8 +131,10 @@ func GenerateNewDeploymentForControlPlane(params GenerateNewDeploymentForControl
 
 // GenerateContainerForControlPlaneParams is a parameter struct for GenerateControlPlaneContainer function.
 type GenerateContainerForControlPlaneParams struct {
-	Image                          string
-	AdmissionWebhookCertSecretName string
+	Image string
+	// AdmissionWebhookCertSecretName is the name of the Secret that holds the certificate for the admission webhook.
+	// If this is nil, the admission webhook will not be enabled.
+	AdmissionWebhookCertSecretName *string
 }
 
 // GenerateControlPlaneContainer generates a control plane container.
@@ -162,7 +164,7 @@ func GenerateControlPlaneContainer(params GenerateContainerForControlPlaneParams
 		Resources:      *DefaultControlPlaneResources(),
 	}
 	// Only add the admission webhook volume mount and port if the secret name is provided.
-	if params.AdmissionWebhookCertSecretName != "" {
+	if params.AdmissionWebhookCertSecretName != nil && *params.AdmissionWebhookCertSecretName != "" {
 		c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
 			Name:      consts.ControlPlaneAdmissionWebhookVolumeName,
 			ReadOnly:  true,

--- a/pkg/utils/kubernetes/resources/deployments_test.go
+++ b/pkg/utils/kubernetes/resources/deployments_test.go
@@ -3,11 +3,14 @@ package resources
 import (
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	operatorv1beta1 "github.com/kong/gateway-operator/api/v1beta1"
 	"github.com/kong/gateway-operator/pkg/consts"
@@ -271,6 +274,311 @@ func TestGenerateNewDeploymentForDataPlane(t *testing.T) {
 			deployment, err := ApplyDeploymentUserPatches(partial, tt.dataplane.Spec.Deployment.PodTemplateSpec)
 			require.NoError(t, err)
 			tt.testFunc(t, &deployment.Spec)
+		})
+	}
+}
+
+func TestGenerateNewDeploymentForControlPlane(t *testing.T) {
+	tests := []struct {
+		name                     string
+		generateControlPlaneArgs GenerateNewDeploymentForControlPlaneParams
+		expectedDeployment       *appsv1.Deployment
+	}{
+		{
+			name: "base case works",
+			generateControlPlaneArgs: GenerateNewDeploymentForControlPlaneParams{
+				ControlPlane: &operatorv1beta1.ControlPlane{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cp-1",
+						Namespace: "test-namespace",
+						UID:       types.UID("1234-5678-9012"),
+					},
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "gateway-operator.konghq.com/v1beta1",
+						Kind:       "ControlPlane",
+					},
+				},
+				ControlPlaneImage:              "kong/kubernetes-ingress-controller:3.1.5",
+				AdmissionWebhookCertSecretName: "admission-webhook-certificate",
+				AdminMTLSCertSecretName:        "cluster-certificate-secret-name",
+			},
+			expectedDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "controlplane-cp-1-",
+					Namespace:    "test-namespace",
+					Labels: map[string]string{
+						"app":                                    "cp-1",
+						"gateway-operator.konghq.com/managed-by": "controlplane",
+						"konghq.com/gateway-operator":            "controlplane",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "gateway-operator.konghq.com/v1beta1",
+							Kind:       "ControlPlane",
+							Name:       "cp-1",
+							UID:        types.UID("1234-5678-9012"),
+							Controller: lo.ToPtr(true),
+						},
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: lo.ToPtr(int32(1)),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "cp-1",
+						},
+					},
+					RevisionHistoryLimit:    lo.ToPtr(int32(10)),
+					ProgressDeadlineSeconds: lo.ToPtr(int32(600)),
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.DeploymentStrategyType("RollingUpdate"),
+						RollingUpdate: &appsv1.RollingUpdateDeployment{
+							MaxUnavailable: lo.ToPtr(intstr.FromString("25%")),
+							MaxSurge:       lo.ToPtr(intstr.FromString("25%")),
+						},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app": "cp-1",
+							},
+						},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "cluster-certificate",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName:  "cluster-certificate-secret-name",
+											DefaultMode: lo.ToPtr(int32(420)),
+											Items: []corev1.KeyToPath{
+												{
+													Key:  "tls.crt",
+													Path: "tls.crt",
+												},
+												{
+													Key:  "tls.key",
+													Path: "tls.key",
+												},
+												{
+													Key:  "ca.crt",
+													Path: "ca.crt",
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "admission-webhook-certificate",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName:  "admission-webhook-certificate",
+											DefaultMode: lo.ToPtr(int32(420)),
+											Items: []corev1.KeyToPath{
+												{
+													Key:  "tls.crt",
+													Path: "tls.crt",
+												},
+												{
+													Key:  "tls.key",
+													Path: "tls.key",
+												},
+											},
+										},
+									},
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Name:  consts.ControlPlaneControllerContainerName,
+									Image: "kong/kubernetes-ingress-controller:3.1.5",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceMemory: resource.MustParse("20Mi"),
+											corev1.ResourceCPU:    resource.MustParse("100m"),
+										},
+										Limits: corev1.ResourceList{
+											corev1.ResourceMemory: resource.MustParse("100Mi"),
+											corev1.ResourceCPU:    resource.MustParse("200m"),
+										},
+									},
+									Ports: []corev1.ContainerPort{
+										{
+											Name:          "health",
+											ContainerPort: 10254,
+											Protocol:      corev1.ProtocolTCP,
+										},
+										{
+											Name:          "webhook",
+											ContainerPort: 8080,
+											Protocol:      corev1.ProtocolTCP,
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "cluster-certificate",
+											MountPath: "/var/cluster-certificate",
+											ReadOnly:  true,
+										},
+										{
+											Name:      "admission-webhook-certificate",
+											MountPath: "/admission-webhook",
+											ReadOnly:  true,
+										},
+									},
+									LivenessProbe:            GenerateControlPlaneProbe("/healthz", intstr.FromInt(10254)),
+									ReadinessProbe:           GenerateControlPlaneProbe("/readyz", intstr.FromInt(10254)),
+									TerminationMessagePath:   "/dev/termination-log",
+									TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+									ImagePullPolicy:          corev1.PullIfNotPresent,
+								},
+							},
+							SecurityContext:               &corev1.PodSecurityContext{},
+							RestartPolicy:                 corev1.RestartPolicyAlways,
+							DNSPolicy:                     corev1.DNSClusterFirst,
+							SchedulerName:                 corev1.DefaultSchedulerName,
+							TerminationGracePeriodSeconds: lo.ToPtr(int64(30)),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no webhook cert secret name specified doesn't the webhook volume, volume mount nor port",
+			generateControlPlaneArgs: GenerateNewDeploymentForControlPlaneParams{
+				ControlPlane: &operatorv1beta1.ControlPlane{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cp-1",
+						Namespace: "test-namespace",
+						UID:       types.UID("1234-5678-9012"),
+					},
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "gateway-operator.konghq.com/v1beta1",
+						Kind:       "ControlPlane",
+					},
+				},
+				ControlPlaneImage:       "kong/kubernetes-ingress-controller:3.1.5",
+				AdminMTLSCertSecretName: "cluster-certificate-secret-name",
+			},
+			expectedDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "controlplane-cp-1-",
+					Namespace:    "test-namespace",
+					Labels: map[string]string{
+						"app":                                    "cp-1",
+						"gateway-operator.konghq.com/managed-by": "controlplane",
+						"konghq.com/gateway-operator":            "controlplane",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "gateway-operator.konghq.com/v1beta1",
+							Kind:       "ControlPlane",
+							Name:       "cp-1",
+							UID:        types.UID("1234-5678-9012"),
+							Controller: lo.ToPtr(true),
+						},
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: lo.ToPtr(int32(1)),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "cp-1",
+						},
+					},
+					RevisionHistoryLimit:    lo.ToPtr(int32(10)),
+					ProgressDeadlineSeconds: lo.ToPtr(int32(600)),
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.DeploymentStrategyType("RollingUpdate"),
+						RollingUpdate: &appsv1.RollingUpdateDeployment{
+							MaxUnavailable: lo.ToPtr(intstr.FromString("25%")),
+							MaxSurge:       lo.ToPtr(intstr.FromString("25%")),
+						},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app": "cp-1",
+							},
+						},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "cluster-certificate",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName:  "cluster-certificate-secret-name",
+											DefaultMode: lo.ToPtr(int32(420)),
+											Items: []corev1.KeyToPath{
+												{
+													Key:  "tls.crt",
+													Path: "tls.crt",
+												},
+												{
+													Key:  "tls.key",
+													Path: "tls.key",
+												},
+												{
+													Key:  "ca.crt",
+													Path: "ca.crt",
+												},
+											},
+										},
+									},
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Name:  consts.ControlPlaneControllerContainerName,
+									Image: "kong/kubernetes-ingress-controller:3.1.5",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceMemory: resource.MustParse("20Mi"),
+											corev1.ResourceCPU:    resource.MustParse("100m"),
+										},
+										Limits: corev1.ResourceList{
+											corev1.ResourceMemory: resource.MustParse("100Mi"),
+											corev1.ResourceCPU:    resource.MustParse("200m"),
+										},
+									},
+									Ports: []corev1.ContainerPort{
+										{
+											Name:          "health",
+											ContainerPort: 10254,
+											Protocol:      corev1.ProtocolTCP,
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "cluster-certificate",
+											MountPath: "/var/cluster-certificate",
+											ReadOnly:  true,
+										},
+									},
+									LivenessProbe:            GenerateControlPlaneProbe("/healthz", intstr.FromInt(10254)),
+									ReadinessProbe:           GenerateControlPlaneProbe("/readyz", intstr.FromInt(10254)),
+									TerminationMessagePath:   "/dev/termination-log",
+									TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+									ImagePullPolicy:          corev1.PullIfNotPresent,
+								},
+							},
+							SecurityContext:               &corev1.PodSecurityContext{},
+							RestartPolicy:                 corev1.RestartPolicyAlways,
+							DNSPolicy:                     corev1.DNSClusterFirst,
+							SchedulerName:                 corev1.DefaultSchedulerName,
+							TerminationGracePeriodSeconds: lo.ToPtr(int64(30)),
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			deployment, err := GenerateNewDeploymentForControlPlane(tt.generateControlPlaneArgs)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedDeployment, deployment)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensure that relevant resources 

- webhook service
- admissionwebhookconfiguration
- admission webhook certificate service

do not exist when `ControlPlane`'s admission webhook is disabled via `CONTROLLER_ADMISSION_WEBHOOK_LISTEN` env.

**Which issue this PR fixes**

Fixes #308 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
