### PR TITLE
refactor(konnect): refactor setting programmed condition

### DIFF
--- a/controller/konnect/ops/conditions.go
+++ b/controller/konnect/ops/conditions.go
@@ -1,0 +1,61 @@
+package ops
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/gateway-operator/controller/konnect/conditions"
+	"github.com/kong/gateway-operator/pkg/consts"
+	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
+)
+
+type entityType interface {
+	SetConditions([]metav1.Condition)
+	GetConditions() []metav1.Condition
+	GetGeneration() int64
+}
+
+// SetKonnectEntityProgrammedCondition sets the KonnectEntityProgrammed condition to true
+// on the provided object.
+func SetKonnectEntityProgrammedCondition(
+	obj entityType,
+) {
+	_setKonnectEntityProgrammedConditon(
+		obj,
+		metav1.ConditionTrue,
+		conditions.KonnectEntityProgrammedReasonProgrammed,
+		"",
+	)
+}
+
+// SetKonnectEntityProgrammedConditionFalse sets the KonnectEntityProgrammed condition
+// to false on the provided object.
+func SetKonnectEntityProgrammedConditionFalse(
+	obj entityType,
+	reason consts.ConditionReason,
+	msg string,
+) {
+	_setKonnectEntityProgrammedConditon(
+		obj,
+		metav1.ConditionFalse,
+		reason,
+		msg,
+	)
+}
+
+func _setKonnectEntityProgrammedConditon(
+	obj entityType,
+	status metav1.ConditionStatus,
+	reason consts.ConditionReason,
+	msg string,
+) {
+	k8sutils.SetCondition(
+		k8sutils.NewConditionWithGeneration(
+			conditions.KonnectEntityProgrammedConditionType,
+			status,
+			reason,
+			msg,
+			obj.GetGeneration(),
+		),
+		obj,
+	)
+}

--- a/controller/konnect/ops/ops_kongcacertificate.go
+++ b/controller/konnect/ops/ops_kongcacertificate.go
@@ -10,12 +10,8 @@ import (
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
-
-	"github.com/kong/gateway-operator/controller/konnect/conditions"
-	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	"github.com/kong/kubernetes-configuration/pkg/metadata"
@@ -23,7 +19,11 @@ import (
 
 // createCACertificate creates a KongCACertificate in Konnect.
 // It sets the KonnectID and the Programmed condition in the KongCACertificate status.
-func createCACertificate(ctx context.Context, sdk CACertificatesSDK, cert *configurationv1alpha1.KongCACertificate) error {
+func createCACertificate(
+	ctx context.Context,
+	sdk CACertificatesSDK,
+	cert *configurationv1alpha1.KongCACertificate,
+) error {
 	cpID := cert.GetControlPlaneID()
 	if cpID == "" {
 		return fmt.Errorf("can't create %T %s without a Konnect ControlPlane ID", cert, client.ObjectKeyFromObject(cert))
@@ -37,31 +37,13 @@ func createCACertificate(ctx context.Context, sdk CACertificatesSDK, cert *confi
 	// TODO: handle already exists
 	// Can't adopt it as it will cause conflicts between the controller
 	// that created that entity and already manages it, hm
-	if errWrapped := wrapErrIfKonnectOpFailed(err, CreateOp, cert); errWrapped != nil {
-		k8sutils.SetCondition(
-			k8sutils.NewConditionWithGeneration(
-				conditions.KonnectEntityProgrammedConditionType,
-				metav1.ConditionFalse,
-				"FailedToCreate",
-				errWrapped.Error(),
-				cert.GetGeneration(),
-			),
-			cert,
-		)
-		return errWrapped
+	if errWrap := wrapErrIfKonnectOpFailed(err, CreateOp, cert); errWrap != nil {
+		SetKonnectEntityProgrammedConditionFalse(cert, "FailedToCreate", errWrap.Error())
+		return errWrap
 	}
 
 	cert.Status.Konnect.SetKonnectID(*resp.CACertificate.ID)
-	k8sutils.SetCondition(
-		k8sutils.NewConditionWithGeneration(
-			conditions.KonnectEntityProgrammedConditionType,
-			metav1.ConditionTrue,
-			conditions.KonnectEntityProgrammedReasonProgrammed,
-			"",
-			cert.GetGeneration(),
-		),
-		cert,
-	)
+	SetKonnectEntityProgrammedCondition(cert)
 
 	return nil
 }
@@ -69,7 +51,11 @@ func createCACertificate(ctx context.Context, sdk CACertificatesSDK, cert *confi
 // updateCACertificate updates a KongCACertificate in Konnect.
 // The KongCACertificate must have a KonnectID set in its status.
 // It returns an error if the KongCACertificate does not have a KonnectID.
-func updateCACertificate(ctx context.Context, sdk CACertificatesSDK, cert *configurationv1alpha1.KongCACertificate) error {
+func updateCACertificate(
+	ctx context.Context,
+	sdk CACertificatesSDK,
+	cert *configurationv1alpha1.KongCACertificate,
+) error {
 	cpID := cert.GetControlPlaneID()
 	if cpID == "" {
 		return fmt.Errorf("can't update %T without a ControlPlaneID", cert)
@@ -86,30 +72,12 @@ func updateCACertificate(ctx context.Context, sdk CACertificatesSDK, cert *confi
 	// TODO: handle already exists
 	// Can't adopt it as it will cause conflicts between the controller
 	// that created that entity and already manages it, hm
-	if errWrapped := wrapErrIfKonnectOpFailed(err, UpdateOp, cert); errWrapped != nil {
-		k8sutils.SetCondition(
-			k8sutils.NewConditionWithGeneration(
-				conditions.KonnectEntityProgrammedConditionType,
-				metav1.ConditionFalse,
-				"FailedToUpdate",
-				errWrapped.Error(),
-				cert.GetGeneration(),
-			),
-			cert,
-		)
-		return errWrapped
+	if errWrap := wrapErrIfKonnectOpFailed(err, UpdateOp, cert); errWrap != nil {
+		SetKonnectEntityProgrammedConditionFalse(cert, "FailedToUpdate", errWrap.Error())
+		return errWrap
 	}
 
-	k8sutils.SetCondition(
-		k8sutils.NewConditionWithGeneration(
-			conditions.KonnectEntityProgrammedConditionType,
-			metav1.ConditionTrue,
-			conditions.KonnectEntityProgrammedReasonProgrammed,
-			"",
-			cert.GetGeneration(),
-		),
-		cert,
-	)
+	SetKonnectEntityProgrammedCondition(cert)
 
 	return nil
 }
@@ -117,12 +85,16 @@ func updateCACertificate(ctx context.Context, sdk CACertificatesSDK, cert *confi
 // deleteCACertificate deletes a KongCACertificate in Konnect.
 // The KongCACertificate must have a KonnectID set in its status.
 // It returns an error if the operation fails.
-func deleteCACertificate(ctx context.Context, sdk CACertificatesSDK, cert *configurationv1alpha1.KongCACertificate) error {
+func deleteCACertificate(
+	ctx context.Context,
+	sdk CACertificatesSDK,
+	cert *configurationv1alpha1.KongCACertificate,
+) error {
 	id := cert.Status.Konnect.GetKonnectID()
 	_, err := sdk.DeleteCaCertificate(ctx, cert.GetControlPlaneID(), id)
-	if errWrapped := wrapErrIfKonnectOpFailed(err, DeleteOp, cert); errWrapped != nil {
+	if errWrap := wrapErrIfKonnectOpFailed(err, DeleteOp, cert); errWrap != nil {
 		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrapped, &sdkError) {
+		if errors.As(errWrap, &sdkError) {
 			if sdkError.StatusCode == 404 {
 				ctrllog.FromContext(ctx).
 					Info("entity not found in Konnect, skipping delete",
@@ -137,7 +109,7 @@ func deleteCACertificate(ctx context.Context, sdk CACertificatesSDK, cert *confi
 		}
 		return FailedKonnectOpError[configurationv1alpha1.KongCACertificate]{
 			Op:  DeleteOp,
-			Err: errWrapped,
+			Err: errWrap,
 		}
 	}
 

--- a/controller/konnect/ops/ops_kongconsumergroup.go
+++ b/controller/konnect/ops/ops_kongconsumergroup.go
@@ -8,12 +8,8 @@ import (
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
-
-	"github.com/kong/gateway-operator/controller/konnect/conditions"
-	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
 	configurationv1beta1 "github.com/kong/kubernetes-configuration/api/configuration/v1beta1"
 	"github.com/kong/kubernetes-configuration/pkg/metadata"
@@ -36,31 +32,13 @@ func createConsumerGroup(
 	// TODO: handle already exists
 	// Can't adopt it as it will cause conflicts between the controller
 	// that created that entity and already manages it, hm
-	if errWrapped := wrapErrIfKonnectOpFailed(err, CreateOp, group); errWrapped != nil {
-		k8sutils.SetCondition(
-			k8sutils.NewConditionWithGeneration(
-				conditions.KonnectEntityProgrammedConditionType,
-				metav1.ConditionFalse,
-				"FailedToCreate",
-				errWrapped.Error(),
-				group.GetGeneration(),
-			),
-			group,
-		)
-		return errWrapped
+	if errWrap := wrapErrIfKonnectOpFailed(err, CreateOp, group); errWrap != nil {
+		SetKonnectEntityProgrammedConditionFalse(group, "FailedToCreate", errWrap.Error())
+		return errWrap
 	}
 
 	group.Status.Konnect.SetKonnectID(*resp.ConsumerGroup.ID)
-	k8sutils.SetCondition(
-		k8sutils.NewConditionWithGeneration(
-			conditions.KonnectEntityProgrammedConditionType,
-			metav1.ConditionTrue,
-			conditions.KonnectEntityProgrammedReasonProgrammed,
-			"",
-			group.GetGeneration(),
-		),
-		group,
-	)
+	SetKonnectEntityProgrammedCondition(group)
 
 	return nil
 }
@@ -89,30 +67,12 @@ func updateConsumerGroup(
 	// TODO: handle already exists
 	// Can't adopt it as it will cause conflicts between the controller
 	// that created that entity and already manages it, hm
-	if errWrapped := wrapErrIfKonnectOpFailed(err, UpdateOp, group); errWrapped != nil {
-		k8sutils.SetCondition(
-			k8sutils.NewConditionWithGeneration(
-				conditions.KonnectEntityProgrammedConditionType,
-				metav1.ConditionFalse,
-				"FailedToCreate",
-				errWrapped.Error(),
-				group.GetGeneration(),
-			),
-			group,
-		)
-		return errWrapped
+	if errWrap := wrapErrIfKonnectOpFailed(err, UpdateOp, group); errWrap != nil {
+		SetKonnectEntityProgrammedConditionFalse(group, "FailedToUpdate", errWrap.Error())
+		return errWrap
 	}
 
-	k8sutils.SetCondition(
-		k8sutils.NewConditionWithGeneration(
-			conditions.KonnectEntityProgrammedConditionType,
-			metav1.ConditionTrue,
-			conditions.KonnectEntityProgrammedReasonProgrammed,
-			"",
-			group.GetGeneration(),
-		),
-		group,
-	)
+	SetKonnectEntityProgrammedCondition(group)
 
 	return nil
 }
@@ -127,10 +87,10 @@ func deleteConsumerGroup(
 ) error {
 	id := consumer.Status.Konnect.GetKonnectID()
 	_, err := sdk.DeleteConsumerGroup(ctx, consumer.Status.Konnect.ControlPlaneID, id)
-	if errWrapped := wrapErrIfKonnectOpFailed(err, DeleteOp, consumer); errWrapped != nil {
+	if errWrap := wrapErrIfKonnectOpFailed(err, DeleteOp, consumer); errWrap != nil {
 		// Consumer delete operation returns an SDKError instead of a NotFoundError.
 		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrapped, &sdkError) {
+		if errors.As(errWrap, &sdkError) {
 			if sdkError.StatusCode == 404 {
 				ctrllog.FromContext(ctx).
 					Info("entity not found in Konnect, skipping delete",
@@ -145,7 +105,7 @@ func deleteConsumerGroup(
 		}
 		return FailedKonnectOpError[configurationv1beta1.KongConsumerGroup]{
 			Op:  DeleteOp,
-			Err: errWrapped,
+			Err: errWrap,
 		}
 	}
 

--- a/controller/konnect/ops/ops_kongservice.go
+++ b/controller/konnect/ops/ops_kongservice.go
@@ -10,12 +10,8 @@ import (
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
-
-	"github.com/kong/gateway-operator/controller/konnect/conditions"
-	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	"github.com/kong/kubernetes-configuration/pkg/metadata"
@@ -41,31 +37,13 @@ func createService(
 	// TODO: handle already exists
 	// Can't adopt it as it will cause conflicts between the controller
 	// that created that entity and already manages it, hm
-	if errWrapped := wrapErrIfKonnectOpFailed(err, CreateOp, svc); errWrapped != nil {
-		k8sutils.SetCondition(
-			k8sutils.NewConditionWithGeneration(
-				conditions.KonnectEntityProgrammedConditionType,
-				metav1.ConditionFalse,
-				"FailedToCreate",
-				errWrapped.Error(),
-				svc.GetGeneration(),
-			),
-			svc,
-		)
-		return errWrapped
+	if errWrap := wrapErrIfKonnectOpFailed(err, CreateOp, svc); errWrap != nil {
+		SetKonnectEntityProgrammedConditionFalse(svc, "FailedToCreate", errWrap.Error())
+		return errWrap
 	}
 
 	svc.Status.Konnect.SetKonnectID(*resp.Service.ID)
-	k8sutils.SetCondition(
-		k8sutils.NewConditionWithGeneration(
-			conditions.KonnectEntityProgrammedConditionType,
-			metav1.ConditionTrue,
-			conditions.KonnectEntityProgrammedReasonProgrammed,
-			"",
-			svc.GetGeneration(),
-		),
-		svc,
-	)
+	SetKonnectEntityProgrammedCondition(svc)
 
 	return nil
 }
@@ -97,10 +75,10 @@ func updateService(
 	// TODO: handle already exists
 	// Can't adopt it as it will cause conflicts between the controller
 	// that created that entity and already manages it, hm
-	if errWrapped := wrapErrIfKonnectOpFailed(err, UpdateOp, svc); errWrapped != nil {
+	if errWrap := wrapErrIfKonnectOpFailed(err, UpdateOp, svc); errWrap != nil {
 		// Service update operation returns an SDKError instead of a NotFoundError.
 		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrapped, &sdkError) {
+		if errors.As(errWrap, &sdkError) {
 			switch sdkError.StatusCode {
 			case 404:
 				if err := createService(ctx, sdk, svc); err != nil {
@@ -120,29 +98,11 @@ func updateService(
 			}
 		}
 
-		k8sutils.SetCondition(
-			k8sutils.NewConditionWithGeneration(
-				conditions.KonnectEntityProgrammedConditionType,
-				metav1.ConditionFalse,
-				"FailedToUpdate",
-				errWrapped.Error(),
-				svc.GetGeneration(),
-			),
-			svc,
-		)
-		return errWrapped
+		SetKonnectEntityProgrammedConditionFalse(svc, "FailedToUpdate", errWrap.Error())
+		return errWrap
 	}
 
-	k8sutils.SetCondition(
-		k8sutils.NewConditionWithGeneration(
-			conditions.KonnectEntityProgrammedConditionType,
-			metav1.ConditionTrue,
-			conditions.KonnectEntityProgrammedReasonProgrammed,
-			"",
-			svc.GetGeneration(),
-		),
-		svc,
-	)
+	SetKonnectEntityProgrammedCondition(svc)
 
 	return nil
 }
@@ -157,10 +117,10 @@ func deleteService(
 ) error {
 	id := svc.GetKonnectStatus().GetKonnectID()
 	_, err := sdk.DeleteService(ctx, svc.Status.Konnect.ControlPlaneID, id)
-	if errWrapped := wrapErrIfKonnectOpFailed(err, DeleteOp, svc); errWrapped != nil {
+	if errWrap := wrapErrIfKonnectOpFailed(err, DeleteOp, svc); errWrap != nil {
 		// Service delete operation returns an SDKError instead of a NotFoundError.
 		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrapped, &sdkError) {
+		if errors.As(errWrap, &sdkError) {
 			switch sdkError.StatusCode {
 			case 404:
 				ctrllog.FromContext(ctx).
@@ -177,7 +137,7 @@ func deleteService(
 		}
 		return FailedKonnectOpError[configurationv1alpha1.KongService]{
 			Op:  DeleteOp,
-			Err: errWrapped,
+			Err: errWrap,
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Reduce code duplication by adding `SetKonnectEntityProgrammedConditionFalse` and `SetKonnectEntityProgrammedCondition` which are used to set entity's programmed condition.
