### PR TITLE
chore(rbac): remove get status rbac permission for konnect entities

### DIFF
--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -168,23 +168,38 @@ rules:
   - configuration.konghq.com
   resources:
   - kongcacertificates/finalizers
+  - kongcacertificates/status
   - kongcertificates/finalizers
+  - kongcertificates/status
   - kongconsumergroups/finalizers
   - kongconsumers/finalizers
   - kongcredentialacls/finalizers
+  - kongcredentialacls/status
   - kongcredentialapikeys/finalizers
+  - kongcredentialapikeys/status
   - kongcredentialbasicauths/finalizers
+  - kongcredentialbasicauths/status
   - kongcredentialhmacs/finalizers
+  - kongcredentialhmacs/status
   - kongcredentialjwts/finalizers
+  - kongcredentialjwts/status
   - kongdataplaneclientcertificates/finalizers
+  - kongdataplaneclientcertificates/status
   - kongkeys/finalizers
+  - kongkeys/status
   - kongkeysets/finalizers
+  - kongkeysets/status
   - kongpluginbindings/status
   - kongroutes/finalizers
+  - kongroutes/status
   - kongservices/finalizers
+  - kongservices/status
   - kongsnis/finalizers
+  - kongsnis/status
   - kongtargets/finalizers
+  - kongtargets/status
   - kongupstreams/finalizers
+  - kongupstreams/status
   - kongvaults/finalizers
   verbs:
   - patch
@@ -192,29 +207,14 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
-  - kongcacertificates/status
-  - kongcertificates/status
   - kongclusterplugins/status
   - kongconsumergroups/status
   - kongconsumers/status
-  - kongcredentialacls/status
-  - kongcredentialapikeys/status
-  - kongcredentialbasicauths/status
-  - kongcredentialhmacs/status
-  - kongcredentialjwts/status
   - kongcustomentities/status
-  - kongdataplaneclientcertificates/status
   - kongingresses/status
-  - kongkeys/status
-  - kongkeysets/status
   - konglicenses/status
   - kongplugins/status
-  - kongroutes/status
-  - kongservices/status
-  - kongsnis/status
-  - kongtargets/status
   - kongupstreampolicies/status
-  - kongupstreams/status
   - kongvaults/status
   - tcpingresses/status
   - udpingresses/status
@@ -405,6 +405,7 @@ rules:
   resources:
   - konnectapiauthconfigurations/finalizers
   - konnectgatewaycontrolplanes/finalizers
+  - konnectgatewaycontrolplanes/status
   verbs:
   - patch
   - update
@@ -412,7 +413,6 @@ rules:
   - konnect.konghq.com
   resources:
   - konnectapiauthconfigurations/status
-  - konnectgatewaycontrolplanes/status
   verbs:
   - get
   - patch

--- a/controller/konnect/reconciler_generic_rbac.go
+++ b/controller/konnect/reconciler_generic_rbac.go
@@ -1,83 +1,83 @@
 package konnect
 
 //+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectapiauthconfigurations,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectapiauthconfigurations/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectapiauthconfigurations/status,verbs=update;patch
 //+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectapiauthconfigurations/finalizers,verbs=update;patch
 
 //+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectgatewaycontrolplanes,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectgatewaycontrolplanes/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectgatewaycontrolplanes/status,verbs=update;patch
 //+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectgatewaycontrolplanes/finalizers,verbs=update;patch
 
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcacertificates,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcacertificates/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcacertificates/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcacertificates/finalizers,verbs=update;patch
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcertificates,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcertificates/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcertificates/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcertificates/finalizers,verbs=update;patch
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongconsumergroups,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongconsumergroups/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongconsumergroups/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongconsumergroups/finalizers,verbs=update;patch
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongconsumers,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongconsumers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongconsumers/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongconsumers/finalizers,verbs=update;patch
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialacls,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialacls/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialacls/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialacls/finalizers,verbs=update;patch
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialapikeys,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialapikeys/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialapikeys/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialapikeys/finalizers,verbs=update;patch
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialbasicauths,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialbasicauths/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialbasicauths/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialbasicauths/finalizers,verbs=update;patch
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialhmacs,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialhmacs/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialhmacs/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialhmacs/finalizers,verbs=update;patch
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialjwts,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialjwts/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialjwts/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialjwts/finalizers,verbs=update;patch
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongdataplaneclientcertificates,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongdataplaneclientcertificates/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongdataplaneclientcertificates/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongdataplaneclientcertificates/finalizers,verbs=update;patch
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongkeys,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongkeys/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongkeys/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongkeys/finalizers,verbs=update;patch
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongkeysets,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongkeysets/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongkeysets/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongkeysets/finalizers,verbs=update;patch
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongroutes,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongroutes/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongroutes/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongroutes/finalizers,verbs=update;patch
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongservices,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongservices/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongservices/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongservices/finalizers,verbs=update;patch
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongsnis,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongsnis/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongsnis/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongsnis/finalizers,verbs=update;patch
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongtargets,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongtargets/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongtargets/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongtargets/finalizers,verbs=update;patch
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongupstreams,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongupstreams/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongupstreams/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongupstreams/finalizers,verbs=update;patch
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongvaults,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongvaults/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongvaults/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongvaults/finalizers,verbs=update;patch


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove the `get` permission for `*/status` resources  for Konnect entity controllers.
 
**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

Not all `get */status` permission are removed. The other controllers like `ControlPlane`, `DataPlane`, `AIGateway` controllers are not touched. Should we also remove the `get */status` permission for controlled resources?

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
