### PR TITLE
fix(konnect): make setting status conditions not update on every reconciliation

### DIFF
--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -230,7 +230,7 @@ func (r *Reconciler) ensureDeployment(
 			}
 		}
 
-		return patch.ApplyPatchIfNonEmpty(ctx, r.Client, logger, existingDeployment, oldExistingDeployment, params.ControlPlane, updated)
+		return patch.ApplyPatchIfNotEmpty(ctx, r.Client, logger, existingDeployment, oldExistingDeployment, updated)
 	}
 
 	if !dataplaneIsSet {

--- a/controller/dataplane/owned_deployment.go
+++ b/controller/dataplane/owned_deployment.go
@@ -345,7 +345,7 @@ func reconcileDataPlaneDeployment(
 			log.Trace(logger, "Deployment diff detected", diff)
 		}
 
-		return patch.ApplyPatchIfNonEmpty(ctx, cl, logger, existing, original, dataplane, updated)
+		return patch.ApplyPatchIfNotEmpty(ctx, cl, logger, existing, original, updated)
 	}
 
 	if err = cl.Create(ctx, desired); err != nil {

--- a/controller/dataplane/owned_resources.go
+++ b/controller/dataplane/owned_resources.go
@@ -104,7 +104,7 @@ func ensureHPAForDataPlane(
 			updated = true
 		}
 
-		return patch.ApplyPatchIfNonEmpty(ctx, cl, log, existingHPA, oldExistingHPA, dataplane, updated)
+		return patch.ApplyPatchIfNotEmpty(ctx, cl, log, existingHPA, oldExistingHPA, updated)
 	}
 
 	if err = cl.Create(ctx, generatedHPA); err != nil {
@@ -160,7 +160,7 @@ func ensurePodDisruptionBudgetForDataPlane(
 			updated = true
 		}
 
-		return patch.ApplyPatchIfNonEmpty(ctx, cl, log, existingPDB, oldExistingPDB, dataplane, updated)
+		return patch.ApplyPatchIfNotEmpty(ctx, cl, log, existingPDB, oldExistingPDB, updated)
 	}
 
 	if err := cl.Create(ctx, generatedPDB); err != nil {

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -176,7 +176,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// If the static Gateway API conditions (Accepted, ResolvedRefs, Conflicted) changed, we need to update the Gateway status
 	if gatewayStatusNeedsUpdate(oldGwConditionsAware, gwConditionAware) {
 		// Requeue will be triggered by the update of the gateway status.
-		if _, err := patch.ApplyGatewayStatusPatchIfNotEmpty(ctx, r.Client, logger, &gateway, oldGateway); err != nil {
+		if _, err := patch.ApplyStatusPatchIfNotEmpty(ctx, r.Client, logger, &gateway, oldGateway); err != nil {
 			return ctrl.Result{}, err
 		}
 		if acceptedCondition.Status == metav1.ConditionTrue {
@@ -368,7 +368,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	gwConditionAware.setProgrammed()
-	res, err := patch.ApplyGatewayStatusPatchIfNotEmpty(ctx, r.Client, logger, &gateway, oldGateway)
+	res, err := patch.ApplyStatusPatchIfNotEmpty(ctx, r.Client, logger, &gateway, oldGateway)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controller/konnect/reconciler_konnectapiauth.go
+++ b/controller/konnect/reconciler_konnectapiauth.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kong/gateway-operator/controller/konnect/ops"
 	sdkops "github.com/kong/gateway-operator/controller/konnect/ops/sdk"
 	"github.com/kong/gateway-operator/controller/pkg/log"
+	"github.com/kong/gateway-operator/controller/pkg/patch"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
@@ -115,7 +116,7 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 
 	token, err := getTokenFromKonnectAPIAuthConfiguration(ctx, r.client, &apiAuth)
 	if err != nil {
-		if res, errStatus := updateStatusWithCondition(
+		if res, errStatus := patch.StatusWithCondition(
 			ctx, r.client, &apiAuth,
 			konnectv1alpha1.KonnectEntityAPIAuthConfigurationValidConditionType,
 			metav1.ConditionFalse,
@@ -155,7 +156,7 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 			apiAuth.Status.OrganizationID = ""
 			apiAuth.Status.ServerURL = serverURL.String()
 
-			res, errUpdate := updateStatusWithCondition(
+			res, errUpdate := patch.StatusWithCondition(
 				ctx, r.client, &apiAuth,
 				konnectv1alpha1.KonnectEntityAPIAuthConfigurationValidConditionType,
 				metav1.ConditionFalse,
@@ -193,7 +194,7 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 		apiAuth.Status.OrganizationID = *respOrg.MeOrganization.ID
 		apiAuth.Status.ServerURL = serverURL.String()
 
-		res, err := updateStatusWithCondition(
+		res, err := patch.StatusWithCondition(
 			ctx, r.client, &apiAuth,
 			konnectv1alpha1.KonnectEntityAPIAuthConfigurationValidConditionType,
 			metav1.ConditionTrue,

--- a/controller/konnect/reconciler_upstreamref.go
+++ b/controller/konnect/reconciler_upstreamref.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/kong/gateway-operator/controller/konnect/constraints"
+	"github.com/kong/gateway-operator/controller/pkg/patch"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
@@ -52,7 +53,7 @@ func handleKongUpstreamRef[T constraints.SupportedKonnectEntityType, TEnt constr
 	}
 	err := cl.Get(ctx, nn, kongUpstream)
 	if err != nil {
-		if res, errStatus := updateStatusWithCondition(
+		if res, errStatus := patch.StatusWithCondition(
 			ctx, cl, ent,
 			konnectv1alpha1.KongUpstreamRefValidConditionType,
 			metav1.ConditionFalse,
@@ -81,7 +82,7 @@ func handleKongUpstreamRef[T constraints.SupportedKonnectEntityType, TEnt constr
 	cond, ok := k8sutils.GetCondition(konnectv1alpha1.KonnectEntityProgrammedConditionType, kongUpstream)
 	if !ok || cond.Status != metav1.ConditionTrue {
 		ent.SetKonnectID("")
-		if res, err := updateStatusWithCondition(
+		if res, err := patch.StatusWithCondition(
 			ctx, cl, ent,
 			konnectv1alpha1.KongUpstreamRefValidConditionType,
 			metav1.ConditionFalse,
@@ -113,7 +114,7 @@ func handleKongUpstreamRef[T constraints.SupportedKonnectEntityType, TEnt constr
 		target.Status.Konnect.UpstreamID = kongUpstream.GetKonnectID()
 	}
 
-	if res, errStatus := updateStatusWithCondition(
+	if res, errStatus := patch.StatusWithCondition(
 		ctx, cl, ent,
 		konnectv1alpha1.KongUpstreamRefValidConditionType,
 		metav1.ConditionTrue,
@@ -135,7 +136,7 @@ func handleKongUpstreamRef[T constraints.SupportedKonnectEntityType, TEnt constr
 	}
 	cp, err := getCPForRef(ctx, cl, cpRef, ent.GetNamespace())
 	if err != nil {
-		if res, errStatus := updateStatusWithCondition(
+		if res, errStatus := patch.StatusWithCondition(
 			ctx, cl, ent,
 			konnectv1alpha1.ControlPlaneRefValidConditionType,
 			metav1.ConditionFalse,
@@ -158,7 +159,7 @@ func handleKongUpstreamRef[T constraints.SupportedKonnectEntityType, TEnt constr
 
 	cond, ok = k8sutils.GetCondition(konnectv1alpha1.KonnectEntityProgrammedConditionType, cp)
 	if !ok || cond.Status != metav1.ConditionTrue || cond.ObservedGeneration != cp.GetGeneration() {
-		if res, errStatus := updateStatusWithCondition(
+		if res, errStatus := patch.StatusWithCondition(
 			ctx, cl, ent,
 			konnectv1alpha1.ControlPlaneRefValidConditionType,
 			metav1.ConditionFalse,
@@ -175,7 +176,7 @@ func handleKongUpstreamRef[T constraints.SupportedKonnectEntityType, TEnt constr
 		resource.SetControlPlaneID(cp.Status.ID)
 	}
 
-	if res, errStatus := updateStatusWithCondition(
+	if res, errStatus := patch.StatusWithCondition(
 		ctx, cl, ent,
 		konnectv1alpha1.ControlPlaneRefValidConditionType,
 		metav1.ConditionTrue,

--- a/controller/pkg/patch/patch_test.go
+++ b/controller/pkg/patch/patch_test.go
@@ -182,7 +182,7 @@ func TestApplyPatchIfNonEmpty(t *testing.T) {
 				WithObjects(tc.dataPlane, hpa).
 				Build()
 
-			result, _, err := ApplyPatchIfNonEmpty(context.Background(), fakeClient, log, hpa, old, tc.dataPlane, tc.updated)
+			result, _, err := ApplyPatchIfNotEmpty(context.Background(), fakeClient, log, hpa, old, tc.updated)
 			if tc.wantErr {
 				require.Error(t, err)
 				return

--- a/controller/pkg/patch/statuscondition.go
+++ b/controller/pkg/patch/statuscondition.go
@@ -1,0 +1,87 @@
+package patch
+
+import (
+	"context"
+	"fmt"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/gateway-operator/pkg/consts"
+	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
+)
+
+// SetStatusWithConditionIfDifferent sets the status of the provided object with the
+// given condition if the condition is different from the current one.
+// It does not take LastTransitionTime into account.
+func SetStatusWithConditionIfDifferent[T interface {
+	client.Object
+	k8sutils.ConditionsAware
+}](
+	ent T,
+	conditionType consts.ConditionType,
+	conditionStatus metav1.ConditionStatus,
+	conditionReason consts.ConditionReason,
+	conditionMessage string,
+) bool {
+	cond, ok := k8sutils.GetCondition(conditionType, ent)
+	if ok &&
+		cond.Status == conditionStatus &&
+		cond.Reason == string(conditionReason) &&
+		cond.Message == conditionMessage &&
+		cond.ObservedGeneration == ent.GetGeneration() {
+		// If the condition is already set and it's as expected, return.
+		// We don't want to bump the condition's LastTransitionTime which
+		// could cause unnecessary requeues.
+		return false
+	}
+
+	k8sutils.SetCondition(
+		k8sutils.NewConditionWithGeneration(
+			conditionType,
+			conditionStatus,
+			conditionReason,
+			conditionMessage,
+			ent.GetGeneration(),
+		),
+		ent,
+	)
+	return true
+}
+
+// StatusWithCondition patches the status of the provided object with the
+// given condition.
+// If the condition is already set and it's as expected, it returns without patching.
+func StatusWithCondition[T interface {
+	client.Object
+	k8sutils.ConditionsAware
+}](
+	ctx context.Context,
+	cl client.Client,
+	ent T,
+	conditionType consts.ConditionType,
+	conditionStatus metav1.ConditionStatus,
+	conditionReason consts.ConditionReason,
+	conditionMessage string,
+) (ctrl.Result, error) {
+	old := ent.DeepCopyObject().(T)
+	if !SetStatusWithConditionIfDifferent(ent,
+		conditionType,
+		conditionStatus,
+		conditionReason,
+		conditionMessage,
+	) {
+		return ctrl.Result{}, nil
+	}
+
+	if err := cl.Status().Patch(ctx, ent, client.MergeFrom(old)); err != nil {
+		if k8serrors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to patch status with %s condition: %w", conditionType, err)
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/controller/pkg/patch/statuscondition_test.go
+++ b/controller/pkg/patch/statuscondition_test.go
@@ -1,0 +1,288 @@
+package patch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	operatorv1beta1 "github.com/kong/gateway-operator/api/v1beta1"
+	"github.com/kong/gateway-operator/modules/manager/scheme"
+	"github.com/kong/gateway-operator/pkg/consts"
+	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
+)
+
+func TestPatchStatusWithCondition(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  interface {
+			client.Object
+			GetConditions() []metav1.Condition
+			SetConditions([]metav1.Condition)
+		}
+		conditionType      consts.ConditionType
+		conditionStatus    metav1.ConditionStatus
+		conditionReason    consts.ConditionReason
+		conditionMessage   string
+		expectedResult     ctrl.Result
+		expectedConditions []metav1.Condition
+		expectedError      bool
+		interceptorFunc    interceptor.Funcs
+	}{
+		{
+			name: "condition is already set and as expected",
+			obj: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "dp1",
+					Generation: 1,
+				},
+				Status: operatorv1beta1.DataPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(consts.ReadyType),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(consts.ResolvedRefsReason),
+							Message:            "Resource is available",
+							ObservedGeneration: 1,
+						},
+					},
+				},
+			},
+			conditionType:    consts.ReadyType,
+			conditionStatus:  metav1.ConditionTrue,
+			conditionReason:  consts.ResolvedRefsReason,
+			conditionMessage: "Resource is available",
+			expectedResult:   ctrl.Result{},
+			expectedConditions: []metav1.Condition{
+				{
+					Type:               string(consts.ReadyType),
+					Status:             metav1.ConditionTrue,
+					Reason:             string(consts.ResolvedRefsReason),
+					Message:            "Resource is available",
+					ObservedGeneration: 1,
+				},
+			},
+		},
+		{
+			name: "condition needs to be updated due to different condition status",
+			obj: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "dp1",
+					Generation: 1,
+				},
+				Status: operatorv1beta1.DataPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(consts.ReadyType),
+							Status:             metav1.ConditionFalse,
+							Reason:             string(consts.ResolvedRefsReason),
+							Message:            "",
+							ObservedGeneration: 1,
+						},
+					},
+				},
+			},
+			conditionType:    consts.ReadyType,
+			conditionStatus:  metav1.ConditionTrue,
+			conditionReason:  consts.ResolvedRefsReason,
+			conditionMessage: "",
+			expectedResult:   ctrl.Result{},
+			expectedConditions: []metav1.Condition{
+				{
+					Type:               string(consts.ReadyType),
+					Status:             metav1.ConditionTrue,
+					Reason:             string(consts.ResolvedRefsReason),
+					Message:            "",
+					ObservedGeneration: 1,
+				},
+			},
+		},
+		{
+			name: "condition needs to be updated due to different condition observed generation",
+			obj: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "dp1",
+					Generation: 2,
+				},
+				Status: operatorv1beta1.DataPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(consts.ReadyType),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(consts.ResolvedRefsReason),
+							Message:            "",
+							ObservedGeneration: 1,
+						},
+					},
+				},
+			},
+			conditionType:    consts.ReadyType,
+			conditionStatus:  metav1.ConditionTrue,
+			conditionReason:  consts.ResolvedRefsReason,
+			conditionMessage: "",
+			expectedResult:   ctrl.Result{},
+			expectedConditions: []metav1.Condition{
+				{
+					Type:               string(consts.ReadyType),
+					Status:             metav1.ConditionTrue,
+					Reason:             string(consts.ResolvedRefsReason),
+					Message:            "",
+					ObservedGeneration: 2,
+				},
+			},
+		},
+		{
+			name: "condition needs to be updated due to different condition reason",
+			obj: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "dp1",
+					Generation: 1,
+				},
+				Status: operatorv1beta1.DataPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(consts.ReadyType),
+							Status:             metav1.ConditionFalse,
+							Reason:             string(consts.ResourceReadyReason),
+							Message:            "",
+							ObservedGeneration: 1,
+						},
+					},
+				},
+			},
+			conditionType:    consts.ReadyType,
+			conditionStatus:  metav1.ConditionFalse,
+			conditionReason:  consts.DependenciesNotReadyReason,
+			conditionMessage: "",
+			expectedResult:   ctrl.Result{},
+			expectedConditions: []metav1.Condition{
+				{
+					Type:               string(consts.ReadyType),
+					Status:             metav1.ConditionFalse,
+					Reason:             string(consts.DependenciesNotReadyReason),
+					Message:            "",
+					ObservedGeneration: 1,
+				},
+			},
+		},
+		{
+			name: "new condition needs to be set on object without conditions",
+			obj: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "dp1",
+					Generation: 1,
+				},
+				Status: operatorv1beta1.DataPlaneStatus{},
+			},
+			conditionType:    consts.ReadyType,
+			conditionStatus:  metav1.ConditionTrue,
+			conditionReason:  consts.ResolvedRefsReason,
+			conditionMessage: "Resource is available",
+			expectedResult:   ctrl.Result{},
+			expectedConditions: []metav1.Condition{
+				{
+					Type:               string(consts.ReadyType),
+					Status:             metav1.ConditionTrue,
+					Reason:             string(consts.ResolvedRefsReason),
+					Message:            "Resource is available",
+					ObservedGeneration: 1,
+				},
+			},
+		},
+		{
+			name: "conflict triggers requeue",
+			obj: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "dp1",
+					Generation: 1,
+				},
+				Status: operatorv1beta1.DataPlaneStatus{},
+			},
+			conditionType:    consts.ReadyType,
+			conditionStatus:  metav1.ConditionTrue,
+			conditionReason:  consts.ResolvedRefsReason,
+			conditionMessage: "Resource is available",
+			expectedResult: ctrl.Result{
+				Requeue: true,
+			},
+			interceptorFunc: interceptor.Funcs{
+				SubResourcePatch: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+					return &k8serrors.StatusError{
+						ErrStatus: metav1.Status{
+							Status: metav1.StatusFailure,
+							Reason: metav1.StatusReasonConflict,
+						},
+					}
+				},
+			},
+		},
+		{
+			name: "error",
+			obj: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "dp1",
+					Generation: 1,
+				},
+				Status: operatorv1beta1.DataPlaneStatus{},
+			},
+			conditionType:    consts.ReadyType,
+			conditionStatus:  metav1.ConditionTrue,
+			conditionReason:  consts.ResolvedRefsReason,
+			conditionMessage: "Resource is available",
+			expectedError:    true,
+			interceptorFunc: interceptor.Funcs{
+				SubResourcePatch: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+					return &k8serrors.StatusError{
+						ErrStatus: metav1.Status{
+							Status: metav1.StatusFailure,
+							Reason: metav1.StatusReason("unknown"),
+						},
+					}
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			cl := fake.NewClientBuilder().
+				WithObjects(tt.obj).
+				WithStatusSubresource(tt.obj).
+				WithScheme(scheme.Get()).
+				WithInterceptorFuncs(tt.interceptorFunc).
+				Build()
+
+			result, err := StatusWithCondition(
+				ctx, cl, tt.obj,
+				tt.conditionType, tt.conditionStatus, tt.conditionReason, tt.conditionMessage,
+			)
+
+			assert.Equal(t, tt.expectedResult, result)
+			if tt.expectedError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			for _, expectedCond := range tt.expectedConditions {
+				actualCond, ok := k8sutils.GetCondition(consts.ConditionType(expectedCond.Type), tt.obj)
+				if !ok {
+					t.Fatalf("condition %s not found", expectedCond.Type)
+				}
+				assert.Equal(t, expectedCond.Status, actualCond.Status)
+				assert.Equal(t, expectedCond.Reason, actualCond.Reason)
+				assert.Equal(t, expectedCond.Message, actualCond.Message)
+				assert.Equal(t, expectedCond.ObservedGeneration, actualCond.ObservedGeneration)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ retract v1.2.2
 require (
 	github.com/Kong/sdk-konnect-go v0.0.16
 	github.com/Masterminds/semver v1.5.0
-	github.com/cert-manager/cert-manager v1.16.1
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-containerregistry v0.20.2
@@ -47,6 +46,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/ericlagergren/decimal v0.0.0-20240411145413-00de7ca16731 // indirect
+	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cert-manager/cert-manager v1.16.1 h1:1ceFMqTtwiqY2vyfaRT85CNiVmK7pJjt3GebYCx9awY=
-github.com/cert-manager/cert-manager v1.16.1/go.mod h1:MfLVTL45hFZsqmaT1O0+b2ugaNNQQZttSFV9hASHUb0=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/pkg/utils/test/consts.go
+++ b/pkg/utils/test/consts.go
@@ -81,6 +81,9 @@ const (
 	// conflicts to be resolved before an object update will be considered failed.
 	ObjectUpdateTimeout = time.Second * 30
 
+	// ObjectUpdateTick is the time duration between checks for object updates.
+	ObjectUpdateTick = 100 * time.Millisecond
+
 	// SubresourceReadinessWait is the maximum amount of time allowed for
 	// sub-resources to become "Ready" after being created on behalf of a
 	// parent resource.

--- a/test/integration/test_konnect_entities.go
+++ b/test/integration/test_konnect_entities.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"testing"
-	"time"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/google/uuid"
@@ -64,7 +63,7 @@ func TestKonnectEntities(t *testing.T) {
 		err := GetClients().MgrClient.Get(GetCtx(), types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace}, cp)
 		require.NoError(t, err)
 		assertKonnectEntityProgrammed(t, cp)
-	}, testutils.ObjectUpdateTimeout, time.Second)
+	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
 	ks := deploy.KongServiceAttachedToCP(t, ctx, clientNamespaced, cp,
 		deploy.WithTestIDLabel(testID),
@@ -75,7 +74,7 @@ func TestKonnectEntities(t *testing.T) {
 		err := GetClients().MgrClient.Get(GetCtx(), types.NamespacedName{Name: ks.Name, Namespace: ks.Namespace}, ks)
 		require.NoError(t, err)
 		assertKonnectEntityProgrammed(t, ks)
-	}, testutils.ObjectUpdateTimeout, time.Second)
+	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
 	kr := deploy.KongRouteAttachedToService(t, ctx, clientNamespaced, ks,
 		deploy.WithTestIDLabel(testID),
@@ -92,7 +91,7 @@ func TestKonnectEntities(t *testing.T) {
 		require.NoError(t, err)
 
 		assertKonnectEntityProgrammed(t, kr)
-	}, testutils.ObjectUpdateTimeout, time.Second)
+	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
 	kcg := deploy.KongConsumerGroupAttachedToCP(t, ctx, clientNamespaced, cp,
 		deploy.WithTestIDLabel(testID),
@@ -104,7 +103,7 @@ func TestKonnectEntities(t *testing.T) {
 		require.NoError(t, err)
 
 		assertKonnectEntityProgrammed(t, kcg)
-	}, testutils.ObjectUpdateTimeout, time.Second)
+	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
 	kc := deploy.KongConsumerAttachedToCP(t, ctx, clientNamespaced, "kc-"+testID, cp,
 		deploy.WithTestIDLabel(testID),
@@ -124,7 +123,7 @@ func TestKonnectEntities(t *testing.T) {
 		require.NoError(t, err)
 
 		assertKonnectEntityProgrammed(t, kc)
-	}, testutils.ObjectUpdateTimeout, time.Second)
+	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
 	kp := deploy.ProxyCachePlugin(t, ctx, clientNamespaced)
 	kpb := deploy.KongPluginBinding(t, ctx, clientNamespaced,
@@ -142,7 +141,7 @@ func TestKonnectEntities(t *testing.T) {
 		require.NoError(t, err)
 
 		assertKonnectEntityProgrammed(t, kpb)
-	}, testutils.ObjectUpdateTimeout, time.Second)
+	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
 	kup := deploy.KongUpstreamAttachedToCP(t, ctx, clientNamespaced, cp,
 		deploy.WithTestIDLabel(testID),
@@ -160,7 +159,7 @@ func TestKonnectEntities(t *testing.T) {
 		require.NoError(t, err)
 
 		assertKonnectEntityProgrammed(t, kup)
-	}, testutils.ObjectUpdateTimeout, time.Second)
+	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
 	kt := deploy.KongTargetAttachedToUpstream(t, ctx, clientNamespaced, kup,
 		deploy.WithTestIDLabel(testID),
@@ -177,7 +176,7 @@ func TestKonnectEntities(t *testing.T) {
 		require.NoError(t, err)
 
 		assertKonnectEntityProgrammed(t, kt)
-	}, testutils.ObjectUpdateTimeout, time.Second)
+	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
 	// Should delete KongTarget because it will block deletion of KongUpstream owning it.
 	t.Cleanup(deleteObjectAndWaitForDeletionFn(t, kt))
@@ -189,7 +188,7 @@ func TestKonnectEntities(t *testing.T) {
 		require.NoError(t, err)
 
 		assertKonnectEntityProgrammed(t, kv)
-	}, testutils.ObjectUpdateTimeout, time.Second)
+	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
 	kcert := deploy.KongCertificateAttachedToCP(t, ctx, clientNamespaced, cp)
 
@@ -202,7 +201,7 @@ func TestKonnectEntities(t *testing.T) {
 		require.NoError(t, err)
 
 		assertKonnectEntityProgrammed(t, kcert)
-	}, testutils.ObjectUpdateTimeout, time.Second)
+	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
 	ksni := deploy.KongSNIAttachedToCertificate(t, ctx, clientNamespaced, kcert,
 		deploy.WithTestIDLabel(testID),
@@ -222,7 +221,7 @@ func TestKonnectEntities(t *testing.T) {
 
 		assertKonnectEntityProgrammed(t, ksni)
 		assert.Equal(t, kcert.GetKonnectID(), ksni.Status.Konnect.CertificateID)
-	}, testutils.ObjectUpdateTimeout, time.Second)
+	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 }
 
 // deleteObjectAndWaitForDeletionFn returns a function that deletes the given object and waits for it to be gone.
@@ -235,7 +234,7 @@ func deleteObjectAndWaitForDeletionFn(t *testing.T, obj client.Object) func() {
 		require.EventuallyWithT(t, func(t *assert.CollectT) {
 			err := GetClients().MgrClient.Get(GetCtx(), types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj)
 			assert.True(t, k8serrors.IsNotFound(err))
-		}, testutils.ObjectUpdateTimeout, time.Second)
+		}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When testing Konnect entities with multiple entities applied e.g. 10s of consumers, using a script like this:

```
#!/bin/bash

function id() {
	cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | fold -w 10 | head -n 1
}

function deploy_consumer() {
	ID=$(id)

	kubectl apply -f - <<- EOF
	kind: KongConsumer
	apiVersion: configuration.konghq.com/v1
	metadata:
	  name: test-${ID}
	username: test-${ID}
	spec:
	  controlPlaneRef:
	    type: konnectNamespacedRef
	    konnectNamespacedRef:
	      name: test1
	EOF
}

function deploy_route() {
	ID=$(id)

	kubectl apply -f - <<- EOF
	kind: KongRoute
	apiVersion: configuration.konghq.com/v1alpha1
	metadata:
	  name: test-${ID}
	spec:
	  name: test-${ID}
	  protocols:
	  - http
	  hosts:
	  - example1.com
	  serviceRef:
	    type: namespacedRef
	    namespacedRef:
	      name: test1
	EOF
}


for i in $(seq 1 ${2});
do
	case ${1} in

	  consumer)
	    deploy_consumer &
	    ;;
	  route)
	    deploy_route &
	    ;;

	  *)
	    STATEMENTS
	    ;;
	esac
done
```

```
./main.sh consumer 50
```

I've noticed that status conditions responsible for indicating the referenced entity (e.g. consumer or CP) are repeatedly updated with `LastTransitionTime` (every 2s or so).

This PR ensures that this is not happening by checking if the condition has the status, reason, message and type as expected.


**Special notes**

Not sure (yet) what's the cause of requeues that can be observed. This can be easily triggered with multiple entities. Having just 1 or 2 doesn't trigger this behavior.