### PR TITLE
ci: create release branches after release

### DIFF
--- a/.github/workflows/__release-workflow.yaml
+++ b/.github/workflows/__release-workflow.yaml
@@ -179,11 +179,6 @@ jobs:
           KONG_LICENSE_DATA: ${{ secrets.kong-license-data }}
           KONG_TEST_GATEWAY_OPERATOR_IMAGE_OVERRIDE: ${{ needs.build-push-images.outputs.full_tag }}
 
-  # NOTE: This job's steps are run when:
-  # - input.base is 'main': then 1 PR is created targeting 'main'
-  # - input.base is not 'main': then 2 PRs will be created:
-  #   - 1 PR targeting 'main' to update VERSION and config/
-  #   - 1 PR targeting the release branch to update VERSION and config/ and trigger the release workflow
   create-release-pr:
     runs-on: ubuntu-latest
     needs:
@@ -191,35 +186,37 @@ jobs:
       - build-push-images
       - test-integration-current-kubernetes
       - test-e2e-current-kubernetes
-    strategy:
-      matrix:
-        base:
-          - ${{ inputs.base }}
-          - main
     steps:
+      - name: Check if we're not trying to trigger a major/minor release from non main
+        if: ${{ inputs.base != 'main' && needs.semver.outputs.patch == '0' }}
+        run: |
+          echo "Trying to release: ${{ needs.semver.outputs.fullversion }} from ${{ inputs.base }}"
+          echo "Major/minor releases can only be triggered from main branch"
+          exit 1
+
+      - name: Check if we're not trying to trigger a patch release from main
+        if: ${{ inputs.base == 'main' && needs.semver.outputs.patch != '0' }}
+        run: |
+          echo "Trying to release: ${{ needs.semver.outputs.fullversion }} from ${{ inputs.base }}"
+          echo "Patch releases can only be triggered from non main, release branch"
+          exit 1
+
       # Use the branch set via inputs as a base for the release.
       # If anything needs to be fixed before the release, it should be done on the base branch
       # before the release workflow is triggered.
-      - name: Checkout repository
-        if: ${{ (inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main') }}
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ matrix.base }}
+          ref: ${{ inputs.base }}
 
       - name: Configure Git for private repositories (this is needed by repositories that include this workflow and have other private dependencies)
-        if: ${{ (inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main') }}
         run: git config --global url."https://${{ secrets.gh-pat }}@github.com".insteadOf "https://github.com"
 
-      - name: Setup golang
-        if: ${{ (inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main') }}
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
-      # The bumped version file is included in the release PR.
-      - name: Ensure version is set
-        if: ${{ (inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main') }}
+      - name: Ensure bumped version is set in VERSION file
         env:
           VERSION: ${{ needs.semver.outputs.fullversion }}
         run: |
@@ -227,13 +224,12 @@ jobs:
           echo ${VERSION} > VERSION
 
       - uses: jdx/mise-action@v2
-        if: ${{ (inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main') }}
         with:
           install: false
 
       # Generated manifests are part of the release PR.
       - name: Generate manifests
-        if: ${{ inputs.regenerate-manifests && ((inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main')) }}
+        if: ${{ inputs.regenerate-manifests }}
         run: make manifests
 
       # The generated bundle is part of the release PR.
@@ -241,11 +237,10 @@ jobs:
       # If anything needs to be fixed before the release, it should be done on the base branch
       # before the release workflow is triggered.
       - name: Generate bundle
-        if: ${{ inputs.regenerate-bundle && ((inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main')) }}
+        if: ${{ inputs.regenerate-bundle }}
         run: make bundle
 
       - name: GPG sign the commits
-        if: ${{ (inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main') }}
         uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4
         with:
           gpg_private_key: ${{ secrets.gpg-private-key }}
@@ -254,24 +249,19 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Commit message
-        if: ${{ (inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main') }}
         env:
-          # NOTE: If the base branch set for workflow is not main (it's a release branch)
-          # then create a commit message which will not trigger the release workflow
-          # (via release-bot.yaml) but which will only update VERSION and config/.
-          MSG: "${{ inputs.base != 'main' && matrix.base == 'main' && format('chore({0}): [main] {1}', inputs.release-type, env.VERSION) || format('chore({0}): [bot] {1}', inputs.release-type, env.VERSION) }}"
+          MSG: "${{ inputs.latest && format('chore({0}): [bot] {1}, [latest]', inputs.release-type, env.VERSION) || format('chore({0}): [bot] {1}', inputs.release-type, env.VERSION)}}"
         run: |
           echo "MSG=${MSG}" >> $GITHUB_ENV
 
-      # PRs to the base branch will update the version file and manifests
+      # PRs will update the version file and manifests
       - name: Create a release PR
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
-        if: ${{ (inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main') }}
         with:
           token: ${{ secrets.gh-pat }}
           path: .
-          branch: release/${{ needs.semver.outputs.fullversion }}/pr-${{ matrix.base }}
-          base: ${{ matrix.base }}
+          branch: release/${{ needs.semver.outputs.fullversion }}/pr-${{ inputs.base }}
+          base: ${{ inputs.base }}
           add-paths: |
             VERSION
             config

--- a/.github/workflows/release-bot.yaml
+++ b/.github/workflows/release-bot.yaml
@@ -140,4 +140,4 @@ jobs:
         with:
           branch: main
           title: '[cherry-pick] ${{ needs.semver.outputs.version }} - ${{ github.sha }}'
-          body: 'Cherry picking ${{ needs.semver.outputs.version }} commit (${{ github.sha }}) onto this branch'
+          body: 'Cherry picking ${{ needs.semver.outputs.version }} commit (${{ github.sha }}) onto main'

--- a/.github/workflows/release-bot.yaml
+++ b/.github/workflows/release-bot.yaml
@@ -14,6 +14,7 @@ jobs:
     outputs:
       release_found: ${{ steps.commit_parser.outputs.release_found }}
       release_type: ${{ steps.commit_parser.outputs.release_type }}
+      release_latest: ${{ steps.commit_parser.outputs.release_latest }}
     runs-on: ubuntu-latest
     
     steps:
@@ -28,9 +29,15 @@ jobs:
             if (commitMessage.includes('chore(release): [bot]')) {
               core.setOutput('release_found', 'true')
               core.setOutput('release_type', 'release')
+              if (commitMessage.includes('[latest]')) {
+                core.setOutput('release_latest', 'true')
+              }
             } else if (commitMessage.includes('chore(prerelease): [bot]')) {
               core.setOutput('release_found', 'true')
               core.setOutput('release_type', 'prerelease')
+              if (commitMessage.includes('[latest]')) {
+                core.setOutput('release_latest', 'true')
+              }
             } else {
               core.setOutput('release_found', 'false')
             }
@@ -97,3 +104,40 @@ jobs:
           tag: v${{ needs.semver.outputs.version }}
           commit: ${{ github.sha }}
           prerelease: ${{ needs.look_for_release.outputs.release_type == 'prerelease' }}
+
+  create-release-branch:
+    needs:
+      - look_for_release
+      - publish-release
+      - semver
+    # NOTE: only create a release branch if the release is not a patch release
+    # or a prerelease.
+    # For patch releases, the release branch should already be in place.
+    # For prereleases, we do not want to create a release branch.
+    if: ${{ needs.look_for_release.outputs.release_found == 'true' && needs.semver.outputs.patch == '0' && needs.semver.outputs.prerelease == '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peterjgrainger/action-create-branch@v2.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # NOTE: using the full ref name because
+          # https://github.com/peterjgrainger/action-create-branch?tab=readme-ov-file#branch
+          branch: 'refs/heads/release/v${{ needs.semver.outputs.major }}.{{ needs.semver.outputs.minor }}.x'
+          sha: '${{ github.sha }}'
+
+  create-cherry-pick-branch-to-main:
+    needs:
+      - look_for_release
+      - publish-release
+      - semver
+    if: ${{ needs.look_for_release.outputs.release_found == 'true' && needs.semver.outputs.patch != '0' && needs.semver.outputs.prerelease == '' && needs.look_for_release.outputs.release_latest == 'true' && github.ref_name != 'main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: carloscastrojumo/github-cherry-pick-action@v1.0.1
+        with:
+          branch: main
+          title: '[cherry-pick] ${{ needs.semver.outputs.version }} - ${{ github.sha }}'
+          body: 'Cherry picking ${{ needs.semver.outputs.version }} commit (${{ github.sha }}) onto this branch'


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes the release pipeline 

- create release branches only for major or minor release **after** the release has been made
- makes the `release-bot.yaml` workflow cherry-pick the commit with release from release branch to `main` (when `latest`, patch release is released)