### PR TITLE
feat(dp): handle PodDisruptionBudget reconciliation for deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 - Introduce `KongPluginInstallation` CRD to allow installing custom Kong
   plugins distributed as container images.
   [400](https://github.com/Kong/gateway-operator/pull/400)
+- Extended `DataPlane` API with a possibility to specify `PodDisruptionBudget` to be
+  created for the `DataPlane` deployments via `spec.resources.podDisruptionBudget`.
+  [#464](https://github.com/Kong/gateway-operator/pull/464)
 
 ### Fixed
 

--- a/api/v1beta1/dataplane_types.go
+++ b/api/v1beta1/dataplane_types.go
@@ -280,7 +280,7 @@ type DataPlaneStatus struct {
 
 	// Selector contains a unique DataPlane identifier used as a deterministic
 	// label selector that is used throughout its dependent resources.
-	// This is used e.g. as a label selector for DataPlane's Services and Deployments.
+	// This is used e.g. as a label selector for DataPlane's Services, Deployments and PodDisruptionBudgets.
 	//
 	// +kubebuilder:validation:MaxLength=512
 	// +kubebuilder:validation:MinLength=8

--- a/config/crd/bases/gateway-operator.konghq.com_dataplanes.yaml
+++ b/config/crd/bases/gateway-operator.konghq.com_dataplanes.yaml
@@ -9322,7 +9322,7 @@ spec:
                 description: |-
                   Selector contains a unique DataPlane identifier used as a deterministic
                   label selector that is used throughout its dependent resources.
-                  This is used e.g. as a label selector for DataPlane's Services and Deployments.
+                  This is used e.g. as a label selector for DataPlane's Services, Deployments and PodDisruptionBudgets.
                 maxLength: 512
                 minLength: 8
                 type: string

--- a/config/crd/dataplane/gateway-operator.konghq.com_dataplanes.yaml
+++ b/config/crd/dataplane/gateway-operator.konghq.com_dataplanes.yaml
@@ -9322,7 +9322,7 @@ spec:
                 description: |-
                   Selector contains a unique DataPlane identifier used as a deterministic
                   label selector that is used throughout its dependent resources.
-                  This is used e.g. as a label selector for DataPlane's Services and Deployments.
+                  This is used e.g. as a label selector for DataPlane's Services, Deployments and PodDisruptionBudgets.
                 maxLength: 512
                 minLength: 8
                 type: string

--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -658,6 +658,23 @@ rules:
   - update
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddistruptionbudgets
+  verbs:
+  - delete
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings

--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -663,17 +663,12 @@ rules:
   - poddisruptionbudgets
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
   - update
   - watch
-- apiGroups:
-  - policy
-  resources:
-  - poddistruptionbudgets
-  verbs:
-  - delete
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/controller/dataplane/controller.go
+++ b/controller/dataplane/controller.go
@@ -204,6 +204,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
+	res, _, err = ensurePodDisruptionBudgetForDataPlane(ctx, r.Client, logger, dataplane)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("could not ensure PodDisruptionBudget for DataPlane %s/%s: %w", dataplane.Namespace, dataplane.Name, err)
+	}
+	if res != op.Noop {
+		log.Debug(logger, "PodDisruptionBudget created/updated", dataplane)
+		return ctrl.Result{}, nil
+	}
+
 	if res, err := ensureDataPlaneReadyStatus(ctx, r.Client, logger, dataplane, dataplane.Generation); err != nil {
 		return ctrl.Result{}, err
 	} else if res.Requeue {

--- a/controller/dataplane/controller_rbac.go
+++ b/controller/dataplane/controller_rbac.go
@@ -4,14 +4,15 @@ package dataplane
 // DataPlaneReconciler - RBAC
 // -----------------------------------------------------------------------------
 
-//+kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=dataplanes,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=dataplanes/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=dataplanes/finalizers,verbs=update
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;get;list;watch;update;patch;delete
-//+kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get
-//+kubebuilder:rbac:groups=core,resources=services,verbs=create;get;list;watch;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=services/status,verbs=get
-//+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
-//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;delete
-//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
-//+kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=create;get;list;patch;watch
+// +kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=dataplanes,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=dataplanes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=dataplanes/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;get;list;watch;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get
+// +kubebuilder:rbac:groups=core,resources=services,verbs=create;get;list;watch;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=services/status,verbs=get
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;delete
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=create;get;list;patch;watch
+// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=create;get;list;watch;update;patch

--- a/controller/dataplane/owned_resources.go
+++ b/controller/dataplane/owned_resources.go
@@ -11,6 +11,7 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -111,6 +112,61 @@ func ensureHPAForDataPlane(
 	}
 
 	return op.Created, nil, nil
+}
+
+func ensurePodDisruptionBudgetForDataPlane(
+	ctx context.Context,
+	cl client.Client,
+	log logr.Logger,
+	dataplane *operatorv1beta1.DataPlane,
+) (res op.Result, pdb *policyv1.PodDisruptionBudget, err error) {
+	matchingLabels := k8sresources.GetManagedLabelForOwner(dataplane)
+	pdbs, err := k8sutils.ListPodDisruptionBudgetsForOwner(ctx, cl, dataplane.Namespace, dataplane.UID, matchingLabels)
+	if err != nil {
+		return op.Noop, nil, fmt.Errorf("failed listing PodDisruptionBudgets for DataPlane %s/%s: %w", dataplane.Namespace, dataplane.Name, err)
+	}
+
+	if dataplane.Spec.Resources.PodDisruptionBudget == nil {
+		if err := k8sreduce.ReducePodDisruptionBudgets(ctx, cl, pdbs, k8sreduce.FilterNone); err != nil {
+			return op.Noop, nil, fmt.Errorf("failed reducing PodDisruptionBudgets for DataPlane %s/%s: %w", dataplane.Namespace, dataplane.Name, err)
+		}
+		return op.Noop, nil, nil
+	}
+
+	if len(pdbs) > 1 {
+		if err := k8sreduce.ReducePodDisruptionBudgets(ctx, cl, pdbs, k8sreduce.FilterPodDisruptionBudgets); err != nil {
+			return op.Noop, nil, fmt.Errorf("failed reducing PodDisruptionBudgets for DataPlane %s/%s: %w", dataplane.Namespace, dataplane.Name, err)
+		}
+		return op.Noop, nil, nil
+	}
+
+	generatedPDB, err := k8sresources.GeneratePodDisruptionBudgetForDataPlane(dataplane)
+	if err != nil {
+		return op.Noop, nil, fmt.Errorf("failed generating PodDisruptionBudget for DataPlane %s/%s: %w", dataplane.Namespace, dataplane.Name, err)
+	}
+
+	if len(pdbs) == 1 {
+		var updated bool
+		existingPDB := &pdbs[0]
+		oldExistingPDB := existingPDB.DeepCopy()
+
+		// Ensure that PDB's metadata is up-to-date.
+		updated, existingPDB.ObjectMeta = k8sutils.EnsureObjectMetaIsUpdated(existingPDB.ObjectMeta, generatedPDB.ObjectMeta)
+
+		// Ensure that PDB's spec is up-to-date.
+		if !cmp.Equal(existingPDB.Spec, generatedPDB.Spec) {
+			existingPDB.Spec = generatedPDB.Spec
+			updated = true
+		}
+
+		return patch.ApplyPatchIfNonEmpty(ctx, cl, log, existingPDB, oldExistingPDB, dataplane, updated)
+	}
+
+	if err := cl.Create(ctx, generatedPDB); err != nil {
+		return op.Noop, nil, fmt.Errorf("failed creating PodDisruptionBudget for DataPlane %s: %w", dataplane.Name, err)
+	}
+
+	return op.Created, generatedPDB, nil
 }
 
 func matchingLabelsToServiceOpt(ml client.MatchingLabels) k8sresources.ServiceOpt {

--- a/controller/dataplane/watch.go
+++ b/controller/dataplane/watch.go
@@ -4,6 +4,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 
@@ -15,14 +16,16 @@ import (
 // the operator.
 func DataPlaneWatchBuilder(mgr ctrl.Manager) *builder.Builder {
 	return ctrl.NewControllerManagedBy(mgr).
-		// watch DataPlane objects
+		// Watch DataPlane objects.
 		For(&operatorv1beta1.DataPlane{}).
-		// watch for changes in Secrets created by the dataplane controller
+		// Watch for changes in Secrets created by the dataplane controller.
 		Owns(&corev1.Secret{}).
-		// watch for changes in Services created by the dataplane controller
+		// Watch for changes in Services created by the dataplane controller.
 		Owns(&corev1.Service{}).
-		// watch for changes in Deployments created by the dataplane controller
+		// Watch for changes in Deployments created by the dataplane controller.
 		Owns(&appsv1.Deployment{}).
-		// watch for changes in HPA created by the dataplane controller
-		Owns(&autoscalingv2.HorizontalPodAutoscaler{})
+		// Watch for changes in HPA created by the dataplane controller.
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
+		// Watch for changes in PodDisruptionBudgets created by the dataplane controller.
+		Owns(&policyv1.PodDisruptionBudget{})
 }

--- a/controller/konnect/constraints.go
+++ b/controller/konnect/constraints.go
@@ -24,11 +24,8 @@ type SupportedKonnectEntityType interface {
 // Separating this from SupportedKonnectEntityType allows us to use EntityType
 // where client.Object is required, since it embeds client.Object and uses pointer
 // to refer to the SupportedKonnectEntityType.
-type EntityType[
-	T SupportedKonnectEntityType,
-] interface {
+type EntityType[T SupportedKonnectEntityType] interface {
 	*T
-
 	// Kubernetes Object methods
 	GetObjectMeta() metav1.Object
 	client.Object

--- a/controller/pkg/patch/patch.go
+++ b/controller/pkg/patch/patch.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	policyv1 "k8s.io/api/policy/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -23,7 +24,7 @@ import (
 func ApplyPatchIfNonEmpty[
 	OwnerT *operatorv1beta1.DataPlane | *operatorv1beta1.ControlPlane,
 	ResourceT interface {
-		*appsv1.Deployment | *autoscalingv2.HorizontalPodAutoscaler | *certmanagerv1.Certificate
+		*appsv1.Deployment | *autoscalingv2.HorizontalPodAutoscaler | *certmanagerv1.Certificate | *policyv1.PodDisruptionBudget
 		client.Object
 	},
 ](

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -894,7 +894,7 @@ DataPlaneStatus defines the observed state of DataPlane
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ | Conditions describe the status of the DataPlane. |
 | `service` _string_ | Service indicates the Service that exposes the DataPlane's configured routes |
 | `addresses` _[Address](#address) array_ | Addresses lists the addresses that have actually been bound to the DataPlane. |
-| `selector` _string_ | Selector contains a unique DataPlane identifier used as a deterministic label selector that is used throughout its dependent resources. This is used e.g. as a label selector for DataPlane's Services and Deployments. |
+| `selector` _string_ | Selector contains a unique DataPlane identifier used as a deterministic label selector that is used throughout its dependent resources. This is used e.g. as a label selector for DataPlane's Services, Deployments and PodDisruptionBudgets. |
 | `readyReplicas` _integer_ | ReadyReplicas indicates how many replicas have reported to be ready. |
 | `replicas` _integer_ | Replicas indicates how many replicas have been set for the DataPlane. |
 | `rollout` _[DataPlaneRolloutStatus](#dataplanerolloutstatus)_ | RolloutStatus contains information about the rollout. It is set only if a rollout strategy was configured in the spec. |

--- a/pkg/utils/kubernetes/reduce/reduce.go
+++ b/pkg/utils/kubernetes/reduce/reduce.go
@@ -166,16 +166,16 @@ func ReduceHPAs(ctx context.Context, k8sClient client.Client, hpas []autoscaling
 	return nil
 }
 
-// +kubebuilder:rbac:groups=policy,resources=poddistruptionbudgets,verbs=delete
+// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=delete
 
 // PDBFilterFunc filters a list of PodDisruptionBudgets.
 type PDBFilterFunc func(hpas []policyv1.PodDisruptionBudget) []policyv1.PodDisruptionBudget
 
 // ReducePodDisruptionBudgets detects the best PodDisruptionBudget in the set and deletes all the others.
 func ReducePodDisruptionBudgets(ctx context.Context, k8sClient client.Client, pdbs []policyv1.PodDisruptionBudget, filter PDBFilterFunc) error {
-	for _, hpa := range filter(pdbs) {
-		hpa := hpa
-		if err := k8sClient.Delete(ctx, &hpa); client.IgnoreNotFound(err) != nil {
+	for _, pdb := range filter(pdbs) {
+		pdb := pdb
+		if err := k8sClient.Delete(ctx, &pdb); client.IgnoreNotFound(err) != nil {
 			return err
 		}
 	}

--- a/pkg/utils/kubernetes/reduce/reduce.go
+++ b/pkg/utils/kubernetes/reduce/reduce.go
@@ -152,8 +152,8 @@ func ReduceNetworkPolicies(ctx context.Context, k8sClient client.Client, network
 
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=delete
 
-// HPAFilterFunc filters a list of HorizontalPodAutoscalers.
-type HPAFilterFunc func(hpas []autoscalingv2.HorizontalPodAutoscaler) []autoscalingv2.HorizontalPodAutoscaler
+// HPAFilterFunc filters a list of HorizontalPodAutoscalers and returns the ones that should be deleted.
+type HPAFilterFunc func([]autoscalingv2.HorizontalPodAutoscaler) []autoscalingv2.HorizontalPodAutoscaler
 
 // ReduceHPAs detects the best HorizontalPodAutoscaler in the set and deletes all the others.
 func ReduceHPAs(ctx context.Context, k8sClient client.Client, hpas []autoscalingv2.HorizontalPodAutoscaler, filter HPAFilterFunc) error {
@@ -168,8 +168,8 @@ func ReduceHPAs(ctx context.Context, k8sClient client.Client, hpas []autoscaling
 
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=delete
 
-// PDBFilterFunc filters a list of PodDisruptionBudgets.
-type PDBFilterFunc func(hpas []policyv1.PodDisruptionBudget) []policyv1.PodDisruptionBudget
+// PDBFilterFunc filters a list of PodDisruptionBudgets and returns the ones that should be deleted.
+type PDBFilterFunc func([]policyv1.PodDisruptionBudget) []policyv1.PodDisruptionBudget
 
 // ReducePodDisruptionBudgets detects the best PodDisruptionBudget in the set and deletes all the others.
 func ReducePodDisruptionBudgets(ctx context.Context, k8sClient client.Client, pdbs []policyv1.PodDisruptionBudget, filter PDBFilterFunc) error {

--- a/pkg/utils/kubernetes/resources/pdbs.go
+++ b/pkg/utils/kubernetes/resources/pdbs.go
@@ -1,0 +1,52 @@
+package resources
+
+import (
+	"fmt"
+
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1beta1 "github.com/kong/gateway-operator/api/v1beta1"
+	"github.com/kong/gateway-operator/pkg/consts"
+	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
+)
+
+// GeneratePodDisruptionBudgetForDataPlane generates a PodDisruptionBudget for the given DataPlane.
+func GeneratePodDisruptionBudgetForDataPlane(dataplane *operatorv1beta1.DataPlane) (*policyv1.PodDisruptionBudget, error) {
+	if dataplane.Spec.Resources.PodDisruptionBudget == nil {
+		return nil, fmt.Errorf("cannot generate PodDisruptionBudget for DataPlane which doesn't have PodDisruptionBudget defined")
+	}
+
+	labels := GetManagedLabelForOwner(dataplane)
+	labels["app"] = dataplane.Name
+	labels[consts.OperatorLabelSelector] = dataplane.Status.Selector
+
+	pdbSpec := dataplane.Spec.Resources.PodDisruptionBudget.Spec
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dataplane.Name,
+			Namespace: dataplane.Namespace,
+			Labels:    labels,
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			// Selector is defined dynamically based on the labels of the DataPlane.
+			Selector: &metav1.LabelSelector{
+				MatchLabels: client.MatchingLabels{
+					// Only pods with the same app and selector label as the DataPlane's Deployment should be
+					// considered for the PDB.
+					"app":                        dataplane.Name,
+					consts.OperatorLabelSelector: dataplane.Status.Selector,
+				},
+			},
+			// The rest of the fields is directly copied from the DP's PDB spec.
+			MinAvailable:               pdbSpec.MinAvailable,
+			MaxUnavailable:             pdbSpec.MaxUnavailable,
+			UnhealthyPodEvictionPolicy: pdbSpec.UnhealthyPodEvictionPolicy,
+		},
+	}
+
+	k8sutils.SetOwnerForObject(pdb, dataplane)
+
+	return pdb, nil
+}

--- a/pkg/utils/test/asserts.go
+++ b/pkg/utils/test/asserts.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -120,6 +121,26 @@ func MustListDataPlaneHPAs(t *testing.T, ctx context.Context, dataplane *operato
 	)
 	require.NoError(t, err)
 	return hpas
+}
+
+// MustListDataPlanePodDisruptionBudgets is a helper function for tests that
+// conveniently lists all PDBs managed by a given dataplane.
+func MustListDataPlanePodDisruptionBudgets(
+	t *testing.T,
+	ctx context.Context,
+	dataplane *operatorv1beta1.DataPlane,
+	clients K8sClients,
+	matchinglabels client.MatchingLabels,
+) []policyv1.PodDisruptionBudget {
+	pdbs, err := k8sutils.ListPodDisruptionBudgetsForOwner(
+		ctx,
+		clients.MgrClient,
+		dataplane.Namespace,
+		dataplane.UID,
+		matchinglabels,
+	)
+	require.NoError(t, err)
+	return pdbs
 }
 
 // MustListServiceEndpointSlices is a helper function for tests that

--- a/pkg/utils/test/predicates.go
+++ b/pkg/utils/test/predicates.go
@@ -14,6 +14,7 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -589,6 +590,60 @@ func DataPlaneHasServiceSecret(t *testing.T, ctx context.Context, dpNN, usingSvc
 			return true
 		}
 		return false
+	}, clients.OperatorClient)
+}
+
+// PodDisruptionBudgetRequirement is a function type used to check if a PodDisruptionBudget meets a certain requirement.
+type PodDisruptionBudgetRequirement func(policyv1.PodDisruptionBudget) bool
+
+// AnyPodDisruptionBudget returns a function that accepts any PodDisruptionBudget.
+func AnyPodDisruptionBudget() PodDisruptionBudgetRequirement {
+	return func(policyv1.PodDisruptionBudget) bool {
+		return true
+	}
+}
+
+// DataPlaneHasPodDisruptionBudget is a helper function for tests that returns a function
+// that can be used to check if a DataPlane has a PodDisruptionBudget.
+// Should be used in conjunction with require.Eventually or assert.Eventually.
+func DataPlaneHasPodDisruptionBudget(
+	t *testing.T,
+	ctx context.Context,
+	dataplane *operatorv1beta1.DataPlane,
+	ret *policyv1.PodDisruptionBudget,
+	clients K8sClients,
+	req PodDisruptionBudgetRequirement,
+) func() bool {
+	dataplaneName := client.ObjectKeyFromObject(dataplane)
+	const dataplaneDeploymentAppLabel = "app"
+
+	return DataPlanePredicate(t, ctx, dataplaneName, func(dataplane *operatorv1beta1.DataPlane) bool {
+		deployments := MustListDataPlaneDeployments(t, ctx, dataplane, clients, client.MatchingLabels{
+			dataplaneDeploymentAppLabel:          dataplane.Name,
+			consts.GatewayOperatorManagedByLabel: consts.DataPlaneManagedLabelValue,
+		})
+		if len(deployments) != 1 {
+			return false
+		}
+
+		pdbs := MustListDataPlanePodDisruptionBudgets(t, ctx, dataplane, clients, client.MatchingLabels{
+			dataplaneDeploymentAppLabel:          dataplane.Name,
+			consts.GatewayOperatorManagedByLabel: consts.DataPlaneManagedLabelValue,
+		})
+		if len(pdbs) != 1 {
+			return false
+		}
+
+		pdb := pdbs[0]
+		if !req(pdb) {
+			return false
+		}
+
+		if ret != nil {
+			*ret = pdb
+		}
+
+		return true
 	}, clients.OperatorClient)
 }
 

--- a/test/integration/zz_generated_registered_testcases.go
+++ b/test/integration/zz_generated_registered_testcases.go
@@ -12,6 +12,7 @@ func init() {
 		TestDataPlaneBlueGreen_ResourcesNotDeletedUntilOwnerIsRemoved,
 		TestDataPlaneEssentials,
 		TestDataPlaneHorizontalScaling,
+		TestDataPlanePodDisruptionBudget,
 		TestDataPlaneUpdate,
 		TestDataPlaneValidation,
 		TestDataPlaneVolumeMounts,


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds PodDisruptionBudget reconciliation for DataPlanes.

**Which issue this PR fixes**

Fixes https://github.com/Kong/gateway-operator/issues/142.


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
