### PR TITLE
feat(konnect): support Secrets in KonnectAPIAuthConfiguration

### DIFF
--- a/config/samples/konnect_apiauth_configuration.yaml
+++ b/config/samples/konnect_apiauth_configuration.yaml
@@ -1,0 +1,30 @@
+kind: KonnectAPIAuthConfiguration
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: konnect-api-auth-1
+  namespace: default
+spec:
+  type: token
+  token: kpat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  serverURL: eu.api.konghq.com
+---
+kind: KonnectAPIAuthConfiguration
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: konnect-api-auth-2
+  namespace: default
+spec:
+  type: secretRef
+  secretRef:
+    name: konnect-api-auth-secret
+  serverURL: eu.api.konghq.com
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: konnect-api-auth-secret
+  namespace: default
+  labels:
+    konghq.com/credential: konnect
+stringData:
+  token: kpat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/config/samples/konnect_apiauth_configuration.yaml
+++ b/config/samples/konnect_apiauth_configuration.yaml
@@ -27,6 +27,8 @@ metadata:
   name: konnect-api-auth-secret
   namespace: default
   labels:
+    # NOTE: this label is required on Konnect credential secrets to make
+    # Secret watch efficient in the operator.
     konghq.com/credential: konnect
 stringData:
   token: kpat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/config/samples/konnect_apiauth_configuration.yaml
+++ b/config/samples/konnect_apiauth_configuration.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   type: token
   token: kpat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  # For complete list of available API URLs see: https://docs.konghq.com/konnect/network/
   serverURL: eu.api.konghq.com
 ---
 kind: KonnectAPIAuthConfiguration
@@ -17,6 +18,7 @@ spec:
   type: secretRef
   secretRef:
     name: konnect-api-auth-secret
+  # For complete list of available API URLs see: https://docs.konghq.com/konnect/network/
   serverURL: eu.api.konghq.com
 ---
 kind: Secret

--- a/controller/konnect/reconciler_konnectapiauth.go
+++ b/controller/konnect/reconciler_konnectapiauth.go
@@ -6,10 +6,15 @@ import (
 	"time"
 
 	sdkkonnectgoops "github.com/Kong/sdk-konnect-go/models/operations"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
@@ -23,6 +28,17 @@ type KonnectAPIAuthConfigurationReconciler struct {
 	DevelopmentMode bool
 	Client          client.Client
 }
+
+const (
+	// SecretTokenKey is the key used to store the token in the Secret.
+	SecretTokenKey = "token"
+	// SecretCredentialLabel is the label used to identify Secrets holding
+	// KonnectAPIAuthConfiguration tokens.
+	SecretCredentialLabel = "konghq.com/credential" //nolint:gosec
+	// SecretCredentialLabelValueKonnect is the value of the label used to
+	// identify Secrets holding KonnectAPIAuthConfiguration tokens.
+	SecretCredentialLabelValueKonnect = "konnect"
+)
 
 // NewKonnectAPIAuthConfigurationReconciler creates a new KonnectAPIAuthConfigurationReconciler.
 func NewKonnectAPIAuthConfigurationReconciler(
@@ -39,8 +55,26 @@ func NewKonnectAPIAuthConfigurationReconciler(
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KonnectAPIAuthConfigurationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	secretLabelPredicate, err := predicate.LabelSelectorPredicate(
+		metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				SecretCredentialLabel: SecretCredentialLabelValueKonnect,
+			},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create Secret label selector predicate: %w", err)
+	}
+
 	b := ctrl.NewControllerManagedBy(mgr).
 		For(&konnectv1alpha1.KonnectAPIAuthConfiguration{}).
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(
+				listKonnectAPIAuthConfigurationsReferencingSecret(mgr.GetClient()),
+			),
+			builder.WithPredicates(secretLabelPredicate),
+		).
 		Named("KonnectAPIAuthConfiguration")
 
 	return b.Complete(r)
@@ -81,9 +115,30 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 		return ctrl.Result{}, nil
 	}
 
+	token, err := getTokenFromKonnectAPIAuthConfiguration(ctx, r.Client, &apiAuth)
+	if err != nil {
+		k8sutils.SetCondition(
+			k8sutils.NewConditionWithGeneration(
+				KonnectEntityAPIAuthConfigurationValidConditionType,
+				metav1.ConditionFalse,
+				KonnectEntityAPIAuthConfigurationReasonInvalid,
+				err.Error(),
+				apiAuth.GetGeneration(),
+			),
+			&apiAuth,
+		)
+		if err := r.Client.Status().Update(ctx, &apiAuth); err != nil {
+			if k8serrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, fmt.Errorf("failed to update status of %s: %w", entityTypeName, err)
+		}
+		return ctrl.Result{}, err
+	}
+
 	sdk := r.SDKFactory.NewKonnectSDK(
 		"https://"+apiAuth.Spec.ServerURL,
-		SDKToken(apiAuth.Spec.Token),
+		SDKToken(token),
 	)
 
 	// TODO(pmalek): check if api auth config has a valid status condition
@@ -101,6 +156,7 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 			cond.Status != metav1.ConditionFalse ||
 			cond.Reason != KonnectEntityAPIAuthConfigurationReasonInvalid ||
 			cond.ObservedGeneration != apiAuth.GetGeneration() ||
+			cond.Message != err.Error() ||
 			apiAuth.Status.OrganizationID != "" ||
 			apiAuth.Status.ServerURL != apiAuth.Spec.ServerURL {
 
@@ -123,9 +179,20 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 	}
 
 	// Update the status only if it would change to prevent unnecessary updates.
+	condMessage := "Token is valid"
+	if apiAuth.Spec.Type == konnectv1alpha1.KonnectAPIAuthTypeSecretRef {
+		nn := types.NamespacedName{
+			Namespace: apiAuth.Spec.SecretRef.Namespace,
+			Name:      apiAuth.Spec.SecretRef.Name,
+		}
+		if nn.Namespace == "" {
+			nn.Namespace = apiAuth.Namespace
+		}
+		condMessage = fmt.Sprintf("Token from Secret %s is valid", nn)
+	}
 	if cond, ok := k8sutils.GetCondition(KonnectEntityAPIAuthConfigurationValidConditionType, &apiAuth); !ok ||
 		cond.Status != metav1.ConditionTrue ||
-		cond.Message != "" ||
+		cond.Message != condMessage ||
 		cond.Reason != KonnectEntityAPIAuthConfigurationReasonValid ||
 		cond.ObservedGeneration != apiAuth.GetGeneration() ||
 		apiAuth.Status.OrganizationID != *respOrg.MeOrganization.ID ||
@@ -139,7 +206,7 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 			KonnectEntityAPIAuthConfigurationValidConditionType,
 			metav1.ConditionTrue,
 			KonnectEntityAPIAuthConfigurationReasonValid,
-			fmt.Sprintf("Referenced KonnectAPIAuthConfiguration %s is valid", client.ObjectKeyFromObject(&apiAuth)),
+			condMessage,
 		)
 		if err != nil || res.Requeue {
 			return res, err
@@ -148,4 +215,39 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// getTokenFromKonnectAPIAuthConfiguration returns the token from the secret reference or the token field.
+func getTokenFromKonnectAPIAuthConfiguration(
+	ctx context.Context, cl client.Client, apiAuth *konnectv1alpha1.KonnectAPIAuthConfiguration,
+) (string, error) {
+	switch apiAuth.Spec.Type {
+	case konnectv1alpha1.KonnectAPIAuthTypeToken:
+		return apiAuth.Spec.Token, nil
+	case konnectv1alpha1.KonnectAPIAuthTypeSecretRef:
+		var secret corev1.Secret
+		nn := types.NamespacedName{
+			Namespace: apiAuth.Spec.SecretRef.Namespace,
+			Name:      apiAuth.Spec.SecretRef.Name,
+		}
+		if nn.Namespace == "" {
+			nn.Namespace = apiAuth.Namespace
+		}
+
+		if err := cl.Get(ctx, nn, &secret); err != nil {
+			return "", fmt.Errorf("failed to get Secret %s: %w", nn, err)
+		}
+		if secret.Labels == nil || secret.Labels[SecretCredentialLabel] != SecretCredentialLabelValueKonnect {
+			return "", fmt.Errorf("Secret %s does not have label %s: %s", nn, SecretCredentialLabel, SecretCredentialLabelValueKonnect)
+		}
+		if secret.Data == nil {
+			return "", fmt.Errorf("Secret %s has no data", nn)
+		}
+		if _, ok := secret.Data[SecretTokenKey]; !ok {
+			return "", fmt.Errorf("Secret %s does not have key %s", nn, SecretTokenKey)
+		}
+		return string(secret.Data[SecretTokenKey]), nil
+	}
+
+	return "", fmt.Errorf("unknown KonnectAPIAuthType: %s", apiAuth.Spec.Type)
 }

--- a/controller/konnect/reconciler_konnectapiauth.go
+++ b/controller/konnect/reconciler_konnectapiauth.go
@@ -225,7 +225,6 @@ func getTokenFromKonnectAPIAuthConfiguration(
 	case konnectv1alpha1.KonnectAPIAuthTypeToken:
 		return apiAuth.Spec.Token, nil
 	case konnectv1alpha1.KonnectAPIAuthTypeSecretRef:
-		var secret corev1.Secret
 		nn := types.NamespacedName{
 			Namespace: apiAuth.Spec.SecretRef.Namespace,
 			Name:      apiAuth.Spec.SecretRef.Name,
@@ -234,6 +233,7 @@ func getTokenFromKonnectAPIAuthConfiguration(
 			nn.Namespace = apiAuth.Namespace
 		}
 
+		var secret corev1.Secret
 		if err := cl.Get(ctx, nn, &secret); err != nil {
 			return "", fmt.Errorf("failed to get Secret %s: %w", nn, err)
 		}

--- a/controller/konnect/reconciler_konnectapiauth_rbac.go
+++ b/controller/konnect/reconciler_konnectapiauth_rbac.go
@@ -2,3 +2,5 @@ package konnect
 
 //+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectapiauthconfigurations,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectapiauthconfigurations/status,verbs=get;update;patch
+
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch

--- a/controller/konnect/reconciler_konnectapiauth_test.go
+++ b/controller/konnect/reconciler_konnectapiauth_test.go
@@ -1,0 +1,161 @@
+package konnect
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+func TestGetTokenFromKonnectAPIAuthConfiguration(t *testing.T) {
+	tests := []struct {
+		name          string
+		apiAuth       *konnectv1alpha1.KonnectAPIAuthConfiguration
+		secret        *corev1.Secret
+		expectedToken string
+		expectedError bool
+	}{
+		{
+			name: "valid Token",
+			apiAuth: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-api-auth",
+					Namespace: "default",
+				},
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type:  konnectv1alpha1.KonnectAPIAuthTypeToken,
+					Token: "kpat_xxxxxxxxxxxx",
+				},
+			},
+			expectedToken: "kpat_xxxxxxxxxxxx",
+		},
+		{
+			name: "valid Secret Reference",
+			apiAuth: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-api-auth",
+					Namespace: "default",
+				},
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type: konnectv1alpha1.KonnectAPIAuthTypeSecretRef,
+					SecretRef: &corev1.SecretReference{
+						Name:      "test-secret",
+						Namespace: "default",
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: "default",
+					Labels: map[string]string{
+						"konghq.com/credential": "konnect",
+					},
+				},
+				Data: map[string][]byte{
+					"token": []byte("test-token"),
+				},
+			},
+			expectedToken: "test-token",
+		},
+		{
+			name: "Secret is missing konghq.com/credential=konnect label",
+			apiAuth: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-api-auth",
+					Namespace: "default",
+				},
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type: konnectv1alpha1.KonnectAPIAuthTypeSecretRef,
+					SecretRef: &corev1.SecretReference{
+						Name:      "test-secret",
+						Namespace: "default",
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"token": []byte("test-token"),
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "missing token from referred Secret",
+			apiAuth: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-api-auth",
+					Namespace: "default",
+				},
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type: konnectv1alpha1.KonnectAPIAuthTypeSecretRef,
+					SecretRef: &corev1.SecretReference{
+						Name:      "test-secret",
+						Namespace: "default",
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: "default",
+					Labels: map[string]string{
+						"konghq.com/credential": "konnect",
+					},
+				},
+				Data: map[string][]byte{
+					"random_key": []byte("dummy"),
+				},
+			},
+			expectedToken: "test-token",
+			expectedError: true,
+		},
+		{
+			name: "Invalid Secret Reference",
+			apiAuth: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-api-auth",
+					Namespace: "default",
+				},
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type: konnectv1alpha1.KonnectAPIAuthTypeSecretRef,
+					SecretRef: &corev1.SecretReference{
+						Name:      "non-existent-secret",
+						Namespace: "default",
+					},
+				},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientBuilder := fake.NewClientBuilder()
+
+			// Create the secret in the fake client
+			if tt.secret != nil {
+				clientBuilder.WithObjects(tt.secret)
+			}
+			cl := clientBuilder.Build()
+
+			// Call the function under test
+			token, err := getTokenFromKonnectAPIAuthConfiguration(context.Background(), cl, tt.apiAuth)
+			if tt.expectedError {
+				assert.NotNil(t, err)
+				return
+			}
+
+			assert.Equal(t, tt.expectedToken, token)
+		})
+	}
+}

--- a/controller/konnect/reconciler_konnectapiauth_watch.go
+++ b/controller/konnect/reconciler_konnectapiauth_watch.go
@@ -1,0 +1,73 @@
+package konnect
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	operatorerrors "github.com/kong/gateway-operator/internal/errors"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+// listKonnectAPIAuthConfigurationsReferencingSecret returns a function that lists
+// KonnectAPIAuthConfiguration resources that reference the given Secret.
+// This function is intended to be used as a handler for the watch on Secrets.
+// NOTE: The Secret has to have the konnect.konghq.com/credential=konnect set
+// so that we can efficiently watch only the relevant Secrets' changes.
+func listKonnectAPIAuthConfigurationsReferencingSecret(cl client.Client) func(ctx context.Context, obj client.Object) []reconcile.Request {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		logger := log.FromContext(ctx)
+
+		secret, ok := obj.(*corev1.Secret)
+		if !ok {
+			logger.Error(
+				operatorerrors.ErrUnexpectedObject,
+				"failed to run map funcs",
+				"expected", "Secret", "found", reflect.TypeOf(obj),
+			)
+			return nil
+		}
+
+		var konnectAPIAuthConfigList konnectv1alpha1.KonnectAPIAuthConfigurationList
+		if err := cl.List(ctx, &konnectAPIAuthConfigList); err != nil {
+			log.FromContext(ctx).Error(
+				fmt.Errorf("unexpected error occurred while listing KonnectAPIAuthConfiguration resources"),
+				"failed to run map funcs",
+				"error", err.Error(),
+			)
+			return nil
+		}
+
+		var recs []reconcile.Request
+		for _, apiAuth := range konnectAPIAuthConfigList.Items {
+			if apiAuth.Spec.Type != konnectv1alpha1.KonnectAPIAuthTypeSecretRef {
+				continue
+			}
+
+			if apiAuth.Spec.SecretRef == nil ||
+				apiAuth.Spec.SecretRef.Name != secret.Name {
+				continue
+			}
+
+			if (apiAuth.Spec.SecretRef.Namespace != "" && apiAuth.Spec.SecretRef.Namespace != secret.Namespace) ||
+				(apiAuth.Spec.SecretRef.Namespace == "" && secret.Namespace != apiAuth.Namespace) {
+				continue
+			}
+
+			recs = append(recs, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: apiAuth.Namespace,
+					Name:      apiAuth.Name,
+				},
+			})
+		}
+		return recs
+	}
+}

--- a/controller/konnect/reconciler_konnectapiauth_watch.go
+++ b/controller/konnect/reconciler_konnectapiauth_watch.go
@@ -37,7 +37,7 @@ func listKonnectAPIAuthConfigurationsReferencingSecret(cl client.Client) func(ct
 
 		var konnectAPIAuthConfigList konnectv1alpha1.KonnectAPIAuthConfigurationList
 		if err := cl.List(ctx, &konnectAPIAuthConfigList); err != nil {
-			log.FromContext(ctx).Error(
+			logger.Error(
 				fmt.Errorf("unexpected error occurred while listing KonnectAPIAuthConfiguration resources"),
 				"failed to run map funcs",
 				"error", err.Error(),

--- a/modules/manager/scheme/scheme.go
+++ b/modules/manager/scheme/scheme.go
@@ -13,18 +13,25 @@ import (
 	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	configurationv1beta1 "github.com/kong/kubernetes-configuration/api/configuration/v1beta1"
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
 // Get returns a scheme aware of all types the manager can interact with.
 func Get() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+
 	utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(operatorv1beta1.AddToScheme(scheme))
+
 	utilruntime.Must(gatewayv1.Install(scheme))
 	utilruntime.Must(gatewayv1beta1.Install(scheme))
+
 	utilruntime.Must(configurationv1.AddToScheme(scheme))
-	utilruntime.Must(configurationv1beta1.AddToScheme(scheme))
 	utilruntime.Must(configurationv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(configurationv1beta1.AddToScheme(scheme))
+
+	utilruntime.Must(konnectv1alpha1.AddToScheme(scheme))
+
 	return scheme
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support for tokens in Secrets in `KonnectAPIAuthConfiguration` reconciler.

This allows the following:

```
kind: KonnectAPIAuthConfiguration
apiVersion: konnect.konghq.com/v1alpha1
metadata:
  name: konnect-api-auth
  namespace: default
spec:
  type: secretRef
  secretRef:
    name: konnect-api-auth-secret
  serverURL: eu.api.konghq.com
---
kind: Secret
apiVersion: v1
metadata:
  name: konnect-api-auth-secret
  namespace: default
  labels:
    konghq.com/credential: konnect
stringData:
  token: kpat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```

The `konghq.com/credential=konnect` is required to efficiently watch for changes in Secrets.

~Depends on #456  and https://github.com/Kong/kubernetes-configuration/pull/16~

**Which issue this PR fixes**

Part of #431 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
