### PR TITLE
feat: attach Kubernetes metadata to Konnect entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,9 @@
 - The `DataPlaneKonnectExtension` CRD has been introduced. Such a CRD can be attached
   to a `DataPlane` via the extensions field to have a konnect-flavored `DataPlane`.
   [#453](https://github.com/Kong/gateway-operator/pull/453)
-- Entities created in Konnect are now labeled  with origin Kubernetes object's metadata.
+- Entities created in Konnect are now labeled (or tagged for those that does not support labels)
+  with origin Kubernetes object's metadata: `k8s-name`, `k8s-namespace`, `k8s-uid`, `k8s-generation`,
+  `k8s-kind`, `k8s-group`, `k8s-version`.
   [#565](https://github.com/Kong/gateway-operator/pull/565)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@
 - The `DataPlaneKonnectExtension` CRD has been introduced. Such a CRD can be attached
   to a `DataPlane` via the extensions field to have a konnect-flavored `DataPlane`.
   [#453](https://github.com/Kong/gateway-operator/pull/453)
+- Entities created in Konnect are now labeled  with origin Kubernetes object's metadata.
+  [#565](https://github.com/Kong/gateway-operator/pull/565)
 
 ### Fixed
 

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -158,11 +158,11 @@ func Update[
 	case *configurationv1alpha1.KongService:
 		return ctrl.Result{}, updateService(ctx, sdk.GetServicesSDK(), ent)
 	case *configurationv1alpha1.KongRoute:
-		return ctrl.Result{}, updateRoute(ctx, sdk.GetRoutesSDK(), cl, ent)
+		return ctrl.Result{}, updateRoute(ctx, sdk.GetRoutesSDK(), ent)
 	case *configurationv1.KongConsumer:
-		return ctrl.Result{}, updateConsumer(ctx, sdk.GetConsumersSDK(), cl, ent)
+		return ctrl.Result{}, updateConsumer(ctx, sdk.GetConsumersSDK(), ent)
 	case *configurationv1beta1.KongConsumerGroup:
-		return ctrl.Result{}, updateConsumerGroup(ctx, sdk.GetConsumerGroupsSDK(), cl, ent)
+		return ctrl.Result{}, updateConsumerGroup(ctx, sdk.GetConsumerGroupsSDK(), ent)
 	case *configurationv1alpha1.KongPluginBinding:
 		return ctrl.Result{}, updatePlugin(ctx, sdk.GetPluginSDK(), cl, ent)
 

--- a/controller/konnect/ops/ops_controlplane.go
+++ b/controller/konnect/ops/ops_controlplane.go
@@ -21,7 +21,9 @@ func createControlPlane(
 	sdk ControlPlaneSDK,
 	cp *konnectv1alpha1.KonnectGatewayControlPlane,
 ) error {
-	resp, err := sdk.CreateControlPlane(ctx, cp.Spec.CreateControlPlaneRequest)
+	req := cp.Spec.CreateControlPlaneRequest
+	req.Labels = WithKubernetesMetadataLabels(cp, req.Labels)
+	resp, err := sdk.CreateControlPlane(ctx, req)
 	// TODO: handle already exists
 	// Can't adopt it as it will cause conflicts between the controller
 	// that created that entity and already manages it, hm
@@ -103,7 +105,7 @@ func updateControlPlane(
 		Description: cp.Spec.Description,
 		AuthType:    (*sdkkonnectcomp.UpdateControlPlaneRequestAuthType)(cp.Spec.AuthType),
 		ProxyUrls:   cp.Spec.ProxyUrls,
-		Labels:      cp.Spec.Labels,
+		Labels:      WithKubernetesMetadataLabels(cp, cp.Spec.Labels),
 	}
 
 	resp, err := sdk.UpdateControlPlane(ctx, id, req)

--- a/controller/konnect/ops/ops_k8s_meta.go
+++ b/controller/konnect/ops/ops_k8s_meta.go
@@ -66,7 +66,7 @@ func GenerateKubernetesMetadataTags(obj client.Object) []string {
 	if k8sNamespace := obj.GetNamespace(); k8sNamespace != "" {
 		labels = append(labels, lo.Entry[string, string]{Key: KubernetesNamespaceLabelKey, Value: k8sNamespace})
 	}
-	var tags []string
+	tags := make([]string, 0, len(labels))
 	for _, label := range labels {
 		tags = append(tags, fmt.Sprintf("%s:%s", label.Key, label.Value))
 	}

--- a/controller/konnect/ops/ops_k8s_meta.go
+++ b/controller/konnect/ops/ops_k8s_meta.go
@@ -1,0 +1,74 @@
+package ops
+
+import (
+	"fmt"
+
+	"github.com/samber/lo"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// KubernetesNamespaceLabelKey is the key for the Kubernetes namespace label.
+	KubernetesNamespaceLabelKey = "k8s-namespace"
+
+	// KubernetesNameLabelKey is the key for the Kubernetes name label.
+	KubernetesNameLabelKey = "k8s-name"
+
+	// KubernetesUIDLabelKey is the key for the Kubernetes UID label.
+	KubernetesUIDLabelKey = "k8s-uid"
+
+	// KubernetesGenerationLabelKey is the key for the Kubernetes generation label.
+	KubernetesGenerationLabelKey = "k8s-generation"
+
+	// KubernetesKindLabelKey is the key for the Kubernetes kind label.
+	KubernetesKindLabelKey = "k8s-kind"
+
+	// KubernetesGroupLabelKey is the key for the Kubernetes group label.
+	KubernetesGroupLabelKey = "k8s-group"
+
+	// KubernetesVersionLabelKey is the key for the Kubernetes version label.
+	KubernetesVersionLabelKey = "k8s-version"
+)
+
+// WithKubernetesMetadataLabels returns a map of user-provided labels to be assigned to a Konnect entity with the origin
+// Kubernetes object's metadata added. These can be assigned to a Konnect entitiy that supports labels (e.g. ControlPlane).
+func WithKubernetesMetadataLabels(obj client.Object, userSetLabels map[string]string) map[string]string {
+	labels := map[string]string{
+		KubernetesNameLabelKey:       obj.GetName(),
+		KubernetesUIDLabelKey:        string(obj.GetUID()),
+		KubernetesGenerationLabelKey: fmt.Sprintf("%d", obj.GetGeneration()),
+		KubernetesKindLabelKey:       obj.GetObjectKind().GroupVersionKind().Kind,
+		KubernetesGroupLabelKey:      obj.GetObjectKind().GroupVersionKind().GroupVersion().Group,
+		KubernetesVersionLabelKey:    obj.GetObjectKind().GroupVersionKind().GroupVersion().Version,
+	}
+	if k8sNamespace := obj.GetNamespace(); k8sNamespace != "" {
+		labels[KubernetesNamespaceLabelKey] = k8sNamespace
+	}
+	for k, v := range userSetLabels {
+		labels[k] = v
+	}
+	return labels
+}
+
+// GenerateKubernetesMetadataTags generates a list of tags from a Kubernetes object's metadata. The tags are formatted as
+// "key:value". These can be attached to a Konnect entity that doesn't support labels, but supports tags (e.g. Route, Service,
+// Consumer, etc.).
+func GenerateKubernetesMetadataTags(obj client.Object) []string {
+	// Use a list of Entry instead of a builtin map to preserve the order of the labels.
+	labels := []lo.Entry[string, string]{
+		{Key: KubernetesGenerationLabelKey, Value: fmt.Sprintf("%d", obj.GetGeneration())},
+		{Key: KubernetesGroupLabelKey, Value: obj.GetObjectKind().GroupVersionKind().GroupVersion().Group},
+		{Key: KubernetesKindLabelKey, Value: obj.GetObjectKind().GroupVersionKind().Kind},
+		{Key: KubernetesNameLabelKey, Value: obj.GetName()},
+		{Key: KubernetesUIDLabelKey, Value: string(obj.GetUID())},
+		{Key: KubernetesVersionLabelKey, Value: obj.GetObjectKind().GroupVersionKind().GroupVersion().Version},
+	}
+	if k8sNamespace := obj.GetNamespace(); k8sNamespace != "" {
+		labels = append(labels, lo.Entry[string, string]{Key: KubernetesNamespaceLabelKey, Value: k8sNamespace})
+	}
+	var tags []string
+	for _, label := range labels {
+		tags = append(tags, fmt.Sprintf("%s:%s", label.Key, label.Value))
+	}
+	return tags
+}

--- a/controller/konnect/ops/ops_k8s_meta_test.go
+++ b/controller/konnect/ops/ops_k8s_meta_test.go
@@ -1,0 +1,145 @@
+package ops_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kong/gateway-operator/controller/konnect/ops"
+)
+
+// testObjectKind is a test object type that implements the client.Object interface.
+type testObjectKind struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+}
+
+func (b *testObjectKind) DeepCopyObject() runtime.Object {
+	return b
+}
+
+func TestWithKubernetesMetadataLabels(t *testing.T) {
+	testCases := []struct {
+		name           string
+		obj            testObjectKind
+		expectedLabels map[string]string
+	}{
+		{
+			name: "all object's expected fields are set",
+			obj: testObjectKind{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "TestObjectKind",
+					APIVersion: "test.objects.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-object",
+					Namespace:  "test-namespace",
+					UID:        "test-uid",
+					Generation: 2,
+				},
+			},
+			expectedLabels: map[string]string{
+				ops.KubernetesKindLabelKey:       "TestObjectKind",
+				ops.KubernetesGroupLabelKey:      "test.objects.io",
+				ops.KubernetesVersionLabelKey:    "v1",
+				ops.KubernetesNameLabelKey:       "test-object",
+				ops.KubernetesNamespaceLabelKey:  "test-namespace",
+				ops.KubernetesUIDLabelKey:        "test-uid",
+				ops.KubernetesGenerationLabelKey: "2",
+			},
+		},
+		{
+			name: "namespace is not set (cluster-scoped object)",
+			obj: testObjectKind{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "TestObjectKind",
+					APIVersion: "test.objects.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-object",
+					UID:        "test-uid",
+					Generation: 2,
+				},
+			},
+			expectedLabels: map[string]string{
+				ops.KubernetesKindLabelKey:       "TestObjectKind",
+				ops.KubernetesGroupLabelKey:      "test.objects.io",
+				ops.KubernetesVersionLabelKey:    "v1",
+				ops.KubernetesNameLabelKey:       "test-object",
+				ops.KubernetesUIDLabelKey:        "test-uid",
+				ops.KubernetesGenerationLabelKey: "2",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			labels := ops.WithKubernetesMetadataLabels(&tc.obj, tc.expectedLabels)
+			require.Equal(t, tc.expectedLabels, labels)
+		})
+	}
+}
+
+func TestGenerateKubernetesMetadataTags(t *testing.T) {
+	testCases := []struct {
+		name         string
+		obj          testObjectKind
+		expectedTags []string
+	}{
+		{
+			name: "all object's expected fields are set",
+			obj: testObjectKind{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "TestObjectKind",
+					APIVersion: "test.objects.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-object",
+					Namespace:  "test-namespace",
+					UID:        "test-uid",
+					Generation: 2,
+				},
+			},
+			expectedTags: []string{
+				"k8s-generation:2",
+				"k8s-group:test.objects.io",
+				"k8s-kind:TestObjectKind",
+				"k8s-name:test-object",
+				"k8s-uid:test-uid",
+				"k8s-version:v1",
+				"k8s-namespace:test-namespace",
+			},
+		},
+		{
+			name: "namespace is not set (cluster-scoped object)",
+			obj: testObjectKind{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "TestObjectKind",
+					APIVersion: "test.objects.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-object",
+					UID:        "test-uid",
+					Generation: 2,
+				},
+			},
+			expectedTags: []string{
+				"k8s-generation:2",
+				"k8s-group:test.objects.io",
+				"k8s-kind:TestObjectKind",
+				"k8s-name:test-object",
+				"k8s-uid:test-uid",
+				"k8s-version:v1",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tags := ops.GenerateKubernetesMetadataTags(&tc.obj)
+			require.Equal(t, tc.expectedTags, tags)
+		})
+	}
+}

--- a/controller/konnect/ops/ops_kongconsumer_test.go
+++ b/controller/konnect/ops/ops_kongconsumer_test.go
@@ -1,74 +1,43 @@
 package ops
 
 import (
-	"context"
 	"testing"
 
-	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
-	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	"github.com/google/uuid"
-	"github.com/samber/lo"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
-	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
-func TestCreateAndUpdateKongConsumer_KubernetesMetadataConsistency(t *testing.T) {
-	var (
-		ctx = context.Background()
-		cg  = &configurationv1.KongConsumer{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "KongConsumer",
-				APIVersion: "configuration.konghq.com/v1beta1",
+func TestKongConsumerToSDKConsumerInput_Tags(t *testing.T) {
+	cg := &configurationv1.KongConsumer{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KongConsumer",
+			APIVersion: "configuration.konghq.com/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "cg-1",
+			Namespace:  "default",
+			Generation: 2,
+			UID:        k8stypes.UID(uuid.NewString()),
+			Annotations: map[string]string{
+				"konghq.com/tags": "tag1,tag2",
 			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "cg-1",
-				Namespace: "default",
-			},
-			Status: configurationv1.KongConsumerStatus{
-				Konnect: &konnectv1alpha1.KonnectEntityStatusWithControlPlaneRef{
-					ControlPlaneID: uuid.NewString(),
-				},
-			},
-		}
-		sdk = &MockConsumersSDK{}
-	)
-
-	t.Log("Triggering CreateConsumer and capturing generated tags")
-	sdk.EXPECT().
-		CreateConsumer(ctx, cg.GetControlPlaneID(), mock.Anything).
-		Return(&sdkkonnectops.CreateConsumerResponse{
-			Consumer: &sdkkonnectcomp.Consumer{
-				ID: lo.ToPtr("12345"),
-			},
-		}, nil)
-	err := createConsumer(ctx, sdk, cg)
-	require.NoError(t, err)
-	require.Len(t, sdk.Calls, 1)
-	call := sdk.Calls[0]
-	require.Equal(t, "CreateConsumer", call.Method)
-	require.IsType(t, sdkkonnectcomp.ConsumerInput{}, call.Arguments[2])
-	capturedCreateTags := call.Arguments[2].(sdkkonnectcomp.ConsumerInput).Tags
-
-	t.Log("Triggering UpsertConsumer and capturing generated tags")
-	sdk.EXPECT().
-		UpsertConsumer(ctx, mock.Anything).
-		Return(&sdkkonnectops.UpsertConsumerResponse{
-			Consumer: &sdkkonnectcomp.Consumer{
-				ID: lo.ToPtr("12345"),
-			},
-		}, nil)
-	err = updateConsumer(ctx, sdk, cg)
-	require.NoError(t, err)
-	require.Len(t, sdk.Calls, 2)
-	call = sdk.Calls[1]
-	require.Equal(t, "UpsertConsumer", call.Method)
-	require.IsType(t, sdkkonnectops.UpsertConsumerRequest{}, call.Arguments[1])
-	capturedUpsertTags := call.Arguments[1].(sdkkonnectops.UpsertConsumerRequest).Consumer.Tags
-
-	require.NotEmpty(t, capturedCreateTags, "tags should be set on create")
-	require.Equal(t, capturedCreateTags, capturedUpsertTags, "tags should be consistent between create and update")
+		},
+	}
+	output := kongConsumerToSDKConsumerInput(cg)
+	expectedTags := []string{
+		"k8s-generation:2",
+		"k8s-kind:KongConsumer",
+		"k8s-name:cg-1",
+		"k8s-uid:" + string(cg.GetUID()),
+		"k8s-version:v1beta1",
+		"k8s-group:configuration.konghq.com",
+		"k8s-namespace:default",
+		"tag1",
+		"tag2",
+	}
+	require.ElementsMatch(t, expectedTags, output.Tags)
 }

--- a/controller/konnect/ops/ops_kongconsumer_test.go
+++ b/controller/konnect/ops/ops_kongconsumer_test.go
@@ -1,0 +1,74 @@
+package ops
+
+import (
+	"context"
+	"testing"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+func TestCreateAndUpdateKongConsumer_KubernetesMetadataConsistency(t *testing.T) {
+	var (
+		ctx = context.Background()
+		cg  = &configurationv1.KongConsumer{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KongConsumer",
+				APIVersion: "configuration.konghq.com/v1beta1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cg-1",
+				Namespace: "default",
+			},
+			Status: configurationv1.KongConsumerStatus{
+				Konnect: &konnectv1alpha1.KonnectEntityStatusWithControlPlaneRef{
+					ControlPlaneID: uuid.NewString(),
+				},
+			},
+		}
+		sdk = &MockConsumersSDK{}
+	)
+
+	t.Log("Triggering CreateConsumer and capturing generated tags")
+	sdk.EXPECT().
+		CreateConsumer(ctx, cg.GetControlPlaneID(), mock.Anything).
+		Return(&sdkkonnectops.CreateConsumerResponse{
+			Consumer: &sdkkonnectcomp.Consumer{
+				ID: lo.ToPtr("12345"),
+			},
+		}, nil)
+	err := createConsumer(ctx, sdk, cg)
+	require.NoError(t, err)
+	require.Len(t, sdk.Calls, 1)
+	call := sdk.Calls[0]
+	require.Equal(t, "CreateConsumer", call.Method)
+	require.IsType(t, sdkkonnectcomp.ConsumerInput{}, call.Arguments[2])
+	capturedCreateTags := call.Arguments[2].(sdkkonnectcomp.ConsumerInput).Tags
+
+	t.Log("Triggering UpsertConsumer and capturing generated tags")
+	sdk.EXPECT().
+		UpsertConsumer(ctx, mock.Anything).
+		Return(&sdkkonnectops.UpsertConsumerResponse{
+			Consumer: &sdkkonnectcomp.Consumer{
+				ID: lo.ToPtr("12345"),
+			},
+		}, nil)
+	err = updateConsumer(ctx, sdk, cg)
+	require.NoError(t, err)
+	require.Len(t, sdk.Calls, 2)
+	call = sdk.Calls[1]
+	require.Equal(t, "UpsertConsumer", call.Method)
+	require.IsType(t, sdkkonnectops.UpsertConsumerRequest{}, call.Arguments[1])
+	capturedUpsertTags := call.Arguments[1].(sdkkonnectops.UpsertConsumerRequest).Consumer.Tags
+
+	require.NotEmpty(t, capturedCreateTags, "tags should be set on create")
+	require.Equal(t, capturedCreateTags, capturedUpsertTags, "tags should be consistent between create and update")
+}

--- a/controller/konnect/ops/ops_kongconsumergroup_test.go
+++ b/controller/konnect/ops/ops_kongconsumergroup_test.go
@@ -1,0 +1,74 @@
+package ops
+
+import (
+	"context"
+	"testing"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configurationv1beta1 "github.com/kong/kubernetes-configuration/api/configuration/v1beta1"
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+func TestCreateAndUpdateKongConsumerGroup_KubernetesMetadataConsistency(t *testing.T) {
+	var (
+		ctx = context.Background()
+		cg  = &configurationv1beta1.KongConsumerGroup{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KongConsumerGroup",
+				APIVersion: "configuration.konghq.com/v1beta1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cg-1",
+				Namespace: "default",
+			},
+			Status: configurationv1beta1.KongConsumerGroupStatus{
+				Konnect: &konnectv1alpha1.KonnectEntityStatusWithControlPlaneRef{
+					ControlPlaneID: uuid.NewString(),
+				},
+			},
+		}
+		sdk = &MockConsumerGroupSDK{}
+	)
+
+	t.Log("Triggering CreateConsumerGroup and capturing generated tags")
+	sdk.EXPECT().
+		CreateConsumerGroup(ctx, cg.GetControlPlaneID(), mock.Anything).
+		Return(&sdkkonnectops.CreateConsumerGroupResponse{
+			ConsumerGroup: &sdkkonnectcomp.ConsumerGroup{
+				ID: lo.ToPtr("12345"),
+			},
+		}, nil)
+	err := createConsumerGroup(ctx, sdk, cg)
+	require.NoError(t, err)
+	require.Len(t, sdk.Calls, 1)
+	call := sdk.Calls[0]
+	require.Equal(t, "CreateConsumerGroup", call.Method)
+	require.IsType(t, sdkkonnectcomp.ConsumerGroupInput{}, call.Arguments[2])
+	capturedCreateTags := call.Arguments[2].(sdkkonnectcomp.ConsumerGroupInput).Tags
+
+	t.Log("Triggering UpsertConsumerGroup and capturing generated tags")
+	sdk.EXPECT().
+		UpsertConsumerGroup(ctx, mock.Anything).
+		Return(&sdkkonnectops.UpsertConsumerGroupResponse{
+			ConsumerGroup: &sdkkonnectcomp.ConsumerGroup{
+				ID: lo.ToPtr("12345"),
+			},
+		}, nil)
+	err = updateConsumerGroup(ctx, sdk, cg)
+	require.NoError(t, err)
+	require.Len(t, sdk.Calls, 2)
+	call = sdk.Calls[1]
+	require.Equal(t, "UpsertConsumerGroup", call.Method)
+	require.IsType(t, sdkkonnectops.UpsertConsumerGroupRequest{}, call.Arguments[1])
+	capturedUpsertTags := call.Arguments[1].(sdkkonnectops.UpsertConsumerGroupRequest).ConsumerGroup.Tags
+
+	require.NotEmpty(t, capturedCreateTags, "tags should be set on create")
+	require.Equal(t, capturedCreateTags, capturedUpsertTags, "tags should be consistent between create and update")
+}

--- a/controller/konnect/ops/ops_kongconsumergroup_test.go
+++ b/controller/konnect/ops/ops_kongconsumergroup_test.go
@@ -1,74 +1,49 @@
 package ops
 
 import (
-	"context"
 	"testing"
 
-	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
-	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	"github.com/google/uuid"
-	"github.com/samber/lo"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	configurationv1beta1 "github.com/kong/kubernetes-configuration/api/configuration/v1beta1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
-func TestCreateAndUpdateKongConsumerGroup_KubernetesMetadataConsistency(t *testing.T) {
-	var (
-		ctx = context.Background()
-		cg  = &configurationv1beta1.KongConsumerGroup{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "KongConsumerGroup",
-				APIVersion: "configuration.konghq.com/v1beta1",
+func TestKongConsumerGroupToSDKConsumerGroupInput_Tags(t *testing.T) {
+	cg := &configurationv1beta1.KongConsumerGroup{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KongConsumerGroup",
+			APIVersion: "configuration.konghq.com/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "cg-1",
+			Namespace:  "default",
+			Generation: 2,
+			UID:        k8stypes.UID(uuid.NewString()),
+			Annotations: map[string]string{
+				"konghq.com/tags": "tag1,tag2",
 			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "cg-1",
-				Namespace: "default",
+		},
+		Status: configurationv1beta1.KongConsumerGroupStatus{
+			Konnect: &konnectv1alpha1.KonnectEntityStatusWithControlPlaneRef{
+				ControlPlaneID: uuid.NewString(),
 			},
-			Status: configurationv1beta1.KongConsumerGroupStatus{
-				Konnect: &konnectv1alpha1.KonnectEntityStatusWithControlPlaneRef{
-					ControlPlaneID: uuid.NewString(),
-				},
-			},
-		}
-		sdk = &MockConsumerGroupSDK{}
-	)
-
-	t.Log("Triggering CreateConsumerGroup and capturing generated tags")
-	sdk.EXPECT().
-		CreateConsumerGroup(ctx, cg.GetControlPlaneID(), mock.Anything).
-		Return(&sdkkonnectops.CreateConsumerGroupResponse{
-			ConsumerGroup: &sdkkonnectcomp.ConsumerGroup{
-				ID: lo.ToPtr("12345"),
-			},
-		}, nil)
-	err := createConsumerGroup(ctx, sdk, cg)
-	require.NoError(t, err)
-	require.Len(t, sdk.Calls, 1)
-	call := sdk.Calls[0]
-	require.Equal(t, "CreateConsumerGroup", call.Method)
-	require.IsType(t, sdkkonnectcomp.ConsumerGroupInput{}, call.Arguments[2])
-	capturedCreateTags := call.Arguments[2].(sdkkonnectcomp.ConsumerGroupInput).Tags
-
-	t.Log("Triggering UpsertConsumerGroup and capturing generated tags")
-	sdk.EXPECT().
-		UpsertConsumerGroup(ctx, mock.Anything).
-		Return(&sdkkonnectops.UpsertConsumerGroupResponse{
-			ConsumerGroup: &sdkkonnectcomp.ConsumerGroup{
-				ID: lo.ToPtr("12345"),
-			},
-		}, nil)
-	err = updateConsumerGroup(ctx, sdk, cg)
-	require.NoError(t, err)
-	require.Len(t, sdk.Calls, 2)
-	call = sdk.Calls[1]
-	require.Equal(t, "UpsertConsumerGroup", call.Method)
-	require.IsType(t, sdkkonnectops.UpsertConsumerGroupRequest{}, call.Arguments[1])
-	capturedUpsertTags := call.Arguments[1].(sdkkonnectops.UpsertConsumerGroupRequest).ConsumerGroup.Tags
-
-	require.NotEmpty(t, capturedCreateTags, "tags should be set on create")
-	require.Equal(t, capturedCreateTags, capturedUpsertTags, "tags should be consistent between create and update")
+		},
+	}
+	expectedTags := []string{
+		"k8s-kind:KongConsumerGroup",
+		"k8s-name:cg-1",
+		"k8s-namespace:default",
+		"k8s-uid:" + string(cg.GetUID()),
+		"k8s-version:v1beta1",
+		"k8s-group:configuration.konghq.com",
+		"k8s-generation:2",
+		"tag1",
+		"tag2",
+	}
+	output := kongConsumerGroupToSDKConsumerGroupInput(cg)
+	require.ElementsMatch(t, expectedTags, output.Tags)
 }

--- a/controller/konnect/ops/ops_kongpluginbinding_test.go
+++ b/controller/konnect/ops/ops_kongpluginbinding_test.go
@@ -4,11 +4,8 @@ import (
 	"context"
 	"testing"
 
-	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
-	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -21,102 +18,88 @@ import (
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
-func TestCreateAndUpdateKongPlugin_KubernetesMetadataConsistency(t *testing.T) {
-	var (
-		ctx           = context.Background()
-		pluginBinding = &configurationv1alpha1.KongPluginBinding{
+func TestKongPluginBindingToSDKPluginInput_Tags(t *testing.T) {
+	ctx := context.Background()
+	pb := &configurationv1alpha1.KongPluginBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KongPluginBinding",
+			APIVersion: "configuration.konghq.com/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "plugin-binding-1",
+			Namespace:  "default",
+			UID:        k8stypes.UID(uuid.NewString()),
+			Generation: 2,
+			Annotations: map[string]string{
+				"konghq.com/tags": "tag1,tag2,duplicate-tag",
+			},
+		},
+		Spec: configurationv1alpha1.KongPluginBindingSpec{
+			PluginReference: configurationv1alpha1.PluginRef{
+				Name: "plugin-1",
+				Kind: lo.ToPtr("KongPlugin"),
+			},
+			Targets: configurationv1alpha1.KongPluginBindingTargets{
+				ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+					Name: "service-1",
+					Kind: "KongService",
+				},
+			},
+		},
+		Status: configurationv1alpha1.KongPluginBindingStatus{
+			Konnect: &konnectv1alpha1.KonnectEntityStatusWithControlPlaneRef{
+				ControlPlaneID: uuid.NewString(),
+			},
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(
+		&configurationv1.KongPlugin{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "KongPluginBinding",
+				Kind:       "KongPlugin",
+				APIVersion: "configuration.konghq.com/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "plugin-1",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "tag3,tag4,duplicate-tag",
+				},
+			},
+			PluginName: "basic-auth",
+		},
+		&configurationv1alpha1.KongService{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KongService",
 				APIVersion: "configuration.konghq.com/v1alpha1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "plugin-binding-1",
+				Name:      "service-1",
 				Namespace: "default",
-				UID:       k8stypes.UID(uuid.NewString()),
 			},
-			Spec: configurationv1alpha1.KongPluginBindingSpec{
-				PluginReference: configurationv1alpha1.PluginRef{
-					Name: "plugin-1",
-					Kind: lo.ToPtr("KongPlugin"),
-				},
-				Targets: configurationv1alpha1.KongPluginBindingTargets{
-					ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
-						Name: "service-1",
-						Kind: "KongService",
-					},
-				},
-			},
-			Status: configurationv1alpha1.KongPluginBindingStatus{
+			Status: configurationv1alpha1.KongServiceStatus{
 				Konnect: &konnectv1alpha1.KonnectEntityStatusWithControlPlaneRef{
-					ControlPlaneID: uuid.NewString(),
-				},
-			},
-		}
-		sdk = &MockPluginSDK{}
-		cl  = fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(
-			&configurationv1.KongPlugin{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "KongPlugin",
-					APIVersion: "configuration.konghq.com/v1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "plugin-1",
-					Namespace: "default",
-				},
-				PluginName: "basic-auth",
-			},
-			&configurationv1alpha1.KongService{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "KongService",
-					APIVersion: "configuration.konghq.com/v1alpha1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "service-1",
-					Namespace: "default",
-				},
-				Status: configurationv1alpha1.KongServiceStatus{
-					Konnect: &konnectv1alpha1.KonnectEntityStatusWithControlPlaneRef{
-						KonnectEntityStatus: konnectv1alpha1.KonnectEntityStatus{
-							ID: "12345",
-						},
+					KonnectEntityStatus: konnectv1alpha1.KonnectEntityStatus{
+						ID: "12345",
 					},
 				},
 			},
-		).Build()
-	)
-
-	t.Log("Triggering CreatePlugin and capturing generated tags")
-	sdk.EXPECT().
-		CreatePlugin(ctx, pluginBinding.GetControlPlaneID(), mock.Anything).
-		Return(&sdkkonnectops.CreatePluginResponse{
-			Plugin: &sdkkonnectcomp.Plugin{
-				ID: lo.ToPtr("12345"),
-			},
-		}, nil)
-	err := createPlugin(ctx, cl, sdk, pluginBinding)
+		},
+	).Build()
+	output, err := kongPluginBindingToSDKPluginInput(ctx, cl, pb)
 	require.NoError(t, err)
-	require.Len(t, sdk.Calls, 1)
-	call := sdk.Calls[0]
-	require.Equal(t, "CreatePlugin", call.Method)
-	require.IsType(t, sdkkonnectcomp.PluginInput{}, call.Arguments[2])
-	capturedCreateTags := call.Arguments[2].(sdkkonnectcomp.PluginInput).Tags
-
-	t.Log("Triggering UpsertPlugin and capturing generated tags")
-	sdk.EXPECT().
-		UpsertPlugin(ctx, mock.Anything).
-		Return(&sdkkonnectops.UpsertPluginResponse{
-			Plugin: &sdkkonnectcomp.Plugin{
-				ID: lo.ToPtr("12345"),
-			},
-		}, nil)
-	err = updatePlugin(ctx, sdk, cl, pluginBinding)
-	require.NoError(t, err)
-	require.Len(t, sdk.Calls, 2)
-	call = sdk.Calls[1]
-	require.Equal(t, "UpsertPlugin", call.Method)
-	require.IsType(t, sdkkonnectops.UpsertPluginRequest{}, call.Arguments[1])
-	capturedUpsertTags := call.Arguments[1].(sdkkonnectops.UpsertPluginRequest).Plugin.Tags
-
-	require.NotEmpty(t, capturedCreateTags, "tags should be set on create")
-	require.Equal(t, capturedCreateTags, capturedUpsertTags, "tags should be consistent between create and update")
+	expectedTags := []string{
+		"k8s-kind:KongPluginBinding",
+		"k8s-name:plugin-binding-1",
+		"k8s-namespace:default",
+		"k8s-uid:" + string(pb.GetUID()),
+		"k8s-version:v1alpha1",
+		"k8s-group:configuration.konghq.com",
+		"k8s-generation:2",
+		"tag1",
+		"tag2",
+		"duplicate-tag",
+		"tag3",
+		"tag4",
+	}
+	require.ElementsMatch(t, expectedTags, output.Tags)
 }

--- a/controller/konnect/ops/ops_kongpluginbinding_test.go
+++ b/controller/konnect/ops/ops_kongpluginbinding_test.go
@@ -1,0 +1,122 @@
+package ops
+
+import (
+	"context"
+	"testing"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kong/gateway-operator/modules/manager/scheme"
+
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+func TestCreateAndUpdateKongPlugin_KubernetesMetadataConsistency(t *testing.T) {
+	var (
+		ctx           = context.Background()
+		pluginBinding = &configurationv1alpha1.KongPluginBinding{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KongPluginBinding",
+				APIVersion: "configuration.konghq.com/v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "plugin-binding-1",
+				Namespace: "default",
+				UID:       k8stypes.UID(uuid.NewString()),
+			},
+			Spec: configurationv1alpha1.KongPluginBindingSpec{
+				PluginReference: configurationv1alpha1.PluginRef{
+					Name: "plugin-1",
+					Kind: lo.ToPtr("KongPlugin"),
+				},
+				Targets: configurationv1alpha1.KongPluginBindingTargets{
+					ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+						Name: "service-1",
+						Kind: "KongService",
+					},
+				},
+			},
+			Status: configurationv1alpha1.KongPluginBindingStatus{
+				Konnect: &konnectv1alpha1.KonnectEntityStatusWithControlPlaneRef{
+					ControlPlaneID: uuid.NewString(),
+				},
+			},
+		}
+		sdk = &MockPluginSDK{}
+		cl  = fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(
+			&configurationv1.KongPlugin{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "KongPlugin",
+					APIVersion: "configuration.konghq.com/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "plugin-1",
+					Namespace: "default",
+				},
+				PluginName: "basic-auth",
+			},
+			&configurationv1alpha1.KongService{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "KongService",
+					APIVersion: "configuration.konghq.com/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service-1",
+					Namespace: "default",
+				},
+				Status: configurationv1alpha1.KongServiceStatus{
+					Konnect: &konnectv1alpha1.KonnectEntityStatusWithControlPlaneRef{
+						KonnectEntityStatus: konnectv1alpha1.KonnectEntityStatus{
+							ID: "12345",
+						},
+					},
+				},
+			},
+		).Build()
+	)
+
+	t.Log("Triggering CreatePlugin and capturing generated tags")
+	sdk.EXPECT().
+		CreatePlugin(ctx, pluginBinding.GetControlPlaneID(), mock.Anything).
+		Return(&sdkkonnectops.CreatePluginResponse{
+			Plugin: &sdkkonnectcomp.Plugin{
+				ID: lo.ToPtr("12345"),
+			},
+		}, nil)
+	err := createPlugin(ctx, cl, sdk, pluginBinding)
+	require.NoError(t, err)
+	require.Len(t, sdk.Calls, 1)
+	call := sdk.Calls[0]
+	require.Equal(t, "CreatePlugin", call.Method)
+	require.IsType(t, sdkkonnectcomp.PluginInput{}, call.Arguments[2])
+	capturedCreateTags := call.Arguments[2].(sdkkonnectcomp.PluginInput).Tags
+
+	t.Log("Triggering UpsertPlugin and capturing generated tags")
+	sdk.EXPECT().
+		UpsertPlugin(ctx, mock.Anything).
+		Return(&sdkkonnectops.UpsertPluginResponse{
+			Plugin: &sdkkonnectcomp.Plugin{
+				ID: lo.ToPtr("12345"),
+			},
+		}, nil)
+	err = updatePlugin(ctx, sdk, cl, pluginBinding)
+	require.NoError(t, err)
+	require.Len(t, sdk.Calls, 2)
+	call = sdk.Calls[1]
+	require.Equal(t, "UpsertPlugin", call.Method)
+	require.IsType(t, sdkkonnectops.UpsertPluginRequest{}, call.Arguments[1])
+	capturedUpsertTags := call.Arguments[1].(sdkkonnectops.UpsertPluginRequest).Plugin.Tags
+
+	require.NotEmpty(t, capturedCreateTags, "tags should be set on create")
+	require.Equal(t, capturedCreateTags, capturedUpsertTags, "tags should be consistent between create and update")
+}

--- a/controller/konnect/ops/ops_kongroute.go
+++ b/controller/konnect/ops/ops_kongroute.go
@@ -10,7 +10,6 @@ import (
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -18,7 +17,6 @@ import (
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
-	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
 func createRoute(
@@ -70,59 +68,19 @@ func createRoute(
 // if the operation fails.
 func updateRoute(
 	ctx context.Context,
-	// sdk *sdkkonnectgo.SDK,
 	sdk RoutesSDK,
-	cl client.Client,
 	route *configurationv1alpha1.KongRoute,
 ) error {
-	if route.Spec.ServiceRef == nil {
-		return fmt.Errorf("can't update %T without a ServiceRef", route)
+	cpID := route.GetControlPlaneID()
+	if cpID == "" {
+		return fmt.Errorf("can't update %T %s without a Konnect ControlPlane ID", route, client.ObjectKeyFromObject(route))
 	}
 
-	// TODO(pmalek) handle other types of CP ref
-	nnSvc := types.NamespacedName{
-		Namespace: route.Namespace,
-		Name:      route.Spec.ServiceRef.NamespacedRef.Name,
-	}
-	var svc configurationv1alpha1.KongService
-	if err := cl.Get(ctx, nnSvc, &svc); err != nil {
-		return fmt.Errorf("failed to get KongService %s: for KongRoute %s: %w",
-			nnSvc, client.ObjectKeyFromObject(route), err,
-		)
-	}
-
-	if svc.Status.Konnect.ID == "" {
-		return fmt.Errorf(
-			"can't update %T when referenced KongService %s does not have the Konnect ID",
-			route, nnSvc,
-		)
-	}
-
-	var cp konnectv1alpha1.KonnectGatewayControlPlane
-	nnCP := types.NamespacedName{
-		Namespace: svc.Namespace,
-		Name:      svc.Spec.ControlPlaneRef.KonnectNamespacedRef.Name,
-	}
-	if err := cl.Get(ctx, nnCP, &cp); err != nil {
-		return fmt.Errorf("failed to get KonnectGatewayControlPlane %s: for KongRoute %s: %w",
-			nnSvc, client.ObjectKeyFromObject(route), err,
-		)
-	}
-
-	if cp.Status.ID == "" {
-		return fmt.Errorf(
-			"can't update %T when referenced KonnectGatewayControlPlane %s does not have the Konnect ID",
-			route, nnSvc,
-		)
-	}
-
-	resp, err := sdk.UpsertRoute(ctx, sdkkonnectops.UpsertRouteRequest{
-		// resp, err := sdk.UpsertRoute(ctx, sdkkonnectops.UpsertRouteRequest{
-		ControlPlaneID: cp.Status.ID,
+	_, err := sdk.UpsertRoute(ctx, sdkkonnectops.UpsertRouteRequest{
+		ControlPlaneID: cpID,
 		RouteID:        route.Status.Konnect.ID,
 		Route:          kongRouteToSDKRouteInput(route),
-	},
-	)
+	})
 
 	// TODO: handle already exists
 	// Can't adopt it as it will cause conflicts between the controller
@@ -141,8 +99,6 @@ func updateRoute(
 		return errWrapped
 	}
 
-	route.Status.Konnect.SetKonnectID(*resp.Route.ID)
-	route.Status.Konnect.SetControlPlaneID(cp.Status.ID)
 	k8sutils.SetCondition(
 		k8sutils.NewConditionWithGeneration(
 			conditions.KonnectEntityProgrammedConditionType,
@@ -212,7 +168,7 @@ func kongRouteToSDKRouteInput(
 		Snis:                    route.Spec.KongRouteAPISpec.Snis,
 		Sources:                 route.Spec.KongRouteAPISpec.Sources,
 		StripPath:               route.Spec.KongRouteAPISpec.StripPath,
-		Tags:                    route.Spec.KongRouteAPISpec.Tags,
+		Tags:                    append(route.Spec.KongRouteAPISpec.Tags, GenerateKubernetesMetadataTags(route)...),
 		Service: &sdkkonnectcomp.RouteService{
 			ID: sdkkonnectgo.String(route.Status.Konnect.ServiceID),
 		},

--- a/controller/konnect/ops/ops_kongroute_test.go
+++ b/controller/konnect/ops/ops_kongroute_test.go
@@ -1,14 +1,9 @@
 package ops
 
 import (
-	"context"
 	"testing"
 
-	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
-	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	"github.com/google/uuid"
-	"github.com/samber/lo"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -17,67 +12,53 @@ import (
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
-func TestCreateAndUpdateKongRoute_KubernetesMetadataConsistency(t *testing.T) {
-	var (
-		ctx   = context.Background()
-		route = &configurationv1alpha1.KongRoute{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "KongRoute",
-				APIVersion: "configuration.konghq.com/v1alpha1",
+func TestKongRouteToSDKRouteInput_Tags(t *testing.T) {
+	route := &configurationv1alpha1.KongRoute{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KongRoute",
+			APIVersion: "configuration.konghq.com/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "route-1",
+			Namespace:  "default",
+			UID:        k8stypes.UID(uuid.NewString()),
+			Generation: 2,
+			Annotations: map[string]string{
+				"konghq.com/tags": "tag1,tag2,duplicate-tag",
 			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "route-1",
-				Namespace: "default",
-				UID:       k8stypes.UID(uuid.NewString()),
-			},
-			Spec: configurationv1alpha1.KongRouteSpec{
-				ServiceRef: &configurationv1alpha1.ServiceRef{
-					Type: configurationv1alpha1.ServiceRefNamespacedRef,
-					NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
-						Name: "service-1",
-					},
+		},
+		Spec: configurationv1alpha1.KongRouteSpec{
+			ServiceRef: &configurationv1alpha1.ServiceRef{
+				Type: configurationv1alpha1.ServiceRefNamespacedRef,
+				NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+					Name: "service-1",
 				},
 			},
-			Status: configurationv1alpha1.KongRouteStatus{
-				Konnect: &konnectv1alpha1.KonnectEntityStatusWithControlPlaneAndServiceRefs{
-					ControlPlaneID: "12345",
-				},
+			KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+				Tags: []string{"tag3", "tag4", "duplicate-tag"},
 			},
-		}
-		sdk = &MockRoutesSDK{}
-	)
-
-	t.Log("Triggering CreateRoute and capturing generated tags")
-	sdk.EXPECT().
-		CreateRoute(ctx, route.GetControlPlaneID(), mock.Anything).
-		Return(&sdkkonnectops.CreateRouteResponse{
-			Route: &sdkkonnectcomp.Route{
-				ID: lo.ToPtr("12345"),
+		},
+		Status: configurationv1alpha1.KongRouteStatus{
+			Konnect: &konnectv1alpha1.KonnectEntityStatusWithControlPlaneAndServiceRefs{
+				ControlPlaneID: "12345",
 			},
-		}, nil)
-	err := createRoute(ctx, sdk, route)
-	require.NoError(t, err)
-	require.Len(t, sdk.Calls, 1)
-	call := sdk.Calls[0]
-	require.Equal(t, "CreateRoute", call.Method)
-	require.IsType(t, sdkkonnectcomp.RouteInput{}, call.Arguments[2])
-	capturedCreateTags := call.Arguments[2].(sdkkonnectcomp.RouteInput).Tags
+		},
+	}
 
-	t.Log("Triggering UpsertRoute and capturing generated tags")
-	sdk.EXPECT().
-		UpsertRoute(ctx, mock.Anything).
-		Return(&sdkkonnectops.UpsertRouteResponse{
-			Route: &sdkkonnectcomp.Route{
-				ID: lo.ToPtr("12345"),
-			},
-		}, nil)
-	err = updateRoute(ctx, sdk, route)
-	require.NoError(t, err)
-	require.Len(t, sdk.Calls, 2)
-	call = sdk.Calls[1]
-	require.Equal(t, "UpsertRoute", call.Method)
-	require.IsType(t, sdkkonnectops.UpsertRouteRequest{}, call.Arguments[1])
-	capturedUpdateTags := call.Arguments[1].(sdkkonnectops.UpsertRouteRequest).Route.Tags
-
-	require.Equal(t, capturedCreateTags, capturedUpdateTags, "tags should be consistent between create and update")
+	output := kongRouteToSDKRouteInput(route)
+	expectedTags := []string{
+		"k8s-kind:KongRoute",
+		"k8s-name:route-1",
+		"k8s-namespace:default",
+		"k8s-uid:" + string(route.GetUID()),
+		"k8s-version:v1alpha1",
+		"k8s-group:configuration.konghq.com",
+		"k8s-generation:2",
+		"tag1",
+		"tag2",
+		"tag3",
+		"tag4",
+		"duplicate-tag",
+	}
+	require.ElementsMatch(t, expectedTags, output.Tags)
 }

--- a/controller/konnect/ops/ops_kongroute_test.go
+++ b/controller/konnect/ops/ops_kongroute_test.go
@@ -1,0 +1,83 @@
+package ops
+
+import (
+	"context"
+	"testing"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+func TestCreateAndUpdateKongRoute_KubernetesMetadataConsistency(t *testing.T) {
+	var (
+		ctx   = context.Background()
+		route = &configurationv1alpha1.KongRoute{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KongRoute",
+				APIVersion: "configuration.konghq.com/v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "route-1",
+				Namespace: "default",
+				UID:       k8stypes.UID(uuid.NewString()),
+			},
+			Spec: configurationv1alpha1.KongRouteSpec{
+				ServiceRef: &configurationv1alpha1.ServiceRef{
+					Type: configurationv1alpha1.ServiceRefNamespacedRef,
+					NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+						Name: "service-1",
+					},
+				},
+			},
+			Status: configurationv1alpha1.KongRouteStatus{
+				Konnect: &konnectv1alpha1.KonnectEntityStatusWithControlPlaneAndServiceRefs{
+					ControlPlaneID: "12345",
+				},
+			},
+		}
+		sdk = &MockRoutesSDK{}
+	)
+
+	t.Log("Triggering CreateRoute and capturing generated tags")
+	sdk.EXPECT().
+		CreateRoute(ctx, route.GetControlPlaneID(), mock.Anything).
+		Return(&sdkkonnectops.CreateRouteResponse{
+			Route: &sdkkonnectcomp.Route{
+				ID: lo.ToPtr("12345"),
+			},
+		}, nil)
+	err := createRoute(ctx, sdk, route)
+	require.NoError(t, err)
+	require.Len(t, sdk.Calls, 1)
+	call := sdk.Calls[0]
+	require.Equal(t, "CreateRoute", call.Method)
+	require.IsType(t, sdkkonnectcomp.RouteInput{}, call.Arguments[2])
+	capturedCreateTags := call.Arguments[2].(sdkkonnectcomp.RouteInput).Tags
+
+	t.Log("Triggering UpsertRoute and capturing generated tags")
+	sdk.EXPECT().
+		UpsertRoute(ctx, mock.Anything).
+		Return(&sdkkonnectops.UpsertRouteResponse{
+			Route: &sdkkonnectcomp.Route{
+				ID: lo.ToPtr("12345"),
+			},
+		}, nil)
+	err = updateRoute(ctx, sdk, route)
+	require.NoError(t, err)
+	require.Len(t, sdk.Calls, 2)
+	call = sdk.Calls[1]
+	require.Equal(t, "UpsertRoute", call.Method)
+	require.IsType(t, sdkkonnectops.UpsertRouteRequest{}, call.Arguments[1])
+	capturedUpdateTags := call.Arguments[1].(sdkkonnectops.UpsertRouteRequest).Route.Tags
+
+	require.Equal(t, capturedCreateTags, capturedUpdateTags, "tags should be consistent between create and update")
+}

--- a/controller/konnect/ops/ops_kongservice.go
+++ b/controller/konnect/ops/ops_kongservice.go
@@ -83,7 +83,7 @@ func updateService(
 	}
 
 	id := svc.GetKonnectStatus().GetKonnectID()
-	resp, err := sdk.UpsertService(ctx,
+	_, err := sdk.UpsertService(ctx,
 		sdkkonnectops.UpsertServiceRequest{
 			ControlPlaneID: svc.GetControlPlaneID(),
 			ServiceID:      id,
@@ -130,8 +130,6 @@ func updateService(
 		return errWrapped
 	}
 
-	svc.Status.Konnect.SetKonnectID(*resp.Service.ID)
-	svc.Status.Konnect.SetControlPlaneID(svc.GetControlPlaneID())
 	k8sutils.SetCondition(
 		k8sutils.NewConditionWithGeneration(
 			conditions.KonnectEntityProgrammedConditionType,
@@ -197,7 +195,7 @@ func kongServiceToSDKServiceInput(
 		Protocol:       svc.Spec.KongServiceAPISpec.Protocol,
 		ReadTimeout:    svc.Spec.KongServiceAPISpec.ReadTimeout,
 		Retries:        svc.Spec.KongServiceAPISpec.Retries,
-		Tags:           svc.Spec.KongServiceAPISpec.Tags,
+		Tags:           append(svc.Spec.KongServiceAPISpec.Tags, GenerateKubernetesMetadataTags(svc)...),
 		TLSVerify:      svc.Spec.KongServiceAPISpec.TLSVerify,
 		TLSVerifyDepth: svc.Spec.KongServiceAPISpec.TLSVerifyDepth,
 		WriteTimeout:   svc.Spec.KongServiceAPISpec.WriteTimeout,

--- a/controller/konnect/ops/ops_kongservice_test.go
+++ b/controller/konnect/ops/ops_kongservice_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -499,60 +498,45 @@ func TestUpdateKongService(t *testing.T) {
 }
 
 func TestCreateAndUpdateKongService_KubernetesMetadataConsistency(t *testing.T) {
-	var (
-		ctx = context.Background()
-		svc = &configurationv1alpha1.KongService{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "KongService",
-				APIVersion: "configuration.konghq.com/v1alpha1",
+	svc := &configurationv1alpha1.KongService{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KongService",
+			APIVersion: "configuration.konghq.com/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "svc-1",
+			Namespace:  "default",
+			UID:        k8stypes.UID(uuid.NewString()),
+			Generation: 2,
+			Annotations: map[string]string{
+				"konghq.com/tags": "tag1,tag2,duplicate-tag",
 			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            "svc-1",
-				Namespace:       "default",
-				UID:             k8stypes.UID(uuid.NewString()),
-				ResourceVersion: "1",
+		},
+		Status: configurationv1alpha1.KongServiceStatus{
+			Konnect: &konnectv1alpha1.KonnectEntityStatusWithControlPlaneRef{
+				ControlPlaneID: uuid.NewString(),
 			},
-			Status: configurationv1alpha1.KongServiceStatus{
-				Konnect: &konnectv1alpha1.KonnectEntityStatusWithControlPlaneRef{
-					ControlPlaneID: uuid.NewString(),
-				},
+		},
+		Spec: configurationv1alpha1.KongServiceSpec{
+			KongServiceAPISpec: configurationv1alpha1.KongServiceAPISpec{
+				Tags: []string{"tag3", "tag4", "duplicate-tag"},
 			},
-		}
-		sdk = &MockServicesSDK{}
-	)
-
-	t.Log("Triggering CreateService and capturing generated tags")
-	sdk.EXPECT().
-		CreateService(ctx, svc.GetControlPlaneID(), mock.Anything).
-		Return(&sdkkonnectops.CreateServiceResponse{
-			Service: &sdkkonnectcomp.Service{
-				ID: lo.ToPtr("12345"),
-			},
-		}, nil)
-	err := createService(ctx, sdk, svc)
-	require.NoError(t, err)
-	require.Len(t, sdk.Calls, 1)
-	call := sdk.Calls[0]
-	require.Equal(t, "CreateService", call.Method)
-	require.IsType(t, sdkkonnectcomp.ServiceInput{}, call.Arguments[2])
-	capturedCreateServiceTags := call.Arguments[2].(sdkkonnectcomp.ServiceInput).Tags
-
-	t.Log("Triggering UpdateService and capturing generated tags")
-	sdk.EXPECT().
-		UpsertService(ctx, mock.Anything).
-		Return(&sdkkonnectops.UpsertServiceResponse{
-			Service: &sdkkonnectcomp.Service{
-				ID: lo.ToPtr("12345"),
-			},
-		}, nil)
-	err = updateService(ctx, sdk, svc)
-	require.NoError(t, err)
-	require.Len(t, sdk.Calls, 2)
-	call = sdk.Calls[1]
-	require.Equal(t, "UpsertService", call.Method)
-	require.IsType(t, sdkkonnectops.UpsertServiceRequest{}, call.Arguments[1])
-	capturedUpsertServiceTags := call.Arguments[1].(sdkkonnectops.UpsertServiceRequest).Service.Tags
-
-	require.NotEmpty(t, capturedCreateServiceTags, "tags should be set on create")
-	require.Equal(t, capturedCreateServiceTags, capturedUpsertServiceTags, "tags should be consistent between create and update")
+		},
+	}
+	output := kongServiceToSDKServiceInput(svc)
+	expectedTags := []string{
+		"k8s-kind:KongService",
+		"k8s-name:svc-1",
+		"k8s-uid:" + string(svc.GetUID()),
+		"k8s-version:v1alpha1",
+		"k8s-group:configuration.konghq.com",
+		"k8s-namespace:default",
+		"k8s-generation:2",
+		"tag1",
+		"tag2",
+		"tag3",
+		"tag4",
+		"duplicate-tag",
+	}
+	require.ElementsMatch(t, expectedTags, output.Tags)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Attaches Kubernetes objects' metadata tags to "Admin API" entities (routes, services, etc.) and labels to ControlPlanes.

When writing tests covering the consistency between create/update operations, noticed that update functions require a `client.Client` to fetch `ControlPlane` to get its Konnect ID. It can be skipped as it's already done in the generic reconciler's `handleControlPlaneRef` that populates entities with the CP Konnect ID in their status.

**Which issue this PR fixes**

Fixes #480.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
