### PR TITLE
chore(tests): fix issues with e2e tests (wrong Gateway image, etc.)

### DIFF
--- a/test/e2e/test_webhook.go
+++ b/test/e2e/test_webhook.go
@@ -11,6 +11,7 @@ import (
 
 	operatorv1beta1 "github.com/kong/gateway-operator/api/v1beta1"
 	"github.com/kong/gateway-operator/pkg/consts"
+	"github.com/kong/gateway-operator/test/helpers"
 )
 
 func init() {
@@ -63,7 +64,7 @@ func TestDataPlaneValidatingWebhook(t *testing.T) {
 														Value: "postgres",
 													},
 												},
-												Image: consts.DefaultDataPlaneImage,
+												Image: helpers.GetDefaultDataPlaneImage(),
 											},
 										},
 									},

--- a/test/helpers/defaults.go
+++ b/test/helpers/defaults.go
@@ -1,6 +1,9 @@
 package helpers
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/kong/gateway-operator/pkg/consts"
@@ -31,6 +34,26 @@ func GetDefaultDataPlaneImage() string {
 	_defaultDataPlaneImageLock.RLock()
 	defer _defaultDataPlaneImageLock.RUnlock()
 	return _defaultDataPlaneImage
+}
+
+// GetDefaultDataPlaneImagePreviousMinor returns the default data plane image with the previous version.
+func GetDefaultDataPlaneImagePreviousMinor() string {
+	defaultDPImage := GetDefaultDataPlaneImage()
+	s := strings.Split(defaultDPImage, ".")
+	if len(s) != 2 {
+		panic(fmt.Sprintf("invalid default data plane image (more than one '.' in version), %s", defaultDPImage))
+	}
+	v, err := strconv.Atoi(s[1])
+	if err != nil {
+		panic(fmt.Sprintf("invalid default data plane image (after '.' not a number), %s", defaultDPImage))
+	}
+	// NOTICE: Kong Gateway 4.0 rather won't happen in foreseeable future, thus for now it's safe to have it hardcoded this way.
+	previous := v - 1
+	if previous < 0 {
+		panic(fmt.Sprintf("invalid default data plane image (previous version is negative), %s", defaultDPImage))
+	}
+	s[1] = strconv.Itoa(previous)
+	return strings.Join(s, ".")
 }
 
 // SetDefaultDataPlaneImage sets the default data plane image.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes issues with e2e tests required to pull the newest KGO OSS in the EE version. 

- setting proper registry for KGO EE and OSS depending on repo
- replace hardcoded values and make them work for OSS and EE
- some nits, like better logging, typos, etc.

Prerequisite for 
- https://github.com/Kong/gateway-operator-enterprise/pull/320