### PR TITLE
tests(envtest): fix Konnect envtests sdk assertions

### DIFF
--- a/test/envtest/kongconsumercredential_acl_test.go
+++ b/test/envtest/kongconsumercredential_acl_test.go
@@ -216,8 +216,7 @@ func TestKongConsumerCredential_ACL(t *testing.T) {
 
 		t.Log("Waiting for KongCredentialACL to be programmed")
 		watchFor(t, ctx, w, watch.Modified, func(k *configurationv1alpha1.KongCredentialACL) bool {
-			return k.GetName() == created.GetName() &&
-				k8sutils.IsProgrammed(k)
+			return k.GetName() == created.GetName() && k8sutils.IsProgrammed(k)
 		}, "KongCredentialACL's Programmed condition should be true eventually")
 
 		t.Log("Checking SDK KongCredentialACL operations")

--- a/test/envtest/kongconsumercredential_apikey_test.go
+++ b/test/envtest/kongconsumercredential_apikey_test.go
@@ -216,8 +216,7 @@ func TestKongConsumerCredential_APIKey(t *testing.T) {
 
 		t.Log("Waiting for KongCredentialAPIKey to be programmed")
 		watchFor(t, ctx, w, watch.Modified, func(k *configurationv1alpha1.KongCredentialAPIKey) bool {
-			return k.GetName() == created.GetName() &&
-				k8sutils.IsProgrammed(k)
+			return k.GetName() == created.GetName() && k8sutils.IsProgrammed(k)
 		}, "KongCredentialAPIKey's Programmed condition should be true eventually")
 
 		t.Log("Checking SDK KongCredentialAPIKey operations")

--- a/test/envtest/kongconsumercredential_basicauth_test.go
+++ b/test/envtest/kongconsumercredential_basicauth_test.go
@@ -218,8 +218,7 @@ func TestKongConsumerCredential_BasicAuth(t *testing.T) {
 
 		t.Log("Waiting for KongCredentialBasicAuth to be programmed")
 		watchFor(t, ctx, w, watch.Modified, func(k *configurationv1alpha1.KongCredentialBasicAuth) bool {
-			return k.GetName() == created.GetName() &&
-				k8sutils.IsProgrammed(k)
+			return k.GetName() == created.GetName() && k8sutils.IsProgrammed(k)
 		}, "KongCredentialBasicAuth's Programmed condition should be true eventually")
 
 		t.Log("Checking SDK KongCredentialBasicAuth operations")

--- a/test/envtest/kongconsumercredential_hmac_test.go
+++ b/test/envtest/kongconsumercredential_hmac_test.go
@@ -214,8 +214,7 @@ func TestKongConsumerCredential_HMAC(t *testing.T) {
 
 		t.Log("Waiting for KongCredentialHMAC to be programmed")
 		watchFor(t, ctx, w, watch.Modified, func(k *configurationv1alpha1.KongCredentialHMAC) bool {
-			return k.GetName() == created.GetName() &&
-				k8sutils.IsProgrammed(k)
+			return k.GetName() == created.GetName() && k8sutils.IsProgrammed(k)
 		}, "KongCredentialHMAC's Programmed condition should be true eventually")
 
 		t.Log("Checking SDK KongCredentialHMAC operations")

--- a/test/envtest/kongconsumercredential_jwt_test.go
+++ b/test/envtest/kongconsumercredential_jwt_test.go
@@ -217,8 +217,7 @@ func TestKongConsumerCredential_JWT(t *testing.T) {
 
 		t.Log("Waiting for KongCredentialJWT to be programmed")
 		watchFor(t, ctx, w, watch.Modified, func(k *configurationv1alpha1.KongCredentialJWT) bool {
-			return k.GetName() == created.GetName() &&
-				k8sutils.IsProgrammed(k)
+			return k.GetName() == created.GetName() && k8sutils.IsProgrammed(k)
 		}, "KongCredentialJWT's Programmed condition should be true eventually")
 
 		t.Log("Checking SDK KongCredentialJWT operations")

--- a/test/envtest/konnect_entities_kongcertificate_test.go
+++ b/test/envtest/konnect_entities_kongcertificate_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
+	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
@@ -176,11 +177,7 @@ func TestKongCertificate(t *testing.T) {
 			if !slices.Equal(c.Spec.Tags, createdCert.Spec.Tags) {
 				return false
 			}
-
-			return c.GetKonnectID() == certID && lo.ContainsBy(c.Status.Conditions, func(condition metav1.Condition) bool {
-				return condition.Type == konnectv1alpha1.KonnectEntityProgrammedConditionType &&
-					condition.Status == metav1.ConditionTrue
-			})
+			return c.GetKonnectID() == certID && k8sutils.IsProgrammed(c)
 		}, "KongCertificate should be programmed and have ID in status after handling conflict")
 
 		t.Log("Ensuring that the SDK's create and list methods are called")

--- a/test/envtest/konnect_entities_kongconsumer_test.go
+++ b/test/envtest/konnect_entities_kongconsumer_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
+	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
 
 	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
@@ -336,17 +337,11 @@ func TestKongConsumer(t *testing.T) {
 		}, nil)
 
 		t.Log("Creating a KongConsumer")
-		createdConsumer := deploy.KongConsumerAttachedToCP(t, ctx, clientNamespaced, username, cp)
+		deploy.KongConsumerAttachedToCP(t, ctx, clientNamespaced, username, cp)
 
 		t.Log("Watching for KongConsumers to verify the created KongConsumer programmed")
 		watchFor(t, ctx, cWatch, watch.Modified, func(c *configurationv1.KongConsumer) bool {
-			if c.GetName() != createdConsumer.GetName() {
-				return false
-			}
-			return c.GetKonnectID() == consumerID && lo.ContainsBy(c.Status.Conditions, func(condition metav1.Condition) bool {
-				return condition.Type == konnectv1alpha1.KonnectEntityProgrammedConditionType &&
-					condition.Status == metav1.ConditionTrue
-			})
+			return c.GetKonnectID() == consumerID && k8sutils.IsProgrammed(c)
 		}, "KongConsumer should be programmed and have ID in status after handling conflict")
 
 		t.Log("Ensuring that the SDK's create and list methods are called")

--- a/test/envtest/konnect_entities_kongsni_test.go
+++ b/test/envtest/konnect_entities_kongsni_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
+	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
@@ -97,10 +98,7 @@ func TestKongSNI(t *testing.T) {
 
 		t.Log("Waiting for SNI to be programmed and get Konnect ID")
 		watchFor(t, ctx, w, watch.Modified, func(s *configurationv1alpha1.KongSNI) bool {
-			return s.GetKonnectID() == "sni-12345" && lo.ContainsBy(s.Status.Conditions,
-				func(c metav1.Condition) bool {
-					return c.Type == "Programmed" && c.Status == metav1.ConditionTrue
-				})
+			return s.GetKonnectID() == "sni-12345" && k8sutils.IsProgrammed(s)
 		}, "SNI didn't get Programmed status condition or didn't get the correct (sni-12345) Konnect ID assigned")
 
 		t.Log("Set up SDK for SNI update")

--- a/test/envtest/konnect_entities_kongupstream_test.go
+++ b/test/envtest/konnect_entities_kongupstream_test.go
@@ -84,15 +84,15 @@ func TestKongUpstream(t *testing.T) {
 			},
 		)
 
-		t.Log("Checking SDK KongUpstream operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.UpstreamsSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
-
 		t.Log("Waiting for Upstream to be programmed and get Konnect ID")
 		watchFor(t, ctx, w, watch.Modified, func(r *configurationv1alpha1.KongUpstream) bool {
 			return r.GetKonnectID() == upstreamID && k8sutils.IsProgrammed(r)
 		}, "KongUpstream didn't get Programmed status condition or didn't get the correct (upstream-12345) Konnect ID assigned")
+
+		t.Log("Checking SDK KongUpstream operations")
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, factory.SDK.UpstreamsSDK.AssertExpectations(t))
+		}, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on Upstream update")
 		sdk.UpstreamsSDK.EXPECT().


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an issue with some envtest based tests for Konnect entities where SDK assertions were done first and checking if the entity was indeed programmed was done after.

This causes the SDK assertions to sometimes fail (as the underlying code may not have managed to fulfil all the asserts yet).

https://github.com/Kong/gateway-operator/actions/runs/11520317393/job/32072355048?pr=806#step:5:345

```
    konnect_entities_kongtarget_test.go:90: FAIL:	CreateTargetWithUpstream(string,mock.argumentMatcher)
        		at: [/home/runner/work/gateway-operator/gateway-operator/controller/konnect/ops/sdk/mocks/zz_generated.kongtarget_mock.go:72 /home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_kongtarget_test.go:69]
    konnect_entities_kongtarget_test.go:90: FAIL: 0 out of 1 expectation(s) were met.
        	The code you are testing needs to make 1 more call(s).
        	at: [/home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_kongtarget_test.go:90 /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.2.linux-amd64/src/runtime/asm_amd64.s:1700]
```