### PR TITLE
refactor(konnect): add indices for objects that reference `KonnectGatewayControlPlane`

### DIFF
--- a/controller/konnect/index.go
+++ b/controller/konnect/index.go
@@ -13,13 +13,13 @@ type ReconciliationIndexOption struct {
 	ExtractValue client.IndexerFunc
 }
 
-// controlPlaneKonnectNamespacedRefRefAsSlice returns a slice of strings representing
+// controlPlaneKonnectNamespacedRefAsSlice returns a slice of strings representing
 // the KonnectNamespacedRef of the object.
-func controlPlaneKonnectNamespacedRefRefAsSlice[
+func controlPlaneKonnectNamespacedRefAsSlice[
 	T constraints.SupportedKonnectEntityType,
 	TEnt constraints.EntityType[T],
 ](ent TEnt) []string {
-	cpRef, ok := controlPlaneIsRefKonnectNamespacedRef(ent)
+	cpRef, ok := controlPlaneRefIsKonnectNamespacedRef(ent)
 	if !ok {
 		return nil
 	}

--- a/controller/konnect/index.go
+++ b/controller/konnect/index.go
@@ -2,6 +2,8 @@ package konnect
 
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/gateway-operator/controller/konnect/constraints"
 )
 
 // ReconciliationIndexOption contains required options of index for a kind of object required for reconciliation.
@@ -9,4 +11,23 @@ type ReconciliationIndexOption struct {
 	IndexObject  client.Object
 	IndexField   string
 	ExtractValue client.IndexerFunc
+}
+
+// controlPlaneKonnectNamespacedRefRefAsSlice returns a slice of strings representing
+// the KonnectNamespacedRef of the object.
+func controlPlaneKonnectNamespacedRefRefAsSlice[
+	T constraints.SupportedKonnectEntityType,
+	TEnt constraints.EntityType[T],
+](ent TEnt) []string {
+	cpRef, ok := controlPlaneIsRefKonnectNamespacedRef(ent)
+	if !ok {
+		return nil
+	}
+
+	konnectRef := cpRef.KonnectNamespacedRef
+	if konnectRef == nil {
+		return nil
+	}
+
+	return []string{konnectRef.Namespace + "/" + konnectRef.Name}
 }

--- a/controller/konnect/index_kongconsumer.go
+++ b/controller/konnect/index_kongconsumer.go
@@ -60,5 +60,5 @@ func kongConsumerReferencesKonnectGatewayControlPlane(object client.Object) []st
 		return nil
 	}
 
-	return controlPlaneKonnectNamespacedRefRefAsSlice(consumer)
+	return controlPlaneKonnectNamespacedRefAsSlice(consumer)
 }

--- a/controller/konnect/index_kongconsumer.go
+++ b/controller/konnect/index_kongconsumer.go
@@ -13,6 +13,8 @@ const (
 	IndexFieldKongConsumerOnKongConsumerGroup = "consumerGroupRef"
 	// IndexFieldKongConsumerOnPlugin is the index field for KongConsumer -> KongPlugin.
 	IndexFieldKongConsumerOnPlugin = "consumerPluginRef"
+	// IndexFieldKongConsumerOnKonnectGatewayControlPlane is the index field for KongConsumer -> KonnectGatewayControlPlane.
+	IndexFieldKongConsumerOnKonnectGatewayControlPlane = "consumerKonnectGatewayControlPlaneRef"
 )
 
 // IndexOptionsForKongConsumer returns required Index options for KongConsumer reconciler.
@@ -27,6 +29,11 @@ func IndexOptionsForKongConsumer() []ReconciliationIndexOption {
 			IndexObject:  &configurationv1.KongConsumer{},
 			IndexField:   IndexFieldKongConsumerOnPlugin,
 			ExtractValue: kongConsumerReferencesKongPluginsViaAnnotation,
+		},
+		{
+			IndexObject:  &configurationv1.KongConsumer{},
+			IndexField:   IndexFieldKongConsumerOnKonnectGatewayControlPlane,
+			ExtractValue: kongConsumerReferencesKonnectGatewayControlPlane,
 		},
 	}
 }
@@ -45,4 +52,13 @@ func kongConsumerReferencesKongPluginsViaAnnotation(object client.Object) []stri
 		return nil
 	}
 	return annotations.ExtractPluginsWithNamespaces(consumer)
+}
+
+func kongConsumerReferencesKonnectGatewayControlPlane(object client.Object) []string {
+	consumer, ok := object.(*configurationv1.KongConsumer)
+	if !ok {
+		return nil
+	}
+
+	return controlPlaneKonnectNamespacedRefRefAsSlice(consumer)
 }

--- a/controller/konnect/index_kongservice.go
+++ b/controller/konnect/index_kongservice.go
@@ -46,5 +46,5 @@ func kongServiceReferencesKonnectGatewayControlPlane(object client.Object) []str
 		return nil
 	}
 
-	return controlPlaneKonnectNamespacedRefRefAsSlice(svc)
+	return controlPlaneKonnectNamespacedRefAsSlice(svc)
 }

--- a/controller/konnect/index_kongservice.go
+++ b/controller/konnect/index_kongservice.go
@@ -11,6 +11,8 @@ import (
 const (
 	// IndexFieldKongServiceOnReferencedPluginNames is the index field for KongService -> KongPlugin.
 	IndexFieldKongServiceOnReferencedPluginNames = "kongServiceKongPluginRef"
+	// IndexFieldKongServiceOnKonnectGatewayControlPlane is the index field for KongService -> KonnectGatewayControlPlane.
+	IndexFieldKongServiceOnKonnectGatewayControlPlane = "kongServiceKonnectGatewayControlPlaneRef"
 )
 
 // IndexOptionsForKongService returns required Index options for KongService reconciler.
@@ -20,6 +22,11 @@ func IndexOptionsForKongService() []ReconciliationIndexOption {
 			IndexObject:  &configurationv1alpha1.KongService{},
 			IndexField:   IndexFieldKongServiceOnReferencedPluginNames,
 			ExtractValue: kongServiceUsesPlugins,
+		},
+		{
+			IndexObject:  &configurationv1alpha1.KongService{},
+			IndexField:   IndexFieldKongServiceOnKonnectGatewayControlPlane,
+			ExtractValue: kongServiceReferencesKonnectGatewayControlPlane,
 		},
 	}
 }
@@ -31,4 +38,13 @@ func kongServiceUsesPlugins(object client.Object) []string {
 	}
 
 	return annotations.ExtractPluginsWithNamespaces(svc)
+}
+
+func kongServiceReferencesKonnectGatewayControlPlane(object client.Object) []string {
+	svc, ok := object.(*configurationv1alpha1.KongService)
+	if !ok {
+		return nil
+	}
+
+	return controlPlaneKonnectNamespacedRefRefAsSlice(svc)
 }

--- a/controller/konnect/index_kongtarget.go
+++ b/controller/konnect/index_kongtarget.go
@@ -1,0 +1,32 @@
+package konnect
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+)
+
+const (
+	// IndexFieldKongTargetOnReferencedUpstream is the index field for KongTarget -> KongUpstream.
+	IndexFieldKongTargetOnReferencedUpstream = "kongTargetUpstreamRef"
+)
+
+// IndexOptionsForKongTarget returns required Index options for KongTarget reconciler.
+func IndexOptionsForKongTarget() []ReconciliationIndexOption {
+	return []ReconciliationIndexOption{
+		{
+			IndexObject:  &configurationv1alpha1.KongTarget{},
+			IndexField:   IndexFieldKongTargetOnReferencedUpstream,
+			ExtractValue: kongTargetReferencesKongUpstream,
+		},
+	}
+}
+
+func kongTargetReferencesKongUpstream(object client.Object) []string {
+	target, ok := object.(*configurationv1alpha1.KongTarget)
+	if !ok {
+		return nil
+	}
+
+	return []string{target.Spec.UpstreamRef.Name}
+}

--- a/controller/konnect/index_kongupstream.go
+++ b/controller/konnect/index_kongupstream.go
@@ -1,0 +1,32 @@
+package konnect
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+)
+
+const (
+	// IndexFieldKongUpstreamOnKonnectGatewayControlPlane is the index field for KongUpstream -> KonnectGatewayControlPlane.
+	IndexFieldKongUpstreamOnKonnectGatewayControlPlane = "kongUpstreamKonnectGatewayControlPlaneRef"
+)
+
+// IndexOptionsForKongUpstream returns required Index options for KongUpstream reconciler.
+func IndexOptionsForKongUpstream() []ReconciliationIndexOption {
+	return []ReconciliationIndexOption{
+		{
+			IndexObject:  &configurationv1alpha1.KongUpstream{},
+			IndexField:   IndexFieldKongUpstreamOnKonnectGatewayControlPlane,
+			ExtractValue: kongUpstreamReferencesKonnectGatewayControlPlane,
+		},
+	}
+}
+
+func kongUpstreamReferencesKonnectGatewayControlPlane(object client.Object) []string {
+	upstream, ok := object.(*configurationv1alpha1.KongUpstream)
+	if !ok {
+		return nil
+	}
+
+	return controlPlaneKonnectNamespacedRefRefAsSlice(upstream)
+}

--- a/controller/konnect/index_kongupstream.go
+++ b/controller/konnect/index_kongupstream.go
@@ -28,5 +28,5 @@ func kongUpstreamReferencesKonnectGatewayControlPlane(object client.Object) []st
 		return nil
 	}
 
-	return controlPlaneKonnectNamespacedRefRefAsSlice(upstream)
+	return controlPlaneKonnectNamespacedRefAsSlice(upstream)
 }

--- a/controller/konnect/reconciler_kongplugin.go
+++ b/controller/konnect/reconciler_kongplugin.go
@@ -338,7 +338,7 @@ func deleteUnusedKongPluginBindings(
 			continue
 		}
 
-		cpRef, ok := controlPlaneIsRefKonnectNamespacedRef(&pb)
+		cpRef, ok := controlPlaneRefIsKonnectNamespacedRef(&pb)
 		if !ok {
 			continue
 		}

--- a/controller/konnect/reconciler_kongplugin_combinations.go
+++ b/controller/konnect/reconciler_kongplugin_combinations.go
@@ -39,7 +39,7 @@ func (relations *ForeignRelations) GroupByControlPlane(
 ) (ForeignRelationsGroupedByControlPlane, error) {
 	ret := make(map[types.NamespacedName]ForeignRelations)
 	for _, service := range relations.Service {
-		cpRef, ok := controlPlaneIsRefKonnectNamespacedRef(&service)
+		cpRef, ok := controlPlaneRefIsKonnectNamespacedRef(&service)
 		if !ok {
 			continue
 		}
@@ -69,7 +69,7 @@ func (relations *ForeignRelations) GroupByControlPlane(
 			return nil, err
 		}
 
-		cpRef, ok := controlPlaneIsRefKonnectNamespacedRef(&svc)
+		cpRef, ok := controlPlaneRefIsKonnectNamespacedRef(&svc)
 		if !ok {
 			continue
 		}
@@ -84,7 +84,7 @@ func (relations *ForeignRelations) GroupByControlPlane(
 		ret[nn] = fr
 	}
 	for _, consumer := range relations.Consumer {
-		cpRef, ok := controlPlaneIsRefKonnectNamespacedRef(&consumer)
+		cpRef, ok := controlPlaneRefIsKonnectNamespacedRef(&consumer)
 		if !ok {
 			continue
 		}

--- a/controller/konnect/watch.go
+++ b/controller/konnect/watch.go
@@ -93,11 +93,14 @@ func objHasControlPlaneRefKonnectNamespacedRef[
 	T constraints.SupportedKonnectEntityType,
 	TEnt constraints.EntityType[T],
 ](ent TEnt) bool {
-	_, ok := controlPlaneIsRefKonnectNamespacedRef(ent)
+	_, ok := controlPlaneRefIsKonnectNamespacedRef(ent)
 	return ok
 }
 
-func controlPlaneIsRefKonnectNamespacedRef[
+// controlPlaneRefIsKonnectNamespacedRef returns:
+// - the ControlPlane KonnectNamespacedRef of the object if it is a KonnectNamespacedRef.
+// - a boolean indicating if the object has a KonnectNamespacedRef.
+func controlPlaneRefIsKonnectNamespacedRef[
 	T constraints.SupportedKonnectEntityType,
 	TEnt constraints.EntityType[T],
 ](ent TEnt) (configurationv1alpha1.ControlPlaneRef, bool) {

--- a/controller/konnect/watch_kongservice.go
+++ b/controller/konnect/watch_kongservice.go
@@ -143,48 +143,16 @@ func enqueueKongServiceForKonnectGatewayControlPlane(
 			return nil
 		}
 		var l configurationv1alpha1.KongServiceList
-		if err := cl.List(ctx, &l, &client.ListOptions{
+		if err := cl.List(ctx, &l,
 			// TODO: change this when cross namespace refs are allowed.
-			Namespace: cp.GetNamespace(),
-		}); err != nil {
+			client.InNamespace(cp.GetNamespace()),
+			client.MatchingFields{
+				IndexFieldKongServiceOnKonnectGatewayControlPlane: cp.Namespace + "/" + cp.Name,
+			},
+		); err != nil {
 			return nil
 		}
 
-		var ret []reconcile.Request
-		for _, svc := range l.Items {
-			if svc.Spec.ControlPlaneRef == nil {
-				continue
-			}
-			switch svc.Spec.ControlPlaneRef.Type {
-			case configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef:
-				// TODO: change this when cross namespace refs are allowed.
-				if svc.Spec.ControlPlaneRef.KonnectNamespacedRef.Name != cp.Name {
-					continue
-				}
-
-				ret = append(ret, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Namespace: svc.Namespace,
-						Name:      svc.Name,
-					},
-				})
-
-			case configurationv1alpha1.ControlPlaneRefKonnectID:
-				ctrllog.FromContext(ctx).Error(
-					fmt.Errorf("unimplemented ControlPlaneRef type %q", svc.Spec.ControlPlaneRef.Type),
-					"unimplemented ControlPlaneRef for KongService",
-					"KongService", svc, "refType", svc.Spec.ControlPlaneRef.Type,
-				)
-				continue
-
-			default:
-				ctrllog.FromContext(ctx).V(logging.DebugLevel.Value()).Info(
-					"unsupported ControlPlaneRef for KongService",
-					"KongService", svc, "refType", svc.Spec.ControlPlaneRef.Type,
-				)
-				continue
-			}
-		}
-		return ret
+		return objectListToReconcileRequests(l.Items)
 	}
 }

--- a/controller/konnect/watch_kongupstream.go
+++ b/controller/konnect/watch_kongupstream.go
@@ -143,48 +143,16 @@ func enqueueKongUpstreamForKonnectGatewayControlPlane(
 			return nil
 		}
 		var l configurationv1alpha1.KongUpstreamList
-		if err := cl.List(ctx, &l, &client.ListOptions{
+		if err := cl.List(ctx, &l,
 			// TODO: change this when cross namespace refs are allowed.
-			Namespace: cp.GetNamespace(),
-		}); err != nil {
+			client.InNamespace(cp.GetNamespace()),
+			client.MatchingFields{
+				IndexFieldKongUpstreamOnKonnectGatewayControlPlane: cp.Namespace + "/" + cp.Name,
+			},
+		); err != nil {
 			return nil
 		}
 
-		var ret []reconcile.Request
-		for _, upstream := range l.Items {
-			if upstream.Spec.ControlPlaneRef == nil {
-				continue
-			}
-			switch upstream.Spec.ControlPlaneRef.Type {
-			case configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef:
-				// TODO: change this when cross namespace refs are allowed.
-				if upstream.Spec.ControlPlaneRef.KonnectNamespacedRef.Name != cp.Name {
-					continue
-				}
-
-				ret = append(ret, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Namespace: upstream.Namespace,
-						Name:      upstream.Name,
-					},
-				})
-
-			case configurationv1alpha1.ControlPlaneRefKonnectID:
-				ctrllog.FromContext(ctx).Error(
-					fmt.Errorf("unimplemented ControlPlaneRef type %q", upstream.Spec.ControlPlaneRef.Type),
-					"unimplemented ControlPlaneRef for KongUpstream",
-					"KongUpstream", upstream, "refType", upstream.Spec.ControlPlaneRef.Type,
-				)
-				continue
-
-			default:
-				ctrllog.FromContext(ctx).V(logging.DebugLevel.Value()).Info(
-					"unsupported ControlPlaneRef for KongUpstream",
-					"KongUpstream", upstream, "refType", upstream.Spec.ControlPlaneRef.Type,
-				)
-				continue
-			}
-		}
-		return ret
+		return objectListToReconcileRequests(l.Items)
 	}
 }

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -589,6 +589,10 @@ func SetupCacheIndicesForKonnectTypes(ctx context.Context, mgr manager.Manager, 
 			IndexOptions: konnect.IndexOptionsForCredentialsJWT(),
 		},
 		{
+			Object:       &configurationv1alpha1.KongCredentialAPIKey{},
+			IndexOptions: konnect.IndexOptionsForCredentialsAPIKey(),
+		},
+		{
 			Object:       &configurationv1.KongConsumer{},
 			IndexOptions: konnect.IndexOptionsForKongConsumer(),
 		},
@@ -599,6 +603,14 @@ func SetupCacheIndicesForKonnectTypes(ctx context.Context, mgr manager.Manager, 
 		{
 			Object:       &configurationv1alpha1.KongRoute{},
 			IndexOptions: konnect.IndexOptionsForKongRoute(),
+		},
+		{
+			Object:       &configurationv1alpha1.KongUpstream{},
+			IndexOptions: konnect.IndexOptionsForKongUpstream(),
+		},
+		{
+			Object:       &configurationv1alpha1.KongTarget{},
+			IndexOptions: konnect.IndexOptionsForKongTarget(),
 		},
 		{
 			Object:       &configurationv1alpha1.KongSNI{},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds index fields for some of the entities that refer to `KonnectGatewayControlPlane` and uses that for listing the objects.