### PR TITLE
feat(konnect): add `KonnectControlPlane` reconciler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,17 @@
   [#387](https://github.com/Kong/gateway-operator/pull/387)
 - Introduce `KongPluginInstallation` CRD to allow installing custom Kong
   plugins distributed as container images.
-  [400](https://github.com/Kong/gateway-operator/pull/400), [424](https://github.com/Kong/gateway-operator/pull/424)
+  [#400](https://github.com/Kong/gateway-operator/pull/400), [#424](https://github.com/Kong/gateway-operator/pull/424)
 - Extended `DataPlane` API with a possibility to specify `PodDisruptionBudget` to be
   created for the `DataPlane` deployments via `spec.resources.podDisruptionBudget`.
   [#464](https://github.com/Kong/gateway-operator/pull/464)
+- Add `KonnectAPIAuthConfiguration` reconciler.
+  [#456](https://github.com/Kong/gateway-operator/pull/456)
+- Add support for Konnect tokens in `Secrets` in `KonnectAPIAuthConfiguration`
+  reconciler.
+  [#459](https://github.com/Kong/gateway-operator/pull/459)
+- Add `KonnectControlPlane` reconciler.
+  [#462](https://github.com/Kong/gateway-operator/pull/462)
 
 ### Fixed
 

--- a/controller/konnect/constraints.go
+++ b/controller/konnect/constraints.go
@@ -12,7 +12,8 @@ import (
 // SupportedKonnectEntityType is an interface that all Konnect entity types
 // must implement.
 type SupportedKonnectEntityType interface {
-	configurationv1alpha1.KongService |
+	konnectv1alpha1.KonnectControlPlane |
+		configurationv1alpha1.KongService |
 		configurationv1alpha1.KongRoute |
 		configurationv1.KongConsumer
 	// TODO: add other types

--- a/controller/konnect/ops_controlplane.go
+++ b/controller/konnect/ops_controlplane.go
@@ -41,7 +41,7 @@ func createControlPlane(
 		return errHandled
 	}
 
-	cp.Status.SetKonnectID(*resp.ControlPlane.ID)
+	cp.Status.SetKonnectID(resp.ControlPlane.ID)
 	k8sutils.SetCondition(
 		k8sutils.NewConditionWithGeneration(
 			KonnectEntityProgrammedConditionType,
@@ -69,8 +69,8 @@ func deleteControlPlane(
 
 	resp, err := sdk.ControlPlanes.DeleteControlPlane(ctx, id)
 	if errHandled := handleResp[konnectv1alpha1.KonnectControlPlane](err, resp, DeleteOp); errHandled != nil {
-		var sdkError *sdkerrors.SDKError
-		if errors.As(errHandled, &sdkError) && sdkError.StatusCode == 404 {
+		var sdkError *sdkerrors.NotFoundError
+		if errors.As(err, &sdkError) {
 			logger.Info("entity not found in Konnect, skipping delete",
 				"op", DeleteOp, "type", cp.GetTypeName(), "id", id,
 			)
@@ -117,7 +117,7 @@ func updateControlPlane(
 			}
 		}
 		// Create succeeded, update status.
-		cp.Status.SetKonnectID(*resp.ControlPlane.ID)
+		cp.Status.SetKonnectID(resp.ControlPlane.ID)
 		k8sutils.SetCondition(
 			k8sutils.NewConditionWithGeneration(
 				KonnectEntityProgrammedConditionType,
@@ -149,7 +149,7 @@ func updateControlPlane(
 		}
 	}
 
-	cp.Status.SetKonnectID(*resp.ControlPlane.ID)
+	cp.Status.SetKonnectID(resp.ControlPlane.ID)
 	k8sutils.SetCondition(
 		k8sutils.NewConditionWithGeneration(
 			KonnectEntityProgrammedConditionType,

--- a/controller/konnect/ops_controlplane.go
+++ b/controller/konnect/ops_controlplane.go
@@ -116,18 +116,6 @@ func updateControlPlane(
 				Err: err,
 			}
 		}
-		// Create succeeded, update status.
-		cp.Status.SetKonnectID(resp.ControlPlane.ID)
-		k8sutils.SetCondition(
-			k8sutils.NewConditionWithGeneration(
-				KonnectEntityProgrammedConditionType,
-				metav1.ConditionTrue,
-				KonnectEntityProgrammedReason,
-				"",
-				cp.GetGeneration(),
-			),
-			cp,
-		)
 
 		return nil
 	}

--- a/controller/konnect/ops_controlplane.go
+++ b/controller/konnect/ops_controlplane.go
@@ -116,6 +116,7 @@ func updateControlPlane(
 				Err: err,
 			}
 		}
+		// Create succeeded, createControlPlane sets the status so no need to do this here.
 
 		return nil
 	}

--- a/controller/konnect/ops_controlplane.go
+++ b/controller/konnect/ops_controlplane.go
@@ -1,0 +1,165 @@
+package konnect
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
+	"github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/Kong/sdk-konnect-go/models/sdkerrors"
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+func createControlPlane(
+	ctx context.Context,
+	sdk *sdkkonnectgo.SDK,
+	logger logr.Logger, //nolint:unparam
+	cp *konnectv1alpha1.KonnectControlPlane,
+) error {
+	resp, err := sdk.ControlPlanes.CreateControlPlane(ctx, cp.Spec.CreateControlPlaneRequest)
+	// TODO: handle already exists
+	// Can't adopt it as it will cause conflicts between the controller
+	// that created that entity and already manages it, hm
+	// TODO: implement entity adoption https://github.com/Kong/gateway-operator/issues/460
+	if errHandled := handleResp[konnectv1alpha1.KonnectControlPlane](err, resp, CreateOp); errHandled != nil {
+		k8sutils.SetCondition(
+			k8sutils.NewConditionWithGeneration(
+				KonnectEntityProgrammedConditionType,
+				metav1.ConditionFalse,
+				"FailedToCreate",
+				errHandled.Error(),
+				cp.GetGeneration(),
+			),
+			cp,
+		)
+		return errHandled
+	}
+
+	cp.Status.SetKonnectID(*resp.ControlPlane.ID)
+	k8sutils.SetCondition(
+		k8sutils.NewConditionWithGeneration(
+			KonnectEntityProgrammedConditionType,
+			metav1.ConditionTrue,
+			KonnectEntityProgrammedReason,
+			"",
+			cp.GetGeneration(),
+		),
+		cp,
+	)
+
+	return nil
+}
+
+func deleteControlPlane(
+	ctx context.Context,
+	sdk *sdkkonnectgo.SDK,
+	logger logr.Logger,
+	cp *konnectv1alpha1.KonnectControlPlane,
+) error {
+	id := cp.GetKonnectStatus().GetKonnectID()
+	if id == "" {
+		return fmt.Errorf("can't remove %T without a Konnect ID", cp)
+	}
+
+	resp, err := sdk.ControlPlanes.DeleteControlPlane(ctx, id)
+	if errHandled := handleResp[konnectv1alpha1.KonnectControlPlane](err, resp, DeleteOp); errHandled != nil {
+		var sdkError *sdkerrors.SDKError
+		if errors.As(errHandled, &sdkError) && sdkError.StatusCode == 404 {
+			logger.Info("entity not found in Konnect, skipping delete",
+				"op", DeleteOp, "type", cp.GetTypeName(), "id", id,
+			)
+			return nil
+		}
+		return FailedKonnectOpError[konnectv1alpha1.KonnectControlPlane]{
+			Op:  DeleteOp,
+			Err: errHandled,
+		}
+	}
+
+	return nil
+}
+
+func updateControlPlane(
+	ctx context.Context,
+	sdk *sdkkonnectgo.SDK,
+	logger logr.Logger,
+	cp *konnectv1alpha1.KonnectControlPlane,
+) error {
+	id := cp.GetKonnectStatus().GetKonnectID()
+	if id == "" {
+		return fmt.Errorf("can't update %T without a Konnect ID", cp)
+	}
+
+	req := components.UpdateControlPlaneRequest{
+		Name:        sdkkonnectgo.String(cp.Spec.Name),
+		Description: cp.Spec.Description,
+		AuthType:    (*components.UpdateControlPlaneRequestAuthType)(cp.Spec.AuthType),
+		ProxyUrls:   cp.Spec.ProxyUrls,
+		Labels:      cp.Spec.Labels,
+	}
+
+	resp, err := sdk.ControlPlanes.UpdateControlPlane(ctx, id, req)
+	var sdkError *sdkerrors.NotFoundError
+	if errors.As(err, &sdkError) {
+		logger.Info("entity not found in Konnect, trying to recreate",
+			"type", cp.GetTypeName(), "id", id,
+		)
+		if err := createControlPlane(ctx, sdk, logger, cp); err != nil {
+			return FailedKonnectOpError[konnectv1alpha1.KonnectControlPlane]{
+				Op:  UpdateOp,
+				Err: err,
+			}
+		}
+		// Create succeeded, update status.
+		cp.Status.SetKonnectID(*resp.ControlPlane.ID)
+		k8sutils.SetCondition(
+			k8sutils.NewConditionWithGeneration(
+				KonnectEntityProgrammedConditionType,
+				metav1.ConditionTrue,
+				KonnectEntityProgrammedReason,
+				"",
+				cp.GetGeneration(),
+			),
+			cp,
+		)
+
+		return nil
+	}
+
+	if errHandled := handleResp[konnectv1alpha1.KonnectControlPlane](err, resp, UpdateOp); errHandled != nil {
+		k8sutils.SetCondition(
+			k8sutils.NewConditionWithGeneration(
+				KonnectEntityProgrammedConditionType,
+				metav1.ConditionFalse,
+				"FailedToUpdate",
+				errHandled.Error(),
+				cp.GetGeneration(),
+			),
+			cp,
+		)
+		return FailedKonnectOpError[konnectv1alpha1.KonnectControlPlane]{
+			Op:  UpdateOp,
+			Err: errHandled,
+		}
+	}
+
+	cp.Status.SetKonnectID(*resp.ControlPlane.ID)
+	k8sutils.SetCondition(
+		k8sutils.NewConditionWithGeneration(
+			KonnectEntityProgrammedConditionType,
+			metav1.ConditionTrue,
+			KonnectEntityProgrammedReason,
+			"",
+			cp.GetGeneration(),
+		),
+		cp,
+	)
+
+	return nil
+}

--- a/controller/konnect/reconciler_generic_test.go
+++ b/controller/konnect/reconciler_generic_test.go
@@ -12,9 +12,11 @@ import (
 
 	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
 func TestNewKonnectEntityReconciler(t *testing.T) {
+	testNewKonnectEntityReconciler(t, konnectv1alpha1.KonnectControlPlane{})
 	testNewKonnectEntityReconciler(t, configurationv1.KongConsumer{})
 	// GetTypeName() is missing.
 	// https://github.com/Kong/kubernetes-configuration/pull/15 fixes that.
@@ -32,13 +34,15 @@ func testNewKonnectEntityReconciler[
 ) {
 	t.Helper()
 
+	sdkFactory := NewSDKFactory()
+
 	t.Run(ent.GetTypeName(), func(t *testing.T) {
 		cl := fakectrlruntimeclient.NewFakeClient()
 		mgr, err := ctrl.NewManager(&rest.Config{}, ctrl.Options{
 			Scheme: scheme.Get(),
 		})
 		require.NoError(t, err)
-		reconciler := NewKonnectEntityReconciler[T, TEnt](ent, false, cl)
+		reconciler := NewKonnectEntityReconciler[T, TEnt](sdkFactory, false, cl)
 		require.NoError(t, reconciler.SetupWithManager(mgr))
 	})
 }

--- a/controller/konnect/sdkfactory.go
+++ b/controller/konnect/sdkfactory.go
@@ -28,6 +28,6 @@ func (f sdkFactory) NewKonnectSDK(serverURL string, token SDKToken) *sdkkonnectg
 				PersonalAccessToken: sdkkonnectgo.String(string(token)),
 			},
 		),
-		sdkkonnectgo.WithServerURL("https://"+serverURL),
+		sdkkonnectgo.WithServerURL(serverURL),
 	)
 }

--- a/controller/konnect/watch.go
+++ b/controller/konnect/watch.go
@@ -8,6 +8,7 @@ import (
 
 	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
 // ReconciliationWatchOptionsForEntity returns the watch options for the given
@@ -20,12 +21,14 @@ func ReconciliationWatchOptionsForEntity[
 	ent TEnt,
 ) []func(*ctrl.Builder) *ctrl.Builder {
 	switch any(ent).(type) {
-	case *configurationv1alpha1.KongService:
-		return nil
 	case *configurationv1alpha1.KongRoute:
-		return nil
+		return []func(*ctrl.Builder) *ctrl.Builder{}
+	case *configurationv1alpha1.KongService:
+		return []func(*ctrl.Builder) *ctrl.Builder{}
 	case *configurationv1.KongConsumer:
-		return nil
+		return []func(*ctrl.Builder) *ctrl.Builder{}
+	case *konnectv1alpha1.KonnectControlPlane:
+		return KonnectControlPlaneReconciliationWatchOptions(cl)
 	default:
 		panic(fmt.Sprintf("unsupported entity type %T", ent))
 	}

--- a/controller/konnect/watch_konnectcontrolplane.go
+++ b/controller/konnect/watch_konnectcontrolplane.go
@@ -1,0 +1,72 @@
+package konnect
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+// TODO(pmalek): this can be extracted and used in reconciler.go
+// as every Konnect entity will have a reference to the KonnectAPIAuthConfiguration.
+// This would require:
+// - mapping function from non List types to List types
+// - a function on each Konnect entity type to get the API Auth configuration
+//   reference from the object
+// - lists have their items stored in Items field, not returned via a method
+
+// KonnectControlPlaneReconciliationWatchOptions returns the watch options for
+// the KonnectControlPlane.
+func KonnectControlPlaneReconciliationWatchOptions(
+	cl client.Client,
+) []func(*ctrl.Builder) *ctrl.Builder {
+	return []func(*ctrl.Builder) *ctrl.Builder{
+		func(b *ctrl.Builder) *ctrl.Builder {
+			return b.Watches(
+				&konnectv1alpha1.KonnectAPIAuthConfiguration{},
+				handler.EnqueueRequestsFromMapFunc(
+					enqueueKonnectControlPlaneForKonnectAPIAuthConfiguration(cl),
+				),
+			)
+		},
+	}
+}
+
+func enqueueKonnectControlPlaneForKonnectAPIAuthConfiguration(
+	cl client.Client,
+) func(ctx context.Context, obj client.Object) []reconcile.Request {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		auth, ok := obj.(*konnectv1alpha1.KonnectAPIAuthConfiguration)
+		if !ok {
+			return nil
+		}
+		var l konnectv1alpha1.KonnectControlPlaneList
+		if err := cl.List(ctx, &l, &client.ListOptions{
+			// TODO: change this when cross namespace refs are allowed.
+			Namespace: auth.GetNamespace(),
+		}); err != nil {
+			return nil
+		}
+		var ret []reconcile.Request
+		for _, cp := range l.Items {
+			authRef := cp.GetKonnectAPIAuthConfigurationRef()
+			if authRef.Name != auth.Name {
+				// TODO: change this when cross namespace refs are allowed.
+				// authRef.Namespace != auth.Namespace {
+				continue
+			}
+			ret = append(ret, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: cp.Namespace,
+					Name:      cp.Name,
+				},
+			})
+		}
+		return ret
+	}
+}

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -27,6 +27,8 @@ import (
 	dataplanevalidator "github.com/kong/gateway-operator/internal/validation/dataplane"
 	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
 const (
@@ -48,10 +50,14 @@ const (
 	DataPlaneOwnedDeploymentFinalizerControllerName = "DataPlaneOwnedDeploymentFinalizer"
 	// AIGatewayControllerName is the name of the GatewayClass controller.
 	AIGatewayControllerName = "AIGateway"
-	// KonnectAPIAuthConfigurationControllerName is the name of the KonnectAPIAuthConfiguration controller.
-	KonnectAPIAuthConfigurationControllerName = "KonnectAPIAuthConfiguration"
+
 	// KongPluginInstallationControllerName is the name of the KongPluginInstallation controller.
 	KongPluginInstallationControllerName = "KongPluginInstallation"
+
+	// KonnectAPIAuthConfigurationControllerName is the name of the KonnectAPIAuthConfiguration controller.
+	KonnectAPIAuthConfigurationControllerName = "KonnectAPIAuthConfiguration"
+	// KonnectControlPlaneControllerName is the name of the KonnectControlPlane controller.
+	KonnectControlPlaneControllerName = "KonnectControlPlane"
 )
 
 // SetupControllersShim runs SetupControllers and returns its result as a slice of the map values.
@@ -289,9 +295,18 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 	// Konnect controllers
 	if c.KonnectControllersEnabled {
 		sdkFactory := konnect.NewSDKFactory()
+
 		controllers[KonnectAPIAuthConfigurationControllerName] = ControllerDef{
 			Enabled: c.KonnectControllersEnabled,
 			Controller: konnect.NewKonnectAPIAuthConfigurationReconciler(
+				sdkFactory,
+				c.DevelopmentMode,
+				mgr.GetClient(),
+			),
+		}
+		controllers[KonnectControlPlaneControllerName] = ControllerDef{
+			Enabled: c.KonnectControllersEnabled,
+			Controller: konnect.NewKonnectEntityReconciler[konnectv1alpha1.KonnectControlPlane](
 				sdkFactory,
 				c.DevelopmentMode,
 				mgr.GetClient(),


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `KonnectControlPlane` reconciler.

Example manifest:

```
kind: KonnectControlPlane
apiVersion: konnect.konghq.com/v1alpha1
metadata:
  name: test1
  namespace: default
spec:
  name: test1
  labels:
    app: test1
    key1: test1
  konnect:
    authRef:
      name: konnect-api-auth-dev-1
---
kind: KonnectAPIAuthConfiguration
apiVersion: konnect.konghq.com/v1alpha1
metadata:
  name: konnect-api-auth-dev-1
  namespace: default
spec:
  type: token
  token: kpat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
  serverURL: eu.api.konghq.com
```

~Depends on https://github.com/Kong/kubernetes-configuration/pull/20~

**Which issue this PR fixes**

Part of #432 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
