### PR TITLE
chore(ci): fix main build pipeline

### DIFF
--- a/.github/workflows/__build-workflow.yaml
+++ b/.github/workflows/__build-workflow.yaml
@@ -223,51 +223,16 @@ jobs:
           # Use outputs when push is set to false to allow subsequent steps to have
           # access to this image.
           # Ref: https://docs.docker.com/build/ci/github-actions/test-before-push/
-          outputs: ${{ !inputs.push && 'type=docker,dest=/tmp/image.tar' }}
+          outputs: |
+            ${{ !inputs.push && 'type=docker,dest=/tmp/image.tar' }}
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: image-${{ matrix.os }}-${{ matrix.arch }}
-          path: /tmp/image.tar
-
-  test-image:
-    name: Run image to verify it and check -version output
-    runs-on: ubuntu-latest
-    needs:
-      - semver
-      - build
-
-    strategy:
-        # Whatever gets changed here should be changed in the multi-arch job below.
-      matrix:
-        include:
-        - os: linux
-          arch: amd64
-        - os: linux
-          arch: arm64
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download artifact with built image
-        uses: actions/download-artifact@v4
-        with:
-          name: image-${{ matrix.os }}-${{ matrix.arch }}
-          path: /tmp/${{ matrix.os }}/${{ matrix.arch }}/
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@v3
         with:
           platforms: ${{ matrix.arch }}
- 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
- 
-      - name: Load image
-        run: |
-          docker load --input /tmp/${{ matrix.os }}/${{ matrix.arch }}/image.tar
-          docker image ls -a
+
+      - name: Load the image into Docker
+        if: ${{ !inputs.push }}
+        run: docker load --input /tmp/image.tar
 
       - name: Test the image by running it with -version flag
         # NOTE: we can't use steps.build.outputs.tags here because it's there's more than one tag
@@ -276,10 +241,15 @@ jobs:
         # reference ${{ inputs.image-name }}.
         run: |
           docker images
-          docker images --format {{.ID}} --filter reference=${{ inputs.image-name }} | xargs -I {} \
-            docker run --rm \
+          docker run --rm \
               --platform ${{ matrix.os }}/${{ matrix.arch }} \
-              {} -version | ${{ inputs.verify-image-script }} ${{ github.repository }}
+              ${{ inputs.image-name }}:${{ steps.meta.outputs.version }} -version | ${{ inputs.verify-image-script }} ${{ github.repository }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-${{ matrix.os }}-${{ matrix.arch }}
+          path: /tmp/image.tar
 
   build-multi-arch:
     name: Build and push multi-arch manifest
@@ -292,14 +262,12 @@ jobs:
     needs:
       - semver
       - build
-      - test-image
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Configure Git for private repositories (this is needed by repositories that include this workflow and have other private dependencies)
         run: git config --global url."https://${{ secrets.gh-pat }}@github.com".insteadOf "https://github.com"
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,9 @@ on:
   push:
     branches:
     - 'main'
+  pull_request:
+    branches:
+      - '*'
   workflow_dispatch: {}
 
 jobs:
@@ -26,4 +29,6 @@ jobs:
       username: ${{ vars.DOCKERHUB_PUSH_USERNAME }}
       registry: docker.io
       image-name: ${{ vars.DOCKERHUB_IMAGE_NAME }}
-      push: true
+      # If we pushed then it means we want to build and push the image.
+      # Branch filter above will decide pushes to which branch will trigger this.
+      push: ${{ github.event.action == 'push' }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -125,17 +125,6 @@ jobs:
     - name: Verify that uninstalling operator CRDs via kustomize works
       run: make uninstall
 
-  build-image:
-    uses: ./.github/workflows/__build-workflow.yaml
-    secrets:
-      dockerhub-token: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
-      gh-pat: ${{ secrets.PAT_GITHUB }}
-    with:
-      username: ${{ vars.DOCKERHUB_PUSH_USERNAME }}
-      registry: docker.io
-      image-name: ${{ vars.DOCKERHUB_IMAGE_NAME }}
-      push: false
-
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes what failed in https://github.com/Kong/gateway-operator/actions/runs/9581575868 

- Build the image via `.github/workflows/__build-workflow.yaml` in `.github/workflows/build.yaml` not in `tests.yaml`
- Do not share the image artifact but just use it in `build` to test the image (run it with `-version`)


Build container jobs passed on CI (part of the PR) and also triggered manually for `fix-main-build` branch: https://github.com/Kong/gateway-operator/actions/runs/9583098895