### PR TITLE
tests: fix data race in KongConsumer data race tests

### DIFF
--- a/controller/konnect/ops/ops_kongconsumer.go
+++ b/controller/konnect/ops/ops_kongconsumer.go
@@ -327,8 +327,8 @@ func kongConsumerToSDKConsumerInput(
 	consumer *configurationv1.KongConsumer,
 ) sdkkonnectcomp.ConsumerInput {
 	return sdkkonnectcomp.ConsumerInput{
-		CustomID: &consumer.CustomID,
+		CustomID: lo.ToPtr(consumer.CustomID),
 		Tags:     GenerateTagsForObject(consumer),
-		Username: &consumer.Username,
+		Username: lo.ToPtr(consumer.Username),
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

An attempt at solving the data race in `KongConsumer` envtest suite.

Example: https://github.com/Kong/gateway-operator/actions/runs/11162590333/job/31027578476?pr=687#step:5:440

```
==================
WARNING: DATA RACE
Read at 0x00c000c88708 by goroutine 4747:
  github.com/kong/gateway-operator/test/envtest.TestKongConsumer.func1.5()
      /home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_kongconsumer_test.go:116 +0x7c
  runtime.call128()
      /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/runtime/asm_amd64.s:773 +0x57
  reflect.Value.Call()
      /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/reflect/value.go:380 +0xb5
  github.com/stretchr/testify/mock.argumentMatcher.Matches()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/mock/mock.go:860 +0x2e4
  github.com/stretchr/testify/mock.Arguments.Diff.func1()
      /home/runner/work/gateway-operator/gateway-operator/controller/konnect/reconciler_generic.go:536 +0x5cf2
  github.com/kong/gateway-operator/controller/konnect.(*KonnectEntityReconciler[github.com/kong/kubernetes-configuration/api/configuration/v1.KongConsumer,*github.com/kong/kubernetes-configuration/api/configuration/v1.KongConsumer]).Reconcile()
      /home/runner/work/gateway-operator/gateway-operator/controller/konnect/reconciler_generic.go:114 +0xa4
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).Reconcile()
      /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:116 +0x1c1
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).reconcileHandler()
      /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:303 +0x53d
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).processNextWorkItem()
      /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263 +0x3ac
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).Start.func2.2()
      /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224 +0xe4

Goroutine 4747 (running) created at:
  github.com/stretchr/testify/assert.EventuallyWithT()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:1978 +0x42a
  github.com/kong/gateway-operator/test/envtest.TestKongConsumer.func1()
      /home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_kongconsumer_test.go:126 +0x1a34
  testing.tRunner()
      /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:1742 +0x44

Goroutine 4275 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).Start.func2()
      /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:220 +0x74b
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).Start()
      /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:231 +0x3ab
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[sigs.k8s.io/controller-runtime/pkg/reconcile.Request]).Start()
      /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:145 +0x4a
  sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1()
      /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/manager/runnable_group.go:226 +0x1c6
  sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.gowrap1()
      /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/manager/runnable_group.go:229 +0x41
==================
```

Possibly fixes #655