### PR TITLE
tests(konnect): fix flaky KongConsumerCredential tests

### DIFF
--- a/test/envtest/assert.go
+++ b/test/envtest/assert.go
@@ -1,0 +1,30 @@
+package envtest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func assertCollectObjectExistsAndHasKonnectID(
+	t *testing.T,
+	ctx context.Context,
+	clientNamespaced client.Client,
+	obj interface {
+		client.Object
+		GetKonnectID() string
+	},
+	konnectID string,
+) func(c *assert.CollectT) {
+	t.Helper()
+
+	return func(c *assert.CollectT) {
+		nn := client.ObjectKeyFromObject(obj)
+		if !assert.NoError(c, clientNamespaced.Get(ctx, nn, obj)) {
+			return
+		}
+		assert.Equal(t, konnectID, obj.GetKonnectID())
+	}
+}

--- a/test/envtest/kongconsumercredential_acl_test.go
+++ b/test/envtest/kongconsumercredential_acl_test.go
@@ -116,6 +116,12 @@ func TestKongConsumerCredential_ACL(t *testing.T) {
 
 	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
 
+	assert.EventuallyWithT(t,
+		assertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kongCredentialACL, aclID),
+		waitTime, tickTime,
+		"KongCredentialACL wasn't created",
+	)
+
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.True(c, factory.SDK.KongCredentialsACLSDK.AssertExpectations(t))
 	}, waitTime, tickTime)

--- a/test/envtest/kongconsumercredential_apikey_test.go
+++ b/test/envtest/kongconsumercredential_apikey_test.go
@@ -115,6 +115,12 @@ func TestKongConsumerCredential_APIKey(t *testing.T) {
 
 	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
 
+	assert.EventuallyWithT(t,
+		assertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kongCredentialAPIKey, keyID),
+		waitTime, tickTime,
+		"KongCredentialAPIKey wasn't created",
+	)
+
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.True(c, factory.SDK.KongCredentialsAPIKeySDK.AssertExpectations(t))
 	}, waitTime, tickTime)

--- a/test/envtest/kongconsumercredential_basicauth_test.go
+++ b/test/envtest/kongconsumercredential_basicauth_test.go
@@ -118,6 +118,12 @@ func TestKongConsumerCredential_BasicAuth(t *testing.T) {
 
 	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
 
+	assert.EventuallyWithT(t,
+		assertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kongCredentialBasicAuth, basicAuthID),
+		waitTime, tickTime,
+		"KongCredentialBasicAuth wasn't created",
+	)
+
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.True(c, factory.SDK.KongCredentialsBasicAuthSDK.AssertExpectations(t))
 	}, waitTime, tickTime)

--- a/test/envtest/kongconsumercredential_hmac_test.go
+++ b/test/envtest/kongconsumercredential_hmac_test.go
@@ -115,6 +115,12 @@ func TestKongConsumerCredential_HMAC(t *testing.T) {
 
 	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
 
+	assert.EventuallyWithT(t,
+		assertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kongCredentialHMAC, hmacID),
+		waitTime, tickTime,
+		"KongCredentialHMAC wasn't created",
+	)
+
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.True(c, factory.SDK.KongCredentialsHMACSDK.AssertExpectations(t))
 	}, waitTime, tickTime)

--- a/test/envtest/kongconsumercredential_jwt_test.go
+++ b/test/envtest/kongconsumercredential_jwt_test.go
@@ -116,7 +116,6 @@ func TestKongConsumerCredential_JWT(t *testing.T) {
 
 	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
 
-	kongCredentialJWT.GetKonnectID()
 	assert.EventuallyWithT(t,
 		assertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kongCredentialJWT, jwtID),
 		waitTime, tickTime,

--- a/test/envtest/kongconsumercredential_jwt_test.go
+++ b/test/envtest/kongconsumercredential_jwt_test.go
@@ -116,6 +116,13 @@ func TestKongConsumerCredential_JWT(t *testing.T) {
 
 	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
 
+	kongCredentialJWT.GetKonnectID()
+	assert.EventuallyWithT(t,
+		assertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kongCredentialJWT, jwtID),
+		waitTime, tickTime,
+		"KongCredentialJWT wasn't created",
+	)
+
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.True(c, factory.SDK.KongCredentialsJWTSDK.AssertExpectations(t))
 	}, waitTime, tickTime)


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes an issue with `KongConsumerCredential*` tests that was spotted in https://github.com/Kong/gateway-operator/actions/runs/11242357547/job/31255881107.

```
   kongconsumercredential_apikey_test.go:40: deployed new KonnectAPIAuthConfiguration test-l95dt/api-auth-config-n9qjp resource
    kongconsumercredential_apikey_test.go:41: deployed new KonnectGatewayControlPlane test-l95dt/cp-0e6fa6d2 resource
    kongconsumercredential_apikey_test.go:44: deployed test-l95dt/kongconsumer-568pg KongConsumer resource
    kongconsumercredential_apikey_test.go:65: deployed new KongCredentialAPIKey test-l95dt/api-key-qfpvs resource
    kongconsumercredential_apikey_test.go:116: Starting manager for test case TestKongConsumerCredential_APIKey
    kongconsumercredential_apikey_test.go:119: FAIL:	CreateKeyAuthWithConsumer(string,operations.CreateKeyAuthWithConsumerRequest)
        		at: [/home/runner/work/gateway-operator/gateway-operator/controller/konnect/ops/credentialapikey_mock.go:72 /home/runner/work/gateway-operator/gateway-operator/test/envtest/kongconsumercredential_apikey_test.go:79]
    kongconsumercredential_apikey_test.go:119: FAIL: 1 out of 2 expectation(s) were met.
        	The code you are testing needs to make 1 more call(s).
        	at: [/home/runner/work/gateway-operator/gateway-operator/test/envtest/kongconsumercredential_apikey_test.go:119 /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/runtime/asm_amd64.s:1695]
    controller.go:80: Test TestKongConsumerCredential_APIKey failed: dumping controller logs
```

This error means that we didn't wait for the credential to get programmed but got straight away to asserting on the mock expectations.

This PR changes that so that we first wait for the credential to get created and programmed (with Konnect ID).