### PR TITLE
chore(tests): fix tests in KGO EE after bumping controller-runtime to v0.19.0

### DIFF
--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,6 +39,7 @@ import (
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -164,6 +166,12 @@ func Run(
 	restCfg.UserAgent = metadata.UserAgent()
 
 	mgr, err := ctrl.NewManager(restCfg, ctrl.Options{
+		Controller: config.Controller{
+			// This is needed because controller-runtime since v0.19.0 keeps a global list of controller
+			// names and panics if there are duplicates. This is a workaround for that in tests.
+			// Ref: https://github.com/kubernetes-sigs/controller-runtime/pull/2902#issuecomment-2284194683
+			SkipNameValidation: lo.ToPtr(true),
+		},
 		Scheme: scheme,
 		Metrics: server.Options{
 			BindAddress: cfg.MetricsAddr,


### PR DESCRIPTION
**What this PR does / why we need it**:

Prerequisite for 
- https://github.com/Kong/gateway-operator-enterprise/pull/272

it overcomes change that has been introduced in [controller-runtime v0.19.0](https://github.com/kubernetes-sigs/controller-runtime/commit/2b941650bce159006c88bd3ca0d132c7bc40e947) and allows run test suit without a hassle. It's not great, not terrible fix. 
