### PR TITLE
chore: use client.IgnoreNotFound(err) where applicable

### DIFF
--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -119,10 +119,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	log.Trace(logger, "reconciling ControlPlane resource", req)
 	cp := new(operatorv1beta1.ControlPlane)
 	if err := r.Client.Get(ctx, req.NamespacedName, cp); err != nil {
-		if k8serrors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	// controlplane is deleted, just run garbage collection for cluster wide resources.
@@ -449,7 +446,7 @@ func (r *Reconciler) patchStatus(ctx context.Context, logger logr.Logger, update
 	current := &operatorv1beta1.ControlPlane{}
 
 	err := r.Client.Get(ctx, client.ObjectKeyFromObject(updated), current)
-	if err != nil && !k8serrors.IsNotFound(err) {
+	if client.IgnoreNotFound(err) != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/controller/dataplane/controller.go
+++ b/controller/dataplane/controller.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	appsv1 "k8s.io/api/apps/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -67,10 +66,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	dpNn := req.NamespacedName
 	dataplane := new(operatorv1beta1.DataPlane)
 	if err := r.Client.Get(ctx, dpNn, dataplane); err != nil {
-		if k8serrors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	if k8sutils.InitReady(dataplane) {

--- a/controller/dataplane/controller_reconciler_utils.go
+++ b/controller/dataplane/controller_reconciler_utils.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -195,7 +194,7 @@ func patchDataPlaneStatus(ctx context.Context, cl client.Client, logger logr.Log
 	current := &operatorv1beta1.DataPlane{}
 
 	err := cl.Get(ctx, client.ObjectKeyFromObject(updated), current)
-	if err != nil && !k8serrors.IsNotFound(err) {
+	if client.IgnoreNotFound(err) != nil {
 		return false, err
 	}
 

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -12,7 +12,6 @@ import (
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -109,10 +108,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	log.Trace(logger, "reconciling gateway resource", req)
 	var gateway gwtypes.Gateway
 	if err := r.Client.Get(ctx, req.NamespacedName, &gateway); err != nil {
-		if k8serrors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	log.Trace(logger, "managing cleanup for gateway resource", gateway)

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -412,10 +412,7 @@ func (r *Reconciler) ensureOwnedControlPlanesDeleted(ctx context.Context, gatewa
 			continue
 		}
 		err = r.Client.Delete(ctx, &controlplanes[i])
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				continue
-			}
+		if client.IgnoreNotFound(err) != nil {
 			errs = append(errs, err)
 			continue
 		}
@@ -439,10 +436,7 @@ func (r *Reconciler) ensureOwnedDataPlanesDeleted(ctx context.Context, gateway *
 	)
 	for i := range dataplanes {
 		err = r.Client.Delete(ctx, &dataplanes[i])
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				continue
-			}
+		if client.IgnoreNotFound(err) != nil {
 			errs = append(errs, err)
 			continue
 		}
@@ -466,10 +460,7 @@ func (r *Reconciler) ensureOwnedNetworkPoliciesDeleted(ctx context.Context, gate
 	)
 	for i := range networkPolicies {
 		err = r.Client.Delete(ctx, &networkPolicies[i])
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				continue
-			}
+		if client.IgnoreNotFound(err) != nil {
 			errs = append(errs, err)
 			continue
 		}

--- a/controller/konnect/reconciler_konnectapiauth.go
+++ b/controller/konnect/reconciler_konnectapiauth.go
@@ -9,7 +9,6 @@ import (
 
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -90,10 +89,7 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 ) (ctrl.Result, error) {
 	var apiAuth konnectv1alpha1.KonnectAPIAuthConfiguration
 	if err := r.client.Get(ctx, req.NamespacedName, &apiAuth); err != nil {
-		if k8serrors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	var (

--- a/controller/specialized/aigateway_controller.go
+++ b/controller/specialized/aigateway_controller.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -58,10 +57,7 @@ func (r *AIGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	var aigateway v1alpha1.AIGateway
 	if err := r.Client.Get(ctx, req.NamespacedName, &aigateway); err != nil {
-		if k8serrors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	log.Trace(logger, "verifying gatewayclass for aigateway", aigateway)

--- a/modules/manager/webhook.go
+++ b/modules/manager/webhook.go
@@ -300,18 +300,14 @@ func (m *webhookManager) cleanupWebhookResources(ctx context.Context) error {
 			},
 		).
 		Build()
-	if err := m.client.Delete(ctx, validatingWebhookConfiguration); err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return err
-		}
+	if err := m.client.Delete(ctx, validatingWebhookConfiguration); client.IgnoreNotFound(err) != nil {
+		return err
 	}
 
 	// delete the Service needed to expose the operator Webhook
 	webhookService := k8sresources.GenerateNewServiceForCertificateConfig(m.cfg.ControllerNamespace, consts.WebhookServiceName)
-	if err := m.client.Delete(ctx, webhookService); err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return err
-		}
+	if err := m.client.Delete(ctx, webhookService); client.IgnoreNotFound(err) != nil {
+		return err
 	}
 
 	certSecret := &corev1.Secret{
@@ -320,10 +316,8 @@ func (m *webhookManager) cleanupWebhookResources(ctx context.Context) error {
 			Namespace: m.cfg.ControllerNamespace,
 		},
 	}
-	if err := m.client.Delete(ctx, certSecret); err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return err
-		}
+	if err := m.client.Delete(ctx, certSecret); client.IgnoreNotFound(err) != nil {
+		return err
 	}
 
 	return nil
@@ -332,42 +326,32 @@ func (m *webhookManager) cleanupWebhookResources(ctx context.Context) error {
 func (m *webhookManager) cleanupCertificateConfigResources(ctx context.Context) error {
 	// delete the certificateConfig ServiceAccount
 	serviceAccount := k8sresources.GenerateNewServiceAccountForCertificateConfig(m.cfg.ControllerNamespace, consts.WebhookCertificateConfigName, consts.WebhookCertificateConfigLabelvalue)
-	if err := m.client.Delete(ctx, serviceAccount); err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return err
-		}
+	if err := m.client.Delete(ctx, serviceAccount); client.IgnoreNotFound(err) != nil {
+		return err
 	}
 
 	// delete the certificateConfig ClusterRole
 	clusterRole := k8sresources.GenerateNewClusterRoleForCertificateConfig(m.cfg.ControllerNamespace, consts.WebhookCertificateConfigName, consts.WebhookCertificateConfigLabelvalue)
-	if err := m.client.Delete(ctx, clusterRole); err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return err
-		}
+	if err := m.client.Delete(ctx, clusterRole); client.IgnoreNotFound(err) != nil {
+		return err
 	}
 
 	// delete the certificateConfig ClusterRoleBinding
 	clusterRoleBinding := k8sresources.GenerateNewClusterRoleBindingForCertificateConfig(m.cfg.ControllerNamespace, consts.WebhookCertificateConfigName, consts.WebhookCertificateConfigLabelvalue)
-	if err := m.client.Delete(ctx, clusterRoleBinding); err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return err
-		}
+	if err := m.client.Delete(ctx, clusterRoleBinding); client.IgnoreNotFound(err) != nil {
+		return err
 	}
 
 	// delete the certificateConfig Role
 	role := k8sresources.GenerateNewRoleForCertificateConfig(m.cfg.ControllerNamespace, consts.WebhookCertificateConfigName, consts.WebhookCertificateConfigLabelvalue)
-	if err := m.client.Delete(ctx, role); err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return err
-		}
+	if err := m.client.Delete(ctx, role); client.IgnoreNotFound(err) != nil {
+		return err
 	}
 
 	// delete the certificateConfig RoleBinding
 	roleBinding := k8sresources.GenerateNewRoleBindingForCertificateConfig(m.cfg.ControllerNamespace, consts.WebhookCertificateConfigName, consts.WebhookCertificateConfigLabelvalue)
-	if err := m.client.Delete(ctx, roleBinding); err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return err
-		}
+	if err := m.client.Delete(ctx, roleBinding); client.IgnoreNotFound(err) != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Use [`client.IgnoreNotFound(err)`](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client#IgnoreNotFound) where applicable.
