### PR TITLE
fix(konnect): when no members are set on CP group then set 0 members in Konnect

### DIFF
--- a/controller/konnect/ops/conditions.go
+++ b/controller/konnect/ops/conditions.go
@@ -66,8 +66,6 @@ const (
 	// ControlPlaneGroupMembersReferenceResolvedConditionType sets the condition for control plane groups
 	// to show whether all of its members are programmed and attached to the group.
 	ControlPlaneGroupMembersReferenceResolvedConditionType = "MembersReferenceResolved"
-	// ControlPlaneGroupMembersReferenceResolvedReasonNoMembers indicates that there are no members specified in the control plane group.
-	ControlPlaneGroupMembersReferenceResolvedReasonNoMembers consts.ConditionReason = "NoMembers"
 	// ControlPlaneGroupMembersReferenceResolvedReasonResolved indicates that all members of the control plane group
 	// are created and attached to the group in Konnect.
 	ControlPlaneGroupMembersReferenceResolvedReasonResolved consts.ConditionReason = "Resolved"

--- a/controller/konnect/ops/ops_controlplane.go
+++ b/controller/konnect/ops/ops_controlplane.go
@@ -133,16 +133,6 @@ func setGroupMembers(
 		return nil
 	}
 
-	// Set MembersReferenceResolved condition to False if there are no members in the CP group.
-	if len(cp.Spec.Members) == 0 {
-		SetControlPlaneGroupMembersReferenceResolvedConditionFalse(
-			cp,
-			ControlPlaneGroupMembersReferenceResolvedReasonNoMembers,
-			"No members in the control plane group",
-		)
-		return nil
-	}
-
 	members, err := iter.MapErr(cp.Spec.Members,
 		func(member *corev1.LocalObjectReference) (sdkkonnectcomp.Members, error) {
 			var (

--- a/controller/konnect/ops/ops_controlplane_test.go
+++ b/controller/konnect/ops/ops_controlplane_test.go
@@ -663,10 +663,19 @@ func TestSetGroupMembers(t *testing.T) {
 			},
 			sdk: func(t *testing.T) *sdkmocks.MockControlPlaneGroupSDK {
 				sdk := sdkmocks.NewMockControlPlaneGroupSDK(t)
+				sdk.EXPECT().
+					PutControlPlanesIDGroupMemberships(
+						mock.Anything,
+						"cpg-12345",
+						&sdkkonnectcomp.GroupMembership{
+							Members: []sdkkonnectcomp.Members{},
+						},
+					).
+					Return(&sdkkonnectops.PutControlPlanesIDGroupMembershipsResponse{}, nil)
 				return sdk
 			},
-			memberRefResolvedStatus: metav1.ConditionFalse,
-			memberRefResolvedReason: ControlPlaneGroupMembersReferenceResolvedReasonNoMembers,
+			memberRefResolvedStatus: metav1.ConditionTrue,
+			memberRefResolvedReason: ControlPlaneGroupMembersReferenceResolvedReasonResolved,
 		},
 		{
 			name: "1 member with Konnect Status ID",


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes an issue where members wouldn't be set on CP groups when no members are listed in the spec.

This uses a fix from https://github.com/Kong/sdk-konnect-go/commit/012f47e44fd9578d48c1092a261df3581e21b868