### PR TITLE
feat(konnect): make controlPlaneRef optional for KongService

### DIFF
--- a/controller/konnect/constraints.go
+++ b/controller/konnect/constraints.go
@@ -6,6 +6,7 @@ import (
 
 	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	configurationv1beta1 "github.com/kong/kubernetes-configuration/api/configuration/v1beta1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
@@ -15,7 +16,8 @@ type SupportedKonnectEntityType interface {
 	konnectv1alpha1.KonnectControlPlane |
 		configurationv1alpha1.KongService |
 		configurationv1alpha1.KongRoute |
-		configurationv1.KongConsumer
+		configurationv1.KongConsumer |
+		configurationv1beta1.KongConsumerGroup
 	// TODO: add other types
 
 	GetTypeName() string

--- a/controller/konnect/errors.go
+++ b/controller/konnect/errors.go
@@ -1,6 +1,10 @@
 package konnect
 
-import "fmt"
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+)
 
 // FailedKonnectOpError is an error type that is returned when an operation against
 // Konnect API fails.
@@ -18,5 +22,24 @@ func (e FailedKonnectOpError[T]) Error() string {
 
 // Unwrap returns the underlying error.
 func (e FailedKonnectOpError[T]) Unwrap() error {
+	return e.Err
+}
+
+// ReferencedControlPlaneDoesNotExistError is an error type that is returned when
+// a Konnect entity references a KonnectControlPlane that does not exist.
+type ReferencedControlPlaneDoesNotExistError struct {
+	Reference types.NamespacedName
+	Err       error
+}
+
+// Error implements the error interface.
+func (e ReferencedControlPlaneDoesNotExistError) Error() string {
+	return fmt.Sprintf("referenced Control Plane %s does not exist: %v",
+		e.Reference, e.Err,
+	)
+}
+
+// Unwrap returns the underlying error.
+func (e ReferencedControlPlaneDoesNotExistError) Unwrap() error {
 	return e.Err
 }

--- a/controller/konnect/ops.go
+++ b/controller/konnect/ops.go
@@ -148,9 +148,13 @@ func logOpComplete[
 func wrapErrIfKonnectOpFailed[
 	T SupportedKonnectEntityType,
 	TEnt EntityType[T],
-](err error, op Op) error {
+](err error, op Op, e TEnt) error {
 	if err != nil {
-		var e TEnt
+		if e == nil {
+			return fmt.Errorf("failed to %s for %T: %w",
+				op, e, err,
+			)
+		}
 		return fmt.Errorf("failed to %s for %T %q: %w",
 			op, client.ObjectKeyFromObject(e), e, err,
 		)

--- a/controller/konnect/ops_controlplane.go
+++ b/controller/konnect/ops_controlplane.go
@@ -26,7 +26,7 @@ func createControlPlane(
 	// Can't adopt it as it will cause conflicts between the controller
 	// that created that entity and already manages it, hm
 	// TODO: implement entity adoption https://github.com/Kong/gateway-operator/issues/460
-	if errWrap := wrapErrIfKonnectOpFailed[konnectv1alpha1.KonnectControlPlane](err, CreateOp); errWrap != nil {
+	if errWrap := wrapErrIfKonnectOpFailed[konnectv1alpha1.KonnectControlPlane](err, CreateOp, cp); errWrap != nil {
 		k8sutils.SetCondition(
 			k8sutils.NewConditionWithGeneration(
 				KonnectEntityProgrammedConditionType,
@@ -66,7 +66,7 @@ func deleteControlPlane(
 	}
 
 	_, err := sdk.ControlPlanes.DeleteControlPlane(ctx, id)
-	if errWrap := wrapErrIfKonnectOpFailed[konnectv1alpha1.KonnectControlPlane](err, DeleteOp); errWrap != nil {
+	if errWrap := wrapErrIfKonnectOpFailed[konnectv1alpha1.KonnectControlPlane](err, DeleteOp, cp); errWrap != nil {
 		var sdkError *sdkerrors.NotFoundError
 		if errors.As(err, &sdkError) {
 			ctrllog.FromContext(ctx).
@@ -120,7 +120,7 @@ func updateControlPlane(
 		return nil
 	}
 
-	if errWrap := wrapErrIfKonnectOpFailed[konnectv1alpha1.KonnectControlPlane](err, UpdateOp); errWrap != nil {
+	if errWrap := wrapErrIfKonnectOpFailed[konnectv1alpha1.KonnectControlPlane](err, UpdateOp, cp); errWrap != nil {
 		k8sutils.SetCondition(
 			k8sutils.NewConditionWithGeneration(
 				KonnectEntityProgrammedConditionType,

--- a/controller/konnect/reconciler_generic_test.go
+++ b/controller/konnect/reconciler_generic_test.go
@@ -10,19 +10,24 @@ import (
 
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 
-	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
 func TestNewKonnectEntityReconciler(t *testing.T) {
 	testNewKonnectEntityReconciler(t, konnectv1alpha1.KonnectControlPlane{})
-	testNewKonnectEntityReconciler(t, configurationv1.KongConsumer{})
-	// GetTypeName() is missing.
-	// https://github.com/Kong/kubernetes-configuration/pull/15 fixes that.
-	// testNewKonnectEntityReconciler(t, configurationv1beta1.KongConsumerGroup{})
 	testNewKonnectEntityReconciler(t, configurationv1alpha1.KongService{})
-	testNewKonnectEntityReconciler(t, configurationv1alpha1.KongRoute{})
+
+	// TODO(pmalek): add support for KongRoute
+	// https://github.com/Kong/gateway-operator/issues/435
+	// testNewKonnectEntityReconciler(t, configurationv1alpha1.KongRoute{})
+
+	// TODO(pmalek): add support for KongConsumer
+	// https://github.com/Kong/gateway-operator/issues/436
+	// testNewKonnectEntityReconciler(t, configurationv1.KongConsumer{})
+
+	// TODO: GetConditions() and SetConditions() is missing from KongConsumerGroup.
+	// testNewKonnectEntityReconciler(t, configurationv1beta1.KongConsumerGroup{})
 }
 
 func testNewKonnectEntityReconciler[

--- a/controller/konnect/watch.go
+++ b/controller/konnect/watch.go
@@ -6,7 +6,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -21,12 +20,8 @@ func ReconciliationWatchOptionsForEntity[
 	ent TEnt,
 ) []func(*ctrl.Builder) *ctrl.Builder {
 	switch any(ent).(type) {
-	case *configurationv1alpha1.KongRoute:
-		return []func(*ctrl.Builder) *ctrl.Builder{}
 	case *configurationv1alpha1.KongService:
 		return KongServiceReconciliationWatchOptions(cl)
-	case *configurationv1.KongConsumer:
-		return []func(*ctrl.Builder) *ctrl.Builder{}
 	case *konnectv1alpha1.KonnectControlPlane:
 		return KonnectControlPlaneReconciliationWatchOptions(cl)
 	default:

--- a/controller/konnect/watch_konnectcontrolplane.go
+++ b/controller/konnect/watch_konnectcontrolplane.go
@@ -27,6 +27,9 @@ func KonnectControlPlaneReconciliationWatchOptions(
 ) []func(*ctrl.Builder) *ctrl.Builder {
 	return []func(*ctrl.Builder) *ctrl.Builder{
 		func(b *ctrl.Builder) *ctrl.Builder {
+			return b.For(&konnectv1alpha1.KonnectControlPlane{})
+		},
+		func(b *ctrl.Builder) *ctrl.Builder {
 			return b.Watches(
 				&konnectv1alpha1.KonnectAPIAuthConfiguration{},
 				handler.EnqueueRequestsFromMapFunc(

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-containerregistry v0.20.2
 	github.com/google/uuid v1.6.0
-	github.com/kong/kubernetes-configuration v0.0.2
+	github.com/kong/kubernetes-configuration v0.0.3
 	github.com/kong/kubernetes-ingress-controller/v3 v3.2.3
 	github.com/kong/kubernetes-telemetry v0.1.4
 	github.com/kong/kubernetes-testing-framework v0.47.1

--- a/go.sum
+++ b/go.sum
@@ -220,8 +220,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kong/go-kong v0.57.1 h1:PATDsjrRr0SMMtN433ONoZqm+7UKmv49zgqQyvWbfPY=
 github.com/kong/go-kong v0.57.1/go.mod h1:lG2zDVU0yynwV9S7gJXDwwi6zVY+MgS8aUX4QhzpDz4=
-github.com/kong/kubernetes-configuration v0.0.2 h1:qAwoS/AMVVL3b5migDVDWtECqXX7asoiUbw/q8s4HZ0=
-github.com/kong/kubernetes-configuration v0.0.2/go.mod h1:UG+Cjeenr4sb8UpuYVUE489qDyCdZ9Dtwwebohu94xU=
+github.com/kong/kubernetes-configuration v0.0.3 h1:+78B9U0vjOZmrz4Eus+O4ndF9gLTYWRQbRyCp4leKdA=
+github.com/kong/kubernetes-configuration v0.0.3/go.mod h1:A+ofqdMxHYmde3ZrQlY8EFfi4xpNa611RCNXU3xOWOc=
 github.com/kong/kubernetes-ingress-controller/v3 v3.2.3 h1:SQ/0hfceGmsvzbkCUxiJUv1ELcFRp4d6IzvYGfHct9o=
 github.com/kong/kubernetes-ingress-controller/v3 v3.2.3/go.mod h1:gshVZnDU2FTe/95I3vSJPsH2kyB8zR+GpUIieCyt8C4=
 github.com/kong/kubernetes-telemetry v0.1.4 h1:Yz7OlECxWKgNRG1wJ5imA4+H0dQEpdU9d86uhwUVpu4=


### PR DESCRIPTION
**What this PR does / why we need it**:

- bump kubernetes-configuration to 0.0.3 https://github.com/Kong/kubernetes-configuration/releases/tag/v0.0.3
- make controlPlaneRef optional in `KongService`
- adjust other areas to account for the bump



**Special notes for your reviewer**:


Related https://github.com/Kong/kubernetes-configuration/issues/31