### PR TITLE
test: add remaining konnect entities integration

### DIFF
--- a/config/samples/konnect-kongpluginbinding.yaml
+++ b/config/samples/konnect-kongpluginbinding.yaml
@@ -56,7 +56,7 @@ spec:
     konnectNamespacedRef:
       name: demo-cp
   pluginRef:
-    name: proxy-cache-all-endpoints
+    name: rate-limit-5-min
   targets:
     serviceRef:
       name: service-1

--- a/controller/konnect/ops/ops_kongpluginbinding.go
+++ b/controller/konnect/ops/ops_kongpluginbinding.go
@@ -262,8 +262,11 @@ func kongPluginBindingToSDKPluginInput(
 	}
 
 	pluginConfig := map[string]any{}
-	if err := json.Unmarshal(plugin.Config.Raw, &pluginConfig); err != nil {
-		return nil, err
+	if rawConfig := plugin.Config.Raw; rawConfig != nil {
+		// If the config is empty (a valid case), there's no need to unmarshal (as it would fail).
+		if err := json.Unmarshal(rawConfig, &pluginConfig); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal KongPlugin %s config: %w", client.ObjectKeyFromObject(plugin), err)
+		}
 	}
 
 	pluginInput := &sdkkonnectcomp.PluginInput{

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -540,7 +540,8 @@ func getServiceRef[T constraints.SupportedKonnectEntityType, TEnt constraints.En
 	case *configurationv1alpha1.KongService,
 		*configurationv1.KongConsumer,
 		*configurationv1beta1.KongConsumerGroup,
-		*konnectv1alpha1.KonnectGatewayControlPlane:
+		*konnectv1alpha1.KonnectGatewayControlPlane,
+		*configurationv1alpha1.KongPluginBinding:
 		return mo.None[configurationv1alpha1.ServiceRef]()
 	case *configurationv1alpha1.KongRoute:
 		if e.Spec.ServiceRef == nil {

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-containerregistry v0.20.2
 	github.com/google/uuid v1.6.0
-	github.com/kong/kubernetes-configuration v0.0.10
+	github.com/kong/kubernetes-configuration v0.0.11
 	github.com/kong/kubernetes-ingress-controller/v3 v3.3.1
 	github.com/kong/kubernetes-telemetry v0.1.5
 	github.com/kong/kubernetes-testing-framework v0.47.2
@@ -68,7 +68,7 @@ require (
 	github.com/homeport/dyff v1.6.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
-	github.com/kong/go-kong v0.58.0 // indirect
+	github.com/kong/go-kong v0.59.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-ciede2000 v0.0.0-20170301095244-782e8c62fec3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -222,10 +222,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
-github.com/kong/go-kong v0.58.0 h1:9Y1Hg7ahCS7Ig+iAb9CZyjeT3ARuDe9ohV7mVa8n/eU=
-github.com/kong/go-kong v0.58.0/go.mod h1:8Vt6HmtgLNgL/7bSwAlz3DIWqBtzG7qEt9+OnMiQOa0=
-github.com/kong/kubernetes-configuration v0.0.10 h1:abz/BAQ/Eht/JaUWJyxygOKWgCvLVbgStyKBzTvMHBY=
-github.com/kong/kubernetes-configuration v0.0.10/go.mod h1:qrBecX5i10cKNcDBJnQLduhhcYh6CKAz7rDi+nLtjdk=
+github.com/kong/go-kong v0.59.0 h1:U6dE2sqb8E8j0kESW/RCW9TkXH8Y3W0EtNDXJVsDNuM=
+github.com/kong/go-kong v0.59.0/go.mod h1:8Vt6HmtgLNgL/7bSwAlz3DIWqBtzG7qEt9+OnMiQOa0=
+github.com/kong/kubernetes-configuration v0.0.11 h1:mCrOjr+mmEHpXUyzuFtt0HJo6nE5/P2uSxA7YW7e6aE=
+github.com/kong/kubernetes-configuration v0.0.11/go.mod h1:G1IwtAroXC2LzceXkQVELh/nQzdZw7Z6Fn1R4po2k1M=
 github.com/kong/kubernetes-ingress-controller/v3 v3.3.1 h1:uWlcwz5oAnVyUZdtDV9p2l9CdlHhLNTKey3AcHF/Jxs=
 github.com/kong/kubernetes-ingress-controller/v3 v3.3.1/go.mod h1:2CBAJ7/J+FyAFn7Y8OLoTO3ApM+qiGIgNLbCyy98Vqk=
 github.com/kong/kubernetes-telemetry v0.1.5 h1:xHwU1q0IvfEYqpj03po73ZKbVarnFPUwzkoFkdVnr9w=

--- a/pkg/utils/test/clients.go
+++ b/pkg/utils/test/clients.go
@@ -14,7 +14,9 @@ import (
 	operatorv1beta1 "github.com/kong/gateway-operator/api/v1beta1"
 	operatorclient "github.com/kong/gateway-operator/pkg/clientset"
 
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	configurationv1beta1 "github.com/kong/kubernetes-configuration/api/configuration/v1beta1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
@@ -58,6 +60,12 @@ func NewK8sClients(env environments.Environment) (K8sClients, error) {
 		return clients, err
 	}
 	if err := configurationv1alpha1.AddToScheme(clients.MgrClient.Scheme()); err != nil {
+		return clients, err
+	}
+	if err := configurationv1.AddToScheme(clients.MgrClient.Scheme()); err != nil {
+		return clients, err
+	}
+	if err := configurationv1beta1.AddToScheme(clients.MgrClient.Scheme()); err != nil {
 		return clients, err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds remaining Konnect entities integration tests and fixes issues found in those.

**Which issue this PR fixes**

Closes https://github.com/Kong/gateway-operator/issues/481.
