### PR TITLE
chore: disable build artifacts upload on GitHub

### DIFF
--- a/.github/workflows/__build-workflow.yaml
+++ b/.github/workflows/__build-workflow.yaml
@@ -208,6 +208,9 @@ jobs:
       - name: Build image
         id: build
         uses: docker/build-push-action@v6.3.0
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
+          DOCKER_BUILD_SUMMARY: false
         with:
           context: .
           build-contexts: ${{ inputs.additional-build-contexts }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Disable build report artifacts.

Reference: https://github.com/docker/build-push-action?tab=readme-ov-file#environment-variables