### PR TITLE
fix(konnect): do not manage finalizers and lifecycle for unmanaged KongPluginBindings

### DIFF
--- a/controller/konnect/plugins.go
+++ b/controller/konnect/plugins.go
@@ -1,6 +1,8 @@
 package konnect
 
 import (
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -24,4 +26,15 @@ var kongPluginsAnnotationChangedPredicate = predicate.Funcs{
 		_, ok := e.Object.GetAnnotations()[consts.PluginsAnnotationKey]
 		return ok
 	},
+}
+
+func ownerRefIsAnyKongPlugin(obj client.Object) bool {
+	return lo.ContainsBy(
+		obj.GetOwnerReferences(),
+		func(ownerRef metav1.OwnerReference) bool {
+			return ownerRef.Kind == "KongPlugin" ||
+				// NOTE: We currently do not support KongClusterPlugin, but we keep this here for future use.
+				ownerRef.Kind == "KongClusterPlugin"
+		},
+	)
 }

--- a/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
+++ b/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
@@ -74,6 +74,12 @@ func (r *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]) enqueueObjectRe
 			return nil
 		}
 
+		// If the KongPluginBinding is unmanaged (created not using an annotation,
+		// and thus not having KongPlugin as an owner), skip it, do not delete it.
+		if !ownerRefIsAnyKongPlugin(kpb) {
+			return nil
+		}
+
 		var (
 			name string
 			e    T
@@ -125,6 +131,9 @@ func (r *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]) enqueueObjectRe
 }
 
 // Reconcile reconciles the Konnect entity that can be set as KongPluginBinding target.
+// It reconciles only entities that are referenced by managed KongPluginBindings,
+// i.e. those that are created by the controller out of konghq.com/plugins annotations.
+//
 // Its purpose is to:
 //   - check if the entity is marked for deletion and mark KongPluginBindings
 //     that reference it.

--- a/controller/konnect/watch_kongplugin.go
+++ b/controller/konnect/watch_kongplugin.go
@@ -68,6 +68,12 @@ func (r *KongPluginReconciler) mapKongPluginBindings(ctx context.Context, obj cl
 		return []ctrl.Request{}
 	}
 
+	// If the KongPluginBinding is unmanaged (created not using an annotation,
+	// and thus not having KongPlugin as an owner), do not enqueue it.
+	if !ownerRefIsAnyKongPlugin(kongPluginBinding) {
+		return nil
+	}
+
 	return []ctrl.Request{
 		{
 			NamespacedName: types.NamespacedName{

--- a/test/envtest/assert.go
+++ b/test/envtest/assert.go
@@ -15,10 +15,15 @@ func assertCollectObjectExistsAndHasKonnectID(
 	obj interface {
 		client.Object
 		GetKonnectID() string
+		GetTypeName() string
 	},
 	konnectID string,
 ) func(c *assert.CollectT) {
 	t.Helper()
+
+	t.Logf("wait for the %s %s to get Konnect ID (%s) assigned",
+		obj.GetTypeName(), client.ObjectKeyFromObject(obj), konnectID,
+	)
 
 	return func(c *assert.CollectT) {
 		nn := client.ObjectKeyFromObject(obj)

--- a/test/envtest/consts.go
+++ b/test/envtest/consts.go
@@ -11,5 +11,5 @@ const (
 	waitTime = 10 * time.Second
 
 	// tickTime is a generic tick time for the tests' eventual conditions.
-	tickTime = 500 * time.Millisecond
+	tickTime = 250 * time.Millisecond
 )

--- a/test/envtest/konnect_entities_kongroute_test.go
+++ b/test/envtest/konnect_entities_kongroute_test.go
@@ -86,6 +86,12 @@ func TestKongRoute(t *testing.T) {
 			},
 		)
 
+		assert.EventuallyWithT(t,
+			assertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, createdRoute, routeID),
+			waitTime, tickTime,
+			"KongRoute wasn't created using Konnect API or its KonnectID wasn't set",
+		)
+
 		t.Log("Checking SDK KongRoute operations")
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.True(c, factory.SDK.RoutesSDK.AssertExpectations(t))


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not manage finalizers and lifecycle for unmanaged `KongPluginBinding`s.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

The approach proposed in this PR will suffer from #645: having KPB with `KongService` and `KongRoute` targets and deleting `KongRoute` we can observe:

- `KongRoute` being deleted on Konnect
- Plugin being deleted on Konnect
- `KongPluginBinding` doesn't get its status updated until next sync period tick (this is caused by #645)

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
