### PR TITLE
chore(tests): disable KIC admission webhook for `TestKongPluginInstallationEssentials`

### DIFF
--- a/test/helpers/generators.go
+++ b/test/helpers/generators.go
@@ -65,9 +65,11 @@ func GenerateGateway(gatewayNSN types.NamespacedName, gatewayClass *gatewayv1.Ga
 	return gateway
 }
 
+type gatewayConfigurationOption func(*operatorv1beta1.GatewayConfiguration)
+
 // GenerateGatewayConfiguration generates a GatewayConfiguration to be used in tests
-func GenerateGatewayConfiguration(namespace string) *operatorv1beta1.GatewayConfiguration {
-	return &operatorv1beta1.GatewayConfiguration{
+func GenerateGatewayConfiguration(namespace string, opts ...gatewayConfigurationOption) *operatorv1beta1.GatewayConfiguration {
+	gwc := &operatorv1beta1.GatewayConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      uuid.NewString(),
@@ -138,6 +140,20 @@ func GenerateGatewayConfiguration(namespace string) *operatorv1beta1.GatewayConf
 				},
 			},
 		},
+	}
+	for _, opt := range opts {
+		opt(gwc)
+	}
+	return gwc
+}
+
+// WithWebhookDisabled disables the admission webhook for the control plane
+func WithWebhookDisabled() func(*operatorv1beta1.GatewayConfiguration) {
+	return func(gc *operatorv1beta1.GatewayConfiguration) {
+		gc.Spec.ControlPlaneOptions.Deployment.PodTemplateSpec.Spec.Containers[0].Env = append(gc.Spec.ControlPlaneOptions.Deployment.PodTemplateSpec.Spec.Containers[0].Env, corev1.EnvVar{
+			Name:  "CONTROLLER_ADMISSION_WEBHOOK_LISTEN",
+			Value: "off",
+		})
 	}
 }
 

--- a/test/helpers/generators.go
+++ b/test/helpers/generators.go
@@ -147,8 +147,8 @@ func GenerateGatewayConfiguration(namespace string, opts ...gatewayConfiguration
 	return gwc
 }
 
-// WithWebhookDisabled disables the admission webhook for the control plane
-func WithWebhookDisabled() func(*operatorv1beta1.GatewayConfiguration) {
+// WithControlPlaneWebhookDisabled disables the admission webhook for the control plane
+func WithControlPlaneWebhookDisabled() func(*operatorv1beta1.GatewayConfiguration) {
 	return func(gc *operatorv1beta1.GatewayConfiguration) {
 		gc.Spec.ControlPlaneOptions.Deployment.PodTemplateSpec.Spec.Containers[0].Env = append(gc.Spec.ControlPlaneOptions.Deployment.PodTemplateSpec.Spec.Containers[0].Env, corev1.EnvVar{
 			Name:  "CONTROLLER_ADMISSION_WEBHOOK_LISTEN",

--- a/test/integration/test_kongplugininstallation.go
+++ b/test/integration/test_kongplugininstallation.go
@@ -208,8 +208,8 @@ func deployGatewayWithKPI(
 	t *testing.T, cleaner *clusters.Cleaner, namespace string,
 ) (gatewayIPAddress string, gatewayConfigNN, httpRouteNN k8stypes.NamespacedName) {
 	// NOTE: Disable webhook for KIC, because it checks for the plugin in Kong Gateway and rejects,
-	// thus it requires strict order of deployment.
-	gatewayConfig := helpers.GenerateGatewayConfiguration(namespace, helpers.WithWebhookDisabled())
+	// thus it requires strict order of deployment which is not guaranteed.
+	gatewayConfig := helpers.GenerateGatewayConfiguration(namespace, helpers.WithControlPlaneWebhookDisabled())
 	t.Logf("deploying GatewayConfiguration %s/%s", gatewayConfig.Namespace, gatewayConfig.Name)
 	gatewayConfig, err := GetClients().OperatorClient.ApisV1beta1().GatewayConfigurations(namespace).Create(GetCtx(), gatewayConfig, metav1.CreateOptions{})
 	require.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Flakiness of `TestKongPluginInstallationEssentials` has been observed, e.g. [here](https://github.com/Kong/gateway-operator/actions/runs/11049041892/job/30693756663#step:5:559) and [here](https://github.com/Kong/gateway-operator/actions/runs/11049419786/job/30694931382?pr=651#step:5:446). It's due to how our webhook in KIC tries to reject as soon as possible that leads to requirement of strict ordering.

**Which issue this PR fixes**

Followup for https://github.com/Kong/gateway-operator/issues/380

**Special notes for your reviewer**:

Remediation from the original PR with disabling a webhook was incorrect because it took into account only the webhook of KGO which in this case is irrelevant. 
