### PR TITLE
chore(ci): pass Konnect PAT to release workflow

### DIFF
--- a/.github/workflows/__release-workflow.yaml
+++ b/.github/workflows/__release-workflow.yaml
@@ -19,6 +19,9 @@ on:
       kong-license-data:
         required: false
         description: "The Kong License to use in the tests (required by EE build)"
+      konnect-pat:
+        required: true
+        description: "The Konnect PAT to use in the tests"
     inputs:
       dockerhub-push-username:
         description: "The username to push images to Docker Hub"
@@ -149,6 +152,8 @@ jobs:
         env:
           KONG_LICENSE_DATA: ${{ secrets.kong-license-data }}
           WEBHOOK_ENABLED: ${{ matrix.webhook-enabled }}
+          KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ secrets.konnect-pat }}
+          KONG_TEST_KONNECT_SERVER_URL: us.api.konghq.tech
 
   test-e2e-current-kubernetes:
     runs-on: ubuntu-latest
@@ -178,6 +183,8 @@ jobs:
         env:
           KONG_LICENSE_DATA: ${{ secrets.kong-license-data }}
           KONG_TEST_GATEWAY_OPERATOR_IMAGE_OVERRIDE: ${{ needs.build-push-images.outputs.full_tag }}
+          KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ secrets.konnect-pat }}
+          KONG_TEST_KONNECT_SERVER_URL: us.api.konghq.tech
 
   create-release-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,7 @@ jobs:
       gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
       gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
       gh-pat: ${{ secrets.PAT_GITHUB }}
+      konnect-pat: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
     with:
       dockerhub-push-username: ${{ vars.DOCKERHUB_PUSH_USERNAME  }}
       image-name: ${{ vars.DOCKERHUB_IMAGE_NAME }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix for https://github.com/Kong/gateway-operator/actions/runs/11479844799/job/31946976733.