### PR TITLE
chore: group dependabot k8s libs bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,36 @@ updates:
     interval: daily
   labels:
   - dependencies
+  # Create a group of dependencies to be updated together in one pull request
+  groups:
+     # Specify a name for the group, which will be used in pull request titles and branch names
+     k8s.io:
+        # Define patterns to include dependencies in the group (based on dependency name)
+        applies-to: version-updates # Applies the group rule to version updates
+        patterns:
+          - "k8s.io/*"
+        exclude-patterns:
+        - k8s.io/klog/*
+        - k8s.io/utils
+        - k8s.io/kube-openapi
 - package-ecosystem: gomod
   directory: /hack/generators/
   schedule:
     interval: daily
   labels:
   - dependencies
+  # Create a group of dependencies to be updated together in one pull request
+  groups:
+     # Specify a name for the group, which will be used in pull request titles and branch names
+     k8s.io:
+        # Define patterns to include dependencies in the group (based on dependency name)
+        applies-to: version-updates # Applies the group rule to version updates
+        patterns:
+          - "k8s.io/*"
+        exclude-patterns:
+        - k8s.io/klog/*
+        - k8s.io/utils
+        - k8s.io/kube-openapi
 - package-ecosystem: github-actions
   directory: /
   schedule:


### PR DESCRIPTION
**What this PR does / why we need it**:

Group k8s libs bumps in dependabot config as per : https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups