### PR TITLE
refactor(konnect): add generic `objectListToReconcileRequests`

### DIFF
--- a/controller/konnect/watch.go
+++ b/controller/konnect/watch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -105,4 +106,28 @@ func controlPlaneIsRefKonnectNamespacedRef[
 		return configurationv1alpha1.ControlPlaneRef{}, false
 	}
 	return cpRef, cpRef.Type == configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef
+}
+
+// objectListToReconcileRequests converts a list of objects to a list of reconcile requests.
+func objectListToReconcileRequests[
+	T any,
+	TPtr interface {
+		*T
+		client.Object
+	},
+](
+	items []T,
+) []ctrl.Request {
+	ret := make([]ctrl.Request, 0, len(items))
+	for _, item := range items {
+		var e TPtr = &item
+		ret = append(ret, ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: e.GetNamespace(),
+				Name:      e.GetName(),
+			},
+		})
+	}
+
+	return ret
 }

--- a/controller/konnect/watch_credentialacl.go
+++ b/controller/konnect/watch_credentialacl.go
@@ -205,16 +205,6 @@ func kongCredentialACLForKongConsumer(
 			return nil
 		}
 
-		var ret []reconcile.Request
-		for _, cred := range l.Items {
-			ret = append(ret, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: cred.Namespace,
-					Name:      cred.Name,
-				},
-			},
-			)
-		}
-		return ret
+		return objectListToReconcileRequests(l.Items)
 	}
 }

--- a/controller/konnect/watch_credentialapikey.go
+++ b/controller/konnect/watch_credentialapikey.go
@@ -205,16 +205,6 @@ func kongCredentialAPIKeyForKongConsumer(
 			return nil
 		}
 
-		var ret []reconcile.Request
-		for _, cred := range l.Items {
-			ret = append(ret, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: cred.Namespace,
-					Name:      cred.Name,
-				},
-			},
-			)
-		}
-		return ret
+		return objectListToReconcileRequests(l.Items)
 	}
 }

--- a/controller/konnect/watch_credentialbasicauth.go
+++ b/controller/konnect/watch_credentialbasicauth.go
@@ -205,16 +205,6 @@ func kongCredentialBasicAuthForKongConsumer(
 			return nil
 		}
 
-		var ret []reconcile.Request
-		for _, cred := range l.Items {
-			ret = append(ret, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: cred.Namespace,
-					Name:      cred.Name,
-				},
-			},
-			)
-		}
-		return ret
+		return objectListToReconcileRequests(l.Items)
 	}
 }

--- a/controller/konnect/watch_credentialjwt.go
+++ b/controller/konnect/watch_credentialjwt.go
@@ -205,16 +205,6 @@ func kongCredentialJWTForKongConsumer(
 			return nil
 		}
 
-		var ret []reconcile.Request
-		for _, cred := range l.Items {
-			ret = append(ret, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: cred.Namespace,
-					Name:      cred.Name,
-				},
-			},
-			)
-		}
-		return ret
+		return objectListToReconcileRequests(l.Items)
 	}
 }

--- a/controller/konnect/watch_kongconsumer.go
+++ b/controller/konnect/watch_kongconsumer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -215,13 +214,7 @@ func enqueueKongConsumerForKongConsumerGroup(
 		}); err != nil {
 			return nil
 		}
-		return lo.Map(l.Items, func(consumer configurationv1.KongConsumer, _ int) reconcile.Request {
-			return reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: consumer.Namespace,
-					Name:      consumer.Name,
-				},
-			}
-		})
+
+		return objectListToReconcileRequests(l.Items)
 	}
 }

--- a/controller/konnect/watch_kongsni.go
+++ b/controller/konnect/watch_kongsni.go
@@ -55,7 +55,7 @@ func kongSNIRefersToKonnectGatewayControlPlane(
 			return true
 		}
 
-		return cert.Spec.ControlPlaneRef != nil && cert.Spec.ControlPlaneRef.Type == configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef
+		return objHasControlPlaneRefKonnectNamespacedRef(&cert)
 	}
 }
 
@@ -82,15 +82,6 @@ func enqueueKongSNIForKongCertificate(
 			return nil
 		}
 
-		ret := make([]reconcile.Request, 0, len(sniList.Items))
-		for _, sni := range sniList.Items {
-			ret = append(ret, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: sni.Namespace,
-					Name:      sni.Name,
-				},
-			})
-		}
-		return ret
+		return objectListToReconcileRequests(sniList.Items)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `objectListToReconcileRequests` which generically converts list of objects into `[]ctrl.Request`.