### PR TITLE
refactor(konnect): add enqueueObjectForKonnectGatewayControlPlane to generically list objects that refer to KonnectGatewayControlPlane

### DIFF
--- a/controller/konnect/watch_kongcacertificate.go
+++ b/controller/konnect/watch_kongcacertificate.go
@@ -41,7 +41,9 @@ func KongCACertificateReconciliationWatchOptions(cl client.Client) []func(*ctrl.
 			return b.Watches(
 				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueKongCACertificateForKonnectControlPlane(cl),
+					enqueueObjectForKonnectGatewayControlPlane[*configurationv1alpha1.KongCACertificateList](
+						cl, IndexFieldKongCACertificateOnKonnectGatewayControlPlane,
+					),
 				),
 			)
 		},
@@ -118,28 +120,5 @@ func enqueueKongCACertificateForKonnectAPIAuthConfiguration(cl client.Client) ha
 			}
 		}
 		return ret
-	}
-}
-
-func enqueueKongCACertificateForKonnectControlPlane(
-	cl client.Client,
-) func(ctx context.Context, obj client.Object) []reconcile.Request {
-	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		cp, ok := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
-		if !ok {
-			return nil
-		}
-		var l configurationv1alpha1.KongCACertificateList
-		if err := cl.List(ctx, &l,
-			// TODO: change this when cross namespace refs are allowed.
-			client.InNamespace(cp.GetNamespace()),
-			client.MatchingFields{
-				IndexFieldKongCACertificateOnKonnectGatewayControlPlane: cp.Namespace + "/" + cp.Name,
-			},
-		); err != nil {
-			return nil
-		}
-
-		return objectListToReconcileRequests(l.Items)
 	}
 }

--- a/controller/konnect/watch_kongconsumer.go
+++ b/controller/konnect/watch_kongconsumer.go
@@ -54,7 +54,9 @@ func KongConsumerReconciliationWatchOptions(
 			return b.Watches(
 				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueKongConsumerForKonnectGatewayControlPlane(cl),
+					enqueueObjectForKonnectGatewayControlPlane[*configurationv1.KongConsumerList](
+						cl, IndexFieldKongConsumerOnKonnectGatewayControlPlane,
+					),
 				),
 			)
 		},
@@ -141,29 +143,6 @@ func enqueueKongConsumerForKonnectAPIAuthConfiguration(
 			}
 		}
 		return ret
-	}
-}
-
-func enqueueKongConsumerForKonnectGatewayControlPlane(
-	cl client.Client,
-) func(ctx context.Context, obj client.Object) []reconcile.Request {
-	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		cp, ok := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
-		if !ok {
-			return nil
-		}
-		var l configurationv1.KongConsumerList
-		if err := cl.List(ctx, &l,
-			// TODO: change this when cross namespace refs are allowed.
-			client.InNamespace(cp.GetNamespace()),
-			client.MatchingFields{
-				IndexFieldKongConsumerOnKonnectGatewayControlPlane: cp.Namespace + "/" + cp.Name,
-			},
-		); err != nil {
-			return nil
-		}
-
-		return objectListToReconcileRequests(l.Items)
 	}
 }
 

--- a/controller/konnect/watch_kongconsumergroup.go
+++ b/controller/konnect/watch_kongconsumergroup.go
@@ -53,7 +53,9 @@ func KongConsumerGroupReconciliationWatchOptions(
 			return b.Watches(
 				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueKongConsumerGroupForKonnectGatewayControlPlane(cl),
+					enqueueObjectForKonnectGatewayControlPlane[*configurationv1beta1.KongConsumerGroupList](
+						cl, IndexFieldKongConsumerGroupOnKonnectGatewayControlPlane,
+					),
 				),
 			)
 		},
@@ -132,28 +134,5 @@ func enqueueKongConsumerGroupForKonnectAPIAuthConfiguration(
 			}
 		}
 		return ret
-	}
-}
-
-func enqueueKongConsumerGroupForKonnectGatewayControlPlane(
-	cl client.Client,
-) func(ctx context.Context, obj client.Object) []reconcile.Request {
-	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		cp, ok := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
-		if !ok {
-			return nil
-		}
-		var l configurationv1beta1.KongConsumerGroupList
-		if err := cl.List(ctx, &l,
-			// TODO: change this when cross namespace refs are allowed.
-			client.InNamespace(cp.GetNamespace()),
-			client.MatchingFields{
-				IndexFieldKongConsumerGroupOnKonnectGatewayControlPlane: cp.Namespace + "/" + cp.Name,
-			},
-		); err != nil {
-			return nil
-		}
-
-		return objectListToReconcileRequests(l.Items)
 	}
 }

--- a/controller/konnect/watch_kongdataplanecertificate.go
+++ b/controller/konnect/watch_kongdataplanecertificate.go
@@ -41,31 +41,12 @@ func KongDataPlaneClientCertificateReconciliationWatchOptions(cl client.Client) 
 			return b.Watches(
 				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueKongDataPlaneClientCertificateForKonnectControlPlane(cl),
+					enqueueObjectForKonnectGatewayControlPlane[*configurationv1alpha1.KongDataPlaneClientCertificateList](
+						cl, IndexFieldKongDataPlaneClientCertificateOnKonnectGatewayControlPlane,
+					),
 				),
 			)
 		},
-	}
-}
-
-func enqueueKongDataPlaneClientCertificateForKonnectControlPlane(cl client.Client) handler.MapFunc {
-	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		auth, ok := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
-		if !ok {
-			return nil
-		}
-		var l configurationv1alpha1.KongDataPlaneClientCertificateList
-		if err := cl.List(ctx, &l,
-			// TODO: change this when cross namespace refs are allowed.
-			client.InNamespace(auth.GetNamespace()),
-			client.MatchingFields{
-				IndexFieldKongDataPlaneClientCertificateOnKonnectGatewayControlPlane: client.ObjectKeyFromObject(auth).String(),
-			},
-		); err != nil {
-			return nil
-		}
-
-		return objectListToReconcileRequests(l.Items)
 	}
 }
 

--- a/controller/konnect/watch_kongpluginbinding.go
+++ b/controller/konnect/watch_kongpluginbinding.go
@@ -60,7 +60,9 @@ func KongPluginBindingReconciliationWatchOptions(
 			return b.Watches(
 				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueKongPluginBindingForKonnectGatewayControlPlane(cl),
+					enqueueObjectForKonnectGatewayControlPlane[*configurationv1alpha1.KongPluginBindingList](
+						cl, IndexFieldKongPluginBindingKonnectGatewayControlPlane,
+					),
 				),
 			)
 		},
@@ -183,29 +185,6 @@ func enqueueKongPluginBindingForKonnectAPIAuthConfiguration(
 			}
 		}
 		return ret
-	}
-}
-
-func enqueueKongPluginBindingForKonnectGatewayControlPlane(
-	cl client.Client,
-) func(ctx context.Context, obj client.Object) []reconcile.Request {
-	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		cp, ok := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
-		if !ok {
-			return nil
-		}
-		var l configurationv1alpha1.KongPluginBindingList
-		if err := cl.List(ctx, &l,
-			// TODO: change this when cross namespace refs are allowed.
-			client.InNamespace(cp.GetNamespace()),
-			client.MatchingFields{
-				IndexFieldKongPluginBindingKonnectGatewayControlPlane: cp.Namespace + "/" + cp.Name,
-			},
-		); err != nil {
-			return nil
-		}
-
-		return objectListToReconcileRequests(l.Items)
 	}
 }
 

--- a/controller/konnect/watch_kongupstream.go
+++ b/controller/konnect/watch_kongupstream.go
@@ -52,7 +52,9 @@ func KongUpstreamReconciliationWatchOptions(
 			return b.Watches(
 				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueKongUpstreamForKonnectGatewayControlPlane(cl),
+					enqueueObjectForKonnectGatewayControlPlane[*configurationv1alpha1.KongUpstreamList](
+						cl, IndexFieldKongUpstreamOnKonnectGatewayControlPlane,
+					),
 				),
 			)
 		},
@@ -131,28 +133,5 @@ func enqueueKongUpstreamForKonnectAPIAuthConfiguration(
 			}
 		}
 		return ret
-	}
-}
-
-func enqueueKongUpstreamForKonnectGatewayControlPlane(
-	cl client.Client,
-) func(ctx context.Context, obj client.Object) []reconcile.Request {
-	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		cp, ok := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
-		if !ok {
-			return nil
-		}
-		var l configurationv1alpha1.KongUpstreamList
-		if err := cl.List(ctx, &l,
-			// TODO: change this when cross namespace refs are allowed.
-			client.InNamespace(cp.GetNamespace()),
-			client.MatchingFields{
-				IndexFieldKongUpstreamOnKonnectGatewayControlPlane: cp.Namespace + "/" + cp.Name,
-			},
-		); err != nil {
-			return nil
-		}
-
-		return objectListToReconcileRequests(l.Items)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Generically list objects that refer to `KonnectGatewayControlPlane`.