### PR TITLE
fix: requeue instead of error when finalizer removal yields a conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@
 - Fixed `ControlPlane` cluster wide resources not migrating to new ownership labels
   (introduced in 1.3.0) when upgrading the operator form 1.2 (or older) to 1.3.0.
   [#369](https://github.com/Kong/gateway-operator/pull/369)
+- Requeue instead of reporting an error when a finalizer removal yields a conflict.
+  [#454](https://github.com/Kong/gateway-operator/pull/454)
 
 ## [v1.3.0]
 

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -116,9 +116,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	log.Trace(logger, "managing cleanup for gateway resource", gateway)
-	cleanupUnderway, result, err := r.cleanup(ctx, logger, &gateway)
-	if cleanupUnderway {
+	shouldReturnEarly, result, err := r.cleanup(ctx, logger, &gateway)
+	if err != nil || result.Requeue {
 		return result, err
+	} else if shouldReturnEarly {
+		return ctrl.Result{}, nil
 	}
 
 	log.Trace(logger, "managing the gateway resource finalizers", gateway)

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -116,8 +116,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	log.Trace(logger, "managing cleanup for gateway resource", gateway)
-	shouldReturnEarly, result, err := r.cleanup(ctx, logger, &gateway)
-	if err != nil || result.Requeue {
+	if shouldReturnEarly, result, err := r.cleanup(ctx, logger, &gateway); err != nil || result.Requeue {
 		return result, err
 	} else if shouldReturnEarly {
 		return ctrl.Result{}, nil

--- a/controller/gateway/controller_cleanup.go
+++ b/controller/gateway/controller_cleanup.go
@@ -64,7 +64,7 @@ func (r *Reconciler) cleanup(
 		if deletions {
 			log.Debug(logger, "deleted owned controlplanes", gateway)
 			// Return early from reconciliation, deletion will trigger a new reconcile.
-			return true, ctrl.Result{}, err
+			return true, ctrl.Result{}, nil
 		}
 	} else {
 		oldGateway := gateway.DeepCopy()


### PR DESCRIPTION
**What this PR does / why we need it**:

Observed in one of the CI test runs https://github.com/Kong/gateway-operator/actions/runs/10148426698/job/28061112791:

```
2024-07-29T16:57:20Z	ERROR	Reconciler error	{"controller": "gateway", "controllerGroup": "gateway.networking.k8s.io", "controllerKind": "Gateway", "Gateway": {"name":"f8518cc4-d6c5-4365-bcfa-5105d5d5b009","namespace":"cc7f49ee-b420-4e22-ad0d-7f8c3e0b7894"}, "namespace": "cc7f49ee-b420-4e22-ad0d-7f8c3e0b7894", "name": "f8518cc4-d6c5-4365-bcfa-5105d5d5b009", "reconcileID": "f141fe3c-f044-43a1-adf0-a9fe2b4aae1a", "error": "failed updating Gateway's finalizers: Operation cannot be fulfilled on gateways.gateway.networking.k8s.io \"f8518cc4-d6c5-4365-bcfa-5105d5d5b009\": the object has been modified; please apply your changes to the latest version and try again"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.4/pkg/internal/controller/controller.go:324
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.4/pkg/internal/controller/controller.go:261
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.4/pkg/internal/controller/controller.go:222
```

This should be retried without an error so that users do not need to be confused about a false positive error being reported in the logs (and also controller-runtime metrics).

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
