### PR TITLE
chore: bump sdk-konnect-go to 0.1.2 and kubernetes-configuration to 0.0.37

### DIFF
--- a/controller/konnect/index_konnectgatewaycontrolplane.go
+++ b/controller/konnect/index_konnectgatewaycontrolplane.go
@@ -41,7 +41,7 @@ func konnectGatewayControlPlaneGroupMembers(object client.Object) []string {
 		return nil
 	}
 
-	if string(*clusterType) != string(sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup) {
+	if string(*clusterType) != string(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup) {
 		return nil
 	}
 

--- a/controller/konnect/ops/ops_controlplane.go
+++ b/controller/konnect/ops/ops_controlplane.go
@@ -38,12 +38,12 @@ func createControlPlane(
 		return errWrap
 	}
 
-	if resp == nil || resp.ControlPlane == nil || resp.ControlPlane.ID == nil {
+	if resp == nil || resp.ControlPlane == nil || resp.ControlPlane.ID == "" {
 		return fmt.Errorf("failed creating %s: %w", cp.GetTypeName(), ErrNilResponse)
 	}
 
 	// At this point, the ControlPlane has been created in Konnect.
-	id := *resp.ControlPlane.ID
+	id := resp.ControlPlane.ID
 	cp.SetKonnectID(id)
 
 	if err := setGroupMembers(ctx, cl, cp, id, sdkGroups); err != nil {
@@ -106,7 +106,7 @@ func updateControlPlane(
 	if resp == nil || resp.ControlPlane == nil {
 		return fmt.Errorf("failed updating ControlPlane: %w", ErrNilResponse)
 	}
-	id = *resp.ControlPlane.ID
+	id = resp.ControlPlane.ID
 
 	if err := setGroupMembers(ctx, cl, cp, id, sdkGroups); err != nil {
 		// If we failed to set group membership, we should return a specific error with a reason
@@ -130,7 +130,7 @@ func setGroupMembers(
 ) error {
 	if len(cp.Spec.Members) == 0 ||
 		cp.Spec.ClusterType == nil ||
-		*cp.Spec.ClusterType != sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup {
+		*cp.Spec.ClusterType != sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup {
 		return nil
 	}
 

--- a/controller/konnect/ops/ops_controlplane_test.go
+++ b/controller/konnect/ops/ops_controlplane_test.go
@@ -61,7 +61,7 @@ func TestCreateControlPlane(t *testing.T) {
 					Return(
 						&sdkkonnectops.CreateControlPlaneResponse{
 							ControlPlane: &sdkkonnectcomp.ControlPlane{
-								ID: lo.ToPtr(cpID),
+								ID: cpID,
 							},
 						},
 						nil,
@@ -136,7 +136,7 @@ func TestCreateControlPlane(t *testing.T) {
 					},
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup),
 							Name:        "cpg-1",
 						},
 						Members: []corev1.LocalObjectReference{
@@ -154,7 +154,7 @@ func TestCreateControlPlane(t *testing.T) {
 					Return(
 						&sdkkonnectops.CreateControlPlaneResponse{
 							ControlPlane: &sdkkonnectcomp.ControlPlane{
-								ID: lo.ToPtr(cpgID),
+								ID: cpgID,
 							},
 						},
 						nil,
@@ -205,7 +205,7 @@ func TestCreateControlPlane(t *testing.T) {
 					},
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup),
 							Name:        "cpg-1",
 						},
 						Members: []corev1.LocalObjectReference{
@@ -223,7 +223,7 @@ func TestCreateControlPlane(t *testing.T) {
 					Return(
 						&sdkkonnectops.CreateControlPlaneResponse{
 							ControlPlane: &sdkkonnectcomp.ControlPlane{
-								ID: lo.ToPtr(cpgID),
+								ID: cpgID,
 							},
 						},
 						nil,
@@ -439,7 +439,7 @@ func TestUpdateControlPlane(t *testing.T) {
 					Return(
 						&sdkkonnectops.UpdateControlPlaneResponse{
 							ControlPlane: &sdkkonnectcomp.ControlPlane{
-								ID: lo.ToPtr("12345"),
+								ID: "12345",
 							},
 						},
 						nil,
@@ -543,7 +543,7 @@ func TestUpdateControlPlane(t *testing.T) {
 					Return(
 						&sdkkonnectops.CreateControlPlaneResponse{
 							ControlPlane: &sdkkonnectcomp.ControlPlane{
-								ID: lo.ToPtr("12345"),
+								ID: "12345",
 							},
 						},
 						nil,
@@ -615,7 +615,7 @@ func TestCreateAndUpdateControlPlane_KubernetesMetadataConsistency(t *testing.T)
 		}).
 		Return(&sdkkonnectops.CreateControlPlaneResponse{
 			ControlPlane: &sdkkonnectcomp.ControlPlane{
-				ID: lo.ToPtr("12345"),
+				ID: "12345",
 			},
 		}, nil)
 	_, err := Create(ctx, sdk.SDK, fakeClient, cp)
@@ -629,7 +629,7 @@ func TestCreateAndUpdateControlPlane_KubernetesMetadataConsistency(t *testing.T)
 		}).
 		Return(&sdkkonnectops.UpdateControlPlaneResponse{
 			ControlPlane: &sdkkonnectcomp.ControlPlane{
-				ID: lo.ToPtr("12345"),
+				ID: "12345",
 			},
 		}, nil)
 	_, err = Update(ctx, sdk.SDK, 0, fakeClient, cp)
@@ -654,7 +654,7 @@ func TestSetGroupMembers(t *testing.T) {
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 						Name:        "cp-group",
-						ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup),
+						ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup),
 					},
 				},
 			},
@@ -673,7 +673,7 @@ func TestSetGroupMembers(t *testing.T) {
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 						Name:        "cp-group",
-						ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup),
+						ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup),
 					},
 					Members: []corev1.LocalObjectReference{
 						{
@@ -726,7 +726,7 @@ func TestSetGroupMembers(t *testing.T) {
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 						Name:        "cp-group",
-						ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup),
+						ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup),
 					},
 					Members: []corev1.LocalObjectReference{
 						{
@@ -760,7 +760,7 @@ func TestSetGroupMembers(t *testing.T) {
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 						Name:        "cp-group",
-						ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup),
+						ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup),
 					},
 					Members: []corev1.LocalObjectReference{
 						{
@@ -830,7 +830,7 @@ func TestSetGroupMembers(t *testing.T) {
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 						Name:        "cp-group",
-						ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup),
+						ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup),
 					},
 					Members: []corev1.LocalObjectReference{
 						{

--- a/controller/konnect/ops/ops_credentialacl.go
+++ b/controller/konnect/ops/ops_credentialacl.go
@@ -134,6 +134,7 @@ func getKongCredentialACLForUID(
 	if resp == nil || resp.Object == nil {
 		return "", fmt.Errorf("failed listing %s: %w", cred.GetTypeName(), ErrNilResponse)
 	}
+	x := sliceToEntityWithIDPtrSlice(resp.Object.Data)
 
-	return getMatchingEntryFromListResponseData(sliceToEntityWithIDSlice(resp.Object.Data), cred)
+	return getMatchingEntryFromListResponseData(x, cred)
 }

--- a/controller/konnect/ops/ops_credentialapikey.go
+++ b/controller/konnect/ops/ops_credentialapikey.go
@@ -132,5 +132,5 @@ func getKongCredentialAPIKeyForUID(
 		return "", fmt.Errorf("failed listing %s: %w", cred.GetTypeName(), ErrNilResponse)
 	}
 
-	return getMatchingEntryFromListResponseData(sliceToEntityWithIDSlice(resp.Object.Data), cred)
+	return getMatchingEntryFromListResponseData(sliceToEntityWithIDPtrSlice(resp.Object.Data), cred)
 }

--- a/controller/konnect/ops/ops_credentialbasicauth.go
+++ b/controller/konnect/ops/ops_credentialbasicauth.go
@@ -132,5 +132,5 @@ func getKongCredentialBasicAuthForUID(
 		return "", fmt.Errorf("failed listing %s: %w", cred.GetTypeName(), ErrNilResponse)
 	}
 
-	return getMatchingEntryFromListResponseData(sliceToEntityWithIDSlice(resp.Object.Data), cred)
+	return getMatchingEntryFromListResponseData(sliceToEntityWithIDPtrSlice(resp.Object.Data), cred)
 }

--- a/controller/konnect/ops/ops_credentialhmac.go
+++ b/controller/konnect/ops/ops_credentialhmac.go
@@ -134,5 +134,5 @@ func getKongCredentialHMACForUID(
 		return "", fmt.Errorf("failed listing %s: %w", cred.GetTypeName(), ErrNilResponse)
 	}
 
-	return getMatchingEntryFromListResponseData(sliceToEntityWithIDSlice(resp.Object.Data), cred)
+	return getMatchingEntryFromListResponseData(sliceToEntityWithIDPtrSlice(resp.Object.Data), cred)
 }

--- a/controller/konnect/ops/ops_credentialjwt.go
+++ b/controller/konnect/ops/ops_credentialjwt.go
@@ -136,5 +136,5 @@ func getKongCredentialJWTForUID(
 		return "", fmt.Errorf("failed listing %s: %w", cred.GetTypeName(), ErrNilResponse)
 	}
 
-	return getMatchingEntryFromListResponseData(sliceToEntityWithIDSlice(resp.Object.Data), cred)
+	return getMatchingEntryFromListResponseData(sliceToEntityWithIDPtrSlice(resp.Object.Data), cred)
 }

--- a/controller/konnect/ops/ops_kongcacertificate.go
+++ b/controller/konnect/ops/ops_kongcacertificate.go
@@ -117,5 +117,5 @@ func getKongCACertificateForUID(
 		return "", fmt.Errorf("failed listing %s: %w", cert.GetTypeName(), ErrNilResponse)
 	}
 
-	return getMatchingEntryFromListResponseData(sliceToEntityWithIDSlice(resp.Object.Data), cert)
+	return getMatchingEntryFromListResponseData(sliceToEntityWithIDPtrSlice(resp.Object.Data), cert)
 }

--- a/controller/konnect/ops/ops_kongcertificate.go
+++ b/controller/konnect/ops/ops_kongcertificate.go
@@ -125,5 +125,5 @@ func getKongCertificateForUID(
 		return "", fmt.Errorf("failed listing %s: %w", cert.GetTypeName(), ErrNilResponse)
 	}
 
-	return getMatchingEntryFromListResponseData(sliceToEntityWithIDSlice(resp.Object.Data), cert)
+	return getMatchingEntryFromListResponseData(sliceToEntityWithIDPtrSlice(resp.Object.Data), cert)
 }

--- a/controller/konnect/ops/ops_kongconsumer.go
+++ b/controller/konnect/ops/ops_kongconsumer.go
@@ -342,5 +342,5 @@ func getKongConsumerForUID(
 		return "", fmt.Errorf("failed listing %s: %w", consumer.GetTypeName(), ErrNilResponse)
 	}
 
-	return getMatchingEntryFromListResponseData(sliceToEntityWithIDSlice(resp.Object.Data), consumer)
+	return getMatchingEntryFromListResponseData(sliceToEntityWithIDPtrSlice(resp.Object.Data), consumer)
 }

--- a/controller/konnect/ops/ops_kongconsumergroup.go
+++ b/controller/konnect/ops/ops_kongconsumergroup.go
@@ -119,5 +119,5 @@ func getKongConsumerGroupForUID(
 		return "", fmt.Errorf("failed listing %s: %w", cg.GetTypeName(), ErrNilResponse)
 	}
 
-	return getMatchingEntryFromListResponseData(sliceToEntityWithIDSlice(resp.Object.Data), cg)
+	return getMatchingEntryFromListResponseData(sliceToEntityWithIDPtrSlice(resp.Object.Data), cg)
 }

--- a/controller/konnect/ops/ops_kongkey.go
+++ b/controller/konnect/ops/ops_kongkey.go
@@ -131,5 +131,5 @@ func getKongKeyForUID(
 		return "", fmt.Errorf("failed to list KongKeys: %w", ErrNilResponse)
 	}
 
-	return getMatchingEntryFromListResponseData(sliceToEntityWithIDSlice(resp.Object.Data), key)
+	return getMatchingEntryFromListResponseData(sliceToEntityWithIDPtrSlice(resp.Object.Data), key)
 }

--- a/controller/konnect/ops/ops_kongkeyset.go
+++ b/controller/konnect/ops/ops_kongkeyset.go
@@ -116,5 +116,5 @@ func getKongKeySetForUID(
 		return "", fmt.Errorf("failed listing %s: %w", keySet.GetTypeName(), ErrNilResponse)
 	}
 
-	return getMatchingEntryFromListResponseData(sliceToEntityWithIDSlice(resp.Object.Data), keySet)
+	return getMatchingEntryFromListResponseData(sliceToEntityWithIDPtrSlice(resp.Object.Data), keySet)
 }

--- a/controller/konnect/ops/ops_kongpluginbinding.go
+++ b/controller/konnect/ops/ops_kongpluginbinding.go
@@ -132,7 +132,7 @@ func getPluginForUID(
 		return "", fmt.Errorf("failed listing %s: %w", pluginBinding.GetTypeName(), ErrNilResponse)
 	}
 
-	return getMatchingEntryFromListResponseData(sliceToEntityWithIDSlice(resp.Object.Data), pluginBinding)
+	return getMatchingEntryFromListResponseData(sliceToEntityWithIDPtrSlice(resp.Object.Data), pluginBinding)
 }
 
 // -----------------------------------------------------------------------------

--- a/controller/konnect/ops/ops_kongroute.go
+++ b/controller/konnect/ops/ops_kongroute.go
@@ -137,5 +137,5 @@ func getKongRouteForUID(
 		return "", fmt.Errorf("failed listing %s: %w", r.GetTypeName(), ErrNilResponse)
 	}
 
-	return getMatchingEntryFromListResponseData(sliceToEntityWithIDSlice(resp.Object.Data), r)
+	return getMatchingEntryFromListResponseData(sliceToEntityWithIDPtrSlice(resp.Object.Data), r)
 }

--- a/controller/konnect/ops/ops_kongservice.go
+++ b/controller/konnect/ops/ops_kongservice.go
@@ -131,5 +131,5 @@ func getKongServiceForUID(
 		return "", fmt.Errorf("failed listing %s: %w", svc.GetTypeName(), ErrNilResponse)
 	}
 
-	return getMatchingEntryFromListResponseData(sliceToEntityWithIDSlice(resp.Object.Data), svc)
+	return getMatchingEntryFromListResponseData(sliceToEntityWithIDPtrSlice(resp.Object.Data), svc)
 }

--- a/controller/konnect/ops/ops_kongsni.go
+++ b/controller/konnect/ops/ops_kongsni.go
@@ -146,5 +146,5 @@ func getKongSNIForUID(ctx context.Context, sdk sdkops.SNIsSDK, sni *configuratio
 		return "", fmt.Errorf("failed listing %s: %w", sni.GetTypeName(), ErrNilResponse)
 	}
 
-	return getMatchingEntryFromListResponseData(sliceToEntityWithIDSlice(resp.Object.Data), sni)
+	return getMatchingEntryFromListResponseData(sliceToEntityWithIDPtrSlice(resp.Object.Data), sni)
 }

--- a/controller/konnect/ops/ops_kongtarget.go
+++ b/controller/konnect/ops/ops_kongtarget.go
@@ -133,5 +133,5 @@ func getKongTargetForUID(
 		return "", fmt.Errorf("failed listing %s: %w", target.GetTypeName(), ErrNilResponse)
 	}
 
-	return getMatchingEntryFromListResponseData(sliceToEntityWithIDSlice(resp.Object.Data), target)
+	return getMatchingEntryFromListResponseData(sliceToEntityWithIDPtrSlice(resp.Object.Data), target)
 }

--- a/controller/konnect/ops/ops_kongupstream.go
+++ b/controller/konnect/ops/ops_kongupstream.go
@@ -135,5 +135,5 @@ func getKongUpstreamForUID(
 		return "", fmt.Errorf("failed listing %s: %w", u.GetTypeName(), ErrNilResponse)
 	}
 
-	return getMatchingEntryFromListResponseData(sliceToEntityWithIDSlice(resp.Object.Data), u)
+	return getMatchingEntryFromListResponseData(sliceToEntityWithIDPtrSlice(resp.Object.Data), u)
 }

--- a/controller/konnect/ops/ops_kongvault.go
+++ b/controller/konnect/ops/ops_kongvault.go
@@ -113,5 +113,5 @@ func getKongVaultForUID(
 		return "", fmt.Errorf("failed to list KongVaults: %w", ErrNilResponse)
 	}
 
-	return getMatchingEntryFromListResponseData(sliceToEntityWithIDSlice(resp.Object.Data), vault)
+	return getMatchingEntryFromListResponseData(sliceToEntityWithIDPtrSlice(resp.Object.Data), vault)
 }

--- a/controller/konnect/reconciler_controlplaneref.go
+++ b/controller/konnect/reconciler_controlplaneref.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
-	"github.com/samber/lo"
 	"github.com/samber/mo"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -140,11 +139,11 @@ func handleControlPlaneRef[T constraints.SupportedKonnectEntityType, TEnt constr
 		}
 
 		// Do not continue reconciling of the control plane has incompatible cluster type to prevent repeated failure of creation.
-		// Only CLUSTER_TYPE_CONTROL_PLANE and CLUSTER_TYPE_HYBRID are supported.
+		// Only CLUSTER_TYPE_CONTROL_PLANE is supported.
 		// The configuration in control plane group type are read only so they are unsupported to attach entities to them:
 		// https://docs.konghq.com/konnect/gateway-manager/control-plane-groups/#limitations
 		if cp.Spec.ClusterType != nil &&
-			!lo.Contains(compatibleControlPlaneClusterTypes, *cp.Spec.ClusterType) {
+			*cp.Spec.ClusterType != sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane {
 			if res, errStatus := patch.StatusWithCondition(
 				ctx, cl, ent,
 				konnectv1alpha1.ControlPlaneRefValidConditionType,
@@ -230,9 +229,4 @@ func conditionMessageReferenceKonnectAPIAuthConfigurationInvalid(apiAuthRef type
 
 func conditionMessageReferenceKonnectAPIAuthConfigurationValid(apiAuthRef types.NamespacedName) string {
 	return fmt.Sprintf("referenced KonnectAPIAuthConfiguration %s is valid", apiAuthRef)
-}
-
-var compatibleControlPlaneClusterTypes = []sdkkonnectcomp.ClusterType{
-	sdkkonnectcomp.ClusterTypeClusterTypeControlPlane,
-	sdkkonnectcomp.ClusterTypeClusterTypeHybrid,
 }

--- a/controller/konnect/reconciler_controlplaneref_test.go
+++ b/controller/konnect/reconciler_controlplaneref_test.go
@@ -32,7 +32,6 @@ type handleControlPlaneRefTestCase[T constraints.SupportedKonnectEntityType, TEn
 }
 
 func TestHandleControlPlaneRef(t *testing.T) {
-
 	var (
 		cpOK = &konnectv1alpha1.KonnectGatewayControlPlane{
 			ObjectMeta: metav1.ObjectMeta{
@@ -59,7 +58,7 @@ func TestHandleControlPlaneRef(t *testing.T) {
 			},
 			Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 				CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-					ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup),
+					ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup),
 				},
 			},
 			Status: konnectv1alpha1.KonnectGatewayControlPlaneStatus{

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3256,7 +3256,7 @@ KonnectGatewayControlPlaneSpec defines the desired state of KonnectGatewayContro
 | --- | --- |
 | `name` _string_ | The name of the control plane. |
 | `description` _string_ | The description of the control plane in Konnect. |
-| `cluster_type` _[ClusterType](#clustertype)_ | The ClusterType value of the cluster associated with the Control Plane. |
+| `cluster_type` _[CreateControlPlaneRequestClusterType](#createcontrolplanerequestclustertype)_ | The ClusterType value of the cluster associated with the Control Plane. |
 | `auth_type` _[AuthType](#authtype)_ | The auth type value of the cluster associated with the Runtime Group. |
 | `cloud_gateway` _boolean_ | Whether this control-plane can be used for cloud-gateways. |
 | `proxy_urls` _[ProxyURL](#proxyurl) array_ | Array of proxy URLs associated with reaching the data-planes connected to a control-plane. |

--- a/go.mod
+++ b/go.mod
@@ -11,13 +11,13 @@ toolchain go1.23.2
 retract v1.2.2
 
 require (
-	github.com/Kong/sdk-konnect-go v0.0.16
+	github.com/Kong/sdk-konnect-go v0.1.2
 	github.com/Masterminds/semver v1.5.0
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-containerregistry v0.20.2
 	github.com/google/uuid v1.6.0
-	github.com/kong/kubernetes-configuration v0.0.36
+	github.com/kong/kubernetes-configuration v0.0.37
 	github.com/kong/kubernetes-telemetry v0.1.7
 	github.com/kong/kubernetes-testing-framework v0.47.2
 	github.com/kong/semver/v4 v4.0.1

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/Kong/sdk-konnect-go v0.0.16 h1:xQMvwhMpypFUlPZiAbNpT/epeL1az2/RGa8/qlzKpmw=
-github.com/Kong/sdk-konnect-go v0.0.16/go.mod h1:ipu67aQNnwDzu/LXKePG46cVqkkZnAHKWpsbhTEI8xE=
+github.com/Kong/sdk-konnect-go v0.1.2 h1:axA0ZxMxmcjsSm0oWPK8NHlKMdatQCm1vANp+TuCAqc=
+github.com/Kong/sdk-konnect-go v0.1.2/go.mod h1:ipu67aQNnwDzu/LXKePG46cVqkkZnAHKWpsbhTEI8xE=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -218,8 +218,8 @@ github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kong/go-kong v0.59.1 h1:AJZtyCD+Zyqe/mF/m+x3/qN/GPVxAH7jq9zGJTHRfjc=
 github.com/kong/go-kong v0.59.1/go.mod h1:8Vt6HmtgLNgL/7bSwAlz3DIWqBtzG7qEt9+OnMiQOa0=
-github.com/kong/kubernetes-configuration v0.0.36 h1:/0rqSl8WAfLDj+4lqvBYFi3FLfdbXXK47Wx3+NX6bF8=
-github.com/kong/kubernetes-configuration v0.0.36/go.mod h1:7Frddjb/OCG9+YY+9TWSEbIwzjoD5ud2R0FSce4FGBM=
+github.com/kong/kubernetes-configuration v0.0.37 h1:bWS/eZcVjqknFrasgFty4Js/1ws/8g2JrfYxxWxyziI=
+github.com/kong/kubernetes-configuration v0.0.37/go.mod h1:G+tpSczTXgujYDF2CQQd8LTBNX/86VsCqe36e6e9BmQ=
 github.com/kong/kubernetes-telemetry v0.1.7 h1:R4NUpvbF5uZ+5kgSQsIcf/oulRBGQCHsffFRDE4wxV4=
 github.com/kong/kubernetes-telemetry v0.1.7/go.mod h1:USy5pcD1+Mm9NtKuz3Pb/rSx71VN76gHCFhdbAB4/lg=
 github.com/kong/kubernetes-testing-framework v0.47.2 h1:+2Z9anTpbV/hwNeN+NFQz53BMU+g3QJydkweBp3tULo=

--- a/test/envtest/konnect_entities_gatewaycontrolplane_test.go
+++ b/test/envtest/konnect_entities_gatewaycontrolplane_test.go
@@ -52,7 +52,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 				Return(
 					&sdkkonnectops.CreateControlPlaneResponse{
 						ControlPlane: &sdkkonnectcomp.ControlPlane{
-							ID: lo.ToPtr("12345"),
+							ID: "12345",
 						},
 					},
 					nil)
@@ -100,7 +100,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 					cp := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
 					cp.Name = "cp-2"
 					cp.Spec.Name = "cp-2"
-					cp.Spec.ClusterType = lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup)
+					cp.Spec.ClusterType = lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup)
 					cp.Spec.Members = []corev1.LocalObjectReference{
 						{
 							Name: "cp-groupmember-1",
@@ -120,7 +120,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 				Return(
 					&sdkkonnectops.CreateControlPlaneResponse{
 						ControlPlane: &sdkkonnectcomp.ControlPlane{
-							ID: lo.ToPtr("12345"),
+							ID: "12345",
 						},
 					},
 					nil)
@@ -129,13 +129,13 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 					mock.Anything,
 					mock.MatchedBy(func(req sdkkonnectcomp.CreateControlPlaneRequest) bool {
 						return req.Name == "cp-2" &&
-							req.ClusterType != nil && *req.ClusterType == sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup
+							req.ClusterType != nil && *req.ClusterType == sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup
 					}),
 				).
 				Return(
 					&sdkkonnectops.CreateControlPlaneResponse{
 						ControlPlane: &sdkkonnectcomp.ControlPlane{
-							ID: lo.ToPtr("12346"),
+							ID: "12346",
 						},
 					},
 					nil)
@@ -168,7 +168,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 				Return(
 					&sdkkonnectops.UpdateControlPlaneResponse{
 						ControlPlane: &sdkkonnectcomp.ControlPlane{
-							ID: lo.ToPtr("12346"),
+							ID: "12346",
 						},
 					},
 					nil).
@@ -243,7 +243,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 					cp := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
 					cp.Name = "cp-3"
 					cp.Spec.Name = "cp-3"
-					cp.Spec.ClusterType = lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup)
+					cp.Spec.ClusterType = lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup)
 					cp.Spec.Members = []corev1.LocalObjectReference{
 						{
 							Name: "cp-groupmember-2",
@@ -263,7 +263,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 				Return(
 					&sdkkonnectops.CreateControlPlaneResponse{
 						ControlPlane: &sdkkonnectcomp.ControlPlane{
-							ID: lo.ToPtr("12345"),
+							ID: "12345",
 						},
 					},
 					nil,
@@ -274,13 +274,13 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 					mock.MatchedBy(func(req sdkkonnectcomp.CreateControlPlaneRequest) bool {
 						return req.Name == "cp-3" &&
 							req.ClusterType != nil &&
-							*req.ClusterType == sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup
+							*req.ClusterType == sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup
 					}),
 				).
 				Return(
 					&sdkkonnectops.CreateControlPlaneResponse{
 						ControlPlane: &sdkkonnectcomp.ControlPlane{
-							ID: lo.ToPtr("123467"),
+							ID: "123467",
 						},
 					},
 					nil,
@@ -314,7 +314,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 				Return(
 					&sdkkonnectops.UpdateControlPlaneResponse{
 						ControlPlane: &sdkkonnectcomp.ControlPlane{
-							ID: lo.ToPtr("123467"),
+							ID: "123467",
 						},
 					},
 					nil,
@@ -412,7 +412,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 						ListControlPlanesResponse: &sdkkonnectcomp.ListControlPlanesResponse{
 							Data: []sdkkonnectcomp.ControlPlane{
 								{
-									ID: lo.ToPtr("123456"),
+									ID: "123456",
 								},
 							},
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:

- bump sdk-konnect-go to [0.1.2](https://github.com/Kong/sdk-konnect-go/releases/tag/v0.1.2)
  -  This release removes HYBRID CP type: https://github.com/Kong/platform-api/pull/767
- bump kcfg to https://github.com/Kong/kubernetes-configuration/pull/140
