### PR TITLE
chore: configure renovate to update upgrade test deps

### DIFF
--- a/.github/ISSUE_TEMPLATE/---release.md
+++ b/.github/ISSUE_TEMPLATE/---release.md
@@ -41,8 +41,8 @@ If the troubleshooting section does not contain the answer to the problem you en
 
 **Only for major and minor releases**:
 
-- [ ] When the release tag is created add a test case in [upgrade E2E test][helm_upgrade_test] with just published tag so that an upgrade path from previous major/minor version is tested.
-  - [ ] When the release contains breaking changes which precludes an automated upgrade make sure to add a comment to this test for future readers.
+- [ ] After the release tag is created, bump the `fromVersion` in the `upgrade from one before latest to latest minor` [upgrade E2E test][helm_upgrade_test] to the one before the latest minor release.
+- [ ] When the release contains breaking changes which precludes an automated upgrade make sure this is documented in the release notes and the Helm chart's [UPGRADE.md][helm-chart-upgrade].
 - [ ] Schedule a retro meeting and invite the team. Link the invite in the [retro notes](https://docs.google.com/document/d/15gDtl425zyttbDwA8qQrh5yBgTD5OpnhjOquqfSJUx4/edit#heading=h.biunbyheelys)
 
 
@@ -50,6 +50,7 @@ If the troubleshooting section does not contain the answer to the problem you en
 [cli_ref_docs]: https://docs.konghq.com/gateway-operator/latest/reference/cli-arguments/
 [helm_upgrade_test]: https://github.com/Kong/gateway-operator/blob/9f33d27ab875b91e50d7e750b45a293c1395da2d/test/e2e/test_upgrade.go
 [release-bot-workflow]: ../workflows/release-bot.yaml
+[helm-chart-upgrade]: https://github.com/Kong/charts/blob/main/charts/gateway-operator/UPGRADE.md
 
 ## Verify default hardcoded versions
 

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "ignorePaths": [],
   "enabledManagers": [
     "custom.regex",
     "kustomize"
@@ -40,10 +41,11 @@
       "datasourceTemplate": "docker",
       "fileMatch": [
         "^pkg/consts/dataplane\\.go$",
-        "^internal/versions/controlplane\\.go$"
+        "^internal/versions/controlplane\\.go$",
+        "^test/e2e/test_helm_install_upgrade\\.go$"
       ],
       "matchStrings": [
-        ".+\\s+=\\s+\"(?<currentValue>.+)\"\\s+//\\s+renovate:\\s+datasource=(?<datasource>.*)\\s+depName=(?<depName>.+)"
+        ".+\\s?[=:]\\s+\"(?<currentValue>.+?)\",?\\s+//\\s+renovate:\\s+datasource=(?<datasource>.*?)\\s+(packageName=(?<packageName>.*)\\s+)?depName=(?<depName>.*)"
       ]
     }
   ],
@@ -52,6 +54,16 @@
       "description": "Strip kustomize/ version prefix",
       "matchPackageNames": ["kubernetes-sigs/kustomize"],
       "extractVersion": "^kustomize/(?<version>.*)$"
+    },
+    {
+      "description": "Ignore minor updates if depName has `@only-patch` suffix.",
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "enabled": false,
+      "matchDepNames": [
+        "/.*@only-patch/"
+      ]
     }
   ]
 }

--- a/test/e2e/test_helm_install_upgrade.go
+++ b/test/e2e/test_helm_install_upgrade.go
@@ -63,11 +63,9 @@ func TestHelmUpgrade(t *testing.T) {
 		assertionsAfterUpgrade []assertion
 	}{
 		{
-			name: "upgrade from one before latest to latest minor",
-			// TODO: use renovate to bump the version in these 2 lines.
-			// https://github.com/Kong/gateway-operator/issues/121
-			fromVersion: "1.3.0",
-			toVersion:   "1.4.0",
+			name:        "upgrade from one before latest to latest minor",
+			fromVersion: "1.3.0", // renovate: datasource=docker packageName=kong/gateway-operator-oss depName=kong/gateway-operator-oss@only-patch
+			toVersion:   "1.4.0", // renovate: datasource=docker packageName=kong/gateway-operator-oss
 			objectsToDeploy: []client.Object{
 				&operatorv1beta1.GatewayConfiguration{
 					ObjectMeta: metav1.ObjectMeta{
@@ -137,10 +135,8 @@ func TestHelmUpgrade(t *testing.T) {
 			},
 		},
 		{
-			name: "upgrade from latest minor to current",
-			// TODO: use renovate to bump the version below
-			// https://github.com/Kong/gateway-operator/issues/121
-			fromVersion:      "1.4.0",
+			name:             "upgrade from latest minor to current",
+			fromVersion:      "1.4.0", // renovate: datasource=docker packageName=kong/gateway-operator-oss
 			upgradeToCurrent: true,
 			objectsToDeploy: []client.Object{
 				&operatorv1beta1.GatewayConfiguration{


### PR DESCRIPTION
**What this PR does / why we need it**:

Sets up Renovate to watch `test/e2e/test_helm_install_upgrade.go` for potential dependencies updates. Where needed, it adds an `@only-patch` suffix in `depName` and specifies an explicit `packageName`. Thanks to the suffix, it disables minor updates for such a dependency.

Tested on a forked repository.

**Which issue this PR fixes**

Fixes https://github.com/Kong/gateway-operator/issues/121.
