### PR TITLE
Fix: Add MembersReferenceResolved condition for cp groups

### DIFF
--- a/controller/konnect/ops/conditions.go
+++ b/controller/konnect/ops/conditions.go
@@ -111,7 +111,7 @@ func _setControlPlaneGroupMembersReferenceResolvedCondition(
 	reason consts.ConditionReason,
 	msg string,
 ) {
-	if cpGroup.Spec.ClusterType == nil || *cpGroup.Spec.ClusterType != sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane {
+	if cpGroup.Spec.ClusterType == nil || *cpGroup.Spec.ClusterType != sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup {
 		return
 	}
 	k8sutils.SetCondition(

--- a/controller/konnect/ops/conditions.go
+++ b/controller/konnect/ops/conditions.go
@@ -66,9 +66,17 @@ const (
 	// ControlPlaneGroupMembersReferenceResolvedConditionType sets the condition for control plane groups
 	// to show whether all of its members are programmed and attached to the group.
 	ControlPlaneGroupMembersReferenceResolvedConditionType = "MembersReferenceResolved"
-	// ControlPlaneGroupMembersReferenceResolvedReasonResolved indicates that all members of the control plane groups
+	// ControlPlaneGroupMembersReferenceResolvedReasonNoMembers indicates that there are no members specified in the control plane group.
+	ControlPlaneGroupMembersReferenceResolvedReasonNoMembers consts.ConditionReason = "NoMembers"
+	// ControlPlaneGroupMembersReferenceResolvedReasonResolved indicates that all members of the control plane group
 	// are created and attached to the group in Konnect.
 	ControlPlaneGroupMembersReferenceResolvedReasonResolved consts.ConditionReason = "Resolved"
+	// ControlPlaneGroupMembersReferenceResolvedReasonPartialNotResolved indicates that some members of the control plane group
+	// are not resolved (not found or not created in Konnect).
+	ControlPlaneGroupMembersReferenceResolvedReasonPartialNotResolved consts.ConditionReason = "SomeMemberNotResolved"
+	// ControlPlaneGroupMembersReferenceResolvedReasonFailedToSet indicates that error happened on setting control plane as
+	// member of the control plane.
+	ControlPlaneGroupMembersReferenceResolvedReasonFailedToSet consts.ConditionReason = "SetGroupMemberFailed"
 )
 
 // SetControlPlaneGroupMembersReferenceResolvedCondition sets MembersReferenceResolved condition of control plane to True.

--- a/controller/konnect/ops/conditions.go
+++ b/controller/konnect/ops/conditions.go
@@ -111,7 +111,7 @@ func _setControlPlaneGroupMembersReferenceResolvedCondition(
 	reason consts.ConditionReason,
 	msg string,
 ) {
-	if cpGroup.Spec.ClusterType == nil || *cpGroup.Spec.ClusterType != sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup {
+	if cpGroup.Spec.ClusterType == nil || *cpGroup.Spec.ClusterType != sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane {
 		return
 	}
 	k8sutils.SetCondition(

--- a/controller/konnect/ops/conditions.go
+++ b/controller/konnect/ops/conditions.go
@@ -1,6 +1,7 @@
 package ops
 
 import (
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/gateway-operator/pkg/consts"
@@ -58,5 +59,61 @@ func _setKonnectEntityProgrammedConditon(
 			obj.GetGeneration(),
 		),
 		obj,
+	)
+}
+
+const (
+	// ControlPlaneGroupMembersReferenceResolvedConditionType sets the condition for control plane groups
+	// to show whether all of its members are programmed and attached to the group.
+	ControlPlaneGroupMembersReferenceResolvedConditionType = "MembersReferenceResolved"
+	// ControlPlaneGroupMembersReferenceResolvedReasonResolved indicates that all members of the control plane groups
+	// are created and attached to the group in Konnect.
+	ControlPlaneGroupMembersReferenceResolvedReasonResolved consts.ConditionReason = "Resolved"
+)
+
+// SetControlPlaneGroupMembersReferenceResolvedCondition sets MembersReferenceResolved condition of control plane to True.
+func SetControlPlaneGroupMembersReferenceResolvedCondition(
+	cpGroup *konnectv1alpha1.KonnectGatewayControlPlane,
+) {
+	_setControlPlaneGroupMembersReferenceResolvedCondition(
+		cpGroup,
+		metav1.ConditionTrue,
+		ControlPlaneGroupMembersReferenceResolvedReasonResolved,
+		"",
+	)
+}
+
+// SetControlPlaneGroupMembersReferenceResolvedConditionFalse sets MembersReferenceResolved condition of control plane to False.
+func SetControlPlaneGroupMembersReferenceResolvedConditionFalse(
+	cpGroup *konnectv1alpha1.KonnectGatewayControlPlane,
+	reason consts.ConditionReason,
+	msg string,
+) {
+	_setControlPlaneGroupMembersReferenceResolvedCondition(
+		cpGroup,
+		metav1.ConditionFalse,
+		reason,
+		msg,
+	)
+}
+
+func _setControlPlaneGroupMembersReferenceResolvedCondition(
+	cpGroup *konnectv1alpha1.KonnectGatewayControlPlane,
+	status metav1.ConditionStatus,
+	reason consts.ConditionReason,
+	msg string,
+) {
+	if cpGroup.Spec.ClusterType == nil || *cpGroup.Spec.ClusterType != sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup {
+		return
+	}
+	k8sutils.SetCondition(
+		k8sutils.NewConditionWithGeneration(
+			ControlPlaneGroupMembersReferenceResolvedConditionType,
+			status,
+			reason,
+			msg,
+			cpGroup.GetGeneration(),
+		),
+		cpGroup,
 	)
 }

--- a/controller/konnect/ops/errors.go
+++ b/controller/konnect/ops/errors.go
@@ -39,3 +39,32 @@ type KonnectEntityCreatedButRelationsFailedError struct {
 func (e KonnectEntityCreatedButRelationsFailedError) Error() string {
 	return fmt.Sprintf("Konnect entity (ID: %s) created but relations failed: %s: %v", e.KonnectID, e.Reason, e.Err)
 }
+
+// GetControlPlaneGroupMemberFailedError is an error type returned when
+// failed to get member of control plane group.
+type GetControlPlaneGroupMemberFailedError struct {
+	MemberName string
+	Err        error
+}
+
+// Error implements the error interface.
+func (e GetControlPlaneGroupMemberFailedError) Error() string {
+	return fmt.Sprintf("failed to get control plane group member %s: %v", e.MemberName, e.Err.Error())
+}
+
+// Unwrap returns the underlying error.
+func (e GetControlPlaneGroupMemberFailedError) Unwrap() error {
+	return e.Err
+}
+
+// ControlPlaneGroupMemberNoKonnectIDError is an error type returned when
+// member of control plane group does not have a Konnect ID.
+type ControlPlaneGroupMemberNoKonnectIDError struct {
+	GroupName  string
+	MemberName string
+}
+
+// Error implements the error interface.
+func (e ControlPlaneGroupMemberNoKonnectIDError) Error() string {
+	return fmt.Sprintf("control plane group %s member %s has no Konnect ID", e.GroupName, e.MemberName)
+}

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -109,7 +109,7 @@ func Create[
 		var id string
 		switch ent := any(e).(type) {
 		case *konnectv1alpha1.KonnectGatewayControlPlane:
-			id, err = getControlPlaneForUID(ctx, sdk.GetControlPlaneSDK(), ent)
+			id, err = getControlPlaneForUID(ctx, sdk.GetControlPlaneSDK(), sdk.GetControlPlaneGroupSDK(), cl, ent)
 		case *configurationv1alpha1.KongService:
 			id, err = getKongServiceForUID(ctx, sdk.GetServicesSDK(), ent)
 		case *configurationv1alpha1.KongRoute:

--- a/controller/konnect/ops/ops_controlplane.go
+++ b/controller/konnect/ops/ops_controlplane.go
@@ -135,6 +135,16 @@ func setGroupMembers(
 		return nil
 	}
 
+	// Set MembersReferenceResolved condition to False if there are no members in the CP group.
+	if len(cp.Spec.Members) == 0 {
+		SetControlPlaneGroupMembersReferenceResolvedConditionFalse(
+			cp,
+			ControlPlaneGroupMembersReferenceResolvedReasonNoMembers,
+			"No members in the control plane group",
+		)
+		return nil
+	}
+
 	members, err := iter.MapErr(cp.Spec.Members,
 		func(member *corev1.LocalObjectReference) (sdkkonnectcomp.Members, error) {
 			var (
@@ -165,7 +175,7 @@ func setGroupMembers(
 	if err != nil {
 		SetControlPlaneGroupMembersReferenceResolvedConditionFalse(
 			cp,
-			"SomeMemberNotResolved",
+			ControlPlaneGroupMembersReferenceResolvedReasonPartialNotResolved,
 			err.Error(),
 		)
 		return fmt.Errorf("failed to set group members, some members couldn't be found: %w", err)
@@ -179,7 +189,7 @@ func setGroupMembers(
 	if err != nil {
 		SetControlPlaneGroupMembersReferenceResolvedConditionFalse(
 			cp,
-			"SetGroupMemberFailed",
+			ControlPlaneGroupMembersReferenceResolvedReasonFailedToSet,
 			err.Error(),
 		)
 		return fmt.Errorf("failed to set members on control plane group %s: %w",
@@ -187,7 +197,9 @@ func setGroupMembers(
 		)
 	}
 
-	SetControlPlaneGroupMembersReferenceResolvedCondition(cp)
+	SetControlPlaneGroupMembersReferenceResolvedCondition(
+		cp,
+	)
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a `MembersReferenceResolved` condition in status of control plane groups.
**Which issue this PR fixes**

Fixes #797 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
