### PR TITLE
conformance: support `HTTPRoutePathRewrite` and `HTTPRouteHostRewrite`

### DIFF
--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -49,15 +49,23 @@ var skippedTestsForTraditionalCompatibleRouter = []string{
 }
 
 var traditionalCompatibleRouterSupportedFeatures = sets.New(
+	// core features
+	features.SupportHTTPRoute,
 	// extended
 	features.SupportHTTPRouteResponseHeaderModification,
+	features.SupportHTTPRoutePathRewrite,
+	features.SupportHTTPRouteHostRewrite,
 )
 
 var expressionsRouterSupportedFeatures = sets.New(
+	// core features
+	features.SupportHTTPRoute,
 	// extended
 	features.SupportHTTPRouteResponseHeaderModification,
 	features.SupportHTTPRouteMethodMatching,
 	features.SupportHTTPRouteQueryParamMatching,
+	features.SupportHTTPRoutePathRewrite,
+	features.SupportHTTPRouteHostRewrite,
 )
 
 type ConformanceConfig struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

Enabled `HTTPRoutePathRewrite` and `HTTPRouteHostRewrite` since those are supported in KIC 3.2.0 which is the default now.