### PR TITLE
fix: fix SNI index used in watch

### DIFF
--- a/controller/konnect/watch_kongsni.go
+++ b/controller/konnect/watch_kongsni.go
@@ -76,7 +76,7 @@ func enqueueKongSNIForKongCertificate(
 		sniList := configurationv1alpha1.KongSNIList{}
 		if err := cl.List(ctx, &sniList, client.InNamespace(cert.Namespace),
 			client.MatchingFields{
-				IndexFieldKongPluginBindingKongServiceReference: cert.Name,
+				IndexFieldKongSNIOnCertificateRefNmae: cert.Name,
 			},
 		); err != nil {
 			return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the following test failures: https://github.com/Kong/gateway-operator/actions/runs/11161401229/job/31023871551#step:5:672

```
=== FAIL: test/envtest TestKongSNI/adding,_patching_and_deleting_KongSNI (11.31s)
    konnect_entities_sni_test.go:56: Creating KongCertificate and setting it to Programmed
    konnect_entities_sni_test.go:57: deployed new KongCertificate test-crdql/cert-gvbx5
    konnect_entities_sni_test.go:75: Setting up a watch for KongSNI events
    konnect_entities_sni_test.go:78: Setting up SDK for creating SNI
    konnect_entities_sni_test.go:92: deployed KongSNI test-crdql/sni-bc55db23
    konnect_entities_sni_test.go:99: Waiting for SNI to be programmed and get Konnect ID
    konnect_entities_sni_test.go:107: Set up SDK for SNI update
    konnect_entities_sni_test.go:117: Patching KongSNI
    konnect_entities_sni_test.go:122: Waiting for KongSNI to be updated in the SDK
    konnect_entities_sni_test.go:127: Setting up SDK for deleting SNI
    konnect_entities_sni_test.go:137: Deleting KongSNI
    konnect_entities_sni_test.go:148: Waiting for SNI to be deleted in SDK
    konnect_entities_sni_test.go:150: FAIL:	DeleteSniWithCertificate(string,operations.DeleteSniWithCertificateRequest)
        		at: [/home/runner/work/gateway-operator/gateway-operator/controller/konnect/ops/kongsni_mock.go:146 /home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_sni_test.go:128]
    konnect_entities_sni_test.go:150: FAIL: 2 out of 3 expectation(s) were met.
        	The code you are testing needs to make 1 more call(s).
        	at: [/home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_sni_test.go:150 /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/runtime/asm_amd64.s:1695]
    konnect_entities_sni_test.go:150: FAIL:	DeleteSniWithCertificate(string,operations.DeleteSniWithCertificateRequest)
        		at: [/home/runner/work/gateway-operator/gateway-operator/controller/konnect/ops/kongsni_mock.go:146 /home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_sni_test.go:128]
    konnect_entities_sni_test.go:150: FAIL: 2 out of 3 expectation(s) were met.
        	The code you are testing needs to make 1 more call(s).
        	at: [/home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_sni_test.go:150 /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/runtime/asm_amd64.s:1695]
    konnect_entities_sni_test.go:150: FAIL:	DeleteSniWithCertificate(string,operations.DeleteSniWithCertificateRequest)
        		at: [/home/runner/work/gateway-operator/gateway-operator/controller/konnect/ops/kongsni_mock.go:146 /home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_sni_test.go:128]
    konnect_entities_sni_test.go:150: FAIL: 2 out of 3 expectation(s) were met.
        	The code you are testing needs to make 1 more call(s).
        	at: [/home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_sni_test.go:150 /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/runtime/asm_amd64.s:1695]
    konnect_entities_sni_test.go:150: FAIL:	DeleteSniWithCertificate(string,operations.DeleteSniWithCertificateRequest)
    controller.go:80: 2024-10-03T11:52:26Z	info	Starting EventSource	{"controller": "KongSNI", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongSNI", "source": "kind source: *v1alpha1.KongSNI"}
    controller.go:80: 2024-10-03T11:52:26Z	info	Starting EventSource	{"controller": "KongSNI", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongSNI", "source": "kind source: *v1alpha1.KongCertificate"}
    controller.go:80: 2024-10-03T11:52:26Z	info	Starting Controller	{"controller": "KongSNI", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongSNI"}
    controller.go:80: 2024-10-03T11:52:26Z	info	Starting workers	{"controller": "KongSNI", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongSNI", "worker count": 8}
    controller.go:80: 2024-10-03T11:52:28Z	debug	controlplane	reconciling	{"controller": "KongSNI", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongSNI", "KongSNI": {"name":"sni-bc55db23","namespace":"test-crdql"}, "namespace": "test-crdql", "name": "sni-bc55db23", "reconcileID": "dfca3928-63ce-46f3-8f5e-793ad2d95e0a", "namespace": "test-crdql", "name": "sni-bc55db23"}
    controller.go:80: 2024-10-03T11:52:29Z	debug	controlplane	reconciling	{"controller": "KongSNI", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongSNI", "KongSNI": {"name":"sni-bc55db23","namespace":"test-crdql"}, "namespace": "test-crdql", "name": "sni-bc55db23", "reconcileID": "99f8cadb-1aa3-40fe-b4e1-ac22cc63dc81", "namespace": "test-crdql", "name": "sni-bc55db23"}
    controller.go:80: 2024-10-03T11:52:29Z	debug	controlplane	reconciling	{"controller": "KongSNI", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongSNI", "KongSNI": {"name":"sni-bc55db23","namespace":"test-crdql"}, "namespace": "test-crdql", "name": "sni-bc55db23", "reconcileID": "d5280c3e-3071-4a4c-b94c-fa2637bae6c7", "namespace": "test-crdql", "name": "sni-bc55db23"}
    controller.go:80: 2024-10-03T11:52:29Z	info	controlplane	operation in Konnect API complete	{"controller": "KongSNI", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongSNI", "KongSNI": {"name":"sni-bc55db23","namespace":"test-crdql"}, "namespace": "test-crdql", "name": "sni-bc55db23", "reconcileID": "d5280c3e-3071-4a4c-b94c-fa2637bae6c7", "op": "create", "duration": 0.00041446, "type": "KongSNI", "konnect_id": "sni-12345"}
    controller.go:80: 2024-10-03T11:52:29Z	debug	controlplane	reconciling	{"controller": "KongSNI", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongSNI", "KongSNI": {"name":"sni-bc55db23","namespace":"test-crdql"}, "namespace": "test-crdql", "name": "sni-bc55db23", "reconcileID": "7f4da648-eb84-44f7-90d4-d2cc[675](https://github.com/Kong/gateway-operator/actions/runs/11161401229/job/31023871551#step:5:676)6d402", "namespace": "test-crdql", "name": "sni-bc55db23"}
    controller.go:80: 2024-10-03T11:52:29Z	debug	controlplane	reconciling	{"controller": "KongSNI", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongSNI", "KongSNI": {"name":"sni-bc55db23","namespace":"test-crdql"}, "namespace": "test-crdql", "name": "sni-bc55db23", "reconcileID": "22ea1af6-0ef7-4197-858f-7ce82613b9dd", "namespace": "test-crdql", "name": "sni-bc55db23"}
    controller.go:80: 2024-10-03T11:52:29Z	debug	controlplane	reconciling	{"controller": "KongSNI", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongSNI", "KongSNI": {"name":"sni-bc55db23","namespace":"test-crdql"}, "namespace": "test-crdql", "name": "sni-bc55db23", "reconcileID": "f26ab1d6-1ef1-45be-b896-5d003108ea64", "namespace": "test-crdql", "name": "sni-bc55db23"}
    controller.go:80: 2024-10-03T11:52:29Z	info	controlplane	operation in Konnect API complete	{"controller": "KongSNI", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongSNI", "KongSNI": {"name":"sni-bc55db23","namespace":"test-crdql"}, "namespace": "test-crdql", "name": "sni-bc55db23", "reconcileID": "f26ab1d6-1ef1-45be-b896-5d003108ea64", "op": "update", "duration": 0.000343979, "type": "KongSNI", "konnect_id": "sni-12345"}
    controller.go:80: 2024-10-03T11:52:29Z	debug	controlplane	reconciling	{"controller": "KongSNI", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongSNI", "KongSNI": {"name":"sni-bc55db23","namespace":"test-crdql"}, "namespace": "test-crdql", "name": "sni-bc55db23", "reconcileID": "e04a8a27-ea40-43a3-a215-8dd9f45a93e9", "namespace": "test-crdql", "name": "sni-bc55db23"}
    controller.go:80: 2024-10-03T11:52:29Z	debug	controlplane	no need for update, requeueing after configured sync period	{"controller": "KongSNI", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongSNI", "KongSNI": {"name":"sni-bc55db23","namespace":"test-crdql"}, "namespace": "test-crdql", "name": "sni-bc55db23", "reconcileID": "e04a8a27-ea40-43a3-a215-8dd9f45a93e9", "namespace": "test-crdql", "name": "sni-bc55db23", "last_update": "2024-10-03T11:52:29Z", "time_from_last_update": 0.316345855, "requeue_after": 3599.[683](https://github.com/Kong/gateway-operator/actions/runs/11161401229/job/31023871551#step:5:684)654145, "requeue_at": "2024-10-03T12:52:28Z"}
    controller.go:80: 2024-10-03T11:52:40Z	info	Stopping and waiting for non leader election runnables
    controller.go:80: 2024-10-03T11:52:40Z	info	Stopping and waiting for leader election runnables
    controller.go:80: 2024-10-03T11:52:40Z	info	Shutdown signal received, waiting for all workers to finish	{"controller": "KongSNI", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongSNI"}
    controller.go:80: 2024-10-03T11:52:40Z	info	All workers finished	{"controller": "KongSNI", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongSNI"}
    controller.go:80: 2024-10-03T11:52:40Z	info	Stopping and waiting for caches
    controller.go:80: 2024-10-03T11:52:40Z	info	Stopping and waiting for webhooks
    controller.go:80: 2024-10-03T11:52:40Z	info	Stopping and waiting for HTTP servers
    controller.go:80: 2024-10-03T11:52:40Z	info	Wait completed, proceeding to shutdown the manager
    kongsni_mock.go:256: FAIL:	DeleteSniWithCertificate(string,operations.DeleteSniWithCertificateRequest)
        		at: [/home/runner/work/gateway-operator/gateway-operator/controller/konnect/ops/kongsni_mock.go:146 /home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_sni_test.go:128]
    kongsni_mock.go:256: FAIL: 2 out of 3 expectation(s) were met.
        	The code you are testing needs to make 1 more call(s).
        	at: [/home/runner/work/gateway-operator/gateway-operator/controller/konnect/ops/kongsni_mock.go:256 /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:1175 /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:1353 /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:1683]
    konnect_entities_sni_test.go:32: stopping envtest environment for test TestKongSNI
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
