### PR TITLE
fix(konnect): do not create Service+Route combinations for `konghq.com/plugins` annotated entities

### DIFF
--- a/controller/konnect/reconciler_kongplugin_combinations_test.go
+++ b/controller/konnect/reconciler_kongplugin_combinations_test.go
@@ -133,7 +133,9 @@ func TestGetCombinations(t *testing.T) {
 			},
 			want: []Rel{
 				{
-					Route:   "r1",
+					Route: "r1",
+				},
+				{
 					Service: "s1",
 				},
 			},
@@ -217,8 +219,39 @@ func TestGetCombinations(t *testing.T) {
 				{
 					Consumer: "c1",
 					Route:    "r1",
+				},
+				{
+					Consumer: "c1",
 					Service:  "s1",
 				},
+			},
+		},
+		{
+			name: "plugins on combination of service and consumers",
+			args: args{
+				relations: ForeignRelations{
+					Service: []configurationv1alpha1.KongService{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "s1",
+							},
+						},
+					},
+					Consumer: []string{"c1", "c2"},
+				},
+			},
+			want: []Rel{
+				{
+					Consumer: "c1",
+					Service:  "s1",
+				},
+				{
+					Consumer: "c2",
+					Service:  "s1",
+				},
+				// {
+				// 	Service: "s1",
+				// },
 			},
 		},
 		{
@@ -254,11 +287,17 @@ func TestGetCombinations(t *testing.T) {
 				{
 					Consumer: "c1",
 					Route:    "r1",
+				},
+				{
+					Consumer: "c1",
 					Service:  "s1",
 				},
 				{
 					Consumer: "c2",
 					Route:    "r1",
+				},
+				{
+					Consumer: "c2",
 					Service:  "s1",
 				},
 			},

--- a/controller/konnect/reconciler_kongplugin_combinations_test.go
+++ b/controller/konnect/reconciler_kongplugin_combinations_test.go
@@ -159,6 +159,13 @@ func TestGetCombinations(t *testing.T) {
 					Consumer: "c1",
 					Service:  "s1",
 				},
+				// NOTE: https://github.com/Kong/gateway-operator/issues/660
+				// is related to the following combination not being present.
+				// Currently we do not generate combination for Service only
+				// when Service **and** Consumers have the annotation present.
+				// {
+				// 	Service: "s1",
+				// },
 			},
 		},
 		{
@@ -184,6 +191,45 @@ func TestGetCombinations(t *testing.T) {
 					Consumer: "c2",
 					Service:  "s1",
 				},
+				// NOTE: https://github.com/Kong/gateway-operator/issues/660
+				// is related to the following combination not being present.
+				// Currently we do not generate combination for Service only
+				// when Service **and** Consumers have the annotation present.
+				// {
+				// 	Service: "s1",
+				// },
+			},
+		},
+		{
+			name: "plugins on combination of service and consumer groups",
+			args: args{
+				relations: ForeignRelations{
+					Service: []configurationv1alpha1.KongService{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "s1",
+							},
+						},
+					},
+					ConsumerGroup: []string{"cg1", "cg2"},
+				},
+			},
+			want: []Rel{
+				{
+					ConsumerGroup: "cg1",
+					Service:       "s1",
+				},
+				{
+					ConsumerGroup: "cg2",
+					Service:       "s1",
+				},
+				// NOTE: https://github.com/Kong/gateway-operator/issues/660
+				// is related to the following combination not being present.
+				// Currently we do not generate combination for Service only
+				// when Service **and** ConsumerGroups have the annotation present.
+				// {
+				// 	Service: "s1",
+				// },
 			},
 		},
 		{
@@ -224,34 +270,6 @@ func TestGetCombinations(t *testing.T) {
 					Consumer: "c1",
 					Service:  "s1",
 				},
-			},
-		},
-		{
-			name: "plugins on combination of service and consumers",
-			args: args{
-				relations: ForeignRelations{
-					Service: []configurationv1alpha1.KongService{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: "s1",
-							},
-						},
-					},
-					Consumer: []string{"c1", "c2"},
-				},
-			},
-			want: []Rel{
-				{
-					Consumer: "c1",
-					Service:  "s1",
-				},
-				{
-					Consumer: "c2",
-					Service:  "s1",
-				},
-				// {
-				// 	Service: "s1",
-				// },
 			},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/Kong/gateway-operator/pull/644 introduced creation of `KongPluginBinding`s based on `konghq.com/plugins` annotations on entities that can have plugins bound (for this specific PR Services and Routes have received support).

In order to do so, the operator needs to generate combinations of objects that should be set as targets of a plugin.

This in the operator is achieved using [`KongPluginBinding`](https://github.com/Kong/kubernetes-configuration/blob/4528505584d6b021e9a4f5b6b42b949a8c3e8845/api/configuration/v1alpha1/kongpluginbinding_types.go).

If a plugin annotation is set on a KongRoute r1 and KongService s1 operator has 3 options to create the binding:

1. Create 2 bindings: 1 binding for `KongRoute` and 1 for `KongService`
1. Create 2 bindings: 1 binding for `KongRoute` and `KongService`, and 1 for `KongService`
1. Create 1 binding: for `KongRoute` and `KongService`

[KIC uses the 1st approach](https://github.com/Kong/kubernetes-ingress-controller/blob/ee797b4e84bd176526af32ab6db54f16ee9c245b/internal/util/relations.go) backed by a UT in [here](https://github.com/Kong/kubernetes-ingress-controller/blob/ee797b4e84bd176526af32ab6db54f16ee9c245b/internal/util/relations_test.go#L89-L111).

This PR changes the behavior that has been introduced by https://github.com/Kong/gateway-operator/pull/644 from 3 to 1 ( to align with KIC ).

Further discussion on this topic can take place in #660
