### PR TITLE
chore(konnect): rely on CEL rules to validate server url

### DIFF
--- a/config/crd/bases/gateway-operator.konghq.com_dataplanekonnectextensions.yaml
+++ b/config/crd/bases/gateway-operator.konghq.com_dataplanekonnectextensions.yaml
@@ -84,9 +84,11 @@ spec:
                       Type can be one of:
                       - konnectID
                       - konnectNamespacedRef
+                      - kic
                     enum:
                     - konnectID
                     - konnectNamespacedRef
+                    - kic
                     type: string
                 required:
                 - type
@@ -96,8 +98,21 @@ spec:
                     must be set
                   rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
                     : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
               controlPlaneRegion:
                 description: ControlPlaneRegion is the region of the Konnect Control
                   Plane.

--- a/controller/konnect/ops/server_url.go
+++ b/controller/konnect/ops/server_url.go
@@ -1,0 +1,23 @@
+package ops
+
+import "strings"
+
+// ServerURL is a type to represent a server URL.
+type ServerURL string
+
+// NewServerURL creates a new ServerURL from a string. It accepts either a full URL or a hostname.
+func NewServerURL(u string) ServerURL {
+	// If the URL does not have an HTTPs scheme, we prepend it HTTPs.
+	// CRD's CEL rules ensure that if the URL has no scheme, it's a valid hostname.
+	const defaultScheme = "https://"
+	if !strings.HasPrefix(u, defaultScheme) {
+		return ServerURL(defaultScheme + u)
+	}
+	// If the URL is a valid URL, we return it as is.
+	// We do not validate it uses HTTPs as it's validated on the CRD level.
+	return ServerURL(u)
+}
+
+func (s ServerURL) String() string {
+	return string(s)
+}

--- a/controller/konnect/ops/server_url_test.go
+++ b/controller/konnect/ops/server_url_test.go
@@ -1,0 +1,34 @@
+package ops_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/gateway-operator/controller/konnect/ops"
+)
+
+func TestServerURL(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "valid URL",
+			input:    "https://localhost:8000",
+			expected: "https://localhost:8000",
+		},
+		{
+			name:     "valid hostname",
+			input:    "konghq.server.somewhere",
+			expected: "https://konghq.server.somewhere",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ops.NewServerURL(tc.input)
+			require.Equal(t, tc.expected, got.String())
+		})
+	}
+}

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -47,8 +47,8 @@ type KonnectEntityReconciler[T constraints.SupportedKonnectEntityType, TEnt cons
 
 // KonnectEntityReconcilerOption is a functional option for the KonnectEntityReconciler.
 type KonnectEntityReconcilerOption[
-	T constraints.SupportedKonnectEntityType,
-	TEnt constraints.EntityType[T],
+T constraints.SupportedKonnectEntityType,
+TEnt constraints.EntityType[T],
 ] func(*KonnectEntityReconciler[T, TEnt])
 
 // WithKonnectEntitySyncPeriod sets the sync period for the reconciler.
@@ -63,8 +63,8 @@ func WithKonnectEntitySyncPeriod[T constraints.SupportedKonnectEntityType, TEnt 
 // NewKonnectEntityReconciler returns a new KonnectEntityReconciler for the given
 // Konnect entity type.
 func NewKonnectEntityReconciler[
-	T constraints.SupportedKonnectEntityType,
-	TEnt constraints.EntityType[T],
+T constraints.SupportedKonnectEntityType,
+TEnt constraints.EntityType[T],
 ](
 	sdkFactory ops.SDKFactory,
 	developmentMode bool,
@@ -96,8 +96,8 @@ func (r *KonnectEntityReconciler[T, TEnt]) SetupWithManager(ctx context.Context,
 		ent            = TEnt(&e)
 		entityTypeName = constraints.EntityTypeName[T]()
 		b              = ctrl.NewControllerManagedBy(mgr).
-				Named(entityTypeName).
-				WithOptions(
+			Named(entityTypeName).
+			WithOptions(
 				controller.Options{
 					MaxConcurrentReconciles: MaxConcurrentReconciles,
 				})
@@ -433,8 +433,9 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 
 	// NOTE: We need to create a new SDK instance for each reconciliation
 	// because the token is retrieved in runtime through KonnectAPIAuthConfiguration.
+	serverURL := ops.NewServerURL(apiAuth.Spec.ServerURL)
 	sdk := r.sdkFactory.NewKonnectSDK(
-		"https://"+apiAuth.Spec.ServerURL,
+		serverURL.String(),
 		ops.SDKToken(token),
 	)
 
@@ -570,11 +571,11 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 
 func setServerURLAndOrgIDFromAPIAuthConfiguration(
 	ent interface {
-		GetKonnectStatus() *konnectv1alpha1.KonnectEntityStatus
-	},
+	GetKonnectStatus() *konnectv1alpha1.KonnectEntityStatus
+},
 	apiAuth konnectv1alpha1.KonnectAPIAuthConfiguration,
 ) {
-	ent.GetKonnectStatus().ServerURL = apiAuth.Spec.ServerURL
+	ent.GetKonnectStatus().ServerURL = ops.NewServerURL(apiAuth.Spec.ServerURL).String()
 	ent.GetKonnectStatus().OrgID = apiAuth.Status.OrganizationID
 }
 

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -515,7 +515,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		}
 
 		if err == nil {
-			setServerURLAndOrgIDFromAPIAuthConfiguration(ent, serverURL, apiAuth)
+			setServerURLAndOrgID(ent, serverURL, apiAuth.Status.OrganizationID)
 		}
 
 		// Regardless of the error, set the status as it can contain the Konnect ID
@@ -540,7 +540,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 	}
 
 	if res, err := ops.Update[T, TEnt](ctx, sdk, r.SyncPeriod, r.Client, ent); err != nil {
-		setServerURLAndOrgIDFromAPIAuthConfiguration(ent, serverURL, apiAuth)
+		setServerURLAndOrgID(ent, serverURL, apiAuth.Status.OrganizationID)
 		if errUpd := r.Client.Status().Update(ctx, ent); errUpd != nil {
 			if k8serrors.IsConflict(errUpd) {
 				return ctrl.Result{Requeue: true}, nil
@@ -553,7 +553,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		return res, nil
 	}
 
-	setServerURLAndOrgIDFromAPIAuthConfiguration(ent, serverURL, apiAuth)
+	setServerURLAndOrgID(ent, serverURL, apiAuth.Status.OrganizationID)
 	if err := r.Client.Status().Update(ctx, ent); err != nil {
 		if k8serrors.IsConflict(err) {
 			return ctrl.Result{Requeue: true}, nil
@@ -569,15 +569,15 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 	}, nil
 }
 
-func setServerURLAndOrgIDFromAPIAuthConfiguration(
+func setServerURLAndOrgID(
 	ent interface {
 		GetKonnectStatus() *konnectv1alpha1.KonnectEntityStatus
 	},
 	serverURL ops.ServerURL,
-	apiAuth konnectv1alpha1.KonnectAPIAuthConfiguration,
+	orgID string,
 ) {
 	ent.GetKonnectStatus().ServerURL = serverURL.String()
-	ent.GetKonnectStatus().OrgID = apiAuth.Status.OrganizationID
+	ent.GetKonnectStatus().OrgID = orgID
 }
 
 // EntityWithControlPlaneRef is an interface for entities that have a ControlPlaneRef.

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -47,8 +47,8 @@ type KonnectEntityReconciler[T constraints.SupportedKonnectEntityType, TEnt cons
 
 // KonnectEntityReconcilerOption is a functional option for the KonnectEntityReconciler.
 type KonnectEntityReconcilerOption[
-T constraints.SupportedKonnectEntityType,
-TEnt constraints.EntityType[T],
+	T constraints.SupportedKonnectEntityType,
+	TEnt constraints.EntityType[T],
 ] func(*KonnectEntityReconciler[T, TEnt])
 
 // WithKonnectEntitySyncPeriod sets the sync period for the reconciler.
@@ -63,8 +63,8 @@ func WithKonnectEntitySyncPeriod[T constraints.SupportedKonnectEntityType, TEnt 
 // NewKonnectEntityReconciler returns a new KonnectEntityReconciler for the given
 // Konnect entity type.
 func NewKonnectEntityReconciler[
-T constraints.SupportedKonnectEntityType,
-TEnt constraints.EntityType[T],
+	T constraints.SupportedKonnectEntityType,
+	TEnt constraints.EntityType[T],
 ](
 	sdkFactory ops.SDKFactory,
 	developmentMode bool,
@@ -96,8 +96,8 @@ func (r *KonnectEntityReconciler[T, TEnt]) SetupWithManager(ctx context.Context,
 		ent            = TEnt(&e)
 		entityTypeName = constraints.EntityTypeName[T]()
 		b              = ctrl.NewControllerManagedBy(mgr).
-			Named(entityTypeName).
-			WithOptions(
+				Named(entityTypeName).
+				WithOptions(
 				controller.Options{
 					MaxConcurrentReconciles: MaxConcurrentReconciles,
 				})
@@ -571,8 +571,8 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 
 func setServerURLAndOrgIDFromAPIAuthConfiguration(
 	ent interface {
-	GetKonnectStatus() *konnectv1alpha1.KonnectEntityStatus
-},
+		GetKonnectStatus() *konnectv1alpha1.KonnectEntityStatus
+	},
 	apiAuth konnectv1alpha1.KonnectAPIAuthConfiguration,
 ) {
 	ent.GetKonnectStatus().ServerURL = ops.NewServerURL(apiAuth.Spec.ServerURL).String()

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -515,7 +515,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		}
 
 		if err == nil {
-			setServerURLAndOrgIDFromAPIAuthConfiguration(ent, apiAuth)
+			setServerURLAndOrgIDFromAPIAuthConfiguration(ent, serverURL, apiAuth)
 		}
 
 		// Regardless of the error, set the status as it can contain the Konnect ID
@@ -540,7 +540,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 	}
 
 	if res, err := ops.Update[T, TEnt](ctx, sdk, r.SyncPeriod, r.Client, ent); err != nil {
-		setServerURLAndOrgIDFromAPIAuthConfiguration(ent, apiAuth)
+		setServerURLAndOrgIDFromAPIAuthConfiguration(ent, serverURL, apiAuth)
 		if errUpd := r.Client.Status().Update(ctx, ent); errUpd != nil {
 			if k8serrors.IsConflict(errUpd) {
 				return ctrl.Result{Requeue: true}, nil
@@ -553,7 +553,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		return res, nil
 	}
 
-	setServerURLAndOrgIDFromAPIAuthConfiguration(ent, apiAuth)
+	setServerURLAndOrgIDFromAPIAuthConfiguration(ent, serverURL, apiAuth)
 	if err := r.Client.Status().Update(ctx, ent); err != nil {
 		if k8serrors.IsConflict(err) {
 			return ctrl.Result{Requeue: true}, nil
@@ -573,9 +573,10 @@ func setServerURLAndOrgIDFromAPIAuthConfiguration(
 	ent interface {
 		GetKonnectStatus() *konnectv1alpha1.KonnectEntityStatus
 	},
+	serverURL ops.ServerURL,
 	apiAuth konnectv1alpha1.KonnectAPIAuthConfiguration,
 ) {
-	ent.GetKonnectStatus().ServerURL = ops.NewServerURL(apiAuth.Spec.ServerURL).String()
+	ent.GetKonnectStatus().ServerURL = serverURL.String()
 	ent.GetKonnectStatus().OrgID = apiAuth.Status.OrganizationID
 }
 

--- a/controller/konnect/reconciler_konnectapiauth.go
+++ b/controller/konnect/reconciler_konnectapiauth.go
@@ -127,9 +127,6 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 	}
 
 	serverURL := ops.NewServerURL(apiAuth.Spec.ServerURL)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
 	sdk := r.sdkFactory.NewKonnectSDK(
 		serverURL.String(),
 		ops.SDKToken(token),

--- a/controller/konnect/reconciler_konnectapiauth_test.go
+++ b/controller/konnect/reconciler_konnectapiauth_test.go
@@ -2,7 +2,6 @@ package konnect
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -157,41 +156,6 @@ func TestGetTokenFromKonnectAPIAuthConfiguration(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.expectedToken, token)
-		})
-	}
-}
-
-func TestGetKonnectServerURL(t *testing.T) {
-	testCases := []struct {
-		name              string
-		serverURL         string
-		expectedServerURL string
-		expectedError     error
-	}{
-		{
-			name:              "valid Server URL, with scheme",
-			serverURL:         "https://konghq.com",
-			expectedServerURL: "https://konghq.com",
-		},
-		{
-			name:              "valid Server URL, without scheme",
-			serverURL:         "konghq.com",
-			expectedServerURL: "https://konghq.com",
-		},
-		{
-			name:              "invalid Server URL",
-			serverURL:         "http://konghq.com",
-			expectedServerURL: "",
-			expectedError:     errors.New("in case scheme is specified in the ServerURL, it must be https://: http://konghq.com"),
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			serverURL, err := getKonnectServerURL(tc.serverURL)
-
-			assert.Equal(t, tc.expectedError, err)
-			assert.Equal(t, tc.expectedServerURL, serverURL)
 		})
 	}
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -477,7 +477,7 @@ It is used to reference a Control Plane entity.
 
 | Field | Description |
 | --- | --- |
-| `type` _string_ | Type can be one of: - konnectID - konnectNamespacedRef |
+| `type` _string_ | Type can be one of: - konnectID - konnectNamespacedRef - kic |
 | `konnectID` _string_ | KonnectID is the schema for the KonnectID type. This field is required when the Type is konnectID. |
 | `konnectNamespacedRef` _[KonnectNamespacedRef](#konnectnamespacedref)_ | KonnectNamespacedRef is a reference to a Konnect Control Plane entity inside the cluster. It contains the name of the Konnect Control Plane. This field is required when the Type is konnectNamespacedRef. |
 
@@ -3158,8 +3158,8 @@ KonnectAPIAuthConfigurationSpec is the specification of the KonnectAPIAuthConfig
 | --- | --- |
 | `type` _[KonnectAPIAuthType](#konnectapiauthtype)_ |  |
 | `token` _string_ | Token is the Konnect token used to authenticate with the Konnect API. |
-| `secretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretreference-v1-core)_ | SecretRef is a reference to a Kubernetes Secret containing the Konnect token. This secret is required to has the konghq.com/credential label set to "konnect". |
-| `serverURL` _string_ | ServerURL is the URL of the Konnect server. |
+| `secretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretreference-v1-core)_ | SecretRef is a reference to a Kubernetes Secret containing the Konnect token. This secret is required to have the konghq.com/credential label set to "konnect". |
+| `serverURL` _string_ | ServerURL is the URL of the Konnect server. It can be either a full URL with an HTTPs scheme or just a hostname. Please refer to https://docs.konghq.com/konnect/network/ for the list of supported hostnames. |
 
 
 _Appears in:_

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-containerregistry v0.20.2
 	github.com/google/uuid v1.6.0
-	github.com/kong/kubernetes-configuration v0.0.29
+	github.com/kong/kubernetes-configuration v0.0.32
 	github.com/kong/kubernetes-telemetry v0.1.5
 	github.com/kong/kubernetes-testing-framework v0.47.2
 	github.com/kong/semver/v4 v4.0.1

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kong/go-kong v0.59.1 h1:AJZtyCD+Zyqe/mF/m+x3/qN/GPVxAH7jq9zGJTHRfjc=
 github.com/kong/go-kong v0.59.1/go.mod h1:8Vt6HmtgLNgL/7bSwAlz3DIWqBtzG7qEt9+OnMiQOa0=
-github.com/kong/kubernetes-configuration v0.0.29 h1:NgjQyZ4PekXW0w4Qi+i/GP3HENWzHfIs3h+wMDWa91o=
-github.com/kong/kubernetes-configuration v0.0.29/go.mod h1:oAdPMWiWJ6qbMPPExUSj3c3YrI675JUIfsDcKWnGW0M=
+github.com/kong/kubernetes-configuration v0.0.32 h1:ChTVdJpYD2dDwHhXAOY9fw/Cgw8hbbA5ZM0GmpiJzYE=
+github.com/kong/kubernetes-configuration v0.0.32/go.mod h1:oAdPMWiWJ6qbMPPExUSj3c3YrI675JUIfsDcKWnGW0M=
 github.com/kong/kubernetes-telemetry v0.1.5 h1:xHwU1q0IvfEYqpj03po73ZKbVarnFPUwzkoFkdVnr9w=
 github.com/kong/kubernetes-telemetry v0.1.5/go.mod h1:1UXyZ6N3e8Fl6YguToQ6tKNveonkhjSqxzY7HVW+Ba4=
 github.com/kong/kubernetes-testing-framework v0.47.2 h1:+2Z9anTpbV/hwNeN+NFQz53BMU+g3QJydkweBp3tULo=


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds less restrictive `NewServerURL` constructor that considers the value passed from the object always valid as the validation is done on the CRD CEL rules level. 

Depends on https://github.com/Kong/kubernetes-configuration/pull/121.

**Which issue this PR fixes**

Part of https://github.com/Kong/kubernetes-configuration/issues/63. 
