### PR TITLE
fix(dataplane): properly default deprecated service account name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
 
+## Unreleased
+
+### Fixes
+
+- Fix setting the `ServiceAccountName` for `DataPlane`'s `Deployment`.
+  [#856](https://github.com/Kong/gateway-operator/pull/856)
+
 ## [v1.4.0]
 
 > Release date: 2024-10-31

--- a/pkg/utils/kubernetes/resources/strategicmerge.go
+++ b/pkg/utils/kubernetes/resources/strategicmerge.go
@@ -58,6 +58,10 @@ func SetDefaultsPodTemplateSpec(pts *corev1.PodTemplateSpec) {
 		return
 	}
 
+	// NOTE: copy the service account name to the deprecated field as the
+	// API server does that itself.
+	pts.Spec.DeprecatedServiceAccount = pts.Spec.ServiceAccountName
+
 	pkgapiscorev1.SetDefaults_PodSpec(&pts.Spec)
 	for i := range pts.Spec.Volumes {
 		SetDefaultsVolume(&pts.Spec.Volumes[i])

--- a/pkg/utils/kubernetes/resources/strategicmerge_test.go
+++ b/pkg/utils/kubernetes/resources/strategicmerge_test.go
@@ -890,3 +890,40 @@ func TestStrategicMergePatchPodTemplateSpec(t *testing.T) {
 		})
 	}
 }
+
+func TestSetDefaultsPodTemplateSpec(t *testing.T) {
+	testcases := []struct {
+		Name     string
+		Patch    *corev1.PodTemplateSpec
+		Expected corev1.PodTemplateSpec
+	}{
+		{
+			Name: "serivce account name is copied to deprecated field",
+			Patch: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "account",
+				},
+			},
+			Expected: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					ServiceAccountName:       "account",
+					DeprecatedServiceAccount: "account",
+					// NOTE: below set fields are irrelevant for the test
+					// but are set by SetDefaultsPodTemplateSpec regardless.
+					RestartPolicy:                 corev1.RestartPolicyAlways,
+					DNSPolicy:                     corev1.DNSClusterFirst,
+					SchedulerName:                 corev1.DefaultSchedulerName,
+					TerminationGracePeriodSeconds: lo.ToPtr(int64(30)),
+					SecurityContext:               &corev1.PodSecurityContext{},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			SetDefaultsPodTemplateSpec(tc.Patch)
+			assert.Equal(t, tc.Expected, *tc.Patch)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

API server fills in the deprecated service account field based on what's set in the service account name field. This causes the operator to incorrectly assume there's a diff which needs an update on the `Deployment`.

```
v1.PodTemplateSpec{
    ObjectMeta: {Labels: {\"app\": \"dataplane-example\", \"dataplane-pod-label\": \"example\", \"gateway-operator.konghq.com/selector\": \"86e60937-f0b6-4816-845f-ece9f4aa6a2a\"}, Annotations: {\"dataplane-pod-annotation\": \"example\"}},
    Spec: v1.PodSpec{
      ... // 8 identical fields
      NodeSelector:                 nil,
      ServiceAccountName:           \"aaa\",
-     DeprecatedServiceAccount:     \"aaa\",
+     DeprecatedServiceAccount:     \"\",
      AutomountServiceAccountToken: nil,
      NodeName:                     \"\",
      ... // 26 identical fields
    },
  }
"}
```

This PR fixes that by copying what's in `serviceAccountName` to `serviceAccount` (deprecated) field.

This is a temporary workaround until #500 (or similar) gets implemented.