### PR TITLE
chore(konnect): do not handle upsert errors

### DIFF
--- a/controller/konnect/ops/ops_credentialacl.go
+++ b/controller/konnect/ops/ops_credentialacl.go
@@ -2,12 +2,10 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
-	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
 
 	sdkops "github.com/kong/gateway-operator/controller/konnect/ops/sdk"
@@ -75,27 +73,6 @@ func updateKongCredentialACL(
 	// Can't adopt it as it will cause conflicts between the controller
 	// that created that entity and already manages it, hm
 	if errWrap := wrapErrIfKonnectOpFailed(err, UpdateOp, cred); errWrap != nil {
-		// ACL update operation returns an SDKError instead of a NotFoundError.
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrap, &sdkError) {
-			switch sdkError.StatusCode {
-			case 404:
-				if err := createKongCredentialACL(ctx, sdk, cred); err != nil {
-					return FailedKonnectOpError[configurationv1alpha1.KongCredentialACL]{
-						Op:  UpdateOp,
-						Err: err,
-					}
-				}
-				return nil
-			default:
-				return FailedKonnectOpError[configurationv1alpha1.KongCredentialACL]{
-					Op:  UpdateOp,
-					Err: sdkError,
-				}
-
-			}
-		}
-
 		return errWrap
 	}
 

--- a/controller/konnect/ops/ops_credentialapikey.go
+++ b/controller/konnect/ops/ops_credentialapikey.go
@@ -69,9 +69,6 @@ func updateKongCredentialAPIKey(
 			KeyAuthWithoutParents:       kongCredentialAPIKeyToKeyAuthWithoutParents(cred),
 		})
 
-	// TODO: handle already exists
-	// Can't adopt it as it will cause conflicts between the controller
-	// that created that entity and already manages it, hm
 	if errWrap := wrapErrIfKonnectOpFailed(err, UpdateOp, cred); errWrap != nil {
 		return errWrap
 	}

--- a/controller/konnect/ops/ops_credentialbasicauth.go
+++ b/controller/konnect/ops/ops_credentialbasicauth.go
@@ -68,9 +68,6 @@ func updateKongCredentialBasicAuth(
 		BasicAuthWithoutParents:     kongCredentialBasicAuthToBasicAuthWithoutParents(cred),
 	})
 
-	// TODO: handle already exists
-	// Can't adopt it as it will cause conflicts between the controller
-	// that created that entity and already manages it, hm
 	if errWrap := wrapErrIfKonnectOpFailed(err, UpdateOp, cred); errWrap != nil {
 		return errWrap
 	}

--- a/controller/konnect/ops/ops_credentialhmac.go
+++ b/controller/konnect/ops/ops_credentialhmac.go
@@ -2,12 +2,10 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
-	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
 
 	sdkops "github.com/kong/gateway-operator/controller/konnect/ops/sdk"
@@ -71,31 +69,7 @@ func updateKongCredentialHMAC(
 			HMACAuthWithoutParents:      kongCredentialHMACToHMACWithoutParents(cred),
 		})
 
-	// TODO: handle already exists
-	// Can't adopt it as it will cause conflicts between the controller
-	// that created that entity and already manages it, hm
 	if errWrap := wrapErrIfKonnectOpFailed(err, UpdateOp, cred); errWrap != nil {
-		// HMAC update operation returns an SDKError instead of a NotFoundError.
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrap, &sdkError) {
-			switch sdkError.StatusCode {
-			case 404:
-				if err := createKongCredentialHMAC(ctx, sdk, cred); err != nil {
-					return FailedKonnectOpError[configurationv1alpha1.KongCredentialHMAC]{
-						Op:  UpdateOp,
-						Err: err,
-					}
-				}
-				return nil
-			default:
-				return FailedKonnectOpError[configurationv1alpha1.KongCredentialHMAC]{
-					Op:  UpdateOp,
-					Err: sdkError,
-				}
-
-			}
-		}
-
 		return errWrap
 	}
 

--- a/controller/konnect/ops/ops_credentialjwt.go
+++ b/controller/konnect/ops/ops_credentialjwt.go
@@ -2,12 +2,10 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
-	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
 
 	sdkops "github.com/kong/gateway-operator/controller/konnect/ops/sdk"
@@ -71,31 +69,7 @@ func updateKongCredentialJWT(
 			JWTWithoutParents:           kongCredentialJWTToJWTWithoutParents(cred),
 		})
 
-	// TODO: handle already exists
-	// Can't adopt it as it will cause conflicts between the controller
-	// that created that entity and already manages it, hm
 	if errWrap := wrapErrIfKonnectOpFailed(err, UpdateOp, cred); errWrap != nil {
-		// JWT update operation returns an SDKError instead of a NotFoundError.
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrap, &sdkError) {
-			switch sdkError.StatusCode {
-			case 404:
-				if err := createKongCredentialJWT(ctx, sdk, cred); err != nil {
-					return FailedKonnectOpError[configurationv1alpha1.KongCredentialJWT]{
-						Op:  UpdateOp,
-						Err: err,
-					}
-				}
-				return nil
-			default:
-				return FailedKonnectOpError[configurationv1alpha1.KongCredentialJWT]{
-					Op:  UpdateOp,
-					Err: sdkError,
-				}
-
-			}
-		}
-
 		return errWrap
 	}
 

--- a/controller/konnect/ops/ops_kongcacertificate.go
+++ b/controller/konnect/ops/ops_kongcacertificate.go
@@ -68,15 +68,9 @@ func updateCACertificate(
 		},
 	)
 
-	// TODO: handle already exists
-	// Can't adopt it as it will cause conflicts between the controller
-	// that created that entity and already manages it, hm
 	if errWrap := wrapErrIfKonnectOpFailed(err, UpdateOp, cert); errWrap != nil {
-		SetKonnectEntityProgrammedConditionFalse(cert, "FailedToUpdate", errWrap.Error())
 		return errWrap
 	}
-
-	SetKonnectEntityProgrammedCondition(cert)
 
 	return nil
 }

--- a/controller/konnect/ops/ops_kongcertificate.go
+++ b/controller/konnect/ops/ops_kongcertificate.go
@@ -2,12 +2,10 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
-	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
 
 	sdkops "github.com/kong/gateway-operator/controller/konnect/ops/sdk"
@@ -70,31 +68,7 @@ func updateCertificate(
 		},
 	)
 
-	// TODO: handle already exists
-	// Can't adopt it as it will cause conflicts between the controller
-	// that created that entity and already manages it, hm
 	if errWrap := wrapErrIfKonnectOpFailed(err, UpdateOp, cert); errWrap != nil {
-		// Certificate update operation returns an SDKError instead of a NotFoundError.
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrap, &sdkError) {
-			switch sdkError.StatusCode {
-			case 404:
-				if err := createCertificate(ctx, sdk, cert); err != nil {
-					return FailedKonnectOpError[configurationv1alpha1.KongCertificate]{
-						Op:  UpdateOp,
-						Err: err,
-					}
-				}
-				// Create succeeded, createCertificate sets the status so no need to do this here.
-
-				return nil
-			default:
-				return FailedKonnectOpError[configurationv1alpha1.KongCertificate]{
-					Op:  UpdateOp,
-					Err: sdkError,
-				}
-			}
-		}
 		return errWrap
 	}
 

--- a/controller/konnect/ops/ops_kongconsumer.go
+++ b/controller/konnect/ops/ops_kongconsumer.go
@@ -125,15 +125,21 @@ func handleConsumerGroupAssignments(
 	populateConsumerGroupRefsValidCondition(invalidConsumerGroups, consumer)
 
 	if err != nil {
-		SetKonnectEntityProgrammedConditionFalse(consumer, konnectv1alpha1.KonnectEntityProgrammedReasonFailedToResolveConsumerGroupRefs, err.Error())
-		return err
+		return KonnectEntityCreatedButRelationsFailedError{
+			KonnectID: consumer.GetKonnectID(),
+			Reason:    konnectv1alpha1.KonnectEntityProgrammedReasonFailedToResolveConsumerGroupRefs,
+			Err:       err,
+		}
 	}
 
 	// Reconcile the ConsumerGroups assigned to the KongConsumer in Konnect (list the actual ConsumerGroups, calculate the
 	// difference, and add/remove the Consumer from the ConsumerGroups accordingly).
 	if err := reconcileConsumerGroupsWithKonnect(ctx, desiredConsumerGroupsIDs, cgSDK, cpID, consumer); err != nil {
-		SetKonnectEntityProgrammedConditionFalse(consumer, konnectv1alpha1.KonnectEntityProgrammedReasonFailedToReconcileConsumerGroupsWithKonnect, err.Error())
-		return err
+		return KonnectEntityCreatedButRelationsFailedError{
+			KonnectID: consumer.GetKonnectID(),
+			Reason:    konnectv1alpha1.KonnectEntityProgrammedReasonFailedToReconcileConsumerGroupsWithKonnect,
+			Err:       err,
+		}
 	}
 	return nil
 }

--- a/controller/konnect/ops/ops_kongdataplaneclientcertificate.go
+++ b/controller/konnect/ops/ops_kongdataplaneclientcertificate.go
@@ -33,12 +33,10 @@ func createKongDataPlaneClientCertificate(
 	// Can't adopt it as it will cause conflicts between the controller
 	// that created that entity and already manages it, hm
 	if errWrap := wrapErrIfKonnectOpFailed(err, CreateOp, cert); errWrap != nil {
-		SetKonnectEntityProgrammedConditionFalse(cert, "FailedToCreate", errWrap.Error())
 		return errWrap
 	}
 
-	cert.Status.Konnect.SetKonnectID(*resp.DataPlaneClientCertificate.Item.ID)
-	SetKonnectEntityProgrammedCondition(cert)
+	cert.SetKonnectID(*resp.DataPlaneClientCertificate.Item.ID)
 
 	return nil
 }

--- a/controller/konnect/ops/ops_kongkey.go
+++ b/controller/konnect/ops/ops_kongkey.go
@@ -2,12 +2,10 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
-	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
 
 	sdkops "github.com/kong/gateway-operator/controller/konnect/ops/sdk"
@@ -69,26 +67,7 @@ func updateKey(
 		},
 	)
 
-	// TODO: handle already exists
-	// Can't adopt it as it will cause conflicts between the controller
-	// that created that entity and already manages it, hm
 	if errWrap := wrapErrIfKonnectOpFailed(err, UpdateOp, key); errWrap != nil {
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrap, &sdkError) {
-			if sdkError.StatusCode == 404 {
-				if err := createKey(ctx, sdk, key); err != nil {
-					return FailedKonnectOpError[configurationv1alpha1.KongKey]{
-						Op:  UpdateOp,
-						Err: err,
-					}
-				}
-				return nil // createKey sets the status so we can return here.
-			}
-			return FailedKonnectOpError[configurationv1alpha1.KongKey]{
-				Op:  UpdateOp,
-				Err: sdkError,
-			}
-		}
 		return errWrap
 	}
 

--- a/controller/konnect/ops/ops_kongkeyset.go
+++ b/controller/konnect/ops/ops_kongkeyset.go
@@ -2,12 +2,10 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
-	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
 
 	sdkops "github.com/kong/gateway-operator/controller/konnect/ops/sdk"
@@ -70,26 +68,7 @@ func updateKeySet(
 		},
 	)
 
-	// TODO: handle already exists
-	// Can't adopt it as it will cause conflicts between the controller
-	// that created that entity and already manages it, hm
 	if errWrap := wrapErrIfKonnectOpFailed(err, UpdateOp, keySet); errWrap != nil {
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrap, &sdkError) {
-			if sdkError.StatusCode == 404 {
-				if err := createKeySet(ctx, sdk, keySet); err != nil {
-					return FailedKonnectOpError[configurationv1alpha1.KongKeySet]{
-						Op:  UpdateOp,
-						Err: err,
-					}
-				}
-				return nil // createKeySet sets the status so we can return here.
-			}
-			return FailedKonnectOpError[configurationv1alpha1.KongKeySet]{
-				Op:  UpdateOp,
-				Err: sdkError,
-			}
-		}
 		return errWrap
 	}
 

--- a/controller/konnect/ops/ops_kongroute.go
+++ b/controller/konnect/ops/ops_kongroute.go
@@ -2,13 +2,11 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
-	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
 
 	sdkops "github.com/kong/gateway-operator/controller/konnect/ops/sdk"
@@ -62,27 +60,6 @@ func updateRoute(
 	})
 
 	if errWrap := wrapErrIfKonnectOpFailed(err, UpdateOp, route); errWrap != nil {
-		// Route update operation returns an SDKError instead of a NotFoundError.
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrap, &sdkError) {
-			switch sdkError.StatusCode {
-			case 404:
-				logEntityNotFoundRecreating(ctx, route, id)
-				if err := createRoute(ctx, sdk, route); err != nil {
-					return FailedKonnectOpError[configurationv1alpha1.KongRoute]{
-						Op:  UpdateOp,
-						Err: err,
-					}
-				}
-				return nil
-			default:
-				return FailedKonnectOpError[configurationv1alpha1.KongRoute]{
-					Op:  UpdateOp,
-					Err: sdkError,
-				}
-			}
-		}
-
 		return errWrap
 	}
 

--- a/controller/konnect/ops/ops_kongservice.go
+++ b/controller/konnect/ops/ops_kongservice.go
@@ -2,12 +2,10 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
-	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
 
 	sdkops "github.com/kong/gateway-operator/controller/konnect/ops/sdk"
@@ -65,28 +63,6 @@ func updateService(
 	)
 
 	if errWrap := wrapErrIfKonnectOpFailed(err, UpdateOp, svc); errWrap != nil {
-		// Service update operation returns an SDKError instead of a NotFoundError.
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrap, &sdkError) {
-			switch sdkError.StatusCode {
-			case 404:
-				logEntityNotFoundRecreating(ctx, svc, id)
-				if err := createService(ctx, sdk, svc); err != nil {
-					return FailedKonnectOpError[configurationv1alpha1.KongService]{
-						Op:  UpdateOp,
-						Err: err,
-					}
-				}
-				// Create succeeded, createService sets the status so no need to do this here.
-				return nil
-			default:
-				return FailedKonnectOpError[configurationv1alpha1.KongService]{
-					Op:  UpdateOp,
-					Err: sdkError,
-				}
-			}
-		}
-
 		return errWrap
 	}
 

--- a/controller/konnect/ops/ops_kongsni.go
+++ b/controller/konnect/ops/ops_kongsni.go
@@ -75,29 +75,6 @@ func updateSNI(
 	// Can't adopt it as it will cause conflicts between the controller
 	// that created that entity and already manages it, hm
 	if errWrap := wrapErrIfKonnectOpFailed(err, UpdateOp, sni); errWrap != nil {
-		// SNI update operation returns an SDKError instead of a NotFoundError.
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrap, &sdkError) {
-			switch sdkError.StatusCode {
-			case 404:
-				logEntityNotFoundRecreating(ctx, sni, id)
-				if err := createSNI(ctx, sdk, sni); err != nil {
-					return FailedKonnectOpError[configurationv1alpha1.KongSNI]{
-						Op:  UpdateOp,
-						Err: err,
-					}
-				}
-				// Create succeeded, createSNI sets the status so no need to do this here.
-
-				return nil
-			default:
-				return FailedKonnectOpError[configurationv1alpha1.KongSNI]{
-					Op:  UpdateOp,
-					Err: sdkError,
-				}
-			}
-		}
-
 		return errWrap
 	}
 

--- a/controller/konnect/ops/ops_kongupstream.go
+++ b/controller/konnect/ops/ops_kongupstream.go
@@ -2,12 +2,10 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
-	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
 
 	sdkops "github.com/kong/gateway-operator/controller/konnect/ops/sdk"
@@ -65,28 +63,6 @@ func updateUpstream(
 	)
 
 	if errWrap := wrapErrIfKonnectOpFailed(err, UpdateOp, upstream); errWrap != nil {
-		// Upstream update operation returns an SDKError instead of a NotFoundError.
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrap, &sdkError) {
-			switch sdkError.StatusCode {
-			case 404:
-				if err := createUpstream(ctx, sdk, upstream); err != nil {
-					return FailedKonnectOpError[configurationv1alpha1.KongUpstream]{
-						Op:  UpdateOp,
-						Err: err,
-					}
-				}
-				// Create succeeded, createUpstream sets the status so no need to do this here.
-
-				return nil
-			default:
-				return FailedKonnectOpError[configurationv1alpha1.KongUpstream]{
-					Op:  UpdateOp,
-					Err: sdkError,
-				}
-			}
-		}
-
 		return errWrap
 	}
 

--- a/controller/konnect/ops/ops_kongvault_test.go
+++ b/controller/konnect/ops/ops_kongvault_test.go
@@ -246,56 +246,6 @@ func TestUpdateKongVault(t *testing.T) {
 				assert.Equal(t, "12345", vault.GetKonnectID())
 			},
 		},
-		{
-			name: "try to create when not found",
-			mockVaultPair: func(t *testing.T) (*sdkmocks.MockVaultSDK, *configurationv1alpha1.KongVault) {
-				sdk := sdkmocks.NewMockVaultSDK(t)
-				vault := &configurationv1alpha1.KongVault{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "vault-1",
-					},
-					Spec: configurationv1alpha1.KongVaultSpec{
-						Config: apiextensionsv1.JSON{
-							Raw: []byte(`{}`),
-						},
-						Backend:     "aws",
-						Prefix:      "aws-vault1",
-						Description: "test vault",
-					},
-					Status: configurationv1alpha1.KongVaultStatus{
-						Konnect: &konnectv1alpha1.KonnectEntityStatusWithControlPlaneRef{
-							KonnectEntityStatus: konnectv1alpha1.KonnectEntityStatus{
-								ID: "12345",
-							},
-							ControlPlaneID: "123456789",
-						},
-					},
-				}
-				sdk.EXPECT().UpsertVault(mock.Anything, sdkkonnectops.UpsertVaultRequest{
-					VaultID:        "12345",
-					ControlPlaneID: "123456789",
-					Vault:          mustConvertKongVaultToVaultInput(t, vault),
-				}).Return(nil, &sdkkonnecterrs.SDKError{
-					Message:    "not found",
-					StatusCode: http.StatusNotFound,
-				})
-				sdk.EXPECT().CreateVault(mock.Anything, "123456789", mustConvertKongVaultToVaultInput(t, vault)).
-					Return(
-						&sdkkonnectops.CreateVaultResponse{
-							Vault: &sdkkonnectcomp.Vault{
-								ID:     lo.ToPtr("12345"),
-								Name:   "aws",
-								Prefix: "aws-vault1",
-							},
-						},
-						nil,
-					)
-				return sdk, vault
-			},
-			assertions: func(t *testing.T, vault *configurationv1alpha1.KongVault) {
-				assert.Equal(t, "12345", vault.GetKonnectStatus().GetKonnectID())
-			},
-		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**What this PR does / why we need it**:

`Upsert*` operations create entities if they do not exist so there's no need to handle that explicitly.

This is what this PR does.

The only entity thus far that requires this to be handled is ControlPlane which is using the newly added `handleUpdateError()`

Additionally, this PR also removes setting object status conditions in `ops_*.go` as that's done in `ops.go` for all types.