### PR TITLE
ci(renovate): use tags for kubernetes/code-generator and extract kustomize's version prefix

### DIFF
--- a/.tools_versions.yaml
+++ b/.tools_versions.yaml
@@ -1,4 +1,4 @@
-# renovate: datasource=github-releases depName=kubernetes/code-generator
+# renovate: datasource=github-tags depName=kubernetes/code-generator
 code-generator: "0.30.1"
 # renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools
 controller-tools: "0.15.0"

--- a/renovate.json
+++ b/renovate.json
@@ -46,5 +46,12 @@
         ".+\\s+=\\s+\"(?<currentValue>.+)\"\\s+//\\s+renovate:\\s+datasource=(?<datasource>.*)\\s+depName=(?<depName>.+)"
       ]
     }
+  ],
+  "packageRules": [
+    {
+      "description": "Strip kustomize/ version prefix",
+      "matchPackageNames": ["kubernetes-sigs/kustomize"],
+      "extractVersion": "^kustomize/(?<version>.*)$"
+    }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- `kubernetes/code-generator` uses [tags](https://github.com/kubernetes/code-generator/tags) not releases on GitHub
- kustomize's tags contain `kustomize/` prefix so strip it