### PR TITLE
fix: set DataPlane's ExternalTrafficPolicy on updates and patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,7 +123,7 @@
   [#710](https://github.com/Kong/gateway-operator/pull/710)
 - Do not reconcile Gateways nor assign any finalizers when the referred GatewayClass is not supported.
   [#711](https://github.com/Kong/gateway-operator/pull/711)
-- Fixed setting `ExternalTrafficPolicy` on `DataPlane`'s ingress `Service during update and patch operations.
+- Fixed setting `ExternalTrafficPolicy` on `DataPlane`'s ingress `Service` during update and patch operations.
   [#750](https://github.com/Kong/gateway-operator/pull/750)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,8 @@
   [#710](https://github.com/Kong/gateway-operator/pull/710)
 - Do not reconcile Gateways nor assign any finalizers when the referred GatewayClass is not supported.
   [#711](https://github.com/Kong/gateway-operator/pull/711)
+- Fixed setting `ExternalTrafficPolicy` on `DataPlane`'s ingress `Service during update and patch operations.
+  [#750](https://github.com/Kong/gateway-operator/pull/750)
 
 ### Changes
 

--- a/controller/dataplane/owned_resources.go
+++ b/controller/dataplane/owned_resources.go
@@ -402,6 +402,10 @@ func ensureIngressServiceForDataPlane(
 			existingService.Spec.Type = generatedService.Spec.Type
 			updated = true
 		}
+		if existingService.Spec.ExternalTrafficPolicy != generatedService.Spec.ExternalTrafficPolicy {
+			existingService.Spec.ExternalTrafficPolicy = generatedService.Spec.ExternalTrafficPolicy
+			updated = true
+		}
 		if !cmp.Equal(existingService.Spec.Selector, generatedService.Spec.Selector) {
 			existingService.Spec.Selector = generatedService.Spec.Selector
 			updated = true

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -66,6 +66,10 @@ func Create[
 
 	case *configurationv1alpha1.KongRoute:
 		err = createRoute(ctx, sdk.GetRoutesSDK(), ent)
+
+		// TODO: modify the create* operation wrappers to not set Programmed conditions and return
+		// a KonnectEntityCreatedButRelationsFailedError if the entity was created but its relations assignment failed.
+
 	case *configurationv1.KongConsumer:
 		err = createConsumer(ctx, sdk.GetConsumersSDK(), sdk.GetConsumerGroupsSDK(), cl, ent)
 	case *configurationv1beta1.KongConsumerGroup:

--- a/test/integration/zz_generated_registered_testcases.go
+++ b/test/integration/zz_generated_registered_testcases.go
@@ -13,6 +13,7 @@ func init() {
 		TestDataPlaneEssentials,
 		TestDataPlaneHorizontalScaling,
 		TestDataPlanePodDisruptionBudget,
+		TestDataPlaneServiceExternalTrafficPolicy,
 		TestDataPlaneUpdate,
 		TestDataPlaneValidation,
 		TestDataPlaneVolumeMounts,


### PR DESCRIPTION
**What this PR does / why we need it**:

#241 added support for setting `ExternalTrafficPolicy` on `DataPlane` ingress `Service`.

It missed an important aspect of it: comparing the policy on existing `Services`.

This PR fixes this.

**Special notes for your reviewer**:

Another consequence of not having #500 implemented and still using error prone "per field comparison" approach.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
