### PR TITLE
tests: fix TestGatewayDataPlaneNetworkPolicy

### DIFF
--- a/test/helpers/envs/env.go
+++ b/test/helpers/envs/env.go
@@ -1,0 +1,18 @@
+package envs
+
+import corev1 "k8s.io/api/core/v1"
+
+// SetValueByName sets the EnvVar in slice with the provided name and value.
+func SetValueByName(envs []corev1.EnvVar, name string, value string) []corev1.EnvVar {
+	for i := range envs {
+		env := &envs[i]
+		if env.Name == name {
+			env.Value = value
+			return envs
+		}
+	}
+	return append(envs, corev1.EnvVar{
+		Name:  name,
+		Value: value,
+	})
+}

--- a/test/helpers/envs/env_test.go
+++ b/test/helpers/envs/env_test.go
@@ -1,0 +1,57 @@
+package envs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestSetValueByName(t *testing.T) {
+	tests := []struct {
+		name     string
+		envs     []corev1.EnvVar
+		setName  string
+		setValue string
+		expected []corev1.EnvVar
+	}{
+		{
+			name: "set new env var",
+			envs: []corev1.EnvVar{
+				{Name: "EXISTING_VAR", Value: "existing_value"},
+			},
+			setName:  "NEW_VAR",
+			setValue: "new_value",
+			expected: []corev1.EnvVar{
+				{Name: "EXISTING_VAR", Value: "existing_value"},
+				{Name: "NEW_VAR", Value: "new_value"},
+			},
+		},
+		{
+			name: "update existing env var",
+			envs: []corev1.EnvVar{
+				{Name: "EXISTING_VAR", Value: "existing_value"},
+			},
+			setName:  "EXISTING_VAR",
+			setValue: "updated_value",
+			expected: []corev1.EnvVar{
+				{Name: "EXISTING_VAR", Value: "updated_value"},
+			},
+		},
+		{
+			name:     "empty envs slice",
+			envs:     []corev1.EnvVar{},
+			setName:  "NEW_VAR",
+			setValue: "new_value",
+			expected: []corev1.EnvVar{
+				{Name: "NEW_VAR", Value: "new_value"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, SetValueByName(tt.envs, tt.setName, tt.setValue))
+		})
+	}
+}

--- a/test/integration/test_gateway.go
+++ b/test/integration/test_gateway.go
@@ -29,6 +29,7 @@ import (
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	testutils "github.com/kong/gateway-operator/pkg/utils/test"
 	"github.com/kong/gateway-operator/test/helpers"
+	"github.com/kong/gateway-operator/test/helpers/envs"
 )
 
 func TestGatewayEssentials(t *testing.T) {
@@ -940,13 +941,13 @@ func setGatewayConfigurationEnvProxyPort(t *testing.T, gatewayConfiguration *ope
 	container := k8sutils.GetPodContainerByName(&dpOptions.Deployment.PodTemplateSpec.Spec, consts.DataPlaneProxyContainerName)
 	require.NotNil(t, container)
 
-	container.Env = SetEnvValueByName(container.Env,
+	container.Env = envs.SetValueByName(container.Env,
 		"KONG_PROXY_LISTEN",
 		fmt.Sprintf("0.0.0.0:%d reuseport backlog=16384, 0.0.0.0:%d http2 ssl reuseport backlog=16384", proxyPort, proxySSLPort),
 	)
-	container.Env = SetEnvValueByName(container.Env,
+	container.Env = envs.SetValueByName(container.Env,
 		"KONG_PORT_MAPS",
-		fmt.Sprintf("80:%d, 443:%d", proxyPort, proxySSLPort),
+		fmt.Sprintf("80:%d,443:%d", proxyPort, proxySSLPort),
 	)
 
 	gatewayConfiguration.Spec.DataPlaneOptions = dpOptions
@@ -963,7 +964,7 @@ func setGatewayConfigurationEnvAdminAPIPort(t *testing.T, gatewayConfiguration *
 	container := k8sutils.GetPodContainerByName(&dpOptions.Deployment.PodTemplateSpec.Spec, consts.DataPlaneProxyContainerName)
 	require.NotNil(t, container)
 
-	container.Env = SetEnvValueByName(container.Env,
+	container.Env = envs.SetValueByName(container.Env,
 		"KONG_ADMIN_LISTEN",
 		fmt.Sprintf("0.0.0.0:%d ssl reuseport backlog=16384", adminAPIPort),
 	)

--- a/test/integration/utils.go
+++ b/test/integration/utils.go
@@ -131,20 +131,6 @@ func GetEnvValueByName(envs []corev1.EnvVar, name string) string {
 	return value
 }
 
-// SetEnvValueByName sets the EnvVar in slice with the provided name and value.
-func SetEnvValueByName(envs []corev1.EnvVar, name string, value string) []corev1.EnvVar {
-	for _, env := range envs {
-		if env.Name == name {
-			env.Value = value
-			return envs
-		}
-	}
-	return append(envs, corev1.EnvVar{
-		Name:  name,
-		Value: value,
-	})
-}
-
 // GetEnvValueFromByName returns the corresponding ValueFrom pointer of LAST item with given name.
 // returns nil if the name not appeared.
 func GetEnvValueFromByName(envs []corev1.EnvVar, name string) *corev1.EnvVarSource {


### PR DESCRIPTION
**What this PR does / why we need it**:

Attempt at fixing #184.

Apparently `SetEnvValueByName` had an ineffectual assignment and this was possibly the culprit for #184.

Also, the `KONG_PORT_MAPS` was set incorrectly with a space:

```
fmt.Sprintf("80:%d, 443:%d", proxyPort, proxySSLPort),
```

**Which issue this PR fixes**

Fixes #184 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
