### PR TITLE
chore: remove deprecated exportloopref from golangci-lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,16 +4,16 @@ linters:
   enable:
   - asciicheck
   - bodyclose
+  - copyloopvar
   - dogsled
   - durationcheck
   - errcheck
   - errorlint
   - exhaustive
-  - exportloopref
   - forbidigo
   - gci
-  - gofmt
   - gocritic
+  - gofmt
   - goimports
   - gomodguard
   - gosec
@@ -22,6 +22,7 @@ linters:
   - importas
   - ineffassign
   - misspell
+  - nakedret
   - nilerr
   - nolintlint
   - predeclared
@@ -32,7 +33,6 @@ linters:
   - unparam
   - unused
   - wastedassign
-  - nakedret
 linters-settings:
   gci:
     sections:

--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -712,7 +712,6 @@ func (r *Reconciler) ensureAdmissionWebhookService(
 
 	if !isAdmissionWebhookEnabled(ctx, cl, logger, cp) {
 		for _, svc := range services {
-			svc := svc
 			if err := cl.Delete(ctx, &svc); err != nil && !k8serrors.IsNotFound(err) {
 				return op.Noop, nil, fmt.Errorf("failed deleting ControlPlane admission webhook Service %s: %w", svc.Name, err)
 			}

--- a/controller/controlplane/controller_reconciler_utils_test.go
+++ b/controller/controlplane/controller_reconciler_utils_test.go
@@ -185,8 +185,6 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			fakeClient := fakectrlruntimeclient.
 				NewClientBuilder().

--- a/controller/controlplane/controller_test.go
+++ b/controller/controlplane/controller_test.go
@@ -422,8 +422,6 @@ func TestReconciler_Reconcile(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.dataplane != nil {
 				k8sutils.SetOwnerForObject(tc.dataplane, tc.controlplane)

--- a/controller/controlplane/controller_utils_test.go
+++ b/controller/controlplane/controller_utils_test.go
@@ -523,7 +523,7 @@ func TestSetControlPlaneDefaults(t *testing.T) {
 
 	for i, tc := range testCases {
 		index := i
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			changed := controlplane.SetDefaults(
 				tc.spec,
@@ -919,7 +919,6 @@ func TestControlPlaneSpecDeepEqual(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.equal, controlplane.SpecDeepEqual(tc.spec1, tc.spec2, tc.envVarsToIgnore...))
 		})

--- a/controller/controlplane/controlplane_controller_reconciler_utils_test.go
+++ b/controller/controlplane/controlplane_controller_reconciler_utils_test.go
@@ -103,7 +103,6 @@ func TestEnsureClusterRole(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		ObjectsToAdd := []controllerruntimeclient.Object{
 			&tc.controlplane,
@@ -243,7 +242,7 @@ func TestEnsureClusterRoleBinding(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		objectsToAdd := []controllerruntimeclient.Object{
 			controlPlane,
 		}

--- a/controller/controlplane/status_conditions_test.go
+++ b/controller/controlplane/status_conditions_test.go
@@ -53,8 +53,6 @@ func TestMarkAsProvisioned(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				dp := tc.controlplane()
 				markAsProvisioned(dp)

--- a/controller/dataplane/bluegreen_controller.go
+++ b/controller/dataplane/bluegreen_controller.go
@@ -410,7 +410,6 @@ func (r *BlueGreenReconciler) prunePreviewSubresources(
 	}
 
 	for _, s := range services {
-		s := s
 
 		secrets, err := k8sutils.ListSecretsForOwner(
 			ctx,
@@ -454,7 +453,6 @@ func removeObjectSliceWithDataPlaneOwnedFinalizer[
 	ctx context.Context, cl client.Client, resources []T,
 ) error {
 	for _, s := range resources {
-		s := s
 		service := PT(&s)
 
 		old := service.DeepCopy()
@@ -579,7 +577,6 @@ func (r *BlueGreenReconciler) reduceLiveDeployments(
 	})
 	// Delete all but the last deployment.
 	for _, deployment := range deployments[:len(deployments)-1] {
-		deployment := deployment
 		log.Debug(logger, "reducing live deployment", dataPlane,
 			"deployment", fmt.Sprintf("%s/%s", deployment.Namespace, deployment.Name))
 

--- a/controller/dataplane/bluegreen_controller_test.go
+++ b/controller/dataplane/bluegreen_controller_test.go
@@ -332,8 +332,6 @@ func TestDataPlaneBlueGreenReconciler_Reconcile(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			ObjectsToAdd := []client.Object{
 				tc.dataplane,
@@ -429,7 +427,6 @@ func TestCanProceedWithPromotion(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			canProceed, err := canProceedWithPromotion(tc.dataplane)
 			if tc.expectedErr != nil {
@@ -561,7 +558,6 @@ func TestEnsurePreviewIngressService(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			fakeClient := fakectrlruntimeclient.

--- a/controller/dataplane/controller_reconciler_utils_test.go
+++ b/controller/dataplane/controller_reconciler_utils_test.go
@@ -506,7 +506,6 @@ func TestDeploymentBuilder(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		fakeClient := fakectrlruntimeclient.
 			NewClientBuilder().
@@ -608,8 +607,6 @@ func TestDataPlaneIngressServiceIsReady(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			res := dataPlaneIngressServiceIsReady(tc.dataPlaneIngressService)
 			assert.Equal(t, tc.expected, res)

--- a/controller/dataplane/controller_test.go
+++ b/controller/dataplane/controller_test.go
@@ -905,8 +905,6 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			ObjectsToAdd := []controllerruntimeclient.Object{
 				tc.dataplane,

--- a/controller/dataplane/controller_utils_test.go
+++ b/controller/dataplane/controller_utils_test.go
@@ -373,8 +373,6 @@ func TestEnsureDataPlaneReadyStatus(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			scheme := runtime.NewScheme()
 

--- a/controller/dataplane/dynamic_test.go
+++ b/controller/dataplane/dynamic_test.go
@@ -383,8 +383,6 @@ func TestCallbackRun(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			ObjectsToAdd := []controllerruntimeclient.Object{
 				tc.dataplane,

--- a/controller/dataplane/owned_resources_test.go
+++ b/controller/dataplane/owned_resources_test.go
@@ -149,7 +149,6 @@ func TestEnsureIngressServiceForDataPlane(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			fakeClient := fakectrlruntimeclient.
 				NewClientBuilder().

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -67,8 +67,6 @@ func TestParseKongProxyListenEnv(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
-
 		t.Run(tc.Name, func(t *testing.T) {
 			actual, err := parseKongListenEnv(tc.KongProxyListen)
 			require.NoError(t, err)
@@ -245,7 +243,6 @@ func TestGatewayAddressesFromService(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			addresses, err := gatewayAddressesFromService(tc.svc)
 			assert.Equal(t, tc.wantErr, err != nil)
@@ -487,8 +484,6 @@ func TestSetAcceptedOnGateway(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(subt *testing.T) {
 			gateway := gatewayConditionsAndListenersAwareT{
 				Gateway: &gatewayv1.Gateway{
@@ -577,7 +572,6 @@ func TestSetDataPlaneIngressServicePorts(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tc := tc
 			err := setDataPlaneIngressServicePorts(&operatorv1beta1.DataPlaneOptions{}, tc.listeners)
 			if tc.expectedError == nil {
 				require.NoError(t, err)
@@ -701,7 +695,6 @@ func TestIsSecretCrossReferenceGranted(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.isGranted, isSecretCrossReferenceGranted("goodNamespace", goodSecretName, tc.referenceGrants))
 		})
@@ -848,7 +841,6 @@ func TestGatewayStatusNeedsUpdate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.needsUpdate, gatewayStatusNeedsUpdate(tc.oldGateway, tc.newGateway))
 		})
@@ -1249,7 +1241,7 @@ func TestGetSupportedKindsWithResolvedRefsCondition(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		ctx := context.Background()
 		client := fakectrlruntimeclient.
 			NewClientBuilder().

--- a/controller/gateway/controller_test.go
+++ b/controller/gateway/controller_test.go
@@ -300,8 +300,6 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			ObjectsToAdd := []controllerruntimeclient.Object{
 				tc.gateway,
@@ -455,7 +453,6 @@ func Test_setControlPlaneOptionsDefaults(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			setControlPlaneOptionsDefaults(&tc.input)
 			require.Equal(t, tc.expected, tc.input)
@@ -624,7 +621,6 @@ func Test_setDataPlaneOptionsDefaults(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			setDataPlaneOptionsDefaults(&tc.input, consts.DefaultDataPlaneImage)
 			require.Equal(t, tc.expected, tc.input)

--- a/controller/gatewayclass/controller_test.go
+++ b/controller/gatewayclass/controller_test.go
@@ -96,8 +96,6 @@ func TestGatewayClassReconciler_Reconcile(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			ObjectsToAdd := []controllerruntimeclient.Object{
 				tc.gatewayClass,

--- a/controller/konnect/reconciler_konnectapiauth_test.go
+++ b/controller/konnect/reconciler_konnectapiauth_test.go
@@ -162,7 +162,7 @@ func TestGetTokenFromKonnectAPIAuthConfiguration(t *testing.T) {
 }
 
 func TestGetKonnectServerURL(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		name              string
 		serverURL         string
 		expectedServerURL string
@@ -187,7 +187,6 @@ func TestGetKonnectServerURL(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			serverURL, err := getKonnectServerURL(tc.serverURL)
 

--- a/controller/pkg/address/address_test.go
+++ b/controller/pkg/address/address_test.go
@@ -285,7 +285,6 @@ func Test_AddressesFromService(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			actual, err := AddressesFromService(tt.service)
 			require.NoError(t, err)

--- a/controller/pkg/patch/patch_test.go
+++ b/controller/pkg/patch/patch_test.go
@@ -163,8 +163,6 @@ func TestApplyPatchIfNonEmpty(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			scheme := runtime.NewScheme()
 

--- a/controller/pkg/secrets/cert_test.go
+++ b/controller/pkg/secrets/cert_test.go
@@ -121,7 +121,6 @@ func Test_ensureContainerImageUpdated(t *testing.T) {
 			updated:       true,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			container := generators.NewContainer("test", tt.originalImage, 80)
 			updated, err := ensureContainerImageUpdated(&container, tt.newImage)
@@ -338,8 +337,6 @@ func TestMaybeCreateCertificateSecret(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 
@@ -392,7 +389,6 @@ func TestMaybeCreateCertificateSecret(t *testing.T) {
 			_, err = x509.ParseECPrivateKey(tlsKeyPemBlock.Bytes)
 			require.NoError(t, err)
 		})
-
 	}
 }
 

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -333,7 +333,6 @@ func TestCreateManager(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			scheme := prepareScheme(t)
 			k8sclient := testk8sclient.NewSimpleClientset()
@@ -481,7 +480,6 @@ func TestTelemetryUpdates(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			scheme := prepareScheme(t)
 			// We need the custom list kinds to prevent:

--- a/internal/utils/dataplane/config_test.go
+++ b/internal/utils/dataplane/config_test.go
@@ -150,7 +150,6 @@ func TestFillDataPlaneProxyContainerEnvs(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			FillDataPlaneProxyContainerEnvs(tc.existing, tc.podTemplateSpec)
 			container := k8sutils.GetPodContainerByName(&tc.podTemplateSpec.Spec, consts.DataPlaneProxyContainerName)

--- a/internal/validation/dataplane/validation_test.go
+++ b/internal/validation/dataplane/validation_test.go
@@ -354,7 +354,6 @@ func TestValidateDeployOptions(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.msg, func(t *testing.T) {
 			v := &Validator{
 				c: b.Build(),
@@ -545,7 +544,6 @@ func TestDataPlaneIngressServiceOptions(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.msg, func(t *testing.T) {
 			b := fakeclient.NewClientBuilder()
 			v := &Validator{
@@ -813,7 +811,6 @@ func TestValidateUpdate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.msg, func(t *testing.T) {
 			v := &Validator{
 				c: b.Build(),

--- a/internal/versions/validation_test.go
+++ b/internal/versions/validation_test.go
@@ -82,7 +82,6 @@ func Test_versionFromImage(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.Tag, func(t *testing.T) {
 			actual, err := FromImage(tc.Tag)
 

--- a/modules/admission/server_test.go
+++ b/modules/admission/server_test.go
@@ -388,7 +388,6 @@ func TestHandleDataPlaneValidation(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			review := &admissionv1.AdmissionReview{
 				Request: &admissionv1.AdmissionRequest{

--- a/modules/manager/webhook_test.go
+++ b/modules/manager/webhook_test.go
@@ -70,7 +70,6 @@ func TestWaitForWebhookCertificate(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/utils/gateway/ownerrefs.go
+++ b/pkg/utils/gateway/ownerrefs.go
@@ -45,7 +45,6 @@ func ListDataPlanesForGateway(
 
 	dataplanes := make([]operatorv1beta1.DataPlane, 0)
 	for _, dataplane := range dataplaneList.Items {
-		dataplane := dataplane
 		if k8sutils.IsOwnedByRefUID(&dataplane, gateway.UID) {
 			dataplanes = append(dataplanes, dataplane)
 		}
@@ -81,7 +80,6 @@ func ListControlPlanesForGateway(
 
 	controlplanes := make([]operatorv1beta1.ControlPlane, 0)
 	for _, controlplane := range controlplaneList.Items {
-		controlplane := controlplane
 		if k8sutils.IsOwnedByRefUID(&controlplane, gateway.UID) {
 			controlplanes = append(controlplanes, controlplane)
 		}
@@ -226,7 +224,6 @@ func ListNetworkPoliciesForGateway(
 
 	networkPolicies := make([]networkingv1.NetworkPolicy, 0)
 	for _, networkPolicy := range networkPolicyList.Items {
-		networkPolicy := networkPolicy
 		if k8sutils.IsOwnedByRefUID(&networkPolicy, gateway.UID) {
 			networkPolicies = append(networkPolicies, networkPolicy)
 		}

--- a/pkg/utils/gateway/ownerrefs_test.go
+++ b/pkg/utils/gateway/ownerrefs_test.go
@@ -252,7 +252,6 @@ func TestListHTTPRoutesForGateway(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cl := fake.NewClientBuilder().
 				WithScheme(scheme.Get()).
@@ -267,6 +266,5 @@ func TestListHTTPRoutesForGateway(t *testing.T) {
 				require.Equal(t, tc.expected, routes)
 			}
 		})
-
 	}
 }

--- a/pkg/utils/kubernetes/compare/comparators_test.go
+++ b/pkg/utils/kubernetes/compare/comparators_test.go
@@ -471,7 +471,6 @@ func TestDeploymentOptionsV1AlphaDeepEqual(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ret := ControlPlaneDeploymentOptionsDeepEqual(tc.o1, tc.o2, tc.envsToIgnore...)
 			if tc.expect {

--- a/pkg/utils/kubernetes/crd_test.go
+++ b/pkg/utils/kubernetes/crd_test.go
@@ -87,7 +87,6 @@ func TestCRDChecker(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			fakeClient := fakectrlruntimeclient.
 				NewClientBuilder().

--- a/pkg/utils/kubernetes/envvars_test.go
+++ b/pkg/utils/kubernetes/envvars_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestUpdateEnv(t *testing.T) {
-
 	exampleVarSource := &corev1.EnvVarSource{
 		FieldRef: &corev1.ObjectFieldSelector{
 			FieldPath: "metadata.name",
@@ -66,7 +65,6 @@ func TestUpdateEnv(t *testing.T) {
 }
 
 func TestUpdateEnvSource(t *testing.T) {
-
 	exampleVarSource := &corev1.EnvVarSource{
 		FieldRef: &corev1.ObjectFieldSelector{
 			FieldPath: "metadata.name",
@@ -291,11 +289,9 @@ func TestGetEnvValueFromContainer(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			c := b.Build()
-			value, found, err :=
-				GetEnvValueFromContainer(context.Background(), tc.container, "default", tc.key, c)
+			value, found, err := GetEnvValueFromContainer(context.Background(), tc.container, "default", tc.key, c)
 			if tc.hasError {
 				require.Error(t, err)
 				return

--- a/pkg/utils/kubernetes/lists.go
+++ b/pkg/utils/kubernetes/lists.go
@@ -40,7 +40,6 @@ func ListDeploymentsForOwner(
 
 	deployments := make([]appsv1.Deployment, 0)
 	for _, deployment := range deploymentList.Items {
-		deployment := deployment
 		if IsOwnedByRefUID(&deployment, uid) {
 			deployments = append(deployments, deployment)
 		}
@@ -75,7 +74,6 @@ func ListHPAsForOwner(
 
 	hpas := make([]autoscalingv2.HorizontalPodAutoscaler, 0)
 	for _, hpa := range hpaList.Items {
-		hpa := hpa
 		if IsOwnedByRefUID(&hpa, uid) {
 			hpas = append(hpas, hpa)
 		}
@@ -110,7 +108,6 @@ func ListPodDisruptionBudgetsForOwner(
 
 	var pdbs []policyv1.PodDisruptionBudget
 	for _, pdb := range pdbList.Items {
-		pdb := pdb
 		if IsOwnedByRefUID(&pdb, uid) {
 			pdbs = append(pdbs, pdb)
 		}
@@ -145,7 +142,6 @@ func ListServicesForOwner(
 
 	services := make([]corev1.Service, 0)
 	for _, service := range serviceList.Items {
-		service := service
 		if IsOwnedByRefUID(&service, uid) {
 			services = append(services, service)
 		}
@@ -180,7 +176,6 @@ func ListServiceAccountsForOwner(
 
 	serviceAccounts := make([]corev1.ServiceAccount, 0)
 	for _, serviceAccount := range serviceAccountList.Items {
-		serviceAccount := serviceAccount
 		if IsOwnedByRefUID(&serviceAccount, uid) {
 			serviceAccounts = append(serviceAccounts, serviceAccount)
 		}
@@ -250,7 +245,6 @@ func ListConfigMapsForOwner(ctx context.Context,
 
 	configMaps := make([]corev1.ConfigMap, 0)
 	for _, cm := range configMapList.Items {
-		cm := cm
 		if IsOwnedByRefUID(&cm, uid) {
 			configMaps = append(configMaps, cm)
 		}
@@ -280,7 +274,6 @@ func ListSecretsForOwner(ctx context.Context,
 
 	secrets := make([]corev1.Secret, 0)
 	for _, secret := range secretList.Items {
-		secret := secret
 		if IsOwnedByRefUID(&secret, uid) {
 			secrets = append(secrets, secret)
 		}

--- a/pkg/utils/kubernetes/lists_test.go
+++ b/pkg/utils/kubernetes/lists_test.go
@@ -71,7 +71,6 @@ func TestListValidatingWebhookConfigurationsForOwner(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			c := fake.NewFakeClient(tc.objects...)
 			ownedCfgs, err := k8sutils.ListValidatingWebhookConfigurations(ctx,

--- a/pkg/utils/kubernetes/metadata_test.go
+++ b/pkg/utils/kubernetes/metadata_test.go
@@ -208,7 +208,6 @@ func TestEnsureObjectMetaIsUpdated(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			toUpdate, ResultingMeta := EnsureObjectMetaIsUpdated(tc.existingObjMeta, tc.generatedObjMeta, tc.options...)
 			assert.Equal(t, tc.toUpdate, toUpdate)

--- a/pkg/utils/kubernetes/reduce/filters_test.go
+++ b/pkg/utils/kubernetes/reduce/filters_test.go
@@ -66,7 +66,6 @@ func TestFilterSecrets(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			filteredSecrets := filterSecrets(tc.secrets)
 			require.Equal(t, filteredSecrets, tc.filteredSecrets)
@@ -108,7 +107,6 @@ func TestFilterServiceAccounts(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			filteredSecrets := filterServiceAccounts(tc.serviceAccount)
 			require.Equal(t, filteredSecrets, tc.filteredServiceAccount)
@@ -488,7 +486,6 @@ func TestFilterDeployments(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			filteredDeployments := filterDeployments(tc.deployments)
 			require.Equal(t, tc.filteredDeployments, filteredDeployments)
@@ -769,7 +766,6 @@ func TestFilterServices(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			filteredServices := filterServices(tc.services, tc.endpointSlices)
 			require.Equal(t, filteredServices, tc.filteredServices)
@@ -848,7 +844,6 @@ func TestFilterValidatingWebhookConfigurations(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			filteredWebhooks := filterValidatingWebhookConfigurations(tc.webhooks)
 			filteredWebhookNames := lo.Map(filteredWebhooks, func(w admregv1.ValidatingWebhookConfiguration, _ int) string {
@@ -982,7 +977,6 @@ func TestFilterClusterRoles(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			filtered := filterClusterRoles(tc.clusterRoles)
 			filteredNames := lo.Map(filtered, func(w rbacv1.ClusterRole, _ int) string {
@@ -1027,7 +1021,6 @@ func TestFilterHPA(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			filtered := FilterHPAs(tc.hpas)
 			filteredNames := lo.Map(filtered, func(hpa autoscalingv2.HorizontalPodAutoscaler, _ int) string {
@@ -1072,7 +1065,6 @@ func TestFilterPodDisruptionBudgets(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			filtered := FilterPodDisruptionBudgets(tc.pdbs)
 			filteredNames := lo.Map(filtered, func(pdb policyv1.PodDisruptionBudget, _ int) string {

--- a/pkg/utils/kubernetes/reduce/reduce.go
+++ b/pkg/utils/kubernetes/reduce/reduce.go
@@ -27,7 +27,6 @@ type PreDeleteHook func(ctx context.Context, cl client.Client, obj client.Object
 func ReduceSecrets(ctx context.Context, k8sClient client.Client, secrets []corev1.Secret, preDeleteHooks ...PreDeleteHook) error {
 	filteredSecrets := filterSecrets(secrets)
 	for _, secret := range filteredSecrets {
-		secret := secret
 		for _, hook := range preDeleteHooks {
 			if err := hook(ctx, k8sClient, &secret); err != nil {
 				return fmt.Errorf("failed to execute pre delete hook: %w", err)
@@ -46,7 +45,6 @@ func ReduceSecrets(ctx context.Context, k8sClient client.Client, secrets []corev
 func ReduceServiceAccounts(ctx context.Context, k8sClient client.Client, serviceAccounts []corev1.ServiceAccount) error {
 	filteredServiceAccounts := filterServiceAccounts(serviceAccounts)
 	for _, serviceAccount := range filteredServiceAccounts {
-		serviceAccount := serviceAccount
 		if err := k8sClient.Delete(ctx, &serviceAccount); client.IgnoreNotFound(err) != nil {
 			return err
 		}
@@ -60,7 +58,6 @@ func ReduceServiceAccounts(ctx context.Context, k8sClient client.Client, service
 func ReduceClusterRoles(ctx context.Context, k8sClient client.Client, clusterRoles []rbacv1.ClusterRole) error {
 	filteredClusterRoles := filterClusterRoles(clusterRoles)
 	for _, clusterRole := range filteredClusterRoles {
-		clusterRole := clusterRole
 		if err := k8sClient.Delete(ctx, &clusterRole); client.IgnoreNotFound(err) != nil {
 			return err
 		}
@@ -74,7 +71,6 @@ func ReduceClusterRoles(ctx context.Context, k8sClient client.Client, clusterRol
 func ReduceClusterRoleBindings(ctx context.Context, k8sClient client.Client, clusterRoleBindings []rbacv1.ClusterRoleBinding) error {
 	filteredCLusterRoleBindings := filterClusterRoleBindings(clusterRoleBindings)
 	for _, clusterRoleBinding := range filteredCLusterRoleBindings {
-		clusterRoleBinding := clusterRoleBinding
 		if err := k8sClient.Delete(ctx, &clusterRoleBinding); client.IgnoreNotFound(err) != nil {
 			return err
 		}
@@ -89,7 +85,6 @@ func ReduceClusterRoleBindings(ctx context.Context, k8sClient client.Client, clu
 func ReduceDeployments(ctx context.Context, k8sClient client.Client, deployments []appsv1.Deployment, preDeleteHooks ...PreDeleteHook) error {
 	filteredDeployments := filterDeployments(deployments)
 	for _, deployment := range filteredDeployments {
-		deployment := deployment
 		for _, hook := range preDeleteHooks {
 			if err := hook(ctx, k8sClient, &deployment); err != nil {
 				return fmt.Errorf("failed to execute pre delete hook: %w", err)
@@ -123,7 +118,6 @@ func ReduceServices(ctx context.Context, k8sClient client.Client, services []cor
 	}
 	filteredServices := filterServices(services, mappedEndpointSlices)
 	for _, service := range filteredServices {
-		service := service
 		for _, hook := range preDeleteHooks {
 			if err := hook(ctx, k8sClient, &service); err != nil {
 				return fmt.Errorf("failed to execute pre delete hook: %w", err)
@@ -142,7 +136,6 @@ func ReduceServices(ctx context.Context, k8sClient client.Client, services []cor
 func ReduceNetworkPolicies(ctx context.Context, k8sClient client.Client, networkPolicies []networkingv1.NetworkPolicy) error {
 	filteredNetworkPolicies := filterNetworkPolicies(networkPolicies)
 	for _, networkPolicy := range filteredNetworkPolicies {
-		networkPolicy := networkPolicy
 		if err := k8sClient.Delete(ctx, &networkPolicy); client.IgnoreNotFound(err) != nil {
 			return err
 		}
@@ -158,7 +151,6 @@ type HPAFilterFunc func([]autoscalingv2.HorizontalPodAutoscaler) []autoscalingv2
 // ReduceHPAs detects the best HorizontalPodAutoscaler in the set and deletes all the others.
 func ReduceHPAs(ctx context.Context, k8sClient client.Client, hpas []autoscalingv2.HorizontalPodAutoscaler, filter HPAFilterFunc) error {
 	for _, hpa := range filter(hpas) {
-		hpa := hpa
 		if err := k8sClient.Delete(ctx, &hpa); client.IgnoreNotFound(err) != nil {
 			return err
 		}
@@ -174,7 +166,6 @@ type PDBFilterFunc func([]policyv1.PodDisruptionBudget) []policyv1.PodDisruption
 // ReducePodDisruptionBudgets detects the best PodDisruptionBudget in the set and deletes all the others.
 func ReducePodDisruptionBudgets(ctx context.Context, k8sClient client.Client, pdbs []policyv1.PodDisruptionBudget, filter PDBFilterFunc) error {
 	for _, pdb := range filter(pdbs) {
-		pdb := pdb
 		if err := k8sClient.Delete(ctx, &pdb); client.IgnoreNotFound(err) != nil {
 			return err
 		}
@@ -188,7 +179,6 @@ func ReducePodDisruptionBudgets(ctx context.Context, k8sClient client.Client, pd
 func ReduceValidatingWebhookConfigurations(ctx context.Context, k8sClient client.Client, webhookConfigurations []admregv1.ValidatingWebhookConfiguration) error {
 	filteredWebhookConfigurations := filterValidatingWebhookConfigurations(webhookConfigurations)
 	for _, webhookConfiguration := range filteredWebhookConfigurations {
-		webhookConfiguration := webhookConfiguration
 		if err := k8sClient.Delete(ctx, &webhookConfiguration); client.IgnoreNotFound(err) != nil {
 			return err
 		}
@@ -202,7 +192,6 @@ func ReduceValidatingWebhookConfigurations(ctx context.Context, k8sClient client
 func ReduceDataPlanes(ctx context.Context, k8sClient client.Client, dataplanes []operatorv1beta1.DataPlane) error {
 	filteredDataPlanes := filterDataPlanes(dataplanes)
 	for _, dataplane := range filteredDataPlanes {
-		dataplane := dataplane
 		if err := k8sClient.Delete(ctx, &dataplane); client.IgnoreNotFound(err) != nil {
 			return err
 		}

--- a/pkg/utils/kubernetes/resources/clusterrole_helpers_test.go
+++ b/pkg/utils/kubernetes/resources/clusterrole_helpers_test.go
@@ -96,7 +96,6 @@ func TestClusterroleHelpers(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.controlplane, func(t *testing.T) {
 			clusterRole, err := resources.GenerateNewClusterRoleForControlPlane(tc.controlplane, tc.image, tc.devMode)
 			if tc.expectedError != nil {

--- a/pkg/utils/kubernetes/resources/deployments_test.go
+++ b/pkg/utils/kubernetes/resources/deployments_test.go
@@ -266,7 +266,6 @@ func TestGenerateNewDeploymentForDataPlane(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			partial, err := GenerateNewDeploymentForDataPlane(tt.dataplane, dataplaneImage)
 			require.NoError(t, err)
@@ -574,7 +573,6 @@ func TestGenerateNewDeploymentForControlPlane(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			deployment, err := GenerateNewDeploymentForControlPlane(tt.generateControlPlaneArgs)
 			require.NoError(t, err)

--- a/pkg/utils/kubernetes/resources/kic_validatingwebhookconfig_test.go
+++ b/pkg/utils/kubernetes/resources/kic_validatingwebhookconfig_test.go
@@ -37,7 +37,6 @@ func TestGenerateValidatingWebhookConfigurationForControlPlane(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.image, func(t *testing.T) {
 			cfg, err := resources.GenerateValidatingWebhookConfigurationForControlPlane(
 				"webhook",

--- a/pkg/utils/kubernetes/resources/resourcerequirements_test.go
+++ b/pkg/utils/kubernetes/resources/resourcerequirements_test.go
@@ -67,7 +67,6 @@ func TestResourceRequirementsEqual(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, ResourceRequirementsEqual(tt.a, tt.b))
 		})

--- a/pkg/utils/kubernetes/resources/services_test.go
+++ b/pkg/utils/kubernetes/resources/services_test.go
@@ -64,7 +64,6 @@ func TestGetSelectorOverrides(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			newSelector, err := getSelectorOverrides(tc.annotationValue)
 			if tc.needsErr {
@@ -221,7 +220,6 @@ func TestGenerateNewIngressServiceForDataPlane(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			svc, err := GenerateNewIngressServiceForDataPlane(tc.dataplane)
 			require.Equal(t, tc.expectedErr, err)

--- a/pkg/utils/kubernetes/resources/strategicmerge_test.go
+++ b/pkg/utils/kubernetes/resources/strategicmerge_test.go
@@ -872,7 +872,6 @@ func TestStrategicMergePatchPodTemplateSpec(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			d, err := makeControlPlaneDeployment()
 			require.NoError(t, err)

--- a/pkg/utils/kubernetes/status_test.go
+++ b/pkg/utils/kubernetes/status_test.go
@@ -69,7 +69,6 @@ func TestGetCondition(t *testing.T) {
 			true,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			resource := &TestResource{
 				Conditions: tt.conditions,
@@ -278,7 +277,6 @@ func TestSetCondition(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			resource := &TestResource{
 				Conditions: tt.conditions,
@@ -333,7 +331,6 @@ func TestIsValidCondition(t *testing.T) {
 			false,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			current := IsConditionTrue(consts.ConditionType(tt.input), resource)
 			assert.Equal(t, current, tt.expected)
@@ -387,7 +384,6 @@ func TestIsReady(t *testing.T) {
 			false,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			resource := &TestResource{
 				Conditions: tt.conditions,
@@ -492,7 +488,6 @@ func TestSetReady(t *testing.T) {
 			false,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			resource := &TestResource{
 				Conditions: tt.conditions,
@@ -636,7 +631,6 @@ func TestNeedsUpdate(t *testing.T) {
 			false,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			current := &TestResource{
 				Conditions: tt.current,

--- a/pkg/utils/kubernetes/volume_test.go
+++ b/pkg/utils/kubernetes/volume_test.go
@@ -74,7 +74,6 @@ func TestHasSameVolumeSource(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			equal := HasSameVolumeSource(tc.baseVolumeSource, tc.comparedVolumeSource)
 			if tc.equal {

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -28,7 +28,6 @@ func Test_extractImageNameAndTag(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			gotName, gotTag, err := extractImageNameAndTag(tt.fullName)
 			if tt.wantErr {

--- a/test/e2e/test_helm_install_upgrade.go
+++ b/test/e2e/test_helm_install_upgrade.go
@@ -327,7 +327,6 @@ func TestHelmUpgrade(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var (
 				tag              string

--- a/test/e2e/test_operator_logs.go
+++ b/test/e2e/test_operator_logs.go
@@ -180,7 +180,6 @@ func TestOperatorLogs(t *testing.T) {
 
 	t.Log("checking that all the subresources have been deleted")
 	for _, gateway := range gateways.Items {
-		gateway := gateway
 		dataplanes := testutils.MustListDataPlanesForGateway(t, ctx, &gateway, *clients)
 		assert.LessOrEqual(t, len(dataplanes), 1)
 		controlplanes := testutils.MustListControlPlanesForGateway(t, ctx, &gateway, *clients)

--- a/test/e2e/test_webhook.go
+++ b/test/e2e/test_webhook.go
@@ -79,7 +79,6 @@ func TestDataPlaneValidatingWebhook(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			dataplaneClient := clients.OperatorClient.ApisV1beta1().DataPlanes(testNamespace.Name)
 			_, err := dataplaneClient.Create(ctx, tc.dataplane, metav1.CreateOptions{})

--- a/test/integration/test_validating.go
+++ b/test/integration/test_validating.go
@@ -178,7 +178,6 @@ func testDataPlaneReconcileValidation(t *testing.T, namespace *corev1.Namespace)
 
 	dataplaneClient := GetClients().OperatorClient.ApisV1beta1().DataPlanes(namespace.Name)
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			dataplane, err := dataplaneClient.Create(GetCtx(), tc.dataplane, metav1.CreateOptions{})
 			require.NoErrorf(t, err, "should not return error when create dataplane for case %s", tc.name)
@@ -403,7 +402,6 @@ func testDataPlaneValidatingWebhook(t *testing.T, namespace *corev1.Namespace) {
 
 	dataplaneClient := GetClients().OperatorClient.ApisV1beta1().DataPlanes(namespace.Name)
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := dataplaneClient.Create(GetCtx(), tc.dataplane, metav1.CreateOptions{})
 			if tc.errMsg == "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove `exportloopref` from golangci-lint config to prevent the following deprecation notice when running `make lint`:

```
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
```
