### PR TITLE
tests: fix TestKonnectEntityReconcilers for KonnectGatewayControlPlane

### DIFF
--- a/test/envtest/konnect_entities_gatewaycontrolplane_test.go
+++ b/test/envtest/konnect_entities_gatewaycontrolplane_test.go
@@ -310,7 +310,13 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 							ID: lo.ToPtr("123467"),
 						},
 					},
-					nil)
+					nil,
+				).
+				// NOTE: UpdateControlPlane can be called depending on the order
+				// of the events in the queue: either the group itself or the member
+				// control plane can be created first.
+				Maybe()
+
 			// verify that mock SDK is called as expected.
 			t.Cleanup(func() {
 				require.True(t, sdk.ControlPlaneSDK.AssertExpectations(t))
@@ -330,6 +336,9 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 			) {
 				return
 			}
+			assert.True(t, conditionsContainProgrammedTrue(cp.Status.Conditions),
+				"Programmed condition should be set and its status should be true",
+			)
 			assert.True(t, controllerutil.ContainsFinalizer(cp, konnect.KonnectCleanupFinalizer),
 				"Finalizer should be set on control plane",
 			)


### PR DESCRIPTION
**What this PR does / why we need it**:

Change the assertions on the `UpdateControlPlane` since whether that will be called depends on the order of `KonnectGatewayControlPlane`s which will be reconciled (cp group or its member).

I've attempted to wait for cp group member to get programmed (before we move on to deploy the group) but that yielded data race for some reason 

```
==================
WARNING: DATA RACE
Read at 0x00c000750a03 by goroutine 288:
  testing.(*common).logDepth()
      go1.23.0/src/testing/testing.go:1018 +0x8c
  testing.(*common).log()
      go1.23.0/src/testing/testing.go:1011 +0x80
  testing.(*common).Errorf()
      go1.23.0/src/testing/testing.go:1075 +0x58
  testing.(*T).Errorf()
      <autogenerated>:1 +0x5c
  github.com/stretchr/testify/mock.(*Mock).fail()
      go1.23.0/global/pkg/mod/github.com/stretchr/testify@v1.9.0/mock/mock.go:337 +0xdc
  github.com/stretchr/testify/mock.(*Mock).MethodCalled()
      go1.23.0/global/pkg/mod/github.com/stretchr/testify@v1.9.0/mock/mock.go:501 +0x6a4
  github.com/stretchr/testify/mock.(*Mock).Called()
      go1.23.0/global/pkg/mod/github.com/stretchr/testify@v1.9.0/mock/mock.go:466 +0x150
  github.com/kong/gateway-operator/controller/konnect/ops.(*MockControlPlaneSDK).UpdateControlPlane()
      gateway-operator/controller/konnect/ops/controlplane_mock.go:185 +0x2c8
  github.com/kong/gateway-operator/controller/konnect/ops.updateControlPlane()
      gateway-operator/controller/konnect/ops/ops_controlplane.go:105 +0x200
  github.com/kong/gateway-operator/controller/konnect/ops.Update[go.shape.struct { k8s.io/apimachinery/pkg/apis/meta/v1.TypeMeta "json:\",inline\""; k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta "json:\"metadata,omitempty\""; Spec github.com/kong/kubernetes-configuration/api/konnect/v1alpha1.KonnectGatewayControlPlaneSpec "json:\"spec,omitempty\""; Status github.com/kong/kubernetes-configuration/api/konnect/v1alpha1.KonnectGatewayControlPlaneStatus "json:\"status,omitempty\"" },go.shape.*github.com/kong/kubernetes-configuration/api/konnect/v1alpha1.KonnectGatewayControlPlane]()
      gateway-operator/controller/konnect/ops/ops.go:228 +0x3b8
  github.com/kong/gateway-operator/controller/konnect.(*KonnectEntityReconciler[go.shape.struct { k8s.io/apimachinery/pkg/apis/meta/v1.TypeMeta "json:\",inline\""; k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta "json:\"metadata,omitempty\""; Spec github.com/kong/kubernetes-configuration/api/konnect/v1alpha1.KonnectGatewayControlPlaneSpec "json:\"spec,omitempty\""; Status github.com/kong/kubernetes-configuration/api/konnect/v1alpha1.KonnectGatewayControlPlaneStatus "json:\"status,omitempty\"" },go.shape.*github.com/kong/kubernetes-configuration/api/konnect/v1alpha1.KonnectGatewayControlPlane]).Reconcile()
      gateway-operator/controller/konnect/reconciler_generic.go:541 +0x3130
  github.com/kong/gateway-operator/controller/konnect.(*KonnectEntityReconciler[github.com/kong/kubernetes-configuration/api/konnect/v1alpha1.KonnectGatewayControlPlane,*github.com/kong/kubernetes-configuration/api/konnect/v1alpha1.KonnectGatewayControlPlane]).Reconcile()
      gateway-operator/controller/konnect/reconciler_generic.go:113 +0x74
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).Reconcile()
      go1.23.0/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:116 +0x118
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).reconcileHandler()
      go1.23.0/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:303 +0x3a4
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).processNextWorkItem()
      go1.23.0/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263 +0x26c
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).Start.func2.2()
      go1.23.0/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224 +0xc8

Previous write at 0x00c000750a03 by goroutine 229:
  testing.tRunner.func1()
      go1.23.0/src/testing/testing.go:1677 +0x5e0
  runtime.deferreturn()
      go1.23.0/src/runtime/panic.go:605 +0x5c
  testing.(*T).Run.gowrap1()
      go1.23.0/src/testing/testing.go:1743 +0x40

Goroutine 288 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).Start.func2()
      go1.23.0/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:220 +0x564
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).Start()
      go1.23.0/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:231 +0x2ec
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[sigs.k8s.io/controller-runtime/pkg/reconcile.Request]).Start()
      go1.23.0/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:145 +0x48
  sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1()
      go1.23.0/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/manager/runnable_group.go:226 +0x170
  sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.gowrap1()
      go1.23.0/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/manager/runnable_group.go:229 +0x44

Goroutine 229 (finished) created at:
  testing.(*T).Run()
      go1.23.0/src/testing/testing.go:1743 +0x5e0
  github.com/kong/gateway-operator/test/envtest.testNewKonnectEntityReconciler[go.shape.struct { k8s.io/apimachinery/pkg/apis/meta/v1.TypeMeta "json:\",inline\""; k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta "json:\"metadata,omitempty\""; Spec github.com/kong/kubernetes-configuration/api/konnect/v1alpha1.KonnectGatewayControlPlaneSpec "json:\"spec,omitempty\""; Status github.com/kong/kubernetes-configuration/api/konnect/v1alpha1.KonnectGatewayControlPlaneStatus "json:\"status,omitempty\"" },go.shape.*github.com/kong/kubernetes-configuration/api/konnect/v1alpha1.KonnectGatewayControlPlane]()
      gateway-operator/test/envtest/konnect_entities_suite_test.go:55 +0x178
  github.com/kong/gateway-operator/test/envtest.TestKonnectEntityReconcilers()
      gateway-operator/test/envtest/konnect_entities_suite_test.go:31 +0xc4
  testing.tRunner()
      go1.23.0/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      go1.23.0/src/testing/testing.go:1743 +0x40
==================
```