### PR TITLE
tests: fix HTTPRoute update in KongPluginInstallation integration test

### DIFF
--- a/pkg/utils/test/predicates.go
+++ b/pkg/utils/test/predicates.go
@@ -551,6 +551,29 @@ func DataPlaneUpdateEventually(t *testing.T, ctx context.Context, dataplaneNN ty
 	}
 }
 
+// HTTPRouteUpdateEventually is a helper function for tests that returns a function
+// that can be used to update the HTTPRoute.
+// Should be used in conjunction with require.Eventually or assert.Eventually.
+func HTTPRouteUpdateEventually(t *testing.T, ctx context.Context, httpRouteNN types.NamespacedName, clients K8sClients, updateFunc func(*gatewayv1.HTTPRoute)) func() bool {
+	return func() bool {
+		cl := clients.GatewayClient.GatewayV1().HTTPRoutes(httpRouteNN.Namespace)
+		dp, err := cl.Get(ctx, httpRouteNN.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Logf("error getting HTTPRoute: %v", err)
+			return false
+		}
+
+		updateFunc(dp)
+
+		_, err = cl.Update(ctx, dp, metav1.UpdateOptions{})
+		if err != nil {
+			t.Logf("error updating HTTPRoute: %v", err)
+			return false
+		}
+		return true
+	}
+}
+
 // ControlPlaneUpdateEventually is a helper function for tests that returns a function
 // that can be used to update the ControlPlane.
 // Should be used in conjunction with require.Eventually or assert.Eventually.


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix an `Update` of `HTTPRoute` which might result in https://github.com/Kong/gateway-operator/actions/runs/11179695772/job/31079877922#step:5:514

```
    test_kongplugininstallation.go:332: 
        	Error Trace:	/home/runner/work/gateway-operator/gateway-operator/test/integration/test_kongplugininstallation.go:332
        	            				/home/runner/work/gateway-operator/gateway-operator/test/integration/test_kongplugininstallation.go:92
        	Error:      	Received unexpected error:
        	            	Operation cannot be fulfilled on httproutes.gateway.networking.k8s.io "6a2edf61-4206-4e08-a695-ede056813fbd": the object has been modified; please apply your changes to the latest version and try again
        	Test:       	TestIntegration/TestKongPluginInstallationEssentials
```


**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
