### PR TITLE
feat(cli): configurable certgen images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
   [#506](https://github.com/Kong/gateway-operator/pull/506)
 - Add `KongConsumerGroup` reconciler for Konnect control planes.
   [#510](https://github.com/Kong/gateway-operator/pull/510)
+- Added command line flags to configure the certificate generator job's images.
+  [#516](https://github.com/Kong/gateway-operator/pull/516)
 
 ### Fixed
 

--- a/modules/cli/cli.go
+++ b/modules/cli/cli.go
@@ -52,6 +52,8 @@ func New(m metadata.Info) *CLI {
 
 	// webhook and validation options
 	flagSet.BoolVar(&deferCfg.ValidatingWebhookEnabled, "enable-validating-webhook", true, "Enable the validating webhook.")
+	flagSet.StringVar(&deferCfg.WebhookCertificateConfigBaseImage, "webhook-certificate-config-base-image", consts.WebhookCertificateConfigBaseImage, "The base image for the certgen Jobs.")
+	flagSet.StringVar(&deferCfg.WebhookCertificateConfigShellImage, "webhook-certificate-config-shell-image", "busybox", "The shell image for the certgen Jobs.")
 
 	flagSet.BoolVar(&deferCfg.Version, "version", false, "Print version information.")
 
@@ -88,10 +90,12 @@ type CLI struct {
 }
 
 type flagsForFurtherEvaluation struct {
-	DisableLeaderElection    bool
-	ClusterCASecretNamespace string
-	ValidatingWebhookEnabled bool
-	Version                  bool
+	DisableLeaderElection              bool
+	ClusterCASecretNamespace           string
+	ValidatingWebhookEnabled           bool
+	Version                            bool
+	WebhookCertificateConfigBaseImage  string
+	WebhookCertificateConfigShellImage string
 }
 
 const (
@@ -167,6 +171,9 @@ func (c *CLI) Parse(arguments []string) manager.Config {
 		anonymousReportsEnabled = false
 	}
 
+	webhookCertificateConfigBaseImage := c.deferFlagValues.WebhookCertificateConfigBaseImage
+	webhookCertificateConfigShellImage := c.deferFlagValues.WebhookCertificateConfigShellImage
+
 	if c.deferFlagValues.Version {
 		type Version struct {
 			Release string `json:"release"`
@@ -218,6 +225,8 @@ func (c *CLI) Parse(arguments []string) manager.Config {
 	c.cfg.WebhookPort = manager.DefaultConfig().WebhookPort
 	c.cfg.LeaderElectionNamespace = controllerNamespace
 	c.cfg.AnonymousReports = anonymousReportsEnabled
+	c.cfg.WebhookCertificateConfigBaseImage = webhookCertificateConfigBaseImage
+	c.cfg.WebhookCertificateConfigShellImage = webhookCertificateConfigShellImage
 
 	return *c.cfg
 }

--- a/modules/cli/cli.go
+++ b/modules/cli/cli.go
@@ -171,9 +171,6 @@ func (c *CLI) Parse(arguments []string) manager.Config {
 		anonymousReportsEnabled = false
 	}
 
-	webhookCertificateConfigBaseImage := c.deferFlagValues.WebhookCertificateConfigBaseImage
-	webhookCertificateConfigShellImage := c.deferFlagValues.WebhookCertificateConfigShellImage
-
 	if c.deferFlagValues.Version {
 		type Version struct {
 			Release string `json:"release"`
@@ -225,8 +222,8 @@ func (c *CLI) Parse(arguments []string) manager.Config {
 	c.cfg.WebhookPort = manager.DefaultConfig().WebhookPort
 	c.cfg.LeaderElectionNamespace = controllerNamespace
 	c.cfg.AnonymousReports = anonymousReportsEnabled
-	c.cfg.WebhookCertificateConfigBaseImage = webhookCertificateConfigBaseImage
-	c.cfg.WebhookCertificateConfigShellImage = webhookCertificateConfigShellImage
+	c.cfg.WebhookCertificateConfigBaseImage = c.deferFlagValues.WebhookCertificateConfigBaseImage
+	c.cfg.WebhookCertificateConfigShellImage = c.deferFlagValues.WebhookCertificateConfigShellImage
 
 	return *c.cfg
 }

--- a/modules/cli/cli.go
+++ b/modules/cli/cli.go
@@ -52,8 +52,8 @@ func New(m metadata.Info) *CLI {
 
 	// webhook and validation options
 	flagSet.BoolVar(&deferCfg.ValidatingWebhookEnabled, "enable-validating-webhook", true, "Enable the validating webhook.")
-	flagSet.StringVar(&deferCfg.WebhookCertificateConfigBaseImage, "webhook-certificate-config-base-image", consts.WebhookCertificateConfigBaseImage, "The base image for the certgen Jobs.")
-	flagSet.StringVar(&deferCfg.WebhookCertificateConfigShellImage, "webhook-certificate-config-shell-image", "busybox", "The shell image for the certgen Jobs.")
+	flagSet.StringVar(&cfg.WebhookCertificateConfigBaseImage, "webhook-certificate-config-base-image", consts.WebhookCertificateConfigBaseImage, "The base image for the certgen Jobs.")
+	flagSet.StringVar(&cfg.WebhookCertificateConfigShellImage, "webhook-certificate-config-shell-image", consts.WebhookCertificateConfigShellImage, "The shell image for the certgen Jobs.")
 
 	flagSet.BoolVar(&deferCfg.Version, "version", false, "Print version information.")
 
@@ -90,12 +90,10 @@ type CLI struct {
 }
 
 type flagsForFurtherEvaluation struct {
-	DisableLeaderElection              bool
-	ClusterCASecretNamespace           string
-	ValidatingWebhookEnabled           bool
-	Version                            bool
-	WebhookCertificateConfigBaseImage  string
-	WebhookCertificateConfigShellImage string
+	DisableLeaderElection    bool
+	ClusterCASecretNamespace string
+	ValidatingWebhookEnabled bool
+	Version                  bool
 }
 
 const (
@@ -222,8 +220,6 @@ func (c *CLI) Parse(arguments []string) manager.Config {
 	c.cfg.WebhookPort = manager.DefaultConfig().WebhookPort
 	c.cfg.LeaderElectionNamespace = controllerNamespace
 	c.cfg.AnonymousReports = anonymousReportsEnabled
-	c.cfg.WebhookCertificateConfigBaseImage = c.deferFlagValues.WebhookCertificateConfigBaseImage
-	c.cfg.WebhookCertificateConfigShellImage = c.deferFlagValues.WebhookCertificateConfigShellImage
 
 	return *c.cfg
 }

--- a/modules/cli/cli_test.go
+++ b/modules/cli/cli_test.go
@@ -78,6 +78,19 @@ func TestParse(t *testing.T) {
 				return cfg
 			},
 		},
+		{
+			name: "webhook certificate configuration arguments are set",
+			args: []string{
+				"--webhook-certificate-config-base-image=mybaseimage:42",
+				"--webhook-certificate-config-shell-image=shellimg",
+			},
+			expectedCfg: func() manager.Config {
+				cfg := expectedDefaultCfg()
+				cfg.WebhookCertificateConfigBaseImage = "mybaseimage:42"
+				cfg.WebhookCertificateConfigShellImage = "shellimg"
+				return cfg
+			},
+		},
 	}
 
 	for _, tC := range testCases {
@@ -154,7 +167,7 @@ func expectedDefaultCfg() manager.Config {
 		KongPluginInstallationControllerEnabled: false,
 		ValidatingWebhookEnabled:                true,
 		WebhookCertificateConfigBaseImage:       consts.WebhookCertificateConfigBaseImage,
-		WebhookCertificateConfigShellImage:      "busybox",
+		WebhookCertificateConfigShellImage:      consts.WebhookCertificateConfigShellImage,
 		LoggerOpts:                              &zap.Options{},
 	}
 }

--- a/modules/cli/cli_test.go
+++ b/modules/cli/cli_test.go
@@ -153,6 +153,8 @@ func expectedDefaultCfg() manager.Config {
 		KonnectSyncPeriod:                       consts.DefaultKonnectSyncPeriod,
 		KongPluginInstallationControllerEnabled: false,
 		ValidatingWebhookEnabled:                true,
+		WebhookCertificateConfigBaseImage:       consts.WebhookCertificateConfigBaseImage,
+		WebhookCertificateConfigShellImage:      "busybox",
 		LoggerOpts:                              &zap.Options{},
 	}
 }

--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -92,7 +92,9 @@ type Config struct {
 	KonnectControllersEnabled bool
 
 	// webhook and validation options
-	ValidatingWebhookEnabled bool
+	ValidatingWebhookEnabled           bool
+	WebhookCertificateConfigBaseImage  string
+	WebhookCertificateConfigShellImage string
 }
 
 // DefaultConfig returns a default configuration for the manager.

--- a/modules/manager/webhook.go
+++ b/modules/manager/webhook.go
@@ -256,16 +256,18 @@ func (m *webhookManager) createWebhookResources(ctx context.Context) error {
 }
 
 func (m *webhookManager) createCertificateConfigJobs(ctx context.Context) error {
-	jobCertificateConfigImage := consts.WebhookCertificateConfigBaseImage
+	jobCertificateConfigBaseImage := m.cfg.WebhookCertificateConfigBaseImage
+	jobCertificateConfigShellImage := m.cfg.WebhookCertificateConfigShellImage
 	if relatedJobImage := os.Getenv("RELATED_IMAGE_CERTIFICATE_CONFIG"); relatedJobImage != "" {
 		// RELATED_IMAGE_CERTIFICATE_CONFIG is set by the operator-sdk when building the operator bundle.
 		// https://github.com/Kong/gateway-operator-archive/issues/261
-		jobCertificateConfigImage = relatedJobImage
+		jobCertificateConfigBaseImage = relatedJobImage
 	}
 	job := k8sresources.GenerateNewWebhookCertificateConfigJob(
 		m.cfg.ControllerNamespace,
 		consts.WebhookCertificateConfigName,
-		jobCertificateConfigImage,
+		jobCertificateConfigBaseImage,
+		jobCertificateConfigShellImage,
 		consts.WebhookCertificateConfigSecretName,
 		consts.WebhookName,
 	)

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -128,6 +128,8 @@ const (
 const (
 	// WebhookCertificateConfigBaseImage is the image to use by the certificate config Jobs.
 	WebhookCertificateConfigBaseImage = "registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.3.0"
+	// WebhookCertificateConfigShellImage is the image to use by the certificate config Jobs.
+	WebhookCertificateConfigShellImage = "busybox"
 	// WebhookName is the ValidatingWebhookConfiguration name.
 	WebhookName = "gateway-operator-validation.konghq.com"
 	// WebhookCertificateConfigSecretName is the name of the secret containing the webhook certificate.

--- a/pkg/utils/kubernetes/resources/jobs.go
+++ b/pkg/utils/kubernetes/resources/jobs.go
@@ -18,7 +18,8 @@ import (
 // GenerateNewWebhookCertificateConfigJob generates the create and patch jobs for the certificateConfig
 func GenerateNewWebhookCertificateConfigJob(namespace,
 	serviceAccountName,
-	imageName,
+	baseImageName,
+	shellImageName,
 	secretName,
 	webhookName string,
 ) *batchv1.Job {
@@ -39,7 +40,7 @@ func GenerateNewWebhookCertificateConfigJob(namespace,
 					fmt.Sprintf("--namespace=%s", namespace),
 					fmt.Sprintf("--secret-name=%s", secretName),
 				},
-				Image:           imageName,
+				Image:           baseImageName,
 				ImagePullPolicy: corev1.PullIfNotPresent,
 			},
 			{
@@ -53,7 +54,7 @@ func GenerateNewWebhookCertificateConfigJob(namespace,
 					fmt.Sprintf("--secret-name=%s", secretName),
 					"--patch-failure-policy=Fail",
 				},
-				Image:           imageName,
+				Image:           baseImageName,
 				ImagePullPolicy: corev1.PullIfNotPresent,
 			},
 		}
@@ -61,7 +62,7 @@ func GenerateNewWebhookCertificateConfigJob(namespace,
 		j.Spec.Template.Spec.Containers = []corev1.Container{
 			{
 				Name:            "done",
-				Image:           "busybox",
+				Image:           shellImageName,
 				Args:            []string{"echo", "done"},
 				ImagePullPolicy: corev1.PullIfNotPresent,
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

Add two new command line options to the manager.

```
  -webhook-certificate-config-base-image string
    	The base image for the certgen Jobs. (default "registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.3.0")
  -webhook-certificate-config-shell-image string
    	The shell image for the certgen Jobs. (default "busybox")
```

Those are optional. If you omit them the defaults will be used which are the previous hard coded values.

By using these command line arguments the user can deploy kong-gateway-operator to a cluster where external Docker repositories are not reachable or prohibited to use them.

**Which issue this PR fixes**

Fixes #515.

**Special notes for your reviewer**:

I don't think this is a significant change and as this is my first PR I am not sure if I have to touch CHANGELOG.md or not.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
