### PR TITLE
refactor(konnect): extract KongPluginBinding finalizer handling to a dedicated reconciler

### DIFF
--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -166,16 +166,6 @@ rules:
   - configuration.konghq.com
   resources:
   - kongpluginbindings
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - configuration.konghq.com
-  resources:
   - kongplugins
   verbs:
   - create

--- a/controller/konnect/constraints/constraints.go
+++ b/controller/konnect/constraints/constraints.go
@@ -42,6 +42,17 @@ type EntityType[T SupportedKonnectEntityType] interface {
 	SetKonnectID(string)
 }
 
+// SupportedKonnectEntityPluginReferenceableType is an interface that all Konnect
+// entity types that can be referenced by a KonnectPluginBinding must implement.
+type SupportedKonnectEntityPluginReferenceableType interface {
+	configurationv1alpha1.KongService |
+		configurationv1alpha1.KongRoute |
+		configurationv1.KongConsumer |
+		configurationv1beta1.KongConsumerGroup
+
+	GetTypeName() string
+}
+
 // EntityWithKonnectAPIAuthConfigurationRef is an interface that all Konnect entity types
 // that reference a KonnectAPIAuthConfiguration must implement.
 // More specifically Konnect's ControlPlane does implement that, while all the other

--- a/controller/konnect/index.go
+++ b/controller/konnect/index.go
@@ -16,9 +16,12 @@ type ReconciliationIndexOption struct {
 }
 
 // ReconciliationIndexOptionsForEntity returns required index options for controller reconciliing the entity.
-func ReconciliationIndexOptionsForEntity[T constraints.SupportedKonnectEntityType,
-	TEnt constraints.EntityType[T]](ent TEnt) []ReconciliationIndexOption {
-	switch any(ent).(type) { //nolint:gocritic // TODO: add index options required for other entities
+func ReconciliationIndexOptionsForEntity[
+	TEnt constraints.EntityType[T],
+	T constraints.SupportedKonnectEntityType,
+]() []ReconciliationIndexOption {
+	var e TEnt
+	switch any(e).(type) { //nolint:gocritic // TODO: add index options required for other entities
 	case *configurationv1alpha1.KongPluginBinding:
 		return IndexOptionsForKongPluginBinding()
 	}

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -92,23 +92,16 @@ const (
 // SetupWithManager sets up the controller with the given manager.
 func (r *KonnectEntityReconciler[T, TEnt]) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	var (
-		e   T
-		ent = TEnt(&e)
-		b   = ctrl.NewControllerManagedBy(mgr).
-			Named(constraints.EntityTypeName[T]()).
-			WithOptions(controller.Options{
-				MaxConcurrentReconciles: MaxConcurrentReconciles,
-			})
+		e              T
+		ent            = TEnt(&e)
 		entityTypeName = constraints.EntityTypeName[T]()
-		logger         = log.GetLogger(ctx, entityTypeName, r.DevelopmentMode)
+		b              = ctrl.NewControllerManagedBy(mgr).
+				Named(entityTypeName).
+				WithOptions(
+				controller.Options{
+					MaxConcurrentReconciles: MaxConcurrentReconciles,
+				})
 	)
-
-	for _, ind := range ReconciliationIndexOptionsForEntity(ent) {
-		logger.Info("creating index", "entityTypeName", entityTypeName, "indexObject", ind.IndexObject, "indexField", ind.IndexField)
-		if err := mgr.GetCache().IndexField(ctx, ind.IndexObject, ind.IndexField, ind.ExtractValue); err != nil {
-			return err
-		}
-	}
 
 	for _, dep := range ReconciliationWatchOptionsForEntity(r.Client, ent) {
 		b = dep(b)

--- a/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
+++ b/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
@@ -23,7 +23,7 @@ import (
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
 
-// KonnectEntityPluginBindingFinalizerReconciler reconciles a Konnect entities.
+// KonnectEntityPluginBindingFinalizerReconciler reconciles Konnect entities that may be referenced by KongPluginBinding.
 // It uses the generic type constraints to constrain the supported types.
 type KonnectEntityPluginBindingFinalizerReconciler[
 	T constraints.SupportedKonnectEntityPluginReferenceableType,

--- a/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
+++ b/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
@@ -121,7 +121,7 @@ func (r *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]) Reconcile(
 		ctx,
 		&kongPluginBindingList,
 		client.MatchingFields{
-			getIndexField(ent): ent.GetName(),
+			r.getKongPluginBindingIndexFieldForType(): ent.GetName(),
 		},
 	)
 	if err != nil {
@@ -181,10 +181,12 @@ func (r *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]) Reconcile(
 	return ctrl.Result{}, nil
 }
 
-func getIndexField[
-	T constraints.SupportedKonnectEntityPluginReferenceableType,
-	TEnt constraints.EntityType[T],
-](ent TEnt) string {
+func (r *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]) getKongPluginBindingIndexFieldForType() string {
+	var (
+		e   T
+		ent = TEnt(&e)
+	)
+
 	switch any(ent).(type) {
 	case *configurationv1alpha1.KongService:
 		return IndexFieldKongPluginBindingKongServiceReference

--- a/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
+++ b/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
@@ -1,0 +1,240 @@
+package konnect
+
+import (
+	"context"
+	"fmt"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/kong/gateway-operator/controller/konnect/constraints"
+	"github.com/kong/gateway-operator/controller/pkg/log"
+	"github.com/kong/gateway-operator/pkg/consts"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+)
+
+// KonnectEntityPluginBindingFinalizerReconciler reconciles a Konnect entities.
+// It uses the generic type constraints to constrain the supported types.
+type KonnectEntityPluginBindingFinalizerReconciler[
+	T constraints.SupportedKonnectEntityPluginReferenceableType,
+	TEnt constraints.EntityType[T],
+] struct {
+	DevelopmentMode bool
+	Client          client.Client
+}
+
+// NewKonnectEntityPluginReconciler returns a new KonnectEntityPluginReconciler
+// for the given Konnect entity type.
+func NewKonnectEntityPluginReconciler[
+	T constraints.SupportedKonnectEntityPluginReferenceableType,
+	TEnt constraints.EntityType[T],
+](
+	developmentMode bool,
+	client client.Client,
+) *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt] {
+	r := &KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]{
+		DevelopmentMode: developmentMode,
+		Client:          client,
+	}
+	return r
+}
+
+// SetupWithManager sets up the controller with the given manager.
+func (r *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]) SetupWithManager(
+	ctx context.Context, mgr ctrl.Manager,
+) error {
+	var (
+		entityTypeName = constraints.EntityTypeName[T]()
+		b              = ctrl.NewControllerManagedBy(mgr).Named(entityTypeName + "PluginBindingCleanupFinalizer")
+	)
+
+	r.setControllerBuilderOptionsForKongPluginBinding(b)
+
+	return b.Complete(r)
+}
+
+func enqueueKongServiceForKongPluginBinding() func(
+	ctx context.Context, obj client.Object) []reconcile.Request {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		kpb, ok := obj.(*configurationv1alpha1.KongPluginBinding)
+		if !ok {
+			return nil
+		}
+
+		if kpb.Spec.Targets.ServiceReference == nil ||
+			kpb.Spec.Targets.ServiceReference.Kind != "KongService" ||
+			kpb.Spec.Targets.ServiceReference.Group != configurationv1alpha1.GroupVersion.Group {
+			return nil
+		}
+
+		return []ctrl.Request{
+			{
+				NamespacedName: types.NamespacedName{
+					Namespace: kpb.Namespace,
+					Name:      kpb.Spec.Targets.ServiceReference.Name,
+				},
+			},
+		}
+	}
+}
+
+// Reconcile reconciles the Konnect entity that can be set as KongPluginBinding target.
+// Its purpose is to:
+//   - check if the entity is marked for deletion and mark KongPluginBindings
+//     that reference it.
+//   - add a finalizer to the entity if there are KongPluginBindings referencing it.
+//     This finalizer designates that this entity needs to have its KongPluginBindings
+//     removed upon deletion
+//   - remove the finalizer if all KongPluginBindings referencing it are removed.
+func (r *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]) Reconcile(
+	ctx context.Context, req ctrl.Request,
+) (ctrl.Result, error) {
+	var (
+		entityTypeName = constraints.EntityTypeName[T]()
+		logger         = log.GetLogger(ctx, entityTypeName, r.DevelopmentMode)
+	)
+
+	var (
+		e   T
+		ent = TEnt(&e)
+	)
+	if err := r.Client.Get(ctx, req.NamespacedName, ent); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	ctx = ctrllog.IntoContext(ctx, logger)
+	log.Debug(logger, "reconciling", ent)
+
+	cl := client.NewNamespacedClient(r.Client, ent.GetNamespace())
+	kongPluginBindingList := configurationv1alpha1.KongPluginBindingList{}
+	err := cl.List(
+		ctx,
+		&kongPluginBindingList,
+		client.MatchingFields{
+			getIndexField(ent): ent.GetName(),
+		},
+	)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	var finalizersChangedAction string
+	// if the entity is marked for deletion, we need to delete all the PluginBindings that reference it.
+	if !ent.GetDeletionTimestamp().IsZero() {
+		for _, kpb := range kongPluginBindingList.Items {
+			if err := cl.Delete(ctx, &kpb); err != nil {
+				if k8serrors.IsNotFound(err) {
+					continue
+				}
+				return ctrl.Result{}, err
+			}
+			log.Debug(logger, "KongPluginBinding deleted", kpb)
+		}
+		// in case no KongPluginBindings are referencing the entity, but it has the finalizer,
+		// we need to remove the finalizer.
+		if controllerutil.RemoveFinalizer(ent, consts.CleanupPluginBindingFinalizer) {
+			finalizersChangedAction = "removed"
+		}
+	} else {
+		// if the entity is not marked for deletion, update the finalizers accordingly.
+		switch len(kongPluginBindingList.Items) {
+		case 0:
+			// in case no KongPluginBindings are referencing the entity, but it has the finalizer,
+			// we need to remove the finalizer.
+			if controllerutil.RemoveFinalizer(ent, consts.CleanupPluginBindingFinalizer) {
+				finalizersChangedAction = "removed"
+			}
+
+		default:
+			// add a finalizer to the entity that means the associated
+			// kongPluginBindings need to be cleaned up upon deletion.
+			if controllerutil.AddFinalizer(ent, consts.CleanupPluginBindingFinalizer) {
+				finalizersChangedAction = "added"
+			}
+		}
+	}
+
+	if finalizersChangedAction != "" {
+		if err = r.Client.Update(ctx, ent); err != nil {
+			if k8serrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, err
+		}
+		log.Debug(logger, "finalizers changed", ent,
+			"action", finalizersChangedAction,
+			"finalizer", consts.CleanupPluginBindingFinalizer,
+		)
+		return ctrl.Result{}, nil
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func getIndexField[
+	T constraints.SupportedKonnectEntityPluginReferenceableType,
+	TEnt constraints.EntityType[T],
+](ent TEnt) string {
+	switch any(ent).(type) {
+	case *configurationv1alpha1.KongService:
+		return IndexFieldKongPluginBindingKongServiceReference
+	default:
+		panic(fmt.Sprintf("unsupported entity type %s", constraints.EntityTypeName[T]()))
+	}
+}
+
+func (r *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]) setControllerBuilderOptionsForKongPluginBinding(
+	b *builder.TypedBuilder[ctrl.Request],
+) {
+	kongPluginsAnnotationChangedPredicate := predicate.Funcs{
+		CreateFunc: func(e event.TypedCreateEvent[client.Object]) bool {
+			_, ok := e.Object.GetAnnotations()[consts.PluginsAnnotationKey]
+			return ok
+		},
+		UpdateFunc: func(e event.TypedUpdateEvent[client.Object]) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+			return e.ObjectNew.GetAnnotations()[consts.PluginsAnnotationKey] !=
+				e.ObjectOld.GetAnnotations()[consts.PluginsAnnotationKey]
+		},
+		DeleteFunc: func(e event.TypedDeleteEvent[client.Object]) bool {
+			_, ok := e.Object.GetAnnotations()[consts.PluginsAnnotationKey]
+			return ok
+		},
+	}
+
+	var (
+		e   T
+		ent = TEnt(&e)
+	)
+
+	switch any(ent).(type) {
+	case *configurationv1alpha1.KongService:
+		b.
+			For(&configurationv1alpha1.KongService{},
+				builder.WithPredicates(
+					predicate.NewPredicateFuncs(kongServiceRefersToKonnectGatewayControlPlane),
+					kongPluginsAnnotationChangedPredicate,
+				),
+			).
+			Watches(
+				&configurationv1alpha1.KongPluginBinding{},
+				handler.EnqueueRequestsFromMapFunc(
+					enqueueKongServiceForKongPluginBinding(),
+				),
+			)
+	default:
+		panic(fmt.Sprintf("unsupported entity type %s", constraints.EntityTypeName[T]()))
+	}
+}

--- a/controller/konnect/reconciler_generic_pluginbindingfinalizer_rbac.go
+++ b/controller/konnect/reconciler_generic_pluginbindingfinalizer_rbac.go
@@ -1,0 +1,5 @@
+package konnect
+
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongservices,verbs=get;update
+
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongpluginbindings,verbs=delete;list

--- a/test/envtest/consts.go
+++ b/test/envtest/consts.go
@@ -1,0 +1,9 @@
+package envtest
+
+import "time"
+
+const (
+	konnectSyncTime = 100 * time.Millisecond
+	waitTime        = 10 * time.Second
+	tickTime        = 500 * time.Millisecond
+)

--- a/test/envtest/kongplugincleanupfinalizer_test.go
+++ b/test/envtest/kongplugincleanupfinalizer_test.go
@@ -1,0 +1,120 @@
+package envtest
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/gateway-operator/controller/konnect"
+	"github.com/kong/gateway-operator/modules/manager"
+	"github.com/kong/gateway-operator/modules/manager/scheme"
+	"github.com/kong/gateway-operator/pkg/consts"
+
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+)
+
+func TestKongPluginFinalizer(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := Context(t, context.Background())
+	defer cancel()
+
+	// Setup up the envtest environment.
+	cfg, ns := Setup(t, ctx, scheme.Get())
+
+	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+
+	clientWithWatch, err := client.NewWithWatch(mgr.GetConfig(), client.Options{
+		Scheme: scheme.Get(),
+	})
+	require.NoError(t, err)
+	clientNamespaced := client.NewNamespacedClient(mgr.GetClient(), ns.Name)
+
+	apiAuth := deployKonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
+	cp := deployKonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
+
+	require.NoError(t, manager.SetupCacheIndicesForKonnectTypes(ctx, mgr, false))
+	reconcilers := []Reconciler{
+		konnect.NewKonnectEntityPluginReconciler[configurationv1alpha1.KongService](false, mgr.GetClient()),
+	}
+
+	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
+
+	rateLimitingkongPlugin := &configurationv1.KongPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "rate-limiting-kp-",
+		},
+		PluginName: "rate-limiting",
+		Config: apiextensionsv1.JSON{
+			Raw: []byte(`{"minute": 5, "policy": "local"}`),
+		},
+	}
+	require.NoError(t, clientNamespaced.Create(ctx, rateLimitingkongPlugin))
+	t.Logf("deployed %s KongPlugin (%s) resource", client.ObjectKeyFromObject(rateLimitingkongPlugin), rateLimitingkongPlugin.PluginName)
+
+	kongService := deployKongService(t, ctx, clientNamespaced,
+		&configurationv1alpha1.KongService{
+			Spec: configurationv1alpha1.KongServiceSpec{
+				ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+					Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+					KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+						Name: cp.Name,
+					},
+				},
+				KongServiceAPISpec: configurationv1alpha1.KongServiceAPISpec{
+					URL: lo.ToPtr("http://example.com"),
+				},
+			},
+		},
+	)
+
+	wKongService := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
+	kpb := deployKongPluginBinding(t, ctx, clientNamespaced,
+		&configurationv1alpha1.KongPluginBinding{
+			Spec: configurationv1alpha1.KongPluginBindingSpec{
+				ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+					Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+					KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+						Name: cp.Name,
+					},
+				},
+				PluginReference: configurationv1alpha1.PluginRef{
+					Name: rateLimitingkongPlugin.Name,
+				},
+				Targets: configurationv1alpha1.KongPluginBindingTargets{
+					ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+						Group: configurationv1alpha1.GroupVersion.Group,
+						Kind:  "KongService",
+						Name:  kongService.Name,
+					},
+				},
+			},
+		},
+	)
+
+	_ = watchFor(t, ctx, wKongService, watch.Modified,
+		func(svc *configurationv1alpha1.KongService) bool {
+			return svc.Name == kongService.Name &&
+				slices.Contains(svc.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
+		},
+		fmt.Sprintf("KongService doesn't have the %s finalizer set", consts.CleanupPluginBindingFinalizer),
+	)
+
+	wKongService = setupWatch[configurationv1alpha1.KongServiceList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
+	require.NoError(t, clientNamespaced.Delete(ctx, kpb))
+	_ = watchFor(t, ctx, wKongService, watch.Modified,
+		func(svc *configurationv1alpha1.KongService) bool {
+			return svc.Name == kongService.Name &&
+				!slices.Contains(svc.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
+		},
+		fmt.Sprintf("KongService has the %s finalizer set but it shouldn't", consts.CleanupPluginBindingFinalizer),
+	)
+}

--- a/test/envtest/konnect_entities_suite_test.go
+++ b/test/envtest/konnect_entities_suite_test.go
@@ -29,7 +29,7 @@ import (
 // TestKonnectEntityReconcilers tests Konnect entity reconcilers. The test cases are run against a real Kubernetes API
 // server provided by the envtest package and a mock Konnect SDK.
 func TestKonnectEntityReconcilers(t *testing.T) {
-	cfg := Setup(t, scheme.Get())
+	cfg, _ := Setup(t, context.Background(), scheme.Get())
 
 	testNewKonnectEntityReconciler(t, cfg, konnectv1alpha1.KonnectGatewayControlPlane{}, konnectGatewayControlPlaneTestCases)
 	testNewKonnectEntityReconciler(t, cfg, configurationv1alpha1.KongService{}, nil)

--- a/test/envtest/setup.go
+++ b/test/envtest/setup.go
@@ -1,27 +1,32 @@
 package envtest
 
 import (
+	"context"
 	"go/build"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	testutil "github.com/kong/gateway-operator/pkg/utils/test"
 )
 
 // Setup sets up a test k8s API server environment and returned the configuration.
-func Setup(t *testing.T, scheme *k8sruntime.Scheme) *rest.Config {
+func Setup(t *testing.T, ctx context.Context, scheme *k8sruntime.Scheme) (*rest.Config, *corev1.Namespace) {
 	t.Helper()
 
 	testEnv := &envtest.Environment{
@@ -74,6 +79,19 @@ func Setup(t *testing.T, scheme *k8sruntime.Scheme) *rest.Config {
 
 	t.Logf("envtest environment (%s) started at %s", i, cfg.Host)
 
+	cl, err := client.New(cfg, client.Options{})
+	require.NoError(t, err)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-",
+			Labels: map[string]string{
+				"gateway-operator.konghq.com/test-name": NameFromT(t),
+			},
+		},
+	}
+	require.NoError(t, cl.Create(ctx, ns))
+
 	t.Cleanup(func() {
 		t.Helper()
 		t.Logf("stopping envtest environment for test %s", t.Name())
@@ -81,5 +99,17 @@ func Setup(t *testing.T, scheme *k8sruntime.Scheme) *rest.Config {
 		wg.Wait()
 	})
 
-	return cfg
+	return cfg, ns
+}
+
+// NameFromT returns a name suitable for use in Kubernetes resources for a given test.
+// This is used e.g. when setting kong addon's name.
+func NameFromT(t *testing.T) string {
+	t.Helper()
+
+	name := strings.ToLower(t.Name())
+	name = strings.ReplaceAll(name, "_", "-")
+	name = strings.ReplaceAll(name, "/", ".")
+
+	return name
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extracts the functionality for handling clean finalizer for entities that can be set as KongPluginBinding targets.

This basically means that when such an entity (for now only `KongService`) is referenced by `KongPluginBinding` then the finalizer is put in place to ensure that this binding will be deleted when the entity that is set as the target is deleted.

Additionally this moves the index set up code to `SetupControllers()` as indices can be reused by different controllers and there can only be 1 index using a designated key in manager's cache.

**Which issue this PR fixes**

Related to #525

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
