### PR TITLE
chore(gatewayapi): requeue without error if GatewayClass update results in a conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@
   [#369](https://github.com/Kong/gateway-operator/pull/369)
 - Requeue instead of reporting an error when a finalizer removal yields a conflict.
   [#454](https://github.com/Kong/gateway-operator/pull/454)
+- Requeue instead of reporting an error when a GatewayClass status update yields a conflict.
+  [#612](https://github.com/Kong/gateway-operator/pull/612)
 
 ### Changes
 

--- a/controller/consts.go
+++ b/controller/consts.go
@@ -1,0 +1,8 @@
+package controller
+
+import "time"
+
+const (
+	// RequeueAfter is the time after which the controller should requeue the request.
+	RequeueWithoutBackoff = time.Millisecond * 200
+)

--- a/controller/gateway/controller_cleanup.go
+++ b/controller/gateway/controller_cleanup.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/kong/gateway-operator/controller"
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	gatewayutils "github.com/kong/gateway-operator/pkg/utils/gateway"
 )
@@ -19,8 +20,6 @@ import (
 // ----------------------------------------------------------------------------
 // Reconciler - Cleanup
 // ----------------------------------------------------------------------------
-
-const requeueWithoutBackoff = 200 * time.Millisecond
 
 // cleanup determines whether cleanup is needed/underway for a Gateway and
 // performs all necessary cleanup steps.
@@ -163,7 +162,7 @@ func handleGatewayFinalizerPatchOrUpdateError(err error, gateway *gatewayv1.Gate
 	if k8serrors.IsNotFound(err) || k8serrors.IsConflict(err) {
 		return ctrl.Result{
 			Requeue:      true,
-			RequeueAfter: requeueWithoutBackoff,
+			RequeueAfter: controller.RequeueWithoutBackoff,
 		}, nil
 	}
 
@@ -175,7 +174,7 @@ func handleGatewayFinalizerPatchOrUpdateError(err error, gateway *gatewayv1.Gate
 		log.Debug(logger, "failed to delete a finalizer on Gateway, requeueing request", gateway, "cause", cause)
 		return ctrl.Result{
 			Requeue:      true,
-			RequeueAfter: requeueWithoutBackoff,
+			RequeueAfter: controller.RequeueWithoutBackoff,
 		}, nil
 	}
 

--- a/controller/webhook_manager_rbac.go
+++ b/controller/webhook_manager_rbac.go
@@ -1,4 +1,4 @@
-package controllers
+package controller
 
 // -----------------------------------------------------------------------------
 // Webhook manager - RBAC Permissions


### PR DESCRIPTION
**What this PR does / why we need it**:

Requeue without error when gatewayclass update is conflict.

This prevents the following errors:

```
2024-09-17T12:49:51Z	ERROR	Reconciler error	{"controller": "gatewayclass", "controllerGroup": "gateway.networking.k8s.io", "controllerKind": "GatewayClass", "GatewayClass": {"name":"96a849e2-b86d-40ce-bdd3-6db95ed22449"}, "namespace": "", "name": "96a849e2-b86d-40ce-bdd3-6db95ed22449", "reconcileID": "d4b26dc7-e50d-41b4-a244-69eff0f988a8", "error": "failed updating GatewayClass: Operation cannot be fulfilled on gatewayclasses.gateway.networking.k8s.io \"96a849e2-b86d-40ce-bdd3-6db95ed22449\": the object has been modified; please apply your changes to the latest version and try again"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:316
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
