### PR TITLE
fix: fix ControlPlane managed resource labels during migration from 1.2 and older

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@
 - Proper `User-Agent` header is now set on outgoing HTTP requests.
   [#387](https://github.com/Kong/gateway-operator/pull/387)
 
+### Fixed
+
+- Fixed `ControlPlane` cluster wide resources not migrating to new ownership labels
+  (introduced in 1.3.0) when upgrading the operator form 1.2 (or older) to 1.3.0.
+  [#369](https://github.com/Kong/gateway-operator/pull/369)
+
 ## [v1.3.0]
 
 > Release date: 2024-06-24

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -63,9 +63,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	validatinWebhookConfigurationOwnerPredicate.UpdateFunc = func(e event.UpdateEvent) bool {
 		return r.validatingWebhookConfigurationHasControlPlaneOwner(e.ObjectOld)
 	}
-	validatinWebhookConfigurationOwnerPredicate.DeleteFunc = func(e event.DeleteEvent) bool {
-		return r.validatingWebhookConfigurationHasControlPlaneOwner(e.Object)
-	}
 
 	return ctrl.NewControllerManagedBy(mgr).
 		// watch ControlPlane objects

--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -293,10 +293,13 @@ func (r *Reconciler) ensureClusterRole(
 	ctx context.Context,
 	cp *operatorv1beta1.ControlPlane,
 ) (createdOrUpdated bool, cr *rbacv1.ClusterRole, err error) {
-	// TODO: This performs a migration from the old managedBy label to the new one.
+	// NOTE: Code below performs a migration from the old managedBy label to the new one.
+	// It lists both resources labeled with the old and the new label set and merges them,
+	// then it reduces the number of resources to 1 and eventually updates the resource.
 	// After several versions of soak time we can remove handling the legacy label set.
 	// PR that introduced the new set of labels: https://github.com/Kong/gateway-operator/pull/259
 	// PR that introduced the migration: https://github.com/Kong/gateway-operator/pull/369
+	// TODO: https://github.com/Kong/gateway-operator/issues/401.
 	clusterRolesLegacy, err := k8sutils.ListClusterRoles(
 		ctx,
 		r.Client,
@@ -375,10 +378,13 @@ func (r *Reconciler) ensureClusterRoleBinding(
 ) (createdOrUpdate bool, crb *rbacv1.ClusterRoleBinding, err error) {
 	logger := log.GetLogger(ctx, "controlplane.ensureClusterRoleBinding", r.DevelopmentMode)
 
-	// TODO: This performs a migration from the old managedBy label to the new one.
+	// NOTE: Code below performs a migration from the old managedBy label to the new one.
+	// It lists both resources labeled with the old and the new label set and merges them,
+	// then it reduces the number of resources to 1 and eventually updates the resource.
 	// After several versions of soak time we can remove handling the legacy label set.
 	// PR that introduced the new set of labels: https://github.com/Kong/gateway-operator/pull/259
 	// PR that introduced the migration: https://github.com/Kong/gateway-operator/pull/369
+	// TODO: https://github.com/Kong/gateway-operator/issues/401.
 	clusterRoleBindingsLegacy, err := k8sutils.ListClusterRoleBindings(
 		ctx,
 		r.Client,
@@ -552,6 +558,7 @@ func (r *Reconciler) ensureOwnedClusterRolesDeleted(
 	ctx context.Context,
 	cp *operatorv1beta1.ControlPlane,
 ) (deletions bool, err error) {
+	// TODO: Remove listing with old labels https://github.com/Kong/gateway-operator/issues/401.
 	clusterRolesLegacy, err := k8sutils.ListClusterRoles(
 		ctx,
 		r.Client,
@@ -598,6 +605,7 @@ func (r *Reconciler) ensureOwnedClusterRoleBindingsDeleted(
 	ctx context.Context,
 	cp *operatorv1beta1.ControlPlane,
 ) (deletions bool, err error) {
+	// TODO: Remove listing with old labels https://github.com/Kong/gateway-operator/issues/401.
 	clusterRoleBindingsLegacy, err := k8sutils.ListClusterRoleBindings(
 		ctx,
 		r.Client,
@@ -640,14 +648,13 @@ func (r *Reconciler) ensureOwnedClusterRoleBindingsDeleted(
 func (r *Reconciler) ensureOwnedValidatingWebhookConfigurationDeleted(ctx context.Context,
 	cp *operatorv1beta1.ControlPlane,
 ) (deletions bool, err error) {
-	// TODO: This performs a migration from the old managedBy label to the new one.
-	// After several versions of soak time we can remove handling the legeacy label set.
-	// PR that introduced the new set of labels: https://github.com/Kong/gateway-operator/pull/259
-	// PR: that introduced the migration: https://github.com/Kong/gateway-operator/pull/369
+	// TODO: Remove listing with old labels https://github.com/Kong/gateway-operator/issues/401.
 	validatingWebhookConfigurationsLegacy, err := k8sutils.ListValidatingWebhookConfigurations(
 		ctx,
 		r.Client,
-		client.MatchingLabels(k8sutils.GetLegacyManagedByLabelSet(cp)),
+		// NOTE: this uses only the 1 label to find the legacy webhook configurations not the label set
+		// because app:<name> is not set on ValidatingWebhookConfiguration.
+		client.MatchingLabels(k8sutils.GetLegacyManagedByLabel(cp)),
 	)
 	if err != nil {
 		return false, fmt.Errorf("failed listing webhook configurations for owner: %w", err)
@@ -766,10 +773,13 @@ func (r *Reconciler) ensureValidatingWebhookConfiguration(
 ) (op.Result, error) {
 	logger := log.GetLogger(ctx, "controlplane.ensureValidatingWebhookConfiguration", r.DevelopmentMode)
 
-	// TODO: This performs a migration from the old managedBy label to the new one.
+	// NOTE: Code below performs a migration from the old managedBy label to the new one.
+	// It lists both resources labeled with the old and the new label set and merges them,
+	// then it reduces the number of resources to 1 and eventually updates the resource.
 	// After several versions of soak time we can remove handling the legacy label set.
 	// PR that introduced the new set of labels: https://github.com/Kong/gateway-operator/pull/259
 	// PR that introduced the migration: https://github.com/Kong/gateway-operator/pull/369
+	// TODO: https://github.com/Kong/gateway-operator/issues/401.
 	validatingWebhookConfigurationsLegacy, err := k8sutils.ListValidatingWebhookConfigurationsForOwner(
 		ctx,
 		r.Client,

--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -648,10 +648,11 @@ func (r *Reconciler) ensureOwnedClusterRoleBindingsDeleted(
 func (r *Reconciler) ensureOwnedValidatingWebhookConfigurationDeleted(ctx context.Context,
 	cp *operatorv1beta1.ControlPlane,
 ) (deletions bool, err error) {
-	// TODO: Remove listing with old labels https://github.com/Kong/gateway-operator/issues/401.
-	validatingWebhookConfigurationsLegacy, err := k8sutils.ListValidatingWebhookConfigurations(
+	// TODO: Remove listing with old labels and owner ref https://github.com/Kong/gateway-operator/issues/401.
+	validatingWebhookConfigurationsLegacy, err := k8sutils.ListValidatingWebhookConfigurationsForOwner(
 		ctx,
 		r.Client,
+		cp.GetUID(),
 		// NOTE: this uses only the 1 label to find the legacy webhook configurations not the label set
 		// because app:<name> is not set on ValidatingWebhookConfiguration.
 		client.MatchingLabels(k8sutils.GetLegacyManagedByLabel(cp)),

--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -294,9 +294,9 @@ func (r *Reconciler) ensureClusterRole(
 	cp *operatorv1beta1.ControlPlane,
 ) (createdOrUpdated bool, cr *rbacv1.ClusterRole, err error) {
 	// TODO: This performs a migration from the old managedBy label to the new one.
-	// After several versions of soak time we can remove handling the legeacy label set.
+	// After several versions of soak time we can remove handling the legacy label set.
 	// PR that introduced the new set of labels: https://github.com/Kong/gateway-operator/pull/259
-	// PR: that introduced the migration: https://github.com/Kong/gateway-operator/pull/369
+	// PR that introduced the migration: https://github.com/Kong/gateway-operator/pull/369
 	clusterRolesLegacy, err := k8sutils.ListClusterRoles(
 		ctx,
 		r.Client,
@@ -376,9 +376,9 @@ func (r *Reconciler) ensureClusterRoleBinding(
 	logger := log.GetLogger(ctx, "controlplane.ensureClusterRoleBinding", r.DevelopmentMode)
 
 	// TODO: This performs a migration from the old managedBy label to the new one.
-	// After several versions of soak time we can remove handling the legeacy label set.
+	// After several versions of soak time we can remove handling the legacy label set.
 	// PR that introduced the new set of labels: https://github.com/Kong/gateway-operator/pull/259
-	// PR: that introduced the migration: https://github.com/Kong/gateway-operator/pull/369
+	// PR that introduced the migration: https://github.com/Kong/gateway-operator/pull/369
 	clusterRoleBindingsLegacy, err := k8sutils.ListClusterRoleBindings(
 		ctx,
 		r.Client,
@@ -767,9 +767,9 @@ func (r *Reconciler) ensureValidatingWebhookConfiguration(
 	logger := log.GetLogger(ctx, "controlplane.ensureValidatingWebhookConfiguration", r.DevelopmentMode)
 
 	// TODO: This performs a migration from the old managedBy label to the new one.
-	// After several versions of soak time we can remove handling the legeacy label set.
+	// After several versions of soak time we can remove handling the legacy label set.
 	// PR that introduced the new set of labels: https://github.com/Kong/gateway-operator/pull/259
-	// PR: that introduced the migration: https://github.com/Kong/gateway-operator/pull/369
+	// PR that introduced the migration: https://github.com/Kong/gateway-operator/pull/369
 	validatingWebhookConfigurationsLegacy, err := k8sutils.ListValidatingWebhookConfigurationsForOwner(
 		ctx,
 		r.Client,

--- a/controller/controlplane/controller_watch.go
+++ b/controller/controlplane/controller_watch.go
@@ -175,13 +175,11 @@ func objectIsOwnedByControlPlane(obj client.Object, cp *operatorv1beta1.ControlP
 		return true
 	}
 
-	if labels := obj.GetLabels(); len(labels) > 0 {
-		if labels[consts.GatewayOperatorManagedByNameLabel] == cp.Name {
-			if obj.GetNamespace() != "" {
-				return cp.GetNamespace() == obj.GetNamespace()
-			} else {
-				return true
-			}
+	if labels[consts.GatewayOperatorManagedByNameLabel] == cp.Name {
+		if obj.GetNamespace() != "" {
+			return cp.GetNamespace() == obj.GetNamespace()
+		} else {
+			return true
 		}
 	}
 

--- a/controller/controlplane/controller_watch.go
+++ b/controller/controlplane/controller_watch.go
@@ -166,9 +166,9 @@ func (r *Reconciler) getControlPlaneRequestFromManagedByNameLabel(ctx context.Co
 
 // objectIsOwnedByControlPlane checks if the object is owned by the control plane.
 //
-// NOTE: We are using the managed-by-name label to identify the owner of the resource
+// NOTE: We are using the managed-by-name label to identify the owner of the resource.
 // To keep backward compatibility, we also check the owner reference which
-// are not used anymore for cluster-scoped resources since that's considered
+// is not used anymore for cluster-scoped resources since that's considered
 // an error.
 func objectIsOwnedByControlPlane(obj client.Object, cp *operatorv1beta1.ControlPlane) bool {
 	if k8sutils.IsOwnedByRefUID(obj, cp.GetUID()) {

--- a/controller/controlplane/controller_watch.go
+++ b/controller/controlplane/controller_watch.go
@@ -175,6 +175,7 @@ func objectIsOwnedByControlPlane(obj client.Object, cp *operatorv1beta1.ControlP
 		return true
 	}
 
+	labels := obj.GetLabels()
 	if labels[consts.GatewayOperatorManagedByNameLabel] == cp.Name {
 		if obj.GetNamespace() != "" {
 			return cp.GetNamespace() == obj.GetNamespace()

--- a/controller/controlplane/controlplane_controller_reconciler_utils_test.go
+++ b/controller/controlplane/controlplane_controller_reconciler_utils_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -24,8 +23,8 @@ import (
 
 func TestEnsureClusterRole(t *testing.T) {
 	clusterRole, err := k8sresources.GenerateNewClusterRoleForControlPlane("test-controlplane", consts.DefaultControlPlaneImage, false)
+	require.NoError(t, err)
 
-	assert.NoError(t, err)
 	clusterRole.Name = "test-clusterrole"
 	wrongClusterRole := clusterRole.DeepCopy()
 	wrongClusterRole.Rules = append(wrongClusterRole.Rules,
@@ -82,12 +81,12 @@ func TestEnsureClusterRole(t *testing.T) {
 		expectedClusterRole rbacv1.ClusterRole
 		err                 error
 	}{
-		{
-			Name:                "no existing clusterrole",
-			controlplane:        controlplane,
-			createdorUpdated:    true,
-			expectedClusterRole: *clusterRole,
-		},
+		// {
+		// 	Name:                "no existing clusterrole",
+		// 	controlplane:        controlplane,
+		// 	createdorUpdated:    true,
+		// 	expectedClusterRole: *clusterRole,
+		// },
 		{
 			Name:                "up to date clusterrole",
 			controlplane:        controlplane,

--- a/controller/controlplane/controlplane_controller_reconciler_utils_test.go
+++ b/controller/controlplane/controlplane_controller_reconciler_utils_test.go
@@ -81,12 +81,12 @@ func TestEnsureClusterRole(t *testing.T) {
 		expectedClusterRole rbacv1.ClusterRole
 		err                 error
 	}{
-		// {
-		// 	Name:                "no existing clusterrole",
-		// 	controlplane:        controlplane,
-		// 	createdorUpdated:    true,
-		// 	expectedClusterRole: *clusterRole,
-		// },
+		{
+			Name:                "no existing clusterrole",
+			controlplane:        controlplane,
+			createdorUpdated:    true,
+			expectedClusterRole: *clusterRole,
+		},
 		{
 			Name:                "up to date clusterrole",
 			controlplane:        controlplane,

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -412,8 +412,12 @@ func (r *Reconciler) ensureOwnedControlPlanesDeleted(ctx context.Context, gatewa
 			continue
 		}
 		err = r.Client.Delete(ctx, &controlplanes[i])
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				continue
+			}
 			errs = append(errs, err)
+			continue
 		}
 		deleted = true
 	}
@@ -435,8 +439,12 @@ func (r *Reconciler) ensureOwnedDataPlanesDeleted(ctx context.Context, gateway *
 	)
 	for i := range dataplanes {
 		err = r.Client.Delete(ctx, &dataplanes[i])
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				continue
+			}
 			errs = append(errs, err)
+			continue
 		}
 		deleted = true
 	}
@@ -458,8 +466,12 @@ func (r *Reconciler) ensureOwnedNetworkPoliciesDeleted(ctx context.Context, gate
 	)
 	for i := range networkPolicies {
 		err = r.Client.Delete(ctx, &networkPolicies[i])
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				continue
+			}
 			errs = append(errs, err)
+			continue
 		}
 		deleted = true
 	}

--- a/pkg/utils/gateway/ownerrefs.go
+++ b/pkg/utils/gateway/ownerrefs.go
@@ -71,7 +71,9 @@ func ListControlPlanesForGateway(
 		ctx,
 		controlplaneList,
 		client.InNamespace(gateway.Namespace),
-		client.MatchingLabels{consts.GatewayOperatorManagedByLabel: consts.GatewayManagedLabelValue},
+		client.MatchingLabels{
+			consts.GatewayOperatorManagedByLabel: consts.GatewayManagedLabelValue,
+		},
 	)
 	if err != nil {
 		return nil, err

--- a/test/helpers/setup.go
+++ b/test/helpers/setup.go
@@ -33,6 +33,9 @@ func SetupTestEnv(t *testing.T, ctx context.Context, env environments.Environmen
 	t.Log("performing test setup")
 	cleaner := clusters.NewCleaner(env.Cluster())
 	t.Cleanup(func() {
+		t.Helper()
+
+		t.Log("performing test cleanup")
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 		defer cancel()
 		assert.NoError(t, cleaner.Cleanup(ctx))


### PR DESCRIPTION
**What this PR does / why we need it**:

#259 introduced a new set of labels that are used on `ControlPlane`'s
- `ClusterRole`s
- `ClusterRoleBindings`s
- `ValidatingWebhookConfiguration`s

This omitted 1 important detail which is migrating on operator upgrade (specifically from 1.2.x and older to 1.3.0).

This PR fixes this by changing the listing and deleting logic for the aforementioned resources so that the old label and owner reference are also taken into account.

This also makes other small changes
- make operator leave the newest `ClusterRole` or `ValidatingWebhookConfiguration` in place when there's more in the cluster;
  - this ensures that when for some reason there are more than 1 of these, the newest with newest rules, stays
- when `ControlPlane` fails to get provisioned - this can happen when operator's webhook doesn't respond - requeue, without this, provisioned `Gateway` gets stuck with `ControlPlaneReady` condition set to `False`.

**Which issue this PR fixes**

Fixes #373 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
