### PR TITLE
feat(konnect): add configurable sync period

### DIFF
--- a/controller/konnect/ops.go
+++ b/controller/konnect/ops.go
@@ -97,7 +97,7 @@ func Delete[
 func Update[
 	T SupportedKonnectEntityType,
 	TEnt EntityType[T],
-](ctx context.Context, sdk *sdkkonnectgo.SDK, cl client.Client, e *T) (ctrl.Result, error) {
+](ctx context.Context, sdk *sdkkonnectgo.SDK, syncPeriod time.Duration, cl client.Client, e *T) (ctrl.Result, error) {
 	var (
 		ent                = TEnt(e)
 		condProgrammed, ok = k8sutils.GetCondition(KonnectEntityProgrammedConditionType, ent)
@@ -110,8 +110,8 @@ func Update[
 		condProgrammed.Status == metav1.ConditionTrue &&
 		condProgrammed.Reason == KonnectEntityProgrammedReason &&
 		condProgrammed.ObservedGeneration == ent.GetObjectMeta().GetGeneration() &&
-		timeFromLastUpdate <= configurableSyncPeriod {
-		requeueAfter := configurableSyncPeriod - timeFromLastUpdate
+		timeFromLastUpdate <= syncPeriod {
+		requeueAfter := syncPeriod - timeFromLastUpdate
 		log.Debug(ctrllog.FromContext(ctx),
 			"no need for update, requeueing after configured sync period", e,
 			"last_update", condProgrammed.LastTransitionTime.Time,

--- a/modules/cli/cli.go
+++ b/modules/cli/cli.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kong/gateway-operator/modules/manager"
 	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/metadata"
+	"github.com/kong/gateway-operator/pkg/consts"
 )
 
 // New returns a new CLI.
@@ -44,6 +45,7 @@ func New(m metadata.Info) *CLI {
 	// controllers for specialized APIs and features
 	flagSet.BoolVar(&cfg.AIGatewayControllerEnabled, "enable-controller-aigateway", false, "Enable the AIGateway controller. (Experimental).")
 	flagSet.BoolVar(&cfg.KongPluginInstallationControllerEnabled, "enable-controller-kongplugininstallation", false, "Enable the KongPluginInstallation controller.")
+	flagSet.DurationVar(&cfg.KonnectSyncPeriod, "konnect-sync-period", consts.DefaultKonnectSyncPeriod, "Sync period for Konnect entities. After a successful reconciliation of Konnect entities the controller will wait this duration before enforcing configuration on Konnect once again.")
 
 	// controllers for Konnect APIs
 	flagSet.BoolVar(&cfg.KonnectControllersEnabled, "enable-controller-konnect", false, "Enable the Konnect controllers.")

--- a/modules/cli/cli_test.go
+++ b/modules/cli/cli_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kong/gateway-operator/modules/manager"
 	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/metadata"
+	"github.com/kong/gateway-operator/pkg/consts"
 )
 
 func TestParse(t *testing.T) {
@@ -149,6 +150,7 @@ func expectedDefaultCfg() manager.Config {
 		DataPlaneControllerEnabled:              true,
 		DataPlaneBlueGreenControllerEnabled:     true,
 		KonnectControllersEnabled:               false,
+		KonnectSyncPeriod:                       consts.DefaultKonnectSyncPeriod,
 		KongPluginInstallationControllerEnabled: false,
 		ValidatingWebhookEnabled:                true,
 		LoggerOpts:                              &zap.Options{},

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -316,6 +316,7 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 				sdkFactory,
 				c.DevelopmentMode,
 				mgr.GetClient(),
+				konnect.WithKonnectEntitySyncPeriod[konnectv1alpha1.KonnectControlPlane](c.KonnectSyncPeriod),
 			),
 		}
 		controllers[KongServiceControllerName] = ControllerDef{
@@ -324,6 +325,7 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 				sdkFactory,
 				c.DevelopmentMode,
 				mgr.GetClient(),
+				konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongService](c.KonnectSyncPeriod),
 			),
 		}
 		controllers[KongConsumerControllerName] = ControllerDef{
@@ -332,6 +334,7 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 				sdkFactory,
 				c.DevelopmentMode,
 				mgr.GetClient(),
+				konnect.WithKonnectEntitySyncPeriod[configurationv1.KongConsumer](c.KonnectSyncPeriod),
 			),
 		}
 	}

--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -84,6 +84,7 @@ type Config struct {
 	// Controllers for specialty APIs and experimental features.
 	AIGatewayControllerEnabled              bool
 	KongPluginInstallationControllerEnabled bool
+	KonnectSyncPeriod                       time.Duration
 
 	// Controllers for Konnect APIs.
 	KonnectControllersEnabled bool

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -1,10 +1,11 @@
 package consts
 
+import "time"
+
 // ServiceType is a re-typing of string to be used to distinguish between proxy and admin service
 type ServiceType string
 
-// -----------------------------------------------------------------------------
-// Consts - Standard Kubernetes Object Labels
+// ----------------------------------------------------------------------------- // Consts - Standard Kubernetes Object Labels
 // -----------------------------------------------------------------------------
 
 const (
@@ -148,4 +149,13 @@ const (
 	ClusterCertEnvKey = "KONG_CLUSTER_CERT"
 	// ClusterCertEnvKey is the environment variable name for the cluster certificate key.
 	ClusterCertKeyEnvKey = "KONG_CLUSTER_CERT_KEY"
+)
+
+// -----------------------------------------------------------------------------
+// Consts - Konnect related consts
+// -----------------------------------------------------------------------------
+
+const (
+	// DefaultKonnectSyncPeriod is the default sync period for Konnect entities.
+	DefaultKonnectSyncPeriod = time.Minute
 )

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -5,7 +5,8 @@ import "time"
 // ServiceType is a re-typing of string to be used to distinguish between proxy and admin service
 type ServiceType string
 
-// ----------------------------------------------------------------------------- // Consts - Standard Kubernetes Object Labels
+// -----------------------------------------------------------------------------
+// Consts - Standard Kubernetes Object Labels
 // -----------------------------------------------------------------------------
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:

Add CLI flag/env to configure Konnect entities sync period. Default is set to 1m.

**Which issue this PR fixes**

Fixes #451

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
