### PR TITLE
fix(konnect): don't block deletion when entity has no Konnect ID and is not Programmed

### DIFF
--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -182,10 +182,14 @@ func Delete[
 ](ctx context.Context, sdk sdkops.SDKWrapper, cl client.Client, e *T) error {
 	ent := TEnt(e)
 	if ent.GetKonnectStatus().GetKonnectID() == "" {
-		return fmt.Errorf(
-			"can't delete %T %s when it does not have the Konnect ID",
-			ent, client.ObjectKeyFromObject(ent),
-		)
+		cond, ok := k8sutils.GetCondition(konnectv1alpha1.KonnectEntityProgrammedConditionType, ent)
+		if ok && cond.Status == metav1.ConditionTrue {
+			return fmt.Errorf(
+				"can't delete %T %s when it does not have the Konnect ID",
+				ent, client.ObjectKeyFromObject(ent),
+			)
+		}
+		return nil
 	}
 
 	var (

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -179,8 +179,7 @@ func Create[
 func Delete[
 	T constraints.SupportedKonnectEntityType,
 	TEnt constraints.EntityType[T],
-](ctx context.Context, sdk sdkops.SDKWrapper, cl client.Client, e TEnt) error {
-	ent := TEnt(e)
+](ctx context.Context, sdk sdkops.SDKWrapper, cl client.Client, ent TEnt) error {
 	if ent.GetKonnectStatus().GetKonnectID() == "" {
 		cond, ok := k8sutils.GetCondition(konnectv1alpha1.KonnectEntityProgrammedConditionType, ent)
 		if ok && cond.Status == metav1.ConditionTrue {
@@ -196,7 +195,7 @@ func Delete[
 		err   error
 		start = time.Now()
 	)
-	switch ent := any(e).(type) {
+	switch ent := any(ent).(type) {
 	case *konnectv1alpha1.KonnectGatewayControlPlane:
 		err = deleteControlPlane(ctx, sdk.GetControlPlaneSDK(), ent)
 	case *configurationv1alpha1.KongService:
@@ -243,7 +242,7 @@ func Delete[
 		return fmt.Errorf("unsupported entity type %T", ent)
 	}
 
-	logOpComplete[T, TEnt](ctx, start, DeleteOp, e, err)
+	logOpComplete[T, TEnt](ctx, start, DeleteOp, ent, err)
 
 	return err
 }

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -179,7 +179,7 @@ func Create[
 func Delete[
 	T constraints.SupportedKonnectEntityType,
 	TEnt constraints.EntityType[T],
-](ctx context.Context, sdk sdkops.SDKWrapper, cl client.Client, e *T) error {
+](ctx context.Context, sdk sdkops.SDKWrapper, cl client.Client, e TEnt) error {
 	ent := TEnt(e)
 	if ent.GetKonnectStatus().GetKonnectID() == "" {
 		cond, ok := k8sutils.GetCondition(konnectv1alpha1.KonnectEntityProgrammedConditionType, ent)

--- a/controller/konnect/ops/ops_test.go
+++ b/controller/konnect/ops/ops_test.go
@@ -1,0 +1,123 @@
+package ops
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+
+	"github.com/kong/gateway-operator/controller/konnect/constraints"
+	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/scheme"
+)
+
+type deleteTestCase[
+	T constraints.SupportedKonnectEntityType,
+	TEnt constraints.EntityType[T],
+] struct {
+	name          string
+	entity        TEnt
+	sdkFunc       func(t *testing.T, sdk *sdkmocks.MockSDKWrapper) *sdkmocks.MockSDKWrapper
+	expectedError string
+}
+
+func TestDelete(t *testing.T) {
+	testCasesForKonnectGatewayControlPlane := []deleteTestCase[
+		konnectv1alpha1.KonnectGatewayControlPlane,
+		*konnectv1alpha1.KonnectGatewayControlPlane,
+	]{
+		{
+			name: "no Konnect ID and no Programmed status condition - delete is not called",
+			entity: &konnectv1alpha1.KonnectGatewayControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "test-ns",
+				},
+			},
+		},
+		{
+			name: "no Konnect ID and Programmed=False status condition - delete is not called",
+			entity: &konnectv1alpha1.KonnectGatewayControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "test-ns",
+				},
+				Status: konnectv1alpha1.KonnectGatewayControlPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   konnectv1alpha1.KonnectEntityProgrammedConditionType,
+							Status: metav1.ConditionFalse,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Konnect ID and Programmed=True status condition",
+			entity: &konnectv1alpha1.KonnectGatewayControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "test-ns",
+				},
+				Status: konnectv1alpha1.KonnectGatewayControlPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   konnectv1alpha1.KonnectEntityProgrammedConditionType,
+							Status: metav1.ConditionTrue,
+						},
+					},
+					KonnectEntityStatus: konnectv1alpha1.KonnectEntityStatus{
+						ID: "12345",
+					},
+				},
+			},
+			sdkFunc: func(t *testing.T, sdk *sdkmocks.MockSDKWrapper) *sdkmocks.MockSDKWrapper {
+				sdk.ControlPlaneSDK.
+					EXPECT().
+					DeleteControlPlane(mock.Anything, "12345").
+					Return(
+						&sdkkonnectops.DeleteControlPlaneResponse{},
+						nil,
+					).
+					Once()
+				return sdk
+			},
+		},
+	}
+
+	testDelete(t, testCasesForKonnectGatewayControlPlane)
+}
+
+func testDelete[
+	T constraints.SupportedKonnectEntityType,
+	TEnt constraints.EntityType[T],
+](t *testing.T, testcases []deleteTestCase[T, TEnt],
+) {
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Get()).
+				Build()
+
+			sdk := sdkmocks.NewMockSDKWrapperWithT(t)
+			if tc.sdkFunc != nil {
+				sdk = tc.sdkFunc(t, sdk)
+			}
+
+			err := Delete(context.Background(), sdk, fakeClient, tc.entity)
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/controller/konnect/ops/ops_test.go
+++ b/controller/konnect/ops/ops_test.go
@@ -4,17 +4,17 @@ import (
 	"context"
 	"testing"
 
+	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
-	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
-
 	"github.com/kong/gateway-operator/controller/konnect/constraints"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
 type deleteTestCase[


### PR DESCRIPTION
**What this PR does / why we need it**:

Deletion of entities should not be blocked when they do not have the Konnect ID assigned and are not Programmed.