### PR TITLE
tests: use mock constructors

### DIFF
--- a/controller/konnect/ops/ops_controlplane_test.go
+++ b/controller/konnect/ops/ops_controlplane_test.go
@@ -22,14 +22,14 @@ func TestCreateControlPlane(t *testing.T) {
 	ctx := context.Background()
 	testCases := []struct {
 		name        string
-		mockCPPair  func() (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane)
+		mockCPPair  func(*testing.T) (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane)
 		expectedErr bool
 		assertions  func(*testing.T, *konnectv1alpha1.KonnectGatewayControlPlane)
 	}{
 		{
 			name: "success",
-			mockCPPair: func() (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane) {
-				sdk := &MockControlPlaneSDK{}
+			mockCPPair: func(t *testing.T) (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane) {
+				sdk := NewMockControlPlaneSDK(t)
 				cp := &konnectv1alpha1.KonnectGatewayControlPlane{
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
@@ -63,8 +63,8 @@ func TestCreateControlPlane(t *testing.T) {
 		},
 		{
 			name: "fail",
-			mockCPPair: func() (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane) {
-				sdk := &MockControlPlaneSDK{}
+			mockCPPair: func(t *testing.T) (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane) {
+				sdk := NewMockControlPlaneSDK(t)
 				cp := &konnectv1alpha1.KonnectGatewayControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cp-1",
@@ -105,13 +105,9 @@ func TestCreateControlPlane(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			sdk, cp := tc.mockCPPair()
+			sdk, cp := tc.mockCPPair(t)
 
 			err := createControlPlane(ctx, sdk, cp)
-			t.Cleanup(func() {
-				assert.True(t, sdk.AssertExpectations(t))
-			})
-
 			tc.assertions(t, cp)
 
 			if tc.expectedErr {
@@ -128,14 +124,14 @@ func TestDeleteControlPlane(t *testing.T) {
 	ctx := context.Background()
 	testCases := []struct {
 		name        string
-		mockCPPair  func() (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane)
+		mockCPPair  func(*testing.T) (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane)
 		expectedErr bool
 		assertions  func(*testing.T, *konnectv1alpha1.KonnectGatewayControlPlane)
 	}{
 		{
 			name: "success",
-			mockCPPair: func() (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane) {
-				sdk := &MockControlPlaneSDK{}
+			mockCPPair: func(t *testing.T) (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane) {
+				sdk := NewMockControlPlaneSDK(t)
 				cp := &konnectv1alpha1.KonnectGatewayControlPlane{
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
@@ -163,8 +159,8 @@ func TestDeleteControlPlane(t *testing.T) {
 		},
 		{
 			name: "fail",
-			mockCPPair: func() (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane) {
-				sdk := &MockControlPlaneSDK{}
+			mockCPPair: func(t *testing.T) (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane) {
+				sdk := NewMockControlPlaneSDK(t)
 				cp := &konnectv1alpha1.KonnectGatewayControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cp-1",
@@ -198,8 +194,8 @@ func TestDeleteControlPlane(t *testing.T) {
 		},
 		{
 			name: "not found error is ignored and considered a success when trying to delete",
-			mockCPPair: func() (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane) {
-				sdk := &MockControlPlaneSDK{}
+			mockCPPair: func(t *testing.T) (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane) {
+				sdk := NewMockControlPlaneSDK(t)
 				cp := &konnectv1alpha1.KonnectGatewayControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cp-1",
@@ -234,7 +230,7 @@ func TestDeleteControlPlane(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			sdk, cp := tc.mockCPPair()
+			sdk, cp := tc.mockCPPair(t)
 
 			err := deleteControlPlane(ctx, sdk, cp)
 
@@ -248,7 +244,6 @@ func TestDeleteControlPlane(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
-			assert.True(t, sdk.AssertExpectations(t))
 		})
 	}
 }
@@ -257,14 +252,14 @@ func TestUpdateControlPlane(t *testing.T) {
 	ctx := context.Background()
 	testCases := []struct {
 		name        string
-		mockCPPair  func() (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane)
+		mockCPPair  func(*testing.T) (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane)
 		expectedErr bool
 		assertions  func(*testing.T, *konnectv1alpha1.KonnectGatewayControlPlane)
 	}{
 		{
 			name: "success",
-			mockCPPair: func() (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane) {
-				sdk := &MockControlPlaneSDK{}
+			mockCPPair: func(t *testing.T) (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane) {
+				sdk := NewMockControlPlaneSDK(t)
 				cp := &konnectv1alpha1.KonnectGatewayControlPlane{
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
@@ -311,8 +306,8 @@ func TestUpdateControlPlane(t *testing.T) {
 		},
 		{
 			name: "fail",
-			mockCPPair: func() (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane) {
-				sdk := &MockControlPlaneSDK{}
+			mockCPPair: func(t *testing.T) (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane) {
+				sdk := NewMockControlPlaneSDK(t)
 				cp := &konnectv1alpha1.KonnectGatewayControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cp-1",
@@ -364,8 +359,8 @@ func TestUpdateControlPlane(t *testing.T) {
 		},
 		{
 			name: "when not found then try to create",
-			mockCPPair: func() (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane) {
-				sdk := &MockControlPlaneSDK{}
+			mockCPPair: func(t *testing.T) (*MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane) {
+				sdk := NewMockControlPlaneSDK(t)
 				cp := &konnectv1alpha1.KonnectGatewayControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cp-1",
@@ -430,7 +425,7 @@ func TestUpdateControlPlane(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			sdk, cp := tc.mockCPPair()
+			sdk, cp := tc.mockCPPair(t)
 
 			err := updateControlPlane(ctx, sdk, cp)
 
@@ -444,7 +439,6 @@ func TestUpdateControlPlane(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
-			assert.True(t, sdk.AssertExpectations(t))
 		})
 	}
 }

--- a/controller/konnect/ops/ops_kongservice_test.go
+++ b/controller/konnect/ops/ops_kongservice_test.go
@@ -23,14 +23,14 @@ func TestCreateKongService(t *testing.T) {
 	ctx := context.Background()
 	testCases := []struct {
 		name            string
-		mockServicePair func() (*MockServicesSDK, *configurationv1alpha1.KongService)
+		mockServicePair func(*testing.T) (*MockServicesSDK, *configurationv1alpha1.KongService)
 		expectedErr     bool
 		assertions      func(*testing.T, *configurationv1alpha1.KongService)
 	}{
 		{
 			name: "success",
-			mockServicePair: func() (*MockServicesSDK, *configurationv1alpha1.KongService) {
-				sdk := &MockServicesSDK{}
+			mockServicePair: func(t *testing.T) (*MockServicesSDK, *configurationv1alpha1.KongService) {
+				sdk := NewMockServicesSDK(t)
 				svc := &configurationv1alpha1.KongService{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "svc-1",
@@ -76,8 +76,8 @@ func TestCreateKongService(t *testing.T) {
 		},
 		{
 			name: "fail - no control plane ID in status returns an error and does not create the Service in Konnect",
-			mockServicePair: func() (*MockServicesSDK, *configurationv1alpha1.KongService) {
-				sdk := &MockServicesSDK{}
+			mockServicePair: func(t *testing.T) (*MockServicesSDK, *configurationv1alpha1.KongService) {
+				sdk := NewMockServicesSDK(t)
 				svc := &configurationv1alpha1.KongService{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "svc-1",
@@ -101,8 +101,8 @@ func TestCreateKongService(t *testing.T) {
 		},
 		{
 			name: "fail",
-			mockServicePair: func() (*MockServicesSDK, *configurationv1alpha1.KongService) {
-				sdk := &MockServicesSDK{}
+			mockServicePair: func(t *testing.T) (*MockServicesSDK, *configurationv1alpha1.KongService) {
+				sdk := NewMockServicesSDK(t)
 				svc := &configurationv1alpha1.KongService{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "svc-1",
@@ -149,12 +149,9 @@ func TestCreateKongService(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			sdk, svc := tc.mockServicePair()
+			sdk, svc := tc.mockServicePair(t)
 
 			err := createService(ctx, sdk, svc)
-			t.Cleanup(func() {
-				assert.True(t, sdk.AssertExpectations(t))
-			})
 
 			tc.assertions(t, svc)
 
@@ -172,14 +169,14 @@ func TestDeleteKongService(t *testing.T) {
 	ctx := context.Background()
 	testCases := []struct {
 		name            string
-		mockServicePair func() (*MockServicesSDK, *configurationv1alpha1.KongService)
+		mockServicePair func(*testing.T) (*MockServicesSDK, *configurationv1alpha1.KongService)
 		expectedErr     bool
 		assertions      func(*testing.T, *configurationv1alpha1.KongService)
 	}{
 		{
 			name: "success",
-			mockServicePair: func() (*MockServicesSDK, *configurationv1alpha1.KongService) {
-				sdk := &MockServicesSDK{}
+			mockServicePair: func(t *testing.T) (*MockServicesSDK, *configurationv1alpha1.KongService) {
+				sdk := NewMockServicesSDK(t)
 				svc := &configurationv1alpha1.KongService{
 					Spec: configurationv1alpha1.KongServiceSpec{
 						KongServiceAPISpec: configurationv1alpha1.KongServiceAPISpec{
@@ -210,8 +207,8 @@ func TestDeleteKongService(t *testing.T) {
 		},
 		{
 			name: "fail",
-			mockServicePair: func() (*MockServicesSDK, *configurationv1alpha1.KongService) {
-				sdk := &MockServicesSDK{}
+			mockServicePair: func(t *testing.T) (*MockServicesSDK, *configurationv1alpha1.KongService) {
+				sdk := NewMockServicesSDK(t)
 				svc := &configurationv1alpha1.KongService{
 					Spec: configurationv1alpha1.KongServiceSpec{
 						KongServiceAPISpec: configurationv1alpha1.KongServiceAPISpec{
@@ -244,8 +241,8 @@ func TestDeleteKongService(t *testing.T) {
 		},
 		{
 			name: "not found error is ignored and considered a success when trying to delete",
-			mockServicePair: func() (*MockServicesSDK, *configurationv1alpha1.KongService) {
-				sdk := &MockServicesSDK{}
+			mockServicePair: func(t *testing.T) (*MockServicesSDK, *configurationv1alpha1.KongService) {
+				sdk := NewMockServicesSDK(t)
 				svc := &configurationv1alpha1.KongService{
 					Spec: configurationv1alpha1.KongServiceSpec{
 						KongServiceAPISpec: configurationv1alpha1.KongServiceAPISpec{
@@ -279,7 +276,7 @@ func TestDeleteKongService(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			sdk, svc := tc.mockServicePair()
+			sdk, svc := tc.mockServicePair(t)
 
 			err := deleteService(ctx, sdk, svc)
 
@@ -293,7 +290,6 @@ func TestDeleteKongService(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
-			assert.True(t, sdk.AssertExpectations(t))
 		})
 	}
 }
@@ -302,14 +298,14 @@ func TestUpdateKongService(t *testing.T) {
 	ctx := context.Background()
 	testCases := []struct {
 		name            string
-		mockServicePair func() (*MockServicesSDK, *configurationv1alpha1.KongService)
+		mockServicePair func(*testing.T) (*MockServicesSDK, *configurationv1alpha1.KongService)
 		expectedErr     bool
 		assertions      func(*testing.T, *configurationv1alpha1.KongService)
 	}{
 		{
 			name: "success",
-			mockServicePair: func() (*MockServicesSDK, *configurationv1alpha1.KongService) {
-				sdk := &MockServicesSDK{}
+			mockServicePair: func(t *testing.T) (*MockServicesSDK, *configurationv1alpha1.KongService) {
+				sdk := NewMockServicesSDK(t)
 				svc := &configurationv1alpha1.KongService{
 					Spec: configurationv1alpha1.KongServiceSpec{
 						KongServiceAPISpec: configurationv1alpha1.KongServiceAPISpec{
@@ -359,8 +355,8 @@ func TestUpdateKongService(t *testing.T) {
 		},
 		{
 			name: "fail",
-			mockServicePair: func() (*MockServicesSDK, *configurationv1alpha1.KongService) {
-				sdk := &MockServicesSDK{}
+			mockServicePair: func(t *testing.T) (*MockServicesSDK, *configurationv1alpha1.KongService) {
+				sdk := NewMockServicesSDK(t)
 				svc := &configurationv1alpha1.KongService{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "svc-1",
@@ -414,8 +410,8 @@ func TestUpdateKongService(t *testing.T) {
 		},
 		{
 			name: "when not found then try to create",
-			mockServicePair: func() (*MockServicesSDK, *configurationv1alpha1.KongService) {
-				sdk := &MockServicesSDK{}
+			mockServicePair: func(t *testing.T) (*MockServicesSDK, *configurationv1alpha1.KongService) {
+				sdk := NewMockServicesSDK(t)
 				svc := &configurationv1alpha1.KongService{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "svc-1",
@@ -481,7 +477,7 @@ func TestUpdateKongService(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			sdk, svc := tc.mockServicePair()
+			sdk, svc := tc.mockServicePair(t)
 
 			err := updateService(ctx, sdk, svc)
 
@@ -495,7 +491,6 @@ func TestUpdateKongService(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
-			assert.True(t, sdk.AssertExpectations(t))
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Use mocks constructors which calls `t.Cleanup(func() { mock.AssertExpectations(t) })` which ensures that all the expected calls have been made.
