### PR TITLE
feat(konnect): handle BadRequest errors and other unrecoverable errors to prevent endless reconciliation

### DIFF
--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -184,15 +184,7 @@ func Create[
 
 	logOpComplete(ctx, start, CreateOp, e, err)
 
-	// If the error is a type field error or bad request error, then don't propagate
-	// it to the caller.
-	// We cannot recover from this error as this requires user to change object's
-	// manifest. The entity's status is already updated with the error.
-	if ErrorIsSDKErrorTypeField(err) || ErrorIsSDKBadRequestError(err) {
-		err = nil
-	}
-
-	return e, err
+	return e, IgnoreUnrecoverableAPIErr(err)
 }
 
 // Delete deletes a Konnect entity.
@@ -404,15 +396,7 @@ func Update[
 
 	logOpComplete(ctx, now, UpdateOp, e, err)
 
-	// If the error is a type field error or bad request error, then don't propagate
-	// it to the caller.
-	// We cannot recover from this error as this requires user to change object's
-	// manifest. The entity's status is already updated with the error.
-	if ErrorIsSDKErrorTypeField(err) || ErrorIsSDKBadRequestError(err) {
-		err = nil
-	}
-
-	return ctrl.Result{}, err
+	return ctrl.Result{}, IgnoreUnrecoverableAPIErr(err)
 }
 
 func logOpComplete[

--- a/controller/konnect/ops/ops_errors.go
+++ b/controller/konnect/ops/ops_errors.go
@@ -9,10 +9,12 @@ import (
 	"slices"
 
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
+	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kong/gateway-operator/controller/konnect/constraints"
+	"github.com/kong/gateway-operator/controller/pkg/log"
 )
 
 // ErrNilResponse is an error indicating that a Konnect operation returned an empty response.
@@ -247,12 +249,13 @@ func handleDeleteError[
 
 // IgnoreUnrecoverableAPIErr ignores unrecoverable errors that would cause the
 // reconciler to endlessly requeue.
-func IgnoreUnrecoverableAPIErr(err error) error {
+func IgnoreUnrecoverableAPIErr(err error, logger logr.Logger) error {
 	// If the error is a type field error or bad request error, then don't propagate
 	// it to the caller.
 	// We cannot recover from this error as this requires user to change object's
 	// manifest. The entity's status is already updated with the error.
 	if ErrorIsSDKErrorTypeField(err) || ErrorIsSDKBadRequestError(err) {
+		log.Debug(logger, "ignoring unrecoverable API error, consult object's status for details", "err", err)
 		return nil
 	}
 

--- a/controller/konnect/ops/ops_errors.go
+++ b/controller/konnect/ops/ops_errors.go
@@ -244,3 +244,17 @@ func handleDeleteError[
 		Err: err,
 	}
 }
+
+// IgnoreUnrecoverableAPIErr ignores unrecoverable errors that would cause the
+// reconciler to endlessly requeue.
+func IgnoreUnrecoverableAPIErr(err error) error {
+	// If the error is a type field error or bad request error, then don't propagate
+	// it to the caller.
+	// We cannot recover from this error as this requires user to change object's
+	// manifest. The entity's status is already updated with the error.
+	if ErrorIsSDKErrorTypeField(err) || ErrorIsSDKBadRequestError(err) {
+		return nil
+	}
+
+	return err
+}

--- a/controller/konnect/ops/ops_test.go
+++ b/controller/konnect/ops/ops_test.go
@@ -2,9 +2,14 @@ package ops
 
 import (
 	"context"
+	"io"
+	"net/http"
 	"testing"
 
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
+	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,9 +18,238 @@ import (
 	"github.com/kong/gateway-operator/controller/konnect/constraints"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
+	"github.com/kong/gateway-operator/pkg/consts"
 
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
+
+type createTestCase[
+	T constraints.SupportedKonnectEntityType,
+	TEnt constraints.EntityType[T],
+] struct {
+	name                  string
+	entity                TEnt
+	sdkFunc               func(t *testing.T, sdk *sdkmocks.MockSDKWrapper) *sdkmocks.MockSDKWrapper
+	expectedErrorContains string
+	assertions            func(t *testing.T, ent TEnt)
+}
+
+func TestCreate(t *testing.T) {
+	testCasesForKonnectGatewayControlPlane := []createTestCase[
+		konnectv1alpha1.KonnectGatewayControlPlane,
+		*konnectv1alpha1.KonnectGatewayControlPlane,
+	]{
+		{
+			name: "BadRequest error is not propagated to the caller but object's status condition is updated",
+			entity: &konnectv1alpha1.KonnectGatewayControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "test-ns",
+				},
+				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+						Name: "test-cp",
+						Labels: map[string]string{
+							"label": "very-long-label-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+						},
+					},
+				},
+			},
+			sdkFunc: func(t *testing.T, sdk *sdkmocks.MockSDKWrapper) *sdkmocks.MockSDKWrapper {
+				sdk.ControlPlaneSDK.
+					EXPECT().
+					CreateControlPlane(
+						mock.Anything,
+						mock.MatchedBy(func(req sdkkonnectcomp.CreateControlPlaneRequest) bool {
+							if req.Name != "test-cp" ||
+								req.Labels == nil {
+								return false
+							}
+							// NOTE: do not check the value as we're truncating the label values to
+							// prevent them from being rejected by Konnect.
+							_, ok := req.Labels["label"]
+							return ok
+						}),
+					).
+					Return(
+						nil,
+						&sdkkonnecterrs.BadRequestError{
+							Status: 400,
+							Title:  "Invalid Request",
+							Detail: "Invalid Parameters",
+							InvalidParameters: []sdkkonnectcomp.InvalidParameters{
+								{
+									InvalidParameterStandard: &sdkkonnectcomp.InvalidParameterStandard{
+										Field:  "labels",
+										Rule:   sdkkonnectcomp.InvalidRulesIsLabel.ToPointer(),
+										Reason: "Label value exceeds maximum of 63 characters",
+									},
+								},
+							},
+						},
+					).
+					Once()
+				return sdk
+			},
+			// No error returned, only object's status condition updated to prevent endless reconciliation
+			// that operator cannot recover from (object's manifest needs to be changed).
+			assertions: func(t *testing.T, ent *konnectv1alpha1.KonnectGatewayControlPlane) {
+				require.Len(t, ent.Status.Conditions, 1)
+				assert.Equal(t, metav1.ConditionFalse, ent.Status.Conditions[0].Status)
+				assert.EqualValues(t, consts.KonnectEntitiesFailedToCreateReason, ent.Status.Conditions[0].Reason)
+				assert.Equal(t,
+					`failed to create KonnectGatewayControlPlane test-ns/test-cp: {"status":400,"title":"Invalid Request","instance":"","detail":"Invalid Parameters","invalid_parameters":[{"field":"labels","rule":"is_label","reason":"Label value exceeds maximum of 63 characters"}]}`,
+					ent.Status.Conditions[0].Message)
+			},
+		},
+		{
+			name: "SDKError (data constraint error) is not propagated to the caller but object's status condition is updated",
+			entity: &konnectv1alpha1.KonnectGatewayControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "test-ns",
+				},
+				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+						Name: "test-cp",
+					},
+				},
+			},
+			sdkFunc: func(t *testing.T, sdk *sdkmocks.MockSDKWrapper) *sdkmocks.MockSDKWrapper {
+				sdk.ControlPlaneSDK.
+					EXPECT().
+					CreateControlPlane(
+						mock.Anything,
+						mock.MatchedBy(func(req sdkkonnectcomp.CreateControlPlaneRequest) bool {
+							return req.Name == "test-cp"
+						}),
+					).
+					Return(
+						nil,
+						&sdkkonnecterrs.SDKError{
+							Message:    "data constraint error",
+							StatusCode: http.StatusBadRequest,
+							Body: `{` +
+								`"code": 3,` +
+								`"message": "validation error",` +
+								`"details": [` +
+								`  {` +
+								`      "@type": "type.googleapis.com/kong.admin.model.v1.ErrorDetail",` +
+								`      "type": "ERROR_TYPE_FIELD",` +
+								`      "field": "tags[0]",` +
+								`      "messages": [` +
+								`        "length must be <= 128, but got 138"` +
+								`      ]` +
+								`  }` +
+								`]` +
+								`}`,
+						},
+					).
+					Once()
+				return sdk
+			},
+			// No error returned, only object's status condition updated to prevent endless reconciliation
+			// that operator cannot recover from (object's manifest needs to be changed).
+			assertions: func(t *testing.T, ent *konnectv1alpha1.KonnectGatewayControlPlane) {
+				require.Len(t, ent.Status.Conditions, 1,
+					"Expected one condition (Programmed) to be set",
+				)
+				assert.Equal(t, metav1.ConditionFalse, ent.Status.Conditions[0].Status,
+					"Expected Programmed condition to be set to false",
+				)
+				assert.EqualValues(t, consts.KonnectEntitiesFailedToCreateReason, ent.Status.Conditions[0].Reason,
+					"Expected Programmed condition's reason to be set to FailedToCreate",
+				)
+				assert.Equal(t,
+					"data constraint error: Status 400\n"+
+						`{"code": 3,"message": "validation error","details": [  {      "@type": "type.googleapis.com/kong.admin.model.v1.ErrorDetail",      "type": "ERROR_TYPE_FIELD",      "field": "tags[0]",      "messages": [        "length must be <= 128, but got 138"      ]  }]}`,
+					ent.Status.Conditions[0].Message,
+					"Expected Programmed condition's message to be set to error message returned by Konnect API",
+				)
+			},
+		},
+		{
+			name: "other types of errors are propagated to the caller and object's status condition is updated",
+			entity: &konnectv1alpha1.KonnectGatewayControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "test-ns",
+				},
+				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+						Name: "test-cp",
+					},
+				},
+			},
+			sdkFunc: func(t *testing.T, sdk *sdkmocks.MockSDKWrapper) *sdkmocks.MockSDKWrapper {
+				sdk.ControlPlaneSDK.
+					EXPECT().
+					CreateControlPlane(
+						mock.Anything,
+						mock.MatchedBy(func(req sdkkonnectcomp.CreateControlPlaneRequest) bool {
+							return req.Name == "test-cp"
+						}),
+					).
+					Return(
+						nil,
+						io.ErrUnexpectedEOF,
+					).
+					Once()
+				return sdk
+			},
+			expectedErrorContains: "unexpected EOF",
+			assertions: func(t *testing.T, ent *konnectv1alpha1.KonnectGatewayControlPlane) {
+				require.Len(t, ent.Status.Conditions, 1,
+					"Expected one condition (Programmed) to be set",
+				)
+				assert.Equal(t, metav1.ConditionFalse, ent.Status.Conditions[0].Status,
+					"Expected Programmed condition to be set to false",
+				)
+				assert.EqualValues(t, consts.KonnectEntitiesFailedToCreateReason, ent.Status.Conditions[0].Reason,
+					"Expected Programmed condition's reason to be set to FailedToCreate",
+				)
+				assert.Equal(t,
+					"failed to create KonnectGatewayControlPlane test-ns/test-cp: unexpected EOF",
+					ent.Status.Conditions[0].Message,
+					"Expected Programmed condition's message to be set to error message returned by Konnect API",
+				)
+			},
+		},
+	}
+
+	testCreate(t, testCasesForKonnectGatewayControlPlane)
+}
+
+func testCreate[
+	T constraints.SupportedKonnectEntityType,
+	TEnt constraints.EntityType[T],
+](t *testing.T, testcases []createTestCase[T, TEnt],
+) {
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Get()).
+				Build()
+
+			sdk := sdkmocks.NewMockSDKWrapperWithT(t)
+			if tc.sdkFunc != nil {
+				sdk = tc.sdkFunc(t, sdk)
+			}
+
+			_, err := Create(context.Background(), sdk, fakeClient, tc.entity)
+			if tc.expectedErrorContains != "" {
+				require.ErrorContains(t, err, tc.expectedErrorContains)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tc.assertions != nil {
+				tc.assertions(t, tc.entity)
+			}
+		})
+	}
+}
 
 type deleteTestCase[
 	T constraints.SupportedKonnectEntityType,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR add handling of BadRequest errors and other unrecoverable errors to prevent endless reconciliation.

When those types of errors are caught, operator will set object's Programmed status condition and not propagate the error to the caller, prevent it from bubbling up in the reconciliation loop.