### PR TITLE
test(envtest): set mock SDK to test creating control plane

### DIFF
--- a/controller/konnect/ops/sdkfactory_mock.go
+++ b/controller/konnect/ops/sdkfactory_mock.go
@@ -62,13 +62,5 @@ func (m MockSDKFactory) NewKonnectSDK(_ string, _ SDKToken) SDKWrapper {
 	if m.SDK != nil {
 		return *m.SDK
 	}
-	return MockSDKWrapper{
-		ControlPlaneSDK:  &MockControlPlaneSDK{},
-		ServicesSDK:      &MockServicesSDK{},
-		RoutesSDK:        &MockRoutesSDK{},
-		ConsumersSDK:     &MockConsumersSDK{},
-		ConsumerGroupSDK: &MockConsumerGroupSDK{},
-		PluginSDK:        &MockPluginSDK{},
-		MeSDK:            &MockMeSDK{},
-	}
+	return NewMockSDKWrapper()
 }

--- a/controller/konnect/ops/sdkfactory_mock.go
+++ b/controller/konnect/ops/sdkfactory_mock.go
@@ -12,6 +12,18 @@ type MockSDKWrapper struct {
 
 var _ SDKWrapper = MockSDKWrapper{}
 
+func NewMockSDKWrapper() *MockSDKWrapper {
+	return &MockSDKWrapper{
+		ControlPlaneSDK:  &MockControlPlaneSDK{},
+		ServicesSDK:      &MockServicesSDK{},
+		RoutesSDK:        &MockRoutesSDK{},
+		ConsumersSDK:     &MockConsumersSDK{},
+		ConsumerGroupSDK: &MockConsumerGroupSDK{},
+		PluginSDK:        &MockPluginSDK{},
+		MeSDK:            &MockMeSDK{},
+	}
+}
+
 func (m MockSDKWrapper) GetControlPlaneSDK() ControlPlaneSDK {
 	return m.ControlPlaneSDK
 }
@@ -41,16 +53,16 @@ func (m MockSDKWrapper) GetMeSDK() MeSDK {
 }
 
 type MockSDKFactory struct {
-	w *MockSDKWrapper
+	Wapper *MockSDKWrapper
 }
 
 var _ SDKFactory = MockSDKFactory{}
 
 func (m MockSDKFactory) NewKonnectSDK(_ string, _ SDKToken) SDKWrapper {
-	if m.w != nil {
-		return *m.w
+	if m.Wapper != nil {
+		return *m.Wapper
 	}
-	return &MockSDKWrapper{
+	return MockSDKWrapper{
 		ControlPlaneSDK:  &MockControlPlaneSDK{},
 		ServicesSDK:      &MockServicesSDK{},
 		RoutesSDK:        &MockRoutesSDK{},

--- a/controller/konnect/ops/sdkfactory_mock.go
+++ b/controller/konnect/ops/sdkfactory_mock.go
@@ -53,14 +53,14 @@ func (m MockSDKWrapper) GetMeSDK() MeSDK {
 }
 
 type MockSDKFactory struct {
-	Wapper *MockSDKWrapper
+	SDK *MockSDKWrapper
 }
 
 var _ SDKFactory = MockSDKFactory{}
 
 func (m MockSDKFactory) NewKonnectSDK(_ string, _ SDKToken) SDKWrapper {
-	if m.Wapper != nil {
-		return *m.Wapper
+	if m.SDK != nil {
+		return *m.SDK
 	}
 	return MockSDKWrapper{
 		ControlPlaneSDK:  &MockControlPlaneSDK{},


### PR DESCRIPTION
**What this PR does / why we need it**:
Add settings of mock Konnect SDKs to test creating of Konnect gateway control plane in envtest.
**Which issue this PR fixes**

Fixes #540 

**Special notes for your reviewer**:
We can add new test cases for reconcilers based on this example.
**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
