### PR TITLE
feat(konnect): assign KongConsumers to KongConsumerGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@
   the creation of a managed `KongPluginBinding` resource, which is taken by the
   `KongPluginBinding` reconciler to create the corresponding plugin object in Konnect.
   [#550](https://github.com/Kong/gateway-operator/pull/550)
+- `KongConsumer` associated with `ConsumerGroups` is now reconciled in Konnect by removing/adding
+  the consumer from/to the consumer groups.
+  [#592](https://github.com/Kong/gateway-operator/pull/592)
 - Add support for `KongConsumer` credentials:
   - basic-auth [#625](https://github.com/Kong/gateway-operator/pull/625)
 

--- a/config/samples/konnect_kongconsumergroup.yaml
+++ b/config/samples/konnect_kongconsumergroup.yaml
@@ -42,6 +42,8 @@ metadata:
   namespace: default
 username: consumer-1
 custom_id: 08433C12-2B81-4738-B61D-3AA2136F0212
+consumerGroups:
+  - consumer-group-1
 spec:
   controlPlaneRef:
     type: konnectNamespacedRef
@@ -51,7 +53,7 @@ spec:
 kind: KongConsumerGroup
 apiVersion: configuration.konghq.com/v1beta1
 metadata:
-  name: consumer-consumer-1
+  name: consumer-group-1
   namespace: default
 spec:
   name: consumer-group-1

--- a/controller/konnect/conditions/conditions.go
+++ b/controller/konnect/conditions/conditions.go
@@ -14,6 +14,12 @@ const (
 	// KonnectEntityProgrammedReasonKonnectAPIOpFailed is the reason for the Programmed condition.
 	// It is set when the entity has failed to be programmed in Konnect.
 	KonnectEntityProgrammedReasonKonnectAPIOpFailed = "KonnectAPIOpFailed"
+	// KonnectEntityProgrammedReasonFailedToResolveConsumerGroupRefs is the reason for the Programmed condition.
+	// It is set when one or more KongConsumerGroup references could not be resolved.
+	KonnectEntityProgrammedReasonFailedToResolveConsumerGroupRefs = "FailedToResolveConsumerGroupRefs"
+	// KonnectEntityProgrammedReasonFailedToReconcileConsumerGroupsWithKonnect is the reason for the Programmed condition.
+	// It is set when one or more KongConsumerGroup references could not be reconciled with Konnect.
+	KonnectEntityProgrammedReasonFailedToReconcileConsumerGroupsWithKonnect = "FailedToReconcileConsumerGroupsWithKonnect"
 )
 
 const (

--- a/controller/konnect/conditions/conditions.go
+++ b/controller/konnect/conditions/conditions.go
@@ -94,3 +94,17 @@ const (
 	// condition type indicating that the KongConsumer reference is invalid.
 	KongConsumerRefReasonInvalid = "Invalid"
 )
+
+const (
+	// KongConsumerGroupRefsValidConditionType is the type of the condition that indicates
+	// whether the KongConsumerGroups referenced by the entity are valid and all point to
+	// existing KongConsumerGroups.
+	KongConsumerGroupRefsValidConditionType = "KongConsumerGroupRefsValid"
+
+	// KongConsumerGroupRefsReasonValid is the reason used with the KongConsumerGroupRefsValid
+	// condition type indicating that all KongConsumerGroup references are valid.
+	KongConsumerGroupRefsReasonValid = "Valid"
+	// KongConsumerGroupRefsReasonInvalid is the reason used with the KongConsumerGroupRefsValid
+	// condition type indicating that one or more KongConsumerGroup references are invalid.
+	KongConsumerGroupRefsReasonInvalid = "Invalid"
+)

--- a/controller/konnect/index.go
+++ b/controller/konnect/index.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect/constraints"
 
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
 
@@ -26,6 +27,8 @@ func ReconciliationIndexOptionsForEntity[
 		return IndexOptionsForKongPluginBinding()
 	case *configurationv1alpha1.KongCredentialBasicAuth:
 		return IndexOptionsForCredentialsBasicAuth()
+	case *configurationv1.KongConsumer:
+		return IndexOptionsForKongConsumer()
 	}
 	return nil
 }

--- a/controller/konnect/index_kongconsumer.go
+++ b/controller/konnect/index_kongconsumer.go
@@ -1,0 +1,31 @@
+package konnect
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
+)
+
+const (
+	// IndexFieldKongConsumerOnKongConsumerGroup is the index field for KongConsumer -> KongConsumerGroup.
+	IndexFieldKongConsumerOnKongConsumerGroup = "consumerGroupRef"
+)
+
+// IndexOptionsForKongConsumer returns required Index options for KongConsumer reconciler.
+func IndexOptionsForKongConsumer() []ReconciliationIndexOption {
+	return []ReconciliationIndexOption{
+		{
+			IndexObject:  &configurationv1.KongConsumer{},
+			IndexField:   IndexFieldKongConsumerOnKongConsumerGroup,
+			ExtractValue: kongConsumerReferencesFromKongConsumerGroup,
+		},
+	}
+}
+
+func kongConsumerReferencesFromKongConsumerGroup(object client.Object) []string {
+	consumer, ok := object.(*configurationv1.KongConsumer)
+	if !ok {
+		return nil
+	}
+	return consumer.ConsumerGroups
+}

--- a/controller/konnect/ops/kongconsumergroup.go
+++ b/controller/konnect/ops/kongconsumergroup.go
@@ -12,4 +12,7 @@ type ConsumerGroupSDK interface {
 	CreateConsumerGroup(ctx context.Context, controlPlaneID string, consumerInput sdkkonnectcomp.ConsumerGroupInput, opts ...sdkkonnectops.Option) (*sdkkonnectops.CreateConsumerGroupResponse, error)
 	UpsertConsumerGroup(ctx context.Context, upsertConsumerRequest sdkkonnectops.UpsertConsumerGroupRequest, opts ...sdkkonnectops.Option) (*sdkkonnectops.UpsertConsumerGroupResponse, error)
 	DeleteConsumerGroup(ctx context.Context, controlPlaneID string, consumerID string, opts ...sdkkonnectops.Option) (*sdkkonnectops.DeleteConsumerGroupResponse, error)
+	AddConsumerToGroup(ctx context.Context, request sdkkonnectops.AddConsumerToGroupRequest, opts ...sdkkonnectops.Option) (*sdkkonnectops.AddConsumerToGroupResponse, error)
+	RemoveConsumerFromGroup(ctx context.Context, request sdkkonnectops.RemoveConsumerFromGroupRequest, opts ...sdkkonnectops.Option) (*sdkkonnectops.RemoveConsumerFromGroupResponse, error)
+	ListConsumerGroupsForConsumer(ctx context.Context, request sdkkonnectops.ListConsumerGroupsForConsumerRequest, opts ...sdkkonnectops.Option) (*sdkkonnectops.ListConsumerGroupsForConsumerResponse, error)
 }

--- a/controller/konnect/ops/kongconsumergroup_mock.go
+++ b/controller/konnect/ops/kongconsumergroup_mock.go
@@ -25,6 +25,80 @@ func (_m *MockConsumerGroupSDK) EXPECT() *MockConsumerGroupSDK_Expecter {
 	return &MockConsumerGroupSDK_Expecter{mock: &_m.Mock}
 }
 
+// AddConsumerToGroup provides a mock function with given fields: ctx, request, opts
+func (_m *MockConsumerGroupSDK) AddConsumerToGroup(ctx context.Context, request operations.AddConsumerToGroupRequest, opts ...operations.Option) (*operations.AddConsumerToGroupResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, request)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddConsumerToGroup")
+	}
+
+	var r0 *operations.AddConsumerToGroupResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, operations.AddConsumerToGroupRequest, ...operations.Option) (*operations.AddConsumerToGroupResponse, error)); ok {
+		return rf(ctx, request, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, operations.AddConsumerToGroupRequest, ...operations.Option) *operations.AddConsumerToGroupResponse); ok {
+		r0 = rf(ctx, request, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*operations.AddConsumerToGroupResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, operations.AddConsumerToGroupRequest, ...operations.Option) error); ok {
+		r1 = rf(ctx, request, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockConsumerGroupSDK_AddConsumerToGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddConsumerToGroup'
+type MockConsumerGroupSDK_AddConsumerToGroup_Call struct {
+	*mock.Call
+}
+
+// AddConsumerToGroup is a helper method to define mock.On call
+//   - ctx context.Context
+//   - request operations.AddConsumerToGroupRequest
+//   - opts ...operations.Option
+func (_e *MockConsumerGroupSDK_Expecter) AddConsumerToGroup(ctx interface{}, request interface{}, opts ...interface{}) *MockConsumerGroupSDK_AddConsumerToGroup_Call {
+	return &MockConsumerGroupSDK_AddConsumerToGroup_Call{Call: _e.mock.On("AddConsumerToGroup",
+		append([]interface{}{ctx, request}, opts...)...)}
+}
+
+func (_c *MockConsumerGroupSDK_AddConsumerToGroup_Call) Run(run func(ctx context.Context, request operations.AddConsumerToGroupRequest, opts ...operations.Option)) *MockConsumerGroupSDK_AddConsumerToGroup_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]operations.Option, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(operations.Option)
+			}
+		}
+		run(args[0].(context.Context), args[1].(operations.AddConsumerToGroupRequest), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockConsumerGroupSDK_AddConsumerToGroup_Call) Return(_a0 *operations.AddConsumerToGroupResponse, _a1 error) *MockConsumerGroupSDK_AddConsumerToGroup_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockConsumerGroupSDK_AddConsumerToGroup_Call) RunAndReturn(run func(context.Context, operations.AddConsumerToGroupRequest, ...operations.Option) (*operations.AddConsumerToGroupResponse, error)) *MockConsumerGroupSDK_AddConsumerToGroup_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateConsumerGroup provides a mock function with given fields: ctx, controlPlaneID, consumerInput, opts
 func (_m *MockConsumerGroupSDK) CreateConsumerGroup(ctx context.Context, controlPlaneID string, consumerInput components.ConsumerGroupInput, opts ...operations.Option) (*operations.CreateConsumerGroupResponse, error) {
 	_va := make([]interface{}, len(opts))
@@ -171,6 +245,154 @@ func (_c *MockConsumerGroupSDK_DeleteConsumerGroup_Call) Return(_a0 *operations.
 }
 
 func (_c *MockConsumerGroupSDK_DeleteConsumerGroup_Call) RunAndReturn(run func(context.Context, string, string, ...operations.Option) (*operations.DeleteConsumerGroupResponse, error)) *MockConsumerGroupSDK_DeleteConsumerGroup_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListConsumerGroupsForConsumer provides a mock function with given fields: ctx, request, opts
+func (_m *MockConsumerGroupSDK) ListConsumerGroupsForConsumer(ctx context.Context, request operations.ListConsumerGroupsForConsumerRequest, opts ...operations.Option) (*operations.ListConsumerGroupsForConsumerResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, request)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListConsumerGroupsForConsumer")
+	}
+
+	var r0 *operations.ListConsumerGroupsForConsumerResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, operations.ListConsumerGroupsForConsumerRequest, ...operations.Option) (*operations.ListConsumerGroupsForConsumerResponse, error)); ok {
+		return rf(ctx, request, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, operations.ListConsumerGroupsForConsumerRequest, ...operations.Option) *operations.ListConsumerGroupsForConsumerResponse); ok {
+		r0 = rf(ctx, request, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*operations.ListConsumerGroupsForConsumerResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, operations.ListConsumerGroupsForConsumerRequest, ...operations.Option) error); ok {
+		r1 = rf(ctx, request, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockConsumerGroupSDK_ListConsumerGroupsForConsumer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListConsumerGroupsForConsumer'
+type MockConsumerGroupSDK_ListConsumerGroupsForConsumer_Call struct {
+	*mock.Call
+}
+
+// ListConsumerGroupsForConsumer is a helper method to define mock.On call
+//   - ctx context.Context
+//   - request operations.ListConsumerGroupsForConsumerRequest
+//   - opts ...operations.Option
+func (_e *MockConsumerGroupSDK_Expecter) ListConsumerGroupsForConsumer(ctx interface{}, request interface{}, opts ...interface{}) *MockConsumerGroupSDK_ListConsumerGroupsForConsumer_Call {
+	return &MockConsumerGroupSDK_ListConsumerGroupsForConsumer_Call{Call: _e.mock.On("ListConsumerGroupsForConsumer",
+		append([]interface{}{ctx, request}, opts...)...)}
+}
+
+func (_c *MockConsumerGroupSDK_ListConsumerGroupsForConsumer_Call) Run(run func(ctx context.Context, request operations.ListConsumerGroupsForConsumerRequest, opts ...operations.Option)) *MockConsumerGroupSDK_ListConsumerGroupsForConsumer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]operations.Option, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(operations.Option)
+			}
+		}
+		run(args[0].(context.Context), args[1].(operations.ListConsumerGroupsForConsumerRequest), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockConsumerGroupSDK_ListConsumerGroupsForConsumer_Call) Return(_a0 *operations.ListConsumerGroupsForConsumerResponse, _a1 error) *MockConsumerGroupSDK_ListConsumerGroupsForConsumer_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockConsumerGroupSDK_ListConsumerGroupsForConsumer_Call) RunAndReturn(run func(context.Context, operations.ListConsumerGroupsForConsumerRequest, ...operations.Option) (*operations.ListConsumerGroupsForConsumerResponse, error)) *MockConsumerGroupSDK_ListConsumerGroupsForConsumer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RemoveConsumerFromGroup provides a mock function with given fields: ctx, request, opts
+func (_m *MockConsumerGroupSDK) RemoveConsumerFromGroup(ctx context.Context, request operations.RemoveConsumerFromGroupRequest, opts ...operations.Option) (*operations.RemoveConsumerFromGroupResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, request)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveConsumerFromGroup")
+	}
+
+	var r0 *operations.RemoveConsumerFromGroupResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, operations.RemoveConsumerFromGroupRequest, ...operations.Option) (*operations.RemoveConsumerFromGroupResponse, error)); ok {
+		return rf(ctx, request, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, operations.RemoveConsumerFromGroupRequest, ...operations.Option) *operations.RemoveConsumerFromGroupResponse); ok {
+		r0 = rf(ctx, request, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*operations.RemoveConsumerFromGroupResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, operations.RemoveConsumerFromGroupRequest, ...operations.Option) error); ok {
+		r1 = rf(ctx, request, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockConsumerGroupSDK_RemoveConsumerFromGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveConsumerFromGroup'
+type MockConsumerGroupSDK_RemoveConsumerFromGroup_Call struct {
+	*mock.Call
+}
+
+// RemoveConsumerFromGroup is a helper method to define mock.On call
+//   - ctx context.Context
+//   - request operations.RemoveConsumerFromGroupRequest
+//   - opts ...operations.Option
+func (_e *MockConsumerGroupSDK_Expecter) RemoveConsumerFromGroup(ctx interface{}, request interface{}, opts ...interface{}) *MockConsumerGroupSDK_RemoveConsumerFromGroup_Call {
+	return &MockConsumerGroupSDK_RemoveConsumerFromGroup_Call{Call: _e.mock.On("RemoveConsumerFromGroup",
+		append([]interface{}{ctx, request}, opts...)...)}
+}
+
+func (_c *MockConsumerGroupSDK_RemoveConsumerFromGroup_Call) Run(run func(ctx context.Context, request operations.RemoveConsumerFromGroupRequest, opts ...operations.Option)) *MockConsumerGroupSDK_RemoveConsumerFromGroup_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]operations.Option, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(operations.Option)
+			}
+		}
+		run(args[0].(context.Context), args[1].(operations.RemoveConsumerFromGroupRequest), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockConsumerGroupSDK_RemoveConsumerFromGroup_Call) Return(_a0 *operations.RemoveConsumerFromGroupResponse, _a1 error) *MockConsumerGroupSDK_RemoveConsumerFromGroup_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockConsumerGroupSDK_RemoveConsumerFromGroup_Call) RunAndReturn(run func(context.Context, operations.RemoveConsumerFromGroupRequest, ...operations.Option) (*operations.RemoveConsumerFromGroupResponse, error)) *MockConsumerGroupSDK_RemoveConsumerFromGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -37,8 +37,6 @@ const (
 	UpdateOp Op = "update"
 	// DeleteOp is the operation type for deleting a Konnect entity.
 	DeleteOp Op = "delete"
-	// ListOp is the operation type for listing Konnect entities.
-	ListOp Op = "list"
 )
 
 // Create creates a Konnect entity.

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -37,6 +37,8 @@ const (
 	UpdateOp Op = "update"
 	// DeleteOp is the operation type for deleting a Konnect entity.
 	DeleteOp Op = "delete"
+	// ListOp is the operation type for listing Konnect entities.
+	ListOp Op = "list"
 )
 
 // Create creates a Konnect entity.
@@ -59,7 +61,7 @@ func Create[
 	case *configurationv1alpha1.KongRoute:
 		return e, createRoute(ctx, sdk.GetRoutesSDK(), ent)
 	case *configurationv1.KongConsumer:
-		return e, createConsumer(ctx, sdk.GetConsumersSDK(), ent)
+		return e, createConsumer(ctx, sdk.GetConsumersSDK(), sdk.GetConsumerGroupsSDK(), cl, ent)
 	case *configurationv1beta1.KongConsumerGroup:
 		return e, createConsumerGroup(ctx, sdk.GetConsumerGroupsSDK(), ent)
 	case *configurationv1alpha1.KongPluginBinding:
@@ -171,7 +173,7 @@ func Update[
 	case *configurationv1alpha1.KongRoute:
 		return ctrl.Result{}, updateRoute(ctx, sdk.GetRoutesSDK(), ent)
 	case *configurationv1.KongConsumer:
-		return ctrl.Result{}, updateConsumer(ctx, sdk.GetConsumersSDK(), ent)
+		return ctrl.Result{}, updateConsumer(ctx, sdk.GetConsumersSDK(), sdk.GetConsumerGroupsSDK(), cl, ent)
 	case *configurationv1beta1.KongConsumerGroup:
 		return ctrl.Result{}, updateConsumerGroup(ctx, sdk.GetConsumerGroupsSDK(), ent)
 	case *configurationv1alpha1.KongPluginBinding:

--- a/controller/konnect/ops/ops_kongconsumer.go
+++ b/controller/konnect/ops/ops_kongconsumer.go
@@ -209,7 +209,7 @@ func reconcileConsumerGroupsWithKonnect(
 		ConsumerID:     consumer.GetKonnectStatus().GetKonnectID(),
 	})
 	if err != nil {
-		return fmt.Errorf("failed to list ConsumerGroups for Consumer %s/%s: %w", consumer.GetNamespace(), consumer.GetName(), err)
+		return fmt.Errorf("failed to list ConsumerGroups for Consumer %s: %w", client.ObjectKeyFromObject(consumer), err)
 	}
 	// Filter out empty IDs with lo.Compact just in case we get nil IDs in the response.
 	actualConsumerGroupsIDs := lo.Compact(lo.Map(cgsResp.Object.Data, func(cg sdkkonnectcomp.ConsumerGroup, _ int) string {
@@ -234,7 +234,7 @@ func reconcileConsumerGroupsWithKonnect(
 			},
 		})
 		if err != nil {
-			return fmt.Errorf("failed to add Consumer %s/%s to ConsumerGroup %s: %w", consumer.GetNamespace(), consumer.GetName(), cgID, err)
+			return fmt.Errorf("failed to add Consumer %s to ConsumerGroup %s: %w", client.ObjectKeyFromObject(consumer), cgID, err)
 		}
 	}
 
@@ -246,7 +246,7 @@ func reconcileConsumerGroupsWithKonnect(
 			ConsumerID:      consumer.GetKonnectStatus().GetKonnectID(),
 		})
 		if err != nil {
-			return fmt.Errorf("failed to remove Consumer %s/%s from ConsumerGroup %s: %w", consumer.GetNamespace(), consumer.GetName(), cgID, err)
+			return fmt.Errorf("failed to remove Consumer %s from ConsumerGroup %s: %w", client.ObjectKeyFromObject(consumer), cgID, err)
 		}
 	}
 

--- a/controller/konnect/ops/ops_kongconsumer.go
+++ b/controller/konnect/ops/ops_kongconsumer.go
@@ -211,8 +211,11 @@ func reconcileConsumerGroupsWithKonnect(
 	if err != nil {
 		return fmt.Errorf("failed to list ConsumerGroups for Consumer %s: %w", client.ObjectKeyFromObject(consumer), err)
 	}
+
+	// Account for an unexpected case where the response body is nil.
+	respBody := lo.FromPtrOr(cgsResp.Object, sdkkonnectops.ListConsumerGroupsForConsumerResponseBody{})
 	// Filter out empty IDs with lo.Compact just in case we get nil IDs in the response.
-	actualConsumerGroupsIDs := lo.Compact(lo.Map(cgsResp.Object.Data, func(cg sdkkonnectcomp.ConsumerGroup, _ int) string {
+	actualConsumerGroupsIDs := lo.Compact(lo.Map(respBody.Data, func(cg sdkkonnectcomp.ConsumerGroup, _ int) string {
 		// Convert nil IDs to empty strings.
 		return lo.FromPtrOr(cg.GetID(), "")
 	}))

--- a/controller/konnect/ops/ops_kongconsumer.go
+++ b/controller/konnect/ops/ops_kongconsumer.go
@@ -196,6 +196,11 @@ func handleConsumerGroupAssignments(
 // reconcileConsumerGroupsWithKonnect reconciles the ConsumerGroups assigned to a KongConsumer in Konnect. It calculates
 // the difference between the desired ConsumerGroups and the actual ConsumerGroups in Konnect and adds or removes the
 // Consumer from the ConsumerGroups accordingly. It returns an error if any of the Konnect operations fail.
+//
+// TODO: https://github.com/Kong/gateway-operator/issues/634
+// Please note this implementation relies on imperative operations to list, add and remove Consumers from ConsumerGroups.
+// This is because the Konnect API does not provide a way to atomically assign a Consumer to multiple ConsumerGroups
+// declaratively. It's to be changed once such an API is made available (KOKO-1952).
 func reconcileConsumerGroupsWithKonnect(
 	ctx context.Context,
 	desiredConsumerGroupsIDs []string,

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,6 @@ github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kong/go-kong v0.59.1 h1:AJZtyCD+Zyqe/mF/m+x3/qN/GPVxAH7jq9zGJTHRfjc=
 github.com/kong/go-kong v0.59.1/go.mod h1:8Vt6HmtgLNgL/7bSwAlz3DIWqBtzG7qEt9+OnMiQOa0=
-github.com/kong/kubernetes-configuration v0.0.17 h1:hK+7ZPPAMPXVYXJIzMWBwFVuIwHf4q8d8ZUdms5GDAQ=
-github.com/kong/kubernetes-configuration v0.0.17/go.mod h1:DXrWtdZzewUyPZBR4zvDoY/B8rHxeqcqCBDbyHA+B0Q=
 github.com/kong/kubernetes-configuration v0.0.18 h1:9PYKdEQuE5z7smtzsdyEfRiDd/1c49StVe1ChazvjbA=
 github.com/kong/kubernetes-configuration v0.0.18/go.mod h1:DXrWtdZzewUyPZBR4zvDoY/B8rHxeqcqCBDbyHA+B0Q=
 github.com/kong/kubernetes-telemetry v0.1.5 h1:xHwU1q0IvfEYqpj03po73ZKbVarnFPUwzkoFkdVnr9w=

--- a/test/envtest/deploy_resources.go
+++ b/test/envtest/deploy_resources.go
@@ -305,7 +305,7 @@ func deployKongConsumerGroupAttachedToCP(
 					Name: cp.Name,
 				},
 			},
-			Name: lo.ToPtr(cgName),
+			Name: cgName,
 		},
 	}
 

--- a/test/envtest/konnect_entities_kongconsumer_test.go
+++ b/test/envtest/konnect_entities_kongconsumer_test.go
@@ -151,7 +151,7 @@ func TestKongConsumer(t *testing.T) {
 
 		sdk.ConsumerGroupSDK.EXPECT().CreateConsumerGroup(mock.Anything, cp.GetKonnectStatus().GetKonnectID(),
 			mock.MatchedBy(func(input sdkkonnectcomp.ConsumerGroupInput) bool {
-				return input.Name != nil && *input.Name == consumerGroupName
+				return input.Name == consumerGroupName
 			}),
 		).Return(&sdkkonnectops.CreateConsumerGroupResponse{
 			ConsumerGroup: &sdkkonnectcomp.ConsumerGroup{

--- a/test/envtest/konnect_entities_kongconsumer_test.go
+++ b/test/envtest/konnect_entities_kongconsumer_test.go
@@ -1,0 +1,1 @@
+package envtest

--- a/test/envtest/konnect_entities_kongconsumer_test.go
+++ b/test/envtest/konnect_entities_kongconsumer_test.go
@@ -1,1 +1,258 @@
 package envtest
+
+import (
+	"context"
+	"testing"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/gateway-operator/controller/konnect"
+	"github.com/kong/gateway-operator/controller/konnect/conditions"
+	konnectops "github.com/kong/gateway-operator/controller/konnect/ops"
+	"github.com/kong/gateway-operator/modules/manager/scheme"
+
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
+	configurationv1beta1 "github.com/kong/kubernetes-configuration/api/configuration/v1beta1"
+)
+
+func TestKongConsumer(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := Context(t, context.Background())
+	defer cancel()
+	cfg, ns := Setup(t, ctx, scheme.Get())
+
+	t.Log("Setting up the manager with reconcilers")
+	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+	factory := konnectops.NewMockSDKFactory(t)
+	sdk := factory.SDK
+	reconcilers := []Reconciler{
+		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1.KongConsumer](konnectInfiniteSyncTime),
+		),
+		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1beta1.KongConsumerGroup](konnectInfiniteSyncTime),
+		),
+	}
+	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
+
+	t.Log("Setting up clients")
+	cl, err := client.NewWithWatch(mgr.GetConfig(), client.Options{
+		Scheme: scheme.Get(),
+	})
+	require.NoError(t, err)
+	clientNamespaced := client.NewNamespacedClient(mgr.GetClient(), ns.Name)
+
+	t.Log("Creating KonnectAPIAuthConfiguration and KonnectGatewayControlPlane")
+	apiAuth := deployKonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
+	cp := deployKonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
+
+	t.Log("Setting up a watch for KongConsumer events")
+	cWatch := setupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
+
+	t.Run("should create, update and delete Consumer without ConsumerGroups successfully", func(t *testing.T) {
+		const (
+			consumerID = "consumer-id"
+			username   = "user-1"
+		)
+		t.Log("Setting up SDK expectations on KongConsumer creation")
+		sdk.ConsumersSDK.EXPECT().CreateConsumer(mock.Anything, cp.GetKonnectStatus().GetKonnectID(),
+			mock.MatchedBy(func(input sdkkonnectcomp.ConsumerInput) bool {
+				return input.Username != nil && *input.Username == username
+			}),
+		).Return(&sdkkonnectops.CreateConsumerResponse{
+			Consumer: &sdkkonnectcomp.Consumer{
+				ID: lo.ToPtr(consumerID),
+			},
+		}, nil)
+
+		t.Log("Setting up SDK expectation on KongConsumerGroups listing")
+		sdk.ConsumerGroupSDK.EXPECT().ListConsumerGroupsForConsumer(mock.Anything, sdkkonnectops.ListConsumerGroupsForConsumerRequest{
+			ConsumerID:     consumerID,
+			ControlPlaneID: cp.GetKonnectStatus().GetKonnectID(),
+		}).Return(&sdkkonnectops.ListConsumerGroupsForConsumerResponse{}, nil)
+
+		t.Log("Creating KongConsumer")
+		createdConsumer := deployKongConsumerAttachedToCP(t, ctx, clientNamespaced, username, cp)
+
+		t.Log("Waiting for KongConsumer to be programmed")
+		watchFor(t, ctx, cWatch, watch.Modified, func(c *configurationv1.KongConsumer) bool {
+			if c.GetName() != createdConsumer.GetName() {
+				return false
+			}
+			return lo.ContainsBy(c.Status.Conditions, func(condition metav1.Condition) bool {
+				return condition.Type == conditions.KonnectEntityProgrammedConditionType &&
+					condition.Status == metav1.ConditionTrue
+			})
+		}, "KongConsumer's Programmed condition should be true eventually")
+
+		t.Log("Waiting for KongConsumer to be created in the SDK")
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, factory.SDK.ConsumersSDK.AssertExpectations(t))
+		}, waitTime, tickTime)
+
+		t.Log("Setting up SDK expectations on KongConsumer update")
+		sdk.ConsumersSDK.EXPECT().UpsertConsumer(mock.Anything, mock.MatchedBy(func(r sdkkonnectops.UpsertConsumerRequest) bool {
+			return r.ConsumerID == consumerID &&
+				r.Consumer.Username != nil && *r.Consumer.Username == "user-1-updated"
+		})).Return(&sdkkonnectops.UpsertConsumerResponse{}, nil)
+
+		t.Log("Patching KongConsumer")
+		consumerToPatch := createdConsumer.DeepCopy()
+		consumerToPatch.Username = "user-1-updated"
+		require.NoError(t, clientNamespaced.Patch(ctx, consumerToPatch, client.MergeFrom(createdConsumer)))
+
+		t.Log("Waiting for KongConsumer to be updated in the SDK")
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, factory.SDK.ConsumersSDK.AssertExpectations(t))
+		}, waitTime, tickTime)
+
+		t.Log("Setting up SDK expectations on KongConsumer deletion")
+		sdk.ConsumersSDK.EXPECT().DeleteConsumer(mock.Anything, cp.GetKonnectStatus().GetKonnectID(), consumerID).
+			Return(&sdkkonnectops.DeleteConsumerResponse{}, nil)
+
+		t.Log("Deleting KongConsumer")
+		require.NoError(t, cl.Delete(ctx, createdConsumer))
+
+		t.Log("Waiting for KongConsumer to be deleted in the SDK")
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, factory.SDK.ConsumersSDK.AssertExpectations(t))
+		}, waitTime, tickTime)
+	})
+
+	t.Log("Setting up a watch for KongConsumerGroup events")
+	cgWatch := setupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, cl, client.InNamespace(ns.Name))
+
+	t.Run("should create, update and delete Consumer with ConsumerGroups successfully", func(t *testing.T) {
+		const (
+			consumerID = "consumer-id"
+			username   = "user-2"
+
+			cgID              = "consumer-group-id"
+			consumerGroupName = "consumer-group-1"
+		)
+		t.Log("Setting up SDK expectations on KongConsumer creation with ConsumerGroup")
+		sdk.ConsumersSDK.EXPECT().CreateConsumer(mock.Anything, cp.GetKonnectStatus().GetKonnectID(),
+			mock.MatchedBy(func(input sdkkonnectcomp.ConsumerInput) bool {
+				return input.Username != nil && *input.Username == username
+			}),
+		).Return(&sdkkonnectops.CreateConsumerResponse{
+			Consumer: &sdkkonnectcomp.Consumer{
+				ID: lo.ToPtr(consumerID),
+			},
+		}, nil)
+
+		sdk.ConsumerGroupSDK.EXPECT().CreateConsumerGroup(mock.Anything, cp.GetKonnectStatus().GetKonnectID(),
+			mock.MatchedBy(func(input sdkkonnectcomp.ConsumerGroupInput) bool {
+				return input.Name != nil && *input.Name == consumerGroupName
+			}),
+		).Return(&sdkkonnectops.CreateConsumerGroupResponse{
+			ConsumerGroup: &sdkkonnectcomp.ConsumerGroup{
+				ID: lo.ToPtr(cgID),
+			},
+		}, nil)
+
+		t.Log("Setting up SDK expectation on KongConsumerGroups listing")
+		emptyListCall := sdk.ConsumerGroupSDK.EXPECT().ListConsumerGroupsForConsumer(mock.Anything, sdkkonnectops.ListConsumerGroupsForConsumerRequest{
+			ConsumerID:     consumerID,
+			ControlPlaneID: cp.GetKonnectStatus().GetKonnectID(),
+		}).Return(&sdkkonnectops.ListConsumerGroupsForConsumerResponse{
+			// Returning no ConsumerGroups associated with the Consumer in Konnect to trigger addition.
+		}, nil)
+
+		t.Log("Setting up SDK expectation on adding Consumer to ConsumerGroup")
+		sdk.ConsumerGroupSDK.EXPECT().AddConsumerToGroup(mock.Anything, sdkkonnectops.AddConsumerToGroupRequest{
+			ConsumerGroupID: cgID,
+			ControlPlaneID:  cp.GetKonnectStatus().GetKonnectID(),
+			RequestBody: &sdkkonnectops.AddConsumerToGroupRequestBody{
+				ConsumerID: lo.ToPtr(consumerID),
+			},
+		}).Return(&sdkkonnectops.AddConsumerToGroupResponse{}, nil)
+
+		t.Log("Creating KongConsumerGroup")
+		createdConsumerGroup := deployKongConsumerGroupAttachedToCP(t, ctx, clientNamespaced, consumerGroupName, cp)
+
+		t.Log("Creating KongConsumer and patching it with ConsumerGroup")
+		createdConsumer := deployKongConsumerAttachedToCP(t, ctx, clientNamespaced, username, cp)
+		consumer := createdConsumer.DeepCopy()
+		consumer.ConsumerGroups = []string{createdConsumerGroup.GetName()}
+		require.NoError(t, clientNamespaced.Patch(ctx, consumer, client.MergeFrom(createdConsumer)))
+
+		t.Log("Waiting for KongConsumer to be programmed")
+		watchFor(t, ctx, cWatch, watch.Modified, func(c *configurationv1.KongConsumer) bool {
+			if c.GetName() != createdConsumer.GetName() {
+				return false
+			}
+			return lo.ContainsBy(c.Status.Conditions, func(condition metav1.Condition) bool {
+				return condition.Type == conditions.KonnectEntityProgrammedConditionType &&
+					condition.Status == metav1.ConditionTrue
+			})
+		}, "KongConsumer's Programmed condition should be true eventually")
+
+		t.Log("Waiting for KongConsumerGroup to be programmed")
+		watchFor(t, ctx, cgWatch, watch.Modified, func(c *configurationv1beta1.KongConsumerGroup) bool {
+			if c.GetName() != createdConsumerGroup.GetName() {
+				return false
+			}
+			return lo.ContainsBy(c.Status.Conditions, func(condition metav1.Condition) bool {
+				return condition.Type == conditions.KonnectEntityProgrammedConditionType &&
+					condition.Status == metav1.ConditionTrue
+			})
+		}, "KongConsumerGroup's Programmed condition should be true eventually")
+
+		t.Log("Waiting for SDK expectations to be met")
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, factory.SDK.ConsumersSDK.AssertExpectations(t))
+		}, waitTime, tickTime)
+
+		t.Log("Setting up SDK expectations on KongConsumer update with ConsumerGroup")
+		sdk.ConsumersSDK.EXPECT().UpsertConsumer(mock.Anything, mock.MatchedBy(func(r sdkkonnectops.UpsertConsumerRequest) bool {
+			return r.ConsumerID == consumerID &&
+				r.Consumer.Username != nil && *r.Consumer.Username == "user-2-updated"
+		})).Return(&sdkkonnectops.UpsertConsumerResponse{}, nil)
+
+		emptyListCall.Unset() // Unset the previous expectation to allow the new one to be set.
+		sdk.ConsumerGroupSDK.EXPECT().ListConsumerGroupsForConsumer(mock.Anything, sdkkonnectops.ListConsumerGroupsForConsumerRequest{
+			ConsumerID:     consumerID,
+			ControlPlaneID: cp.GetKonnectStatus().GetKonnectID(),
+		}).Return(&sdkkonnectops.ListConsumerGroupsForConsumerResponse{
+			Object: &sdkkonnectops.ListConsumerGroupsForConsumerResponseBody{
+				Data: []sdkkonnectcomp.ConsumerGroup{
+					{
+						// Returning an ID that we haven't defined to be associated with the Consumer.
+						// Should trigger removal.
+						ID: lo.ToPtr("not-defined-in-crd"),
+					},
+					{
+						// Returning the ID of the ConsumerGroup we have defined to be associated with the Consumer.
+						// Should not trigger any action as it's already associated.
+						ID: lo.ToPtr(cgID),
+					},
+				},
+			},
+		}, nil)
+
+		sdk.ConsumerGroupSDK.EXPECT().RemoveConsumerFromGroup(mock.Anything, sdkkonnectops.RemoveConsumerFromGroupRequest{
+			ConsumerGroupID: "not-defined-in-crd",
+			ControlPlaneID:  cp.GetKonnectStatus().GetKonnectID(),
+			ConsumerID:      consumerID,
+		}).Return(&sdkkonnectops.RemoveConsumerFromGroupResponse{}, nil)
+
+		t.Log("Patching KongConsumer to trigger reconciliation")
+		consumerToPatch := createdConsumer.DeepCopy()
+		consumerToPatch.Username = "user-2-updated"
+		require.NoError(t, clientNamespaced.Patch(ctx, consumerToPatch, client.MergeFrom(createdConsumer)))
+
+		t.Log("Waiting for SDK expectations to be met")
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, factory.SDK.ConsumerGroupSDK.AssertExpectations(t))
+		}, waitTime, tickTime)
+	})
+}

--- a/test/integration/test_konnect_entities.go
+++ b/test/integration/test_konnect_entities.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kong/gateway-operator/controller/konnect/conditions"
 	testutils "github.com/kong/gateway-operator/pkg/utils/test"
 	"github.com/kong/gateway-operator/test"
 	"github.com/kong/gateway-operator/test/helpers"
@@ -83,9 +84,7 @@ func TestKonnectEntities(t *testing.T) {
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		err := GetClients().MgrClient.Get(GetCtx(), types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace}, cp)
 		require.NoError(t, err)
-		assert.NotEmpty(t, cp.Status.KonnectEntityStatus.GetKonnectID())
-		assert.NotEmpty(t, cp.Status.KonnectEntityStatus.GetOrgID())
-		assert.NotEmpty(t, cp.Status.KonnectEntityStatus.GetServerURL())
+		assertKonnectEntityProgrammed(t, cp.GetConditions(), cp.GetKonnectStatus())
 	}, testutils.ObjectUpdateTimeout, time.Second)
 
 	t.Logf("Creating KongService")
@@ -113,13 +112,7 @@ func TestKonnectEntities(t *testing.T) {
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		err := GetClients().MgrClient.Get(GetCtx(), types.NamespacedName{Name: ks.Name, Namespace: ks.Namespace}, ks)
 		require.NoError(t, err)
-
-		if !assert.NotNil(t, ks.Status.Konnect) {
-			return
-		}
-		assert.NotEmpty(t, ks.Status.Konnect.KonnectEntityStatus.GetKonnectID())
-		assert.NotEmpty(t, ks.Status.Konnect.KonnectEntityStatus.GetOrgID())
-		assert.NotEmpty(t, ks.Status.Konnect.KonnectEntityStatus.GetServerURL())
+		assertKonnectEntityProgrammed(t, ks.GetConditions(), ks.GetKonnectStatus())
 	}, testutils.ObjectUpdateTimeout, time.Second)
 
 	t.Logf("Creating KongRoute")
@@ -150,44 +143,7 @@ func TestKonnectEntities(t *testing.T) {
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		err := GetClients().MgrClient.Get(GetCtx(), types.NamespacedName{Name: kr.Name, Namespace: kr.Namespace}, &kr)
 		require.NoError(t, err)
-
-		if !assert.NotNil(t, kr.Status.Konnect) {
-			return
-		}
-		assert.NotEmpty(t, kr.Status.Konnect.KonnectEntityStatus.GetKonnectID())
-		assert.NotEmpty(t, kr.Status.Konnect.KonnectEntityStatus.GetOrgID())
-		assert.NotEmpty(t, kr.Status.Konnect.KonnectEntityStatus.GetServerURL())
-	}, testutils.ObjectUpdateTimeout, time.Second)
-
-	t.Logf("Creating KongConsumer")
-	kcName := "kc-" + testID
-	kc := configurationv1.KongConsumer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      kcName,
-			Namespace: ns.Name,
-		},
-		Username: kcName,
-		Spec: configurationv1.KongConsumerSpec{
-			ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
-				Type:                 configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
-				KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{Name: cp.Name},
-			},
-		},
-	}
-	err = GetClients().MgrClient.Create(GetCtx(), &kc)
-	require.NoError(t, err)
-
-	t.Logf("Waiting for KongConsumer to be updated with Konnect ID")
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		err := GetClients().MgrClient.Get(GetCtx(), types.NamespacedName{Name: kc.Name, Namespace: ns.Name}, &kc)
-		require.NoError(t, err)
-
-		if !assert.NotNil(t, kc.Status.Konnect) {
-			return
-		}
-		assert.NotEmpty(t, kc.Status.Konnect.KonnectEntityStatus.GetKonnectID())
-		assert.NotEmpty(t, kc.Status.Konnect.KonnectEntityStatus.GetOrgID())
-		assert.NotEmpty(t, kc.Status.Konnect.KonnectEntityStatus.GetServerURL())
+		assertKonnectEntityProgrammed(t, kr.GetConditions(), kr.GetKonnectStatus())
 	}, testutils.ObjectUpdateTimeout, time.Second)
 
 	t.Logf("Creating KongConsumerGroup")
@@ -214,13 +170,35 @@ func TestKonnectEntities(t *testing.T) {
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		err := GetClients().MgrClient.Get(GetCtx(), types.NamespacedName{Name: kcg.Name, Namespace: ns.Name}, &kcg)
 		require.NoError(t, err)
+		assertKonnectEntityProgrammed(t, kcg.GetConditions(), kcg.GetKonnectStatus())
+	}, testutils.ObjectUpdateTimeout, time.Second)
 
-		if !assert.NotNil(t, kcg.Status.Konnect) {
-			return
-		}
-		assert.NotEmpty(t, kcg.Status.Konnect.KonnectEntityStatus.GetKonnectID())
-		assert.NotEmpty(t, kcg.Status.Konnect.KonnectEntityStatus.GetOrgID())
-		assert.NotEmpty(t, kcg.Status.Konnect.KonnectEntityStatus.GetServerURL())
+	t.Logf("Creating KongConsumer")
+	kcName := "kc-" + testID
+	kc := configurationv1.KongConsumer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kcName,
+			Namespace: ns.Name,
+		},
+		Username: kcName,
+		ConsumerGroups: []string{
+			kcg.Name,
+		},
+		Spec: configurationv1.KongConsumerSpec{
+			ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+				Type:                 configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+				KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{Name: cp.Name},
+			},
+		},
+	}
+	err = GetClients().MgrClient.Create(GetCtx(), &kc)
+	require.NoError(t, err)
+
+	t.Logf("Waiting for KongConsumer to be updated with Konnect ID and Programmed")
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		err := GetClients().MgrClient.Get(GetCtx(), types.NamespacedName{Name: kc.Name, Namespace: ns.Name}, &kc)
+		require.NoError(t, err)
+		assertKonnectEntityProgrammed(t, kc.GetConditions(), kc.GetKonnectStatus())
 	}, testutils.ObjectUpdateTimeout, time.Second)
 
 	t.Logf("Creating KongPlugin and KongPluginBinding")
@@ -268,13 +246,7 @@ func TestKonnectEntities(t *testing.T) {
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		err := GetClients().MgrClient.Get(GetCtx(), types.NamespacedName{Name: kpb.Name, Namespace: ns.Name}, &kpb)
 		require.NoError(t, err)
-
-		if !assert.NotNil(t, kpb.Status.Konnect) {
-			return
-		}
-		assert.NotEmpty(t, kpb.Status.Konnect.KonnectEntityStatus.GetKonnectID())
-		assert.NotEmpty(t, kpb.Status.Konnect.KonnectEntityStatus.GetOrgID())
-		assert.NotEmpty(t, kpb.Status.Konnect.KonnectEntityStatus.GetServerURL())
+		assertKonnectEntityProgrammed(t, kpb.GetConditions(), kpb.GetKonnectStatus())
 	}, testutils.ObjectUpdateTimeout, time.Second)
 }
 
@@ -290,4 +262,20 @@ func deleteObjectAndWaitForDeletionFn(t *testing.T, obj client.Object) func() {
 			assert.True(t, k8serrors.IsNotFound(err))
 		}, testutils.ObjectUpdateTimeout, time.Second)
 	}
+}
+
+// assertKonnectEntityProgrammed asserts that the KonnectEntityProgrammed condition is set to true and the Konnect
+// status fields are populated.
+func assertKonnectEntityProgrammed(t assert.TestingT, cs []metav1.Condition, konnectStatus *konnectv1alpha1.KonnectEntityStatus) {
+	if !assert.NotNil(t, konnectStatus) {
+		return
+	}
+	assert.NotEmpty(t, konnectStatus.GetKonnectID())
+	assert.NotEmpty(t, konnectStatus.GetOrgID())
+	assert.NotEmpty(t, konnectStatus.GetServerURL())
+
+	assert.True(t, lo.ContainsBy(cs, func(condition metav1.Condition) bool {
+		return condition.Type == conditions.KonnectEntityProgrammedConditionType &&
+			condition.Status == metav1.ConditionTrue
+	}))
 }

--- a/test/integration/test_konnect_entities.go
+++ b/test/integration/test_konnect_entities.go
@@ -191,8 +191,7 @@ func TestKonnectEntities(t *testing.T) {
 			},
 		},
 	}
-	err = GetClients().MgrClient.Create(GetCtx(), &kc)
-	require.NoError(t, err)
+	require.NoError(t, GetClients().MgrClient.Create(GetCtx(), &kc))
 
 	t.Logf("Waiting for KongConsumer to be updated with Konnect ID and Programmed")
 	require.EventuallyWithT(t, func(t *assert.CollectT) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Extends the `KongConsumer` reconciler to handle `KongConsumerGroups` that a given `KongConsumer` is assigned to. Adds envtests suite covering the reconciler expected behavior.

Marked with `do not merge` as it uses a not-released Konnect Go SDK version that relies on a yet-not-merged Konnect API definition PR: https://github.com/Kong/platform-api/pull/724

**Which issue this PR fixes**

Fixes https://github.com/Kong/gateway-operator/issues/519.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
