### PR TITLE
konnect: allow customizing max concurrent reconciles

### DIFF
--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -40,10 +40,11 @@ const (
 // KonnectEntityReconciler reconciles a Konnect entities.
 // It uses the generic type constraints to constrain the supported types.
 type KonnectEntityReconciler[T constraints.SupportedKonnectEntityType, TEnt constraints.EntityType[T]] struct {
-	sdkFactory      sdkops.SDKFactory
-	DevelopmentMode bool
-	Client          client.Client
-	SyncPeriod      time.Duration
+	sdkFactory              sdkops.SDKFactory
+	DevelopmentMode         bool
+	Client                  client.Client
+	SyncPeriod              time.Duration
+	MaxConcurrentReconciles uint
 }
 
 // KonnectEntityReconcilerOption is a functional option for the KonnectEntityReconciler.
@@ -61,6 +62,15 @@ func WithKonnectEntitySyncPeriod[T constraints.SupportedKonnectEntityType, TEnt 
 	}
 }
 
+// WithKonnectMaxConcurrentReconciles sets the max concurrent reconciles for the reconciler.
+func WithKonnectMaxConcurrentReconciles[T constraints.SupportedKonnectEntityType, TEnt constraints.EntityType[T]](
+	maxConcurrent uint,
+) KonnectEntityReconcilerOption[T, TEnt] {
+	return func(r *KonnectEntityReconciler[T, TEnt]) {
+		r.MaxConcurrentReconciles = maxConcurrent
+	}
+}
+
 // NewKonnectEntityReconciler returns a new KonnectEntityReconciler for the given
 // Konnect entity type.
 func NewKonnectEntityReconciler[
@@ -73,10 +83,11 @@ func NewKonnectEntityReconciler[
 	opts ...KonnectEntityReconcilerOption[T, TEnt],
 ) *KonnectEntityReconciler[T, TEnt] {
 	r := &KonnectEntityReconciler[T, TEnt]{
-		sdkFactory:      sdkFactory,
-		DevelopmentMode: developmentMode,
-		Client:          client,
-		SyncPeriod:      consts.DefaultKonnectSyncPeriod,
+		sdkFactory:              sdkFactory,
+		DevelopmentMode:         developmentMode,
+		Client:                  client,
+		SyncPeriod:              consts.DefaultKonnectSyncPeriod,
+		MaxConcurrentReconciles: consts.DefaultKonnectMaxConcurrentReconciles,
 	}
 	for _, opt := range opts {
 		opt(r)

--- a/modules/cli/cli.go
+++ b/modules/cli/cli.go
@@ -45,10 +45,11 @@ func New(m metadata.Info) *CLI {
 	// controllers for specialized APIs and features
 	flagSet.BoolVar(&cfg.AIGatewayControllerEnabled, "enable-controller-aigateway", false, "Enable the AIGateway controller. (Experimental).")
 	flagSet.BoolVar(&cfg.KongPluginInstallationControllerEnabled, "enable-controller-kongplugininstallation", false, "Enable the KongPluginInstallation controller.")
-	flagSet.DurationVar(&cfg.KonnectSyncPeriod, "konnect-sync-period", consts.DefaultKonnectSyncPeriod, "Sync period for Konnect entities. After a successful reconciliation of Konnect entities the controller will wait this duration before enforcing configuration on Konnect once again.")
 
 	// controllers for Konnect APIs
 	flagSet.BoolVar(&cfg.KonnectControllersEnabled, "enable-controller-konnect", false, "Enable the Konnect controllers.")
+	flagSet.DurationVar(&cfg.KonnectSyncPeriod, "konnect-sync-period", consts.DefaultKonnectSyncPeriod, "Sync period for Konnect entities. After a successful reconciliation of Konnect entities the controller will wait this duration before enforcing configuration on Konnect once again.")
+	flagSet.UintVar(&cfg.KonnectMaxConcurrentReconciles, "konnect-controller-max-concurrent-reconciles", consts.DefaultKonnectMaxConcurrentReconciles, "Maximum number of concurrent reconciles for Konnect entities.")
 
 	// webhook and validation options
 	flagSet.BoolVar(&deferCfg.ValidatingWebhookEnabled, "enable-validating-webhook", true, "Enable the validating webhook.")

--- a/modules/cli/cli_test.go
+++ b/modules/cli/cli_test.go
@@ -169,5 +169,6 @@ func expectedDefaultCfg() manager.Config {
 		WebhookCertificateConfigBaseImage:       consts.WebhookCertificateConfigBaseImage,
 		WebhookCertificateConfigShellImage:      consts.WebhookCertificateConfigShellImage,
 		LoggerOpts:                              &zap.Options{},
+		KonnectMaxConcurrentReconciles:          consts.DefaultKonnectMaxConcurrentReconciles,
 	}
 }

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
@@ -507,6 +508,14 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 		}
 
 		sdkFactory := sdkops.NewSDKFactory()
+		controllerFactory := konnectControllerFactory{
+			sdkFactory:              sdkFactory,
+			devMode:                 c.DevelopmentMode,
+			client:                  mgr.GetClient(),
+			syncPeriod:              c.KonnectSyncPeriod,
+			maxConcurrentReconciles: c.KonnectMaxConcurrentReconciles,
+		}
+
 		konnectControllers := map[string]ControllerDef{
 			KonnectAPIAuthConfigurationControllerName: {
 				Enabled: c.KonnectControllersEnabled,
@@ -516,168 +525,7 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 					mgr.GetClient(),
 				),
 			},
-			KonnectGatewayControlPlaneControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[konnectv1alpha1.KonnectGatewayControlPlane](c.KonnectSyncPeriod),
-				),
-			},
-			KongServiceControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongService](c.KonnectSyncPeriod),
-				),
-			},
-			KongRouteControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongRoute](c.KonnectSyncPeriod),
-				),
-			},
-			KongConsumerControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[configurationv1.KongConsumer](c.KonnectSyncPeriod),
-				),
-			},
-			KongConsumerGroupControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[configurationv1beta1.KongConsumerGroup](c.KonnectSyncPeriod),
-				),
-			},
-			KongUpstreamControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongUpstream](c.KonnectSyncPeriod),
-				),
-			},
-			KongCACertificateControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCACertificate](c.KonnectSyncPeriod),
-				),
-			},
-			KongCertificateControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCertificate](c.KonnectSyncPeriod),
-				),
-			},
-			KongTargetControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongTarget](c.KonnectSyncPeriod),
-				),
-			},
-			KongPluginBindingControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongPluginBinding](c.KonnectSyncPeriod),
-				),
-			},
-			KongCredentialBasicAuthControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialBasicAuth](c.KonnectSyncPeriod),
-				),
-			},
-			KongCredentialAPIKeyControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialAPIKey](c.KonnectSyncPeriod),
-				),
-			},
-			KongCredentialACLControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialACL](c.KonnectSyncPeriod),
-				),
-			},
-			KongCredentialHMACControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialHMAC](c.KonnectSyncPeriod),
-				),
-			},
-			KongCredentialJWTControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialJWT](c.KonnectSyncPeriod),
-				),
-			},
-			KongKeyControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongKey](c.KonnectSyncPeriod),
-				),
-			},
-			KongKeySetControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongKeySet](c.KonnectSyncPeriod),
-				),
-			},
-			KongDataPlaneClientCertificateControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongDataPlaneClientCertificate](c.KonnectSyncPeriod),
-				),
-			},
+
 			KongPluginControllerName: {
 				Enabled: c.KonnectControllersEnabled,
 				Controller: konnect.NewKongPluginReconciler(
@@ -685,54 +533,35 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 					mgr.GetClient(),
 				),
 			},
-			KongVaultControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongVault](c.KonnectSyncPeriod),
-				),
-			},
-			KongSNIControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityReconciler(
-					sdkFactory,
-					c.DevelopmentMode,
-					mgr.GetClient(),
-					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongSNI](c.KonnectSyncPeriod),
-				),
-			},
 
 			// Controllers responsible for cleaning up KongPluginBinding cleanup finalizers.
-			KongServicePluginBindingFinalizerControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityPluginReconciler[configurationv1alpha1.KongService](
-					c.DevelopmentMode,
-					mgr.GetClient(),
-				),
-			},
-			KongRoutePluginBindingFinalizerControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityPluginReconciler[configurationv1alpha1.KongRoute](
-					c.DevelopmentMode,
-					mgr.GetClient(),
-				),
-			},
-			KongConsumerPluginBindingFinalizerControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityPluginReconciler[configurationv1.KongConsumer](
-					c.DevelopmentMode,
-					mgr.GetClient(),
-				),
-			},
-			KongConsumerGroupPluginBindingFinalizerControllerName: {
-				Enabled: c.KonnectControllersEnabled,
-				Controller: konnect.NewKonnectEntityPluginReconciler[configurationv1beta1.KongConsumerGroup](
-					c.DevelopmentMode,
-					mgr.GetClient(),
-				),
-			},
+			KongServicePluginBindingFinalizerControllerName:       newKonnectPluginController[configurationv1alpha1.KongService](controllerFactory),
+			KongRoutePluginBindingFinalizerControllerName:         newKonnectPluginController[configurationv1alpha1.KongRoute](controllerFactory),
+			KongConsumerPluginBindingFinalizerControllerName:      newKonnectPluginController[configurationv1.KongConsumer](controllerFactory),
+			KongConsumerGroupPluginBindingFinalizerControllerName: newKonnectPluginController[configurationv1beta1.KongConsumerGroup](controllerFactory),
+
+			// Controllers responsible for creating, updating and deleting Konnect entities.
+			KonnectGatewayControlPlaneControllerName:     newKonnectController[konnectv1alpha1.KonnectGatewayControlPlane](controllerFactory),
+			KongServiceControllerName:                    newKonnectController[configurationv1alpha1.KongService](controllerFactory),
+			KongRouteControllerName:                      newKonnectController[configurationv1alpha1.KongRoute](controllerFactory),
+			KongConsumerControllerName:                   newKonnectController[configurationv1.KongConsumer](controllerFactory),
+			KongConsumerGroupControllerName:              newKonnectController[configurationv1beta1.KongConsumerGroup](controllerFactory),
+			KongUpstreamControllerName:                   newKonnectController[configurationv1alpha1.KongUpstream](controllerFactory),
+			KongCACertificateControllerName:              newKonnectController[configurationv1alpha1.KongCACertificate](controllerFactory),
+			KongCertificateControllerName:                newKonnectController[configurationv1alpha1.KongCertificate](controllerFactory),
+			KongTargetControllerName:                     newKonnectController[configurationv1alpha1.KongTarget](controllerFactory),
+			KongPluginBindingControllerName:              newKonnectController[configurationv1alpha1.KongPluginBinding](controllerFactory),
+			KongCredentialBasicAuthControllerName:        newKonnectController[configurationv1alpha1.KongCredentialBasicAuth](controllerFactory),
+			KongCredentialAPIKeyControllerName:           newKonnectController[configurationv1alpha1.KongCredentialAPIKey](controllerFactory),
+			KongCredentialACLControllerName:              newKonnectController[configurationv1alpha1.KongCredentialACL](controllerFactory),
+			KongCredentialHMACControllerName:             newKonnectController[configurationv1alpha1.KongCredentialHMAC](controllerFactory),
+			KongCredentialJWTControllerName:              newKonnectController[configurationv1alpha1.KongCredentialJWT](controllerFactory),
+			KongKeyControllerName:                        newKonnectController[configurationv1alpha1.KongKey](controllerFactory),
+			KongKeySetControllerName:                     newKonnectController[configurationv1alpha1.KongKeySet](controllerFactory),
+			KongDataPlaneClientCertificateControllerName: newKonnectController[configurationv1alpha1.KongDataPlaneClientCertificate](controllerFactory),
+			KongVaultControllerName:                      newKonnectController[configurationv1alpha1.KongVault](controllerFactory),
+			KongSNIControllerName:                        newKonnectController[configurationv1alpha1.KongSNI](controllerFactory),
+			// NOTE: Reconcilers for new supported entities should be added here.
 		}
 
 		// Merge Konnect controllers into the controllers map. This is done this way instead of directly assigning
@@ -858,4 +687,41 @@ func SetupCacheIndicesForKonnectTypes(ctx context.Context, mgr manager.Manager, 
 	}
 
 	return nil
+}
+
+type konnectControllerFactory struct {
+	sdkFactory              sdkops.SDKFactory
+	devMode                 bool
+	client                  client.Client
+	syncPeriod              time.Duration
+	maxConcurrentReconciles uint
+}
+
+func newKonnectController[
+	T constraints.SupportedKonnectEntityType,
+	TEnt constraints.EntityType[T],
+](f konnectControllerFactory) ControllerDef {
+	return ControllerDef{
+		Enabled: true,
+		Controller: konnect.NewKonnectEntityReconciler(
+			f.sdkFactory,
+			f.devMode,
+			f.client,
+			konnect.WithKonnectEntitySyncPeriod[T, TEnt](f.syncPeriod),
+			konnect.WithKonnectMaxConcurrentReconciles[T, TEnt](f.maxConcurrentReconciles),
+		),
+	}
+}
+
+func newKonnectPluginController[
+	T constraints.SupportedKonnectEntityPluginReferenceableType,
+	TEnt constraints.EntityType[T],
+](f konnectControllerFactory) ControllerDef {
+	return ControllerDef{
+		Enabled: true,
+		Controller: konnect.NewKonnectEntityPluginReconciler[T, TEnt](
+			f.devMode,
+			f.client,
+		),
+	}
 }

--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -87,6 +87,7 @@ type Config struct {
 	AIGatewayControllerEnabled              bool
 	KongPluginInstallationControllerEnabled bool
 	KonnectSyncPeriod                       time.Duration
+	KonnectMaxConcurrentReconciles          uint
 
 	// Controllers for Konnect APIs.
 	KonnectControllersEnabled bool

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -169,4 +169,7 @@ const (
 const (
 	// DefaultKonnectSyncPeriod is the default sync period for Konnect entities.
 	DefaultKonnectSyncPeriod = time.Minute
+
+	// DefaultKonnectMaxConcurrentReconciles is the default max concurrent reconciles for Konnect entities.
+	DefaultKonnectMaxConcurrentReconciles = uint(8)
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow specifying `MaxConcurrentReconciles` in Konnect generic reconciler.

Retain the default of 8.