### PR TITLE
chore: enable nakedret linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -32,6 +32,7 @@ linters:
   - unparam
   - unused
   - wastedassign
+  - nakedret
 linters-settings:
   gci:
     sections:

--- a/controller/controlplane/controller_watch.go
+++ b/controller/controlplane/controller_watch.go
@@ -203,7 +203,7 @@ func (r *Reconciler) getControlPlanesFromDataPlane(ctx context.Context, obj clie
 			"failed to map ControlPlane on DataPlane",
 			"expected", "DataPlane", "found", reflect.TypeOf(obj),
 		)
-		return
+		return nil
 	}
 
 	controlPlaneList := &operatorv1beta1.ControlPlaneList{}
@@ -213,7 +213,7 @@ func (r *Reconciler) getControlPlanesFromDataPlane(ctx context.Context, obj clie
 			index.DataPlaneNameIndex: dataplane.Name,
 		}); err != nil {
 		log.FromContext(ctx).Error(err, "failed to map ControlPlane on DataPlane")
-		return
+		return nil
 	}
 
 	recs = make([]reconcile.Request, 0, len(controlPlaneList.Items))

--- a/controller/gateway/controller_watch.go
+++ b/controller/gateway/controller_watch.go
@@ -128,7 +128,7 @@ func (r *Reconciler) listGatewaysForGatewayClass(ctx context.Context, obj client
 	return
 }
 
-func (r *Reconciler) listGatewaysForGatewayConfig(ctx context.Context, obj client.Object) (recs []reconcile.Request) {
+func (r *Reconciler) listGatewaysForGatewayConfig(ctx context.Context, obj client.Object) []reconcile.Request {
 	logger := log.FromContext(ctx)
 
 	gatewayConfig, ok := obj.(*operatorv1beta1.GatewayConfiguration)
@@ -138,7 +138,7 @@ func (r *Reconciler) listGatewaysForGatewayConfig(ctx context.Context, obj clien
 			"failed to run map funcs",
 			"expected", "GatewayConfiguration", "found", reflect.TypeOf(obj),
 		)
-		return
+		return nil
 	}
 
 	gatewayClassList := new(gatewayv1.GatewayClassList)
@@ -148,7 +148,7 @@ func (r *Reconciler) listGatewaysForGatewayConfig(ctx context.Context, obj clien
 			"failed to run map funcs",
 			"error", err.Error(),
 		)
-		return
+		return nil
 	}
 
 	matchingGatewayClasses := make(map[string]struct{})
@@ -168,9 +168,10 @@ func (r *Reconciler) listGatewaysForGatewayConfig(ctx context.Context, obj clien
 			"failed to run map funcs",
 			"error", err.Error(),
 		)
-		return
+		return nil
 	}
 
+	var recs []reconcile.Request
 	for _, gateway := range gatewayList.Items {
 		if _, ok := matchingGatewayClasses[string(gateway.Spec.GatewayClassName)]; ok {
 			recs = append(recs, reconcile.Request{
@@ -181,8 +182,7 @@ func (r *Reconciler) listGatewaysForGatewayConfig(ctx context.Context, obj clien
 			})
 		}
 	}
-
-	return
+	return recs
 }
 
 // listReferenceGrantsForGateway is a watch predicate which finds all Gateways mentioned in a From clause for a

--- a/controller/pkg/secrets/cert.go
+++ b/controller/pkg/secrets/cert.go
@@ -434,8 +434,7 @@ func ensureContainerImageUpdated(container *corev1.Container, imageVersionStr st
 
 	imageParts := strings.Split(container.Image, ":")
 	if len(imageParts) > 3 {
-		err = fmt.Errorf("invalid container image found: %s", container.Image)
-		return
+		return false, fmt.Errorf("invalid container image found: %s", container.Image)
 	}
 
 	// This is a special case for registries that specify a non default port,
@@ -462,5 +461,5 @@ func ensureContainerImageUpdated(container *corev1.Container, imageVersionStr st
 		updated = true
 	}
 
-	return
+	return updated, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable `nakedret` linter to avoid using naked returns.
