### PR TITLE
tests: enforce passing t to NewMockSDKFactory

### DIFF
--- a/controller/konnect/ops/sdkfactory_mock.go
+++ b/controller/konnect/ops/sdkfactory_mock.go
@@ -1,5 +1,11 @@
 package ops
 
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
 type MockSDKWrapper struct {
 	ControlPlaneSDK  *MockControlPlaneSDK
 	ServicesSDK      *MockServicesSDK
@@ -12,15 +18,15 @@ type MockSDKWrapper struct {
 
 var _ SDKWrapper = MockSDKWrapper{}
 
-func NewMockSDKWrapper() *MockSDKWrapper {
+func NewMockSDKWrapperWithT(t *testing.T) *MockSDKWrapper {
 	return &MockSDKWrapper{
-		ControlPlaneSDK:  &MockControlPlaneSDK{},
-		ServicesSDK:      &MockServicesSDK{},
-		RoutesSDK:        &MockRoutesSDK{},
-		ConsumersSDK:     &MockConsumersSDK{},
-		ConsumerGroupSDK: &MockConsumerGroupSDK{},
-		PluginSDK:        &MockPluginSDK{},
-		MeSDK:            &MockMeSDK{},
+		ControlPlaneSDK:  NewMockControlPlaneSDK(t),
+		ServicesSDK:      NewMockServicesSDK(t),
+		RoutesSDK:        NewMockRoutesSDK(t),
+		ConsumersSDK:     NewMockConsumersSDK(t),
+		ConsumerGroupSDK: NewMockConsumerGroupSDK(t),
+		PluginSDK:        NewMockPluginSDK(t),
+		MeSDK:            NewMockMeSDK(t),
 	}
 }
 
@@ -53,14 +59,20 @@ func (m MockSDKWrapper) GetMeSDK() MeSDK {
 }
 
 type MockSDKFactory struct {
+	t   *testing.T
 	SDK *MockSDKWrapper
 }
 
 var _ SDKFactory = MockSDKFactory{}
 
-func (m MockSDKFactory) NewKonnectSDK(_ string, _ SDKToken) SDKWrapper {
-	if m.SDK != nil {
-		return *m.SDK
+func NewMockSDKFactory(t *testing.T) *MockSDKFactory {
+	return &MockSDKFactory{
+		t:   t,
+		SDK: NewMockSDKWrapperWithT(t),
 	}
-	return NewMockSDKWrapper()
+}
+
+func (m MockSDKFactory) NewKonnectSDK(_ string, _ SDKToken) SDKWrapper {
+	require.NotNil(m.t, m.SDK)
+	return *m.SDK
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Enforce passing t to NewMockSDKFactory and by extension get the benefits of mocks' constructors calling `t.Cleanup(func() { mock.AssertExpectations(t) })`.

This also removes the usage of logr logger as that proven to cause data races locally:

```
WARNING: DATA RACE
Read at 0x00c00129cee3 by goroutine 526:
  testing.(*common).logDepth()
      /Users/patryk.malek@konghq.com/.gvm/gos/go1.23.0/src/testing/testing.go:1018 +0x8c
  testing.(*common).log()
      /Users/patryk.malek@konghq.com/.gvm/gos/go1.23.0/src/testing/testing.go:1011 +0x70
  testing.(*common).Log()
      /Users/patryk.malek@konghq.com/.gvm/gos/go1.23.0/src/testing/testing.go:1052 +0x50
  testing.(*T).Log()
      <autogenerated>:1 +0x4c
  github.com/go-logr/logr/testr.logError()
      /Users/patryk.malek@konghq.com/.gvm/pkgsets/go1.23.0/global/pkg/mod/github.com/go-logr/logr@v1.4.2/testr/testr.go:111 +0x150
  github.com/go-logr/logr/testr.testloggerInterface.Error()
      /Users/patryk.malek@konghq.com/.gvm/pkgsets/go1.23.0/global/pkg/mod/github.com/go-logr/logr@v1.4.2/testr/testr.go:153 +0xd4
  github.com/go-logr/logr/testr.(*testloggerInterface).Error()
      <autogenerated>:1 +0xc8
  github.com/go-logr/logr.Logger.Error()
      /Users/patryk.malek@konghq.com/.gvm/pkgsets/go1.23.0/global/pkg/mod/github.com/go-logr/logr@v1.4.2/logr.go:301 +0xd0
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).reconcileHandler()
      /Users/patryk.malek@konghq.com/.gvm/pkgsets/go1.23.0/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:316 +0xa68
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).processNextWorkItem()
      /Users/patryk.malek@konghq.com/.gvm/pkgsets/go1.23.0/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263 +0x26c
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).Start.func2.2()
      /Users/patryk.malek@konghq.com/.gvm/pkgsets/go1.23.0/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224 +0xc8

Previous write at 0x00c00129cee3 by goroutine 203:
  testing.tRunner.func1()
      /Users/patryk.malek@konghq.com/.gvm/gos/go1.23.0/src/testing/testing.go:1677 +0x5e0
  runtime.deferreturn()
      /Users/patryk.malek@konghq.com/.gvm/gos/go1.23.0/src/runtime/panic.go:605 +0x5c
  testing.(*T).Run.gowrap1()
      /Users/patryk.malek@konghq.com/.gvm/gos/go1.23.0/src/testing/testing.go:1743 +0x40

Goroutine 526 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).Start.func2()
      /Users/patryk.malek@konghq.com/.gvm/pkgsets/go1.23.0/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:220 +0x564
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).Start()
      /Users/patryk.malek@konghq.com/.gvm/pkgsets/go1.23.0/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:231 +0x2ec
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[sigs.k8s.io/controller-runtime/pkg/reconcile.Request]).Start()
      /Users/patryk.malek@konghq.com/.gvm/pkgsets/go1.23.0/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:145 +0x48
  sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1()
      /Users/patryk.malek@konghq.com/.gvm/pkgsets/go1.23.0/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/manager/runnable_group.go:226 +0x170
  sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.gowrap1()
      /Users/patryk.malek@konghq.com/.gvm/pkgsets/go1.23.0/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/manager/runnable_group.go:229 +0x44

Goroutine 203 (finished) created at:
  testing.(*T).Run()
      /Users/patryk.malek@konghq.com/.gvm/gos/go1.23.0/src/testing/testing.go:1743 +0x5e0
  github.com/kong/gateway-operator/test/envtest.testNewKonnectEntityReconciler[go.shape.struct { k8s.io/apimachinery/pkg/apis/meta/v1.TypeMeta "json:\",inline\""; k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta "json:\"metadata,omitempty\""; Spec github.com/kong/kubernetes-configuration/api/konnect/v1alpha1.KonnectGatewayControlPlaneSpec "json:\"spec,omitempty\""; Status github.com/kong/kubernetes-configuration/api/konnect/v1alpha1.KonnectGatewayControlPlaneStatus "json:\"status,omitempty\"" },go.shape.*github.com/kong/kubernetes-configuration/api/konnect/v1alpha1.KonnectGatewayControlPlane]()
      /Users/patryk.malek@konghq.com/code_/gateway-operator/test/envtest/reconciler_setupwithmanager_test.go:157 +0x170
  github.com/kong/gateway-operator/test/envtest.TestNewKonnectEntityReconciler()
      /Users/patryk.malek@konghq.com/code_/gateway-operator/test/envtest/reconciler_setupwithmanager_test.go:39 +0xa8
  testing.tRunner()
      /Users/patryk.malek@konghq.com/.gvm/gos/go1.23.0/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /Users/patryk.malek@konghq.com/.gvm/gos/go1.23.0/src/testing/testing.go:1743 +0x40
==================
```