### PR TITLE
fix: diff DataPlane log

### DIFF
--- a/controller/dataplane/owned_deployment.go
+++ b/controller/dataplane/owned_deployment.go
@@ -342,7 +342,7 @@ func reconcileDataPlaneDeployment(
 		}
 		if updated {
 			diff := cmp.Diff(original.Spec.Template, desired.Spec.Template, opts...)
-			log.Trace(logger, "Deployment diff detected", diff)
+			log.Trace(logger, "DataPlane Deployment diff detected", dataplane, "diff", diff)
 		}
 
 		return patch.ApplyPatchIfNotEmpty(ctx, cl, logger, existing, original, updated)


### PR DESCRIPTION
**What this PR does / why we need it**:

3rd parameter of log functions (including `Trace`) is `rawObj`, not `string`. This has been reported by user in https://github.com/Kong/gateway-operator/issues/522#issuecomment-2309964408.

Current code yields:

```
unexpected type processed for trace logging: string, this is a bug!
```

This PR fixes it.
