### PR TITLE
chore(ci): add envtest to requirements for CI to pass

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -205,7 +205,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: tests-report
-        path: envtest-tests.xml  
+        path: envtest-tests.xml
 
   conformance-tests:
     runs-on: ubuntu-latest
@@ -465,8 +465,7 @@ jobs:
     needs:
       - unit-tests
       - integration-tests
-      # https://github.com/Kong/gateway-operator/issues/11#issuecomment-1514712925
-      # - conformance-tests
+      - conformance-tests
       - e2e-tests
     if: ${{ always() }}
     runs-on: ubuntu-latest
@@ -503,8 +502,9 @@ jobs:
       - install-with-kustomize
       - build
       - unit-tests
+      - envtest-tests
       - samples
-      # - conformance-tests
+      - conformance-tests
       - integration-tests
       - integration-tests-bluegreen
       - integration-tests-provision-fail


### PR DESCRIPTION
**What this PR does / why we need it**:

`envtest` tests were missing from the requirements of `passed` so adding that. Additionally add `conformance` tests as these are already running regularly as part of CI.