### PR TITLE
fix(dataplane): do not set ExternalTrafficPolicy for ClusterIP services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,9 @@
   [#711](https://github.com/Kong/gateway-operator/pull/711)
 - Fixed setting `ExternalTrafficPolicy` on `DataPlane`'s ingress `Service` during update and patch operations.
   [#750](https://github.com/Kong/gateway-operator/pull/750)
+- Fixed setting `ExternalTrafficPolicy` on `DataPlane`'s ingress `Service`.
+  Remove the default value (`Cluster`). Prevent setting this field for `ClusterIP` `Service`s.
+  [#812](https://github.com/Kong/gateway-operator/pull/812)
 
 ### Changes
 

--- a/api/v1beta1/dataplane_types.go
+++ b/api/v1beta1/dataplane_types.go
@@ -239,6 +239,7 @@ type DataPlaneServicePort struct {
 // ServiceOptions is used to includes options to customize the ingress service,
 // such as the annotations.
 // +apireference:kgo:include
+// +kubebuilder:validation:XValidation:message="Cannot set ExternalTrafficPolicy for ClusterIP service.", rule="has(self.type) && self.type == 'ClusterIP' ? !has(self.externalTrafficPolicy) : true"
 type ServiceOptions struct {
 	// Type determines how the Service is exposed.
 	// Defaults to `LoadBalancer`.
@@ -285,7 +286,6 @@ type ServiceOptions struct {
 	// More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
 	//
 	// +optional
-	// +kubebuilder:default=Cluster
 	// +kubebuilder:validation:Enum=Cluster;Local
 	ExternalTrafficPolicy corev1.ServiceExternalTrafficPolicy `json:"externalTrafficPolicy,omitempty"`
 }

--- a/config/crd/bases/gateway-operator.konghq.com_dataplanes.yaml
+++ b/config/crd/bases/gateway-operator.konghq.com_dataplanes.yaml
@@ -8858,7 +8858,6 @@ spec:
                               More info: http://kubernetes.io/docs/user-guide/annotations
                             type: object
                           externalTrafficPolicy:
-                            default: Cluster
                             description: |-
                               ExternalTrafficPolicy describes how nodes distribute service traffic they
                               receive on one of the Service's "externally-facing" addresses (NodePorts,
@@ -8941,6 +8940,11 @@ spec:
                             - ClusterIP
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: Cannot set ExternalTrafficPolicy for ClusterIP
+                            service.
+                          rule: 'has(self.type) && self.type == ''ClusterIP'' ? !has(self.externalTrafficPolicy)
+                            : true'
                     type: object
                 type: object
               pluginsToInstall:

--- a/config/crd/bases/gateway-operator.konghq.com_gatewayconfigurations.yaml
+++ b/config/crd/bases/gateway-operator.konghq.com_gatewayconfigurations.yaml
@@ -17130,7 +17130,6 @@ spec:
                                   More info: http://kubernetes.io/docs/user-guide/annotations
                                 type: object
                               externalTrafficPolicy:
-                                default: Cluster
                                 description: |-
                                   ExternalTrafficPolicy describes how nodes distribute service traffic they
                                   receive on one of the Service's "externally-facing" addresses (NodePorts,
@@ -17172,6 +17171,11 @@ spec:
                                 - ClusterIP
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: Cannot set ExternalTrafficPolicy for ClusterIP
+                                service.
+                              rule: 'has(self.type) && self.type == ''ClusterIP''
+                                ? !has(self.externalTrafficPolicy) : true'
                         type: object
                     type: object
                   pluginsToInstall:

--- a/config/crd/dataplane/gateway-operator.konghq.com_dataplanes.yaml
+++ b/config/crd/dataplane/gateway-operator.konghq.com_dataplanes.yaml
@@ -8858,7 +8858,6 @@ spec:
                               More info: http://kubernetes.io/docs/user-guide/annotations
                             type: object
                           externalTrafficPolicy:
-                            default: Cluster
                             description: |-
                               ExternalTrafficPolicy describes how nodes distribute service traffic they
                               receive on one of the Service's "externally-facing" addresses (NodePorts,
@@ -8941,6 +8940,11 @@ spec:
                             - ClusterIP
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: Cannot set ExternalTrafficPolicy for ClusterIP
+                            service.
+                          rule: 'has(self.type) && self.type == ''ClusterIP'' ? !has(self.externalTrafficPolicy)
+                            : true'
                     type: object
                 type: object
               pluginsToInstall:

--- a/controller/dataplane/owned_resources.go
+++ b/controller/dataplane/owned_resources.go
@@ -402,7 +402,8 @@ func ensureIngressServiceForDataPlane(
 			existingService.Spec.Type = generatedService.Spec.Type
 			updated = true
 		}
-		if existingService.Spec.ExternalTrafficPolicy != generatedService.Spec.ExternalTrafficPolicy {
+		if generatedService.Spec.ExternalTrafficPolicy != "" &&
+			existingService.Spec.ExternalTrafficPolicy != generatedService.Spec.ExternalTrafficPolicy {
 			existingService.Spec.ExternalTrafficPolicy = generatedService.Spec.ExternalTrafficPolicy
 			updated = true
 		}

--- a/pkg/utils/kubernetes/resources/services.go
+++ b/pkg/utils/kubernetes/resources/services.go
@@ -61,10 +61,11 @@ func GenerateNewIngressServiceForDataPlane(dataplane *operatorv1beta1.DataPlane,
 			Selector: map[string]string{
 				"app": dataplane.Name,
 			},
-			Ports:                 DefaultDataPlaneIngressServicePorts,
-			ExternalTrafficPolicy: getDataPlaneIngressServiceExternalTrafficPolicy(dataplane),
+			Ports: DefaultDataPlaneIngressServicePorts,
 		},
 	}
+
+	setDataPlaneIngressServiceExternalTrafficPolicy(dataplane, svc)
 	LabelObjectAsDataPlaneManaged(svc)
 
 	for _, opt := range opts {
@@ -112,12 +113,18 @@ func getDataPlaneIngressServiceType(dataplane *operatorv1beta1.DataPlane) corev1
 	return dataplane.Spec.Network.Services.Ingress.Type
 }
 
-func getDataPlaneIngressServiceExternalTrafficPolicy(dataplane *operatorv1beta1.DataPlane) corev1.ServiceExternalTrafficPolicy {
-	if dataplane == nil || dataplane.Spec.Network.Services == nil {
-		return corev1.ServiceExternalTrafficPolicyCluster
+func setDataPlaneIngressServiceExternalTrafficPolicy(
+	dataplane *operatorv1beta1.DataPlane,
+	svc *corev1.Service,
+) {
+	if dataplane == nil ||
+		dataplane.Spec.Network.Services == nil ||
+		dataplane.Spec.Network.Services.Ingress == nil ||
+		dataplane.Spec.Network.Services.Ingress.ExternalTrafficPolicy == "" {
+		return
 	}
 
-	return dataplane.Spec.Network.Services.Ingress.ExternalTrafficPolicy
+	svc.Spec.ExternalTrafficPolicy = dataplane.Spec.Network.Services.Ingress.ExternalTrafficPolicy
 }
 
 // ServiceOpt is an option function for a Service.


### PR DESCRIPTION
**What this PR does / why we need it**:

Disallow setting `ExternalTrafficPolicy` for `DataPlane`'s ingress service when `type=ClusterIP`.

Additionally, do not set the default value (`Cluster`). Only use what's provided in user provided manifests.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
