### PR TITLE
chore: impersonate KGO RBACs with `make _run`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -507,6 +507,7 @@ impersonate-kgo:
 	KUBECONFIG=$(TMP_KUBECONFIG) kubectl config set-credentials kgo --token=$(shell kubectl create token --namespace=kong-system controller-manager)
 	KUBECONFIG=$(TMP_KUBECONFIG) kubectl config set-context kgo --cluster=$(shell kubectl config get-contexts | grep '^\*' | tr -s ' ' | cut -d ' ' -f 3) --user=kgo --namespace=kong-system
 	KUBECONFIG=$(TMP_KUBECONFIG) kubectl config use-context kgo
+
 # Run a controller from your host.
 .PHONY: run
 run: webhook-certs-dir manifests generate install.all _ensure-kong-system-namespace install.rbacs

--- a/Makefile
+++ b/Makefile
@@ -510,7 +510,7 @@ impersonate-kgo:
 # Run a controller from your host.
 .PHONY: run
 run: webhook-certs-dir manifests generate install.all _ensure-kong-system-namespace install.rbacs
-	$(MAKE) _run
+	@$(MAKE) _run
 
 # Run the operator without checking any preconditions, installing CRDs etc.
 # This is mostly useful when 'run' was run at least once on a server and CRDs, RBACs

--- a/Makefile
+++ b/Makefile
@@ -507,9 +507,6 @@ impersonate-kgo:
 	KUBECONFIG=$(TMP_KUBECONFIG) kubectl config set-credentials kgo --token=$(shell kubectl create token --namespace=kong-system controller-manager)
 	KUBECONFIG=$(TMP_KUBECONFIG) kubectl config set-context kgo --cluster=$(shell kubectl config get-contexts | grep '^\*' | tr -s ' ' | cut -d ' ' -f 3) --user=kgo --namespace=kong-system
 	KUBECONFIG=$(TMP_KUBECONFIG) kubectl config use-context kgo
-
-
-
 # Run a controller from your host.
 .PHONY: run
 run: webhook-certs-dir manifests generate install.all _ensure-kong-system-namespace install.rbacs

--- a/Makefile
+++ b/Makefile
@@ -502,6 +502,11 @@ _ensure-kong-system-namespace:
 run: webhook-certs-dir manifests generate install.all _ensure-kong-system-namespace install.rbacs
 	@$(MAKE) _run
 
+# Run a controller from your host and make it impersonate the controller-manager service account from kong-system namespace.
+.PHONY: run.with_impersonate
+run.with_impersonate: webhook-certs-dir manifests generate install.all _ensure-kong-system-namespace install.rbacs
+	@$(MAKE) _run.with-impersonate
+
 KUBECONFIG ?= $(HOME)/.kube/config
 
 # Run the operator without checking any preconditions, installing CRDs etc.

--- a/Makefile
+++ b/Makefile
@@ -497,29 +497,21 @@ webhook-certs-dir:
 _ensure-kong-system-namespace:
 	@kubectl create ns kong-system 2>/dev/null || true
 
-TMP_DIR := $(shell mktemp -d)
-KUBECONFIG ?= $(HOME)/.kube/config
-TMP_KUBECONFIG := $(TMP_DIR)/kubeconfig
-
-.PHONY: impersonate-kgo
-impersonate-kgo:
-	cp $(KUBECONFIG) $(TMP_KUBECONFIG)
-	KUBECONFIG=$(TMP_KUBECONFIG) kubectl config set-credentials kgo --token=$(shell kubectl create token --namespace=kong-system controller-manager)
-	KUBECONFIG=$(TMP_KUBECONFIG) kubectl config set-context kgo --cluster=$(shell kubectl config get-contexts | grep '^\*' | tr -s ' ' | cut -d ' ' -f 3) --user=kgo --namespace=kong-system
-	KUBECONFIG=$(TMP_KUBECONFIG) kubectl config use-context kgo
-
 # Run a controller from your host.
 .PHONY: run
 run: webhook-certs-dir manifests generate install.all _ensure-kong-system-namespace install.rbacs
 	@$(MAKE) _run
 
+KUBECONFIG ?= $(HOME)/.kube/config
+
 # Run the operator without checking any preconditions, installing CRDs etc.
 # This is mostly useful when 'run' was run at least once on a server and CRDs, RBACs
 # etc didn't change in between the runs.
-# The operator will use a temporary kubeconfig file and impersonate the real RBACs.
 .PHONY: _run
-_run: impersonate-kgo
-	KUBECONFIG=$(TMP_KUBECONFIG) GATEWAY_OPERATOR_DEVELOPMENT_MODE=true go run ./cmd/main.go \
+_run:
+	KUBECONFIG=$(KUBECONFIG) \
+		GATEWAY_OPERATOR_DEVELOPMENT_MODE=true \
+		go run ./cmd/main.go \
 		--no-leader-election \
 		-cluster-ca-secret-namespace kong-system \
 		-enable-controller-kongplugininstallation \
@@ -528,6 +520,21 @@ _run: impersonate-kgo
 		-zap-time-encoding iso8601 \
 		-zap-log-level 2 \
 		-zap-devel true
+
+# Run the operator locally with impersonation of controller-manager service account from kong-system namespace.
+# The operator will use a temporary kubeconfig file and impersonate the real RBACs.
+.PHONY: _run.with-impersonate
+_run.with-impersonate:
+	@$(eval TMP := $(shell mktemp -d))
+	@$(eval TMP_KUBECONFIG := $(TMP)/kubeconfig)
+	[ ! -z "$(KUBECONFIG)" ] || exit 1
+	cp $(KUBECONFIG) $(TMP_KUBECONFIG)
+	@$(eval TMP_TOKEN := $(shell kubectl create token --namespace=kong-system controller-manager))
+	@$(eval CLUSTER := $(shell kubectl config get-contexts | grep '^\*' | tr -s ' ' | cut -d ' ' -f 3))
+	KUBECONFIG=$(TMP_KUBECONFIG) kubectl config set-credentials kgo --token=$(TMP_TOKEN)
+	KUBECONFIG=$(TMP_KUBECONFIG) kubectl config set-context kgo --cluster=$(CLUSTER) --user=kgo --namespace=kong-system
+	KUBECONFIG=$(TMP_KUBECONFIG) kubectl config use-context kgo
+	bash -c "trap 'echo deleting temporary kubeconfig $(TMP); rm -rf $(TMP)' EXIT; $(MAKE) _run KUBECONFIG=$(TMP_KUBECONFIG)"
 
 SKAFFOLD_RUN_PROFILE ?= dev
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When running `make run`, a new context that uses the KGO RBACs is set and used. This way, `make run` will allow us to properly test with the actual KGO RBACs, instead of using the admin user.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
