### PR TITLE
tests: use DockerHub token in integration and e2e tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -416,6 +416,8 @@ jobs:
         KONG_TEST_GATEWAY_OPERATOR_IMAGE_LOAD: gateway-operator:e2e-${{ github.sha }}
         GOTESTSUM_JUNITFILE: "e2e-tests.xml"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DOCKERHUB_PULL_TOKEN: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+        DOCKERHUB_PULL_USERNAME: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
 
     - name: upload diagnostics
       if: always()

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -256,6 +256,8 @@ jobs:
         KONG_CONTROLLER_OUT: stdout
         GOTESTSUM_JUNITFILE: integration-tests-webhook-enabled-${{ matrix.webhook-enabled }}.xml
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DOCKERHUB_PULL_TOKEN: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+        DOCKERHUB_PULL_USERNAME: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
 
     - name: upload diagnostics
       if: always()
@@ -308,6 +310,8 @@ jobs:
         KONG_CONTROLLER_OUT: stdout
         GOTESTSUM_JUNITFILE: integration-tests-bluegreen-webhook-enabled-${{ matrix.webhook-enabled }}.xml
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DOCKERHUB_PULL_TOKEN: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+        DOCKERHUB_PULL_USERNAME: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
 
     - name: upload diagnostics
       if: always()
@@ -358,6 +362,8 @@ jobs:
         KONG_PLUGIN_IMAGE_REGISTRY_CREDENTIALS: ${{ secrets.KONG_PLUGIN_IMAGE_REGISTRY_CREDENTIALS }}
         GOTESTSUM_JUNITFILE: integration-tests-provision-dataplane-fail.xml
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DOCKERHUB_PULL_TOKEN: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+        DOCKERHUB_PULL_USERNAME: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
     
     - name: upload diagnostics
       if: always()

--- a/test/e2e/test_helm_install_upgrade.go
+++ b/test/e2e/test_helm_install_upgrade.go
@@ -24,6 +24,7 @@ import (
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	testutils "github.com/kong/gateway-operator/pkg/utils/test"
 	"github.com/kong/gateway-operator/pkg/vars"
+	"github.com/kong/gateway-operator/test/helpers"
 )
 
 func init() {
@@ -45,6 +46,8 @@ func TestHelmUpgrade(t *testing.T) {
 	// createEnvironment will queue up environment cleanup if necessary
 	// and dumping diagnostics if the test fails.
 	e := CreateEnvironment(t, ctx)
+	_, err := helpers.CreateDockerSecretBasedOnEnvVars(ctx, e.Clients.K8sClient.CoreV1().Secrets(e.Namespace.Name))
+	require.NoError(t, err)
 
 	// assertion is run after the upgrade to assert the state of the resources in the cluster.
 	type assertion struct {

--- a/test/e2e/test_operator_logs.go
+++ b/test/e2e/test_operator_logs.go
@@ -73,11 +73,14 @@ func TestOperatorLogs(t *testing.T) {
 	// createEnvironment will queue up environment cleanup if necessary
 	// and dumping diagnostics if the test fails.
 	e := CreateEnvironment(t, ctx, WithInstallViaKustomize())
+	_, err := helpers.CreateDockerSecretBasedOnEnvVars(ctx, e.Clients.K8sClient.CoreV1().Secrets(e.Namespace.Name))
+	require.NoError(t, err)
+
 	clients, testNamespace, cleaner := e.Clients, e.Namespace, e.Cleaner
 
 	t.Log("finding the Pod for the Gateway Operator")
 	podList := &corev1.PodList{}
-	err := clients.MgrClient.List(ctx, podList, client.MatchingLabels{
+	err = clients.MgrClient.List(ctx, podList, client.MatchingLabels{
 		"control-plane": "controller-manager",
 	})
 	require.NoError(t, err)

--- a/test/e2e/test_webhook.go
+++ b/test/e2e/test_webhook.go
@@ -11,6 +11,7 @@ import (
 
 	operatorv1beta1 "github.com/kong/gateway-operator/api/v1beta1"
 	"github.com/kong/gateway-operator/pkg/consts"
+	"github.com/kong/gateway-operator/test/helpers"
 )
 
 func init() {
@@ -24,6 +25,9 @@ func TestDataPlaneValidatingWebhook(t *testing.T) {
 	// createEnvironment will queue up environment cleanup if necessary
 	// and dumping diagnostics if the test fails.
 	e := CreateEnvironment(t, ctx, WithInstallViaKustomize())
+	_, err := helpers.CreateDockerSecretBasedOnEnvVars(ctx, e.Clients.K8sClient.CoreV1().Secrets(e.Namespace.Name))
+	require.NoError(t, err)
+
 	clients, testNamespace := e.Clients, e.Namespace
 
 	testCases := []struct {

--- a/test/helpers/dockerconfig.go
+++ b/test/helpers/dockerconfig.go
@@ -1,0 +1,111 @@
+package helpers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientgocorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type dockerRegistryConfig struct {
+	Auths map[string]DockerRegistryAuth `json:"auths"`
+}
+
+// DockerRegistryAuth represents the auth field in the docker registry config.
+type DockerRegistryAuth struct {
+	Auth string `json:"auth"`
+}
+
+// DockerRegistryConfigManager is a helper to manage the docker registry config
+// for a k8s secret of type kubernetes.io/dockerconfigjson.
+type DockerRegistryConfigManager struct {
+	config dockerRegistryConfig
+}
+
+// NewDockerRegistryConfigManager creates a new DockerRegistryConfigManager.
+func NewDockerRegistryConfigManager() *DockerRegistryConfigManager {
+	return &DockerRegistryConfigManager{
+		config: dockerRegistryConfig{
+			Auths: map[string]DockerRegistryAuth{},
+		},
+	}
+}
+
+// Add adds new registry credentials to the config.
+func (c *DockerRegistryConfigManager) Add(
+	registry string,
+	username string,
+	token string,
+) error {
+	auth := fmt.Sprintf("%s:%s", username, token)
+	authEncoded := base64.StdEncoding.EncodeToString([]byte(auth))
+	c.config.Auths[registry] = DockerRegistryAuth{
+		Auth: authEncoded,
+	}
+	return nil
+}
+
+// EncodeForRegcred encodes the config for a k8s secret of type kubernetes.io/dockerconfigjson.
+func (c *DockerRegistryConfigManager) EncodeForRegcred() ([]byte, error) {
+	b, err := json.Marshal(c.config)
+	if err != nil {
+		return nil, err
+	}
+	// out := make([]byte, base64.StdEncoding.EncodedLen(len(b)))
+	// base64.StdEncoding.Encode(out, b)
+	return b, nil
+}
+
+// MissingDockerHubEnvVarError is an error type for missing required env vars for DockerHub pull secret.
+type MissingDockerHubEnvVarError struct{}
+
+// Error returns the error message.
+func (e MissingDockerHubEnvVarError) Error() string {
+	return "missing required env vars for DockerHub pull secret"
+}
+
+// CreateDockerSecretBasedOnEnvVars creates a k8s secret of type kubernetes.io/dockerconfigjson.
+// The provided client controls in which namespace to create the secret.
+func CreateDockerSecretBasedOnEnvVars(
+	ctx context.Context, cl clientgocorev1.SecretInterface,
+) (*corev1.Secret, error) {
+	dockerHubUser := os.Getenv("DOCKERHUB_PULL_USERNAME")
+	dockerHubToken := os.Getenv("DOCKERHUB_PULL_TOKEN")
+	if dockerHubUser == "" || dockerHubToken == "" {
+		return nil, MissingDockerHubEnvVarError{}
+	}
+
+	if secret, err := cl.Get(ctx, "regcred", metav1.GetOptions{}); err == nil {
+		return secret, nil
+	}
+
+	regCfgMgr := NewDockerRegistryConfigManager()
+	if err := regCfgMgr.Add("https://index.docker.io/v1/", dockerHubUser, dockerHubToken); err != nil {
+		return nil, err
+	}
+	cfgEncoded, err := regCfgMgr.EncodeForRegcred()
+	if err != nil {
+		return nil, err
+	}
+	dockerHubTokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "regcred",
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		StringData: map[string]string{
+			corev1.DockerConfigJsonKey: string(cfgEncoded),
+		},
+	}
+
+	dockerHubTokenSecret, err = cl.Create(ctx, dockerHubTokenSecret, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return dockerHubTokenSecret, nil
+}

--- a/test/helpers/dockerconfig_test.go
+++ b/test/helpers/dockerconfig_test.go
@@ -1,0 +1,51 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDockerRegistryConfigManager(t *testing.T) {
+	tests := []struct {
+		name          string
+		update        func(*testing.T, *DockerRegistryConfigManager)
+		expectedJSON  string
+		expectedError error
+	}{
+		{
+			name:         "Empty",
+			expectedJSON: `{"auths":{}}`,
+		},
+		{
+			name: "Valid configuration",
+			update: func(t *testing.T, c *DockerRegistryConfigManager) {
+				require.NoError(t,
+					c.Add(
+						"registry1",
+						"username1",
+						"token1",
+					),
+				)
+			},
+			expectedJSON: `{"auths":{"registry1":{"auth":"dXNlcm5hbWUxOnRva2VuMQ=="}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := NewDockerRegistryConfigManager()
+			if tt.update != nil {
+				tt.update(t, mgr)
+			}
+
+			jsonData, err := mgr.EncodeForRegcred()
+			if tt.expectedError != nil {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedJSON, string(jsonData))
+		})
+	}
+}

--- a/test/helpers/generators.go
+++ b/test/helpers/generators.go
@@ -103,6 +103,12 @@ func GenerateGatewayConfiguration(namespace string) *operatorv1beta1.GatewayConf
 									},
 								},
 							},
+							ImagePullSecrets: []corev1.LocalObjectReference{
+								{
+									// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+									Name: "regcred",
+								},
+							},
 						},
 					},
 				},
@@ -130,6 +136,12 @@ func GenerateGatewayConfiguration(namespace string) *operatorv1beta1.GatewayConf
 												},
 											},
 										},
+									},
+								},
+								ImagePullSecrets: []corev1.LocalObjectReference{
+									{
+										// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+										Name: "regcred",
 									},
 								},
 							},

--- a/test/integration/suite.go
+++ b/test/integration/suite.go
@@ -144,6 +144,10 @@ func TestMain(
 
 	fmt.Println("INFO: creating system namespaces and serviceaccounts")
 	exitOnErr(clusters.CreateNamespace(GetCtx(), GetEnv().Cluster(), "kong-system"))
+	if _, err := helpers.CreateDockerSecretBasedOnEnvVars(
+		ctx, clients.K8sClient.CoreV1().Secrets("kong-system")); err != nil {
+		exitOnErr(err)
+	}
 
 	configPath, cleaner, err := config.DumpKustomizeConfigToTempDir()
 	exitOnErr(err)

--- a/test/integration/test_aigateway.go
+++ b/test/integration/test_aigateway.go
@@ -55,6 +55,12 @@ func TestAIGatewayCreation(t *testing.T) {
 										},
 									},
 								}},
+								ImagePullSecrets: []corev1.LocalObjectReference{
+									{
+										// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+										Name: "regcred",
+									},
+								},
 							},
 						},
 					},

--- a/test/integration/test_controlplane.go
+++ b/test/integration/test_controlplane.go
@@ -57,6 +57,12 @@ func TestControlPlaneWhenNoDataPlane(t *testing.T) {
 									Image: consts.DefaultControlPlaneImage,
 								},
 							},
+							ImagePullSecrets: []corev1.LocalObjectReference{
+								{
+									// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+									Name: "regcred",
+								},
+							},
 						},
 					},
 				},
@@ -85,6 +91,12 @@ func TestControlPlaneWhenNoDataPlane(t *testing.T) {
 									{
 										Name:  consts.DataPlaneProxyContainerName,
 										Image: helpers.GetDefaultDataPlaneImage(),
+									},
+								},
+								ImagePullSecrets: []corev1.LocalObjectReference{
+									{
+										// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+										Name: "regcred",
 									},
 								},
 							},
@@ -182,6 +194,12 @@ func TestControlPlaneEssentials(t *testing.T) {
 										}(),
 									},
 								},
+								ImagePullSecrets: []corev1.LocalObjectReference{
+									{
+										// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+										Name: "regcred",
+									},
+								},
 							},
 						},
 					},
@@ -227,6 +245,12 @@ func TestControlPlaneEssentials(t *testing.T) {
 										p.PeriodSeconds = 1
 										return p
 									}(),
+								},
+							},
+							ImagePullSecrets: []corev1.LocalObjectReference{
+								{
+									// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+									Name: "regcred",
 								},
 							},
 						},
@@ -556,6 +580,12 @@ func TestControlPlaneUpdate(t *testing.T) {
 										InitialDelaySeconds: 1,
 										PeriodSeconds:       1,
 									},
+								},
+							},
+							ImagePullSecrets: []corev1.LocalObjectReference{
+								{
+									// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+									Name: "regcred",
 								},
 							},
 						},

--- a/test/integration/test_dataplane.go
+++ b/test/integration/test_dataplane.go
@@ -63,6 +63,12 @@ func TestDataPlaneEssentials(t *testing.T) {
 										Image: helpers.GetDefaultDataPlaneImage(),
 									},
 								},
+								ImagePullSecrets: []corev1.LocalObjectReference{
+									{
+										// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+										Name: "regcred",
+									},
+								},
 							},
 						},
 					},
@@ -256,6 +262,12 @@ func TestDataPlaneUpdate(t *testing.T) {
 										},
 										Name:  consts.DataPlaneProxyContainerName,
 										Image: helpers.GetDefaultDataPlaneImage(),
+									},
+								},
+								ImagePullSecrets: []corev1.LocalObjectReference{
+									{
+										// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+										Name: "regcred",
 									},
 								},
 							},
@@ -529,6 +541,12 @@ func TestDataPlaneHorizontalScaling(t *testing.T) {
 										Image: helpers.GetDefaultDataPlaneImage(),
 									},
 								},
+								ImagePullSecrets: []corev1.LocalObjectReference{
+									{
+										// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+										Name: "regcred",
+									},
+								},
 							},
 						},
 					},
@@ -720,6 +738,12 @@ func TestDataPlaneVolumeMounts(t *testing.T) {
 										},
 									},
 								},
+								ImagePullSecrets: []corev1.LocalObjectReference{
+									{
+										// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+										Name: "regcred",
+									},
+								},
 							},
 						},
 					},
@@ -853,6 +877,12 @@ func TestDataPlanePodDisruptionBudget(t *testing.T) {
 									{
 										Name:  consts.DataPlaneProxyContainerName,
 										Image: helpers.GetDefaultDataPlaneImage(),
+									},
+								},
+								ImagePullSecrets: []corev1.LocalObjectReference{
+									{
+										// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+										Name: "regcred",
 									},
 								},
 							},

--- a/test/integration/test_dataplane_bluegreen.go
+++ b/test/integration/test_dataplane_bluegreen.go
@@ -486,6 +486,12 @@ func testBlueGreenDataPlaneSpec() operatorv1beta1.DataPlaneSpec {
 									},
 								},
 							},
+							ImagePullSecrets: []corev1.LocalObjectReference{
+								{
+									// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+									Name: "regcred",
+								},
+							},
 						},
 					},
 				},

--- a/test/integration/test_gatewayconfiguration.go
+++ b/test/integration/test_gatewayconfiguration.go
@@ -79,6 +79,12 @@ func TestGatewayConfigurationEssentials(t *testing.T) {
 										},
 									},
 								},
+								ImagePullSecrets: []corev1.LocalObjectReference{
+									{
+										// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+										Name: "regcred",
+									},
+								},
 							},
 						},
 					},
@@ -109,6 +115,12 @@ func TestGatewayConfigurationEssentials(t *testing.T) {
 											},
 										},
 									},
+								},
+							},
+							ImagePullSecrets: []corev1.LocalObjectReference{
+								{
+									// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+									Name: "regcred",
 								},
 							},
 						},

--- a/test/integration/test_manual_upgrades_and_downgrades.go
+++ b/test/integration/test_manual_upgrades_and_downgrades.go
@@ -63,6 +63,12 @@ func TestManualGatewayUpgradesAndDowngrades(t *testing.T) {
 									},
 								},
 							},
+							ImagePullSecrets: []corev1.LocalObjectReference{
+								{
+									// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+									Name: "regcred",
+								},
+							},
 						},
 					},
 				},
@@ -81,6 +87,12 @@ func TestManualGatewayUpgradesAndDowngrades(t *testing.T) {
 											PeriodSeconds:       1,
 											SuccessThreshold:    1,
 										},
+									},
+								},
+								ImagePullSecrets: []corev1.LocalObjectReference{
+									{
+										// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+										Name: "regcred",
 									},
 								},
 							},

--- a/test/integration/test_validating.go
+++ b/test/integration/test_validating.go
@@ -89,6 +89,12 @@ func testDataPlaneReconcileValidation(t *testing.T, namespace *corev1.Namespace)
 												},
 											},
 										},
+										ImagePullSecrets: []corev1.LocalObjectReference{
+											{
+												// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+												Name: "regcred",
+											},
+										},
 									},
 								},
 							},
@@ -123,6 +129,12 @@ func testDataPlaneReconcileValidation(t *testing.T, namespace *corev1.Namespace)
 														Value: "xxx",
 													},
 												},
+											},
+										},
+										ImagePullSecrets: []corev1.LocalObjectReference{
+											{
+												// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+												Name: "regcred",
 											},
 										},
 									},
@@ -163,6 +175,12 @@ func testDataPlaneReconcileValidation(t *testing.T, namespace *corev1.Namespace)
 														},
 													},
 												},
+											},
+										},
+										ImagePullSecrets: []corev1.LocalObjectReference{
+											{
+												// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+												Name: "regcred",
 											},
 										},
 									},
@@ -317,6 +335,12 @@ func testDataPlaneValidatingWebhook(t *testing.T, namespace *corev1.Namespace) {
 												},
 											},
 										},
+										ImagePullSecrets: []corev1.LocalObjectReference{
+											{
+												// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+												Name: "regcred",
+											},
+										},
 									},
 								},
 							},
@@ -349,6 +373,12 @@ func testDataPlaneValidatingWebhook(t *testing.T, namespace *corev1.Namespace) {
 														Value: "xxx",
 													},
 												},
+											},
+										},
+										ImagePullSecrets: []corev1.LocalObjectReference{
+											{
+												// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+												Name: "regcred",
 											},
 										},
 									},
@@ -388,6 +418,12 @@ func testDataPlaneValidatingWebhook(t *testing.T, namespace *corev1.Namespace) {
 														},
 													},
 												},
+											},
+										},
+										ImagePullSecrets: []corev1.LocalObjectReference{
+											{
+												// Created by CreateDockerSecretBasedOnEnvVars in SetupTestEnv
+												Name: "regcred",
 											},
 										},
 									},


### PR DESCRIPTION
**What this PR does / why we need it**:

Add dockerconfigjson `Secret` creation in integration and e2e tests.

This is currently being controlled via envs:

- `DOCKERHUB_PULL_USERNAME`
- `DOCKERHUB_PULL_TOKEN`


Registry is hardcoded to `https://index.docker.io/v1/`

**Which issue this PR fixes**

Part of #452 


