### PR TITLE
feat(konnect): add finalizer handling for unmanaged KongPluginBindings for `KongConsumer` and `KongConsumerGroup` 

### DIFF
--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -82,6 +82,12 @@ const (
 	KongTargetControllerName = "KongTarget"
 	// KongServicePluginBindingFinalizerControllerName is the name of the KongService PluginBinding finalizer controller.
 	KongServicePluginBindingFinalizerControllerName = "KongServicePluginBindingFinalizer"
+	// KongRoutePluginBindingFinalizerControllerName is the name of the KongRoute PluginBinding finalizer controller.
+	KongRoutePluginBindingFinalizerControllerName = "KongRoutePluginBindingFinalizer"
+	// KongConsumerPluginBindingFinalizerControllerName is the name of the KongConsumer PluginBinding finalizer controller.
+	KongConsumerPluginBindingFinalizerControllerName = "KongConsumerPluginBindingFinalizer"
+	// KongConsumerGroupPluginBindingFinalizerControllerName is the name of the KongConsumerGroup PluginBinding finalizer controller.
+	KongConsumerGroupPluginBindingFinalizerControllerName = "KongConsumerGroupPluginBindingFinalizer"
 	// KongCredentialsSecretControllerName is the name of the Credentials Secret controller.
 	KongCredentialsSecretControllerName = "KongCredentialSecret"
 	// KongCredentialBasicAuthControllerName is the name of the KongCredentialBasicAuth controller.
@@ -542,14 +548,6 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 					mgr.GetClient(),
 				),
 			},
-			// Controllers responsible for cleaning up KongPluginBinding cleanup finalizers.
-			KongServicePluginBindingFinalizerControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityPluginReconciler[configurationv1alpha1.KongService](
-					c.DevelopmentMode,
-					mgr.GetClient(),
-				),
-			},
 			KongVaultControllerName: {
 				Enabled: c.KonnectControllersEnabled,
 				Controller: konnect.NewKonnectEntityReconciler[configurationv1alpha1.KongVault](
@@ -566,6 +564,36 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 					c.DevelopmentMode,
 					mgr.GetClient(),
 					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongSNI](c.KonnectSyncPeriod),
+				),
+			},
+
+			// Controllers responsible for cleaning up KongPluginBinding cleanup finalizers.
+			KongServicePluginBindingFinalizerControllerName: {
+				Enabled: c.KonnectControllersEnabled,
+				Controller: konnect.NewKonnectEntityPluginReconciler[configurationv1alpha1.KongService](
+					c.DevelopmentMode,
+					mgr.GetClient(),
+				),
+			},
+			KongRoutePluginBindingFinalizerControllerName: {
+				Enabled: c.KonnectControllersEnabled,
+				Controller: konnect.NewKonnectEntityPluginReconciler[configurationv1alpha1.KongRoute](
+					c.DevelopmentMode,
+					mgr.GetClient(),
+				),
+			},
+			KongConsumerPluginBindingFinalizerControllerName: {
+				Enabled: c.KonnectControllersEnabled,
+				Controller: konnect.NewKonnectEntityPluginReconciler[configurationv1.KongConsumer](
+					c.DevelopmentMode,
+					mgr.GetClient(),
+				),
+			},
+			KongConsumerGroupPluginBindingFinalizerControllerName: {
+				Enabled: c.KonnectControllersEnabled,
+				Controller: konnect.NewKonnectEntityPluginReconciler[configurationv1beta1.KongConsumerGroup](
+					c.DevelopmentMode,
+					mgr.GetClient(),
 				),
 			},
 		}

--- a/test/envtest/kongplugincleanupfinalizer_test.go
+++ b/test/envtest/kongplugincleanupfinalizer_test.go
@@ -16,7 +16,9 @@ import (
 	"github.com/kong/gateway-operator/pkg/consts"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
 
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	configurationv1beta1 "github.com/kong/kubernetes-configuration/api/configuration/v1beta1"
 )
 
 func TestKongPluginFinalizer(t *testing.T) {
@@ -43,6 +45,8 @@ func TestKongPluginFinalizer(t *testing.T) {
 	StartReconcilers(ctx, t, mgr, logs,
 		konnect.NewKonnectEntityPluginReconciler[configurationv1alpha1.KongService](false, mgr.GetClient()),
 		konnect.NewKonnectEntityPluginReconciler[configurationv1alpha1.KongRoute](false, mgr.GetClient()),
+		konnect.NewKonnectEntityPluginReconciler[configurationv1.KongConsumer](false, mgr.GetClient()),
+		konnect.NewKonnectEntityPluginReconciler[configurationv1beta1.KongConsumerGroup](false, mgr.GetClient()),
 	)
 
 	t.Run("KongService", func(t *testing.T) {
@@ -107,6 +111,70 @@ func TestKongPluginFinalizer(t *testing.T) {
 					!slices.Contains(svc.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
 			},
 			fmt.Sprintf("KongRoute has the %s finalizer set but it shouldn't", consts.CleanupPluginBindingFinalizer),
+		)
+	})
+
+	t.Run("KongConsumer", func(t *testing.T) {
+		rateLimitingkongPlugin := deploy.RateLimitingPlugin(t, ctx, clientNamespaced)
+
+		wKongConsumer := setupWatch[configurationv1.KongConsumerList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
+		kongConsumer := deploy.KongConsumerAttachedToCP(t, ctx, clientNamespaced, "username-1", cp)
+		kpb := deploy.KongPluginBinding(t, ctx, clientNamespaced,
+			konnect.NewKongPluginBindingBuilder().
+				WithControlPlaneRefKonnectNamespaced(cp.Name).
+				WithPluginRef(rateLimitingkongPlugin.Name).
+				WithConsumerTarget(kongConsumer.Name).
+				Build(),
+		)
+
+		_ = watchFor(t, ctx, wKongConsumer, watch.Modified,
+			func(svc *configurationv1.KongConsumer) bool {
+				return svc.Name == kongConsumer.Name &&
+					slices.Contains(svc.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
+			},
+			fmt.Sprintf("KongConsumer doesn't have the %s finalizer set", consts.CleanupPluginBindingFinalizer),
+		)
+
+		wKongConsumer = setupWatch[configurationv1.KongConsumerList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
+		require.NoError(t, clientNamespaced.Delete(ctx, kpb))
+		_ = watchFor(t, ctx, wKongConsumer, watch.Modified,
+			func(svc *configurationv1.KongConsumer) bool {
+				return svc.Name == kongConsumer.Name &&
+					!slices.Contains(svc.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
+			},
+			fmt.Sprintf("KongConsumer has the %s finalizer set but it shouldn't", consts.CleanupPluginBindingFinalizer),
+		)
+	})
+
+	t.Run("KongConsumerGroup", func(t *testing.T) {
+		rateLimitingkongPlugin := deploy.RateLimitingPlugin(t, ctx, clientNamespaced)
+
+		wKongConsumerGroup := setupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
+		kongConsumerGroup := deploy.KongConsumerGroupAttachedToCP(t, ctx, clientNamespaced, cp)
+		kpb := deploy.KongPluginBinding(t, ctx, clientNamespaced,
+			konnect.NewKongPluginBindingBuilder().
+				WithControlPlaneRefKonnectNamespaced(cp.Name).
+				WithPluginRef(rateLimitingkongPlugin.Name).
+				WithConsumerGroupTarget(kongConsumerGroup.Name).
+				Build(),
+		)
+
+		_ = watchFor(t, ctx, wKongConsumerGroup, watch.Modified,
+			func(svc *configurationv1beta1.KongConsumerGroup) bool {
+				return svc.Name == kongConsumerGroup.Name &&
+					slices.Contains(svc.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
+			},
+			fmt.Sprintf("KongConsumerGroup doesn't have the %s finalizer set", consts.CleanupPluginBindingFinalizer),
+		)
+
+		wKongConsumerGroup = setupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
+		require.NoError(t, clientNamespaced.Delete(ctx, kpb))
+		_ = watchFor(t, ctx, wKongConsumerGroup, watch.Modified,
+			func(svc *configurationv1beta1.KongConsumerGroup) bool {
+				return svc.Name == kongConsumerGroup.Name &&
+					!slices.Contains(svc.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
+			},
+			fmt.Sprintf("KongConsumerGroup has the %s finalizer set but it shouldn't", consts.CleanupPluginBindingFinalizer),
 		)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds handling of `gateway.konghq.com/cleanup-plugin-binding` finalizer for unmanaged (created by users) `KongPluginBinding`s targeting `KongConsumer` and `KongConsumerGroup`.

This PR also does some refactoring in `controller/konnect/reconciler_generic_pluginbindingfinalizer.go` to decrease code duplication.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

Follow up on #683 and #611

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
