### PR TITLE
tests: bump version in e2e upgrade tests

### DIFF
--- a/test/e2e/test_helm_install_upgrade.go
+++ b/test/e2e/test_helm_install_upgrade.go
@@ -203,19 +203,19 @@ func TestHelmUpgrade(t *testing.T) {
 			},
 		},
 		{
-			name:             "upgrade from 1.3.0 to current",
-			fromVersion:      "1.3.0",
+			name:             "upgrade from 1.4.0 to current",
+			fromVersion:      "1.4.0",
 			upgradeToCurrent: true,
 			objectsToDeploy: []client.Object{
 				&operatorv1beta1.GatewayConfiguration{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "gwconf-upgrade-130-current",
+						Name: "gwconf-upgrade-140-current",
 					},
 					Spec: baseGatewayConfigurationSpec(),
 				},
 				&gatewayv1.GatewayClass{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "gwclass-upgrade-130-current",
+						Name: "gwclass-upgrade-140-current",
 					},
 					Spec: gatewayv1.GatewayClassSpec{
 						ParametersRef: &gatewayv1.ParametersReference{
@@ -229,13 +229,13 @@ func TestHelmUpgrade(t *testing.T) {
 				},
 				&gatewayv1.Gateway{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "gw-upgrade-130-current-",
+						GenerateName: "gw-upgrade-140-current-",
 						Labels: map[string]string{
-							"gw-upgrade-130-current": "true",
+							"gw-upgrade-140-current": "true",
 						},
 					},
 					Spec: gatewayv1.GatewaySpec{
-						GatewayClassName: gatewayv1.ObjectName("gwclass-upgrade-130-current"),
+						GatewayClassName: gatewayv1.ObjectName("gwclass-upgrade-140-current"),
 						Listeners: []gatewayv1.Listener{{
 							Name:     "http",
 							Protocol: gatewayv1.HTTPProtocolType,
@@ -248,7 +248,7 @@ func TestHelmUpgrade(t *testing.T) {
 				{
 					Name: "Gateway is programmed",
 					Func: func(c *assert.CollectT, cl *testutils.K8sClients) {
-						gatewayAndItsListenersAreProgrammedAssertion("gw-upgrade-130-current=true")(ctx, c, cl.MgrClient)
+						gatewayAndItsListenersAreProgrammedAssertion("gw-upgrade-140-current=true")(ctx, c, cl.MgrClient)
 					},
 				},
 			},
@@ -256,20 +256,20 @@ func TestHelmUpgrade(t *testing.T) {
 				{
 					Name: "Gateway is programmed",
 					Func: func(c *assert.CollectT, cl *testutils.K8sClients) {
-						gatewayAndItsListenersAreProgrammedAssertion("gw-upgrade-130-current=true")(ctx, c, cl.MgrClient)
+						gatewayAndItsListenersAreProgrammedAssertion("gw-upgrade-140-current=true")(ctx, c, cl.MgrClient)
 					},
 				},
 				{
 					Name: fmt.Sprintf("DataPlane deployment is patched after operator upgrade (due to change in default Kong image version to %q)", helpers.GetDefaultDataPlaneImage()),
 					Func: func(c *assert.CollectT, cl *testutils.K8sClients) {
-						gatewayDataPlaneDeploymentIsPatched("gw-upgrade-130-current=true")(ctx, c, cl.MgrClient)
-						gatewayDataPlaneDeploymentHasImageSetTo("gw-upgrade-130-current=true", helpers.GetDefaultDataPlaneImage())(ctx, c, cl.MgrClient)
+						gatewayDataPlaneDeploymentIsPatched("gw-upgrade-140-current=true")(ctx, c, cl.MgrClient)
+						gatewayDataPlaneDeploymentHasImageSetTo("gw-upgrade-140-current=true", helpers.GetDefaultDataPlaneImage())(ctx, c, cl.MgrClient)
 					},
 				},
 				{
 					Name: "Cluster wide resources owned by the ControlPlane get the proper set of labels",
 					Func: func(c *assert.CollectT, cl *testutils.K8sClients) {
-						clusterWideResourcesAreProperlyManaged("gw-upgrade-130-current=true")(ctx, c, cl.MgrClient)
+						clusterWideResourcesAreProperlyManaged("gw-upgrade-140-current=true")(ctx, c, cl.MgrClient)
 					},
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps the KGO version in the upgrade tests to the latest v1.4.0.