### PR TITLE
chore: prepare 1.4.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- [v1.4.0-rc.0](#v140-rc0)
 - [v1.3.0](#v130)
 - [v1.2.3](#v123)
 - [v1.2.2](#v122)
@@ -21,9 +22,9 @@
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
 
-## Unreleased
+## [v1.4.0-rc.0]
 
-> Release date: TBD
+> Release date: 2024-10-23
 
 ### Added
 
@@ -789,6 +790,7 @@ leftovers from previous operator deployments in the cluster. The user needs to d
 (clusterrole, clusterrolebinding, validatingWebhookConfiguration) before
 re-installing the operator through the bundle.
 
+[v1.4.0-rc.0]: https://github.com/Kong/gateway-operator/compare/v1.3.0..v1.4.0-rc.0
 [v1.3.0]: https://github.com/Kong/gateway-operator/compare/v1.2.3..v1.3.0
 [v1.2.3]: https://github.com/Kong/gateway-operator/compare/v1.2.2..v1.2.3
 [v1.2.2]: https://github.com/Kong/gateway-operator/compare/v1.2.1..v1.2.2


### PR DESCRIPTION
**What this PR does / why we need it**:

Preparing changelog for `1.4.0-rc.0`

Part of #720 
