### PR TITLE
tests: fix TestKongConsumerCredential_* tests by using correct testing handle

### DIFF
--- a/test/envtest/assert.go
+++ b/test/envtest/assert.go
@@ -25,6 +25,6 @@ func assertCollectObjectExistsAndHasKonnectID(
 		if !assert.NoError(c, clientNamespaced.Get(ctx, nn, obj)) {
 			return
 		}
-		assert.Equal(t, konnectID, obj.GetKonnectID())
+		assert.Equal(c, konnectID, obj.GetKonnectID())
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`assertCollectObjectExistsAndHasKonnectID` didn't use the correct testing handle which caused several test failures (due to eventually consistent nature of the assert that uses that handle).

This PR fixes it.