### PR TITLE
Fix(rbac): add permission of deleting KongRoute in RBAC

### DIFF
--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -152,7 +152,6 @@ rules:
   - kongdataplaneclientcertificates
   - kongkeys
   - kongkeysets
-  - kongroutes
   - kongservices
   - kongsnis
   - kongtargets
@@ -229,6 +228,17 @@ rules:
   - kongplugins
   verbs:
   - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongroutes
+  verbs:
   - delete
   - get
   - list

--- a/controller/konnect/reconciler_generic_rbac.go
+++ b/controller/konnect/reconciler_generic_rbac.go
@@ -58,7 +58,7 @@ package konnect
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongkeysets/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongkeysets/finalizers,verbs=update;patch
 
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongroutes,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongroutes,verbs=get;list;watch;update;patch;delete
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongroutes/status,verbs=update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongroutes/finalizers,verbs=update;patch
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `delete` permission on `KongRoute` to allow deleting `KongRoute`s where its service is deleted.

**Which issue this PR fixes**

Fixes #777

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
