### PR TITLE
chore: fix `log message has odd number of arguments`

### DIFF
--- a/controller/dataplane/owned_finalizer_controller.go
+++ b/controller/dataplane/owned_finalizer_controller.go
@@ -142,7 +142,9 @@ func (r DataPlaneOwnedResourceFinalizerReconciler[T, PT]) Reconcile(ctx context.
 	// If the object does not have the finalizer, we don't need to do anything.
 	hasDataPlaneOwnedFinalizer := lo.Contains(obj.GetFinalizers(), consts.DataPlaneOwnedWaitForOwnerFinalizer)
 	if !hasDataPlaneOwnedFinalizer {
-		log.Debug(logger, fmt.Sprintf("object has no %q finalizer", consts.DataPlaneOwnedWaitForOwnerFinalizer), obj)
+		log.Debug(logger, "object has no finalizer",
+			"finalizer", consts.DataPlaneOwnedWaitForOwnerFinalizer,
+		)
 		return ctrl.Result{}, nil
 	}
 
@@ -191,7 +193,9 @@ func (r DataPlaneOwnedResourceFinalizerReconciler[T, PT]) Reconcile(ctx context.
 		return ctrl.Result{}, fmt.Errorf("failed to remove finalizer from %s %s: %w", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), err)
 	}
 
-	log.Debug(logger, fmt.Sprintf("removed %q finalizer", consts.DataPlaneOwnedWaitForOwnerFinalizer), obj)
+	log.Debug(logger, "removed finalizer",
+		"finalizer", consts.DataPlaneOwnedWaitForOwnerFinalizer,
+	)
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix log entry missed in #848

```
{
	"level": "error",
	"ts": "2024-11-12T15:27:22.383+0100",
	"logger": "Deployment",
	"msg": "removed \"gateway-operator.konghq.com/wait-for-owner\" finalizer",
	"controller": "deployment",
	"controllerGroup": "apps",
	"controllerKind": "Deployment",
	"Deployment": {
		"name": "dataplane-dataplane-example-r8dsg",
		"namespace": "default"
	},
	"namespace": "default",
	"name": "dataplane-dataplane-example-r8dsg",
	"reconcileID": "2b0505cb-82dc-4a00-9d8c-2f6b0e528c3d",
	"error": "log message has odd number of arguments",
	"stacktrace": "github.com/kong/gateway-operator/controller/pkg/log.oddKeyValues\n\t/Users/USER/code_/gateway-operator/controller/pkg/log/log.go:47\ngithub.com/kong/gateway-operator/controller/pkg/log._log\n\t/Users/USER/code_/gateway-operator/controller/pkg/log/log.go:37\ngithub.com/kong/gateway-operator/controller/pkg/log.Debug\n\t/Users/USER/code_/gateway-operator/controller/pkg/log/log.go:20\ngithub.com/kong/gateway-operator/controller/dataplane.DataPlaneOwnedResourceFinalizerReconciler[...].Reconcile\n\t/Users/USER/code_/gateway-operator/controller/dataplane/owned_finalizer_controller.go:194\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/Users/USER/.gvm/pkgsets/go1.23.2/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/USER/.gvm/pkgsets/go1.23.2/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/USER/.gvm/pkgsets/go1.23.2/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/Users/USER/.gvm/pkgsets/go1.23.2/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:224"
}
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
