### PR TITLE
refactor: drop rawObj parameter from logger's methods

### DIFF
--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -240,7 +240,7 @@ func (r *Reconciler) ensureDeployment(
 		return op.Noop, nil, fmt.Errorf("failed creating ControlPlane Deployment %s: %w", generatedDeployment.Name, err)
 	}
 
-	log.Debug(logger, "deployment for ControlPlane created", params.ControlPlane, "deployment", generatedDeployment.Name)
+	log.Debug(logger, "deployment for ControlPlane created", "deployment", generatedDeployment.Name)
 	return op.Created, generatedDeployment, nil
 }
 
@@ -431,7 +431,6 @@ func (r *Reconciler) ensureClusterRoleBinding(
 		// Delete and re-create ClusterRoleBinding if name of ClusterRole changed because RoleRef is immutable.
 		if !k8sresources.CompareClusterRoleName(existing, clusterRoleName) {
 			log.Debug(logger, "ClusterRole name changed, delete and re-create a ClusterRoleBinding",
-				existing,
 				"old_cluster_role", existing.RoleRef.Name,
 				"new_cluster_role", clusterRoleName,
 			)
@@ -865,7 +864,7 @@ func (r *Reconciler) ensureValidatingWebhookConfiguration(
 		}
 
 		if updated {
-			log.Debug(logger, "patching existing ValidatingWebhookConfiguration", webhookConfiguration)
+			log.Debug(logger, "patching existing ValidatingWebhookConfiguration")
 			return op.Updated, r.Client.Patch(ctx, &webhookConfiguration, client.MergeFrom(old))
 		}
 

--- a/controller/dataplane/controller_reconciler_utils.go
+++ b/controller/dataplane/controller_reconciler_utils.go
@@ -159,12 +159,12 @@ func populateDedicatedConfigMapForKongPluginInstallation(
 		Namespace: kpi.Namespace,
 		Name:      kpi.Status.UnderlyingConfigMapName,
 	}
-	log.Trace(logger, fmt.Sprintf("Fetch underlying ConfigMap %s for KongPluginInstallation", backingCMNN), kpi)
+	log.Trace(logger, fmt.Sprintf("Fetch underlying ConfigMap %s for KongPluginInstallation", backingCMNN))
 	if err := c.Get(ctx, backingCMNN, &underlyingCM); err != nil {
 		return customPlugin{}, false, fmt.Errorf("could not fetch underlying ConfigMap to clone %s: %w", backingCMNN, err)
 	}
 
-	log.Trace(logger, "Find ConfigMap mapped to KongPluginInstallation", kpi)
+	log.Trace(logger, "Find ConfigMap mapped to KongPluginInstallation")
 	mappedConfigMapForKPI := lo.Filter(cms, func(cm corev1.ConfigMap, _ int) bool {
 		kpiNN := cm.Annotations[consts.AnnotationMappedToKongPluginInstallation]
 		return kpiNN == client.ObjectKeyFromObject(&kpi).String()
@@ -172,7 +172,7 @@ func populateDedicatedConfigMapForKongPluginInstallation(
 	var cm corev1.ConfigMap
 	switch len(mappedConfigMapForKPI) {
 	case 0:
-		log.Trace(logger, "Create new ConfigMap for KongPluginInstallation", kpi)
+		log.Trace(logger, "Create new ConfigMap for KongPluginInstallation")
 		cm.GenerateName = dataplane.Name + "-"
 		cm.Namespace = dataplane.Namespace
 		k8sutils.SetOwnerForObject(&cm, dataplane)
@@ -183,12 +183,12 @@ func populateDedicatedConfigMapForKongPluginInstallation(
 			return customPlugin{}, false, fmt.Errorf("could not create new ConfigMap for KongPluginInstallation: %w", err)
 		}
 	case 1:
-		log.Trace(logger, fmt.Sprintf("Check if update existing ConfigMap %s for KongPluginInstallation", client.ObjectKeyFromObject(&cm)), kpi)
+		log.Trace(logger, fmt.Sprintf("Check if update existing ConfigMap %s for KongPluginInstallation", client.ObjectKeyFromObject(&cm)))
 		cm = mappedConfigMapForKPI[0]
 		if maps.Equal(cm.Data, underlyingCM.Data) {
-			log.Trace(logger, fmt.Sprintf("Nothing to update in existing ConfigMap %s for KongPluginInstallation", client.ObjectKeyFromObject(&cm)), kpi)
+			log.Trace(logger, fmt.Sprintf("Nothing to update in existing ConfigMap %s for KongPluginInstallation", client.ObjectKeyFromObject(&cm)))
 		} else {
-			log.Trace(logger, fmt.Sprintf("Update existing ConfigMap %s for KongPluginInstallation", client.ObjectKeyFromObject(&cm)), kpi)
+			log.Trace(logger, fmt.Sprintf("Update existing ConfigMap %s for KongPluginInstallation", client.ObjectKeyFromObject(&cm)))
 			cm.Data = underlyingCM.Data
 			if err := c.Update(ctx, &cm); err != nil {
 				if k8serrors.IsConflict(err) {
@@ -382,7 +382,7 @@ func patchDataPlaneStatus(ctx context.Context, cl client.Client, logger logr.Log
 		current.Status.Service != updated.Status.Service ||
 		current.Status.Selector != updated.Status.Selector {
 
-		log.Debug(logger, "patching DataPlane status", updated, "status", updated.Status)
+		log.Debug(logger, "patching DataPlane status", "status", updated.Status)
 		return true, cl.Status().Patch(ctx, updated, client.MergeFrom(current))
 	}
 

--- a/controller/dataplane/controller_utils.go
+++ b/controller/dataplane/controller_utils.go
@@ -140,7 +140,7 @@ func ensureDataPlaneReadyStatus(
 
 	switch len(deployments) {
 	case 0:
-		log.Debug(logger, "Deployment for DataPlane not present yet", dataplane)
+		log.Debug(logger, "Deployment for DataPlane not present yet")
 
 		// Set Ready to false for dataplane as the underlying deployment is not ready.
 		k8sutils.SetCondition(
@@ -168,13 +168,13 @@ func ensureDataPlaneReadyStatus(
 	case 1: // Expect just 1.
 
 	default: // More than 1.
-		log.Info(logger, "expected only 1 Deployment for DataPlane", dataplane)
+		log.Info(logger, "expected only 1 Deployment for DataPlane")
 		return ctrl.Result{Requeue: true}, nil
 	}
 
 	deployment := deployments[0]
 	if _, ready := isDeploymentReady(deployment.Status); !ready {
-		log.Debug(logger, "Deployment for DataPlane not ready yet", dataplane)
+		log.Debug(logger, "Deployment for DataPlane not ready yet")
 
 		// Set Ready to false for dataplane as the underlying deployment is not ready.
 		k8sutils.SetCondition(
@@ -201,7 +201,7 @@ func ensureDataPlaneReadyStatus(
 
 	switch len(services) {
 	case 0:
-		log.Debug(logger, "Ingress Service for DataPlane not present", dataplane)
+		log.Debug(logger, "Ingress Service for DataPlane not present")
 
 		// Set Ready to false for dataplane as the Service is not ready yet.
 		k8sutils.SetCondition(
@@ -224,13 +224,13 @@ func ensureDataPlaneReadyStatus(
 	case 1: // Expect just 1.
 
 	default: // More than 1.
-		log.Info(logger, "expected only 1 ingress Service for DataPlane", dataplane)
+		log.Info(logger, "expected only 1 ingress Service for DataPlane")
 		return ctrl.Result{Requeue: true}, nil
 	}
 
 	ingressService := services[0]
 	if !dataPlaneIngressServiceIsReady(&ingressService) {
-		log.Debug(logger, "Ingress Service for DataPlane not ready yet", dataplane)
+		log.Debug(logger, "Ingress Service for DataPlane not ready yet")
 
 		// Set Ready to false for dataplane as the Service is not ready yet.
 		k8sutils.SetCondition(

--- a/controller/dataplane/konnectextension_controller.go
+++ b/controller/dataplane/konnectextension_controller.go
@@ -112,7 +112,7 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return ctrl.Result{}, err
 		}
 
-		log.Info(logger, "KonnectExtension finalizer updated", konnectExtension)
+		log.Info(logger, "KonnectExtension finalizer updated")
 	}
 
 	return ctrl.Result{}, nil

--- a/controller/dataplane/owned_deployment.go
+++ b/controller/dataplane/owned_deployment.go
@@ -342,7 +342,7 @@ func reconcileDataPlaneDeployment(
 		}
 		if updated {
 			diff := cmp.Diff(original.Spec.Template, desired.Spec.Template, opts...)
-			log.Trace(logger, "DataPlane Deployment diff detected", dataplane, "diff", diff)
+			log.Trace(logger, "DataPlane Deployment diff detected", "diff", diff)
 		}
 
 		return patch.ApplyPatchIfNotEmpty(ctx, cl, logger, existing, original, updated)
@@ -352,6 +352,6 @@ func reconcileDataPlaneDeployment(
 		return op.Noop, nil, fmt.Errorf("failed creating Deployment for DataPlane %s: %w", dataplane.Name, err)
 	}
 
-	log.Debug(logger, "deployment for DataPlane created", dataplane, "deployment", desired.Name)
+	log.Debug(logger, "deployment for DataPlane created", "deployment", desired.Name)
 	return op.Created, desired, nil
 }

--- a/controller/dataplane/owned_finalizer_controller.go
+++ b/controller/dataplane/owned_finalizer_controller.go
@@ -172,7 +172,7 @@ func (r DataPlaneOwnedResourceFinalizerReconciler[T, PT]) Reconcile(ctx context.
 
 	// If the DataPlane still exists, we wait for it to be deleted.
 	if !ownerIsGone {
-		log.Debug(logger, "not deleting, owner dataplane still exists", obj, "dataplane", ownerRef.Name)
+		log.Debug(logger, "not deleting, owner dataplane still exists", "dataplane", ownerRef.Name)
 		return ctrl.Result{}, nil
 	}
 
@@ -185,7 +185,7 @@ func (r DataPlaneOwnedResourceFinalizerReconciler[T, PT]) Reconcile(ctx context.
 	if err := r.Client.Patch(ctx, obj, client.MergeFrom(old)); err != nil {
 		if k8serrors.IsNotFound(err) {
 			// If the object is already gone, we don't need to do anything.
-			log.Debug(logger, "object is already gone", obj)
+			log.Debug(logger, "object is already gone")
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to remove finalizer from %s %s: %w", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), err)

--- a/controller/gateway/controller_watch.go
+++ b/controller/gateway/controller_watch.go
@@ -230,9 +230,9 @@ func (r *Reconciler) listManagedGatewaysInNamespace(ctx context.Context, obj cli
 
 		if _, err := gatewayclass.Get(ctx, r.Client, string(gateway.Spec.GatewayClassName)); err != nil {
 			if errors.As(err, &operatorerrors.ErrUnsupportedGatewayClass{}) {
-				log.Debug(logger, "gateway class not supported, ignoring", gateway)
+				log.Debug(logger, "gateway class not supported, ignoring")
 			} else {
-				log.Error(logger, err, "failed to get Gateway's GatewayClass", gateway,
+				log.Error(logger, err, "failed to get Gateway's GatewayClass",
 					"gatewayClass", objKey.Name,
 					"gateway", gateway.Name,
 					"namespace", gateway.Namespace,

--- a/controller/gatewayclass/controller.go
+++ b/controller/gatewayclass/controller.go
@@ -43,13 +43,13 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.GetLogger(ctx, "gatewayclass", r.DevelopmentMode)
 
-	log.Trace(logger, "reconciling gatewayclass resource", req)
+	log.Trace(logger, "reconciling gatewayclass resource")
 
 	gwc := gatewayclass.NewDecorator()
 	if err := r.Client.Get(ctx, req.NamespacedName, gwc.GatewayClass); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log.Debug(logger, "processing gatewayclass", gwc.GatewayClass)
+	log.Debug(logger, "processing gatewayclass")
 
 	if !gwc.IsControlled() {
 		return ctrl.Result{}, nil
@@ -70,7 +70,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		)
 		if err := r.Status().Patch(ctx, gwc.GatewayClass, client.MergeFrom(oldGwc)); err != nil {
 			if k8serrors.IsConflict(err) {
-				log.Debug(logger, "conflict found when updating GatewayClass, retrying", gwc.GatewayClass)
+				log.Debug(logger, "conflict found when updating GatewayClass, retrying")
 				return ctrl.Result{
 					Requeue:      true,
 					RequeueAfter: controller.RequeueWithoutBackoff,

--- a/controller/kongplugininstallation/controller.go
+++ b/controller/kongplugininstallation/controller.go
@@ -87,7 +87,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.GetLogger(ctx, "kongplugininstallation", r.DevelopmentMode)
 
-	log.Trace(logger, "reconciling KongPluginInstallation resource", req)
+	log.Trace(logger, "reconciling KongPluginInstallation resource")
 	var kpi v1alpha1.KongPluginInstallation
 	if err := r.Client.Get(ctx, req.NamespacedName, &kpi); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -98,10 +98,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	log.Trace(logger, "managing KongPluginInstallation resource", kpi)
+	log.Trace(logger, "managing KongPluginInstallation resource")
 	var credentialsStore credentials.Store
 	if kpi.Spec.ImagePullSecretRef != nil {
-		log.Trace(logger, "getting secret for KongPluginInstallation resource", kpi)
+		log.Trace(logger, "getting secret for KongPluginInstallation resource")
 		kpiNamespace := gatewayv1.Namespace(kpi.Namespace)
 		imagePullSecretRef := kpi.Spec.ImagePullSecretRef
 		ref.EnsureNamespaceInSecretRef(imagePullSecretRef, kpiNamespace)
@@ -148,7 +148,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
-	log.Trace(logger, "fetch plugin for KongPluginInstallation resource", kpi)
+	log.Trace(logger, "fetch plugin for KongPluginInstallation resource")
 	plugin, err := image.FetchPlugin(ctx, kpi.Spec.Image, credentialsStore)
 	if err != nil {
 		return ctrl.Result{}, setStatusConditionFailedForKongPluginInstallation(ctx, r.Client, &kpi, fmt.Sprintf("problem with the image: %q error: %s", kpi.Spec.Image, err))

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -273,7 +273,7 @@ func shouldUpdate[
 		timeFromLastUpdate <= syncPeriod {
 		requeueAfter := syncPeriod - timeFromLastUpdate
 		log.Debug(ctrllog.FromContext(ctx),
-			"no need for update, requeueing after configured sync period", ent,
+			"no need for update, requeueing after configured sync period",
 			"last_update", condProgrammed.LastTransitionTime.Time.String(),
 			"time_from_last_update", timeFromLastUpdate.String(),
 			"requeue_after", requeueAfter.String(),

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -142,7 +142,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		logger = logger.WithValues("konnect_id", id)
 	}
 	ctx = ctrllog.IntoContext(ctx, logger)
-	log.Debug(logger, "reconciling", ent)
+	log.Debug(logger, "reconciling")
 
 	// If a type has a ControlPlane ref, handle it.
 	res, err := handleControlPlaneRef(ctx, r.Client, ent)
@@ -212,7 +212,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 						}
 						return ctrl.Result{}, fmt.Errorf("failed to remove finalizer %s: %w", KonnectCleanupFinalizer, err)
 					}
-					log.Debug(logger, "finalizer removed as the owning KongConsumer is being deleted or is already gone", ent,
+					log.Debug(logger, "finalizer removed as the owning KongConsumer is being deleted or is already gone",
 						"finalizer", KonnectCleanupFinalizer,
 					)
 				}
@@ -252,7 +252,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 						}
 						return ctrl.Result{}, fmt.Errorf("failed to remove finalizer %s: %w", KonnectCleanupFinalizer, err)
 					}
-					log.Debug(logger, "finalizer removed as the owning KongUpstream is being deleted or is already gone", ent,
+					log.Debug(logger, "finalizer removed as the owning KongUpstream is being deleted or is already gone",
 						"finalizer", KonnectCleanupFinalizer,
 					)
 				}
@@ -291,7 +291,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 						}
 						return ctrl.Result{}, fmt.Errorf("failed to remove finalizer %s: %w", KonnectCleanupFinalizer, err)
 					}
-					log.Debug(logger, "finalizer removed as the owning KongCertificate is being deleted or is already gone", ent,
+					log.Debug(logger, "finalizer removed as the owning KongCertificate is being deleted or is already gone",
 						"finalizer", KonnectCleanupFinalizer,
 					)
 				}
@@ -329,7 +329,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 						}
 						return ctrl.Result{}, fmt.Errorf("failed to remove finalizer %s: %w", KonnectCleanupFinalizer, err)
 					}
-					log.Debug(logger, "finalizer removed as the owning KongKeySet is being deleted or is already gone", ent,
+					log.Debug(logger, "finalizer removed as the owning KongKeySet is being deleted or is already gone",
 						"finalizer", KonnectCleanupFinalizer,
 					)
 					return ctrl.Result{}, nil

--- a/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
+++ b/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
@@ -158,7 +158,7 @@ func (r *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]) Reconcile(
 	}
 
 	ctx = ctrllog.IntoContext(ctx, logger)
-	log.Debug(logger, "reconciling", ent)
+	log.Debug(logger, "reconciling")
 
 	cl := client.NewNamespacedClient(r.Client, ent.GetNamespace())
 	kongPluginBindingList := configurationv1alpha1.KongPluginBindingList{}
@@ -183,7 +183,7 @@ func (r *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]) Reconcile(
 				}
 				return ctrl.Result{}, err
 			}
-			log.Debug(logger, "KongPluginBinding deleted", kpb)
+			log.Debug(logger, "KongPluginBinding deleted")
 		}
 		// in case no KongPluginBindings are referencing the entity, but it has the finalizer,
 		// we need to remove the finalizer.
@@ -216,7 +216,7 @@ func (r *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]) Reconcile(
 			}
 			return ctrl.Result{}, err
 		}
-		log.Debug(logger, "finalizers changed", ent,
+		log.Debug(logger, "finalizers changed",
 			"action", finalizersChangedAction,
 			"finalizer", consts.CleanupPluginBindingFinalizer,
 		)

--- a/controller/konnect/reconciler_kongplugin.go
+++ b/controller/konnect/reconciler_kongplugin.go
@@ -100,7 +100,7 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	log.Debug(logger, "reconciling", kongPlugin)
+	log.Debug(logger, "reconciling")
 	clientWithNamespace := client.NewNamespacedClient(r.client, kongPlugin.Namespace)
 	kongPluginNN := client.ObjectKeyFromObject(&kongPlugin)
 
@@ -195,7 +195,7 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				if err = clientWithNamespace.Create(ctx, kongPluginBinding); err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to create KongPluginBinding: %w", err)
 				}
-				log.Debug(logger, "Managed KongPluginBinding created", kongPluginBinding)
+				log.Debug(logger, "Managed KongPluginBinding created")
 
 			case 1:
 				existing := kpbList[0]
@@ -214,13 +214,13 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					}
 					return ctrl.Result{}, fmt.Errorf("failed to update KongPluginBinding: %w", err)
 				}
-				log.Debug(logger, "Managed KongPluginBinding updated", kongPluginBinding)
+				log.Debug(logger, "Managed KongPluginBinding updated")
 
 			default:
 				if err := k8sreduce.ReduceKongPluginBindings(ctx, clientWithNamespace, kpbList); err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to reduce KongPluginBindings: %w", err)
 				}
-				log.Info(logger, "deleted duplicated KongPluginBindings for KongPlugin", kongPlugin)
+				log.Info(logger, "deleted duplicated KongPluginBindings for KongPlugin")
 			}
 
 		}
@@ -239,7 +239,7 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				}
 				return ctrl.Result{}, err
 			}
-			log.Debug(logger, "KongPlugin finalizer added", kongPlugin, "finalizer", consts.PluginInUseFinalizer)
+			log.Debug(logger, "KongPlugin finalizer added", "finalizer", consts.PluginInUseFinalizer)
 			return ctrl.Result{}, nil
 		}
 	} else {
@@ -250,12 +250,12 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				}
 				return ctrl.Result{}, err
 			}
-			log.Debug(logger, "KongPlugin finalizer removed", kongPlugin, "finalizer", consts.PluginInUseFinalizer)
+			log.Debug(logger, "KongPlugin finalizer removed", "finalizer", consts.PluginInUseFinalizer)
 			return ctrl.Result{}, nil
 		}
 	}
 
-	log.Debug(logger, "reconciliation completed", kongPlugin)
+	log.Debug(logger, "reconciliation completed")
 	return ctrl.Result{}, nil
 }
 
@@ -338,7 +338,7 @@ func deleteKongPluginBindings(
 			}
 			return err
 		}
-		log.Info(logger, "KongPluginBinding deleted", pb)
+		log.Info(logger, "KongPluginBinding deleted")
 	}
 	return nil
 }

--- a/controller/konnect/reconciler_konnectapiauth.go
+++ b/controller/konnect/reconciler_konnectapiauth.go
@@ -98,7 +98,7 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 		logger         = log.GetLogger(ctx, entityTypeName, r.developmentMode)
 	)
 
-	log.Debug(logger, "reconciling", apiAuth)
+	log.Debug(logger, "reconciling")
 	if !apiAuth.GetDeletionTimestamp().IsZero() {
 		logger.Info("resource is being deleted")
 		// wait for termination grace period before cleaning up

--- a/controller/konnect/watch_kongplugin.go
+++ b/controller/konnect/watch_kongplugin.go
@@ -36,7 +36,7 @@ func mapPluginsFromAnnotation[
 			logger := log.GetLogger(ctx, entityTypeName, devMode)
 			log.Error(logger,
 				fmt.Errorf("cannot cast object to %s", entityTypeName),
-				fmt.Sprintf("%s mapping handler", entityTypeName), obj,
+				fmt.Sprintf("%s mapping handler", entityTypeName),
 			)
 			return []ctrl.Request{}
 		}
@@ -64,7 +64,10 @@ func (r *KongPluginReconciler) mapKongPluginBindings(ctx context.Context, obj cl
 	logger := log.GetLogger(ctx, "KongPlugin", r.developmentMode)
 	kongPluginBinding, ok := obj.(*configurationv1alpha1.KongPluginBinding)
 	if !ok {
-		log.Error(logger, errors.New("cannot cast object to KongPluginBinding"), "KongPluginBinding mapping handler", obj)
+		log.Error(logger,
+			errors.New("cannot cast object to KongPluginBinding"),
+			"KongPluginBinding mapping handler",
+		)
 		return []ctrl.Request{}
 	}
 

--- a/controller/konnect/watch_kongpluginbinding.go
+++ b/controller/konnect/watch_kongpluginbinding.go
@@ -241,7 +241,6 @@ func enqueueKongPluginBindingFor[
 				logger,
 				fmt.Errorf("unsupported entity type %s in KongPluginBinding watch", constraints.EntityTypeName[T]()),
 				"unsupported entity type",
-				ent,
 			)
 			return nil
 
@@ -259,7 +258,6 @@ func enqueueKongPluginBindingFor[
 				logger,
 				err,
 				"failed to list KongPluginBindings referencing %ss", constraints.EntityTypeName[T](),
-				ent,
 			)
 			return nil
 		}

--- a/controller/pkg/patch/patch.go
+++ b/controller/pkg/patch/patch.go
@@ -28,7 +28,7 @@ func ApplyPatchIfNotEmpty[
 	kind := existingResource.GetObjectKind().GroupVersionKind().Kind
 
 	if !updated {
-		log.Trace(logger, "No need for update", existingResource, kind, existingResource.GetName())
+		log.Trace(logger, "No need for update", "kind", kind, "name", existingResource.GetName())
 		return op.Noop, existingResource, nil
 	}
 
@@ -41,7 +41,7 @@ func ApplyPatchIfNotEmpty[
 	}
 	// Only perform the patch operation if the resulting patch is non empty.
 	if len(b) == 0 || bytes.Equal(b, []byte("{}")) {
-		log.Trace(logger, "No need for update", existingResource, kind, existingResource.GetName())
+		log.Trace(logger, "No need for update", "kind", kind, "name", existingResource.GetName())
 		return op.Noop, existingResource, nil
 	}
 
@@ -49,7 +49,7 @@ func ApplyPatchIfNotEmpty[
 		var t T
 		return op.Noop, t, fmt.Errorf("failed patching %s %s: %w", kind, existingResource.GetName(), err)
 	}
-	log.Debug(logger, "Resource modified", existingResource, kind, existingResource.GetName())
+	log.Debug(logger, "Resource modified", "kind", kind, "name", existingResource.GetName())
 	return op.Updated, existingResource, nil
 }
 
@@ -74,7 +74,7 @@ func ApplyStatusPatchIfNotEmpty[
 	}
 	// Only perform the patch operation if the resulting patch is non empty.
 	if len(b) == 0 || bytes.Equal(b, []byte("{}")) {
-		log.Trace(logger, "No need for status patch", existing)
+		log.Trace(logger, "No need for status patch")
 		return op.Noop, nil
 	}
 
@@ -83,6 +83,6 @@ func ApplyStatusPatchIfNotEmpty[
 			existing, client.ObjectKeyFromObject(existing), err,
 		)
 	}
-	log.Debug(logger, "Resource modified", existing)
+	log.Debug(logger, "Resource modified")
 	return op.Updated, nil
 }

--- a/controller/pkg/secrets/cert_test.go
+++ b/controller/pkg/secrets/cert_test.go
@@ -31,7 +31,6 @@ import (
 	operatorv1beta1 "github.com/kong/gateway-operator/api/v1beta1"
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/controller/pkg/op"
-	gwtypes "github.com/kong/gateway-operator/internal/types"
 	k8sresources "github.com/kong/gateway-operator/pkg/utils/kubernetes/resources"
 )
 
@@ -151,43 +150,37 @@ func TestLog(t *testing.T) {
 		o.DestWriter = &buf
 	})
 
-	gw := gwtypes.Gateway{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "gw",
-			Namespace: "ns",
-		},
-	}
 	t.Run("info logging works both for values and pointers to objects", func(t *testing.T) {
 		t.Cleanup(func() { buf.Reset() })
-		log.Info(logger, "message about gw", gw)
+		log.Info(logger, "message about gw")
 		require.NotContains(t, buf.String(), "unexpected type processed for")
 		buf.Reset()
-		log.Info(logger, "message about gw", &gw)
+		log.Info(logger, "message about gw")
 		require.NotContains(t, buf.String(), "unexpected type processed for")
 	})
 
 	t.Run("debug logging works both for values and pointers to objects", func(t *testing.T) {
 		t.Cleanup(func() { buf.Reset() })
-		log.Debug(logger, "message about gw", gw)
+		log.Debug(logger, "message about gw")
 		require.NotContains(t, buf.String(), "unexpected type processed for")
-		log.Debug(logger, "message about gw", &gw)
+		log.Debug(logger, "message about gw")
 		require.NotContains(t, buf.String(), "unexpected type processed for")
 	})
 
 	t.Run("trace logging works both for values and pointers to objects", func(t *testing.T) {
 		t.Cleanup(func() { buf.Reset() })
-		log.Trace(logger, "message about gw", gw)
+		log.Trace(logger, "message about gw")
 		require.NotContains(t, buf.String(), "unexpected type processed for")
 		t.Logf("log: %s", buf.String())
 		buf.Reset()
-		log.Trace(logger, "message about gw", &gw)
+		log.Trace(logger, "message about gw")
 		require.NotContains(t, buf.String(), "unexpected type processed for")
 		t.Logf("log: %s", buf.String())
 	})
 
 	t.Run("logging works and prints correct fields", func(t *testing.T) {
 		t.Cleanup(func() { buf.Reset() })
-		log.Info(logger, "message about gw", gw)
+		log.Info(logger, "message about gw")
 		entry := struct {
 			Level string `json:"level,omitempty"`
 			Msg   string `json:"msg,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the `rawObj` parameter - which was unused anyway since #727 has been merged -  from logger's methods.

1 important change here is that now, `Info()`, `Debug()`, `Trace()` and `Error()` accept only the (optional error for `Error()`) logger instance, message (`string`) and key value pairs as variadic parameter. The last part makes this error prone and susceptible for providing an invalid argument lists (i.e. odd number of arguments).

We could potentially alleviate this with making these functions accept a strongly typed:

```
type KV struct {
	K string
	V any
}
```

but then we'd need to allocate on each log call like so:

```
func Info(logger logr.Logger, msg string, kvs ... KV) {
	keyValues := make([]interface{}, 0, len(kvs)*2)
	for _, kv := range kvs {
		keyValues = append(keyValues, kv.K, kv.V)
	}
	_log(logger, logging.InfoLevel, msg, keyValues...)
}
```

Feel free to drop your comments on this performance vs type safety trade off.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

[Code handling the development mode logger setting](https://github.com/Kong/gateway-operator/blob/37f6d5eef6d8c2d3cbd249f67d3cf4bc054ca99f/controller/pkg/log/log.go#L54-L61) makes the dev mode logger not have several fields which might be beneficial for debugging/observability.

This makes the following difference between development mode enabled and disabled on logs:

- development mode disabled

```json
{
	"level": "debug",
	"ts": "2024-11-05T12:24:42.434+0100",
	"logger": "dataplane",
	"msg": "reconciliation complete for DataPlane resource",
	"controller": "dataplane",
	"controllerGroup": "gateway-operator.konghq.com",
	"controllerKind": "DataPlane",
	"DataPlane": {
		"name": "dataplane-example",
		"namespace": "default"
	},
	"namespace": "default",
	"name": "dataplane-example",
	"reconcileID": "2641ef78-cebe-4f69-a907-5e2cd84eb846"
}
```

- development mode enabled

```json
{
	"level": "\u001b[35mDEBUG\u001b[0m",
	"ts": "2024-11-05T12:31:13.633+0100",
	"logger": "DATAPLANE",
	"msg": "reconciliation complete for DataPlane resource"
}
```

we might want to remove that code to make those uniform.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
