### PR TITLE
refactor(konnect): add generic watch func for objects referring directly to KonnectGatewayControlPlane

### DIFF
--- a/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
+++ b/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
@@ -207,7 +207,7 @@ func (r *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]) setControllerBu
 		b.
 			For(&configurationv1alpha1.KongService{},
 				builder.WithPredicates(
-					predicate.NewPredicateFuncs(kongServiceRefersToKonnectGatewayControlPlane),
+					predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1alpha1.KongService]),
 					kongPluginsAnnotationChangedPredicate,
 				),
 			).

--- a/controller/konnect/watch_kongkey.go
+++ b/controller/konnect/watch_kongkey.go
@@ -3,7 +3,6 @@ package konnect
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -14,7 +13,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	operatorerrors "github.com/kong/gateway-operator/internal/errors"
 	"github.com/kong/gateway-operator/modules/manager/logging"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
@@ -27,7 +25,7 @@ func KongKeyReconciliationWatchOptions(cl client.Client) []func(*ctrl.Builder) *
 		func(b *ctrl.Builder) *ctrl.Builder {
 			return b.For(&configurationv1alpha1.KongKey{},
 				builder.WithPredicates(
-					predicate.NewPredicateFuncs(kongKeyRefersToKonnectControlPlane),
+					predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1alpha1.KongKey]),
 				),
 			)
 		},
@@ -48,20 +46,6 @@ func KongKeyReconciliationWatchOptions(cl client.Client) []func(*ctrl.Builder) *
 			)
 		},
 	}
-}
-
-func kongKeyRefersToKonnectControlPlane(obj client.Object) bool {
-	kongKey, ok := obj.(*configurationv1alpha1.KongKey)
-	if !ok {
-		ctrllog.FromContext(context.Background()).Error(
-			operatorerrors.ErrUnexpectedObject,
-			"failed to run predicate function",
-			"expected", "KongKey", "found", reflect.TypeOf(obj),
-		)
-		return false
-	}
-	return kongKey.Spec.ControlPlaneRef != nil &&
-		kongKey.Spec.ControlPlaneRef.Type == configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef
 }
 
 func enqueueKongKeyForKonnectAPIAuthConfiguration(cl client.Client) handler.MapFunc {

--- a/controller/konnect/watch_kongpluginbinding.go
+++ b/controller/konnect/watch_kongpluginbinding.go
@@ -3,7 +3,6 @@ package konnect
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/types"
@@ -15,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	operatorerrors "github.com/kong/gateway-operator/internal/errors"
 	"github.com/kong/gateway-operator/modules/manager/logging"
 
 	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
@@ -45,7 +43,7 @@ func KongPluginBindingReconciliationWatchOptions(
 		func(b *ctrl.Builder) *ctrl.Builder {
 			return b.For(&configurationv1alpha1.KongPluginBinding{},
 				builder.WithPredicates(
-					predicate.NewPredicateFuncs(kongPluginBindingRefersToKonnectGatewayControlPlane),
+					predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1alpha1.KongPluginBinding]),
 				),
 			)
 		},
@@ -106,27 +104,6 @@ func KongPluginBindingReconciliationWatchOptions(
 			)
 		},
 	}
-}
-
-// -----------------------------------------------------------------------------
-// KongPluginBinding reconciler - Watch Predicates
-// -----------------------------------------------------------------------------
-
-// kongPluginBindingRefersToKonnectGatewayControlPlane returns true if the KongPluginBinding
-// refers to a KonnectGatewayControlPlane.
-func kongPluginBindingRefersToKonnectGatewayControlPlane(obj client.Object) bool {
-	kongPB, ok := obj.(*configurationv1alpha1.KongPluginBinding)
-	if !ok {
-		ctrllog.FromContext(context.Background()).Error(
-			operatorerrors.ErrUnexpectedObject,
-			"failed to run predicate function",
-			"expected", "KongPluginBinding", "found", reflect.TypeOf(obj),
-		)
-		return false
-	}
-
-	cpRef := kongPB.Spec.ControlPlaneRef
-	return cpRef != nil && cpRef.Type == configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef
 }
 
 // -----------------------------------------------------------------------------

--- a/controller/konnect/watch_kongvault.go
+++ b/controller/konnect/watch_kongvault.go
@@ -3,7 +3,6 @@ package konnect
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -14,7 +13,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	operatorerrors "github.com/kong/gateway-operator/internal/errors"
 	"github.com/kong/gateway-operator/modules/manager/logging"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
@@ -27,7 +25,7 @@ func KongVaultReconciliationWatchOptions(cl client.Client) []func(*ctrl.Builder)
 		func(b *ctrl.Builder) *ctrl.Builder {
 			return b.For(&configurationv1alpha1.KongVault{},
 				builder.WithPredicates(
-					predicate.NewPredicateFuncs(kongVaultRefersToKonnectGatewayControlPlane()),
+					predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1alpha1.KongVault]),
 				),
 			)
 		},
@@ -47,23 +45,6 @@ func KongVaultReconciliationWatchOptions(cl client.Client) []func(*ctrl.Builder)
 				),
 			)
 		},
-	}
-}
-
-func kongVaultRefersToKonnectGatewayControlPlane() func(obj client.Object) bool {
-	return func(obj client.Object) bool {
-		kongVault, ok := obj.(*configurationv1alpha1.KongVault)
-		if !ok {
-			ctrllog.FromContext(context.Background()).Error(
-				operatorerrors.ErrUnexpectedObject,
-				"failed to run predicate function",
-				"expected", "KongVault", "found", reflect.TypeOf(obj),
-			)
-			return false
-		}
-
-		cpRef := kongVault.Spec.ControlPlaneRef
-		return cpRef != nil && cpRef.Type == configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef
 	}
 }
 
@@ -197,6 +178,5 @@ func enqueueKongVaultForKonnectGatewayControlPlane(
 
 		}
 		return ret
-
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Rewrite `kong*RefersToKonnectControlPlane` into generic `objRefersToKonnectGatewayControlPlane` that does the same thing.