### PR TITLE
refactor(konnect): add handleDeleteError to uniformly handle delete errors

### DIFF
--- a/controller/konnect/constraints/constraints.go
+++ b/controller/konnect/constraints/constraints.go
@@ -53,6 +53,7 @@ type EntityType[T SupportedKonnectEntityType] interface {
 	SetConditions([]metav1.Condition)
 	GetKonnectStatus() *konnectv1alpha1.KonnectEntityStatus
 	SetKonnectID(string)
+	GetTypeName() string
 }
 
 // SupportedKonnectEntityPluginReferenceableType is an interface that all Konnect

--- a/controller/konnect/ops/ops_credentialacl.go
+++ b/controller/konnect/ops/ops_credentialacl.go
@@ -8,7 +8,6 @@ import (
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
@@ -118,25 +117,7 @@ func deleteKongCredentialACL(
 			ACLID:                       id,
 		})
 	if errWrap := wrapErrIfKonnectOpFailed(err, DeleteOp, cred); errWrap != nil {
-		// Service delete operation returns an SDKError instead of a NotFoundError.
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrap, &sdkError) {
-			if sdkError.StatusCode == 404 {
-				ctrllog.FromContext(ctx).
-					Info("entity not found in Konnect, skipping delete",
-						"op", DeleteOp, "type", cred.GetTypeName(), "id", id,
-					)
-				return nil
-			}
-			return FailedKonnectOpError[configurationv1alpha1.KongCredentialACL]{
-				Op:  DeleteOp,
-				Err: sdkError,
-			}
-		}
-		return FailedKonnectOpError[configurationv1alpha1.KongService]{
-			Op:  DeleteOp,
-			Err: errWrap,
-		}
+		return handleDeleteError(ctx, err, cred)
 	}
 
 	return nil

--- a/controller/konnect/ops/ops_credentialapikey.go
+++ b/controller/konnect/ops/ops_credentialapikey.go
@@ -2,13 +2,10 @@ package ops
 
 import (
 	"context"
-	"errors"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
-	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
@@ -97,25 +94,7 @@ func deleteKongCredentialAPIKey(
 			KeyAuthID:                   id,
 		})
 	if errWrap := wrapErrIfKonnectOpFailed(err, DeleteOp, cred); errWrap != nil {
-		// Service delete operation returns an SDKError instead of a NotFoundError.
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrap, &sdkError) {
-			if sdkError.StatusCode == 404 {
-				ctrllog.FromContext(ctx).
-					Info("entity not found in Konnect, skipping delete",
-						"op", DeleteOp, "type", cred.GetTypeName(), "id", id,
-					)
-				return nil
-			}
-			return FailedKonnectOpError[configurationv1alpha1.KongCredentialAPIKey]{
-				Op:  DeleteOp,
-				Err: sdkError,
-			}
-		}
-		return FailedKonnectOpError[configurationv1alpha1.KongService]{
-			Op:  DeleteOp,
-			Err: errWrap,
-		}
+		return handleDeleteError(ctx, err, cred)
 	}
 
 	return nil

--- a/controller/konnect/ops/ops_credentialbasicauth.go
+++ b/controller/konnect/ops/ops_credentialbasicauth.go
@@ -2,13 +2,10 @@ package ops
 
 import (
 	"context"
-	"errors"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
-	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
@@ -96,25 +93,7 @@ func deleteKongCredentialBasicAuth(
 			BasicAuthID:                 id,
 		})
 	if errWrap := wrapErrIfKonnectOpFailed(err, DeleteOp, cred); errWrap != nil {
-		// Service delete operation returns an SDKError instead of a NotFoundError.
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrap, &sdkError) {
-			if sdkError.StatusCode == 404 {
-				ctrllog.FromContext(ctx).
-					Info("entity not found in Konnect, skipping delete",
-						"op", DeleteOp, "type", cred.GetTypeName(), "id", id,
-					)
-				return nil
-			}
-			return FailedKonnectOpError[configurationv1alpha1.KongCredentialBasicAuth]{
-				Op:  DeleteOp,
-				Err: sdkError,
-			}
-		}
-		return FailedKonnectOpError[configurationv1alpha1.KongService]{
-			Op:  DeleteOp,
-			Err: errWrap,
-		}
+		return handleDeleteError(ctx, err, cred)
 	}
 
 	return nil

--- a/controller/konnect/ops/ops_credentialjwt.go
+++ b/controller/konnect/ops/ops_credentialjwt.go
@@ -7,7 +7,6 @@ import (
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
@@ -117,25 +116,7 @@ func deleteKongCredentialJWT(
 			JWTID:                       id,
 		})
 	if errWrap := wrapErrIfKonnectOpFailed(err, DeleteOp, cred); errWrap != nil {
-		// Service delete operation returns an SDKError instead of a NotFoundError.
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrap, &sdkError) {
-			if sdkError.StatusCode == 404 {
-				ctrllog.FromContext(ctx).
-					Info("entity not found in Konnect, skipping delete",
-						"op", DeleteOp, "type", cred.GetTypeName(), "id", id,
-					)
-				return nil
-			}
-			return FailedKonnectOpError[configurationv1alpha1.KongCredentialJWT]{
-				Op:  DeleteOp,
-				Err: sdkError,
-			}
-		}
-		return FailedKonnectOpError[configurationv1alpha1.KongService]{
-			Op:  DeleteOp,
-			Err: errWrap,
-		}
+		return handleDeleteError(ctx, err, cred)
 	}
 
 	return nil

--- a/controller/konnect/ops/ops_errors.go
+++ b/controller/konnect/ops/ops_errors.go
@@ -152,7 +152,7 @@ func handleDeleteError[
 
 	var sdkError *sdkkonnecterrs.SDKError
 	if errors.As(err, &sdkError) {
-		if sdkError.StatusCode == 404 {
+		if sdkError.StatusCode == http.StatusNotFound {
 			logDeleteSkipped()
 			return nil
 		}

--- a/controller/konnect/ops/ops_errors.go
+++ b/controller/konnect/ops/ops_errors.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/controller/konnect/ops/ops_errors.go
+++ b/controller/konnect/ops/ops_errors.go
@@ -1,12 +1,16 @@
 package ops
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/kong/gateway-operator/controller/konnect/constraints"
 )
 
 // ErrNilResponse is an error indicating that a Konnect operation returned an empty response.
@@ -122,4 +126,43 @@ func SDKErrorIsConflict(sdkError *sdkkonnecterrs.SDKError) bool {
 		return true
 	}
 	return false
+}
+
+// handleDeleteError handles errors that occur during a delete operation.
+// It logs a message and returns nil if the entity was not found in Konnect (when
+// the delete operation is skipped).
+func handleDeleteError[
+	T constraints.SupportedKonnectEntityType,
+	TEnt constraints.EntityType[T],
+](ctx context.Context, err error, ent TEnt) error {
+	logDeleteSkipped := func() {
+		ctrllog.FromContext(ctx).
+			Info("entity not found in Konnect, skipping delete",
+				"op", DeleteOp,
+				"type", ent.GetTypeName(),
+				"id", ent.GetKonnectStatus().GetKonnectID(),
+			)
+	}
+
+	var sdkNotFoundError *sdkkonnecterrs.NotFoundError
+	if errors.As(err, &sdkNotFoundError) {
+		logDeleteSkipped()
+		return nil
+	}
+
+	var sdkError *sdkkonnecterrs.SDKError
+	if errors.As(err, &sdkError) {
+		if sdkError.StatusCode == 404 {
+			logDeleteSkipped()
+			return nil
+		}
+		return FailedKonnectOpError[T]{
+			Op:  DeleteOp,
+			Err: sdkError,
+		}
+	}
+	return FailedKonnectOpError[T]{
+		Op:  DeleteOp,
+		Err: err,
+	}
 }

--- a/controller/konnect/ops/ops_kongcacertificate.go
+++ b/controller/konnect/ops/ops_kongcacertificate.go
@@ -2,12 +2,9 @@ package ops
 
 import (
 	"context"
-	"errors"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
-	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
@@ -88,24 +85,7 @@ func deleteCACertificate(
 	id := cert.Status.Konnect.GetKonnectID()
 	_, err := sdk.DeleteCaCertificate(ctx, cert.GetControlPlaneID(), id)
 	if errWrap := wrapErrIfKonnectOpFailed(err, DeleteOp, cert); errWrap != nil {
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrap, &sdkError) {
-			if sdkError.StatusCode == 404 {
-				ctrllog.FromContext(ctx).
-					Info("entity not found in Konnect, skipping delete",
-						"op", DeleteOp, "type", cert.GetTypeName(), "id", id,
-					)
-				return nil
-			}
-			return FailedKonnectOpError[configurationv1alpha1.KongCACertificate]{
-				Op:  DeleteOp,
-				Err: sdkError,
-			}
-		}
-		return FailedKonnectOpError[configurationv1alpha1.KongCACertificate]{
-			Op:  DeleteOp,
-			Err: errWrap,
-		}
+		return handleDeleteError(ctx, err, cert)
 	}
 
 	return nil

--- a/controller/konnect/ops/ops_kongcertificate.go
+++ b/controller/konnect/ops/ops_kongcertificate.go
@@ -7,7 +7,6 @@ import (
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
@@ -109,24 +108,7 @@ func deleteCertificate(
 	id := cert.Status.Konnect.GetKonnectID()
 	_, err := sdk.DeleteCertificate(ctx, cert.GetControlPlaneID(), id)
 	if errWrap := wrapErrIfKonnectOpFailed(err, DeleteOp, cert); errWrap != nil {
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrap, &sdkError) {
-			if sdkError.StatusCode == 404 {
-				ctrllog.FromContext(ctx).
-					Info("entity not found in Konnect, skipping delete",
-						"op", DeleteOp, "type", cert.GetTypeName(), "id", id,
-					)
-				return nil
-			}
-			return FailedKonnectOpError[configurationv1alpha1.KongCertificate]{
-				Op:  DeleteOp,
-				Err: sdkError,
-			}
-		}
-		return FailedKonnectOpError[configurationv1alpha1.KongCertificate]{
-			Op:  DeleteOp,
-			Err: errWrap,
-		}
+		return handleDeleteError(ctx, err, cert)
 	}
 
 	return nil

--- a/controller/konnect/ops/ops_kongkey.go
+++ b/controller/konnect/ops/ops_kongkey.go
@@ -9,7 +9,6 @@ import (
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
@@ -105,24 +104,7 @@ func deleteKey(
 	id := key.Status.Konnect.GetKonnectID()
 	_, err := sdk.DeleteKey(ctx, key.GetControlPlaneID(), id)
 	if errWrap := wrapErrIfKonnectOpFailed(err, DeleteOp, key); errWrap != nil {
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrap, &sdkError) {
-			if sdkError.StatusCode == 404 {
-				ctrllog.FromContext(ctx).
-					Info("entity not found in Konnect, skipping delete",
-						"op", DeleteOp, "type", key.GetTypeName(), "id", id,
-					)
-				return nil
-			}
-			return FailedKonnectOpError[configurationv1alpha1.KongKey]{
-				Op:  DeleteOp,
-				Err: sdkError,
-			}
-		}
-		return FailedKonnectOpError[configurationv1alpha1.KongKey]{
-			Op:  DeleteOp,
-			Err: errWrap,
-		}
+		return handleDeleteError(ctx, err, key)
 	}
 
 	return nil

--- a/controller/konnect/ops/ops_kongkeyset.go
+++ b/controller/konnect/ops/ops_kongkeyset.go
@@ -9,7 +9,6 @@ import (
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
@@ -106,24 +105,7 @@ func deleteKeySet(
 	id := keySet.Status.Konnect.GetKonnectID()
 	_, err := sdk.DeleteKeySet(ctx, keySet.GetControlPlaneID(), id)
 	if errWrap := wrapErrIfKonnectOpFailed(err, DeleteOp, keySet); errWrap != nil {
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrap, &sdkError) {
-			if sdkError.StatusCode == 404 {
-				ctrllog.FromContext(ctx).
-					Info("entity not found in Konnect, skipping delete",
-						"op", DeleteOp, "type", keySet.GetTypeName(), "id", id,
-					)
-				return nil
-			}
-			return FailedKonnectOpError[configurationv1alpha1.KongKeySet]{
-				Op:  DeleteOp,
-				Err: sdkError,
-			}
-		}
-		return FailedKonnectOpError[configurationv1alpha1.KongKeySet]{
-			Op:  DeleteOp,
-			Err: errWrap,
-		}
+		return handleDeleteError(ctx, err, keySet)
 	}
 
 	return nil

--- a/controller/konnect/ops/ops_kongroute.go
+++ b/controller/konnect/ops/ops_kongroute.go
@@ -10,7 +10,6 @@ import (
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
@@ -99,25 +98,7 @@ func deleteRoute(
 	id := route.GetKonnectStatus().GetKonnectID()
 	_, err := sdk.DeleteRoute(ctx, route.Status.Konnect.ControlPlaneID, id)
 	if errWrap := wrapErrIfKonnectOpFailed(err, DeleteOp, route); errWrap != nil {
-		// Service delete operation returns an SDKError instead of a NotFoundError.
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrap, &sdkError) {
-			if sdkError.StatusCode == 404 {
-				ctrllog.FromContext(ctx).
-					Info("entity not found in Konnect, skipping delete",
-						"op", DeleteOp, "type", route.GetTypeName(), "id", id,
-					)
-				return nil
-			}
-			return FailedKonnectOpError[configurationv1alpha1.KongRoute]{
-				Op:  DeleteOp,
-				Err: sdkError,
-			}
-		}
-		return FailedKonnectOpError[configurationv1alpha1.KongService]{
-			Op:  DeleteOp,
-			Err: errWrap,
-		}
+		return handleDeleteError(ctx, err, route)
 	}
 
 	return nil

--- a/controller/konnect/ops/ops_kongtarget.go
+++ b/controller/konnect/ops/ops_kongtarget.go
@@ -2,16 +2,12 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net/http"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
-	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
@@ -97,25 +93,7 @@ func deleteTarget(
 	})
 
 	if errWrapped := wrapErrIfKonnectOpFailed(err, DeleteOp, target); errWrapped != nil {
-		// Service delete operation returns an SDKError instead of a NotFoundError.
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrapped, &sdkError) {
-			if sdkError.StatusCode == http.StatusNotFound {
-				ctrllog.FromContext(ctx).
-					Info("entity not found in Konnect, skipping delete",
-						"op", DeleteOp, "type", target.GetTypeName(), "id", id,
-					)
-				return nil
-			}
-			return FailedKonnectOpError[configurationv1alpha1.KongTarget]{
-				Op:  DeleteOp,
-				Err: sdkError,
-			}
-		}
-		return FailedKonnectOpError[configurationv1alpha1.KongTarget]{
-			Op:  DeleteOp,
-			Err: errWrapped,
-		}
+		return handleDeleteError(ctx, err, target)
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduces `handleDeleteError` which handles delete errors uniformly in every object type delete operation.