### PR TITLE
refactor(konnect): refactor plugin reconciler watch handlers

### DIFF
--- a/controller/konnect/index_credentials_basicauth.go
+++ b/controller/konnect/index_credentials_basicauth.go
@@ -17,13 +17,13 @@ func IndexOptionsForCredentialsBasicAuth() []ReconciliationIndexOption {
 		{
 			IndexObject:  &configurationv1alpha1.KongCredentialBasicAuth{},
 			IndexField:   IndexFieldKongCredentialBasicAuthReferencesKongConsumer,
-			ExtractValue: kongKongCredentialBasicAuthReferencesConsumer,
+			ExtractValue: kongCredentialBasicAuthReferencesConsumer,
 		},
 	}
 }
 
-// kongKongCredentialBasicAuthReferencesConsumer returns the name of referenced Consumer.
-func kongKongCredentialBasicAuthReferencesConsumer(obj client.Object) []string {
+// kongCredentialBasicAuthReferencesConsumer returns the name of referenced Consumer.
+func kongCredentialBasicAuthReferencesConsumer(obj client.Object) []string {
 	cred, ok := obj.(*configurationv1alpha1.KongCredentialBasicAuth)
 	if !ok {
 		return nil

--- a/controller/konnect/reconciler_kongplugin.go
+++ b/controller/konnect/reconciler_kongplugin.go
@@ -53,14 +53,14 @@ func (r *KongPluginReconciler) SetupWithManager(_ context.Context, mgr ctrl.Mana
 		).
 		Watches(
 			&configurationv1alpha1.KongService{},
-			handler.EnqueueRequestsFromMapFunc(r.mapKongServices),
+			handler.EnqueueRequestsFromMapFunc(mapPluginsFromAnnotation[configurationv1alpha1.KongService](r.developmentMode)),
 			builder.WithPredicates(
 				kongPluginsAnnotationChangedPredicate,
 			),
 		).
 		Watches(
 			&configurationv1alpha1.KongRoute{},
-			handler.EnqueueRequestsFromMapFunc(r.mapKongRoutes),
+			handler.EnqueueRequestsFromMapFunc(mapPluginsFromAnnotation[configurationv1alpha1.KongRoute](r.developmentMode)),
 			builder.WithPredicates(
 				kongPluginsAnnotationChangedPredicate,
 			),

--- a/controller/konnect/watch_kongplugin.go
+++ b/controller/konnect/watch_kongplugin.go
@@ -3,39 +3,60 @@ package konnect
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kong/gateway-operator/controller/konnect/constraints"
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/pkg/annotations"
 
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	configurationv1beta1 "github.com/kong/kubernetes-configuration/api/configuration/v1beta1"
 )
 
-// mapKongServices enqueue requests for KongPlugin objects based on KongService annotations.
-func (r *KongPluginReconciler) mapKongServices(ctx context.Context, obj client.Object) []ctrl.Request {
-	logger := log.GetLogger(ctx, "KongPlugin", r.developmentMode)
-	kongService, ok := obj.(*configurationv1alpha1.KongService)
-	if !ok {
-		log.Error(logger, errors.New("cannot cast object to KongService"), "KongService mapping handler", obj)
-		return []ctrl.Request{}
+// mapPluginsFromAnnotation enqueue requests for KongPlugins based on
+// provided object's annotations.
+func mapPluginsFromAnnotation[
+	T interface {
+		configurationv1alpha1.KongService |
+			configurationv1alpha1.KongRoute |
+			configurationv1.KongConsumer |
+			configurationv1beta1.KongConsumerGroup
+		GetTypeName() string
+	},
+](devMode bool) func(ctx context.Context, obj client.Object) []ctrl.Request {
+	return func(ctx context.Context, obj client.Object) []ctrl.Request {
+		_, ok := any(obj).(*T)
+		if !ok {
+			entityTypeName := constraints.EntityTypeName[T]()
+			logger := log.GetLogger(ctx, entityTypeName, devMode)
+			log.Error(logger,
+				fmt.Errorf("cannot cast object to %s", entityTypeName),
+				fmt.Sprintf("%s mapping handler", entityTypeName), obj,
+			)
+			return []ctrl.Request{}
+		}
+
+		var (
+			namespace = obj.GetNamespace()
+			plugins   = annotations.ExtractPlugins(obj)
+			requests  = make([]ctrl.Request, 0, len(plugins))
+		)
+
+		for _, p := range plugins {
+			requests = append(requests, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Namespace: namespace,
+					Name:      p,
+				},
+			})
+		}
+		return requests
 	}
-
-	return mapObjectRequestsForItsPlugins(kongService)
-}
-
-// mapKongRoutes enqueue requests for KongPlugin objects based on KongRoute annotations.
-func (r *KongPluginReconciler) mapKongRoutes(ctx context.Context, obj client.Object) []ctrl.Request {
-	logger := log.GetLogger(ctx, "KongPlugin", r.developmentMode)
-	kongRoute, ok := obj.(*configurationv1alpha1.KongRoute)
-	if !ok {
-		log.Error(logger, errors.New("cannot cast object to KongRoute"), "KongRoute mapping handler", obj)
-		return []ctrl.Request{}
-	}
-
-	return mapObjectRequestsForItsPlugins(kongRoute)
 }
 
 // mapKongPluginBindings enqueue requests for KongPlugins referenced by KongPluginBindings in their .spec.pluginRef field.
@@ -55,21 +76,4 @@ func (r *KongPluginReconciler) mapKongPluginBindings(ctx context.Context, obj cl
 			},
 		},
 	}
-}
-
-func mapObjectRequestsForItsPlugins(obj client.Object) []ctrl.Request {
-	var (
-		namespace = obj.GetNamespace()
-		plugins   = annotations.ExtractPlugins(obj)
-		requests  = make([]ctrl.Request, 0, len(plugins))
-	)
-	for _, p := range plugins {
-		requests = append(requests, ctrl.Request{
-			NamespacedName: client.ObjectKey{
-				Namespace: namespace,
-				Name:      p,
-			},
-		})
-	}
-	return requests
 }

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -84,10 +84,10 @@ const (
 	KongServicePluginBindingFinalizerControllerName = "KongServicePluginBindingFinalizer"
 	// KongCredentialsSecretControllerName is the name of the Credentials Secret controller.
 	KongCredentialsSecretControllerName = "KongCredentialSecret"
-	// KongKongCredentialBasicAuthControllerName is the name of the KongCredentialBasicAuth controller.
-	KongKongCredentialBasicAuthControllerName = "KongCredentialBasicAuth" //nolint:gosec
-	// KongKongCredentialAPIKeyControllerName is the name of the KongCredentialAPIKey controller.
-	KongKongCredentialAPIKeyControllerName = "KongCredentialAPIKey" //nolint:gosec
+	// KongCredentialBasicAuthControllerName is the name of the KongCredentialBasicAuth controller.
+	KongCredentialBasicAuthControllerName = "KongCredentialBasicAuth" //nolint:gosec
+	// KongCredentialAPIKeyControllerName is the name of the KongCredentialAPIKey controller.
+	KongCredentialAPIKeyControllerName = "KongCredentialAPIKey" //nolint:gosec
 	// KongCACertificateControllerName is the name of the KongCACertificate controller.
 	KongCACertificateControllerName = "KongCACertificate"
 	// KongCertificateControllerName is the name of the KongCertificate controller.
@@ -436,7 +436,7 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongPluginBinding](c.KonnectSyncPeriod),
 				),
 			},
-			KongKongCredentialBasicAuthControllerName: {
+			KongCredentialBasicAuthControllerName: {
 				Enabled: c.KonnectControllersEnabled,
 				Controller: konnect.NewKonnectEntityReconciler(
 					sdkFactory,
@@ -445,7 +445,7 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialBasicAuth](c.KonnectSyncPeriod),
 				),
 			},
-			KongKongCredentialAPIKeyControllerName: {
+			KongCredentialAPIKeyControllerName: {
 				Enabled: c.KonnectControllersEnabled,
 				Controller: konnect.NewKonnectEntityReconciler(
 					sdkFactory,


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactors `mapKongRoutes` and `mapKongServices` into `mapPluginsFromAnnotation` which takes 1 of 4 supported types to have `konghq.com/plugins`  annotation set and enqueues plugins from that annotation.

This PR also removes stuttering from some of the var and const names.