### PR TITLE
feat: Add watch for KongPlugin and KongClusterPlugin in KongPluginBinding controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
   [#516](https://github.com/Kong/gateway-operator/pull/516)
 - Add `KongPluginBinding` reconciler for Konnect Plugins.
   [#513](https://github.com/Kong/gateway-operator/pull/513)
+  [#535](https://github.com/Kong/gateway-operator/pull/535)
 
 ### Fixed
 

--- a/controller/konnect/index.go
+++ b/controller/konnect/index.go
@@ -1,0 +1,24 @@
+package konnect
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+)
+
+// ReconciliationIndexOption contains required options of index for a kind of object required for reconciliation.
+type ReconciliationIndexOption struct {
+	IndexObject  client.Object
+	IndexField   string
+	ExtractValue client.IndexerFunc
+}
+
+// ReconciliationIndexOptionsForEntity returns required index options for controller reconciliing the entity.
+func ReconciliationIndexOptionsForEntity[T SupportedKonnectEntityType,
+	TEnt EntityType[T]](ent TEnt) []ReconciliationIndexOption {
+	switch any(ent).(type) { //nolint:gocritic // TODO: add index options required for other entities
+	case *configurationv1alpha1.KongPluginBinding:
+		return IndexOptionsForKongPluginBinding()
+	}
+	return nil
+}

--- a/controller/konnect/index_kongpluginbinding.go
+++ b/controller/konnect/index_kongpluginbinding.go
@@ -1,0 +1,54 @@
+package konnect
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+)
+
+const (
+	// IndexFieldKongPluginBindingKongPluginReference is the index field for KongPlugin -> KongPluginBinding.
+	IndexFieldKongPluginBindingKongPluginReference = "kongPluginRef"
+	// IndexFieldKongPluginBindingKongClusterPluginReference is the index field for KongClusterPlugin -> KongPluginBinding.
+	IndexFieldKongPluginBindingKongClusterPluginReference = "kongClusterPluginRef"
+)
+
+// IndexOptionsForKongPluginBinding returns required Index options for KongPluginBinding reconclier.
+func IndexOptionsForKongPluginBinding() []ReconciliationIndexOption {
+	return []ReconciliationIndexOption{
+		{
+			IndexObject:  &configurationv1alpha1.KongPluginBinding{},
+			IndexField:   IndexFieldKongPluginBindingKongClusterPluginReference,
+			ExtractValue: kongPluginReferencesFromKongPluginBinding,
+		},
+		{
+			IndexObject:  &configurationv1alpha1.KongPluginBinding{},
+			IndexField:   IndexFieldKongPluginBindingKongClusterPluginReference,
+			ExtractValue: kongClusterPluginReferencesFromKongPluginBinding,
+		},
+	}
+}
+
+// kongPluginReferencesFromKongPluginBinding returns namespace/name of referenced KongPlugin in KongPluginBinding spec.
+func kongPluginReferencesFromKongPluginBinding(obj client.Object) []string {
+	binding, ok := obj.(*configurationv1alpha1.KongPluginBinding)
+	if !ok {
+		return nil
+	}
+	if binding.Spec.PluginReference.Kind != nil && *binding.Spec.PluginReference.Kind != "KongPlugin" {
+		return nil
+	}
+	return []string{binding.Namespace + "/" + binding.Spec.PluginReference.Name}
+}
+
+// kongClusterPluginReferencesFromKongPluginBinding returns name of referenced KongClusterPlugin in KongPluginBinding spec.
+func kongClusterPluginReferencesFromKongPluginBinding(obj client.Object) []string {
+	binding, ok := obj.(*configurationv1alpha1.KongPluginBinding)
+	if !ok {
+		return nil
+	}
+	if binding.Spec.PluginReference.Kind == nil || *binding.Spec.PluginReference.Kind != "KongClusterPlugin" {
+		return nil
+	}
+	return []string{binding.Spec.PluginReference.Name}
+}

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -98,6 +98,13 @@ func (r *KonnectEntityReconciler[T, TEnt]) SetupWithManager(mgr ctrl.Manager) er
 			})
 	)
 
+	for _, ind := range ReconciliationIndexOptionsForEntity(ent) {
+		if err := mgr.GetCache().IndexField(context.Background(), ind.IndexObject, ind.IndexField, ind.ExtractValue); err != nil {
+			fmt.Println("Create index:", err)
+			return err
+		}
+	}
+
 	for _, dep := range ReconciliationWatchOptionsForEntity(r.Client, ent) {
 		b = dep(b)
 	}

--- a/controller/konnect/reconciler_generic_test.go
+++ b/controller/konnect/reconciler_generic_test.go
@@ -22,7 +22,10 @@ func TestNewKonnectEntityReconciler(t *testing.T) {
 	testNewKonnectEntityReconciler(t, configurationv1.KongConsumer{})
 	testNewKonnectEntityReconciler(t, configurationv1alpha1.KongRoute{})
 	testNewKonnectEntityReconciler(t, configurationv1beta1.KongConsumerGroup{})
-	testNewKonnectEntityReconciler(t, configurationv1alpha1.KongPluginBinding{})
+	// TODO: Reconcilers setting index require a real k8s API server:
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/657
+	// Maybe we should import envtest.
+	// testNewKonnectEntityReconciler(t, configurationv1alpha1.KongPluginBinding{})
 }
 
 func testNewKonnectEntityReconciler[
@@ -39,9 +42,11 @@ func testNewKonnectEntityReconciler[
 	t.Run(ent.GetTypeName(), func(t *testing.T) {
 		cl := fakectrlruntimeclient.NewFakeClient()
 		mgr, err := ctrl.NewManager(&rest.Config{}, ctrl.Options{
+
 			Scheme: scheme.Get(),
 		})
 		require.NoError(t, err)
+
 		reconciler := NewKonnectEntityReconciler[T, TEnt](sdkFactory, false, cl)
 		require.NoError(t, reconciler.SetupWithManager(mgr))
 	})


### PR DESCRIPTION


**What this PR does / why we need it**:

Add watches of `KongPlguin` and `KongClusterPlugin` in `KongPluginBinding` to enqueue `KongPluginBinding` when referenced `KongPlugin` or `KongClusterPlugin` changes.

**Which issue this PR fixes**

Fixes #528 and #529

**Special notes for your reviewer**:
Since the PR adds `IndexField` to manager's cache, it requires a k8s server to run the reconciler. Should we import the `envtest` framework for testing (maybe in another PR)?

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
