### PR TITLE
chore: perform go mod download in shared build-workflow

### DIFF
--- a/.github/workflows/__build-workflow.yaml
+++ b/.github/workflows/__build-workflow.yaml
@@ -195,6 +195,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      
+      # Path for additional-build-contexts may ponits to dependences that are pulled by Go toolchain,
+      # so we need to download them before building the image.
+      - name: Set up Go dependencies for additional build contexts
+        if: ${{ inputs.additional-build-contexts != ''}}
+        run: go mod download
 
       - run: echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
       - run: echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV

--- a/.github/workflows/__build-workflow.yaml
+++ b/.github/workflows/__build-workflow.yaml
@@ -196,7 +196,7 @@ jobs:
         with:
           go-version-file: go.mod
       
-      # Path for additional-build-contexts may point to dependences that are pulled by Go toolchain,
+      # Path for additional-build-contexts may point to dependencies that are pulled by Go toolchain,
       # so we need to download them before building the image.
       - name: Set up Go dependencies for additional build contexts
         if: ${{ inputs.additional-build-contexts != ''}}

--- a/.github/workflows/__build-workflow.yaml
+++ b/.github/workflows/__build-workflow.yaml
@@ -196,7 +196,7 @@ jobs:
         with:
           go-version-file: go.mod
       
-      # Path for additional-build-contexts may ponits to dependences that are pulled by Go toolchain,
+      # Path for additional-build-contexts may point to dependences that are pulled by Go toolchain,
       # so we need to download them before building the image.
       - name: Set up Go dependencies for additional build contexts
         if: ${{ inputs.additional-build-contexts != ''}}


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensure that Go dependencies are downloaded when `inputs.additional-build-contexts` is specified. It points to a package downloaded by Go toolchain in case of EE build and due to limitations of GH Workflows it has to be done here 
