### PR TITLE
feat(konnect): make KongPlugin reconciler create KongPluginBindings for plugins attached to KongRoutes and KongServices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,10 +72,12 @@
 - Add `KongService`, `KongRoute`, `KongConsumer`, and `KongConsumerGroup` watchers
   in the `KongPluginBinding` reconciler.
   [#571](https://github.com/Kong/gateway-operator/pull/571)
-- Annotating `KongService`s with the `konghq.com/plugins` annotation results in
-  the creation of a managed `KongPluginBinding` resource, which is taken by the
-  `KongPluginBinding` reconciler to create the corresponding plugin object in Konnect.
-  [#550](https://github.com/Kong/gateway-operator/pull/550)
+- Annotating the following resource with the `konghq.com/plugins` annotation results in
+  the creation of a managed `KongPluginBinding` resource:
+  - `KongService` [#550](https://github.com/Kong/gateway-operator/pull/550)
+  - `KongRoute` [#644](https://github.com/Kong/gateway-operator/pull/644)
+  These `KongPluginBinding`s are taken by the `KongPluginBinding` reconciler
+  to create the corresponding plugin objects in Konnect.
 - `KongConsumer` associated with `ConsumerGroups` is now reconciled in Konnect by removing/adding
   the consumer from/to the consumer groups.
   [#592](https://github.com/Kong/gateway-operator/pull/592)

--- a/config/samples/konnect-kongpluginbinding-kongservice-kongroute.yaml
+++ b/config/samples/konnect-kongpluginbinding-kongservice-kongroute.yaml
@@ -1,0 +1,86 @@
+---
+kind: KonnectAPIAuthConfiguration
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: demo-auth
+  namespace: default
+spec:
+  type: token
+  token: kpat_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+  serverURL: eu.api.konghq.tech 
+---
+kind: KonnectGatewayControlPlane
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: demo-cp
+  namespace: default
+spec:
+  name: demo-cp
+  labels:
+    app: demo-cp
+    key1: demo-cp
+  konnect:
+    authRef:
+      name: demo-auth
+      # namespace not required if APIAuthConfiguration is in the same namespace
+---
+kind: KongService
+apiVersion: configuration.konghq.com/v1alpha1
+metadata:
+  name: service-1
+  namespace: default
+spec:
+  name: service-1
+  host: example.com
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: demo-cp
+---
+kind: KongRoute
+apiVersion: configuration.konghq.com/v1alpha1
+metadata:
+  name: route-1
+  namespace: default
+  annotations:
+    konghq.com/plugins: rate-limit-5-min
+spec:
+  name: route-1
+  protocols:
+  - http
+  hosts:
+  - example.com
+  serviceRef:
+    type: namespacedRef
+    namespacedRef:
+      name: service-1
+---
+apiVersion: configuration.konghq.com/v1
+kind: KongPlugin
+metadata:
+ name: rate-limit-5-min
+config:
+ minute: 5
+ policy: local
+plugin: rate-limiting
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: KongPluginBinding
+metadata:
+  name: plugin-binding-kongservice-kongroute
+spec:
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: demo-cp
+  pluginRef:
+    name: rate-limit-5-min
+  targets:
+    serviceRef:
+      name: service-1
+      kind: KongService
+      group: configuration.konghq.com
+    routeRef:
+      name: route-1
+      kind: KongRoute
+      group: configuration.konghq.com

--- a/config/samples/konnect-kongservice-and-kongroute-plugin-annotated.yaml
+++ b/config/samples/konnect-kongservice-and-kongroute-plugin-annotated.yaml
@@ -1,0 +1,69 @@
+kind: KonnectAPIAuthConfiguration
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: demo-auth
+  namespace: default
+spec:
+  type: token
+  token: kpat_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+  serverURL: eu.api.konghq.tech 
+---
+kind: KonnectGatewayControlPlane
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: demo-cp
+  namespace: default
+spec:
+  name: demo-cp
+  labels:
+    app: demo-cp
+    key1: demo-cp
+  konnect:
+    authRef:
+      name: demo-auth
+      # namespace not required if APIAuthConfiguration is in the same namespace
+---
+# This KongPlugin is bound to both the KongService and KongRoute
+# hence it will create 1 KongPluginBinding with both of those set as targets.
+apiVersion: configuration.konghq.com/v1
+kind: KongPlugin
+metadata:
+  name: rate-limit-5-min
+  namespace: default
+config:
+  minute: 5
+  policy: local
+plugin: rate-limiting
+---
+kind: KongService
+apiVersion: configuration.konghq.com/v1alpha1
+metadata:
+  name: service-1
+  namespace: default
+  annotations:
+    konghq.com/plugins: rate-limit-5-min
+spec:
+  name: service-1
+  host: example.com
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: demo-cp
+---
+kind: KongRoute
+apiVersion: configuration.konghq.com/v1alpha1
+metadata:
+  name: route-1
+  namespace: default
+  annotations:
+    konghq.com/plugins: rate-limit-5-min
+spec:
+  name: route-1
+  protocols:
+  - http
+  hosts:
+  - example.com
+  serviceRef:
+    type: namespacedRef
+    namespacedRef:
+      name: service-1

--- a/controller/konnect/index.go
+++ b/controller/konnect/index.go
@@ -25,6 +25,10 @@ func ReconciliationIndexOptionsForEntity[
 	switch any(e).(type) {
 	case *configurationv1alpha1.KongPluginBinding:
 		return IndexOptionsForKongPluginBinding()
+	case *configurationv1alpha1.KongService:
+		return IndexOptionsForKongService()
+	case *configurationv1alpha1.KongRoute:
+		return IndexOptionsForKongRoute()
 	case *configurationv1alpha1.KongCredentialBasicAuth:
 		return IndexOptionsForCredentialsBasicAuth()
 	case *configurationv1.KongConsumer:

--- a/controller/konnect/index_kongroute.go
+++ b/controller/konnect/index_kongroute.go
@@ -14,8 +14,6 @@ import (
 const (
 	// IndexFieldKongRouteOnReferencedPluginNames is the index field for KongRoute -> KongPlugin.
 	IndexFieldKongRouteOnReferencedPluginNames = "kongRouteKongPluginRef"
-	// IndexFieldKongRouteOnServiceReference is the index field for KongRoute -> Service.
-	IndexFieldKongRouteOnServiceReference = "kongRouteServiceRef"
 )
 
 // IndexOptionsForKongRoute returns required Index options for KongRoute reconciler.

--- a/controller/konnect/index_kongroute.go
+++ b/controller/konnect/index_kongroute.go
@@ -1,0 +1,46 @@
+package konnect
+
+import (
+	"strings"
+
+	"github.com/samber/lo"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/gateway-operator/pkg/consts"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+)
+
+const (
+	// IndexFieldKongRouteOnReferencedPluginNames is the index field for KongRoute -> KongPlugin.
+	IndexFieldKongRouteOnReferencedPluginNames = "kongRouteKongPluginRef"
+	// IndexFieldKongRouteOnServiceReference is the index field for KongRoute -> Service.
+	IndexFieldKongRouteOnServiceReference = "kongRouteServiceRef"
+)
+
+// IndexOptionsForKongRoute returns required Index options for KongRoute reconciler.
+func IndexOptionsForKongRoute() []ReconciliationIndexOption {
+	return []ReconciliationIndexOption{
+		{
+			IndexObject:  &configurationv1alpha1.KongRoute{},
+			IndexField:   IndexFieldKongRouteOnReferencedPluginNames,
+			ExtractValue: kongRouteUsesPlugins,
+		},
+	}
+}
+
+func kongRouteUsesPlugins(object client.Object) []string {
+	route, ok := object.(*configurationv1alpha1.KongRoute)
+	if !ok {
+		return nil
+	}
+	ann, ok := route.Annotations[consts.PluginsAnnotationKey]
+	if !ok {
+		return nil
+	}
+
+	namespace := route.GetNamespace()
+	return lo.Map(strings.Split(ann, ","), func(p string, _ int) string {
+		return namespace + "/" + p
+	})
+}

--- a/controller/konnect/index_kongroute.go
+++ b/controller/konnect/index_kongroute.go
@@ -1,12 +1,9 @@
 package konnect
 
 import (
-	"strings"
-
-	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kong/gateway-operator/pkg/consts"
+	"github.com/kong/gateway-operator/pkg/annotations"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
@@ -32,13 +29,5 @@ func kongRouteUsesPlugins(object client.Object) []string {
 	if !ok {
 		return nil
 	}
-	ann, ok := route.Annotations[consts.PluginsAnnotationKey]
-	if !ok {
-		return nil
-	}
-
-	namespace := route.GetNamespace()
-	return lo.Map(strings.Split(ann, ","), func(p string, _ int) string {
-		return namespace + "/" + p
-	})
+	return annotations.ExtractPlugins(route)
 }

--- a/controller/konnect/index_kongservice.go
+++ b/controller/konnect/index_kongservice.go
@@ -1,14 +1,11 @@
 package konnect
 
 import (
-	"strings"
-
-	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kong/gateway-operator/pkg/consts"
-
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+
+	"github.com/kong/gateway-operator/pkg/annotations"
 )
 
 const (
@@ -32,13 +29,6 @@ func kongServiceUsesPlugins(object client.Object) []string {
 	if !ok {
 		return nil
 	}
-	ann, ok := svc.Annotations[consts.PluginsAnnotationKey]
-	if !ok {
-		return nil
-	}
 
-	namespace := svc.GetNamespace()
-	return lo.Map(strings.Split(ann, ","), func(p string, _ int) string {
-		return namespace + "/" + p
-	})
+	return annotations.ExtractPlugins(svc)
 }

--- a/controller/konnect/index_kongservice.go
+++ b/controller/konnect/index_kongservice.go
@@ -3,9 +3,9 @@ package konnect
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
-
 	"github.com/kong/gateway-operator/pkg/annotations"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
 
 const (

--- a/controller/konnect/index_kongservice.go
+++ b/controller/konnect/index_kongservice.go
@@ -1,0 +1,44 @@
+package konnect
+
+import (
+	"strings"
+
+	"github.com/samber/lo"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/gateway-operator/pkg/consts"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+)
+
+const (
+	// IndexFieldKongServiceOnReferencedPluginNames is the index field for KongService -> KongPlugin.
+	IndexFieldKongServiceOnReferencedPluginNames = "kongServiceKongPluginRef"
+)
+
+// IndexOptionsForKongService returns required Index options for KongService reconciler.
+func IndexOptionsForKongService() []ReconciliationIndexOption {
+	return []ReconciliationIndexOption{
+		{
+			IndexObject:  &configurationv1alpha1.KongService{},
+			IndexField:   IndexFieldKongServiceOnReferencedPluginNames,
+			ExtractValue: kongServiceUsesPlugins,
+		},
+	}
+}
+
+func kongServiceUsesPlugins(object client.Object) []string {
+	svc, ok := object.(*configurationv1alpha1.KongService)
+	if !ok {
+		return nil
+	}
+	ann, ok := svc.Annotations[consts.PluginsAnnotationKey]
+	if !ok {
+		return nil
+	}
+
+	namespace := svc.GetNamespace()
+	return lo.Map(strings.Split(ann, ","), func(p string, _ int) string {
+		return namespace + "/" + p
+	})
+}

--- a/controller/konnect/kongpluginbuilder.go
+++ b/controller/konnect/kongpluginbuilder.go
@@ -1,7 +1,12 @@
 package konnect
 
 import (
+	"fmt"
+
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // KongPluginBindingBuilder helps to build KongPluginBinding objects.
@@ -66,6 +71,17 @@ func (b *KongPluginBindingBuilder) WithRouteTarget(routeName string) *KongPlugin
 		Name:  routeName,
 	}
 	return b
+}
+
+func (b *KongPluginBindingBuilder) WithOwnerReference(owner client.Object, scheme *runtime.Scheme) (*KongPluginBindingBuilder, error) {
+	opts := []controllerutil.OwnerReferenceOption{
+		controllerutil.WithBlockOwnerDeletion(true),
+	}
+	if err := controllerutil.SetOwnerReference(owner, b.binding, scheme, opts...); err != nil {
+		return nil, fmt.Errorf("failed to set owner reference: %w", err)
+	}
+
+	return b, nil
 }
 
 // Build returns the KongPluginBinding.

--- a/controller/konnect/kongpluginbuilder.go
+++ b/controller/konnect/kongpluginbuilder.go
@@ -1,0 +1,75 @@
+package konnect
+
+import (
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+)
+
+// KongPluginBindingBuilder helps to build KongPluginBinding objects.
+type KongPluginBindingBuilder struct {
+	binding *configurationv1alpha1.KongPluginBinding
+}
+
+// NewKongPluginBindingBuilder creates a new KongPluginBindingBuilder.
+func NewKongPluginBindingBuilder() *KongPluginBindingBuilder {
+	return &KongPluginBindingBuilder{
+		binding: &configurationv1alpha1.KongPluginBinding{},
+	}
+}
+
+// WithName sets the name of the KongPluginBinding.
+func (b *KongPluginBindingBuilder) WithName(name string) *KongPluginBindingBuilder {
+	b.binding.Name = name
+	return b
+}
+
+// WithGenerateName sets the generate name of the KongPluginBinding.
+func (b *KongPluginBindingBuilder) WithGenerateName(name string) *KongPluginBindingBuilder {
+	b.binding.GenerateName = name
+	return b
+}
+
+// WithNamespace sets the namespace of the KongPluginBinding.
+func (b *KongPluginBindingBuilder) WithNamespace(namespace string) *KongPluginBindingBuilder {
+	b.binding.Namespace = namespace
+	return b
+}
+
+// WithPluginRef sets the plugin reference of the KongPluginBinding.
+func (b *KongPluginBindingBuilder) WithPluginRef(pluginName string) *KongPluginBindingBuilder {
+	b.binding.Spec.PluginReference.Name = pluginName
+	return b
+}
+
+// WithControlPlaneRef sets the control plane reference of the KongPluginBinding.
+func (b *KongPluginBindingBuilder) WithControlPlaneRef(ref *configurationv1alpha1.ControlPlaneRef) *KongPluginBindingBuilder {
+	// TODO: Cross check this with other types of ControlPlaneRefs
+	// used by Route, Consumer and/or ConsumerGroups that also bind this plugin
+	// in this KongPluginBinding spec.
+	b.binding.Spec.ControlPlaneRef = ref
+	return b
+}
+
+// WithServiceTarget sets the service target of the KongPluginBinding.
+func (b *KongPluginBindingBuilder) WithServiceTarget(serviceName string) *KongPluginBindingBuilder {
+	b.binding.Spec.Targets.ServiceReference = &configurationv1alpha1.TargetRefWithGroupKind{
+		Group: configurationv1alpha1.GroupVersion.Group,
+		Kind:  "KongService",
+		Name:  serviceName,
+	}
+	return b
+}
+
+// WithRouteTarget sets the route target of the KongPluginBinding.
+func (b *KongPluginBindingBuilder) WithRouteTarget(routeName string) *KongPluginBindingBuilder {
+	b.binding.Spec.Targets.RouteReference = &configurationv1alpha1.TargetRefWithGroupKind{
+		Group: configurationv1alpha1.GroupVersion.Group,
+		Kind:  "KongRoute",
+		Name:  routeName,
+	}
+	return b
+}
+
+// Build returns the KongPluginBinding.
+func (b *KongPluginBindingBuilder) Build() *configurationv1alpha1.KongPluginBinding {
+	return b.binding
+}

--- a/controller/konnect/kongpluginbuilder.go
+++ b/controller/konnect/kongpluginbuilder.go
@@ -3,10 +3,11 @@ package konnect
 import (
 	"fmt"
 
-	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
 
 // KongPluginBindingBuilder helps to build KongPluginBinding objects.
@@ -73,6 +74,7 @@ func (b *KongPluginBindingBuilder) WithRouteTarget(routeName string) *KongPlugin
 	return b
 }
 
+// WithOwnerReference sets the owner reference of the KongPluginBinding.
 func (b *KongPluginBindingBuilder) WithOwnerReference(owner client.Object, scheme *runtime.Scheme) (*KongPluginBindingBuilder, error) {
 	opts := []controllerutil.OwnerReferenceOption{
 		controllerutil.WithBlockOwnerDeletion(true),

--- a/controller/konnect/kongpluginbuilder.go
+++ b/controller/konnect/kongpluginbuilder.go
@@ -41,10 +41,9 @@ func (b *KongPluginBindingBuilder) WithPluginRef(pluginName string) *KongPluginB
 }
 
 // WithControlPlaneRef sets the control plane reference of the KongPluginBinding.
+// NOTE: Users have to ensure that the ControlPlaneRef that's set here
+// is the same across all the KongPluginBinding targets.
 func (b *KongPluginBindingBuilder) WithControlPlaneRef(ref *configurationv1alpha1.ControlPlaneRef) *KongPluginBindingBuilder {
-	// TODO: Cross check this with other types of ControlPlaneRefs
-	// used by Route, Consumer and/or ConsumerGroups that also bind this plugin
-	// in this KongPluginBinding spec.
 	b.binding.Spec.ControlPlaneRef = ref
 	return b
 }

--- a/controller/konnect/ops/ops_kongpluginbinding.go
+++ b/controller/konnect/ops/ops_kongpluginbinding.go
@@ -196,7 +196,8 @@ func getPluginBindingTargets(
 		targetObjects = append(targetObjects, &kongRoute)
 	}
 
-	// TODO(mlavacca): add support for KongConsumer
+	// TODO: https://github.com/Kong/gateway-operator/issues/526 add support for KongConsumer
+	// TODO: https://github.com/Kong/gateway-operator/issues/527 add support for KongConsumerGroup
 
 	return targetObjects, nil
 }
@@ -251,7 +252,7 @@ func kongPluginWithTargetsToKongPluginInput(
 				return nil, fmt.Errorf("KongService %s is not configured in Konnect yet", client.ObjectKeyFromObject(t))
 			}
 			pluginInput.Service = &sdkkonnectcomp.PluginService{
-				ID: lo.ToPtr(t.GetKonnectStatus().ID),
+				ID: lo.ToPtr(id),
 			}
 		case *configurationv1alpha1.KongRoute:
 			id := t.GetKonnectID()
@@ -259,9 +260,10 @@ func kongPluginWithTargetsToKongPluginInput(
 				return nil, fmt.Errorf("KongRoute %s is not configured in Konnect yet", client.ObjectKeyFromObject(t))
 			}
 			pluginInput.Route = &sdkkonnectcomp.PluginRoute{
-				ID: lo.ToPtr(t.GetKonnectStatus().ID),
+				ID: lo.ToPtr(id),
 			}
-		// TODO(mlavacca): add support for KongConsumer
+		// TODO: https://github.com/Kong/gateway-operator/issues/526 add support for KongConsumer
+		// TODO: https://github.com/Kong/gateway-operator/issues/527 add support for KongConsumerGroup
 		default:
 			return nil, fmt.Errorf("unsupported target type %T", t)
 		}

--- a/controller/konnect/plugins.go
+++ b/controller/konnect/plugins.go
@@ -1,0 +1,27 @@
+package konnect
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/kong/gateway-operator/pkg/consts"
+)
+
+var kongPluginsAnnotationChangedPredicate = predicate.Funcs{
+	CreateFunc: func(e event.TypedCreateEvent[client.Object]) bool {
+		_, ok := e.Object.GetAnnotations()[consts.PluginsAnnotationKey]
+		return ok
+	},
+	UpdateFunc: func(e event.TypedUpdateEvent[client.Object]) bool {
+		if e.ObjectOld == nil || e.ObjectNew == nil {
+			return false
+		}
+		return e.ObjectNew.GetAnnotations()[consts.PluginsAnnotationKey] !=
+			e.ObjectOld.GetAnnotations()[consts.PluginsAnnotationKey]
+	},
+	DeleteFunc: func(e event.TypedDeleteEvent[client.Object]) bool {
+		_, ok := e.Object.GetAnnotations()[consts.PluginsAnnotationKey]
+		return ok
+	},
+}

--- a/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
+++ b/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
@@ -10,7 +10,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -198,24 +197,6 @@ func (r *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]) getKongPluginBi
 func (r *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]) setControllerBuilderOptionsForKongPluginBinding(
 	b *builder.TypedBuilder[ctrl.Request],
 ) {
-	kongPluginsAnnotationChangedPredicate := predicate.Funcs{
-		CreateFunc: func(e event.TypedCreateEvent[client.Object]) bool {
-			_, ok := e.Object.GetAnnotations()[consts.PluginsAnnotationKey]
-			return ok
-		},
-		UpdateFunc: func(e event.TypedUpdateEvent[client.Object]) bool {
-			if e.ObjectOld == nil || e.ObjectNew == nil {
-				return false
-			}
-			return e.ObjectNew.GetAnnotations()[consts.PluginsAnnotationKey] !=
-				e.ObjectOld.GetAnnotations()[consts.PluginsAnnotationKey]
-		},
-		DeleteFunc: func(e event.TypedDeleteEvent[client.Object]) bool {
-			_, ok := e.Object.GetAnnotations()[consts.PluginsAnnotationKey]
-			return ok
-		},
-	}
-
 	var (
 		e   T
 		ent = TEnt(&e)

--- a/controller/konnect/reconciler_kongplugin.go
+++ b/controller/konnect/reconciler_kongplugin.go
@@ -181,10 +181,12 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 			// TODO consumers and consumer groups
 
-			kongPluginBinding := builder.Build()
-			if err := controllerutil.SetOwnerReference(&kongPlugin, kongPluginBinding, clientWithNamespace.Scheme(), controllerutil.WithBlockOwnerDeletion(true)); err != nil {
+			builder, err = builder.WithOwnerReference(&kongPlugin, clientWithNamespace.Scheme())
+			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to set owner reference: %w", err)
 			}
+
+			kongPluginBinding := builder.Build()
 
 			switch len(kpbList) {
 			case 0:

--- a/controller/konnect/reconciler_kongplugin.go
+++ b/controller/konnect/reconciler_kongplugin.go
@@ -141,7 +141,7 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// Delete the KongPluginBindings that are not used anymore.
 	if err := deleteUnusedKongPluginBindings(ctx, logger, clientWithNamespace, &kongPlugin, groupedCombinations, kongPluginBindingList.Items); err != nil {
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed deleting unused KongPluginBindings for %s KongPlugin: %w", client.ObjectKeyFromObject(kongPlugin), err)
 	}
 
 	// pluginReferenceFound represents whether the plugin is referenced by any resource.

--- a/controller/konnect/reconciler_kongplugin.go
+++ b/controller/konnect/reconciler_kongplugin.go
@@ -110,7 +110,7 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		},
 	)
 	if err != nil {
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed listing KongServices referencing %s KongPlugin: %w", client.ObjectKeyFromObject(kongPlugin), err)
 	}
 
 	kongRouteList := configurationv1alpha1.KongRouteList{}
@@ -120,7 +120,7 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		},
 	)
 	if err != nil {
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed listing KongRoutes referencing %s KongPlugin: %w", client.ObjectKeyFromObject(kongPlugin), err)
 	}
 
 	foreignRelations := ForeignRelations{

--- a/controller/konnect/reconciler_kongplugin.go
+++ b/controller/konnect/reconciler_kongplugin.go
@@ -137,8 +137,6 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
-	// pluginReferenceFound represents whether the plugin is referenced by any resource.
-	var pluginReferenceFound bool
 	groupedCombinations := grouped.GetCombinations()
 
 	// Delete the KongPluginBindings that are not used anymore.
@@ -146,6 +144,8 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	// pluginReferenceFound represents whether the plugin is referenced by any resource.
+	var pluginReferenceFound bool
 	for cpNN, relations := range groupedCombinations {
 		for _, rel := range relations {
 			pluginReferenceFound = true

--- a/controller/konnect/reconciler_kongplugin.go
+++ b/controller/konnect/reconciler_kongplugin.go
@@ -2,19 +2,24 @@ package konnect
 
 import (
 	"context"
+	"fmt"
+	"reflect"
+	"slices"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"github.com/samber/lo"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/pkg/consts"
-	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
 	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
@@ -49,6 +54,16 @@ func (r *KongPluginReconciler) SetupWithManager(_ context.Context, mgr ctrl.Mana
 		Watches(
 			&configurationv1alpha1.KongService{},
 			handler.EnqueueRequestsFromMapFunc(r.mapKongServices),
+			builder.WithPredicates(
+				kongPluginsAnnotationChangedPredicate,
+			),
+		).
+		Watches(
+			&configurationv1alpha1.KongRoute{},
+			handler.EnqueueRequestsFromMapFunc(r.mapKongRoutes),
+			builder.WithPredicates(
+				kongPluginsAnnotationChangedPredicate,
+			),
 		).
 		Complete(r)
 }
@@ -69,16 +84,16 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	log.Debug(logger, "reconciling", kongPlugin)
+	clientWithNamespace := client.NewNamespacedClient(r.client, kongPlugin.Namespace)
 
 	// Get the pluginBindings that use this KongPlugin
 	kongPluginBindingList := configurationv1alpha1.KongPluginBindingList{}
-	err := r.client.List(
+	err := clientWithNamespace.List(
 		ctx,
 		&kongPluginBindingList,
 		client.MatchingFields{
 			IndexFieldKongPluginBindingKongPluginReference: kongPlugin.Namespace + "/" + kongPlugin.Name,
 		},
-		client.InNamespace(kongPlugin.Namespace),
 	)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -88,130 +103,124 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// the same logic for KongRoute, KongConsumer, and KongConsumerGroup as well.
 	// https://github.com/Kong/gateway-operator/issues/583
 
-	// Group the PluginBindings by reference type and name.
-	bindingMapping := mapKongPluginBindingsByTargetTypeAndRef(kongPluginBindingList.Items)
-
-	// Get all the KongServices referenced by the KongPluginBindings
-	// TODO(mlavacca): use indexers instead of listing all KongServices
-	// https://github.com/Kong/gateway-operator/issues/596
 	kongServiceList := configurationv1alpha1.KongServiceList{}
-	err = r.client.List(
-		ctx,
-		&kongServiceList,
-		client.InNamespace(kongPlugin.Namespace),
+	err = clientWithNamespace.List(ctx, &kongServiceList,
+		client.MatchingFields{
+			IndexFieldKongServiceOnReferencedPluginNames: kongPlugin.Namespace + "/" + kongPlugin.Name,
+		},
 	)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	pluginBindingsToDelete := []configurationv1alpha1.KongPluginBinding{}
-	// pluginReferenceFound represents whether the plugin is referenced by any KongService
+	kongRouteList := configurationv1alpha1.KongRouteList{}
+	err = clientWithNamespace.List(ctx, &kongRouteList,
+		client.MatchingFields{
+			IndexFieldKongRouteOnReferencedPluginNames: kongPlugin.Namespace + "/" + kongPlugin.Name,
+		},
+	)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	foreignRelations := ForeignRelations{
+		Service: lo.Filter(kongServiceList.Items,
+			func(s configurationv1alpha1.KongService, _ int) bool { return s.DeletionTimestamp.IsZero() },
+		),
+		Route: lo.Filter(kongRouteList.Items,
+			func(s configurationv1alpha1.KongRoute, _ int) bool { return s.DeletionTimestamp.IsZero() },
+		),
+		// TODO consumers and consumer groups
+	}
+	grouped, err := foreignRelations.GroupByControlPlane(ctx, r.client)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// pluginReferenceFound represents whether the plugin is referenced by any resource.
 	var pluginReferenceFound bool
-	for _, kongService := range kongServiceList.Items {
-		if !kongService.DeletionTimestamp.IsZero() {
-			continue
-		}
+	groupedCombinations := grouped.GetCombinations()
 
-		var pluginSlice []string
+	// Delete the KongPluginBindings that are not used anymore.
+	if err := deleteUnusedKongPluginBindings(ctx, logger, clientWithNamespace, &kongPlugin, groupedCombinations, kongPluginBindingList.Items); err != nil {
+		return ctrl.Result{}, err
+	}
 
-		// get the referenced plugins from the KongService annotations
-		plugins, ok := kongService.Annotations[consts.PluginsAnnotationKey]
-		if !ok {
-			// if the konghq.com/plugins annotation is not present, we need to delete all the managed
-			// KongPluginBindings that reference the KongService
-			for _, pb := range bindingMapping.byServiceName[kongService.Name] {
-				if lo.ContainsBy(pb.OwnerReferences, func(ownerRef metav1.OwnerReference) bool {
-					if ownerRef.Kind == "KongPlugin" && ownerRef.Name == kongPlugin.Name && ownerRef.UID == kongPlugin.UID {
-						return true
-					}
-					return false
-				}) {
-					// The PluginBinding is dangling, so it needs to be deleted
-					pluginBindingsToDelete = append(pluginBindingsToDelete, pb)
-				} else {
-					pluginReferenceFound = true
-				}
+	for cpNN, relations := range groupedCombinations {
+		for _, rel := range relations {
+			pluginReferenceFound = true
+
+			builder := NewKongPluginBindingBuilder().
+				WithGenerateName(kongPlugin.Name + "-").
+				WithNamespace(kongPlugin.Namespace).
+				WithPluginRef(kongPlugin.Name).
+				WithControlPlaneRef(&configurationv1alpha1.ControlPlaneRef{
+					Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+					KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+						Namespace: cpNN.Namespace,
+						Name:      cpNN.Name,
+					},
+				})
+
+			l := kongPluginBindingList.Items
+
+			if rel.Service != "" {
+				l = lo.Filter(l, func(pb configurationv1alpha1.KongPluginBinding, _ int) bool {
+					return pb.Spec.Targets.ServiceReference != nil &&
+						pb.Spec.Targets.ServiceReference.Name == rel.Service
+				})
+				builder.WithServiceTarget(rel.Service)
 			}
-		} else {
-			pluginSlice = strings.Split(plugins, ",")
-
-			for _, pb := range kongPluginBindingList.Items {
-				// if the kongPluginBinding targets the KongService,
-				if pb.Spec.Targets.ServiceReference != nil &&
-					pb.Spec.Targets.ServiceReference.Name == kongService.Name &&
-					// but the service does not contain the plugin referenced by the binding in the annotation, and
-					!lo.Contains(pluginSlice, pb.Spec.PluginReference.Name) &&
-					// the plugin is managed (created out of an annotation)
-					lo.ContainsBy(pb.OwnerReferences, func(ownerRef metav1.OwnerReference) bool {
-						if ownerRef.Kind == "KongPlugin" && ownerRef.Name == kongPlugin.Name && ownerRef.UID == kongPlugin.UID {
-							return true
-						}
-						return false
-					}) {
-					// then mark it for deletion, as the plugin is not referenced by the KongService anymore
-					pluginBindingsToDelete = append(pluginBindingsToDelete, pb)
-				}
+			if rel.Route != "" {
+				l = lo.Filter(l, func(pb configurationv1alpha1.KongPluginBinding, _ int) bool {
+					return pb.Spec.Targets.RouteReference != nil &&
+						pb.Spec.Targets.RouteReference.Name == rel.Route
+				})
+				builder.WithRouteTarget(rel.Route)
 			}
 
-			// iterate over all the KongService annotations
-			for _, pluginName := range pluginSlice {
-				if pluginName != kongPlugin.Name {
+			// TODO consumers and consumer groups
+
+			kongPluginBinding := builder.Build()
+			if err := controllerutil.SetOwnerReference(&kongPlugin, kongPluginBinding, clientWithNamespace.Scheme(), controllerutil.WithBlockOwnerDeletion(true)); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to set owner reference: %w", err)
+			}
+
+			switch len(l) {
+			case 0:
+				if err = clientWithNamespace.Create(ctx, kongPluginBinding); err != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to create KongPluginBinding: %w", err)
+				}
+				log.Debug(logger, "Managed KongPluginBinding created", kongPluginBinding)
+
+			case 1:
+				existing := l[0]
+				if reflect.DeepEqual(existing.Spec.Targets.ServiceReference, kongPluginBinding.Spec.Targets.ServiceReference) &&
+					reflect.DeepEqual(existing.Spec.Targets.RouteReference, kongPluginBinding.Spec.Targets.RouteReference) {
+					// TODO consumers and consumer groups checks
 					continue
 				}
 
-				pluginReferenceFound = true
-				// if the KongPluginBinding does not exist yet, create it
-				if len(bindingMapping.byServiceName[kongService.Name]) == 0 {
-					kongPluginBinding := configurationv1alpha1.KongPluginBinding{
-						ObjectMeta: metav1.ObjectMeta{
-							GenerateName: kongPlugin.Name + "-",
-							Namespace:    kongPlugin.Namespace,
-						},
-						Spec: configurationv1alpha1.KongPluginBindingSpec{
-							Targets: configurationv1alpha1.KongPluginBindingTargets{
-								ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
-									Group: configurationv1alpha1.GroupVersion.Group,
-									Kind:  "KongService",
-									Name:  kongService.Name,
-								},
-							},
-							// TODO: Cross check this with other types of ControlPlaneRefs
-							// used by Route, Consumer and/or ConsumerGroups that also bind this plugin
-							// in this KongPluginBinding spec.
-							ControlPlaneRef: kongService.Spec.ControlPlaneRef,
-							PluginReference: configurationv1alpha1.PluginRef{
-								Name: kongPlugin.Name,
-							},
-						},
+				existing.Spec.Targets = kongPluginBinding.Spec.Targets
+
+				if err = clientWithNamespace.Update(ctx, &existing); err != nil {
+					if k8serrors.IsConflict(err) {
+						return ctrl.Result{Requeue: true}, nil
 					}
-					k8sutils.SetOwnerForObject(&kongPluginBinding, &kongPlugin)
-					if err = r.client.Create(ctx, &kongPluginBinding); err != nil {
-						return ctrl.Result{}, err
-					}
-					log.Debug(logger, "Managed KongPluginBinding created", kongPluginBinding)
+					return ctrl.Result{}, fmt.Errorf("failed to update KongPluginBinding: %w", err)
 				}
+				log.Debug(logger, "Managed KongPluginBinding updated", kongPluginBinding)
+
+			default:
+				// TODO: remove surplus KongPluginBindings
 			}
+
 		}
 	}
 
-	// iterate over all the KongPluginBindings to be deleted and delete them.
-	for _, pb := range pluginBindingsToDelete {
-		// NOTE: we check the deletion timestamp here because attempting to delete
-		// and return here would prevent KongPlugin finalizer update below.
-		if !pb.DeletionTimestamp.IsZero() {
-			continue
-		}
-		if err = r.client.Delete(ctx, &pb); err != nil {
-			if k8serrors.IsNotFound(err) {
-				continue
-			}
-			return ctrl.Result{}, err
-		}
-		log.Info(logger, "KongPluginBinding deleted", pb)
-		return ctrl.Result{}, nil
-	}
+	pluginReferenceFound = pluginReferenceFound || len(kongPluginBindingList.Items) > 0
 
-	// If some KongService is using the plugin, add a finalizer on the plugin.
+	// If an entity is using the plugin, add a finalizer on the plugin.
 	// The KongPlugin cannot be deleted until all objects that reference it are
 	// deleted or do not reference it anymore.
 	if pluginReferenceFound {
@@ -242,31 +251,189 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	return ctrl.Result{}, nil
 }
 
-type kongPluginBindingMapping struct {
-	byServiceName map[string][]configurationv1alpha1.KongPluginBinding
-	byRouteName   map[string][]configurationv1alpha1.KongPluginBinding
+func deleteKongPluginBindings(
+	ctx context.Context,
+	logger logr.Logger,
+	cl client.Client,
+	pluginBindingsToDelete map[types.NamespacedName]configurationv1alpha1.KongPluginBinding,
+) error {
+	for _, pb := range pluginBindingsToDelete {
+		// NOTE: we check the deletion timestamp here because attempting to delete
+		// and return here would prevent KongPlugin finalizer update.
+		if !pb.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if err := cl.Delete(ctx, &pb); err != nil {
+			if k8serrors.IsNotFound(err) {
+				continue
+			}
+			return err
+		}
+		log.Info(logger, "KongPluginBinding deleted", pb)
+	}
+	return nil
 }
 
-func mapKongPluginBindingsByTargetTypeAndRef(bindings []configurationv1alpha1.KongPluginBinding) kongPluginBindingMapping {
-	ret := kongPluginBindingMapping{
-		byServiceName: map[string][]configurationv1alpha1.KongPluginBinding{},
-		byRouteName:   map[string][]configurationv1alpha1.KongPluginBinding{},
+func ownerRefIsPlugin(kongPlugin *configurationv1.KongPlugin) func(ownerRef metav1.OwnerReference) bool {
+	return func(ownerRef metav1.OwnerReference) bool {
+		return ownerRef.Kind == "KongPlugin" &&
+			ownerRef.Name == kongPlugin.Name &&
+			ownerRef.UID == kongPlugin.UID
 	}
+}
 
-	for _, b := range bindings {
-		serviceRef := b.Spec.Targets.ServiceReference
-		if serviceRef != nil &&
-			serviceRef.Group == configurationv1alpha1.GroupVersion.Group &&
-			serviceRef.Kind == "KongService" {
-			ret.byServiceName[serviceRef.Name] = append(ret.byServiceName[serviceRef.Name], b)
+func deleteUnusedKongPluginBindings(
+	ctx context.Context,
+	logger logr.Logger,
+	clientWithNamespace client.Client,
+	kongPlugin *configurationv1.KongPlugin,
+	groupedCombinations map[types.NamespacedName][]Rel,
+	kongPluginBindings []configurationv1alpha1.KongPluginBinding,
+) error {
+	kongServiceList := configurationv1alpha1.KongServiceList{}
+	if err := clientWithNamespace.List(ctx, &kongServiceList); err != nil {
+		return err
+	}
+	serviceMap := lo.SliceToMap(
+		kongServiceList.Items,
+		func(obj configurationv1alpha1.KongService) (string, configurationv1alpha1.KongService) {
+			return obj.Name, obj
+		},
+	)
+
+	kongRouteList := configurationv1alpha1.KongRouteList{}
+	if err := clientWithNamespace.List(ctx, &kongRouteList); err != nil {
+		return err
+	}
+	routeMap := lo.SliceToMap(
+		kongRouteList.Items,
+		func(obj configurationv1alpha1.KongRoute) (string, configurationv1alpha1.KongRoute) {
+			return obj.Name, obj
+		},
+	)
+
+	pluginBindingsToDelete := make(map[types.NamespacedName]configurationv1alpha1.KongPluginBinding)
+	for _, pb := range kongPluginBindings {
+		// If the KongPluginBinding has a deletion timestamp, do not delete it.
+		if !pb.DeletionTimestamp.IsZero() {
+			continue
 		}
 
-		routeRef := b.Spec.Targets.RouteReference
-		if routeRef != nil &&
-			routeRef.Group == configurationv1alpha1.GroupVersion.Group &&
-			routeRef.Kind == "KongRoute" {
-			ret.byRouteName[routeRef.Name] = append(ret.byRouteName[routeRef.Name], b)
+		// If the KongPluginBinding is unmanaged (created not using an annotation), skip it, do not delete it.
+		if !lo.ContainsBy(pb.OwnerReferences, ownerRefIsPlugin(kongPlugin)) {
+			continue
 		}
+
+		cpRef := pb.Spec.ControlPlaneRef
+		if cpRef == nil ||
+			cpRef.KonnectNamespacedRef == nil ||
+			cpRef.Type != configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef {
+			continue
+		}
+
+		combinations, ok := groupedCombinations[types.NamespacedName{
+			// TODO: implement cross namespace references
+			Namespace: pb.Namespace,
+			Name:      cpRef.KonnectNamespacedRef.Name,
+		}]
+		if !ok {
+			pluginBindingsToDelete[client.ObjectKeyFromObject(&pb)] = pb
+			continue
+		}
+
+		// If the konghq.com/plugins annotation is not present, it doesn't contain
+		// the plugin in question or the object referring to the plugin has a non zero deletion timestamp,
+		// we need to delete all the managed KongPluginBindings that reference the object.
+
+		serviceRef := pb.Spec.Targets.ServiceReference
+		routeRef := pb.Spec.Targets.RouteReference
+		switch {
+
+		case serviceRef != nil && routeRef != nil:
+			combinationFound := false
+			for _, rel := range combinations {
+				if rel.Service != serviceRef.Name &&
+					rel.Route != routeRef.Name {
+					continue
+				}
+				combinationFound = true
+				break
+			}
+
+			if !combinationFound {
+				pluginBindingsToDelete[client.ObjectKeyFromObject(&pb)] = pb
+				continue
+			}
+
+			s, serviceExists := serviceMap[serviceRef.Name]
+			r, routeExists := routeMap[routeRef.Name]
+			if !serviceExists || !routeExists ||
+				!objHasPluginConfigured(&s, kongPlugin.Name) || !s.DeletionTimestamp.IsZero() ||
+				!objHasPluginConfigured(&r, kongPlugin.Name) || !r.DeletionTimestamp.IsZero() {
+				pluginBindingsToDelete[client.ObjectKeyFromObject(&pb)] = pb
+				continue
+			}
+
+		case serviceRef != nil:
+			combinationFound := false
+			for _, rel := range combinations {
+				if rel.Service != serviceRef.Name ||
+					rel.Route != "" {
+					continue
+				}
+				combinationFound = true
+				break
+			}
+
+			if !combinationFound {
+				pluginBindingsToDelete[client.ObjectKeyFromObject(&pb)] = pb
+				continue
+			}
+
+			s, serviceExists := serviceMap[serviceRef.Name]
+			if !serviceExists ||
+				!objHasPluginConfigured(&s, kongPlugin.Name) || !s.DeletionTimestamp.IsZero() {
+				pluginBindingsToDelete[client.ObjectKeyFromObject(&pb)] = pb
+				continue
+			}
+
+		case routeRef != nil:
+			combinationFound := false
+			for _, rel := range combinations {
+				if rel.Route != routeRef.Name ||
+					rel.Service != "" {
+					continue
+				}
+				combinationFound = true
+				break
+			}
+
+			if !combinationFound {
+				pluginBindingsToDelete[client.ObjectKeyFromObject(&pb)] = pb
+				continue
+			}
+
+			r, routeExists := routeMap[routeRef.Name]
+			if !routeExists ||
+				!objHasPluginConfigured(&r, kongPlugin.Name) || !r.DeletionTimestamp.IsZero() {
+				pluginBindingsToDelete[client.ObjectKeyFromObject(&pb)] = pb
+				continue
+			}
+		}
+
 	}
-	return ret
+
+	if err := deleteKongPluginBindings(ctx, logger, clientWithNamespace, pluginBindingsToDelete); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func objHasPluginConfigured(obj client.Object, pluginName string) bool {
+	plugins, ok := obj.GetAnnotations()[consts.PluginsAnnotationKey]
+	if !ok {
+		return false
+	}
+	return slices.Contains(strings.Split(plugins, ","), pluginName)
 }

--- a/controller/konnect/reconciler_kongplugin.go
+++ b/controller/konnect/reconciler_kongplugin.go
@@ -162,17 +162,17 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					},
 				})
 
-			l := kongPluginBindingList.Items
+			kpbList := kongPluginBindingList.Items
 
 			if rel.Service != "" {
-				l = lo.Filter(l, func(pb configurationv1alpha1.KongPluginBinding, _ int) bool {
+				kpbList = lo.Filter(kpbList, func(pb configurationv1alpha1.KongPluginBinding, _ int) bool {
 					return pb.Spec.Targets.ServiceReference != nil &&
 						pb.Spec.Targets.ServiceReference.Name == rel.Service
 				})
 				builder.WithServiceTarget(rel.Service)
 			}
 			if rel.Route != "" {
-				l = lo.Filter(l, func(pb configurationv1alpha1.KongPluginBinding, _ int) bool {
+				kpbList = lo.Filter(kpbList, func(pb configurationv1alpha1.KongPluginBinding, _ int) bool {
 					return pb.Spec.Targets.RouteReference != nil &&
 						pb.Spec.Targets.RouteReference.Name == rel.Route
 				})
@@ -186,7 +186,7 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				return ctrl.Result{}, fmt.Errorf("failed to set owner reference: %w", err)
 			}
 
-			switch len(l) {
+			switch len(kpbList) {
 			case 0:
 				if err = clientWithNamespace.Create(ctx, kongPluginBinding); err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to create KongPluginBinding: %w", err)
@@ -194,7 +194,7 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				log.Debug(logger, "Managed KongPluginBinding created", kongPluginBinding)
 
 			case 1:
-				existing := l[0]
+				existing := kpbList[0]
 				if reflect.DeepEqual(existing.Spec.Targets.ServiceReference, kongPluginBinding.Spec.Targets.ServiceReference) &&
 					reflect.DeepEqual(existing.Spec.Targets.RouteReference, kongPluginBinding.Spec.Targets.RouteReference) {
 					// TODO consumers and consumer groups checks

--- a/controller/konnect/reconciler_kongplugin_combinations.go
+++ b/controller/konnect/reconciler_kongplugin_combinations.go
@@ -1,0 +1,253 @@
+package konnect
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+)
+
+// ForeignRelations contains all the relations between Kong entities and KongPlugin.
+type ForeignRelations struct {
+	Consumer, ConsumerGroup []string
+	Route                   []configurationv1alpha1.KongRoute
+	Service                 []configurationv1alpha1.KongService
+}
+
+// ForeignRelationsGroupedByControlPlane is a map of ForeignRelations grouped by ControlPlane.
+type ForeignRelationsGroupedByControlPlane map[types.NamespacedName]ForeignRelations
+
+// GetCombinations returns all possible combinations of relations
+// grouped by ControlPlane.
+func (f ForeignRelationsGroupedByControlPlane) GetCombinations() map[types.NamespacedName][]Rel {
+	ret := make(map[types.NamespacedName][]Rel, len(f))
+	for nn, fr := range f {
+		ret[nn] = fr.GetCombinations()
+	}
+	return ret
+}
+
+// GetCombinations groups all the entities by ControlPlane.
+// NOTE: currently only supports Konnect ControlPlane which is referenced by a konnectNamespacedRef.
+func (relations *ForeignRelations) GroupByControlPlane(
+	ctx context.Context,
+	cl client.Client,
+) (ForeignRelationsGroupedByControlPlane, error) {
+	ret := make(map[types.NamespacedName]ForeignRelations)
+	for _, service := range relations.Service {
+		cpRef := service.Spec.ControlPlaneRef
+		if cpRef == nil ||
+			cpRef.KonnectNamespacedRef == nil ||
+			cpRef.Type != configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef {
+			continue
+		}
+		nn := types.NamespacedName{
+			// TODO: implement cross namespace references
+			Namespace: service.Namespace,
+			Name:      cpRef.KonnectNamespacedRef.Name,
+		}
+		fr := ret[nn]
+		fr.Service = append(fr.Service, service)
+		ret[nn] = fr
+	}
+	for _, route := range relations.Route {
+		svcRef := route.Spec.ServiceRef
+		if svcRef == nil || svcRef.NamespacedRef == nil {
+			continue
+		}
+
+		svc := configurationv1alpha1.KongService{}
+		err := cl.Get(ctx,
+			types.NamespacedName{
+				Namespace: route.Namespace,
+				Name:      svcRef.NamespacedRef.Name,
+			}, &svc,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		cpRef := svc.Spec.ControlPlaneRef
+		if cpRef == nil || cpRef.KonnectNamespacedRef == nil {
+			continue
+		}
+
+		nn := types.NamespacedName{
+			// TODO: implement cross namespace references
+			Namespace: route.Namespace,
+			Name:      cpRef.KonnectNamespacedRef.Name,
+		}
+		fr := ret[nn]
+		fr.Route = append(fr.Route, route)
+		ret[nn] = fr
+	}
+
+	// TODO consumers and consumer groups
+
+	return ret, nil
+}
+
+// Rel represents a relation between Kong entities and KongPlugin.
+type Rel struct {
+	Consumer, ConsumerGroup, Route, Service string
+}
+
+// GetCombinations returns all possible combinations of relations.
+func (relations *ForeignRelations) GetCombinations() []Rel {
+	var (
+		lConsumer      = len(relations.Consumer)
+		lConsumerGroup = len(relations.ConsumerGroup)
+		lRoutes        = len(relations.Route)
+		lServices      = len(relations.Service)
+		l              = lRoutes + lServices
+	)
+
+	var cartesianProduct []Rel
+
+	if lConsumer > 0 { //nolint:gocritic
+		if l > 0 {
+			cartesianProduct = make([]Rel, 0, l*lConsumer)
+			servicesForRoutes := sets.NewString()
+
+			for _, consumer := range relations.Consumer {
+				for _, route := range relations.Route {
+
+					var serviceForRouteFound bool
+					for _, service := range relations.Service {
+						if route.Spec.ServiceRef.NamespacedRef.Name == service.Name {
+							serviceForRouteFound = true
+							servicesForRoutes.Insert(service.Name)
+							cartesianProduct = append(cartesianProduct, Rel{
+								Service:  service.Name,
+								Route:    route.Name,
+								Consumer: consumer,
+							})
+						} else {
+							cartesianProduct = append(cartesianProduct, Rel{
+								Service:  service.Name,
+								Consumer: consumer,
+							})
+						}
+					}
+					if !serviceForRouteFound {
+						cartesianProduct = append(cartesianProduct, Rel{
+							Route:    route.Name,
+							Consumer: consumer,
+						})
+					}
+				}
+
+				for _, service := range relations.Service {
+					if !servicesForRoutes.Has(service.Name) {
+						cartesianProduct = append(cartesianProduct, Rel{
+							Service:  service.Name,
+							Consumer: consumer,
+						})
+					}
+				}
+			}
+
+		} else {
+			cartesianProduct = make([]Rel, 0, len(relations.Consumer))
+			for _, consumer := range relations.Consumer {
+				cartesianProduct = append(cartesianProduct, Rel{Consumer: consumer})
+			}
+		}
+	} else if lConsumerGroup > 0 {
+		if l > 0 {
+			cartesianProduct = make([]Rel, 0, l*lConsumerGroup)
+			servicesForRoutes := sets.NewString()
+
+			for _, group := range relations.ConsumerGroup {
+				for _, route := range relations.Route {
+
+					var serviceForRouteFound bool
+					for _, service := range relations.Service {
+						serviceRef := route.Spec.ServiceRef
+						if serviceRef.Type != configurationv1alpha1.ServiceRefNamespacedRef {
+							continue
+						}
+
+						if serviceRef.NamespacedRef.Name == service.Name {
+							serviceForRouteFound = true
+							servicesForRoutes.Insert(service.Name)
+							cartesianProduct = append(cartesianProduct, Rel{
+								Service:       service.Name,
+								Route:         route.Name,
+								ConsumerGroup: group,
+							})
+						} else {
+							cartesianProduct = append(cartesianProduct, Rel{
+								Service:       service.Name,
+								ConsumerGroup: group,
+							})
+						}
+					}
+					if !serviceForRouteFound {
+						cartesianProduct = append(cartesianProduct, Rel{
+							Route:         route.Name,
+							ConsumerGroup: group,
+						})
+					}
+				}
+
+				for _, service := range relations.Service {
+					if !servicesForRoutes.Has(service.Name) {
+						cartesianProduct = append(cartesianProduct, Rel{
+							Service:       service.Name,
+							ConsumerGroup: group,
+						})
+					}
+				}
+			}
+
+		} else {
+			cartesianProduct = make([]Rel, 0, lConsumerGroup)
+			for _, group := range relations.ConsumerGroup {
+				cartesianProduct = append(cartesianProduct, Rel{ConsumerGroup: group})
+			}
+		}
+	} else if l > 0 {
+		cartesianProduct = make([]Rel, 0, l)
+		servicesForRoutes := sets.NewString()
+		for _, route := range relations.Route {
+			var serviceForRouteFound bool
+			for _, service := range relations.Service {
+				serviceRef := route.Spec.ServiceRef
+				if serviceRef.Type != configurationv1alpha1.ServiceRefNamespacedRef {
+					continue
+				}
+
+				if serviceRef.NamespacedRef.Name == service.Name {
+					serviceForRouteFound = true
+					servicesForRoutes.Insert(service.Name)
+					cartesianProduct = append(cartesianProduct, Rel{
+						Service: service.Name,
+						Route:   route.Name,
+					})
+				} else {
+					cartesianProduct = append(cartesianProduct, Rel{
+						Service: service.Name,
+					})
+				}
+			}
+			if !serviceForRouteFound {
+				cartesianProduct = append(cartesianProduct, Rel{
+					Route: route.Name,
+				})
+			}
+		}
+		for _, service := range relations.Service {
+			if !servicesForRoutes.Has(service.Name) {
+				cartesianProduct = append(cartesianProduct, Rel{
+					Service: service.Name,
+				})
+			}
+		}
+	}
+
+	return cartesianProduct
+}

--- a/controller/konnect/reconciler_kongplugin_combinations_test.go
+++ b/controller/konnect/reconciler_kongplugin_combinations_test.go
@@ -1,0 +1,272 @@
+package konnect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+)
+
+func TestGetCombinations(t *testing.T) {
+	type args struct {
+		relations ForeignRelations
+	}
+	tests := []struct {
+		name string
+		args args
+		want []Rel
+	}{
+		{
+			name: "empty",
+			args: args{
+				relations: ForeignRelations{},
+			},
+			want: nil,
+		},
+		{
+			name: "plugins on consumer only",
+			args: args{
+				relations: ForeignRelations{
+					Consumer: []string{"foo", "bar"},
+				},
+			},
+			want: []Rel{
+				{
+					Consumer: "foo",
+				},
+				{
+					Consumer: "bar",
+				},
+			},
+		},
+		{
+			name: "plugins on consumer group only",
+			args: args{
+				relations: ForeignRelations{
+					ConsumerGroup: []string{"foo", "bar"},
+				},
+			},
+			want: []Rel{
+				{
+					ConsumerGroup: "foo",
+				},
+				{
+					ConsumerGroup: "bar",
+				},
+			},
+		},
+		{
+			name: "plugins on service only",
+			args: args{
+				relations: ForeignRelations{
+					Service: []configurationv1alpha1.KongService{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "s1",
+							},
+						},
+					},
+				},
+			},
+			want: []Rel{
+				{
+					Service: "s1",
+				},
+			},
+		},
+		{
+			name: "plugins on services only",
+			args: args{
+				relations: ForeignRelations{
+					Service: []configurationv1alpha1.KongService{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "s1",
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "s2",
+							},
+						},
+					},
+				},
+			},
+			want: []Rel{
+				{
+					Service: "s1",
+				},
+				{
+					Service: "s2",
+				},
+			},
+		},
+		{
+			name: "plugins on combination of service and route",
+			args: args{
+				relations: ForeignRelations{
+					Route: []configurationv1alpha1.KongRoute{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "r1",
+							},
+							Spec: configurationv1alpha1.KongRouteSpec{
+								ServiceRef: &configurationv1alpha1.ServiceRef{
+									Type: configurationv1alpha1.ServiceRefNamespacedRef,
+									NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+										Name: "s1",
+									},
+								},
+							},
+						},
+					},
+					Service: []configurationv1alpha1.KongService{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "s1",
+							},
+						},
+					},
+				},
+			},
+			want: []Rel{
+				{
+					Route:   "r1",
+					Service: "s1",
+				},
+			},
+		},
+		{
+			name: "plugins on combination of service and consumer",
+			args: args{
+				relations: ForeignRelations{
+					Service: []configurationv1alpha1.KongService{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "s1",
+							},
+						},
+					},
+					Consumer: []string{"c1"},
+				},
+			},
+			want: []Rel{
+				{
+					Consumer: "c1",
+					Service:  "s1",
+				},
+			},
+		},
+		{
+			name: "plugins on combination of service and consumers",
+			args: args{
+				relations: ForeignRelations{
+					Service: []configurationv1alpha1.KongService{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "s1",
+							},
+						},
+					},
+					Consumer: []string{"c1", "c2"},
+				},
+			},
+			want: []Rel{
+				{
+					Consumer: "c1",
+					Service:  "s1",
+				},
+				{
+					Consumer: "c2",
+					Service:  "s1",
+				},
+			},
+		},
+		{
+			name: "plugins on combination of service,route and consumer",
+			args: args{
+				relations: ForeignRelations{
+					Route: []configurationv1alpha1.KongRoute{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "r1",
+							},
+							Spec: configurationv1alpha1.KongRouteSpec{
+								ServiceRef: &configurationv1alpha1.ServiceRef{
+									Type: configurationv1alpha1.ServiceRefNamespacedRef,
+									NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+										Name: "s1",
+									},
+								},
+							},
+						},
+					},
+					Service: []configurationv1alpha1.KongService{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "s1",
+							},
+						},
+					},
+					Consumer: []string{"c1"},
+				},
+			},
+			want: []Rel{
+				{
+					Consumer: "c1",
+					Route:    "r1",
+					Service:  "s1",
+				},
+			},
+		},
+		{
+			name: "plugins on combination of service,route and consumers",
+			args: args{
+				relations: ForeignRelations{
+					Route: []configurationv1alpha1.KongRoute{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "r1",
+							},
+							Spec: configurationv1alpha1.KongRouteSpec{
+								ServiceRef: &configurationv1alpha1.ServiceRef{
+									Type: configurationv1alpha1.ServiceRefNamespacedRef,
+									NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+										Name: "s1",
+									},
+								},
+							},
+						},
+					},
+					Service: []configurationv1alpha1.KongService{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "s1",
+							},
+						},
+					},
+					Consumer: []string{"c1", "c2"},
+				},
+			},
+			want: []Rel{
+				{
+					Consumer: "c1",
+					Route:    "r1",
+					Service:  "s1",
+				},
+				{
+					Consumer: "c2",
+					Route:    "r1",
+					Service:  "s1",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.args.relations.GetCombinations())
+		})
+	}
+}

--- a/controller/konnect/watch_kongplugin.go
+++ b/controller/konnect/watch_kongplugin.go
@@ -8,17 +8,15 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/pkg/consts"
 
-	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
 
 // mapKongServices enqueue requests for KongPlugin objects based on KongService annotations.
-func (r *KongPluginReconciler) mapKongServices(ctx context.Context, obj client.Object) []reconcile.Request {
+func (r *KongPluginReconciler) mapKongServices(ctx context.Context, obj client.Object) []ctrl.Request {
 	logger := log.GetLogger(ctx, "KongPlugin", r.developmentMode)
 	kongService, ok := obj.(*configurationv1alpha1.KongService)
 	if !ok {
@@ -26,25 +24,51 @@ func (r *KongPluginReconciler) mapKongServices(ctx context.Context, obj client.O
 		return []ctrl.Request{}
 	}
 
-	requests := []ctrl.Request{}
-	if plugins, ok := kongService.Annotations[consts.PluginsAnnotationKey]; ok {
-		for _, p := range strings.Split(plugins, ",") {
-			kp := configurationv1.KongPlugin{}
-			if r.client.Get(ctx, client.ObjectKey{Namespace: kongService.Namespace, Name: p}, &kp) == nil {
-				requests = append(requests, ctrl.Request{
-					NamespacedName: client.ObjectKey{
-						Namespace: kp.Namespace,
-						Name:      kp.Name,
-					},
-				})
-			}
-		}
+	ann, ok := kongService.Annotations[consts.PluginsAnnotationKey]
+	if !ok {
+		return nil
+	}
+	plugins := strings.Split(ann, ",")
+	requests := make([]ctrl.Request, 0, len(plugins))
+	for _, p := range plugins {
+		requests = append(requests, ctrl.Request{
+			NamespacedName: client.ObjectKey{
+				Namespace: kongService.Namespace,
+				Name:      p,
+			},
+		})
+	}
+	return requests
+}
+
+// mapKongRoutes enqueue requests for KongPlugin objects based on KongRoute annotations.
+func (r *KongPluginReconciler) mapKongRoutes(ctx context.Context, obj client.Object) []ctrl.Request {
+	logger := log.GetLogger(ctx, "KongPlugin", r.developmentMode)
+	kongRoute, ok := obj.(*configurationv1alpha1.KongRoute)
+	if !ok {
+		log.Error(logger, errors.New("cannot cast object to KongRoute"), "KongRoute mapping handler", obj)
+		return []ctrl.Request{}
+	}
+
+	ann, ok := kongRoute.Annotations[consts.PluginsAnnotationKey]
+	if !ok {
+		return nil
+	}
+	plugins := strings.Split(ann, ",")
+	requests := make([]ctrl.Request, 0, len(plugins))
+	for _, p := range plugins {
+		requests = append(requests, ctrl.Request{
+			NamespacedName: client.ObjectKey{
+				Namespace: kongRoute.Namespace,
+				Name:      p,
+			},
+		})
 	}
 	return requests
 }
 
 // mapKongPluginBindings enqueue requests for KongPlugins referenced by KongPluginBindings in their .spec.pluginRef field.
-func (r *KongPluginReconciler) mapKongPluginBindings(ctx context.Context, obj client.Object) []reconcile.Request {
+func (r *KongPluginReconciler) mapKongPluginBindings(ctx context.Context, obj client.Object) []ctrl.Request {
 	logger := log.GetLogger(ctx, "KongPlugin", r.developmentMode)
 	kongPluginBinding, ok := obj.(*configurationv1alpha1.KongPluginBinding)
 	if !ok {

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -487,12 +487,19 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 // a predefined key and so that different controllers can share the same indices.
 func SetupCacheIndicesForKonnectTypes(ctx context.Context, mgr manager.Manager, developmentMode bool) error {
 	if err := setupCacheIndicesForKonnectType[configurationv1alpha1.KongPluginBinding](ctx, mgr, developmentMode); err != nil {
-		return fmt.Errorf("failed to setup cache indices for %s: %w",
-			constraints.EntityTypeName[configurationv1alpha1.KongPluginBinding](), err)
+		return err
 	}
 	if err := setupCacheIndicesForKonnectType[configurationv1alpha1.KongCredentialBasicAuth](ctx, mgr, developmentMode); err != nil {
-		return fmt.Errorf("failed to setup cache indices for %s: %w",
-			constraints.EntityTypeName[configurationv1alpha1.KongCredentialBasicAuth](), err)
+		return err
+	}
+	if err := setupCacheIndicesForKonnectType[configurationv1.KongConsumer](ctx, mgr, developmentMode); err != nil {
+		return err
+	}
+	if err := setupCacheIndicesForKonnectType[configurationv1alpha1.KongService](ctx, mgr, developmentMode); err != nil {
+		return err
+	}
+	if err := setupCacheIndicesForKonnectType[configurationv1alpha1.KongRoute](ctx, mgr, developmentMode); err != nil {
+		return err
 	}
 	return nil
 }
@@ -515,7 +522,7 @@ func setupCacheIndicesForKonnectType[
 			GetCache().
 			IndexField(ctx, ind.IndexObject, ind.IndexField, ind.ExtractValue)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to setup cache indices for %s: %w", constraints.EntityTypeName[T](), err)
 		}
 	}
 	return nil

--- a/pkg/annotations/plugins.go
+++ b/pkg/annotations/plugins.go
@@ -1,0 +1,28 @@
+package annotations
+
+import (
+	"strings"
+
+	"github.com/kong/gateway-operator/pkg/consts"
+)
+
+// ExtractPlugins extracts plugin names from the given object's
+// konghq.com/plugins annotation.
+func ExtractPlugins(obj interface {
+	GetAnnotations() map[string]string
+	GetNamespace() string
+},
+) []string {
+	ann, ok := obj.GetAnnotations()[consts.PluginsAnnotationKey]
+	if !ok {
+		return nil
+	}
+
+	namespace := obj.GetNamespace()
+	split := strings.Split(ann, ",")
+	ret := make([]string, 0, len(split))
+	for _, p := range split {
+		ret = append(ret, namespace+"/"+strings.TrimSpace(p))
+	}
+	return ret
+}

--- a/pkg/annotations/plugins_test.go
+++ b/pkg/annotations/plugins_test.go
@@ -1,0 +1,86 @@
+package annotations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kong/gateway-operator/pkg/consts"
+)
+
+type mockObject struct {
+	annotations map[string]string
+	namespace   string
+}
+
+func (m *mockObject) GetAnnotations() map[string]string {
+	return m.annotations
+}
+
+func (m *mockObject) GetNamespace() string {
+	return m.namespace
+}
+
+func TestExtractPlugins(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      *mockObject
+		expected []string
+	}{
+		{
+			name: "no annotations",
+			obj: &mockObject{
+				annotations: map[string]string{},
+				namespace:   "default",
+			},
+			expected: nil,
+		},
+		{
+			name: "single plugin",
+			obj: &mockObject{
+				annotations: map[string]string{
+					consts.PluginsAnnotationKey: "plugin1",
+				},
+				namespace: "default",
+			},
+			expected: []string{"default/plugin1"},
+		},
+		{
+			name: "multiple plugins",
+			obj: &mockObject{
+				annotations: map[string]string{
+					consts.PluginsAnnotationKey: "plugin1,plugin2,plugin3",
+				},
+				namespace: "default",
+			},
+			expected: []string{"default/plugin1", "default/plugin2", "default/plugin3"},
+		},
+		{
+			name: "plugins with spaces",
+			obj: &mockObject{
+				annotations: map[string]string{
+					consts.PluginsAnnotationKey: " plugin1 , plugin2 , plugin3 ",
+				},
+				namespace: "default",
+			},
+			expected: []string{"default/plugin1", "default/plugin2", "default/plugin3"},
+		},
+		{
+			name: "different namespace",
+			obj: &mockObject{
+				annotations: map[string]string{
+					consts.PluginsAnnotationKey: "plugin1,plugin2",
+				},
+				namespace: "custom",
+			},
+			expected: []string{"custom/plugin1", "custom/plugin2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractPlugins(tt.obj)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/test/envtest/deploy_resources.go
+++ b/test/envtest/deploy_resources.go
@@ -126,7 +126,6 @@ func deployKonnectGatewayControlPlaneWithID(
 }
 
 // deployKongService deploys a KongService resource and returns the resource.
-// The caller can also specify the status which will be updated on the resource.
 func deployKongService(
 	t *testing.T,
 	ctx context.Context,
@@ -140,8 +139,6 @@ func deployKongService(
 	kongService.Spec.Name = lo.ToPtr(name)
 	require.NoError(t, cl.Create(ctx, kongService))
 	t.Logf("deployed %s KongService resource", client.ObjectKeyFromObject(kongService))
-
-	require.NoError(t, cl.Status().Update(ctx, kongService))
 
 	return kongService
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces mechanism of creating `KongPluginBinding`s for both `KongRoute`s and `KongService`s based on annotation on those.

A mechanism to clean unused `KongPluginBinding`s has also been introduced.

Creating a cartesian product of possible relations (if e.g. the same plugin is used on `KongService` and `KongRoute` create 1 binding with both set as targets) is based on https://github.com/Kong/kubernetes-ingress-controller/blob/ee797b4e84bd176526af32ab6db54f16ee9c245b/internal/util/relations.go with 1 small change:

For `KongConsumer`, `KongService` and `KongRoute` relations it creates a single entry (and thus a single `KongPluginBinding`) where KIC (and the linked implementation) would create 2: 

- 1 for `KongConsumer` and `KongService`
- 1 for `KongConsumer` and `KongRoute`

**Which issue this PR fixes**

Fixes #525 

**Special notes for your reviewer**:

- `envtest` based test will follow in a separate PR to not make this PR any bigger.

- This introduces a small gap where `KongPluginBinding` (and thus Konnect plugin entity) can be deleted and recreated when target set of a plugin has changed, for instance when `KongService` and `KongRoute` are annotated with the same plugin and then `KongRoute` gets that annotation removed the reconciler will remove the `KongPluginBinding` as the target set doesn't match and then recreate a new one, having only the service as target.
  
  Implementing an improvement for this would require adding a mechanism which could map the plugin relations (combinations of resources having the `konghq.com/plugins` annotation set) to existing `KongPluginBinding`s.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
