### PR TITLE
chore(crd): bump `Kong/kubernetes-configuration` and change `KonnectControlPlane` to `KonnectGatewayControlPlane`

### DIFF
--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -334,7 +334,7 @@ rules:
   - konnect.konghq.com
   resources:
   - konnectapiauthconfigurations
-  - konnectcontrolplanes
+  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -345,7 +345,7 @@ rules:
   - konnect.konghq.com
   resources:
   - konnectapiauthconfigurations/status
-  - konnectcontrolplanes/status
+  - konnectgatewaycontrolplanes/status
   verbs:
   - get
   - patch

--- a/config/samples/konnect-kongpluginbinding.yaml
+++ b/config/samples/konnect-kongpluginbinding.yaml
@@ -9,7 +9,7 @@ spec:
   token: kpat_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
   serverURL: eu.api.konghq.tech 
 ---
-kind: KonnectControlPlane
+kind: KonnectGatewayControlPlane
 apiVersion: konnect.konghq.com/v1alpha1
 metadata:
   name: demo-cp

--- a/config/samples/konnect_kongconsumer.yaml
+++ b/config/samples/konnect_kongconsumer.yaml
@@ -8,7 +8,7 @@ spec:
   token: kpat_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
   serverURL: us.api.konghq.com
 ---
-kind: KonnectControlPlane
+kind: KonnectGatewayControlPlane
 apiVersion: konnect.konghq.com/v1alpha1
 metadata:
   name: test1

--- a/config/samples/konnect_kongconsumergroup.yaml
+++ b/config/samples/konnect_kongconsumergroup.yaml
@@ -8,7 +8,7 @@ spec:
   token: kpat_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
   serverURL: us.api.konghq.com
 ---
-kind: KonnectControlPlane
+kind: KonnectGatewayControlPlane
 apiVersion: konnect.konghq.com/v1alpha1
 metadata:
   name: test1

--- a/config/samples/konnect_kongroute.yaml
+++ b/config/samples/konnect_kongroute.yaml
@@ -8,7 +8,7 @@ spec:
   token: kpat_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
   serverURL: us.api.konghq.com
 ---
-kind: KonnectControlPlane
+kind: KonnectGatewayControlPlane
 apiVersion: konnect.konghq.com/v1alpha1
 metadata:
   name: test1

--- a/config/samples/konnect_kongservice.yaml
+++ b/config/samples/konnect_kongservice.yaml
@@ -8,7 +8,7 @@ spec:
   token: kpat_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
   serverURL: us.api.konghq.com
 ---
-kind: KonnectControlPlane
+kind: KonnectGatewayControlPlane
 apiVersion: konnect.konghq.com/v1alpha1
 metadata:
   name: test1

--- a/controller/konnect/constraints.go
+++ b/controller/konnect/constraints.go
@@ -13,7 +13,7 @@ import (
 // SupportedKonnectEntityType is an interface that all Konnect entity types
 // must implement.
 type SupportedKonnectEntityType interface {
-	konnectv1alpha1.KonnectControlPlane |
+	konnectv1alpha1.KonnectGatewayControlPlane |
 		configurationv1alpha1.KongService |
 		configurationv1alpha1.KongRoute |
 		configurationv1.KongConsumer |

--- a/controller/konnect/errors.go
+++ b/controller/konnect/errors.go
@@ -26,7 +26,7 @@ func (e FailedKonnectOpError[T]) Unwrap() error {
 }
 
 // ReferencedControlPlaneDoesNotExistError is an error type that is returned when
-// a Konnect entity references a KonnectControlPlane that does not exist.
+// a Konnect entity references a KonnectGatewayControlPlane that does not exist.
 type ReferencedControlPlaneDoesNotExistError struct {
 	Reference types.NamespacedName
 	Err       error

--- a/controller/konnect/ops.go
+++ b/controller/konnect/ops.go
@@ -51,7 +51,7 @@ func Create[
 	defer logOpComplete[T, TEnt](ctx, time.Now(), CreateOp, e)
 
 	switch ent := any(e).(type) {
-	case *konnectv1alpha1.KonnectControlPlane:
+	case *konnectv1alpha1.KonnectGatewayControlPlane:
 		return e, createControlPlane(ctx, sdk, ent)
 	case *configurationv1alpha1.KongService:
 		return e, createService(ctx, sdk, ent)
@@ -89,7 +89,7 @@ func Delete[
 	defer logOpComplete[T, TEnt](ctx, time.Now(), DeleteOp, e)
 
 	switch ent := any(e).(type) {
-	case *konnectv1alpha1.KonnectControlPlane:
+	case *konnectv1alpha1.KonnectGatewayControlPlane:
 		return deleteControlPlane(ctx, sdk, ent)
 	case *configurationv1alpha1.KongService:
 		return deleteService(ctx, sdk, ent)
@@ -152,7 +152,7 @@ func Update[
 	defer logOpComplete[T, TEnt](ctx, now, UpdateOp, e)
 
 	switch ent := any(e).(type) {
-	case *konnectv1alpha1.KonnectControlPlane:
+	case *konnectv1alpha1.KonnectGatewayControlPlane:
 		return ctrl.Result{}, updateControlPlane(ctx, sdk, ent)
 	case *configurationv1alpha1.KongService:
 		return ctrl.Result{}, updateService(ctx, sdk, cl, ent)

--- a/controller/konnect/ops_controlplane.go
+++ b/controller/konnect/ops_controlplane.go
@@ -18,7 +18,7 @@ import (
 func createControlPlane(
 	ctx context.Context,
 	sdk *sdkkonnectgo.SDK,
-	cp *konnectv1alpha1.KonnectControlPlane,
+	cp *konnectv1alpha1.KonnectGatewayControlPlane,
 ) error {
 	resp, err := sdk.ControlPlanes.CreateControlPlane(ctx, cp.Spec.CreateControlPlaneRequest)
 	// TODO: handle already exists
@@ -59,7 +59,7 @@ func createControlPlane(
 func deleteControlPlane(
 	ctx context.Context,
 	sdk *sdkkonnectgo.SDK,
-	cp *konnectv1alpha1.KonnectControlPlane,
+	cp *konnectv1alpha1.KonnectGatewayControlPlane,
 ) error {
 	id := cp.GetKonnectStatus().GetKonnectID()
 	_, err := sdk.ControlPlanes.DeleteControlPlane(ctx, id)
@@ -74,12 +74,12 @@ func deleteControlPlane(
 		}
 		var sdkError *sdkerrors.SDKError
 		if errors.As(errWrap, &sdkError) {
-			return FailedKonnectOpError[konnectv1alpha1.KonnectControlPlane]{
+			return FailedKonnectOpError[konnectv1alpha1.KonnectGatewayControlPlane]{
 				Op:  DeleteOp,
 				Err: sdkError,
 			}
 		}
-		return FailedKonnectOpError[konnectv1alpha1.KonnectControlPlane]{
+		return FailedKonnectOpError[konnectv1alpha1.KonnectGatewayControlPlane]{
 			Op:  DeleteOp,
 			Err: errWrap,
 		}
@@ -94,7 +94,7 @@ func deleteControlPlane(
 func updateControlPlane(
 	ctx context.Context,
 	sdk *sdkkonnectgo.SDK,
-	cp *konnectv1alpha1.KonnectControlPlane,
+	cp *konnectv1alpha1.KonnectGatewayControlPlane,
 ) error {
 	id := cp.GetKonnectStatus().GetKonnectID()
 	req := components.UpdateControlPlaneRequest{
@@ -113,7 +113,7 @@ func updateControlPlane(
 				"type", cp.GetTypeName(), "id", id,
 			)
 		if err := createControlPlane(ctx, sdk, cp); err != nil {
-			return FailedKonnectOpError[konnectv1alpha1.KonnectControlPlane]{
+			return FailedKonnectOpError[konnectv1alpha1.KonnectGatewayControlPlane]{
 				Op:  UpdateOp,
 				Err: err,
 			}
@@ -134,7 +134,7 @@ func updateControlPlane(
 			),
 			cp,
 		)
-		return FailedKonnectOpError[konnectv1alpha1.KonnectControlPlane]{
+		return FailedKonnectOpError[konnectv1alpha1.KonnectGatewayControlPlane]{
 			Op:  UpdateOp,
 			Err: errWrap,
 		}

--- a/controller/konnect/ops_kongconsumer.go
+++ b/controller/konnect/ops_kongconsumer.go
@@ -86,16 +86,16 @@ func updateConsumer(
 		Namespace: consumer.Namespace,
 		Name:      consumer.Spec.ControlPlaneRef.KonnectNamespacedRef.Name,
 	}
-	var cp konnectv1alpha1.KonnectControlPlane
+	var cp konnectv1alpha1.KonnectGatewayControlPlane
 	if err := cl.Get(ctx, nnCP, &cp); err != nil {
-		return fmt.Errorf("failed to get KonnectControlPlane %s: for %T %s: %w",
+		return fmt.Errorf("failed to get KonnectGatewayControlPlane %s: for %T %s: %w",
 			nnCP, consumer, client.ObjectKeyFromObject(consumer), err,
 		)
 	}
 
 	if cp.Status.ID == "" {
 		return fmt.Errorf(
-			"can't update %T when referenced KonnectControlPlane %s does not have the Konnect ID",
+			"can't update %T when referenced KonnectGatewayControlPlane %s does not have the Konnect ID",
 			consumer, nnCP,
 		)
 	}

--- a/controller/konnect/ops_kongconsumergroup.go
+++ b/controller/konnect/ops_kongconsumergroup.go
@@ -86,16 +86,16 @@ func updateConsumerGroup(
 		Namespace: group.Namespace,
 		Name:      group.Spec.ControlPlaneRef.KonnectNamespacedRef.Name,
 	}
-	var cp konnectv1alpha1.KonnectControlPlane
+	var cp konnectv1alpha1.KonnectGatewayControlPlane
 	if err := cl.Get(ctx, nnCP, &cp); err != nil {
-		return fmt.Errorf("failed to get KonnectControlPlane %s: for %T %s: %w",
+		return fmt.Errorf("failed to get KonnectGatewayControlPlane %s: for %T %s: %w",
 			nnCP, group, client.ObjectKeyFromObject(group), err,
 		)
 	}
 
 	if cp.Status.ID == "" {
 		return fmt.Errorf(
-			"can't update %T when referenced KonnectControlPlane %s does not have the Konnect ID",
+			"can't update %T when referenced KonnectGatewayControlPlane %s does not have the Konnect ID",
 			group, nnCP,
 		)
 	}

--- a/controller/konnect/ops_kongpluginbinding.go
+++ b/controller/konnect/ops_kongpluginbinding.go
@@ -101,16 +101,16 @@ func updatePlugin(
 		Namespace: pb.Namespace,
 		Name:      pb.Spec.ControlPlaneRef.KonnectNamespacedRef.Name,
 	}
-	var cp konnectv1alpha1.KonnectControlPlane
+	var cp konnectv1alpha1.KonnectGatewayControlPlane
 	if err := cl.Get(ctx, nnCP, &cp); err != nil {
-		return fmt.Errorf("failed to get KonnectControlPlane %s: for %T %s: %w",
+		return fmt.Errorf("failed to get KonnectGatewayControlPlane %s: for %T %s: %w",
 			nnCP, pb, client.ObjectKeyFromObject(pb), err,
 		)
 	}
 
 	if cp.Status.ID == "" {
 		return fmt.Errorf(
-			"can't update %T when referenced KonnectControlPlane %s does not have the Konnect ID",
+			"can't update %T when referenced KonnectGatewayControlPlane %s does not have the Konnect ID",
 			pb, nnCP,
 		)
 	}
@@ -272,7 +272,7 @@ func kongPluginBindingToSDKPluginInput(
 		Enabled: lo.ToPtr(!plugin.Disabled),
 	}
 
-	// TODO(mlavacca): check all the entities reference the same KonnectControlPlane
+	// TODO(mlavacca): check all the entities reference the same KonnectGatewayControlPlane
 
 	for _, t := range targets {
 		switch t := t.(type) {

--- a/controller/konnect/ops_kongroute.go
+++ b/controller/konnect/ops_kongroute.go
@@ -96,20 +96,20 @@ func updateRoute(
 		)
 	}
 
-	var cp konnectv1alpha1.KonnectControlPlane
+	var cp konnectv1alpha1.KonnectGatewayControlPlane
 	nnCP := types.NamespacedName{
 		Namespace: svc.Namespace,
 		Name:      svc.Spec.ControlPlaneRef.KonnectNamespacedRef.Name,
 	}
 	if err := cl.Get(ctx, nnCP, &cp); err != nil {
-		return fmt.Errorf("failed to get KonnectControlPlane %s: for KongRoute %s: %w",
+		return fmt.Errorf("failed to get KonnectGatewayControlPlane %s: for KongRoute %s: %w",
 			nnSvc, client.ObjectKeyFromObject(route), err,
 		)
 	}
 
 	if cp.Status.ID == "" {
 		return fmt.Errorf(
-			"can't update %T when referenced KonnectControlPlane %s does not have the Konnect ID",
+			"can't update %T when referenced KonnectGatewayControlPlane %s does not have the Konnect ID",
 			route, nnSvc,
 		)
 	}

--- a/controller/konnect/ops_kongservice.go
+++ b/controller/konnect/ops_kongservice.go
@@ -86,16 +86,16 @@ func updateService(
 		Namespace: svc.Namespace,
 		Name:      svc.Spec.ControlPlaneRef.KonnectNamespacedRef.Name,
 	}
-	var cp konnectv1alpha1.KonnectControlPlane
+	var cp konnectv1alpha1.KonnectGatewayControlPlane
 	if err := cl.Get(ctx, nnCP, &cp); err != nil {
-		return fmt.Errorf("failed to get KonnectControlPlane %s: for %T %s: %w",
+		return fmt.Errorf("failed to get KonnectGatewayControlPlane %s: for %T %s: %w",
 			nnCP, svc, client.ObjectKeyFromObject(svc), err,
 		)
 	}
 
 	if cp.Status.ID == "" {
 		return fmt.Errorf(
-			"can't update %T when referenced KonnectControlPlane %s does not have the Konnect ID",
+			"can't update %T when referenced KonnectGatewayControlPlane %s does not have the Konnect ID",
 			svc, nnCP,
 		)
 	}

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -443,7 +443,7 @@ func getCPForRef(
 	cl client.Client,
 	cpRef configurationv1alpha1.ControlPlaneRef,
 	namespace string,
-) (*konnectv1alpha1.KonnectControlPlane, error) {
+) (*konnectv1alpha1.KonnectGatewayControlPlane, error) {
 	if cpRef.Type != configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef {
 		return nil, fmt.Errorf("unsupported ControlPlane ref type %q", cpRef.Type)
 	}
@@ -453,7 +453,7 @@ func getCPForRef(
 		Namespace: namespace,
 	}
 
-	var cp konnectv1alpha1.KonnectControlPlane
+	var cp konnectv1alpha1.KonnectGatewayControlPlane
 	if err := cl.Get(ctx, nn, &cp); err != nil {
 		return nil, fmt.Errorf("failed to get ControlPlane %s", nn)
 	}
@@ -536,7 +536,7 @@ func getServiceRef[T SupportedKonnectEntityType, TEnt EntityType[T]](
 	case *configurationv1alpha1.KongService,
 		*configurationv1.KongConsumer,
 		*configurationv1beta1.KongConsumerGroup,
-		*konnectv1alpha1.KonnectControlPlane:
+		*konnectv1alpha1.KonnectGatewayControlPlane:
 		return mo.None[configurationv1alpha1.ServiceRef]()
 	case *configurationv1alpha1.KongRoute:
 		if e.Spec.ServiceRef == nil {
@@ -707,7 +707,7 @@ func getControlPlaneRef[T SupportedKonnectEntityType, TEnt EntityType[T]](
 	e TEnt,
 ) mo.Option[configurationv1alpha1.ControlPlaneRef] {
 	switch e := any(e).(type) {
-	case *konnectv1alpha1.KonnectControlPlane, *configurationv1alpha1.KongRoute:
+	case *konnectv1alpha1.KonnectGatewayControlPlane, *configurationv1alpha1.KongRoute:
 		return mo.None[configurationv1alpha1.ControlPlaneRef]()
 	case *configurationv1.KongConsumer:
 		if e.Spec.ControlPlaneRef == nil {
@@ -749,7 +749,7 @@ func handleControlPlaneRef[T SupportedKonnectEntityType, TEnt EntityType[T]](
 
 	switch cpRef.Type {
 	case configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef:
-		cp := konnectv1alpha1.KonnectControlPlane{}
+		cp := konnectv1alpha1.KonnectGatewayControlPlane{}
 		// TODO(pmalek): handle cross namespace refs
 		nn := types.NamespacedName{
 			Name:      cpRef.KonnectNamespacedRef.Name,

--- a/controller/konnect/reconciler_generic_rbac.go
+++ b/controller/konnect/reconciler_generic_rbac.go
@@ -3,8 +3,8 @@ package konnect
 //+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectapiauthconfigurations,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectapiauthconfigurations/status,verbs=get;update;patch
 
-//+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectcontrolplanes,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectcontrolplanes/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectgatewaycontrolplanes,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectgatewaycontrolplanes/status,verbs=get;update;patch
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongservices,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongservices/status,verbs=get;update;patch

--- a/controller/konnect/reconciler_generic_test.go
+++ b/controller/konnect/reconciler_generic_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestNewKonnectEntityReconciler(t *testing.T) {
-	testNewKonnectEntityReconciler(t, konnectv1alpha1.KonnectControlPlane{})
+	testNewKonnectEntityReconciler(t, konnectv1alpha1.KonnectGatewayControlPlane{})
 	testNewKonnectEntityReconciler(t, configurationv1alpha1.KongService{})
 	testNewKonnectEntityReconciler(t, configurationv1.KongConsumer{})
 	testNewKonnectEntityReconciler(t, configurationv1alpha1.KongRoute{})

--- a/controller/konnect/watch.go
+++ b/controller/konnect/watch.go
@@ -30,8 +30,8 @@ func ReconciliationWatchOptionsForEntity[
 		return KongRouteReconciliationWatchOptions(cl)
 	case *configurationv1alpha1.KongService:
 		return KongServiceReconciliationWatchOptions(cl)
-	case *konnectv1alpha1.KonnectControlPlane:
-		return KonnectControlPlaneReconciliationWatchOptions(cl)
+	case *konnectv1alpha1.KonnectGatewayControlPlane:
+		return KonnectGatewayControlPlaneReconciliationWatchOptions(cl)
 	case *configurationv1alpha1.KongPluginBinding:
 		return KongPluginBindingReconciliationWatchOptions(cl)
 	default:

--- a/controller/konnect/watch_kongconsumer.go
+++ b/controller/konnect/watch_kongconsumer.go
@@ -39,7 +39,7 @@ func KongConsumerReconciliationWatchOptions(
 		func(b *ctrl.Builder) *ctrl.Builder {
 			return b.For(&configurationv1.KongConsumer{},
 				builder.WithPredicates(
-					predicate.NewPredicateFuncs(kongConsumerRefersToKonnectControlPlane),
+					predicate.NewPredicateFuncs(kongConsumerRefersToKonnectGatewayControlPlane),
 				),
 			)
 		},
@@ -53,18 +53,18 @@ func KongConsumerReconciliationWatchOptions(
 		},
 		func(b *ctrl.Builder) *ctrl.Builder {
 			return b.Watches(
-				&konnectv1alpha1.KonnectControlPlane{},
+				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueKongConsumerForKonnectControlPlane(cl),
+					enqueueKongConsumerForKonnectGatewayControlPlane(cl),
 				),
 			)
 		},
 	}
 }
 
-// kongConsumerRefersToKonnectControlPlane returns true if the KongConsumer
-// refers to a KonnectControlPlane.
-func kongConsumerRefersToKonnectControlPlane(obj client.Object) bool {
+// kongConsumerRefersToKonnectGatewayControlPlane returns true if the KongConsumer
+// refers to a KonnectGatewayControlPlane.
+func kongConsumerRefersToKonnectGatewayControlPlane(obj client.Object) bool {
 	kongConsumer, ok := obj.(*configurationv1.KongConsumer)
 	if !ok {
 		ctrllog.FromContext(context.Background()).Error(
@@ -112,12 +112,12 @@ func enqueueKongConsumerForKonnectAPIAuthConfiguration(
 				if nn.Namespace != auth.Namespace {
 					continue
 				}
-				var cp konnectv1alpha1.KonnectControlPlane
+				var cp konnectv1alpha1.KonnectGatewayControlPlane
 				if err := cl.Get(ctx, nn, &cp); err != nil {
 					ctrllog.FromContext(ctx).Error(
 						err,
-						"failed to get KonnectControlPlane",
-						"KonnectControlPlane", nn,
+						"failed to get KonnectGatewayControlPlane",
+						"KonnectGatewayControlPlane", nn,
 					)
 					continue
 				}
@@ -154,11 +154,11 @@ func enqueueKongConsumerForKonnectAPIAuthConfiguration(
 	}
 }
 
-func enqueueKongConsumerForKonnectControlPlane(
+func enqueueKongConsumerForKonnectGatewayControlPlane(
 	cl client.Client,
 ) func(ctx context.Context, obj client.Object) []reconcile.Request {
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		cp, ok := obj.(*konnectv1alpha1.KonnectControlPlane)
+		cp, ok := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
 		if !ok {
 			return nil
 		}

--- a/controller/konnect/watch_kongconsumergroup.go
+++ b/controller/konnect/watch_kongconsumergroup.go
@@ -39,7 +39,7 @@ func KongConsumerGroupReconciliationWatchOptions(
 		func(b *ctrl.Builder) *ctrl.Builder {
 			return b.For(&configurationv1beta1.KongConsumerGroup{},
 				builder.WithPredicates(
-					predicate.NewPredicateFuncs(kongConsumerGroupRefersToKonnectControlPlane),
+					predicate.NewPredicateFuncs(kongConsumerGroupRefersToKonnectGatewayControlPlane),
 				),
 			)
 		},
@@ -53,18 +53,18 @@ func KongConsumerGroupReconciliationWatchOptions(
 		},
 		func(b *ctrl.Builder) *ctrl.Builder {
 			return b.Watches(
-				&konnectv1alpha1.KonnectControlPlane{},
+				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueKongConsumerGroupForKonnectControlPlane(cl),
+					enqueueKongConsumerGroupForKonnectGatewayControlPlane(cl),
 				),
 			)
 		},
 	}
 }
 
-// kongConsumerGroupRefersToKonnectControlPlane returns true if the KongConsumerGroup
-// refers to a KonnectControlPlane.
-func kongConsumerGroupRefersToKonnectControlPlane(obj client.Object) bool {
+// kongConsumerGroupRefersToKonnectGatewayControlPlane returns true if the KongConsumerGroup
+// refers to a KonnectGatewayControlPlane.
+func kongConsumerGroupRefersToKonnectGatewayControlPlane(obj client.Object) bool {
 	kongConsumerGroup, ok := obj.(*configurationv1beta1.KongConsumerGroup)
 	if !ok {
 		ctrllog.FromContext(context.Background()).Error(
@@ -112,12 +112,12 @@ func enqueueKongConsumerGroupForKonnectAPIAuthConfiguration(
 				if nn.Namespace != auth.Namespace {
 					continue
 				}
-				var cp konnectv1alpha1.KonnectControlPlane
+				var cp konnectv1alpha1.KonnectGatewayControlPlane
 				if err := cl.Get(ctx, nn, &cp); err != nil {
 					ctrllog.FromContext(ctx).Error(
 						err,
-						"failed to get KonnectControlPlane",
-						"KonnectControlPlane", nn,
+						"failed to get KonnectGatewayControlPlane",
+						"KonnectGatewayControlPlane", nn,
 					)
 					continue
 				}
@@ -154,11 +154,11 @@ func enqueueKongConsumerGroupForKonnectAPIAuthConfiguration(
 	}
 }
 
-func enqueueKongConsumerGroupForKonnectControlPlane(
+func enqueueKongConsumerGroupForKonnectGatewayControlPlane(
 	cl client.Client,
 ) func(ctx context.Context, obj client.Object) []reconcile.Request {
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		cp, ok := obj.(*konnectv1alpha1.KonnectControlPlane)
+		cp, ok := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
 		if !ok {
 			return nil
 		}

--- a/controller/konnect/watch_kongpluginbinding.go
+++ b/controller/konnect/watch_kongpluginbinding.go
@@ -44,7 +44,7 @@ func KongPluginBindingReconciliationWatchOptions(
 		func(b *ctrl.Builder) *ctrl.Builder {
 			return b.For(&configurationv1alpha1.KongPluginBinding{},
 				builder.WithPredicates(
-					predicate.NewPredicateFuncs(kongPluginBindingRefersToKonnectControlPlane),
+					predicate.NewPredicateFuncs(kongPluginBindingRefersToKonnectGatewayControlPlane),
 				),
 			)
 		},
@@ -58,9 +58,9 @@ func KongPluginBindingReconciliationWatchOptions(
 		},
 		func(b *ctrl.Builder) *ctrl.Builder {
 			return b.Watches(
-				&konnectv1alpha1.KonnectControlPlane{},
+				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueKongPluginBindingForKonnectControlPlane(cl),
+					enqueueKongPluginBindingForKonnectGatewayControlPlane(cl),
 				),
 			)
 		},
@@ -90,9 +90,9 @@ func KongPluginBindingReconciliationWatchOptions(
 // KongPluginBinding reconciler - Watch Predicates
 // -----------------------------------------------------------------------------
 
-// kongPluginBindingRefersToKonnectControlPlane returns true if the KongPluginBinding
-// refers to a KonnectControlPlane.
-func kongPluginBindingRefersToKonnectControlPlane(obj client.Object) bool {
+// kongPluginBindingRefersToKonnectGatewayControlPlane returns true if the KongPluginBinding
+// refers to a KonnectGatewayControlPlane.
+func kongPluginBindingRefersToKonnectGatewayControlPlane(obj client.Object) bool {
 	kongPB, ok := obj.(*configurationv1alpha1.KongPluginBinding)
 	if !ok {
 		ctrllog.FromContext(context.Background()).Error(
@@ -144,12 +144,12 @@ func enqueueKongPluginBindingForKonnectAPIAuthConfiguration(
 				if nn.Namespace != auth.Namespace {
 					continue
 				}
-				var cp konnectv1alpha1.KonnectControlPlane
+				var cp konnectv1alpha1.KonnectGatewayControlPlane
 				if err := cl.Get(ctx, nn, &cp); err != nil {
 					ctrllog.FromContext(ctx).Error(
 						err,
-						"failed to get KonnectControlPlane",
-						"KonnectControlPlane", nn,
+						"failed to get KonnectGatewayControlPlane",
+						"KonnectGatewayControlPlane", nn,
 					)
 					continue
 				}
@@ -186,11 +186,11 @@ func enqueueKongPluginBindingForKonnectAPIAuthConfiguration(
 	}
 }
 
-func enqueueKongPluginBindingForKonnectControlPlane(
+func enqueueKongPluginBindingForKonnectGatewayControlPlane(
 	cl client.Client,
 ) func(ctx context.Context, obj client.Object) []reconcile.Request {
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		cp, ok := obj.(*konnectv1alpha1.KonnectControlPlane)
+		cp, ok := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
 		if !ok {
 			return nil
 		}

--- a/controller/konnect/watch_kongroute.go
+++ b/controller/konnect/watch_kongroute.go
@@ -36,7 +36,7 @@ func KongRouteReconciliationWatchOptions(
 		func(b *ctrl.Builder) *ctrl.Builder {
 			return b.For(&configurationv1alpha1.KongRoute{},
 				builder.WithPredicates(
-					predicate.NewPredicateFuncs(kongRouteRefersToKonnectControlPlane(cl)),
+					predicate.NewPredicateFuncs(kongRouteRefersToKonnectGatewayControlPlane(cl)),
 				),
 			)
 		},
@@ -51,9 +51,9 @@ func KongRouteReconciliationWatchOptions(
 	}
 }
 
-// kongRouteRefersToKonnectControlPlane returns true if the KongRoute
-// refers to a KonnectControlPlane.
-func kongRouteRefersToKonnectControlPlane(cl client.Client) func(obj client.Object) bool {
+// kongRouteRefersToKonnectGatewayControlPlane returns true if the KongRoute
+// refers to a KonnectGatewayControlPlane.
+func kongRouteRefersToKonnectGatewayControlPlane(cl client.Client) func(obj client.Object) bool {
 	return func(obj client.Object) bool {
 		kongRoute, ok := obj.(*configurationv1alpha1.KongRoute)
 		if !ok {
@@ -92,7 +92,7 @@ func enqueueKongRouteForKongService(
 			return nil
 		}
 
-		// If the KongService does not refer to a KonnectControlPlane,
+		// If the KongService does not refer to a KonnectGatewayControlPlane,
 		// we do not need to enqueue any KongRoutes bound to this KongService.
 		cpRef := kongSvc.Spec.ControlPlaneRef
 		if cpRef == nil || cpRef.Type != configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef {

--- a/controller/konnect/watch_kongservice.go
+++ b/controller/konnect/watch_kongservice.go
@@ -38,7 +38,7 @@ func KongServiceReconciliationWatchOptions(
 		func(b *ctrl.Builder) *ctrl.Builder {
 			return b.For(&configurationv1alpha1.KongService{},
 				builder.WithPredicates(
-					predicate.NewPredicateFuncs(kongServiceRefersToKonnectControlPlane),
+					predicate.NewPredicateFuncs(kongServiceRefersToKonnectGatewayControlPlane),
 				),
 			)
 		},
@@ -52,18 +52,18 @@ func KongServiceReconciliationWatchOptions(
 		},
 		func(b *ctrl.Builder) *ctrl.Builder {
 			return b.Watches(
-				&konnectv1alpha1.KonnectControlPlane{},
+				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueKongServiceForKonnectControlPlane(cl),
+					enqueueKongServiceForKonnectGatewayControlPlane(cl),
 				),
 			)
 		},
 	}
 }
 
-// kongServiceRefersToKonnectControlPlane returns true if the KongService
-// refers to a KonnectControlPlane.
-func kongServiceRefersToKonnectControlPlane(obj client.Object) bool {
+// kongServiceRefersToKonnectGatewayControlPlane returns true if the KongService
+// refers to a KonnectGatewayControlPlane.
+func kongServiceRefersToKonnectGatewayControlPlane(obj client.Object) bool {
 	kongSvc, ok := obj.(*configurationv1alpha1.KongService)
 	if !ok {
 		ctrllog.FromContext(context.Background()).Error(
@@ -111,12 +111,12 @@ func enqueueKongServiceForKonnectAPIAuthConfiguration(
 				if nn.Namespace != auth.Namespace {
 					continue
 				}
-				var cp konnectv1alpha1.KonnectControlPlane
+				var cp konnectv1alpha1.KonnectGatewayControlPlane
 				if err := cl.Get(ctx, nn, &cp); err != nil {
 					ctrllog.FromContext(ctx).Error(
 						err,
-						"failed to get KonnectControlPlane",
-						"KonnectControlPlane", nn,
+						"failed to get KonnectGatewayControlPlane",
+						"KonnectGatewayControlPlane", nn,
 					)
 					continue
 				}
@@ -153,11 +153,11 @@ func enqueueKongServiceForKonnectAPIAuthConfiguration(
 	}
 }
 
-func enqueueKongServiceForKonnectControlPlane(
+func enqueueKongServiceForKonnectGatewayControlPlane(
 	cl client.Client,
 ) func(ctx context.Context, obj client.Object) []reconcile.Request {
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		cp, ok := obj.(*konnectv1alpha1.KonnectControlPlane)
+		cp, ok := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
 		if !ok {
 			return nil
 		}

--- a/controller/konnect/watch_konnectcontrolplane.go
+++ b/controller/konnect/watch_konnectcontrolplane.go
@@ -20,27 +20,27 @@ import (
 //   reference from the object
 // - lists have their items stored in Items field, not returned via a method
 
-// KonnectControlPlaneReconciliationWatchOptions returns the watch options for
-// the KonnectControlPlane.
-func KonnectControlPlaneReconciliationWatchOptions(
+// KonnectGatewayControlPlaneReconciliationWatchOptions returns the watch options for
+// the KonnectGatewayControlPlane.
+func KonnectGatewayControlPlaneReconciliationWatchOptions(
 	cl client.Client,
 ) []func(*ctrl.Builder) *ctrl.Builder {
 	return []func(*ctrl.Builder) *ctrl.Builder{
 		func(b *ctrl.Builder) *ctrl.Builder {
-			return b.For(&konnectv1alpha1.KonnectControlPlane{})
+			return b.For(&konnectv1alpha1.KonnectGatewayControlPlane{})
 		},
 		func(b *ctrl.Builder) *ctrl.Builder {
 			return b.Watches(
 				&konnectv1alpha1.KonnectAPIAuthConfiguration{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueKonnectControlPlaneForKonnectAPIAuthConfiguration(cl),
+					enqueueKonnectGatewayControlPlaneForKonnectAPIAuthConfiguration(cl),
 				),
 			)
 		},
 	}
 }
 
-func enqueueKonnectControlPlaneForKonnectAPIAuthConfiguration(
+func enqueueKonnectGatewayControlPlaneForKonnectAPIAuthConfiguration(
 	cl client.Client,
 ) func(ctx context.Context, obj client.Object) []reconcile.Request {
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -48,7 +48,7 @@ func enqueueKonnectControlPlaneForKonnectAPIAuthConfiguration(
 		if !ok {
 			return nil
 		}
-		var l konnectv1alpha1.KonnectControlPlaneList
+		var l konnectv1alpha1.KonnectGatewayControlPlaneList
 		if err := cl.List(ctx, &l, &client.ListOptions{
 			// TODO: change this when cross namespace refs are allowed.
 			Namespace: auth.GetNamespace(),

--- a/controller/konnect/watch_test.go
+++ b/controller/konnect/watch_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestWatchOptions(t *testing.T) {
-	testReconciliationWatchOptionsForEntity(t, &konnectv1alpha1.KonnectControlPlane{})
+	testReconciliationWatchOptionsForEntity(t, &konnectv1alpha1.KonnectGatewayControlPlane{})
 	testReconciliationWatchOptionsForEntity(t, &configurationv1alpha1.KongService{})
 	testReconciliationWatchOptionsForEntity(t, &configurationv1.KongConsumer{})
 	testReconciliationWatchOptionsForEntity(t, &configurationv1alpha1.KongRoute{})

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-containerregistry v0.20.2
 	github.com/google/uuid v1.6.0
-	github.com/kong/kubernetes-configuration v0.0.9
+	github.com/kong/kubernetes-configuration v0.0.10-0.20240903120346-bbf3f3aa8742
 	github.com/kong/kubernetes-ingress-controller/v3 v3.3.1
 	github.com/kong/kubernetes-telemetry v0.1.5
 	github.com/kong/kubernetes-testing-framework v0.47.2
@@ -68,7 +68,7 @@ require (
 	github.com/homeport/dyff v1.6.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
-	github.com/kong/go-kong v0.57.1 // indirect
+	github.com/kong/go-kong v0.58.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-ciede2000 v0.0.0-20170301095244-782e8c62fec3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -222,10 +222,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
-github.com/kong/go-kong v0.57.1 h1:PATDsjrRr0SMMtN433ONoZqm+7UKmv49zgqQyvWbfPY=
-github.com/kong/go-kong v0.57.1/go.mod h1:lG2zDVU0yynwV9S7gJXDwwi6zVY+MgS8aUX4QhzpDz4=
-github.com/kong/kubernetes-configuration v0.0.9 h1:sNw/Y2e51qtBHTnA+CS+aS66lrAtg2ndpBW3zv9ObYE=
-github.com/kong/kubernetes-configuration v0.0.9/go.mod h1:5RTuYhTVoyfjKFaeJ6dziN/8dqVHcLnHR6wAyT/WfVU=
+github.com/kong/go-kong v0.58.0 h1:9Y1Hg7ahCS7Ig+iAb9CZyjeT3ARuDe9ohV7mVa8n/eU=
+github.com/kong/go-kong v0.58.0/go.mod h1:8Vt6HmtgLNgL/7bSwAlz3DIWqBtzG7qEt9+OnMiQOa0=
+github.com/kong/kubernetes-configuration v0.0.10-0.20240903120346-bbf3f3aa8742 h1:rca5gsKcQctA2IpUA51GW0eUXhU7IcdRHPXz7XmE+kY=
+github.com/kong/kubernetes-configuration v0.0.10-0.20240903120346-bbf3f3aa8742/go.mod h1:qrBecX5i10cKNcDBJnQLduhhcYh6CKAz7rDi+nLtjdk=
 github.com/kong/kubernetes-ingress-controller/v3 v3.3.1 h1:uWlcwz5oAnVyUZdtDV9p2l9CdlHhLNTKey3AcHF/Jxs=
 github.com/kong/kubernetes-ingress-controller/v3 v3.3.1/go.mod h1:2CBAJ7/J+FyAFn7Y8OLoTO3ApM+qiGIgNLbCyy98Vqk=
 github.com/kong/kubernetes-telemetry v0.1.5 h1:xHwU1q0IvfEYqpj03po73ZKbVarnFPUwzkoFkdVnr9w=

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -59,8 +59,8 @@ const (
 
 	// KonnectAPIAuthConfigurationControllerName is the name of the KonnectAPIAuthConfiguration controller.
 	KonnectAPIAuthConfigurationControllerName = "KonnectAPIAuthConfiguration"
-	// KonnectControlPlaneControllerName is the name of the KonnectControlPlane controller.
-	KonnectControlPlaneControllerName = "KonnectControlPlane"
+	// KonnectGatewayControlPlaneControllerName is the name of the KonnectGatewayControlPlane controller.
+	KonnectGatewayControlPlaneControllerName = "KonnectGatewayControlPlane"
 	// KongServiceControllerName is the name of the KongService controller.
 	KongServiceControllerName = "KongService"
 	// KongRouteControllerName is the name of the KongRoute controller.
@@ -315,13 +315,13 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 				mgr.GetClient(),
 			),
 		}
-		controllers[KonnectControlPlaneControllerName] = ControllerDef{
+		controllers[KonnectGatewayControlPlaneControllerName] = ControllerDef{
 			Enabled: c.KonnectControllersEnabled,
 			Controller: konnect.NewKonnectEntityReconciler(
 				sdkFactory,
 				c.DevelopmentMode,
 				mgr.GetClient(),
-				konnect.WithKonnectEntitySyncPeriod[konnectv1alpha1.KonnectControlPlane](c.KonnectSyncPeriod),
+				konnect.WithKonnectEntitySyncPeriod[konnectv1alpha1.KonnectGatewayControlPlane](c.KonnectSyncPeriod),
 			),
 		}
 		controllers[KongServiceControllerName] = ControllerDef{

--- a/test/integration/test_konnect_entities.go
+++ b/test/integration/test_konnect_entities.go
@@ -27,7 +27,7 @@ func TestKonnectEntities(t *testing.T) {
 	// We can't use a cleaner to delete objects because it handles deletes in FIFO order and that won't work in this
 	// case: KonnectAPIAuthConfiguration shouldn't be deleted before any other object as that is required for others to
 	// complete their finalizer which is deleting a reflecting entity in Konnect. That's why we're only cleaning up a
-	// KonnectControlPlane and waiting for its deletion synchronously with deleteObjectAndWaitForDeletionFn to ensure it
+	// KonnectGatewayControlPlane and waiting for its deletion synchronously with deleteObjectAndWaitForDeletionFn to ensure it
 	// was successfully deleted along with its children. The KonnectAPIAuthConfiguration is implicitly deleted along
 	// with the namespace.
 	ns, _ := helpers.SetupTestEnv(t, GetCtx(), GetEnv())
@@ -54,13 +54,13 @@ func TestKonnectEntities(t *testing.T) {
 	require.NoError(t, err)
 
 	cpName := "cp-" + testID
-	t.Logf("Creating KonnectControlPlane %s", cpName)
-	cp := &konnectv1alpha1.KonnectControlPlane{
+	t.Logf("Creating KonnectGatewayControlPlane %s", cpName)
+	cp := &konnectv1alpha1.KonnectGatewayControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cpName,
 			Namespace: ns.Name,
 		},
-		Spec: konnectv1alpha1.KonnectControlPlaneSpec{
+		Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 			CreateControlPlaneRequest: components.CreateControlPlaneRequest{
 				Name:        cpName,
 				ClusterType: lo.ToPtr(components.ClusterTypeClusterTypeControlPlane),


### PR DESCRIPTION

**What this PR does / why we need it**:
Since we have changed `KonnectControlPlane` to `KonnectGatewayControlPlane` in [Kong/kubernetes-configuration
](https://github.com/Kong/kubernetes-configuration), we should replace them in the repo.
**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:
Should we add a changelog entry here?
**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
