### PR TITLE
fix(konnect): handle KongConsumerGroup conflict on creation

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -43,14 +43,8 @@ linters-settings:
   importas:
     no-unaliased: true
     alias:
-      - pkg: k8s.io/api/core/v1
-        alias: corev1
-      - pkg: k8s.io/api/apps/v1
-        alias: appsv1
-      - pkg: k8s.io/api/admission/v1
-        alias: admissionv1
-      - pkg: k8s.io/api/certificates/v1
-        alias: certificatesv1
+      - pkg: k8s.io/api/([a-z])/(v[\w\d]+)
+        alias: ${1}${2}
 
       - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
         alias: metav1
@@ -62,6 +56,8 @@ linters-settings:
 
       - pkg: github.com/kong/gateway-operator/internal/types
         alias: gwtypes
+      - pkg: github.com/kong/kubernetes-configuration/api/configuration/([\w\d]+)
+        alias: configuration${1}
 
       - pkg: github.com/Kong/sdk-konnect-go/models/components
         alias: sdkkonnectcomp
@@ -69,6 +65,7 @@ linters-settings:
         alias: sdkkonnectops
       - pkg: github.com/Kong/sdk-konnect-go/models/sdkerrors
         alias: sdkkonnecterrs
+
   revive:
     rules:
       - name: errorf

--- a/controller/konnect/ops/kongconsumergroup.go
+++ b/controller/konnect/ops/kongconsumergroup.go
@@ -15,4 +15,5 @@ type ConsumerGroupSDK interface {
 	AddConsumerToGroup(ctx context.Context, request sdkkonnectops.AddConsumerToGroupRequest, opts ...sdkkonnectops.Option) (*sdkkonnectops.AddConsumerToGroupResponse, error)
 	RemoveConsumerFromGroup(ctx context.Context, request sdkkonnectops.RemoveConsumerFromGroupRequest, opts ...sdkkonnectops.Option) (*sdkkonnectops.RemoveConsumerFromGroupResponse, error)
 	ListConsumerGroupsForConsumer(ctx context.Context, request sdkkonnectops.ListConsumerGroupsForConsumerRequest, opts ...sdkkonnectops.Option) (*sdkkonnectops.ListConsumerGroupsForConsumerResponse, error)
+	ListConsumerGroup(ctx context.Context, request sdkkonnectops.ListConsumerGroupRequest, opts ...sdkkonnectops.Option) (*sdkkonnectops.ListConsumerGroupResponse, error)
 }

--- a/controller/konnect/ops/kongconsumergroup_mock.go
+++ b/controller/konnect/ops/kongconsumergroup_mock.go
@@ -249,6 +249,80 @@ func (_c *MockConsumerGroupSDK_DeleteConsumerGroup_Call) RunAndReturn(run func(c
 	return _c
 }
 
+// ListConsumerGroup provides a mock function with given fields: ctx, request, opts
+func (_m *MockConsumerGroupSDK) ListConsumerGroup(ctx context.Context, request operations.ListConsumerGroupRequest, opts ...operations.Option) (*operations.ListConsumerGroupResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, request)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListConsumerGroup")
+	}
+
+	var r0 *operations.ListConsumerGroupResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, operations.ListConsumerGroupRequest, ...operations.Option) (*operations.ListConsumerGroupResponse, error)); ok {
+		return rf(ctx, request, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, operations.ListConsumerGroupRequest, ...operations.Option) *operations.ListConsumerGroupResponse); ok {
+		r0 = rf(ctx, request, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*operations.ListConsumerGroupResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, operations.ListConsumerGroupRequest, ...operations.Option) error); ok {
+		r1 = rf(ctx, request, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockConsumerGroupSDK_ListConsumerGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListConsumerGroup'
+type MockConsumerGroupSDK_ListConsumerGroup_Call struct {
+	*mock.Call
+}
+
+// ListConsumerGroup is a helper method to define mock.On call
+//   - ctx context.Context
+//   - request operations.ListConsumerGroupRequest
+//   - opts ...operations.Option
+func (_e *MockConsumerGroupSDK_Expecter) ListConsumerGroup(ctx interface{}, request interface{}, opts ...interface{}) *MockConsumerGroupSDK_ListConsumerGroup_Call {
+	return &MockConsumerGroupSDK_ListConsumerGroup_Call{Call: _e.mock.On("ListConsumerGroup",
+		append([]interface{}{ctx, request}, opts...)...)}
+}
+
+func (_c *MockConsumerGroupSDK_ListConsumerGroup_Call) Run(run func(ctx context.Context, request operations.ListConsumerGroupRequest, opts ...operations.Option)) *MockConsumerGroupSDK_ListConsumerGroup_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]operations.Option, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(operations.Option)
+			}
+		}
+		run(args[0].(context.Context), args[1].(operations.ListConsumerGroupRequest), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockConsumerGroupSDK_ListConsumerGroup_Call) Return(_a0 *operations.ListConsumerGroupResponse, _a1 error) *MockConsumerGroupSDK_ListConsumerGroup_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockConsumerGroupSDK_ListConsumerGroup_Call) RunAndReturn(run func(context.Context, operations.ListConsumerGroupRequest, ...operations.Option) (*operations.ListConsumerGroupResponse, error)) *MockConsumerGroupSDK_ListConsumerGroup_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListConsumerGroupsForConsumer provides a mock function with given fields: ctx, request, opts
 func (_m *MockConsumerGroupSDK) ListConsumerGroupsForConsumer(ctx context.Context, request operations.ListConsumerGroupsForConsumerRequest, opts ...operations.Option) (*operations.ListConsumerGroupsForConsumerResponse, error) {
 	_va := make([]interface{}, len(opts))

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -61,16 +61,8 @@ func Create[
 		err = createService(ctx, sdk.GetServicesSDK(), ent)
 	case *configurationv1alpha1.KongRoute:
 		err = createRoute(ctx, sdk.GetRoutesSDK(), ent)
-
-		// TODO: modify the create* operation wrappers to not set Programmed conditions and return
-		// a KonnectEntityCreatedButRelationsFailedError if the entity was created but its relations assignment failed.
-
 	case *configurationv1.KongConsumer:
 		err = createConsumer(ctx, sdk.GetConsumersSDK(), sdk.GetConsumerGroupsSDK(), cl, ent)
-
-		// TODO: modify the create* operation wrappers to not set Programmed conditions and return
-		// a KonnectEntityCreatedButRelationsFailedError if the entity was created but its relations assignment failed.
-
 	case *configurationv1beta1.KongConsumerGroup:
 		err = createConsumerGroup(ctx, sdk.GetConsumerGroupsSDK(), ent)
 	case *configurationv1alpha1.KongPluginBinding:
@@ -126,6 +118,8 @@ func Create[
 			id, err = getSNIForUID(ctx, sdk.GetSNIsSDK(), ent)
 		case *configurationv1.KongConsumer:
 			id, err = getConsumerForUID(ctx, sdk.GetConsumersSDK(), ent)
+		case *configurationv1beta1.KongConsumerGroup:
+			id, err = getConsumerGroupForUID(ctx, sdk.GetConsumerGroupsSDK(), ent)
 			// ---------------------------------------------------------------------
 			// TODO: add other Konnect types
 		default:
@@ -148,7 +142,7 @@ func Create[
 		SetKonnectEntityProgrammedCondition(e)
 	}
 
-	logOpComplete[T, TEnt](ctx, start, CreateOp, e, err)
+	logOpComplete(ctx, start, CreateOp, e, err)
 
 	return e, err
 }

--- a/controller/konnect/ops/ops_errors.go
+++ b/controller/konnect/ops/ops_errors.go
@@ -94,5 +94,17 @@ func SDKErrorIsConflict(sdkError *sdkkonnecterrs.SDKError) bool {
 		return false
 	}
 
-	return sdkErrorBody.Code == 3 && sdkErrorBody.Message == "data constraint error"
+	const (
+		dataConstraintMesasge = "data constraint error"
+	)
+
+	if sdkErrorBody.Message != dataConstraintMesasge {
+		return false
+	}
+
+	switch sdkErrorBody.Code {
+	case 3, 6:
+		return true
+	}
+	return false
 }

--- a/controller/konnect/ops/ops_kongroute.go
+++ b/controller/konnect/ops/ops_kongroute.go
@@ -79,7 +79,6 @@ func updateRoute(
 						Err: err,
 					}
 				}
-				// Create succeeded, createService sets the status so no need to do this here.
 				return nil
 			default:
 				return FailedKonnectOpError[configurationv1alpha1.KongRoute]{

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -23,7 +23,7 @@ import (
 	"github.com/kong/gateway-operator/controller/kongplugininstallation"
 	"github.com/kong/gateway-operator/controller/konnect"
 	"github.com/kong/gateway-operator/controller/konnect/constraints"
-	konnectops "github.com/kong/gateway-operator/controller/konnect/ops"
+	"github.com/kong/gateway-operator/controller/konnect/ops"
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/controller/specialized"
 	"github.com/kong/gateway-operator/internal/utils/index"
@@ -506,7 +506,7 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 			return nil, err
 		}
 
-		sdkFactory := konnectops.NewSDKFactory()
+		sdkFactory := ops.NewSDKFactory()
 		konnectControllers := map[string]ControllerDef{
 			KonnectAPIAuthConfigurationControllerName: {
 				Enabled: c.KonnectControllersEnabled,

--- a/test/envtest/konnect_entities_kongconsumer_test.go
+++ b/test/envtest/konnect_entities_kongconsumer_test.go
@@ -18,7 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
-	konnectops "github.com/kong/gateway-operator/controller/konnect/ops"
+	"github.com/kong/gateway-operator/controller/konnect/ops"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
 
@@ -35,7 +35,7 @@ func TestKongConsumer(t *testing.T) {
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
-	factory := konnectops.NewMockSDKFactory(t)
+	factory := ops.NewMockSDKFactory(t)
 	sdk := factory.SDK
 	reconcilers := []Reconciler{
 		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
@@ -353,6 +353,5 @@ func TestKongConsumer(t *testing.T) {
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.True(c, factory.SDK.ConsumersSDK.AssertExpectations(t))
 		}, waitTime, tickTime)
-
 	})
 }

--- a/test/envtest/konnect_entities_kongconsumergroup_test.go
+++ b/test/envtest/konnect_entities_kongconsumergroup_test.go
@@ -1,0 +1,218 @@
+package envtest
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
+	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/gateway-operator/controller/konnect"
+	"github.com/kong/gateway-operator/controller/konnect/ops"
+	"github.com/kong/gateway-operator/modules/manager/scheme"
+	"github.com/kong/gateway-operator/test/helpers/deploy"
+
+	configurationv1beta1 "github.com/kong/kubernetes-configuration/api/configuration/v1beta1"
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+func TestKongConsumerGroup(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := Context(t, context.Background())
+	defer cancel()
+	cfg, ns := Setup(t, ctx, scheme.Get())
+
+	t.Log("Setting up the manager with reconcilers")
+	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+	factory := ops.NewMockSDKFactory(t)
+	sdk := factory.SDK
+	reconcilers := []Reconciler{
+		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1beta1.KongConsumerGroup](konnectInfiniteSyncTime),
+		),
+	}
+	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
+
+	t.Log("Setting up clients")
+	cl, err := client.NewWithWatch(mgr.GetConfig(), client.Options{
+		Scheme: scheme.Get(),
+	})
+	require.NoError(t, err)
+	clientNamespaced := client.NewNamespacedClient(mgr.GetClient(), ns.Name)
+
+	t.Log("Creating KonnectAPIAuthConfiguration and KonnectGatewayControlPlane")
+	apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
+	cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
+
+	t.Log("Setting up a watch for KongConsumerGroup events")
+	cWatch := setupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, cl, client.InNamespace(ns.Name))
+
+	t.Run("should create, update and delete ConsumerGroup successfully", func(t *testing.T) {
+		const (
+			cgID          = "consumer-id"
+			cgName        = "consumer-group"
+			updatedCGName = "consumer-group-updated"
+		)
+		t.Log("Setting up SDK expectations on KongConsumerGroup creation")
+		sdk.ConsumerGroupSDK.EXPECT().
+			CreateConsumerGroup(mock.Anything, cp.GetKonnectStatus().GetKonnectID(),
+				mock.MatchedBy(func(cg sdkkonnectcomp.ConsumerGroupInput) bool {
+					return cg.Name == cgName
+				}),
+			).Return(&sdkkonnectops.CreateConsumerGroupResponse{
+			ConsumerGroup: &sdkkonnectcomp.ConsumerGroup{
+				ID: lo.ToPtr(cgID),
+			},
+		}, nil,
+		)
+
+		t.Log("Creating KongConsumerGroup")
+		cg := deploy.KongConsumerGroupAttachedToCP(t, ctx, clientNamespaced, cp,
+			func(obj client.Object) {
+				cg := obj.(*configurationv1beta1.KongConsumerGroup)
+				cg.Spec.Name = cgName
+			},
+		)
+
+		t.Log("Waiting for KongConsumerGroup to be programmed")
+		watchFor(t, ctx, cWatch, watch.Modified, func(c *configurationv1beta1.KongConsumerGroup) bool {
+			if c.GetName() != cg.GetName() {
+				return false
+			}
+			return lo.ContainsBy(c.Status.Conditions, func(condition metav1.Condition) bool {
+				return condition.Type == konnectv1alpha1.KonnectEntityProgrammedConditionType &&
+					condition.Status == metav1.ConditionTrue
+			})
+		}, "KongConsumerGroup's Programmed condition should be true eventually")
+
+		t.Log("Waiting for KongConsumerGroup to be created in the SDK")
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, factory.SDK.ConsumerGroupSDK.AssertExpectations(t))
+		}, waitTime, tickTime)
+
+		t.Log("Setting up SDK expectations on KongConsumerGroup update")
+		sdk.ConsumerGroupSDK.EXPECT().
+			UpsertConsumerGroup(mock.Anything, mock.MatchedBy(func(r sdkkonnectops.UpsertConsumerGroupRequest) bool {
+				return r.ConsumerGroupID == cgID && r.ConsumerGroup.Name == updatedCGName
+			})).
+			Return(&sdkkonnectops.UpsertConsumerGroupResponse{}, nil)
+
+		t.Log("Patching KongConsumerGroup")
+		cgToPatch := cg.DeepCopy()
+		cgToPatch.Spec.Name = updatedCGName
+		require.NoError(t, clientNamespaced.Patch(ctx, cgToPatch, client.MergeFrom(cg)))
+
+		t.Log("Waiting for KongConsumerGroup to be updated in the SDK")
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, factory.SDK.ConsumerGroupSDK.AssertExpectations(t))
+		}, waitTime, tickTime)
+
+		t.Log("Setting up SDK expectations on KongConsumerGroup deletion")
+		sdk.ConsumerGroupSDK.EXPECT().
+			DeleteConsumerGroup(mock.Anything, cp.GetKonnectStatus().GetKonnectID(), cgID).
+			Return(&sdkkonnectops.DeleteConsumerGroupResponse{}, nil)
+
+		t.Log("Deleting KongConsumerGroup")
+		require.NoError(t, cl.Delete(ctx, cg))
+
+		require.EventuallyWithT(t,
+			func(c *assert.CollectT) {
+				assert.True(c, k8serrors.IsNotFound(
+					clientNamespaced.Get(ctx, client.ObjectKeyFromObject(cg), cg),
+				))
+			}, waitTime, tickTime,
+		)
+
+		t.Log("Waiting for KongConsumerGroup to be deleted in the SDK")
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, factory.SDK.ConsumerGroupSDK.AssertExpectations(t))
+		}, waitTime, tickTime)
+	})
+
+	t.Run("should create ConsumerGroup successfully on conflict when ConsumerGroup with matching uid tag exists", func(t *testing.T) {
+		const (
+			cgID          = "consumer-id-2"
+			cgName        = "consumer-group-2"
+			updatedCGName = "consumer-group-updated-2"
+		)
+		t.Log("Setting up SDK expectations on KongConsumerGroup creation")
+		sdk.ConsumerGroupSDK.EXPECT().
+			CreateConsumerGroup(mock.Anything, cp.GetKonnectStatus().GetKonnectID(),
+				mock.MatchedBy(func(cg sdkkonnectcomp.ConsumerGroupInput) bool {
+					return cg.Name == cgName
+				}),
+			).Return(
+			nil,
+			&sdkkonnecterrs.SDKError{
+				StatusCode: 400,
+				Body: `{
+					"code": 3,
+					"message": "data constraint error",
+					"details": [
+						{
+							"@type": "type.googleapis.com/kong.admin.model.v1.ErrorDetail",
+							"type": "ERROR_TYPE_REFERENCE",
+							"field": "name",
+							"messages": [
+								"name (type: unique) constraint failed"
+							]
+						}
+					]
+				}`,
+			},
+		)
+
+		sdk.ConsumerGroupSDK.EXPECT().
+			ListConsumerGroup(mock.Anything,
+				mock.MatchedBy(func(r sdkkonnectops.ListConsumerGroupRequest) bool {
+					return r.ControlPlaneID == cp.GetKonnectStatus().GetKonnectID() &&
+						r.Tags != nil && strings.HasPrefix(*r.Tags, ops.KubernetesUIDLabelKey)
+				}),
+			).Return(
+			&sdkkonnectops.ListConsumerGroupResponse{
+				Object: &sdkkonnectops.ListConsumerGroupResponseBody{
+					Data: []sdkkonnectcomp.ConsumerGroup{
+						{
+							ID: lo.ToPtr(cgID),
+						},
+					},
+				},
+			},
+			nil,
+		)
+
+		t.Log("Creating KongConsumerGroup")
+		cg := deploy.KongConsumerGroupAttachedToCP(t, ctx, clientNamespaced, cp,
+			func(obj client.Object) {
+				cg := obj.(*configurationv1beta1.KongConsumerGroup)
+				cg.Spec.Name = cgName
+			},
+		)
+
+		t.Log("Waiting for KongConsumerGroup to be programmed")
+		watchFor(t, ctx, cWatch, watch.Modified, func(c *configurationv1beta1.KongConsumerGroup) bool {
+			if c.GetName() != cg.GetName() && c.GetKonnectID() != cgID {
+				return false
+			}
+			return lo.ContainsBy(c.Status.Conditions, func(condition metav1.Condition) bool {
+				return condition.Type == konnectv1alpha1.KonnectEntityProgrammedConditionType &&
+					condition.Status == metav1.ConditionTrue
+			})
+		}, "KongConsumerGroup's Programmed condition should be true eventually")
+
+		t.Log("Waiting for KongConsumerGroup to be created in the SDK")
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, factory.SDK.ConsumerGroupSDK.AssertExpectations(t))
+		}, waitTime, tickTime)
+	})
+}

--- a/test/envtest/konnect_entities_kongvault_test.go
+++ b/test/envtest/konnect_entities_kongvault_test.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
-	konnectops "github.com/kong/gateway-operator/controller/konnect/ops"
+	"github.com/kong/gateway-operator/controller/konnect/ops"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
 
@@ -31,7 +31,7 @@ func TestKongVault(t *testing.T) {
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
-	factory := konnectops.NewMockSDKFactory(t)
+	factory := ops.NewMockSDKFactory(t)
 	sdk := factory.SDK
 	reconcilers := []Reconciler{
 		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow up on #753 for `ConsumerGroup`s.