### PR TITLE
chore(rbac) add permission to update kongpluginbindings/status

### DIFF
--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -207,6 +207,7 @@ rules:
   - kongkeys/status
   - kongkeysets/status
   - konglicenses/status
+  - kongpluginbindings/status
   - kongplugins/status
   - kongroutes/status
   - kongservices/status

--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -179,6 +179,7 @@ rules:
   - kongdataplaneclientcertificates/finalizers
   - kongkeys/finalizers
   - kongkeysets/finalizers
+  - kongpluginbindings/status
   - kongroutes/finalizers
   - kongservices/finalizers
   - kongsnis/finalizers
@@ -207,7 +208,6 @@ rules:
   - kongkeys/status
   - kongkeysets/status
   - konglicenses/status
-  - kongpluginbindings/status
   - kongplugins/status
   - kongroutes/status
   - kongservices/status

--- a/controller/konnect/reconciler_kongplugin_rbac.go
+++ b/controller/konnect/reconciler_kongplugin_rbac.go
@@ -6,4 +6,4 @@ package konnect
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongservices,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongroutes,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongpluginbindings,verbs=get;list;create;watch;update;patch;delete
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongpluginbindings/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongpluginbindings/status,verbs=update;patch

--- a/controller/konnect/reconciler_kongplugin_rbac.go
+++ b/controller/konnect/reconciler_kongplugin_rbac.go
@@ -6,3 +6,4 @@ package konnect
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongservices,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongroutes,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongpluginbindings,verbs=get;list;create;watch;update;patch;delete
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongpluginbindings/status,verbs=get;update;patch


### PR DESCRIPTION
**What this PR does / why we need it**:
Add permissions to update `kongpluginbindings/status` in RBAC for `KongPluginBinding` reconcilers to update status.
**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
