### PR TITLE
tests: fix KongCredential tests in envtest suite

### DIFF
--- a/controller/konnect/ops/ops_credentialapikey.go
+++ b/controller/konnect/ops/ops_credentialapikey.go
@@ -96,7 +96,7 @@ func deleteKongCredentialAPIKey(
 		sdkkonnectops.DeleteKeyAuthWithConsumerRequest{
 			ControlPlaneID:              cpID,
 			ConsumerIDForNestedEntities: cred.Status.Konnect.GetConsumerID(),
-			// BasicAuthID:                 id,
+			KeyAuthID:                   id,
 		})
 	if errWrap := wrapErrIfKonnectOpFailed(err, DeleteOp, cred); errWrap != nil {
 		// Service delete operation returns an SDKError instead of a NotFoundError.

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -854,12 +854,6 @@ func handleKongConsumerRef[T constraints.SupportedKonnectEntityType, TEnt constr
 			client.ObjectKeyFromObject(&consumer), constraints.EntityTypeName[T](), client.ObjectKeyFromObject(ent),
 		)
 	}
-	if cred, ok := any(ent).(*configurationv1alpha1.KongCredentialHMAC); ok {
-		if cred.Status.Konnect == nil {
-			cred.Status.Konnect = &konnectv1alpha1.KonnectEntityStatusWithControlPlaneAndConsumerRefs{}
-		}
-		cred.Status.Konnect.ConsumerID = consumer.Status.Konnect.GetKonnectID()
-	}
 
 	if res, errStatus := updateStatusWithCondition(
 		ctx, cl, ent,

--- a/test/envtest/consts.go
+++ b/test/envtest/consts.go
@@ -7,9 +7,6 @@ const (
 	// sync period. It's set to 60m that is virtually infinite for the tests.
 	konnectInfiniteSyncTime = time.Minute * 60
 
-	// konnectSyncTime is used for tests that want to verify behavior of the reconcilers relying on the fixed sync.
-	konnectSyncTime = 100 * time.Millisecond
-
 	// waitTime is a generic wait time for the tests' eventual conditions.
 	waitTime = 10 * time.Second
 

--- a/test/envtest/konnect_entities_gatewaycontrolplane_test.go
+++ b/test/envtest/konnect_entities_gatewaycontrolplane_test.go
@@ -121,7 +121,8 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 				CreateControlPlane(
 					mock.Anything,
 					mock.MatchedBy(func(req sdkkonnectcomp.CreateControlPlaneRequest) bool {
-						return req.Name == "cp-2"
+						return req.Name == "cp-2" &&
+							req.ClusterType != nil && *req.ClusterType == sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup
 					}),
 				).
 				Return(

--- a/test/helpers/deploy/deploy_resources.go
+++ b/test/helpers/deploy/deploy_resources.go
@@ -87,7 +87,7 @@ func KonnectAPIAuthConfiguration(
 		opt(apiAuth)
 	}
 	require.NoError(t, cl.Create(ctx, apiAuth))
-	t.Logf("deployed new %s KonnectAPIAuthConfiguration", client.ObjectKeyFromObject(apiAuth))
+	logObjectCreate(t, apiAuth)
 
 	return apiAuth
 }
@@ -148,7 +148,7 @@ func KonnectGatewayControlPlane(
 		opt(cp)
 	}
 	require.NoError(t, cl.Create(ctx, cp))
-	t.Logf("deployed new %s KonnectGatewayControlPlane", client.ObjectKeyFromObject(cp))
+	logObjectCreate(t, cp)
 
 	return cp
 }
@@ -215,7 +215,7 @@ func KongServiceAttachedToCP(
 		opt(&kongService)
 	}
 	require.NoError(t, cl.Create(ctx, &kongService))
-	t.Logf("deployed new %s KongService", client.ObjectKeyFromObject(&kongService))
+	logObjectCreate(t, &kongService)
 
 	return &kongService
 }
@@ -251,7 +251,7 @@ func KongRouteAttachedToService(
 		opt(&kongRoute)
 	}
 	require.NoError(t, cl.Create(ctx, &kongRoute))
-	t.Logf("deployed new %s KongRoute", client.ObjectKeyFromObject(&kongRoute))
+	logObjectCreate(t, &kongRoute)
 
 	return &kongRoute
 }
@@ -298,9 +298,38 @@ func KongPluginBinding(
 		opt(kpb)
 	}
 	require.NoError(t, cl.Create(ctx, kpb))
-	t.Logf("deployed new unmanaged KongPluginBinding %s", client.ObjectKeyFromObject(kpb))
+	logObjectCreate(t, kpb)
 
 	return kpb
+}
+
+// KongCredentialAPIKey deploys a KongCredentialAPIKey resource and returns the resource.
+func KongCredentialAPIKey(
+	t *testing.T,
+	ctx context.Context,
+	cl client.Client,
+	consumerName string,
+) *configurationv1alpha1.KongCredentialAPIKey {
+	t.Helper()
+
+	c := &configurationv1alpha1.KongCredentialAPIKey{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "api-key-",
+		},
+		Spec: configurationv1alpha1.KongCredentialAPIKeySpec{
+			ConsumerRef: corev1.LocalObjectReference{
+				Name: consumerName,
+			},
+			KongCredentialAPIKeyAPISpec: configurationv1alpha1.KongCredentialAPIKeyAPISpec{
+				Key: "key",
+			},
+		},
+	}
+
+	require.NoError(t, cl.Create(ctx, c))
+	logObjectCreate(t, c)
+
+	return c
 }
 
 // KongCredentialBasicAuth deploys a KongCredentialBasicAuth resource and returns the resource.
@@ -330,7 +359,7 @@ func KongCredentialBasicAuth(
 	}
 
 	require.NoError(t, cl.Create(ctx, c))
-	t.Logf("deployed new unmanaged KongCredentialBasicAuth %s", client.ObjectKeyFromObject(c))
+	logObjectCreate(t, c)
 
 	return c
 }
@@ -360,7 +389,7 @@ func KongCredentialACL(
 	}
 
 	require.NoError(t, cl.Create(ctx, c))
-	t.Logf("deployed new unmanaged KongCredentialACL %s", client.ObjectKeyFromObject(c))
+	logObjectCreate(t, c)
 
 	return c
 }
@@ -389,7 +418,7 @@ func KongCredentialHMAC(
 	}
 
 	require.NoError(t, cl.Create(ctx, c))
-	t.Logf("deployed new unmanaged KongCredentialHMAC %s", client.ObjectKeyFromObject(c))
+	logObjectCreate(t, c)
 
 	return c
 }
@@ -418,7 +447,7 @@ func KongCredentialJWT(
 	}
 
 	require.NoError(t, cl.Create(ctx, c))
-	t.Logf("deployed new unmanaged KongCredentialJWT %s", client.ObjectKeyFromObject(c))
+	logObjectCreate(t, c)
 
 	return c
 }
@@ -449,7 +478,7 @@ func KongCACertificateAttachedToCP(
 		},
 	}
 	require.NoError(t, cl.Create(ctx, cert))
-	t.Logf("deployed new KongCACertificate %s", client.ObjectKeyFromObject(cert))
+	logObjectCreate(t, cert)
 
 	return cert
 }
@@ -481,7 +510,7 @@ func KongCertificateAttachedToCP(
 		},
 	}
 	require.NoError(t, cl.Create(ctx, cert))
-	t.Logf("deployed new KongCertificate %s", client.ObjectKeyFromObject(cert))
+	logObjectCreate(t, cert)
 
 	return cert
 }
@@ -514,7 +543,7 @@ func KongUpstreamAttachedToCP(
 	}
 
 	require.NoError(t, cl.Create(ctx, u))
-	t.Logf("deployed new KongUpstream %s", client.ObjectKeyFromObject(u))
+	logObjectCreate(t, u)
 
 	return u
 }
@@ -544,7 +573,7 @@ func KongTargetAttachedToUpstream(
 	}
 
 	require.NoError(t, cl.Create(ctx, u))
-	t.Logf("deployed new KongTarget %s", client.ObjectKeyFromObject(u))
+	logObjectCreate(t, u)
 
 	return u
 }
@@ -579,7 +608,7 @@ func KongConsumerAttachedToCP(
 	}
 
 	require.NoError(t, cl.Create(ctx, c))
-	t.Logf("deployed new KongConsumer %s", client.ObjectKeyFromObject(c))
+	logObjectCreate(t, c)
 
 	return c
 }
@@ -614,7 +643,7 @@ func KongConsumerGroupAttachedToCP(
 	}
 
 	require.NoError(t, cl.Create(ctx, &cg))
-	t.Logf("deployed new KongConsumerGroup %s", client.ObjectKeyFromObject(&cg))
+	logObjectCreate(t, &cg)
 
 	return &cg
 }
@@ -652,7 +681,7 @@ func KongVaultAttachedToCP(
 	}
 
 	require.NoError(t, cl.Create(ctx, vault))
-	t.Logf("deployed new KongVault %s", client.ObjectKeyFromObject(vault))
+	logObjectCreate(t, vault)
 
 	return vault
 }
@@ -692,7 +721,7 @@ func KongKeyAttachedToCP(
 		opt(key)
 	}
 	require.NoError(t, cl.Create(ctx, key))
-	t.Logf("deployed new KongKey %s", client.ObjectKeyFromObject(key))
+	logObjectCreate(t, key)
 	return key
 }
 
@@ -769,7 +798,7 @@ func KongKeySetAttachedToCP(
 		},
 	}
 	require.NoError(t, cl.Create(ctx, keySet))
-	t.Logf("deployed new KongKeySet %s", client.ObjectKeyFromObject(keySet))
+	logObjectCreate(t, keySet)
 
 	return keySet
 }
@@ -834,7 +863,18 @@ func KongDataPlaneClientCertificateAttachedToCP(
 		},
 	}
 	require.NoError(t, cl.Create(ctx, cert))
-	t.Logf("deployed new KongDataPlaneClientCertificate %s", client.ObjectKeyFromObject(cert))
+	logObjectCreate(t, cert)
 
 	return cert
+}
+
+func logObjectCreate[
+	T interface {
+		client.Object
+		GetTypeName() string
+	},
+](t *testing.T, obj T) {
+	t.Helper()
+
+	t.Logf("deployed new %s %s resource", obj.GetTypeName(), client.ObjectKeyFromObject(obj))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR

- removes checks in `envtest` suite for removal of `KongConsumer` credentials removal after `KongConsumer` is removed. This does not work in `envtest` suite because there is no controller that would assign the deletion timestamp to entities having owner references set after said owner (`KongConsumer`) is deleted.
- adds test in `envtest` suite for APIKey credential

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

#708 tracks re-adding those tests in a different test suite.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
