### PR TITLE
feat(konnect): add KongRoute reconciler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
   [#470](https://github.com/Kong/gateway-operator/pull/470)
 - Add `KongConsumer` reconciler for Konnect control planes.
   [#493](https://github.com/Kong/gateway-operator/pull/493)
+- Add `KongRoute` reconciler for Konnect control planes.
+  [#506](https://github.com/Kong/gateway-operator/pull/506)
 
 ### Fixed
 

--- a/config/samples/konnect_kongroute.yaml
+++ b/config/samples/konnect_kongroute.yaml
@@ -1,0 +1,52 @@
+kind: KonnectAPIAuthConfiguration
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: konnect-api-auth-dev-1
+  namespace: default
+spec:
+  type: token
+  token: kpat_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+  serverURL: us.api.konghq.com
+---
+kind: KonnectControlPlane
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: test1
+  namespace: default
+spec:
+  name: test1
+  labels:
+    app: test1
+    key1: test1
+  konnect:
+    authRef:
+      name: konnect-api-auth-dev-1
+---
+kind: KongService
+apiVersion: configuration.konghq.com/v1alpha1
+metadata:
+  name: service-1
+  namespace: default
+spec:
+  name: service-1
+  host: example.com
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: test1
+---
+kind: KongRoute
+apiVersion: configuration.konghq.com/v1alpha1
+metadata:
+  name: service-1
+  namespace: default
+spec:
+  name: route-1
+  protocols:
+  - http
+  hosts:
+  - example.com
+  serviceRef:
+    type: namespacedRef
+    namespacedRef:
+      name: service-1

--- a/controller/konnect/conditions.go
+++ b/controller/konnect/conditions.go
@@ -8,9 +8,12 @@ const (
 	// indicates whether the entity has been programmed in Konnect.
 	KonnectEntityProgrammedConditionType = "Programmed"
 
-	// KonnectEntityProgrammedReason is the reason for the Programmed condition.
+	// KonnectEntityProgrammedReasonProgrammed is the reason for the Programmed condition.
 	// It is set when the entity has been programmed in Konnect.
-	KonnectEntityProgrammedReason = "Programmed"
+	KonnectEntityProgrammedReasonProgrammed = "Programmed"
+	// KonnectEntityProgrammedReasonKonnectAPIOpFailed is the reason for the Programmed condition.
+	// It is set when the entity has failed to be programmed in Konnect.
+	KonnectEntityProgrammedReasonKonnectAPIOpFailed = "KonnectAPIOpFailed"
 )
 
 const (
@@ -62,4 +65,18 @@ const (
 	// ControlPlaneRefReasonInvalid is the reason used with the ControlPlaneRefValid
 	// condition type indicating that the ControlPlane reference is invalid.
 	ControlPlaneRefReasonInvalid = "Invalid"
+)
+
+const (
+	// KongServiceRefValidConditionType is the type of the condition that indicates
+	// whether the KongService reference is valid and points to an existing
+	// KongService.
+	KongServiceRefValidConditionType = "KongServiceRefValid"
+
+	// KongServiceRefReasonValid is the reason used with the KongServiceRefValid
+	// condition type indicating that the KongService reference is valid.
+	KongServiceRefReasonValid = "Valid"
+	// KongServiceRefReasonInvalid is the reason used with the KongServiceRefValid
+	// condition type indicating that the KongService reference is invalid.
+	KongServiceRefReasonInvalid = "Invalid"
 )

--- a/controller/konnect/constraints.go
+++ b/controller/konnect/constraints.go
@@ -37,6 +37,7 @@ type EntityType[T SupportedKonnectEntityType] interface {
 	GetConditions() []metav1.Condition
 	SetConditions([]metav1.Condition)
 	GetKonnectStatus() *konnectv1alpha1.KonnectEntityStatus
+	SetKonnectID(string)
 }
 
 // EntityWithKonnectAPIAuthConfigurationRef is an interface that all Konnect entity types

--- a/controller/konnect/errors.go
+++ b/controller/konnect/errors.go
@@ -43,3 +43,14 @@ func (e ReferencedControlPlaneDoesNotExistError) Error() string {
 func (e ReferencedControlPlaneDoesNotExistError) Unwrap() error {
 	return e.Err
 }
+
+// ReferencedKongServiceIsBeingDeleted is an error type that is returned when
+// a Konnect entity references a Kong Service which is being deleted.
+type ReferencedKongServiceIsBeingDeleted struct {
+	Reference types.NamespacedName
+}
+
+// Error implements the error interface.
+func (e ReferencedKongServiceIsBeingDeleted) Error() string {
+	return fmt.Sprintf("referenced Kong Service %s is being deleted", e.Reference)
+}

--- a/controller/konnect/ops.go
+++ b/controller/konnect/ops.go
@@ -49,6 +49,8 @@ func Create[
 		return e, createControlPlane(ctx, sdk, ent)
 	case *configurationv1alpha1.KongService:
 		return e, createService(ctx, sdk, ent)
+	case *configurationv1alpha1.KongRoute:
+		return e, createRoute(ctx, sdk, ent)
 	case *configurationv1.KongConsumer:
 		return e, createConsumer(ctx, sdk, ent)
 
@@ -81,6 +83,8 @@ func Delete[
 		return deleteControlPlane(ctx, sdk, ent)
 	case *configurationv1alpha1.KongService:
 		return deleteService(ctx, sdk, ent)
+	case *configurationv1alpha1.KongRoute:
+		return deleteRoute(ctx, sdk, ent)
 	case *configurationv1.KongConsumer:
 		return deleteConsumer(ctx, sdk, ent)
 
@@ -108,7 +112,7 @@ func Update[
 	// the configured sync period, requeue after the remaining time.
 	if ok &&
 		condProgrammed.Status == metav1.ConditionTrue &&
-		condProgrammed.Reason == KonnectEntityProgrammedReason &&
+		condProgrammed.Reason == KonnectEntityProgrammedReasonProgrammed &&
 		condProgrammed.ObservedGeneration == ent.GetObjectMeta().GetGeneration() &&
 		timeFromLastUpdate <= syncPeriod {
 		requeueAfter := syncPeriod - timeFromLastUpdate
@@ -138,6 +142,8 @@ func Update[
 		return ctrl.Result{}, updateControlPlane(ctx, sdk, ent)
 	case *configurationv1alpha1.KongService:
 		return ctrl.Result{}, updateService(ctx, sdk, cl, ent)
+	case *configurationv1alpha1.KongRoute:
+		return ctrl.Result{}, updateRoute(ctx, sdk, cl, ent)
 	case *configurationv1.KongConsumer:
 		return ctrl.Result{}, updateConsumer(ctx, sdk, cl, ent)
 

--- a/controller/konnect/ops_kongroute.go
+++ b/controller/konnect/ops_kongroute.go
@@ -1,0 +1,217 @@
+package konnect
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
+	sdkkonnectgocomp "github.com/Kong/sdk-konnect-go/models/components"
+	sdkkonnectgoops "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/Kong/sdk-konnect-go/models/sdkerrors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+func createRoute(
+	ctx context.Context,
+	sdk *sdkkonnectgo.SDK,
+	route *configurationv1alpha1.KongRoute,
+) error {
+	if route.GetControlPlaneID() == "" {
+		return fmt.Errorf("can't create %T %s without a Konnect ControlPlane ID", route, client.ObjectKeyFromObject(route))
+	}
+
+	resp, err := sdk.Routes.CreateRoute(ctx, route.Status.Konnect.ControlPlaneID, kongRouteToSDKRouteInput(route))
+
+	// TODO: handle already exists
+	// Can't adopt it as it will cause conflicts between the controller
+	// that created that entity and already manages it, hm
+	if errWrapped := wrapErrIfKonnectOpFailed(err, CreateOp, route); errWrapped != nil {
+		k8sutils.SetCondition(
+			k8sutils.NewConditionWithGeneration(
+				KonnectEntityProgrammedConditionType,
+				metav1.ConditionFalse,
+				"FailedToCreate",
+				errWrapped.Error(),
+				route.GetGeneration(),
+			),
+			route,
+		)
+		return errWrapped
+	}
+
+	route.Status.Konnect.SetKonnectID(*resp.Route.ID)
+	k8sutils.SetCondition(
+		k8sutils.NewConditionWithGeneration(
+			KonnectEntityProgrammedConditionType,
+			metav1.ConditionTrue,
+			KonnectEntityProgrammedReasonProgrammed,
+			"",
+			route.GetGeneration(),
+		),
+		route,
+	)
+
+	return nil
+}
+
+// updateRoute updates the Konnect Route entity.
+// It is assumed that provided KongRoute has Konnect ID set in status.
+// It returns an error if the KongRoute does not have a ControlPlaneRef or
+// if the operation fails.
+func updateRoute(
+	ctx context.Context,
+	sdk *sdkkonnectgo.SDK,
+	cl client.Client,
+	route *configurationv1alpha1.KongRoute,
+) error {
+	if route.Spec.ServiceRef == nil {
+		return fmt.Errorf("can't update %T without a ServiceRef", route)
+	}
+
+	// TODO(pmalek) handle other types of CP ref
+	nnSvc := types.NamespacedName{
+		Namespace: route.Namespace,
+		Name:      route.Spec.ServiceRef.NamespacedRef.Name,
+	}
+	var svc configurationv1alpha1.KongService
+	if err := cl.Get(ctx, nnSvc, &svc); err != nil {
+		return fmt.Errorf("failed to get KongService %s: for KongRoute %s: %w",
+			nnSvc, client.ObjectKeyFromObject(route), err,
+		)
+	}
+
+	if svc.Status.Konnect.ID == "" {
+		return fmt.Errorf(
+			"can't update %T when referenced KongService %s does not have the Konnect ID",
+			route, nnSvc,
+		)
+	}
+
+	var cp konnectv1alpha1.KonnectControlPlane
+	nnCP := types.NamespacedName{
+		Namespace: svc.Namespace,
+		Name:      svc.Spec.ControlPlaneRef.KonnectNamespacedRef.Name,
+	}
+	if err := cl.Get(ctx, nnCP, &cp); err != nil {
+		return fmt.Errorf("failed to get KonnectControlPlane %s: for KongRoute %s: %w",
+			nnSvc, client.ObjectKeyFromObject(route), err,
+		)
+	}
+
+	if cp.Status.ID == "" {
+		return fmt.Errorf(
+			"can't update %T when referenced KonnectControlPlane %s does not have the Konnect ID",
+			route, nnSvc,
+		)
+	}
+
+	resp, err := sdk.Routes.UpsertRoute(ctx, sdkkonnectgoops.UpsertRouteRequest{
+		ControlPlaneID: cp.Status.ID,
+		RouteID:        route.Status.Konnect.ID,
+		Route:          kongRouteToSDKRouteInput(route),
+	},
+	)
+
+	// TODO: handle already exists
+	// Can't adopt it as it will cause conflicts between the controller
+	// that created that entity and already manages it, hm
+	if errWrapped := wrapErrIfKonnectOpFailed(err, UpdateOp, route); errWrapped != nil {
+		k8sutils.SetCondition(
+			k8sutils.NewConditionWithGeneration(
+				KonnectEntityProgrammedConditionType,
+				metav1.ConditionFalse,
+				"FailedToCreate",
+				errWrapped.Error(),
+				route.GetGeneration(),
+			),
+			route,
+		)
+		return errWrapped
+	}
+
+	route.Status.Konnect.SetKonnectID(*resp.Route.ID)
+	route.Status.Konnect.SetControlPlaneID(cp.Status.ID)
+	k8sutils.SetCondition(
+		k8sutils.NewConditionWithGeneration(
+			KonnectEntityProgrammedConditionType,
+			metav1.ConditionTrue,
+			KonnectEntityProgrammedReasonProgrammed,
+			"",
+			route.GetGeneration(),
+		),
+		route,
+	)
+
+	return nil
+}
+
+// deleteRoute deletes a KongRoute in Konnect.
+// It is assumed that provided KongRoute has Konnect ID set in status.
+// It returns an error if the operation fails.
+func deleteRoute(
+	ctx context.Context,
+	sdk *sdkkonnectgo.SDK,
+	route *configurationv1alpha1.KongRoute,
+) error {
+	id := route.GetKonnectStatus().GetKonnectID()
+	_, err := sdk.Routes.DeleteRoute(ctx, route.Status.Konnect.ControlPlaneID, id)
+	if errWrapped := wrapErrIfKonnectOpFailed(err, DeleteOp, route); errWrapped != nil {
+		// Service delete operation returns an SDKError instead of a NotFoundError.
+		var sdkError *sdkerrors.SDKError
+		if errors.As(errWrapped, &sdkError) {
+			if sdkError.StatusCode == 404 {
+				ctrllog.FromContext(ctx).
+					Info("entity not found in Konnect, skipping delete",
+						"op", DeleteOp, "type", route.GetTypeName(), "id", id,
+					)
+				return nil
+			}
+			return FailedKonnectOpError[configurationv1alpha1.KongRoute]{
+				Op:  DeleteOp,
+				Err: sdkError,
+			}
+		}
+		return FailedKonnectOpError[configurationv1alpha1.KongService]{
+			Op:  DeleteOp,
+			Err: errWrapped,
+		}
+	}
+
+	return nil
+}
+
+func kongRouteToSDKRouteInput(
+	route *configurationv1alpha1.KongRoute,
+) sdkkonnectgocomp.RouteInput {
+	return sdkkonnectgocomp.RouteInput{
+		Destinations:            route.Spec.KongRouteAPISpec.Destinations,
+		Headers:                 route.Spec.KongRouteAPISpec.Headers,
+		Hosts:                   route.Spec.KongRouteAPISpec.Hosts,
+		HTTPSRedirectStatusCode: route.Spec.KongRouteAPISpec.HTTPSRedirectStatusCode,
+		Methods:                 route.Spec.KongRouteAPISpec.Methods,
+		Name:                    route.Spec.KongRouteAPISpec.Name,
+		PathHandling:            route.Spec.KongRouteAPISpec.PathHandling,
+		Paths:                   route.Spec.KongRouteAPISpec.Paths,
+		PreserveHost:            route.Spec.KongRouteAPISpec.PreserveHost,
+		Protocols:               route.Spec.KongRouteAPISpec.Protocols,
+		RegexPriority:           route.Spec.KongRouteAPISpec.RegexPriority,
+		RequestBuffering:        route.Spec.KongRouteAPISpec.RequestBuffering,
+		ResponseBuffering:       route.Spec.KongRouteAPISpec.ResponseBuffering,
+		Snis:                    route.Spec.KongRouteAPISpec.Snis,
+		Sources:                 route.Spec.KongRouteAPISpec.Sources,
+		StripPath:               route.Spec.KongRouteAPISpec.StripPath,
+		Tags:                    route.Spec.KongRouteAPISpec.Tags,
+		Service: &sdkkonnectgocomp.RouteService{
+			ID: sdkkonnectgo.String(route.Status.Konnect.ServiceID),
+		},
+	}
+}

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -153,15 +153,12 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 			return ctrl.Result{}, err
 		}
 
-		// If the referenced KongService is being deleted (has a delete timestamp set)
-		// then we remove the entity.
+		// If the referenced KongService is being deleted (has a non zero deletion timestamp)
+		// then we remove the entity if it has not been deleted yet (deletion timestamp is zero).
 		// We do this because Konnect blocks deletion of entities like Services
 		// if they contain entities like Routes.
 		if ent.GetDeletionTimestamp().IsZero() {
 			if err := r.Client.Delete(ctx, ent); err != nil {
-				if k8serrors.IsConflict(err) {
-					return ctrl.Result{Requeue: true}, nil
-				}
 				return ctrl.Result{}, fmt.Errorf("failed to delete %s: %w", client.ObjectKeyFromObject(ent), err)
 			}
 			return ctrl.Result{}, nil

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -147,7 +147,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		return ctrl.Result{}, nil
 	}
 	// If a type has a KongService ref, handle it.
-	res, err = handlKongServiceRef(ctx, r.Client, ent)
+	res, err = handleKongServiceRef(ctx, r.Client, ent)
 	if err != nil {
 		if !errors.As(err, &ReferencedKongServiceIsBeingDeleted{}) {
 			return ctrl.Result{}, err
@@ -539,10 +539,10 @@ func getServiceRef[T SupportedKonnectEntityType, TEnt EntityType[T]](
 	}
 }
 
-// handlKongServiceRef handles the ServiceRef for the given entity.
+// handleKongServiceRef handles the ServiceRef for the given entity.
 // It sets the owner reference to the referenced KongService and updates the
 // status of the entity based on the referenced KongService status.
-func handlKongServiceRef[T SupportedKonnectEntityType, TEnt EntityType[T]](
+func handleKongServiceRef[T SupportedKonnectEntityType, TEnt EntityType[T]](
 	ctx context.Context,
 	cl client.Client,
 	ent TEnt,

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -126,6 +126,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 	ctx = ctrllog.IntoContext(ctx, logger)
 	log.Debug(logger, "reconciling", ent)
 
+	// If a type has a ControlPlane ref, handle it.
 	res, err := handleControlPlaneRef(ctx, r.Client, ent)
 	if err != nil || res.Requeue {
 		// If the referenced ControlPlane is not found and the object is deleted,
@@ -145,6 +146,30 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// Status update will requeue the entity.
 		return ctrl.Result{}, nil
 	}
+	// If a type has a KongService ref, handle it.
+	res, err = handlKongServiceRef(ctx, r.Client, ent)
+	if err != nil {
+		if !errors.As(err, &ReferencedKongServiceIsBeingDeleted{}) {
+			return ctrl.Result{}, err
+		}
+
+		// If the referenced KongService is being deleted (has a delete timestamp set)
+		// then we remove the entity.
+		// We do this because Konnect blocks deletion of entities like Services
+		// if they contain entities like Routes.
+		if ent.GetDeletionTimestamp().IsZero() {
+			if err := r.Client.Delete(ctx, ent); err != nil {
+				if k8serrors.IsConflict(err) {
+					return ctrl.Result{Requeue: true}, nil
+				}
+				return ctrl.Result{}, fmt.Errorf("failed to delete %s: %w", client.ObjectKeyFromObject(ent), err)
+			}
+			return ctrl.Result{}, nil
+		}
+	} else if res.Requeue {
+		return res, nil
+	}
+
 	apiAuthRef, err := getAPIAuthRefNN(ctx, r.Client, ent)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get APIAuth ref for %s: %w", client.ObjectKeyFromObject(ent), err)
@@ -274,6 +299,15 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 
 		if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 			if err := Delete[T, TEnt](ctx, sdk, r.Client, ent); err != nil {
+				if res, errStatus := updateStatusWithCondition(
+					ctx, r.Client, ent,
+					KonnectEntityProgrammedConditionType,
+					metav1.ConditionFalse,
+					KonnectEntityProgrammedReasonKonnectAPIOpFailed,
+					err.Error(),
+				); errStatus != nil || res.Requeue {
+					return res, errStatus
+				}
 				return ctrl.Result{}, err
 			}
 			if err := r.Client.Update(ctx, ent); err != nil {
@@ -357,6 +391,12 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 	}, nil
 }
 
+// EntityWithControlPlaneRef is an interface for entities that have a ControlPlaneRef.
+type EntityWithControlPlaneRef interface {
+	SetControlPlaneID(string)
+	GetControlPlaneID() string
+}
+
 func updateStatusWithCondition[T interface {
 	client.Object
 	k8sutils.ConditionsAware
@@ -393,6 +433,46 @@ func updateStatusWithCondition[T interface {
 	return ctrl.Result{}, nil
 }
 
+func getCPForRef(
+	ctx context.Context,
+	cl client.Client,
+	cpRef configurationv1alpha1.ControlPlaneRef,
+	namespace string,
+) (*konnectv1alpha1.KonnectControlPlane, error) {
+	if cpRef.Type != configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef {
+		return nil, fmt.Errorf("unsupported ControlPlane ref type %q", cpRef.Type)
+	}
+	// TODO(pmalek): handle cross namespace refs
+	nn := types.NamespacedName{
+		Name:      cpRef.KonnectNamespacedRef.Name,
+		Namespace: namespace,
+	}
+
+	var cp konnectv1alpha1.KonnectControlPlane
+	if err := cl.Get(ctx, nn, &cp); err != nil {
+		return nil, fmt.Errorf("failed to get ControlPlane %s", nn)
+	}
+	return &cp, nil
+}
+
+func getCPAuthRefForRef(
+	ctx context.Context,
+	cl client.Client,
+	cpRef configurationv1alpha1.ControlPlaneRef,
+	namespace string,
+) (types.NamespacedName, error) {
+	cp, err := getCPForRef(ctx, cl, cpRef, namespace)
+	if err != nil {
+		return types.NamespacedName{}, err
+	}
+
+	return types.NamespacedName{
+		Name: cp.GetKonnectAPIAuthConfigurationRef().Name,
+		// TODO(pmalek): enable if cross namespace refs are allowed
+		Namespace: cp.GetNamespace(),
+	}, nil
+}
+
 func getAPIAuthRefNN[T SupportedKonnectEntityType, TEnt EntityType[T]](
 	ctx context.Context,
 	cl client.Client,
@@ -402,24 +482,32 @@ func getAPIAuthRefNN[T SupportedKonnectEntityType, TEnt EntityType[T]](
 	// ref from the referenced ControlPlane.
 	cpRef, ok := getControlPlaneRef(ent).Get()
 	if ok {
-		if cpRef.Type != configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef {
-			return types.NamespacedName{}, fmt.Errorf("unsupported ControlPlane ref type %q", cpRef.Type)
+		return getCPAuthRefForRef(ctx, cl, cpRef, ent.GetNamespace())
+	}
+
+	// If the entity has a KongServiceRef, get the KonnectAPIAuthConfiguration
+	// ref from the referenced KongService.
+	svcRef, ok := getServiceRef(ent).Get()
+	if ok {
+		if svcRef.Type != configurationv1alpha1.ServiceRefNamespacedRef {
+			return types.NamespacedName{}, fmt.Errorf("unsupported KongService ref type %q", svcRef.Type)
 		}
 		// TODO(pmalek): handle cross namespace refs
 		nn := types.NamespacedName{
-			Name:      cpRef.KonnectNamespacedRef.Name,
+			Name:      svcRef.NamespacedRef.Name,
 			Namespace: ent.GetNamespace(),
 		}
 
-		var cp konnectv1alpha1.KonnectControlPlane
-		if err := cl.Get(ctx, nn, &cp); err != nil {
-			return types.NamespacedName{}, fmt.Errorf("failed to get ControlPlane %s", nn)
+		var svc configurationv1alpha1.KongService
+		if err := cl.Get(ctx, nn, &svc); err != nil {
+			return types.NamespacedName{}, fmt.Errorf("failed to get KongService %s", nn)
 		}
-		return types.NamespacedName{
-			Name: cp.GetKonnectAPIAuthConfigurationRef().Name,
-			// TODO(pmalek): enable if cross namespace refs are allowed
-			Namespace: cp.GetNamespace(),
-		}, nil
+
+		cpRef, ok := getControlPlaneRef(&svc).Get()
+		if !ok {
+			return types.NamespacedName{}, fmt.Errorf("KongService %s does not have a ControlPlaneRef", nn)
+		}
+		return getCPAuthRefForRef(ctx, cl, cpRef, ent.GetNamespace())
 	}
 
 	if ref, ok := any(ent).(EntityWithKonnectAPIAuthConfigurationRef); ok {
@@ -436,11 +524,184 @@ func getAPIAuthRefNN[T SupportedKonnectEntityType, TEnt EntityType[T]](
 	)
 }
 
+func getServiceRef[T SupportedKonnectEntityType, TEnt EntityType[T]](
+	e TEnt,
+) mo.Option[configurationv1alpha1.ServiceRef] {
+	switch e := any(e).(type) {
+	case *configurationv1alpha1.KongService,
+		*configurationv1.KongConsumer,
+		*konnectv1alpha1.KonnectControlPlane:
+		return mo.None[configurationv1alpha1.ServiceRef]()
+	case *configurationv1alpha1.KongRoute:
+		if e.Spec.ServiceRef == nil {
+			return mo.None[configurationv1alpha1.ServiceRef]()
+		}
+		return mo.Some(*e.Spec.ServiceRef)
+	default:
+		panic(fmt.Sprintf("unsupported entity type %T", e))
+	}
+}
+
+// handlKongServiceRef handles the ServiceRef for the given entity.
+// It sets the owner reference to the referenced KongService and updates the
+// status of the entity based on the referenced KongService status.
+func handlKongServiceRef[T SupportedKonnectEntityType, TEnt EntityType[T]](
+	ctx context.Context,
+	cl client.Client,
+	ent TEnt,
+) (ctrl.Result, error) {
+	kongServiceRef, ok := getServiceRef(ent).Get()
+	if !ok {
+		return ctrl.Result{}, nil
+	}
+	switch kongServiceRef.Type {
+	case configurationv1alpha1.ServiceRefNamespacedRef:
+		svc := configurationv1alpha1.KongService{}
+		nn := types.NamespacedName{
+			Name: kongServiceRef.NamespacedRef.Name,
+			// TODO: handle cross namespace refs
+			Namespace: ent.GetNamespace(),
+		}
+
+		if err := cl.Get(ctx, nn, &svc); err != nil {
+			if res, errStatus := updateStatusWithCondition(
+				ctx, cl, ent,
+				KongServiceRefValidConditionType,
+				metav1.ConditionFalse,
+				KongServiceRefReasonInvalid,
+				err.Error(),
+			); errStatus != nil || res.Requeue {
+				return res, errStatus
+			}
+
+			return ctrl.Result{}, fmt.Errorf("Can't get the referenced KongService %s: %w", nn, err)
+		}
+
+		// If referenced KongService is being deleted, return an error so that we
+		// can remove the entity from Konnect first.
+		if delTimestamp := svc.GetDeletionTimestamp(); !delTimestamp.IsZero() {
+			return ctrl.Result{}, ReferencedKongServiceIsBeingDeleted{
+				Reference: nn,
+			}
+		}
+
+		cond, ok := k8sutils.GetCondition(KonnectEntityProgrammedConditionType, &svc)
+		if !ok || cond.Status != metav1.ConditionTrue {
+			ent.SetKonnectID("")
+			if res, err := updateStatusWithCondition(
+				ctx, cl, ent,
+				KongServiceRefValidConditionType,
+				metav1.ConditionFalse,
+				KongServiceRefReasonInvalid,
+				fmt.Sprintf("Referenced KongService %s is not programmed yet", nn),
+			); err != nil || res.Requeue {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil
+		}
+
+		old := ent.DeepCopyObject().(TEnt)
+		if err := controllerutil.SetOwnerReference(&svc, ent, cl.Scheme(), controllerutil.WithBlockOwnerDeletion(true)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to set owner reference: %w", err)
+		}
+		if err := cl.Patch(ctx, ent, client.MergeFrom(old)); err != nil {
+			if k8serrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
+		}
+
+		// TODO(pmalek): make this generic.
+		// Service ID is not stored in KonnectEntityStatus because not all entities
+		// have a ServiceRef, hence the type constraints in the reconciler can't be used.
+		if route, ok := any(ent).(*configurationv1alpha1.KongRoute); ok {
+			if route.Status.Konnect == nil {
+				route.Status.Konnect = &konnectv1alpha1.KonnectEntityStatusWithControlPlaneAndServiceRefs{}
+			}
+			route.Status.Konnect.ServiceID = svc.Status.Konnect.GetKonnectID()
+		}
+
+		if res, errStatus := updateStatusWithCondition(
+			ctx, cl, ent,
+			KongServiceRefValidConditionType,
+			metav1.ConditionTrue,
+			KongServiceRefReasonValid,
+			fmt.Sprintf("Referenced KongService %s programmed", nn),
+		); errStatus != nil || res.Requeue {
+			return res, errStatus
+		}
+
+		cpRef, ok := getControlPlaneRef(&svc).Get()
+		if !ok {
+			return ctrl.Result{}, fmt.Errorf(
+				"KongRoute references a KongService %s which does not have a ControlPlane ref",
+				client.ObjectKeyFromObject(&svc),
+			)
+		}
+		cp, err := getCPForRef(ctx, cl, cpRef, ent.GetNamespace())
+		if err != nil {
+			if res, errStatus := updateStatusWithCondition(
+				ctx, cl, ent,
+				ControlPlaneRefValidConditionType,
+				metav1.ConditionFalse,
+				ControlPlaneRefReasonInvalid,
+				err.Error(),
+			); errStatus != nil || res.Requeue {
+				return res, errStatus
+			}
+			if k8serrors.IsNotFound(err) {
+				return ctrl.Result{}, ReferencedControlPlaneDoesNotExistError{
+					Reference: nn,
+					Err:       err,
+				}
+			}
+			return ctrl.Result{}, err
+		}
+
+		cond, ok = k8sutils.GetCondition(KonnectEntityProgrammedConditionType, cp)
+		if !ok || cond.Status != metav1.ConditionTrue || cond.ObservedGeneration != cp.GetGeneration() {
+			if res, errStatus := updateStatusWithCondition(
+				ctx, cl, ent,
+				ControlPlaneRefValidConditionType,
+				metav1.ConditionFalse,
+				ControlPlaneRefReasonInvalid,
+				fmt.Sprintf("Referenced ControlPlane %s is not programmed yet", nn),
+			); errStatus != nil || res.Requeue {
+				return res, errStatus
+			}
+
+			return ctrl.Result{Requeue: true}, nil
+		}
+
+		// TODO(pmalek): make this generic.
+		// CP ID is not stored in KonnectEntityStatus because not all entities
+		// have a ControlPlaneRef, hence the type constraints in the reconciler can't be used.
+		if resource, ok := any(ent).(EntityWithControlPlaneRef); ok {
+			resource.SetControlPlaneID(cp.Status.ID)
+		}
+
+		if res, errStatus := updateStatusWithCondition(
+			ctx, cl, ent,
+			ControlPlaneRefValidConditionType,
+			metav1.ConditionTrue,
+			ControlPlaneRefReasonValid,
+			fmt.Sprintf("Referenced ControlPlane %s is programmed", nn),
+		); errStatus != nil || res.Requeue {
+			return res, errStatus
+		}
+
+	default:
+		return ctrl.Result{}, fmt.Errorf("unimplemented KongService ref type %q", kongServiceRef.Type)
+	}
+
+	return ctrl.Result{}, nil
+}
+
 func getControlPlaneRef[T SupportedKonnectEntityType, TEnt EntityType[T]](
 	e TEnt,
 ) mo.Option[configurationv1alpha1.ControlPlaneRef] {
 	switch e := any(e).(type) {
-	case *konnectv1alpha1.KonnectControlPlane:
+	case *konnectv1alpha1.KonnectControlPlane, *configurationv1alpha1.KongRoute:
 		return mo.None[configurationv1alpha1.ControlPlaneRef]()
 	case *configurationv1.KongConsumer:
 		if e.Spec.ControlPlaneRef == nil {
@@ -523,10 +784,6 @@ func handleControlPlaneRef[T SupportedKonnectEntityType, TEnt EntityType[T]](
 			return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
 		}
 
-		type EntityWithControlPlaneRef interface {
-			SetControlPlaneID(string)
-			GetControlPlaneID() string
-		}
 		// TODO(pmalek): make this generic.
 		// CP ID is not stored in KonnectEntityStatus because not all entities
 		// have a ControlPlaneRef, hence the type constraints in the reconciler can't be used.

--- a/controller/konnect/reconciler_generic_test.go
+++ b/controller/konnect/reconciler_generic_test.go
@@ -19,10 +19,7 @@ func TestNewKonnectEntityReconciler(t *testing.T) {
 	testNewKonnectEntityReconciler(t, konnectv1alpha1.KonnectControlPlane{})
 	testNewKonnectEntityReconciler(t, configurationv1alpha1.KongService{})
 	testNewKonnectEntityReconciler(t, configurationv1.KongConsumer{})
-
-	// TODO(pmalek): add support for KongRoute
-	// https://github.com/Kong/gateway-operator/issues/435
-	// testNewKonnectEntityReconciler(t, configurationv1alpha1.KongRoute{})
+	testNewKonnectEntityReconciler(t, configurationv1alpha1.KongRoute{})
 
 	// TODO: GetConditions() and SetConditions() is missing from KongConsumerGroup.
 	// testNewKonnectEntityReconciler(t, configurationv1beta1.KongConsumerGroup{})

--- a/controller/konnect/watch.go
+++ b/controller/konnect/watch.go
@@ -23,6 +23,8 @@ func ReconciliationWatchOptionsForEntity[
 	switch any(ent).(type) {
 	case *configurationv1.KongConsumer:
 		return KongConsumerReconciliationWatchOptions(cl)
+	case *configurationv1alpha1.KongRoute:
+		return KongRouteReconciliationWatchOptions(cl)
 	case *configurationv1alpha1.KongService:
 		return KongServiceReconciliationWatchOptions(cl)
 	case *konnectv1alpha1.KonnectControlPlane:

--- a/controller/konnect/watch_kongroute.go
+++ b/controller/konnect/watch_kongroute.go
@@ -91,6 +91,14 @@ func enqueueKongRouteForKongService(
 		if !ok {
 			return nil
 		}
+
+		// If the KongService does not refer to a KonnectControlPlane,
+		// we do not need to enqueue any KongRoutes bound to this KongService.
+		cpRef := kongSvc.Spec.ControlPlaneRef
+		if cpRef == nil || cpRef.Type != configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef {
+			return nil
+		}
+
 		var l configurationv1alpha1.KongRouteList
 		if err := cl.List(ctx, &l, &client.ListOptions{
 			// TODO: change this when cross namespace refs are allowed.
@@ -126,7 +134,7 @@ func enqueueKongRouteForKongService(
 
 			default:
 				ctrllog.FromContext(ctx).V(logging.DebugLevel.Value()).Info(
-					"unsupported ControlPlaneRef for KongRoute",
+					"unsupported ServiceRef for KongRoute",
 					"KongRoute", route, "refType", svcRef.Type,
 				)
 				continue

--- a/controller/konnect/watch_kongroute.go
+++ b/controller/konnect/watch_kongroute.go
@@ -1,0 +1,137 @@
+package konnect
+
+import (
+	"context"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	operatorerrors "github.com/kong/gateway-operator/internal/errors"
+	"github.com/kong/gateway-operator/modules/manager/logging"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+)
+
+// TODO(pmalek): this can be extracted and used in reconciler.go
+// as every Konnect entity will have a reference to the KonnectAPIAuthConfiguration.
+// This would require:
+// - mapping function from non List types to List types
+// - a function on each Konnect entity type to get the API Auth configuration
+//   reference from the object
+// - lists have their items stored in Items field, not returned via a method
+
+// KongRouteReconciliationWatchOptions returns the watch options for
+// the KongRoute.
+func KongRouteReconciliationWatchOptions(
+	cl client.Client,
+) []func(*ctrl.Builder) *ctrl.Builder {
+	return []func(*ctrl.Builder) *ctrl.Builder{
+		func(b *ctrl.Builder) *ctrl.Builder {
+			return b.For(&configurationv1alpha1.KongRoute{},
+				builder.WithPredicates(
+					predicate.NewPredicateFuncs(kongRouteRefersToKonnectControlPlane(cl)),
+				),
+			)
+		},
+		func(b *ctrl.Builder) *ctrl.Builder {
+			return b.Watches(
+				&configurationv1alpha1.KongService{},
+				handler.EnqueueRequestsFromMapFunc(
+					enqueueKongRouteForKongService(cl),
+				),
+			)
+		},
+	}
+}
+
+// kongRouteRefersToKonnectControlPlane returns true if the KongRoute
+// refers to a KonnectControlPlane.
+func kongRouteRefersToKonnectControlPlane(cl client.Client) func(obj client.Object) bool {
+	return func(obj client.Object) bool {
+		kongRoute, ok := obj.(*configurationv1alpha1.KongRoute)
+		if !ok {
+			ctrllog.FromContext(context.Background()).Error(
+				operatorerrors.ErrUnexpectedObject,
+				"failed to run predicate function",
+				"expected", "KongRoute", "found", reflect.TypeOf(obj),
+			)
+			return false
+		}
+
+		scvRef := kongRoute.Spec.ServiceRef
+		if scvRef == nil || scvRef.Type != configurationv1alpha1.ServiceRefNamespacedRef {
+			return false
+		}
+		nn := types.NamespacedName{
+			Namespace: kongRoute.Namespace,
+			Name:      scvRef.NamespacedRef.Name,
+		}
+		kongSvc := configurationv1alpha1.KongService{}
+		if err := cl.Get(context.Background(), nn, &kongSvc); client.IgnoreNotFound(err) != nil {
+			return true
+		}
+
+		cpRef := kongSvc.Spec.ControlPlaneRef
+		return cpRef != nil && cpRef.Type == configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef
+	}
+}
+
+func enqueueKongRouteForKongService(
+	cl client.Client,
+) func(ctx context.Context, obj client.Object) []reconcile.Request {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		kongSvc, ok := obj.(*configurationv1alpha1.KongService)
+		if !ok {
+			return nil
+		}
+		var l configurationv1alpha1.KongRouteList
+		if err := cl.List(ctx, &l, &client.ListOptions{
+			// TODO: change this when cross namespace refs are allowed.
+			Namespace: kongSvc.GetNamespace(),
+		}); err != nil {
+			return nil
+		}
+
+		var ret []reconcile.Request
+		for _, route := range l.Items {
+			svcRef, ok := getServiceRef(&route).Get()
+			if !ok {
+				continue
+			}
+
+			switch svcRef.Type {
+			case configurationv1alpha1.ServiceRefNamespacedRef:
+				if svcRef.NamespacedRef == nil {
+					continue
+				}
+
+				// TODO: change this when cross namespace refs are allowed.
+				if svcRef.NamespacedRef.Name != kongSvc.GetName() {
+					continue
+				}
+
+				ret = append(ret, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: route.Namespace,
+						Name:      route.Name,
+					},
+				})
+
+			default:
+				ctrllog.FromContext(ctx).V(logging.DebugLevel.Value()).Info(
+					"unsupported ControlPlaneRef for KongRoute",
+					"KongRoute", route, "refType", svcRef.Type,
+				)
+				continue
+			}
+		}
+		return ret
+	}
+}

--- a/controller/konnect/watch_kongservice.go
+++ b/controller/konnect/watch_kongservice.go
@@ -171,6 +171,9 @@ func enqueueKongServiceForKonnectControlPlane(
 
 		var ret []reconcile.Request
 		for _, svc := range l.Items {
+			if svc.Spec.ControlPlaneRef == nil {
+				continue
+			}
 			switch svc.Spec.ControlPlaneRef.Type {
 			case configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef:
 				// TODO: change this when cross namespace refs are allowed.

--- a/controller/konnect/watch_test.go
+++ b/controller/konnect/watch_test.go
@@ -1,0 +1,37 @@
+package konnect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+func TestWatchOptions(t *testing.T) {
+	testReconciliationWatchOptionsForEntity(t, &konnectv1alpha1.KonnectControlPlane{})
+	testReconciliationWatchOptionsForEntity(t, &configurationv1alpha1.KongService{})
+	testReconciliationWatchOptionsForEntity(t, &configurationv1.KongConsumer{})
+	testReconciliationWatchOptionsForEntity(t, &configurationv1alpha1.KongRoute{})
+}
+
+func testReconciliationWatchOptionsForEntity[
+	T SupportedKonnectEntityType,
+	TEnt EntityType[T],
+](
+	t *testing.T,
+	ent TEnt,
+) {
+	t.Helper()
+
+	var tt T = *ent
+	t.Run(tt.GetTypeName(), func(t *testing.T) {
+		cl := fakectrlruntimeclient.NewFakeClient()
+		require.NotNil(t, cl)
+		watchOptions := ReconciliationWatchOptionsForEntity[T, TEnt](cl, ent)
+		_ = watchOptions
+	})
+}

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -62,6 +62,8 @@ const (
 	KonnectControlPlaneControllerName = "KonnectControlPlane"
 	// KongServiceControllerName is the name of the KongService controller.
 	KongServiceControllerName = "KongService"
+	// KongRouteControllerName is the name of the KongRoute controller.
+	KongRouteControllerName = "KongRoute"
 	// KongConsumerControllerName is the name of the KongConsumer controller.
 	KongConsumerControllerName = "KongConsumer"
 )
@@ -312,7 +314,7 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 		}
 		controllers[KonnectControlPlaneControllerName] = ControllerDef{
 			Enabled: c.KonnectControllersEnabled,
-			Controller: konnect.NewKonnectEntityReconciler[konnectv1alpha1.KonnectControlPlane](
+			Controller: konnect.NewKonnectEntityReconciler(
 				sdkFactory,
 				c.DevelopmentMode,
 				mgr.GetClient(),
@@ -321,16 +323,25 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 		}
 		controllers[KongServiceControllerName] = ControllerDef{
 			Enabled: c.KonnectControllersEnabled,
-			Controller: konnect.NewKonnectEntityReconciler[configurationv1alpha1.KongService](
+			Controller: konnect.NewKonnectEntityReconciler(
 				sdkFactory,
 				c.DevelopmentMode,
 				mgr.GetClient(),
 				konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongService](c.KonnectSyncPeriod),
 			),
 		}
+		controllers[KongRouteControllerName] = ControllerDef{
+			Enabled: c.KonnectControllersEnabled,
+			Controller: konnect.NewKonnectEntityReconciler(
+				sdkFactory,
+				c.DevelopmentMode,
+				mgr.GetClient(),
+				konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongRoute](c.KonnectSyncPeriod),
+			),
+		}
 		controllers[KongConsumerControllerName] = ControllerDef{
 			Enabled: c.KonnectControllersEnabled,
-			Controller: konnect.NewKonnectEntityReconciler[configurationv1.KongConsumer](
+			Controller: konnect.NewKonnectEntityReconciler(
 				sdkFactory,
 				c.DevelopmentMode,
 				mgr.GetClient(),


### PR DESCRIPTION
**What this PR does / why we need it**:

Add KongRoute reconciler.

This adds cascade delete for KongService: Konnect blocks deletion of Services when they contain Routes. This PR makes it so that when this happens (user requests a deletion of `KongService`) then the operator will mark the route for deletion, so that it is deleted first and then `KongService` deletion can resume.

!Requires: https://github.com/Kong/kubernetes-configuration/pull/53!

**Which issue this PR fixes**

Part of #435 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
