### PR TITLE
chore: use IsZero() for ctr.Result to make check

### DIFF
--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -229,7 +229,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			log.Debug(logger, "unable to update ControlPlane resource", cp, "error", err)
 			return res, err
 		}
-		if res.Requeue {
+		if !res.IsZero() {
 			log.Debug(logger, "unable to update ControlPlane resource", cp)
 			return res, nil
 		}
@@ -383,7 +383,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				log.Debug(logger, "unable to reconcile ControlPlane status", cp, "error", err)
 				return ctrl.Result{}, err
 			}
-			if res.Requeue {
+			if !res.IsZero() {
 				log.Debug(logger, "unable to update ControlPlane resource", cp)
 				return res, nil
 			}
@@ -406,7 +406,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			log.Debug(logger, "unable to patch ControlPlane status", cp, "error", err)
 			return ctrl.Result{}, err
 		}
-		if res.Requeue {
+		if !res.IsZero() {
 			log.Debug(logger, "unable to patch ControlPlane status", cp)
 			return res, nil
 		}
@@ -421,7 +421,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		log.Debug(logger, "unable to patch ControlPlane status", cp, "error", err)
 		return ctrl.Result{}, err
 	}
-	if result.Requeue {
+	if !result.IsZero() {
 		log.Debug(logger, "unable to patch ControlPlane status", cp)
 		return result, nil
 	}

--- a/controller/dataplane/bluegreen_controller.go
+++ b/controller/dataplane/bluegreen_controller.go
@@ -106,7 +106,7 @@ func (r *BlueGreenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	if res, err := r.ensureDataPlaneLiveReadyStatus(ctx, logger, &dataplane); err != nil {
 		return ctrl.Result{}, err
-	} else if res.Requeue {
+	} else if !res.IsZero() {
 		return res, nil
 	}
 
@@ -120,7 +120,7 @@ func (r *BlueGreenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// can update the Ready status condition of the DataPlane.
 		if res, err := ensureDataPlaneReadyStatus(ctx, r.Client, logger, &dataplane, dataplane.Generation); err != nil {
 			return ctrl.Result{}, err
-		} else if res.Requeue {
+		} else if !res.IsZero() {
 			return res, nil
 		}
 	} else if !ok || c.ObservedGeneration != dataplane.Generation {

--- a/controller/dataplane/controller.go
+++ b/controller/dataplane/controller.go
@@ -222,7 +222,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	if res, err := ensureDataPlaneReadyStatus(ctx, r.Client, logger, dataplane, dataplane.Generation); err != nil {
 		return ctrl.Result{}, err
-	} else if res.Requeue {
+	} else if !res.IsZero() {
 		return res, nil
 	}
 

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -113,7 +113,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	log.Trace(logger, "managing cleanup for gateway resource", gateway)
-	if shouldReturnEarly, result, err := r.cleanup(ctx, logger, &gateway); err != nil || result.Requeue {
+	if shouldReturnEarly, result, err := r.cleanup(ctx, logger, &gateway); err != nil || !result.IsZero() {
 		return result, err
 	} else if shouldReturnEarly {
 		return ctrl.Result{}, nil
@@ -130,7 +130,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			if err != nil {
 				return res, fmt.Errorf("failed updating Gateway's finalizers: %w", err)
 			}
-			if res.Requeue {
+			if !res.IsZero() {
 				return res, nil
 			}
 		}

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -132,7 +132,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 
 	// If a type has a ControlPlane ref, handle it.
 	res, err := handleControlPlaneRef(ctx, r.Client, ent)
-	if err != nil || res.Requeue {
+	if err != nil || !res.IsZero() {
 		// If the referenced ControlPlane is not found and the object is deleted,
 		// remove the finalizer and update the status.
 		// There's no need to remove the entity on Konnect because the ControlPlane
@@ -167,7 +167,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 			}
 			return ctrl.Result{}, nil
 		}
-	} else if res.Requeue {
+	} else if !res.IsZero() {
 		return res, nil
 	}
 	// If a type has a KongConsumer ref, handle it.
@@ -207,7 +207,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		}
 
 		return ctrl.Result{}, err
-	} else if res.Requeue {
+	} else if !res.IsZero() {
 		return res, nil
 	}
 
@@ -246,7 +246,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		}
 
 		return ctrl.Result{}, err
-	} else if res.Requeue {
+	} else if !res.IsZero() {
 		return res, nil
 	}
 
@@ -264,7 +264,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 				metav1.ConditionFalse,
 				conditions.KonnectEntityAPIAuthConfigurationResolvedRefReasonRefNotFound,
 				fmt.Sprintf("Referenced KonnectAPIAuthConfiguration %s not found", apiAuthRef),
-			); err != nil || res.Requeue {
+			); err != nil || !res.IsZero() {
 				return ctrl.Result{}, err
 			}
 
@@ -277,7 +277,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 			metav1.ConditionFalse,
 			conditions.KonnectEntityAPIAuthConfigurationResolvedRefReasonRefInvalid,
 			fmt.Sprintf("KonnectAPIAuthConfiguration reference %s is invalid: %v", apiAuthRef, err),
-		); err != nil || res.Requeue {
+		); err != nil || !res.IsZero() {
 			return ctrl.Result{}, err
 		}
 
@@ -295,7 +295,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 			metav1.ConditionTrue,
 			conditions.KonnectEntityAPIAuthConfigurationResolvedRefReasonResolvedRef,
 			fmt.Sprintf("KonnectAPIAuthConfiguration reference %s is resolved", apiAuthRef),
-		); err != nil || res.Requeue {
+		); err != nil || !res.IsZero() {
 			return res, err
 		}
 		return ctrl.Result{}, nil
@@ -314,7 +314,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 			metav1.ConditionFalse,
 			conditions.KonnectEntityAPIAuthConfigurationReasonInvalid,
 			conditionMessageReferenceKonnectAPIAuthConfigurationInvalid(apiAuthRef),
-		); err != nil || res.Requeue {
+		); err != nil || !res.IsZero() {
 			return res, err
 		}
 
@@ -336,7 +336,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 			metav1.ConditionTrue,
 			conditions.KonnectEntityAPIAuthConfigurationReasonValid,
 			conditionMessageReferenceKonnectAPIAuthConfigurationValid(apiAuthRef),
-		); err != nil || res.Requeue {
+		); err != nil || !res.IsZero() {
 			return res, err
 		}
 		return ctrl.Result{}, nil
@@ -350,7 +350,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 			metav1.ConditionFalse,
 			conditions.KonnectEntityAPIAuthConfigurationReasonInvalid,
 			err.Error(),
-		); errStatus != nil || res.Requeue {
+		); errStatus != nil || !res.IsZero() {
 			return res, errStatus
 		}
 		return ctrl.Result{}, err
@@ -385,7 +385,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 					metav1.ConditionFalse,
 					conditions.KonnectEntityProgrammedReasonKonnectAPIOpFailed,
 					err.Error(),
-				); errStatus != nil || res.Requeue {
+				); errStatus != nil || !res.IsZero() {
 					return res, errStatus
 				}
 				return ctrl.Result{}, err
@@ -451,7 +451,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 
 	if res, err := ops.Update[T, TEnt](ctx, sdk, r.SyncPeriod, r.Client, ent); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update object: %w", err)
-	} else if res.Requeue || res.RequeueAfter > 0 {
+	} else if !res.IsZero() {
 		return res, nil
 	}
 
@@ -707,7 +707,7 @@ func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constra
 				metav1.ConditionFalse,
 				conditions.KongServiceRefReasonInvalid,
 				err.Error(),
-			); errStatus != nil || res.Requeue {
+			); errStatus != nil || !res.IsZero() {
 				return res, errStatus
 			}
 
@@ -731,7 +731,7 @@ func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constra
 				metav1.ConditionFalse,
 				conditions.KongServiceRefReasonInvalid,
 				fmt.Sprintf("Referenced KongService %s is not programmed yet", nn),
-			); err != nil || res.Requeue {
+			); err != nil || !res.IsZero() {
 				return ctrl.Result{}, err
 			}
 			return ctrl.Result{Requeue: true}, nil
@@ -764,7 +764,7 @@ func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constra
 			metav1.ConditionTrue,
 			conditions.KongServiceRefReasonValid,
 			fmt.Sprintf("Referenced KongService %s programmed", nn),
-		); errStatus != nil || res.Requeue {
+		); errStatus != nil || !res.IsZero() {
 			return res, errStatus
 		}
 
@@ -783,7 +783,7 @@ func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constra
 				metav1.ConditionFalse,
 				conditions.ControlPlaneRefReasonInvalid,
 				err.Error(),
-			); errStatus != nil || res.Requeue {
+			); errStatus != nil || !res.IsZero() {
 				return res, errStatus
 			}
 			if k8serrors.IsNotFound(err) {
@@ -803,7 +803,7 @@ func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constra
 				metav1.ConditionFalse,
 				conditions.ControlPlaneRefReasonInvalid,
 				fmt.Sprintf("Referenced ControlPlane %s is not programmed yet", nn),
-			); errStatus != nil || res.Requeue {
+			); errStatus != nil || !res.IsZero() {
 				return res, errStatus
 			}
 
@@ -823,7 +823,7 @@ func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constra
 			metav1.ConditionTrue,
 			conditions.ControlPlaneRefReasonValid,
 			fmt.Sprintf("Referenced ControlPlane %s is programmed", nn),
-		); errStatus != nil || res.Requeue {
+		); errStatus != nil || !res.IsZero() {
 			return res, errStatus
 		}
 
@@ -859,7 +859,7 @@ func handleKongConsumerRef[T constraints.SupportedKonnectEntityType, TEnt constr
 			metav1.ConditionFalse,
 			conditions.KongConsumerRefReasonInvalid,
 			err.Error(),
-		); errStatus != nil || res.Requeue {
+		); errStatus != nil || !res.IsZero() {
 			return res, errStatus
 		}
 
@@ -887,7 +887,7 @@ func handleKongConsumerRef[T constraints.SupportedKonnectEntityType, TEnt constr
 			metav1.ConditionFalse,
 			conditions.KongConsumerRefReasonInvalid,
 			fmt.Sprintf("Referenced KongConsumer %s is not programmed yet", nn),
-		); err != nil || res.Requeue {
+		); err != nil || !res.IsZero() {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{Requeue: true}, nil
@@ -926,7 +926,7 @@ func handleKongConsumerRef[T constraints.SupportedKonnectEntityType, TEnt constr
 		metav1.ConditionTrue,
 		conditions.KongConsumerRefReasonValid,
 		fmt.Sprintf("Referenced KongConsumer %s programmed", nn),
-	); errStatus != nil || res.Requeue {
+	); errStatus != nil || !res.IsZero() {
 		return res, errStatus
 	}
 
@@ -945,7 +945,7 @@ func handleKongConsumerRef[T constraints.SupportedKonnectEntityType, TEnt constr
 			metav1.ConditionFalse,
 			conditions.ControlPlaneRefReasonInvalid,
 			err.Error(),
-		); errStatus != nil || res.Requeue {
+		); errStatus != nil || !res.IsZero() {
 			return res, errStatus
 		}
 		if k8serrors.IsNotFound(err) {
@@ -965,7 +965,7 @@ func handleKongConsumerRef[T constraints.SupportedKonnectEntityType, TEnt constr
 			metav1.ConditionFalse,
 			conditions.ControlPlaneRefReasonInvalid,
 			fmt.Sprintf("Referenced ControlPlane %s is not programmed yet", nn),
-		); errStatus != nil || res.Requeue {
+		); errStatus != nil || !res.IsZero() {
 			return res, errStatus
 		}
 
@@ -982,7 +982,7 @@ func handleKongConsumerRef[T constraints.SupportedKonnectEntityType, TEnt constr
 		metav1.ConditionTrue,
 		conditions.ControlPlaneRefReasonValid,
 		fmt.Sprintf("Referenced ControlPlane %s is programmed", nn),
-	); errStatus != nil || res.Requeue {
+	); errStatus != nil || !res.IsZero() {
 		return res, errStatus
 	}
 
@@ -1080,7 +1080,7 @@ func handleControlPlaneRef[T constraints.SupportedKonnectEntityType, TEnt constr
 				metav1.ConditionFalse,
 				conditions.ControlPlaneRefReasonInvalid,
 				err.Error(),
-			); errStatus != nil || res.Requeue {
+			); errStatus != nil || !res.IsZero() {
 				return res, errStatus
 			}
 			if k8serrors.IsNotFound(err) {
@@ -1100,7 +1100,7 @@ func handleControlPlaneRef[T constraints.SupportedKonnectEntityType, TEnt constr
 				metav1.ConditionFalse,
 				conditions.ControlPlaneRefReasonInvalid,
 				fmt.Sprintf("Referenced ControlPlane %s is not programmed yet", nn),
-			); errStatus != nil || res.Requeue {
+			); errStatus != nil || !res.IsZero() {
 				return res, errStatus
 			}
 
@@ -1137,7 +1137,7 @@ func handleControlPlaneRef[T constraints.SupportedKonnectEntityType, TEnt constr
 			metav1.ConditionTrue,
 			conditions.ControlPlaneRefReasonValid,
 			fmt.Sprintf("Referenced ControlPlane %s is programmed", nn),
-		); errStatus != nil || res.Requeue {
+		); errStatus != nil || !res.IsZero() {
 			return res, errStatus
 		}
 		return ctrl.Result{}, nil

--- a/controller/konnect/reconciler_konnectapiauth.go
+++ b/controller/konnect/reconciler_konnectapiauth.go
@@ -123,7 +123,7 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 			metav1.ConditionFalse,
 			conditions.KonnectEntityAPIAuthConfigurationReasonInvalid,
 			err.Error(),
-		); errStatus != nil || res.Requeue {
+		); errStatus != nil || !res.IsZero() {
 			return res, errStatus
 		}
 		return ctrl.Result{}, err
@@ -167,7 +167,7 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 				conditions.KonnectEntityAPIAuthConfigurationReasonInvalid,
 				err.Error(),
 			)
-			if errUpdate != nil || res.Requeue {
+			if errUpdate != nil || !res.IsZero() {
 				return res, errUpdate
 			}
 			return ctrl.Result{}, nil
@@ -205,7 +205,7 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 			conditions.KonnectEntityAPIAuthConfigurationReasonValid,
 			condMessage,
 		)
-		if err != nil || res.Requeue {
+		if err != nil || !res.IsZero() {
 			return res, err
 		}
 		return ctrl.Result{}, nil

--- a/controller/konnect/reconciler_upstreamref.go
+++ b/controller/konnect/reconciler_upstreamref.go
@@ -59,7 +59,7 @@ func handleKongUpstreamRef[T constraints.SupportedKonnectEntityType, TEnt constr
 			metav1.ConditionFalse,
 			conditions.KongUpstreamRefReasonInvalid,
 			err.Error(),
-		); errStatus != nil || res.Requeue {
+		); errStatus != nil || !res.IsZero() {
 			return res, errStatus
 		}
 
@@ -88,7 +88,7 @@ func handleKongUpstreamRef[T constraints.SupportedKonnectEntityType, TEnt constr
 			metav1.ConditionFalse,
 			conditions.KongUpstreamRefReasonInvalid,
 			fmt.Sprintf("Referenced KongUpstream %s is not programmed yet", nn),
-		); err != nil || res.Requeue {
+		); err != nil || !res.IsZero() {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{Requeue: true}, nil
@@ -120,7 +120,7 @@ func handleKongUpstreamRef[T constraints.SupportedKonnectEntityType, TEnt constr
 		metav1.ConditionTrue,
 		conditions.KongUpstreamRefReasonValid,
 		fmt.Sprintf("Referenced KongUpstream %s programmed", nn),
-	); errStatus != nil || res.Requeue {
+	); errStatus != nil || !res.IsZero() {
 		return res, errStatus
 	}
 
@@ -142,7 +142,7 @@ func handleKongUpstreamRef[T constraints.SupportedKonnectEntityType, TEnt constr
 			metav1.ConditionFalse,
 			conditions.ControlPlaneRefReasonInvalid,
 			err.Error(),
-		); errStatus != nil || res.Requeue {
+		); errStatus != nil || !res.IsZero() {
 			return res, errStatus
 		}
 		if k8serrors.IsNotFound(err) {
@@ -165,7 +165,7 @@ func handleKongUpstreamRef[T constraints.SupportedKonnectEntityType, TEnt constr
 			metav1.ConditionFalse,
 			conditions.ControlPlaneRefReasonInvalid,
 			fmt.Sprintf("Referenced ControlPlane %s is not programmed yet", nn),
-		); errStatus != nil || res.Requeue {
+		); errStatus != nil || !res.IsZero() {
 			return res, errStatus
 		}
 
@@ -182,7 +182,7 @@ func handleKongUpstreamRef[T constraints.SupportedKonnectEntityType, TEnt constr
 		metav1.ConditionTrue,
 		conditions.ControlPlaneRefReasonValid,
 		fmt.Sprintf("Referenced ControlPlane %s is programmed", nn),
-	); errStatus != nil || res.Requeue {
+	); errStatus != nil || !res.IsZero() {
 		return res, errStatus
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**

During the review of https://github.com/Kong/gateway-operator/pull/476 @pmalek mentioned that for `ctrl.Result` not only the field `Requeue` but also `RequeueAfter` indicates a need of requeue see https://github.com/Kong/gateway-operator/pull/476#discussion_r1771453386. This PR ensures that both fields are checked in all cases with a built-in method `IsZero()`. 

**Which issue this PR fixes**

Spotted during the review of PR for the issue https://github.com/Kong/gateway-operator/issues/380
