### PR TITLE
refactor: KongPluginBinding watch functions

### DIFF
--- a/controller/konnect/index_kongpluginbinding.go
+++ b/controller/konnect/index_kongpluginbinding.go
@@ -127,10 +127,9 @@ func kongPluginBindingReferencesKonnectGatewayControlPlane(obj client.Object) []
 	if !ok {
 		return nil
 	}
-	cpRef := binding.Spec.ControlPlaneRef
-	if cpRef == nil ||
-		cpRef.Type != configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef ||
-		cpRef.KonnectNamespacedRef == nil {
+
+	cpRef, ok := controlPlaneRefIsKonnectNamespacedRef(binding)
+	if !ok {
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactor KongPluginBinding watch functions. Reduce code duplication where possible.
