### PR TITLE
chore(refactor): extract and make generic checking `ReferenceGrant` for `Secret`

### DIFF
--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/controller/pkg/op"
 	"github.com/kong/gateway-operator/controller/pkg/patch"
+	"github.com/kong/gateway-operator/controller/pkg/secrets/ref"
 	"github.com/kong/gateway-operator/controller/pkg/watch"
 	operatorerrors "github.com/kong/gateway-operator/internal/errors"
 	gwtypes "github.com/kong/gateway-operator/internal/types"
@@ -87,7 +88,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 		Watches(
 			&gatewayv1beta1.ReferenceGrant{},
 			handler.EnqueueRequestsFromMapFunc(r.listReferenceGrantsForGateway),
-			builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantHasGatewayFrom))).
+			builder.WithPredicates(ref.ReferenceGrantForSecretFrom(gatewayv1.GroupName, gatewayv1beta1.Kind("Gateway")))).
 		// watch HTTPRoutes so that Gateway listener status can be updated.
 		Watches(
 			&gatewayv1beta1.HTTPRoute{},

--- a/controller/pkg/secrets/ref/ref.go
+++ b/controller/pkg/secrets/ref/ref.go
@@ -32,7 +32,7 @@ func ReferenceGrantForSecretFrom(group gatewayv1.Group, kind gatewayv1.Kind) pre
 	)
 }
 
-// IsReferenceGrantForObj checks if the ReferenceGrant in .Spec.From specifies Group and Kind of the object.
+// IsReferenceGrantForObj checks if ReferenceGrant's from clause matches the provided object's Group, Kind and namespace.
 func IsReferenceGrantForObj(referenceGrant *gatewayv1beta1.ReferenceGrant, obj client.Object) bool {
 	for _, from := range referenceGrant.Spec.From {
 		if string(from.Namespace) == obj.GetNamespace() &&

--- a/controller/pkg/secrets/ref/ref.go
+++ b/controller/pkg/secrets/ref/ref.go
@@ -1,0 +1,125 @@
+package ref
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+// Predicates to filter only the ReferenceGrants that allow a Gateway cross-namespace reference.
+func ReferenceGrantForSecretFrom(group gatewayv1.Group, kind gatewayv1.Kind) predicate.TypedFuncs[client.Object] {
+	return predicate.NewPredicateFuncs(
+		func(obj client.Object) bool {
+			grant, ok := obj.(*gatewayv1beta1.ReferenceGrant)
+			if !ok {
+				return false
+			}
+			for _, from := range grant.Spec.From {
+				if from.Kind == kind && from.Group == group {
+					return true
+				}
+			}
+			return false
+		},
+	)
+}
+
+// IsReferenceGrantForObj checks if the ReferenceGrant in .Spec.From specifies Group and Kind of the object.
+func IsReferenceGrantForObj(referenceGrant *gatewayv1beta1.ReferenceGrant, obj client.Object) bool {
+	for _, from := range referenceGrant.Spec.From {
+		if string(from.Namespace) == obj.GetNamespace() &&
+			from.Kind == gatewayv1.Kind(obj.GetObjectKind().GroupVersionKind().Kind) &&
+			from.Group == gatewayv1.Group(obj.GetObjectKind().GroupVersionKind().Group) {
+			return true
+		}
+	}
+	return false
+}
+
+// EnsureNamespaceInSecretRef ensures that the Namespace in the SecretObjectReference is set.
+// If it is not set, it is set to referencerNamespace.
+func EnsureNamespaceInSecretRef(secretRef *gatewayv1.SecretObjectReference, referencerNamespace gatewayv1.Namespace) {
+	if secretRef.Namespace == nil || *secretRef.Namespace == "" {
+		secretRef.Namespace = lo.ToPtr(referencerNamespace)
+	}
+}
+
+// DoesFieldReferenceCoreV1Secret checks if the SecretObjectReference refers to a Secret in the Corev1 group.
+// If it does not, an error with explanation is returned.
+func DoesFieldReferenceCoreV1Secret(secretRef gatewayv1.SecretObjectReference, fieldName string) error {
+	var errMessages []string
+	if secretRef.Group != nil && *secretRef.Group != "" && *secretRef.Group != gatewayv1.Group(corev1.SchemeGroupVersion.Group) {
+		errMessages = append(errMessages, fmt.Sprintf("Group %s not supported in %s.", *secretRef.Group, fieldName))
+	}
+	if secretRef.Kind != nil && *secretRef.Kind != "" && *secretRef.Kind != gatewayv1.Kind("Secret") {
+		errMessages = append(errMessages, fmt.Sprintf("Kind %s not supported in %s.", *secretRef.Kind, fieldName))
+	}
+	if len(errMessages) > 0 {
+		return errors.New(strings.Join(errMessages, " "))
+	}
+	return nil
+}
+
+// CheckReferenceGrantForSecret checks if the reference from the object (fromObj) to the secret specified in secretRef
+// is granted. It is expected that secretRef.Namespace is set otherwise an error is returned. Examining returned values
+// makes sense only if err is nil. When isReferenceGranted is false, whyNotGranted provides the reason (otherwise it is
+// expected to be discarded).
+func CheckReferenceGrantForSecret(
+	ctx context.Context, c client.Client, fromObj client.Object, secretRef gatewayv1.SecretObjectReference,
+) (whyNotGranted string, isReferenceGranted bool, err error) {
+	if secretRef.Namespace == nil || *secretRef.Namespace == "" {
+		return "", false, fmt.Errorf("caller must ensure that Namespace in SecretObjectReference is set (bug in the code)")
+	}
+	if gatewayv1.Namespace(fromObj.GetNamespace()) == *secretRef.Namespace {
+		return "", true, nil
+	}
+
+	referenceGrantList := &gatewayv1beta1.ReferenceGrantList{}
+	if err := c.List(ctx, referenceGrantList, client.InNamespace(*secretRef.Namespace)); err != nil {
+		return "", false, fmt.Errorf("failed to list ReferenceGrants: %w", err)
+	}
+	if !isSecretCrossReferenceGranted(fromObj, secretRef.Name, referenceGrantList.Items) {
+		return fmt.Sprintf("Secret %s/%s reference not allowed by any ReferenceGrant", *secretRef.Namespace, secretRef.Name), false, nil
+	}
+	return "", true, nil
+}
+
+func isSecretCrossReferenceGranted(
+	fromObj client.Object, secretName gatewayv1.ObjectName, referenceGrants []gatewayv1beta1.ReferenceGrant,
+) bool {
+	fromObjGroup := gatewayv1.Group(fromObj.GetObjectKind().GroupVersionKind().Group)
+	fromObjKind := gatewayv1.Kind(fromObj.GetObjectKind().GroupVersionKind().Kind)
+	fromObjNamespace := gatewayv1.Namespace(fromObj.GetNamespace())
+	for _, rg := range referenceGrants {
+		var fromFound bool
+		for _, from := range rg.Spec.From {
+			if from.Group == fromObjGroup && from.Kind == fromObjKind && from.Namespace == fromObjNamespace {
+				fromFound = true
+				break
+			}
+		}
+		if fromFound {
+			for _, to := range rg.Spec.To {
+				if to.Group != "" && to.Group != "core" {
+					continue
+				}
+				if to.Kind != "Secret" {
+					continue
+				}
+				if to.Name != nil && secretName != *to.Name {
+					continue
+				}
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/controller/pkg/secrets/ref/ref_test.go
+++ b/controller/pkg/secrets/ref/ref_test.go
@@ -1,0 +1,195 @@
+package ref
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/kong/gateway-operator/api/v1alpha1"
+	gwtypes "github.com/kong/gateway-operator/internal/types"
+)
+
+func TestIsSecretCrossReferenceGranted(t *testing.T) {
+	customizeReferenceGrant := func(rg gatewayv1beta1.ReferenceGrant, opts ...func(rg *gatewayv1beta1.ReferenceGrant)) gatewayv1beta1.ReferenceGrant {
+		rg = *rg.DeepCopy()
+		for _, opt := range opts {
+			opt(&rg)
+		}
+		return rg
+	}
+
+	const (
+		badSecretName   = gwtypes.ObjectName("wrong-secret")
+		emptySecretName = gwtypes.ObjectName("")
+		goodSecretName  = gwtypes.ObjectName("good-secret")
+	)
+	referenceGrantForObj := func(obj client.Object) gatewayv1beta1.ReferenceGrant {
+		return gatewayv1beta1.ReferenceGrant{
+			Spec: gatewayv1beta1.ReferenceGrantSpec{
+				From: []gatewayv1beta1.ReferenceGrantFrom{
+					{
+						Group:     gatewayv1.Group(obj.GetObjectKind().GroupVersionKind().Group),
+						Kind:      gatewayv1.Kind(obj.GetObjectKind().GroupVersionKind().Kind),
+						Namespace: gatewayv1.Namespace(obj.GetNamespace()),
+					},
+				},
+				To: []gatewayv1beta1.ReferenceGrantTo{
+					{
+						Group: "",
+						Kind:  "Secret",
+						Name:  lo.ToPtr(goodSecretName),
+					},
+				},
+			},
+		}
+	}
+	var (
+		objGateway = &gatewayv1.Gateway{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Gateway",
+				APIVersion: gatewayv1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "goodNamespace",
+			},
+		}
+		objKPI = &v1alpha1.KongPluginInstallation{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KongPluginInstallation",
+				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "goodNamespace",
+			},
+		}
+	)
+
+	testCases := []struct {
+		name            string
+		forObj          client.Object
+		referenceGrants []gatewayv1beta1.ReferenceGrant
+		isGranted       bool
+	}{
+		{
+			name:      "no referenceGrants",
+			forObj:    objGateway,
+			isGranted: false,
+		},
+		{
+			name:   "granted for Gateway",
+			forObj: objGateway,
+			referenceGrants: []gatewayv1beta1.ReferenceGrant{
+				referenceGrantForObj(objGateway),
+			},
+			isGranted: true,
+		},
+		{
+			name:   "granted for KPI",
+			forObj: objKPI,
+			referenceGrants: []gatewayv1beta1.ReferenceGrant{
+				referenceGrantForObj(objKPI),
+			},
+			isGranted: true,
+		},
+		{
+			name:   "not granted, wrong Kind",
+			forObj: objGateway,
+			referenceGrants: []gatewayv1beta1.ReferenceGrant{
+				referenceGrantForObj(objKPI),
+			},
+			isGranted: false,
+		},
+		{
+			name:   "not granted, bad 'from' group",
+			forObj: objGateway,
+			referenceGrants: []gatewayv1beta1.ReferenceGrant{
+				customizeReferenceGrant(referenceGrantForObj(objGateway), func(rg *gatewayv1beta1.ReferenceGrant) {
+					rg.Spec.From[0].Group = "wrong-group"
+				}),
+			},
+			isGranted: false,
+		},
+		{
+			name:   "granted, for one Kind Gateway bad 'from' group, but it expects KPI that is properly granted",
+			forObj: objKPI,
+			referenceGrants: []gatewayv1beta1.ReferenceGrant{
+				customizeReferenceGrant(referenceGrantForObj(objGateway), func(rg *gatewayv1beta1.ReferenceGrant) {
+					rg.Spec.From[0].Group = "wrong-group"
+				}),
+				referenceGrantForObj(objKPI),
+			},
+			isGranted: true,
+		},
+		{
+			name:   "not granted, bad 'to' group",
+			forObj: objKPI,
+			referenceGrants: []gatewayv1beta1.ReferenceGrant{
+				customizeReferenceGrant(referenceGrantForObj(objKPI), func(rg *gatewayv1beta1.ReferenceGrant) {
+					rg.Spec.To[0].Group = "wrong-group"
+				}),
+			},
+			isGranted: false,
+		},
+		{
+			name:   "not granted, bad 'from' kind",
+			forObj: objGateway,
+			referenceGrants: []gatewayv1beta1.ReferenceGrant{
+				customizeReferenceGrant(referenceGrantForObj(objGateway), func(rg *gatewayv1beta1.ReferenceGrant) {
+					rg.Spec.From[0].Kind = "wrong-kind"
+				}),
+			},
+			isGranted: false,
+		},
+		{
+			name:   "not granted, bad 'to' kind",
+			forObj: objKPI,
+			referenceGrants: []gatewayv1beta1.ReferenceGrant{
+				customizeReferenceGrant(referenceGrantForObj(objKPI), func(rg *gatewayv1beta1.ReferenceGrant) {
+					rg.Spec.To[0].Kind = "wrong-kind"
+				}),
+			},
+			isGranted: false,
+		},
+		{
+			name:   "not granted, bad 'from' namespace",
+			forObj: objGateway,
+			referenceGrants: []gatewayv1beta1.ReferenceGrant{
+				customizeReferenceGrant(referenceGrantForObj(objGateway), func(rg *gatewayv1beta1.ReferenceGrant) {
+					rg.Spec.From[0].Namespace = "bad-namespace"
+				}),
+			},
+			isGranted: false,
+		},
+		{
+			name:   "not granted, empty 'to' secret name",
+			forObj: objKPI,
+			referenceGrants: []gatewayv1beta1.ReferenceGrant{
+				customizeReferenceGrant(referenceGrantForObj(objKPI), func(rg *gatewayv1beta1.ReferenceGrant) {
+					rg.Spec.To[0].Name = lo.ToPtr(emptySecretName)
+				}),
+			},
+			isGranted: false,
+		},
+		{
+			name:   "not granted, bad 'to' secret name",
+			forObj: objGateway,
+			referenceGrants: []gatewayv1beta1.ReferenceGrant{
+				customizeReferenceGrant(referenceGrantForObj(objGateway), func(rg *gatewayv1beta1.ReferenceGrant) {
+					rg.Spec.To[0].Name = lo.ToPtr(badSecretName)
+				}),
+			},
+			isGranted: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.isGranted, isSecretCrossReferenceGranted(tc.forObj, goodSecretName, tc.referenceGrants))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Move code related to checking `ReferenceGrant` for `Secret` to a dedicated package and make it reusable. It will be used not only by `Gateway`, but also by `KongPluginInstallation` (see actual implementation https://github.com/Kong/gateway-operator/pull/615), so make it generic too.

**Which issue this PR fixes**

Prerequisite for https://github.com/Kong/gateway-operator/issues/610

**Special notes for your reviewer**:

Unit test is moved and adjusted to check whether it works properly for other Kind. We maintain no integration test because conformance tests cover this feature for `Gateway` and it proves that changes from this PR work as expected.

