### PR TITLE
chore: improve basic reconciliation for KongPluginInstallation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
   [#387](https://github.com/Kong/gateway-operator/pull/387)
 - Introduce `KongPluginInstallation` CRD to allow installing custom Kong
   plugins distributed as container images.
-  [#400](https://github.com/Kong/gateway-operator/pull/400), [#424](https://github.com/Kong/gateway-operator/pull/424), [#474](https://github.com/Kong/gateway-operator/pull/474)
+  [#400](https://github.com/Kong/gateway-operator/pull/400), [#424](https://github.com/Kong/gateway-operator/pull/424), [#474](https://github.com/Kong/gateway-operator/pull/474), [#560](https://github.com/Kong/gateway-operator/pull/560)
 - Extended `DataPlane` API with a possibility to specify `PodDisruptionBudget` to be
   created for the `DataPlane` deployments via `spec.resources.podDisruptionBudget`.
   [#464](https://github.com/Kong/gateway-operator/pull/464)

--- a/Makefile
+++ b/Makefile
@@ -479,8 +479,7 @@ _run:
 	GATEWAY_OPERATOR_DEVELOPMENT_MODE=true go run ./cmd/main.go \
 		--no-leader-election \
 		-cluster-ca-secret-namespace kong-system \
-		-enable-controller-controlplane \
-		-enable-controller-gateway \
+		-enable-controller-kongplugininstallation \
 		-enable-controller-aigateway \
 		-enable-controller-konnect \
 		-zap-time-encoding iso8601 \

--- a/pkg/consts/kongplugininstallation.go
+++ b/pkg/consts/kongplugininstallation.go
@@ -1,0 +1,11 @@
+package consts
+
+const (
+	// KongPluginInstallationManagedLabelValue indicates that an object's lifecycle is managed by the
+	// KongPluginInstallation controller.
+	KongPluginInstallationManagedLabelValue = "kong-plugin-installation"
+
+	// AnnotationKongPluginInstallationName is the annotation key used to store the name of the KongPluginInstallation
+	// that maps to particular ConfigMap.
+	AnnotationKongPluginInstallationMappedKongPluginInstallation = OperatorLabelPrefix + "mapped-to-kong-plugin-installation"
+)

--- a/pkg/utils/kubernetes/resources/annotations.go
+++ b/pkg/utils/kubernetes/resources/annotations.go
@@ -1,0 +1,21 @@
+package resources
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/gateway-operator/api/v1alpha1"
+	"github.com/kong/gateway-operator/pkg/consts"
+)
+
+// AnnotateConfigMapWithKongPluginInstallation ensures that annotation that maps
+// particular ConfigMap with KongPluginInstallation based which it's been populated.
+// Annotation value is in the form `Namespace/Name` of the KongPluginInstallation.
+func AnnotateConfigMapWithKongPluginInstallation(cm *corev1.ConfigMap, kpi v1alpha1.KongPluginInstallation) {
+	annotations := cm.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[consts.AnnotationKongPluginInstallationMappedKongPluginInstallation] = client.ObjectKeyFromObject(&kpi).String()
+	cm.SetAnnotations(annotations)
+}

--- a/pkg/utils/kubernetes/resources/labels.go
+++ b/pkg/utils/kubernetes/resources/labels.go
@@ -14,8 +14,8 @@ import (
 )
 
 // LabelObjectAsDataPlaneManaged ensures that labels are set on the
-// provided object to signal that it's owned by a DataPlane resource and that its
-// lifecycle is managed by this operator.
+// provided object to signal that it's owned by a DataPlane resource
+// and that its lifecycle is managed by this operator.
 func LabelObjectAsDataPlaneManaged(obj metav1.Object) {
 	labels := obj.GetLabels()
 	if labels == nil {
@@ -25,6 +25,21 @@ func LabelObjectAsDataPlaneManaged(obj metav1.Object) {
 	// TODO: Remove adding this to managed resources after several versions with
 	// the new managed-by label were released: https://github.com/Kong/gateway-operator/issues/156
 	labels[consts.GatewayOperatorManagedByLabelLegacy] = consts.DataPlaneManagedLabelValue
+	obj.SetLabels(labels)
+}
+
+// LabelObjectAsDataPlaneManaged ensures that labels are set on the
+// provided object to signal that it's owned by a KongPluginInstallation
+// resource and that its lifecycle is managed by this operator.
+func LabelObjectAsKongPluginInstallationManaged(obj metav1.Object) {
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[consts.GatewayOperatorManagedByLabel] = consts.KongPluginInstallationManagedLabelValue
+	// TODO: Remove adding this to managed resources after several versions with
+	// the new managed-by label were released: https://github.com/Kong/gateway-operator/issues/156
+	labels[consts.GatewayOperatorManagedByLabelLegacy] = consts.KongPluginInstallationManagedLabelValue
 	obj.SetLabels(labels)
 }
 

--- a/test/integration/test_kongplugininstallation.go
+++ b/test/integration/test_kongplugininstallation.go
@@ -15,6 +15,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/gateway-operator/api/v1alpha1"
+	"github.com/kong/gateway-operator/pkg/consts"
 	"github.com/kong/gateway-operator/test/helpers"
 )
 
@@ -65,7 +66,9 @@ func TestKongPluginInstallationEssentials(t *testing.T) {
 		}
 		var found bool
 		respectiveCM, found = lo.Find(configMaps.Items, func(cm corev1.ConfigMap) bool {
-			return strings.HasPrefix(cm.Name, kpiNN.Name)
+			return cm.Labels[consts.GatewayOperatorManagedByLabel] == consts.KongPluginInstallationManagedLabelValue &&
+				cm.Annotations[consts.AnnotationKongPluginInstallationMappedKongPluginInstallation] == kpiNN.String() &&
+				strings.HasPrefix(cm.Name, kpiNN.Name)
 		})
 		if !assert.True(c, found) {
 			return


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-up for PRs #424 & #474, prerequisite for 

- https://github.com/Kong/gateway-operator/pull/476

it contains a handful of improvements

- make `Makefile` aligned with skaffold configuration
- labels created ConfigMaps with managed by specified to `KongPluginInstallation` (the same as other resources do)
- introduce mapping with dedicated annotation to easily discover which `KongPluginInstallation` a particular `ConfigMap` responds (label can't be used for this due to length limitation)
- setting a transitive state of `Pending` when it's not yet known if the plugin will be fetched successfully or not

**Which issue this PR fixes**

Part of https://github.com/Kong/gateway-operator/issues/379

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
