### PR TITLE
chore: introduce index for `DataPlane`s referencing `KongPluginInstallation`s

### DIFF
--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -199,8 +199,7 @@ func Run(
 		secretName:      cfg.ClusterCASecretName,
 		secretNamespace: cfg.ClusterCASecretNamespace,
 	}
-	err = mgr.Add(caMgr)
-	if err != nil {
+	if err = mgr.Add(caMgr); err != nil {
 		return fmt.Errorf("unable to start manager: %w", err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements what was mentioned in the comment https://github.com/Kong/gateway-operator/pull/476#discussion_r1771253595 during the review - index for `DataPlane`s that references `KongPluginInstallation`s to avoid fetching all of them and filtering in the code.

**Which issue this PR fixes**

Improvement for https://github.com/Kong/gateway-operator/issues/380

**Special notes for your reviewer**:

The code for indices for Konnect entities and other ones may one day be merged, but this is out of the scope of this PR. Only to make it similar in terms of what is logged has been addressed. Furthermore, log format seems a little redundant

```log
KongPluginBinding	creating index	{"entityTypeName": "KongPluginBinding", "indexObject": {"metadata":{"creationTimestamp":null},"spec":{"pluginRef":{"name":""},"targets":{}},"status":{}}, "indexField": "kongPluginRef"}
KongPluginBinding	creating index	{"entityTypeName": "KongPluginBinding", "indexObject": {"metadata":{"creationTimestamp":null},"spec":{"pluginRef":{"name":""},"targets":{}},"status":{}}, "indexField": "kongServiceRef"}
KongPluginBinding	creating index	{"entityTypeName": "KongPluginBinding", "indexObject": {"metadata":{"creationTimestamp":null},"spec":{"pluginRef":{"name":""},"targets":{}},"status":{}}, "indexField": "kongRouteRef"}
KongPluginBinding	creating index	{"entityTypeName": "KongPluginBinding", "indexObject": {"metadata":{"creationTimestamp":null},"spec":{"pluginRef":{"name":""},"targets":{}},"status":{}}, "indexField": "kongConsumerRef"}
```
Now it's like that
```log
2024-09-27T17:46:22+02:00	INFO	ControlPlane	creating index	{"indexField": "dataplane"}
2024-09-27T17:46:22+02:00	INFO	DataPlane	creating index	{"indexField": "KongPluginInstallations"}
2024-09-27T17:46:22+02:00	INFO	KongPluginBinding	creating index	{"indexField": "kongPluginRef"}
2024-09-27T17:46:22+02:00	INFO	KongPluginBinding	creating index	{"indexField": "kongServiceRef"}
2024-09-27T17:46:22+02:00	INFO	KongPluginBinding	creating index	{"indexField": "kongRouteRef"}
2024-09-27T17:46:22+02:00	INFO	KongPluginBinding	creating index	{"indexField": "kongConsumerRef"}
2024-09-27T17:46:22+02:00	INFO	KongPluginBinding	creating index	{"indexField": "kongConsumerGroupRef"}
```

