### PR TITLE
fix: fix `enqueueObjectForKonnectGatewayControlPlane` type parameters

### DIFF
--- a/controller/konnect/watch.go
+++ b/controller/konnect/watch.go
@@ -125,6 +125,10 @@ func objectListToReconcileRequests[
 	items []T,
 	filters ...func(TPtr) bool,
 ) []ctrl.Request {
+	if len(items) == 0 {
+		return nil
+	}
+
 	ret := make([]ctrl.Request, 0, len(items))
 	for _, item := range items {
 		var e TPtr = &item
@@ -151,6 +155,10 @@ func objectListToReconcileRequests[
 // as the object.
 func enqueueObjectForKonnectGatewayControlPlane[
 	TList interface {
+		GetItems() []T
+	},
+	TListPtr interface {
+		*TList
 		client.ObjectList
 		GetItems() []T
 	},
@@ -165,8 +173,11 @@ func enqueueObjectForKonnectGatewayControlPlane[
 		if !ok {
 			return nil
 		}
-		var l TList
-		if err := cl.List(ctx, l,
+		var (
+			l    TList
+			lPtr TListPtr = &l
+		)
+		if err := cl.List(ctx, lPtr,
 			// TODO: change this when cross namespace refs are allowed.
 			client.InNamespace(cp.GetNamespace()),
 			client.MatchingFields{

--- a/controller/konnect/watch_kongcacertificate.go
+++ b/controller/konnect/watch_kongcacertificate.go
@@ -41,7 +41,7 @@ func KongCACertificateReconciliationWatchOptions(cl client.Client) []func(*ctrl.
 			return b.Watches(
 				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueObjectForKonnectGatewayControlPlane[*configurationv1alpha1.KongCACertificateList](
+					enqueueObjectForKonnectGatewayControlPlane[configurationv1alpha1.KongCACertificateList](
 						cl, IndexFieldKongCACertificateOnKonnectGatewayControlPlane,
 					),
 				),

--- a/controller/konnect/watch_kongcertificate.go
+++ b/controller/konnect/watch_kongcertificate.go
@@ -41,7 +41,7 @@ func KongCertificateReconciliationWatchOptions(cl client.Client) []func(*ctrl.Bu
 			return b.Watches(
 				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueObjectForKonnectGatewayControlPlane[*configurationv1alpha1.KongCertificateList](
+					enqueueObjectForKonnectGatewayControlPlane[configurationv1alpha1.KongCertificateList](
 						cl, IndexFieldKongCertificateOnKonnectGatewayControlPlane,
 					),
 				),

--- a/controller/konnect/watch_kongconsumer.go
+++ b/controller/konnect/watch_kongconsumer.go
@@ -54,7 +54,7 @@ func KongConsumerReconciliationWatchOptions(
 			return b.Watches(
 				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueObjectForKonnectGatewayControlPlane[*configurationv1.KongConsumerList](
+					enqueueObjectForKonnectGatewayControlPlane[configurationv1.KongConsumerList](
 						cl, IndexFieldKongConsumerOnKonnectGatewayControlPlane,
 					),
 				),

--- a/controller/konnect/watch_kongconsumergroup.go
+++ b/controller/konnect/watch_kongconsumergroup.go
@@ -53,7 +53,7 @@ func KongConsumerGroupReconciliationWatchOptions(
 			return b.Watches(
 				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueObjectForKonnectGatewayControlPlane[*configurationv1beta1.KongConsumerGroupList](
+					enqueueObjectForKonnectGatewayControlPlane[configurationv1beta1.KongConsumerGroupList](
 						cl, IndexFieldKongConsumerGroupOnKonnectGatewayControlPlane,
 					),
 				),

--- a/controller/konnect/watch_kongdataplanecertificate.go
+++ b/controller/konnect/watch_kongdataplanecertificate.go
@@ -41,7 +41,7 @@ func KongDataPlaneClientCertificateReconciliationWatchOptions(cl client.Client) 
 			return b.Watches(
 				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueObjectForKonnectGatewayControlPlane[*configurationv1alpha1.KongDataPlaneClientCertificateList](
+					enqueueObjectForKonnectGatewayControlPlane[configurationv1alpha1.KongDataPlaneClientCertificateList](
 						cl, IndexFieldKongDataPlaneClientCertificateOnKonnectGatewayControlPlane,
 					),
 				),

--- a/controller/konnect/watch_kongkey.go
+++ b/controller/konnect/watch_kongkey.go
@@ -49,7 +49,7 @@ func KongKeyReconciliationWatchOptions(cl client.Client) []func(*ctrl.Builder) *
 			return b.Watches(
 				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueObjectForKonnectGatewayControlPlane[*configurationv1alpha1.KongKeyList](
+					enqueueObjectForKonnectGatewayControlPlane[configurationv1alpha1.KongKeyList](
 						cl, IndexFieldKongKeyOnKonnectGatewayControlPlane,
 					),
 				),

--- a/controller/konnect/watch_kongkeyset.go
+++ b/controller/konnect/watch_kongkeyset.go
@@ -41,7 +41,7 @@ func KongKeySetReconciliationWatchOptions(cl client.Client) []func(*ctrl.Builder
 			return b.Watches(
 				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueObjectForKonnectGatewayControlPlane[*configurationv1alpha1.KongKeySetList](
+					enqueueObjectForKonnectGatewayControlPlane[configurationv1alpha1.KongKeySetList](
 						cl, IndexFieldKongKeySetOnKonnectGatewayControlPlane,
 					),
 				),

--- a/controller/konnect/watch_kongpluginbinding.go
+++ b/controller/konnect/watch_kongpluginbinding.go
@@ -60,7 +60,7 @@ func KongPluginBindingReconciliationWatchOptions(
 			return b.Watches(
 				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueObjectForKonnectGatewayControlPlane[*configurationv1alpha1.KongPluginBindingList](
+					enqueueObjectForKonnectGatewayControlPlane[configurationv1alpha1.KongPluginBindingList](
 						cl, IndexFieldKongPluginBindingKonnectGatewayControlPlane,
 					),
 				),

--- a/controller/konnect/watch_kongservice.go
+++ b/controller/konnect/watch_kongservice.go
@@ -52,7 +52,7 @@ func KongServiceReconciliationWatchOptions(
 			return b.Watches(
 				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueObjectForKonnectGatewayControlPlane[*configurationv1alpha1.KongServiceList](
+					enqueueObjectForKonnectGatewayControlPlane[configurationv1alpha1.KongServiceList](
 						cl, IndexFieldKongServiceOnKonnectGatewayControlPlane,
 					),
 				),

--- a/controller/konnect/watch_kongupstream.go
+++ b/controller/konnect/watch_kongupstream.go
@@ -52,7 +52,7 @@ func KongUpstreamReconciliationWatchOptions(
 			return b.Watches(
 				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueObjectForKonnectGatewayControlPlane[*configurationv1alpha1.KongUpstreamList](
+					enqueueObjectForKonnectGatewayControlPlane[configurationv1alpha1.KongUpstreamList](
 						cl, IndexFieldKongUpstreamOnKonnectGatewayControlPlane,
 					),
 				),

--- a/controller/konnect/watch_kongvault.go
+++ b/controller/konnect/watch_kongvault.go
@@ -41,7 +41,7 @@ func KongVaultReconciliationWatchOptions(cl client.Client) []func(*ctrl.Builder)
 			return b.Watches(
 				&konnectv1alpha1.KonnectGatewayControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueObjectForKonnectGatewayControlPlane[*configurationv1alpha1.KongVaultList](
+					enqueueObjectForKonnectGatewayControlPlane[configurationv1alpha1.KongVaultList](
 						cl, IndexFieldKongVaultOnKonnectGatewayControlPlane,
 					),
 				),


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix watch function's type parameters. After #816, the list operation returns an errors

```
errors.errorString {s: "expected pointer, but got nil"}
```

because the type used in `enqueueObjectForKonnectGatewayControlPlane`'s constraints is a pointer to list type which is `nil` by default.

This PR fixes it by adding more types constraints which allow to explicitly use a stack allocated variable for listing.

Also add a test for that.