### PR TITLE
chore: change format of image for KongPluginInstallation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
   [#387](https://github.com/Kong/gateway-operator/pull/387)
 - Introduce `KongPluginInstallation` CRD to allow installing custom Kong
   plugins distributed as container images.
-  [#400](https://github.com/Kong/gateway-operator/pull/400), [#424](https://github.com/Kong/gateway-operator/pull/424)
+  [#400](https://github.com/Kong/gateway-operator/pull/400), [#424](https://github.com/Kong/gateway-operator/pull/424), [#474](https://github.com/Kong/gateway-operator/pull/474)
 - Extended `DataPlane` API with a possibility to specify `PodDisruptionBudget` to be
   created for the `DataPlane` deployments via `spec.resources.podDisruptionBudget`.
   [#464](https://github.com/Kong/gateway-operator/pull/464)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Builder
 # ------------------------------------------------------------------------------
 
-FROM --platform=$BUILDPLATFORM golang:1.22.6 as builder
+FROM --platform=$BUILDPLATFORM golang:1.22.6 AS builder
 
 WORKDIR /workspace
 ARG GOPATH
@@ -55,7 +55,7 @@ RUN --mount=type=cache,target=$GOPATH/pkg/mod \
 
 # Use distroless as minimal base image to package the operator binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot as distroless
+FROM gcr.io/distroless/static:nonroot AS distroless
 
 ARG TAG
 ARG NAME="Kong Gateway Operator"

--- a/controller/kongplugininstallation/image/image.go
+++ b/controller/kongplugininstallation/image/image.go
@@ -148,7 +148,7 @@ func (sl sizeLimitBytes) String() string {
 	return fmt.Sprintf("%.2f MiB", float64(sl)/(1024*1024))
 }
 
-func extractKongPluginFromLayer(r io.Reader) (map[string]string, error) {
+func extractKongPluginFromLayer(r io.Reader) (PluginFiles, error) {
 	// Search for the files walking through the archive.
 	// The size of a plugin is limited to the size of a ConfigMap in Kubernetes.
 	const sizeLimit_1MiB sizeLimitBytes = 1024 * 1024

--- a/controller/kongplugininstallation/image/image.go
+++ b/controller/kongplugininstallation/image/image.go
@@ -120,13 +120,13 @@ func (sl sizeLimitBytes) String() string {
 }
 
 func extractKongPluginFromLayer(r io.Reader) (map[string]string, error) {
-	// The target file name expected in image with a custom Kong plugin.
+	// The target files' names expected in an image with a custom Kong plugin.
 	const (
 		kongPluginHandler = "handler.lua"
 		kongPluginSchema  = "schema.lua"
 	)
-	// Search for the file walking through the archive.
-	// Size of plugin is limited to size of a ConfigMap in Kubernetes.
+	// Search for the files walking through the archive.
+	//The size of a plugin is limited to the size of a ConfigMap in Kubernetes.
 	const sizeLimit_1MiB sizeLimitBytes = 1024 * 1024
 
 	gr, err := gzip.NewReader(r)
@@ -148,7 +148,7 @@ func extractKongPluginFromLayer(r io.Reader) (map[string]string, error) {
 			file := make([]byte, h.Size)
 			if _, err := io.ReadFull(tr, file); err != nil {
 				if errors.Is(err, io.ErrUnexpectedEOF) {
-					return nil, fmt.Errorf("plugin size exceed %s", sizeLimit_1MiB)
+					return nil, fmt.Errorf("plugin size limit of %s exceeded", sizeLimit_1MiB)
 				}
 				return nil, fmt.Errorf("failed to read %s from image: %w", fileName, err)
 			}
@@ -167,7 +167,7 @@ func extractKongPluginFromLayer(r io.Reader) (map[string]string, error) {
 		}
 	}
 	if len(missingFiles) > 0 {
-		return nil, fmt.Errorf("not found in the image required files: %s", strings.Join(missingFiles, ", "))
+		return nil, fmt.Errorf("required files not found in the image: %s", strings.Join(missingFiles, ", "))
 	}
 
 	return pluginFiles, nil

--- a/controller/kongplugininstallation/image/image_test.go
+++ b/controller/kongplugininstallation/image/image_test.go
@@ -115,7 +115,7 @@ func TestFetchPluginContent(t *testing.T) {
 		_, err := image.FetchPlugin(
 			context.Background(), registryUrl+"plugin-example/missing-file", nil,
 		)
-		require.ErrorContains(t, err, `not found in the image required files: schema.lua`)
+		require.ErrorContains(t, err, `required files not found in the image: schema.lua`)
 	})
 
 	// Single file - handler.lua is over 1 MiB.
@@ -123,7 +123,7 @@ func TestFetchPluginContent(t *testing.T) {
 		_, err := image.FetchPlugin(
 			context.Background(), registryUrl+"plugin-example/invalid-size-one", nil,
 		)
-		require.ErrorContains(t, err, "plugin size exceed 1.00 MiB")
+		require.ErrorContains(t, err, "plugin size limit of 1.00 MiB exceeded")
 	})
 
 	// Each file is 512 KiB so together they are 1 MiB.
@@ -131,7 +131,7 @@ func TestFetchPluginContent(t *testing.T) {
 		_, err := image.FetchPlugin(
 			context.Background(), registryUrl+"plugin-example/invalid-size-combined", nil,
 		)
-		require.ErrorContains(t, err, "plugin size exceed 1.00 MiB")
+		require.ErrorContains(t, err, "plugin size limit of 1.00 MiB exceeded")
 	})
 }
 

--- a/controller/kongplugininstallation/image/image_test.go
+++ b/controller/kongplugininstallation/image/image_test.go
@@ -59,26 +59,26 @@ func TestCredentialsStoreFromString(t *testing.T) {
 
 func TestFetchPluginContent(t *testing.T) {
 	t.Run("invalid image URL", func(t *testing.T) {
-		_, err := image.FetchPluginContent(context.Background(), "foo bar", nil)
+		_, err := image.FetchPlugin(context.Background(), "foo bar", nil)
 		require.ErrorContains(t, err, "unexpected format of image url: could not parse reference: foo bar")
 	})
 
 	const registryUrl = "northamerica-northeast1-docker.pkg.dev/k8s-team-playground/"
 
 	t.Run("valid image (Docker format)", func(t *testing.T) {
-		plugin, err := image.FetchPluginContent(
-			context.Background(), registryUrl+"plugin-example/valid", nil,
+		plugin, err := image.FetchPlugin(
+			context.Background(), registryUrl+"plugin-example/valid:0.1.0", nil,
 		)
 		require.NoError(t, err)
-		require.Equal(t, string(plugin), "plugin-content\n")
+		requireExpectedContent(t, plugin)
 	})
 
 	t.Run("valid image (OCI format)", func(t *testing.T) {
-		plugin, err := image.FetchPluginContent(
-			context.Background(), registryUrl+"plugin-example/valid-oci", nil,
+		plugin, err := image.FetchPlugin(
+			context.Background(), registryUrl+"plugin-example/valid-oci:0.1.0", nil,
 		)
 		require.NoError(t, err)
-		require.Equal(t, string(plugin), "plugin-content\n")
+		requireExpectedContent(t, plugin)
 	})
 
 	t.Run("valid image from private registry", func(t *testing.T) {
@@ -90,31 +90,65 @@ func TestFetchPluginContent(t *testing.T) {
 		credsStore, err := image.CredentialsStoreFromString(credentials)
 		require.NoError(t, err)
 
-		plugin, err := image.FetchPluginContent(
-			context.Background(), registryUrl+"plugin-example-private/valid:v1.0", credsStore,
+		plugin, err := image.FetchPlugin(
+			context.Background(), registryUrl+"plugin-example-private/valid:0.1.0", credsStore,
 		)
 		require.NoError(t, err)
-		require.Equal(t, string(plugin), "plugin-content-private\n")
+		requireExpectedContentPrivate(t, plugin)
 	})
 
 	t.Run("invalid image - too many layers", func(t *testing.T) {
-		_, err := image.FetchPluginContent(
+		_, err := image.FetchPlugin(
 			context.Background(), registryUrl+"plugin-example/invalid-layers", nil,
 		)
 		require.ErrorContains(t, err, "expected exactly one layer with plugin, found 2 layers")
 	})
 
-	t.Run("invalid image - invalid name of plugin inside of it", func(t *testing.T) {
-		_, err := image.FetchPluginContent(
+	t.Run("invalid image - invalid names of files", func(t *testing.T) {
+		_, err := image.FetchPlugin(
 			context.Background(), registryUrl+"plugin-example/invalid-name", nil,
 		)
-		require.ErrorContains(t, err, `file "plugin.lua" not found in the image`)
+		require.ErrorContains(t, err, `file "add-header.lua" is unexpected, required files are handler.lua and schema.lua`)
 	})
 
-	t.Run("invalid image - invalid too big plugin", func(t *testing.T) {
-		_, err := image.FetchPluginContent(
-			context.Background(), registryUrl+"plugin-example/invalid-size", nil,
+	t.Run("invalid image - missing file", func(t *testing.T) {
+		_, err := image.FetchPlugin(
+			context.Background(), registryUrl+"plugin-example/missing-file", nil,
+		)
+		require.ErrorContains(t, err, `not found in the image required files: schema.lua`)
+	})
+
+	// Single file - handler.lua is over 1 MiB.
+	t.Run("invalid image - invalid too big plugin (size of single file)", func(t *testing.T) {
+		_, err := image.FetchPlugin(
+			context.Background(), registryUrl+"plugin-example/invalid-size-one", nil,
 		)
 		require.ErrorContains(t, err, "plugin size exceed 1.00 MiB")
 	})
+
+	// Each file is 512 KiB so together they are 1 MiB.
+	t.Run("invalid image - invalid too big plugin (size of files combined)", func(t *testing.T) {
+		_, err := image.FetchPlugin(
+			context.Background(), registryUrl+"plugin-example/invalid-size-combined", nil,
+		)
+		require.ErrorContains(t, err, "plugin size exceed 1.00 MiB")
+	})
+}
+
+func requireExpectedContent(t *testing.T, actual map[string]string) {
+	t.Helper()
+	require.Len(t, actual, 2)
+	require.Equal(t, map[string]string{
+		"handler.lua": "handler-content\n",
+		"schema.lua":  "schema-content\n",
+	}, actual)
+}
+
+func requireExpectedContentPrivate(t *testing.T, actual map[string]string) {
+	t.Helper()
+	require.Len(t, actual, 2)
+	require.Equal(t, map[string]string{
+		"handler.lua": "handler-content-private\n",
+		"schema.lua":  "schema-content-private\n",
+	}, actual)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Rework a little bit what has been introduced in 

- https://github.com/Kong/gateway-operator/pull/424

It's simple to deal with a plugin in the format

```dockerfile
FROM scratch

COPY plugin /
```

where `plugin` is a dir that contains `handler.lua` and `schema.lua` which are copied to the root of an image (the final image contains only those two files). Tests are adjusted accordingly. 


**Which issue this PR fixes**

Follow up for https://github.com/Kong/gateway-operator/issues/379

**Special notes for your reviewer**:

Everything mentioned in the respective section of the PR https://github.com/Kong/gateway-operator/pull/424 remains in force. 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
