### PR TITLE
tests: fix flaky SDK assertion

### DIFF
--- a/test/envtest/kongpluginbinding_unmanaged_test.go
+++ b/test/envtest/kongpluginbinding_unmanaged_test.go
@@ -3,6 +3,7 @@ package envtest
 import (
 	"context"
 	"testing"
+	"time"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
@@ -100,6 +101,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			},
 			"KongPlugin wasn't updated to get the plugin-in-use finalizer",
 		)
+		kongPluginBindingGetKonnectIDAssignedEventually(t, ctx, clientNamespaced, kpb, pluginID, waitTime, tickTime)
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.True(c, sdk.PluginSDK.AssertExpectations(t))
 		}, waitTime, tickTime)
@@ -194,6 +196,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			},
 			"KongPlugin wasn't updated to get the plugin-in-use finalizer",
 		)
+		kongPluginBindingGetKonnectIDAssignedEventually(t, ctx, clientNamespaced, kpb, pluginID, waitTime, tickTime)
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.True(c, sdk.PluginSDK.AssertExpectations(t))
 		}, waitTime, tickTime)
@@ -295,6 +298,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			},
 			"KongPlugin wasn't updated to get the plugin-in-use finalizer",
 		)
+		kongPluginBindingGetKonnectIDAssignedEventually(t, ctx, clientNamespaced, kpb, pluginID, waitTime, tickTime)
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.True(c, sdk.PluginSDK.AssertExpectations(t))
 		}, waitTime, tickTime)
@@ -403,6 +407,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			},
 			"KongPlugin wasn't updated to get the plugin-in-use finalizer",
 		)
+		kongPluginBindingGetKonnectIDAssignedEventually(t, ctx, clientNamespaced, kpb, pluginID, waitTime, tickTime)
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.True(c, sdk.PluginSDK.AssertExpectations(t))
 		}, waitTime, tickTime)
@@ -505,6 +510,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			},
 			"KongPlugin wasn't updated to get the plugin-in-use finalizer",
 		)
+		kongPluginBindingGetKonnectIDAssignedEventually(t, ctx, clientNamespaced, kpb, pluginID, waitTime, tickTime)
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.True(c, sdk.PluginSDK.AssertExpectations(t))
 		}, waitTime, tickTime)
@@ -555,4 +561,24 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			assert.True(c, sdk.PluginSDK.AssertExpectations(t))
 		}, waitTime, tickTime)
 	})
+}
+
+func kongPluginBindingGetKonnectIDAssignedEventually(
+	t *testing.T,
+	ctx context.Context,
+	clientNamespaced client.Client,
+	kpb *configurationv1alpha1.KongPluginBinding,
+	pluginID string,
+	waitTime time.Duration,
+	tickTime time.Duration,
+) {
+	t.Helper()
+
+	t.Logf("wait for the KongPluginBinding %s to get Konnect ID assigned", client.ObjectKeyFromObject(kpb))
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		if !assert.NoError(c, clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb)) {
+			return
+		}
+		assert.True(c, kpb.GetKonnectStatus().GetKonnectID() == pluginID)
+	}, waitTime, tickTime)
 }

--- a/test/envtest/kongpluginbinding_unmanaged_test.go
+++ b/test/envtest/kongpluginbinding_unmanaged_test.go
@@ -569,8 +569,8 @@ func kongPluginBindingGetKonnectIDAssignedEventually(
 	clientNamespaced client.Client,
 	kpb *configurationv1alpha1.KongPluginBinding,
 	pluginID string,
-	waitTime time.Duration,
-	tickTime time.Duration,
+	waitTime time.Duration, //nolint:unparam
+	tickTime time.Duration, //nolint:unparam
 ) {
 	t.Helper()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR aims to fix the flakiness in plugin SDK assertions that appeared in https://github.com/Kong/gateway-operator/actions/runs/11097835652/job/30829655627?pr=667#step:5:373

```
  kongpluginbinding_unmanaged_test.go:104: FAIL:	CreatePlugin(string,string,string)
        		at: [/home/runner/work/gateway-operator/gateway-operator/controller/konnect/ops/plugin_mock.go:76 /home/runner/work/gateway-operator/gateway-operator/test/envtest/kongpluginbinding_unmanaged_test.go:68]
    kongpluginbinding_unmanaged_test.go:104: FAIL: 0 out of 1 expectation(s) were met.
        	The code you are testing needs to make 1 more call(s).
        	at: [/home/runner/work/gateway-operator/gateway-operator/test/envtest/kongpluginbinding_unmanaged_test.go:104 /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/runtime/asm_amd64.s:1695]
```

The idea behind the fix is to wait for the resource to have a Konnect ID assigned and only then check the plugin sdk assertions.
