### PR TITLE
feat: set proper User-Agent for each request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
 
+## Unreleased
+
+> Release date: TBD
+
+### Added
+
+- Proper `User-Agent` header is now set on outgoing HTTP requests.
+  [#387](https://github.com/Kong/gateway-operator/pull/387)
+
 ## [v1.3.0]
 
 > Release date: 2024-06-24

--- a/modules/manager/metadata/metadata.go
+++ b/modules/manager/metadata/metadata.go
@@ -3,7 +3,7 @@ package metadata
 
 import (
 	"fmt"
-	"strings"
+	"runtime"
 )
 
 // -----------------------------------------------------------------------------
@@ -49,10 +49,9 @@ type Info struct {
 
 // UserAgent returns the User-Agent string to use in all HTTP requests made by KGO.
 func (inf Info) UserAgent() string {
-	org := strings.ToLower(inf.Organization)
 	return fmt.Sprintf("%s/%s (%s/%s) (%s)",
-			inf.ProjectName, inf.Release, runtime.GOOS, runtime.GOARCH, inf.Flavor,
-		)
+		inf.ProjectName, inf.Release, runtime.GOOS, runtime.GOARCH, inf.Flavor,
+	)
 }
 
 var (

--- a/modules/manager/metadata/metadata.go
+++ b/modules/manager/metadata/metadata.go
@@ -50,10 +50,9 @@ type Info struct {
 // UserAgent returns the User-Agent string to use in all HTTP requests made by KGO.
 func (inf Info) UserAgent() string {
 	org := strings.ToLower(inf.Organization)
-	if inf.Flavor == OSSFlavor {
-		return fmt.Sprintf("%s-%s-%s/%s", org, inf.ProjectName, OSSFlavor, inf.Release)
-	}
-	return fmt.Sprintf("%s-%s/%s", org, inf.ProjectName, inf.Release)
+	return fmt.Sprintf("%s/%s (%s/%s) (%s)",
+			inf.ProjectName, inf.Release, runtime.GOOS, runtime.GOARCH, inf.Flavor,
+		)
 }
 
 var (

--- a/modules/manager/metadata/metadata.go
+++ b/modules/manager/metadata/metadata.go
@@ -1,12 +1,27 @@
 // Package metadata includes metadata variables for logging and reporting.
 package metadata
 
+import (
+	"fmt"
+	"strings"
+)
+
 // -----------------------------------------------------------------------------
 // Controller Manager - Versioning Information
 // -----------------------------------------------------------------------------
 
 // WARNING: moving any of these variables requires changes to both the Makefile
 //          and the Dockerfile which modify them during the link step with -X
+
+// BuildFlavor is the flavor of the build.
+type BuildFlavor string
+
+const (
+	// OSSFlavor is the open-source flavor.
+	OSSFlavor BuildFlavor = "oss"
+	// EEFlavor is the enterprise flavor.
+	EEFlavor BuildFlavor = "enterprise"
+)
 
 // Info is a struct type that holds the metadata for the controller manager.
 type Info struct {
@@ -29,7 +44,16 @@ type Info struct {
 	Organization string
 
 	// Flavor is the flavor of the build.
-	Flavor string
+	Flavor BuildFlavor
+}
+
+// UserAgent returns the User-Agent string to use in all HTTP requests made by KGO.
+func (inf Info) UserAgent() string {
+	org := strings.ToLower(inf.Organization)
+	if inf.Flavor == OSSFlavor {
+		return fmt.Sprintf("%s-%s-%s/%s", org, inf.ProjectName, OSSFlavor, inf.Release)
+	}
+	return fmt.Sprintf("%s-%s/%s", org, inf.ProjectName, inf.Release)
 }
 
 var (
@@ -50,9 +74,6 @@ var (
 
 	// Organization is the Kong organization
 	organization = "Kong"
-
-	// Flavor is the flavor of the build.
-	flavor = "oss"
 )
 
 // Metadata returns the metadata for the controller manager.
@@ -64,6 +85,6 @@ func Metadata() Info {
 		Commit:       commit,
 		ProjectName:  projectName,
 		Organization: organization,
-		Flavor:       flavor,
+		Flavor:       OSSFlavor,
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Proper `User-Agent` header is now set on outgoing HTTP requests. An example one is
`kong-gateway-operator-oss-v1.4.0`. The naming pattern follows how Docker images are named where the OSS build has `-oss` suffix.

**Which issue this PR fixes**

Part of https://github.com/Kong/gateway-operator-enterprise/issues/111

**Special notes for your reviewer**:

Take a look at https://github.com/Kong/gateway-operator-enterprise/pull/229 which requires changes presented in this PR.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
