### PR TITLE
chore(ci): re-enable DOCKER_BUILD_SUMMARY

### DIFF
--- a/.github/workflows/__build-workflow.yaml
+++ b/.github/workflows/__build-workflow.yaml
@@ -188,14 +188,12 @@ jobs:
             ${{ env.TAGS_STANDARD }}${{ env.TAGS_SUPPLEMENTAL }}
           flavor: latest=${{ inputs.latest }},suffix=-${{ matrix.arch }}
 
-      - uses: docker/setup-buildx-action@v3
-
       # Setup Golang to use go pkg cache which is utilized in Dockerfile's cache mount.
       - name: Setup golang
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      
+
       # Path for additional-build-contexts may point to dependencies that are pulled by Go toolchain,
       # so we need to download them before building the image.
       - name: Set up Go dependencies for additional build contexts
@@ -208,9 +206,6 @@ jobs:
       - name: Build image
         id: build
         uses: docker/build-push-action@v6.9.0
-        env:
-          DOCKER_BUILD_RECORD_UPLOAD: false
-          DOCKER_BUILD_SUMMARY: false
         with:
           context: .
           build-contexts: ${{ inputs.additional-build-contexts }}
@@ -226,7 +221,8 @@ jobs:
             REPO_INFO=https://github.com/${{ github.repository }}.git
             GOPATH=${{ env.GOPATH}}
             GOCACHE=${{ env.GOCACHE}}
-            PAT_GITHUB=${{ secrets.gh-pat }}
+          secrets: |
+            pat-github=${{ secrets.gh-pat }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Use outputs when push is set to false to allow subsequent steps to have


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes in the EE repo are introduced in the PR

- https://github.com/Kong/gateway-operator-enterprise/pull/321

thus it's safe to re-enable `DOCKER_BUILD_SUMMARY`.

Furthermore it removes redundant setup of Buildx Action.

**Which issue this PR fixes**

Part of https://github.com/Kong/gateway-operator-enterprise/issues/245

**Special notes for your reviewer**:

Review together with 

- https://github.com/Kong/gateway-operator-enterprise/pull/321