### PR TITLE
fix: add controlplaneRef to managed kpb

### DIFF
--- a/controller/konnect/reconciler_kongplugin.go
+++ b/controller/konnect/reconciler_kongplugin.go
@@ -211,6 +211,7 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 									Name:  kongService.Name,
 								},
 							},
+							ControlPlaneRef: kongService.Spec.ControlPlaneRef,
 							PluginReference: configurationv1alpha1.PluginRef{
 								Name: kongPlugin.Name,
 							},

--- a/controller/konnect/reconciler_kongplugin.go
+++ b/controller/konnect/reconciler_kongplugin.go
@@ -211,6 +211,9 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 									Name:  kongService.Name,
 								},
 							},
+							// TODO: Cross check this with other types of ControlPlaneRefs
+							// used by Route, Consumer and/or ConsumerGroups that also bind this plugin
+							// in this KongPluginBinding spec.
 							ControlPlaneRef: kongService.Spec.ControlPlaneRef,
 							PluginReference: configurationv1alpha1.PluginRef{
 								Name: kongPlugin.Name,


### PR DESCRIPTION
**What this PR does / why we need it**:

copy the KongService `ControlPlaneRef` into the managed `KongPluginBinding`

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
