### PR TITLE
ci: allow disabling addons in tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -251,6 +251,7 @@ jobs:
     - name: run integration tests
       run: make test.integration
       env:
+        KONG_TEST_DISABLE_CERTMANAGER: "true"
         WEBHOOK_ENABLED: ${{ matrix.webhook-enabled }}
         KONG_CONTROLLER_OUT: stdout
         GOTESTSUM_JUNITFILE: integration-tests-webhook-enabled-${{ matrix.webhook-enabled }}.xml
@@ -302,6 +303,7 @@ jobs:
     - name: run integration tests
       run: make test.integration_bluegreen
       env:
+        KONG_TEST_DISABLE_CERTMANAGER: "true"
         WEBHOOK_ENABLED: ${{ matrix.webhook-enabled }}
         KONG_CONTROLLER_OUT: stdout
         GOTESTSUM_JUNITFILE: integration-tests-bluegreen-webhook-enabled-${{ matrix.webhook-enabled }}.xml
@@ -338,8 +340,6 @@ jobs:
     steps:
     - name: checkout repository
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
 
     - name: setup golang
       uses: actions/setup-go@v5
@@ -353,6 +353,7 @@ jobs:
     - name: run integration tests
       run: make test.integration_provision_dataplane_fail
       env:
+        KONG_TEST_DISABLE_CERTMANAGER: "true"
         KONG_CONTROLLER_OUT: stdout
         GOTESTSUM_JUNITFILE: integration-tests-provision-dataplane-fail.xml
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -404,6 +405,7 @@ jobs:
     - name: run e2e tests
       run: make test.e2e
       env:
+        KONG_TEST_DISABLE_CERTMANAGER: "true"
         KONG_TEST_GATEWAY_OPERATOR_IMAGE_LOAD: gateway-operator:e2e-${{ github.sha }}
         GOTESTSUM_JUNITFILE: "e2e-tests.xml"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kong/gateway-operator/modules/manager"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	testutils "github.com/kong/gateway-operator/pkg/utils/test"
+	"github.com/kong/gateway-operator/test"
 )
 
 // -----------------------------------------------------------------------------
@@ -80,7 +81,9 @@ func TestMain(m *testing.M) {
 	// that would allow e.g. cross namespace traffic.
 	// Related upstream discussion: https://github.com/kubernetes-sigs/gateway-api/discussions/2137
 	env, err = testutils.BuildEnvironment(ctx, existingCluster, func(b *environments.Builder, t clusters.Type) {
-		b.WithAddons(metallb.New())
+		if !test.IsMetalLBDisabled() {
+			b.WithAddons(metallb.New())
+		}
 	})
 	exitOnErr(err)
 

--- a/test/envvars.go
+++ b/test/envvars.go
@@ -1,0 +1,40 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// IsCalicoCNIDisabled returns true if the Calico CNI plugin is disabled in the test environment.
+func IsCalicoCNIDisabled() bool {
+	ret := strings.ToLower(os.Getenv("KONG_TEST_DISABLE_CALICO")) == "true"
+	if ret {
+		fmt.Println("INFO: CalicoCNI plugin is disabled")
+	} else {
+		fmt.Println("INFO: CalicoCNI plugin is enabled")
+	}
+	return ret
+}
+
+// IsCertManagerDisabled returns true if the Cert-Manager is disabled in the test environment.
+func IsCertManagerDisabled() bool {
+	ret := strings.ToLower(os.Getenv("KONG_TEST_DISABLE_CERTMANAGER")) == "true"
+	if ret {
+		fmt.Println("INFO: CertManager plugin is disabled")
+	} else {
+		fmt.Println("INFO: CertManager plugin is enabled")
+	}
+	return ret
+}
+
+// IsMetalLBDisabled returns true if the MetalLB is disabled in the test environment.
+func IsMetalLBDisabled() bool {
+	ret := strings.ToLower(os.Getenv("KONG_TEST_DISABLE_METALLB")) == "true"
+	if ret {
+		fmt.Println("INFO: MetalLB plugin is disabled")
+	} else {
+		fmt.Println("INFO: MetalLB plugin is enabled")
+	}
+	return ret
+}

--- a/test/integration/suite.go
+++ b/test/integration/suite.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kong/gateway-operator/config"
 	"github.com/kong/gateway-operator/modules/manager"
 	testutils "github.com/kong/gateway-operator/pkg/utils/test"
+	"github.com/kong/gateway-operator/test"
 	"github.com/kong/gateway-operator/test/helpers"
 	"github.com/kong/gateway-operator/test/helpers/certificate"
 )
@@ -40,9 +41,6 @@ var (
 	webhookServerIP      = os.Getenv("GATEWAY_OPERATOR_WEBHOOK_IP")
 	bluegreenController  = strings.ToLower(os.Getenv("GATEWAY_OPERATOR_BLUEGREEN_CONTROLLER")) == "true"
 	webhookServerPort    = 9443
-	disableCalicoCNI     = strings.ToLower(os.Getenv("KONG_TEST_DISABLE_CALICO")) == "true"
-	disableCertManager   = strings.ToLower(os.Getenv("KONG_TEST_DISABLE_CERTMANAGER")) == "true"
-	disableMetalLB       = strings.ToLower(os.Getenv("KONG_TEST_DISABLE_METALLB")) == "true"
 )
 
 // -----------------------------------------------------------------------------
@@ -124,13 +122,13 @@ func TestMain(
 	fmt.Println("INFO: configuring cluster for testing environment")
 	env, err = testutils.BuildEnvironment(GetCtx(), existingCluster,
 		func(b *environments.Builder, ct clusters.Type) {
-			if !disableCalicoCNI {
+			if !test.IsCalicoCNIDisabled() {
 				b.WithCalicoCNI()
 			}
-			if !disableCertManager {
+			if !test.IsCertManagerDisabled() {
 				b.WithAddons(certmanager.New())
 			}
-			if !disableMetalLB && ct == kind.KindClusterType {
+			if !test.IsMetalLBDisabled() && ct == kind.KindClusterType {
 				b.WithAddons(metallb.New())
 			}
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows disabling addons that are used in tests: metallb, certmanager, calico CI; via env variables.

Additionally it disables installing by default certmanager in integration tests suite as it's not required there.