### PR TITLE
test: extract version from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/kr/pretty v0.3.1
 	github.com/samber/lo v1.47.0
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/mod v0.17.0
 	k8s.io/api v0.31.0
 	k8s.io/apimachinery v0.31.0
 	k8s.io/client-go v0.31.0
@@ -101,7 +102,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.28.0 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
-	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240814211410-ddb44dafa142 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240814211410-ddb44dafa142 // indirect

--- a/pkg/utils/test/projectroot.go
+++ b/pkg/utils/test/projectroot.go
@@ -1,0 +1,15 @@
+package test
+
+import (
+	"path/filepath"
+	"runtime"
+)
+
+// ProjectRootPath returns the root directory of this project.
+func ProjectRootPath() string {
+	_, b, _, _ := runtime.Caller(0) //nolint:dogsled
+
+	// Returns root directory of this project.
+	// NOTE: it depends on the path of this file itself. When the file is moved, the second param may need updating.
+	return filepath.Join(filepath.Dir(b), "../../..")
+}

--- a/pkg/utils/test/setup_helpers.go
+++ b/pkg/utils/test/setup_helpers.go
@@ -192,8 +192,8 @@ func BuildMTLSCredentials(ctx context.Context, k8sClient *kubernetes.Clientset, 
 // ExtractModuleVersion extracts version of an imported module in go.mod.
 // If the module is not found, or we failed to parse the module version, it will return an error.
 func ExtractModuleVersion(moduleName string) (string, error) {
-	// TODO: use a path non relevant to the file itself
-	content, err := os.ReadFile("../../go.mod")
+	projectRoot := ProjectRootPath()
+	content, err := os.ReadFile(filepath.Join(projectRoot, "go.mod"))
 	if err != nil {
 		return "", err
 	}
@@ -229,7 +229,7 @@ func DeployCRDs(ctx context.Context, crdPath string, operatorClient *operatorcli
 	// First extract version of `kong/kubernetes-configuration` module used
 	kongCRDVersion, err := ExtractModuleVersion(kubernetesConfigurationModuleName)
 	if err != nil {
-		return fmt.Errorf("failed to extract Kong CRD version: %w", err)
+		return fmt.Errorf("failed to extract Kong CRDs (%s) module's version: %w", kubernetesConfigurationModuleName, err)
 	}
 	// Then install CRDs from the module found in `$GOPATH`.
 	kongCRDPath := filepath.Join(build.Default.GOPATH, "pkg", "mod", "github.com", "kong",


### PR DESCRIPTION
**What this PR does / why we need it**:
Read version of Kong configuration CRDs from version of `kong/kubernetes-configuration` module and install from modules in `GOPATH`. Used to align the installed CRDs and imported CRDs in the integration tests.

**Which issue this PR fixes**

Fixes #548  

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
