### PR TITLE
feat(konnect): add KongConsumer reconciler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
   [#462](https://github.com/Kong/gateway-operator/pull/462)
 - Add `KongService` reconciler for Konnect control planes.
   [#470](https://github.com/Kong/gateway-operator/pull/470)
+- Add `KongConsumer` reconciler for Konnect control planes.
+  [#493](https://github.com/Kong/gateway-operator/pull/493)
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -510,8 +510,7 @@ debug.skaffold.continuous: _ensure-kong-system-namespace
 
 # Install CRDs into the K8s cluster specified in ~/.kube/config.
 .PHONY: install
-install: manifests kustomize install-gateway-api-crds
-	$(KUSTOMIZE) build $(KIC_CRDS_URL) | kubectl apply -f -
+install: manifests kustomize install-gateway-api-crds install.kic-crds
 	$(KUSTOMIZE) build config/crd | kubectl apply --server-side -f -
 
 KUBERNETES_CONFIGURATION_CRDS_PACKAGE ?= github.com/kong/kubernetes-configuration
@@ -525,10 +524,14 @@ install.kubernetes-configuration-crds: kustomize
 
 # Install standard and experimental CRDs into the K8s cluster specified in ~/.kube/config.
 .PHONY: install.all
-install.all: manifests kustomize install-gateway-api-crds install.kubernetes-configuration-crds
-	$(KUSTOMIZE) build $(KIC_CRDS_URL) | kubectl apply -f -
+install.all: manifests kustomize install-gateway-api-crds install.kic-crds install.kubernetes-configuration-crds
 	kubectl apply --server-side -f $(PROJECT_DIR)/config/crd/bases/
 	kubectl get crd -ojsonpath='{.items[*].metadata.name}' | xargs -n1 kubectl wait --for condition=established crd
+
+# Install KIC CRDs into the K8s cluster specified in ~/.kube/config.
+.PHONY: install.kic-crds
+install.kic-crds: kustomize
+	$(KUSTOMIZE) build $(KIC_CRDS_URL) | kubectl apply -f -
 
 # Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
 # Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/config/samples/konnect_kongconsumer.yaml
+++ b/config/samples/konnect_kongconsumer.yaml
@@ -1,0 +1,49 @@
+kind: KonnectAPIAuthConfiguration
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: konnect-api-auth-dev-1
+  namespace: default
+spec:
+  type: token
+  token: kpat_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+  serverURL: us.api.konghq.com
+---
+kind: KonnectControlPlane
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: test1
+  namespace: default
+spec:
+  name: test1
+  labels:
+    app: test1
+    key1: test1
+  konnect:
+    authRef:
+      name: konnect-api-auth-dev-1
+---
+kind: KongService
+apiVersion: configuration.konghq.com/v1alpha1
+metadata:
+  name: service-1
+  namespace: default
+spec:
+  name: service-1
+  host: example.com
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: test1
+---
+kind: KongConsumer
+apiVersion: configuration.konghq.com/v1
+metadata:
+  name: consumer-1
+  namespace: default
+username: consumer-1
+custom_id: 08433C12-2B81-4738-B61D-3AA2136F0212
+spec:
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: test1

--- a/controller/konnect/consts.go
+++ b/controller/konnect/consts.go
@@ -1,0 +1,9 @@
+package konnect
+
+const (
+	// AnnotationPrefix is the prefix for Kong annotations.
+	AnnotationPrefix = "konghq.com"
+
+	// UserTagKey is the key for the user tag annotation.
+	UserTagKey = "/tags"
+)

--- a/controller/konnect/ops.go
+++ b/controller/konnect/ops.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -48,6 +49,8 @@ func Create[
 		return e, createControlPlane(ctx, sdk, ent)
 	case *configurationv1alpha1.KongService:
 		return e, createService(ctx, sdk, ent)
+	case *configurationv1.KongConsumer:
+		return e, createConsumer(ctx, sdk, ent)
 
 		// ---------------------------------------------------------------------
 		// TODO: add other Konnect types
@@ -69,6 +72,8 @@ func Delete[
 		return deleteControlPlane(ctx, sdk, ent)
 	case *configurationv1alpha1.KongService:
 		return deleteService(ctx, sdk, ent)
+	case *configurationv1.KongConsumer:
+		return deleteConsumer(ctx, sdk, ent)
 
 		// ---------------------------------------------------------------------
 		// TODO: add other Konnect types
@@ -116,6 +121,8 @@ func Update[
 		return ctrl.Result{}, updateControlPlane(ctx, sdk, ent)
 	case *configurationv1alpha1.KongService:
 		return ctrl.Result{}, updateService(ctx, sdk, cl, ent)
+	case *configurationv1.KongConsumer:
+		return ctrl.Result{}, updateConsumer(ctx, sdk, cl, ent)
 
 		// ---------------------------------------------------------------------
 		// TODO: add other Konnect types

--- a/controller/konnect/ops.go
+++ b/controller/konnect/ops.go
@@ -61,10 +61,19 @@ func Create[
 }
 
 // Delete deletes a Konnect entity.
+// It returns an error if the entity does not have a Konnect ID or if the operation fails.
 func Delete[
 	T SupportedKonnectEntityType,
 	TEnt EntityType[T],
 ](ctx context.Context, sdk *sdkkonnectgo.SDK, cl client.Client, e *T) error {
+	ent := TEnt(e)
+	if ent.GetKonnectStatus().GetKonnectID() == "" {
+		return fmt.Errorf(
+			"can't delete %T %s when it does not have the Konnect ID",
+			ent, client.ObjectKeyFromObject(ent),
+		)
+	}
+
 	defer logOpComplete[T, TEnt](ctx, time.Now(), DeleteOp, e)
 
 	switch ent := any(e).(type) {
@@ -84,6 +93,7 @@ func Delete[
 }
 
 // Update updates a Konnect entity.
+// It returns an error if the entity does not have a Konnect ID or if the operation fails.
 func Update[
 	T SupportedKonnectEntityType,
 	TEnt EntityType[T],
@@ -112,6 +122,13 @@ func Update[
 		return ctrl.Result{
 			RequeueAfter: requeueAfter,
 		}, nil
+	}
+
+	if ent.GetKonnectStatus().GetKonnectID() == "" {
+		return ctrl.Result{}, fmt.Errorf(
+			"can't update %T %s when it does not have the Konnect ID",
+			ent, client.ObjectKeyFromObject(ent),
+		)
 	}
 
 	defer logOpComplete[T, TEnt](ctx, now, UpdateOp, e)

--- a/controller/konnect/ops_controlplane.go
+++ b/controller/konnect/ops_controlplane.go
@@ -56,7 +56,6 @@ func createControlPlane(
 
 // deleteControlPlane deletes a Konnect ControlPlane.
 // It is assumed that the Konnect ControlPlane has a Konnect ID.
-
 func deleteControlPlane(
 	ctx context.Context,
 	sdk *sdkkonnectgo.SDK,

--- a/controller/konnect/ops_controlplane.go
+++ b/controller/konnect/ops_controlplane.go
@@ -3,7 +3,6 @@ package konnect
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
 	"github.com/Kong/sdk-konnect-go/models/components"
@@ -55,16 +54,15 @@ func createControlPlane(
 	return nil
 }
 
+// deleteControlPlane deletes a Konnect ControlPlane.
+// It is assumed that the Konnect ControlPlane has a Konnect ID.
+
 func deleteControlPlane(
 	ctx context.Context,
 	sdk *sdkkonnectgo.SDK,
 	cp *konnectv1alpha1.KonnectControlPlane,
 ) error {
 	id := cp.GetKonnectStatus().GetKonnectID()
-	if id == "" {
-		return fmt.Errorf("can't remove %T without a Konnect ID", cp)
-	}
-
 	_, err := sdk.ControlPlanes.DeleteControlPlane(ctx, id)
 	if errWrap := wrapErrIfKonnectOpFailed[konnectv1alpha1.KonnectControlPlane](err, DeleteOp, cp); errWrap != nil {
 		var sdkError *sdkerrors.NotFoundError
@@ -84,16 +82,15 @@ func deleteControlPlane(
 	return nil
 }
 
+// updateControlPlane updates a Konnect ControlPlane.
+// It is assumed that the Konnect ControlPlane has a Konnect ID.
+// It returns an error if the operation fails.
 func updateControlPlane(
 	ctx context.Context,
 	sdk *sdkkonnectgo.SDK,
 	cp *konnectv1alpha1.KonnectControlPlane,
 ) error {
 	id := cp.GetKonnectStatus().GetKonnectID()
-	if id == "" {
-		return fmt.Errorf("can't update %T without a Konnect ID", cp)
-	}
-
 	req := components.UpdateControlPlaneRequest{
 		Name:        sdkkonnectgo.String(cp.Spec.Name),
 		Description: cp.Spec.Description,

--- a/controller/konnect/ops_kongconsumer.go
+++ b/controller/konnect/ops_kongconsumer.go
@@ -1,0 +1,195 @@
+package konnect
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
+	sdkkonnectgocomp "github.com/Kong/sdk-konnect-go/models/components"
+	sdkkonnectgoops "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/Kong/sdk-konnect-go/models/sdkerrors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
+
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+func createConsumer(
+	ctx context.Context,
+	sdk *sdkkonnectgo.SDK,
+	consumer *configurationv1.KongConsumer,
+) error {
+	if consumer.GetControlPlaneID() == "" {
+		return fmt.Errorf("can't create %T %s without a Konnect ControlPlane ID", consumer, client.ObjectKeyFromObject(consumer))
+	}
+
+	resp, err := sdk.Consumers.CreateConsumer(ctx,
+		consumer.Status.Konnect.ControlPlaneID,
+		kongConsumerToSDKConsumerInput(consumer),
+	)
+
+	// TODO: handle already exists
+	// Can't adopt it as it will cause conflicts between the controller
+	// that created that entity and already manages it, hm
+	if errWrapped := wrapErrIfKonnectOpFailed[configurationv1.KongConsumer](err, CreateOp, consumer); errWrapped != nil {
+		k8sutils.SetCondition(
+			k8sutils.NewConditionWithGeneration(
+				KonnectEntityProgrammedConditionType,
+				metav1.ConditionFalse,
+				"FailedToCreate",
+				errWrapped.Error(),
+				consumer.GetGeneration(),
+			),
+			consumer,
+		)
+		return errWrapped
+	}
+
+	consumer.Status.Konnect.SetKonnectID(*resp.Consumer.ID)
+	k8sutils.SetCondition(
+		k8sutils.NewConditionWithGeneration(
+			KonnectEntityProgrammedConditionType,
+			metav1.ConditionTrue,
+			KonnectEntityProgrammedReason,
+			"",
+			consumer.GetGeneration(),
+		),
+		consumer,
+	)
+
+	return nil
+}
+
+func updateConsumer(
+	ctx context.Context,
+	sdk *sdkkonnectgo.SDK,
+	cl client.Client,
+	consumer *configurationv1.KongConsumer,
+) error {
+	// TODO(pmalek) handle other types of CP ref
+	// TODO(pmalek) handle cross namespace refs
+	nnCP := types.NamespacedName{
+		Namespace: consumer.Namespace,
+		Name:      consumer.Spec.ControlPlaneRef.KonnectNamespacedRef.Name,
+	}
+	var cp konnectv1alpha1.KonnectControlPlane
+	if err := cl.Get(ctx, nnCP, &cp); err != nil {
+		return fmt.Errorf("failed to get KonnectControlPlane %s: for %T %s: %w",
+			nnCP, consumer, client.ObjectKeyFromObject(consumer), err,
+		)
+	}
+
+	if cp.Status.ID == "" {
+		return fmt.Errorf(
+			"can't update %T when referenced KonnectControlPlane %s does not have the Konnect ID",
+			consumer, nnCP,
+		)
+	}
+	if consumer.Status.Konnect == nil || consumer.Status.Konnect.ID == "" {
+		return fmt.Errorf(
+			"can't update %T %s when it does not have the Konnect ID",
+			consumer, client.ObjectKeyFromObject(consumer),
+		)
+	}
+
+	resp, err := sdk.Consumers.UpsertConsumer(ctx,
+		sdkkonnectgoops.UpsertConsumerRequest{
+			ControlPlaneID: cp.Status.ID,
+			ConsumerID:     consumer.GetKonnectStatus().GetKonnectID(),
+			Consumer:       kongConsumerToSDKConsumerInput(consumer),
+		},
+	)
+
+	// TODO: handle already exists
+	// Can't adopt it as it will cause conflicts between the controller
+	// that created that entity and already manages it, hm
+	if errWrapped := wrapErrIfKonnectOpFailed[configurationv1.KongConsumer](err, UpdateOp, consumer); errWrapped != nil {
+		k8sutils.SetCondition(
+			k8sutils.NewConditionWithGeneration(
+				KonnectEntityProgrammedConditionType,
+				metav1.ConditionFalse,
+				"FailedToCreate",
+				errWrapped.Error(),
+				consumer.GetGeneration(),
+			),
+			consumer,
+		)
+		return errWrapped
+	}
+
+	consumer.Status.Konnect.SetKonnectID(*resp.Consumer.ID)
+	consumer.Status.Konnect.SetControlPlaneID(cp.Status.ID)
+	k8sutils.SetCondition(
+		k8sutils.NewConditionWithGeneration(
+			KonnectEntityProgrammedConditionType,
+			metav1.ConditionTrue,
+			KonnectEntityProgrammedReason,
+			"",
+			consumer.GetGeneration(),
+		),
+		consumer,
+	)
+
+	return nil
+}
+
+func deleteConsumer(
+	ctx context.Context,
+	sdk *sdkkonnectgo.SDK,
+	consumer *configurationv1.KongConsumer,
+) error {
+	id := consumer.Status.Konnect.GetKonnectID()
+	if id == "" {
+		return fmt.Errorf("can't remove %T without a Konnect ID", consumer)
+	}
+
+	_, err := sdk.Consumers.DeleteConsumer(ctx, consumer.Status.Konnect.ControlPlaneID, id)
+	if errWrapped := wrapErrIfKonnectOpFailed[configurationv1.KongConsumer](err, DeleteOp, consumer); errWrapped != nil {
+		// Consumer delete operation returns an SDKError instead of a NotFoundError.
+		var sdkError *sdkerrors.SDKError
+		if errors.As(errWrapped, &sdkError) && sdkError.StatusCode == 404 {
+			ctrllog.FromContext(ctx).
+				Info("entity not found in Konnect, skipping delete",
+					"op", DeleteOp, "type", consumer.GetTypeName(), "id", id,
+				)
+			return nil
+		}
+		return FailedKonnectOpError[configurationv1.KongConsumer]{
+			Op:  DeleteOp,
+			Err: errWrapped,
+		}
+	}
+
+	return nil
+}
+
+func kongConsumerToSDKConsumerInput(
+	consumer *configurationv1.KongConsumer,
+) sdkkonnectgocomp.ConsumerInput {
+	return sdkkonnectgocomp.ConsumerInput{
+		CustomID: &consumer.CustomID,
+		Tags:     ExtractUserTags(consumer),
+		Username: &consumer.Username,
+	}
+}
+
+// ExtractUserTags extracts a set of tags from a comma-separated string.
+// Copy pasted from: https://github.com/Kong/kubernetes-ingress-controller/blob/eb80ec2c58f4d53f8c6d7c997bcfb1f334b801e1/internal/annotations/annotations.go#L407-L416
+func ExtractUserTags(obj metav1.Object) []string {
+	anns := obj.GetAnnotations()
+	val := anns[AnnotationPrefix+UserTagKey]
+	// If the annotation is not present, the map provides an empty value,
+	// and splitting that will create a slice containing a single empty string tag.
+	// These aren't valid, hence this special case.
+	if len(val) == 0 {
+		return []string{}
+	}
+	return strings.Split(val, ",")
+}

--- a/controller/konnect/ops_kongconsumer.go
+++ b/controller/konnect/ops_kongconsumer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
 	sdkkonnectgocomp "github.com/Kong/sdk-konnect-go/models/components"
@@ -19,6 +18,7 @@ import (
 
 	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+	"github.com/kong/kubernetes-configuration/pkg/metadata"
 )
 
 func createConsumer(
@@ -175,21 +175,7 @@ func kongConsumerToSDKConsumerInput(
 ) sdkkonnectgocomp.ConsumerInput {
 	return sdkkonnectgocomp.ConsumerInput{
 		CustomID: &consumer.CustomID,
-		Tags:     ExtractUserTags(consumer),
+		Tags:     metadata.ExtractTags(consumer),
 		Username: &consumer.Username,
 	}
-}
-
-// ExtractUserTags extracts a set of tags from a comma-separated string.
-// Copy pasted from: https://github.com/Kong/kubernetes-ingress-controller/blob/eb80ec2c58f4d53f8c6d7c997bcfb1f334b801e1/internal/annotations/annotations.go#L407-L416
-func ExtractUserTags(obj metav1.Object) []string {
-	anns := obj.GetAnnotations()
-	val := anns[AnnotationPrefix+UserTagKey]
-	// If the annotation is not present, the map provides an empty value,
-	// and splitting that will create a slice containing a single empty string tag.
-	// These aren't valid, hence this special case.
-	if len(val) == 0 {
-		return []string{}
-	}
-	return strings.Split(val, ",")
 }

--- a/controller/konnect/ops_kongservice.go
+++ b/controller/konnect/ops_kongservice.go
@@ -80,8 +80,8 @@ func updateService(
 	}
 	var cp konnectv1alpha1.KonnectControlPlane
 	if err := cl.Get(ctx, nnCP, &cp); err != nil {
-		return fmt.Errorf("failed to get KonnectControlPlane %s: for KongService %s: %w",
-			nnCP, client.ObjectKeyFromObject(svc), err,
+		return fmt.Errorf("failed to get KonnectControlPlane %s: for %T %s: %w",
+			nnCP, svc, client.ObjectKeyFromObject(svc), err,
 		)
 	}
 

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -424,6 +425,11 @@ func getControlPlaneRef[T SupportedKonnectEntityType, TEnt EntityType[T]](
 	switch e := any(e).(type) {
 	case *konnectv1alpha1.KonnectControlPlane:
 		return mo.None[configurationv1alpha1.ControlPlaneRef]()
+	case *configurationv1.KongConsumer:
+		if e.Spec.ControlPlaneRef == nil {
+			return mo.None[configurationv1alpha1.ControlPlaneRef]()
+		}
+		return mo.Some(*e.Spec.ControlPlaneRef)
 	case *configurationv1alpha1.KongService:
 		if e.Spec.ControlPlaneRef == nil {
 			return mo.None[configurationv1alpha1.ControlPlaneRef]()

--- a/controller/konnect/reconciler_generic_test.go
+++ b/controller/konnect/reconciler_generic_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -17,14 +18,11 @@ import (
 func TestNewKonnectEntityReconciler(t *testing.T) {
 	testNewKonnectEntityReconciler(t, konnectv1alpha1.KonnectControlPlane{})
 	testNewKonnectEntityReconciler(t, configurationv1alpha1.KongService{})
+	testNewKonnectEntityReconciler(t, configurationv1.KongConsumer{})
 
 	// TODO(pmalek): add support for KongRoute
 	// https://github.com/Kong/gateway-operator/issues/435
 	// testNewKonnectEntityReconciler(t, configurationv1alpha1.KongRoute{})
-
-	// TODO(pmalek): add support for KongConsumer
-	// https://github.com/Kong/gateway-operator/issues/436
-	// testNewKonnectEntityReconciler(t, configurationv1.KongConsumer{})
 
 	// TODO: GetConditions() and SetConditions() is missing from KongConsumerGroup.
 	// testNewKonnectEntityReconciler(t, configurationv1beta1.KongConsumerGroup{})

--- a/controller/konnect/watch.go
+++ b/controller/konnect/watch.go
@@ -6,6 +6,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -20,6 +21,8 @@ func ReconciliationWatchOptionsForEntity[
 	ent TEnt,
 ) []func(*ctrl.Builder) *ctrl.Builder {
 	switch any(ent).(type) {
+	case *configurationv1.KongConsumer:
+		return KongConsumerReconciliationWatchOptions(cl)
 	case *configurationv1alpha1.KongService:
 		return KongServiceReconciliationWatchOptions(cl)
 	case *konnectv1alpha1.KonnectControlPlane:

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-containerregistry v0.20.2
 	github.com/google/uuid v1.6.0
-	github.com/kong/kubernetes-configuration v0.0.4
+	github.com/kong/kubernetes-configuration v0.0.5
 	github.com/kong/kubernetes-ingress-controller/v3 v3.2.3
 	github.com/kong/kubernetes-telemetry v0.1.5
 	github.com/kong/kubernetes-testing-framework v0.47.1

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-containerregistry v0.20.2
 	github.com/google/uuid v1.6.0
-	github.com/kong/kubernetes-configuration v0.0.3
+	github.com/kong/kubernetes-configuration v0.0.4
 	github.com/kong/kubernetes-ingress-controller/v3 v3.2.3
 	github.com/kong/kubernetes-telemetry v0.1.5
 	github.com/kong/kubernetes-testing-framework v0.47.1

--- a/go.sum
+++ b/go.sum
@@ -221,8 +221,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kong/go-kong v0.57.1 h1:PATDsjrRr0SMMtN433ONoZqm+7UKmv49zgqQyvWbfPY=
 github.com/kong/go-kong v0.57.1/go.mod h1:lG2zDVU0yynwV9S7gJXDwwi6zVY+MgS8aUX4QhzpDz4=
-github.com/kong/kubernetes-configuration v0.0.4 h1:fapqKt5wJWmXVomx1f7f4Lp7dhuUTXWbZiJ45Iu1k4o=
-github.com/kong/kubernetes-configuration v0.0.4/go.mod h1:uZlMcsRGt+Y3sLxF4xrLWXb+rn6fvoWEVCdc5SEj4GA=
+github.com/kong/kubernetes-configuration v0.0.5 h1:+enzAC2Y0uP32bNKdXxTd8hdvG4Ej75NcoU4wSrSoRw=
+github.com/kong/kubernetes-configuration v0.0.5/go.mod h1:uZlMcsRGt+Y3sLxF4xrLWXb+rn6fvoWEVCdc5SEj4GA=
 github.com/kong/kubernetes-ingress-controller/v3 v3.2.3 h1:SQ/0hfceGmsvzbkCUxiJUv1ELcFRp4d6IzvYGfHct9o=
 github.com/kong/kubernetes-ingress-controller/v3 v3.2.3/go.mod h1:gshVZnDU2FTe/95I3vSJPsH2kyB8zR+GpUIieCyt8C4=
 github.com/kong/kubernetes-telemetry v0.1.5 h1:xHwU1q0IvfEYqpj03po73ZKbVarnFPUwzkoFkdVnr9w=

--- a/go.sum
+++ b/go.sum
@@ -221,8 +221,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kong/go-kong v0.57.1 h1:PATDsjrRr0SMMtN433ONoZqm+7UKmv49zgqQyvWbfPY=
 github.com/kong/go-kong v0.57.1/go.mod h1:lG2zDVU0yynwV9S7gJXDwwi6zVY+MgS8aUX4QhzpDz4=
-github.com/kong/kubernetes-configuration v0.0.3 h1:+78B9U0vjOZmrz4Eus+O4ndF9gLTYWRQbRyCp4leKdA=
-github.com/kong/kubernetes-configuration v0.0.3/go.mod h1:A+ofqdMxHYmde3ZrQlY8EFfi4xpNa611RCNXU3xOWOc=
+github.com/kong/kubernetes-configuration v0.0.4 h1:fapqKt5wJWmXVomx1f7f4Lp7dhuUTXWbZiJ45Iu1k4o=
+github.com/kong/kubernetes-configuration v0.0.4/go.mod h1:uZlMcsRGt+Y3sLxF4xrLWXb+rn6fvoWEVCdc5SEj4GA=
 github.com/kong/kubernetes-ingress-controller/v3 v3.2.3 h1:SQ/0hfceGmsvzbkCUxiJUv1ELcFRp4d6IzvYGfHct9o=
 github.com/kong/kubernetes-ingress-controller/v3 v3.2.3/go.mod h1:gshVZnDU2FTe/95I3vSJPsH2kyB8zR+GpUIieCyt8C4=
 github.com/kong/kubernetes-telemetry v0.1.5 h1:xHwU1q0IvfEYqpj03po73ZKbVarnFPUwzkoFkdVnr9w=

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -61,6 +62,8 @@ const (
 	KonnectControlPlaneControllerName = "KonnectControlPlane"
 	// KongServiceControllerName is the name of the KongService controller.
 	KongServiceControllerName = "KongService"
+	// KongConsumerControllerName is the name of the KongConsumer controller.
+	KongConsumerControllerName = "KongConsumer"
 )
 
 // SetupControllersShim runs SetupControllers and returns its result as a slice of the map values.
@@ -318,6 +321,14 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 		controllers[KongServiceControllerName] = ControllerDef{
 			Enabled: c.KonnectControllersEnabled,
 			Controller: konnect.NewKonnectEntityReconciler[configurationv1alpha1.KongService](
+				sdkFactory,
+				c.DevelopmentMode,
+				mgr.GetClient(),
+			),
+		}
+		controllers[KongConsumerControllerName] = ControllerDef{
+			Enabled: c.KonnectControllersEnabled,
+			Controller: konnect.NewKonnectEntityReconciler[configurationv1.KongConsumer](
 				sdkFactory,
 				c.DevelopmentMode,
 				mgr.GetClient(),


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `KongConsumer` reconciler

Blocked by https://github.com/Kong/kubernetes-configuration/pull/43

**Which issue this PR fixes**

Part of #436 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
