### PR TITLE
chore(deps): bump kong/kubernetes-configuration to v0.0.43

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -562,7 +562,7 @@ install: manifests kustomize install-gateway-api-crds
 
 KUBERNETES_CONFIGURATION_CRDS_PACKAGE ?= github.com/kong/kubernetes-configuration
 KUBERNETES_CONFIGURATION_CRDS_VERSION ?= $(shell go list -m -f '{{ .Version }}' $(KUBERNETES_CONFIGURATION_CRDS_PACKAGE))
-KUBERNETES_CONFIGURATION_CRDS_CRDS_LOCAL_PATH = $(shell go env GOPATH)/pkg/mod/$(KUBERNETES_CONFIGURATION_CRDS_PACKAGE)@$(KUBERNETES_CONFIGURATION_CRDS_VERSION)/config/crd
+KUBERNETES_CONFIGURATION_CRDS_CRDS_LOCAL_PATH = $(shell go env GOPATH)/pkg/mod/$(KUBERNETES_CONFIGURATION_CRDS_PACKAGE)@$(KUBERNETES_CONFIGURATION_CRDS_VERSION)/config/crd/gateway-operator
 
 # Install kubernetes-configuration CRDs into the K8s cluster specified in ~/.kube/config.
 .PHONY: install.kubernetes-configuration-crds

--- a/controller/konnect/ops/ops_kongroute_test.go
+++ b/controller/konnect/ops/ops_kongroute_test.go
@@ -31,7 +31,7 @@ func TestKongRouteToSDKRouteInput_Tags(t *testing.T) {
 		Spec: configurationv1alpha1.KongRouteSpec{
 			ServiceRef: &configurationv1alpha1.ServiceRef{
 				Type: configurationv1alpha1.ServiceRefNamespacedRef,
-				NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+				NamespacedRef: &configurationv1alpha1.KongObjectRef{
 					Name: "service-1",
 				},
 			},

--- a/controller/konnect/reconciler_kongplugin_combinations_test.go
+++ b/controller/konnect/reconciler_kongplugin_combinations_test.go
@@ -145,7 +145,7 @@ func TestGetCombinations(t *testing.T) {
 							Spec: configurationv1alpha1.KongRouteSpec{
 								ServiceRef: &configurationv1alpha1.ServiceRef{
 									Type: configurationv1alpha1.ServiceRefNamespacedRef,
-									NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+									NamespacedRef: &configurationv1alpha1.KongObjectRef{
 										Name: "s1",
 									},
 								},
@@ -302,7 +302,7 @@ func TestGetCombinations(t *testing.T) {
 							Spec: configurationv1alpha1.KongRouteSpec{
 								ServiceRef: &configurationv1alpha1.ServiceRef{
 									Type: configurationv1alpha1.ServiceRefNamespacedRef,
-									NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+									NamespacedRef: &configurationv1alpha1.KongObjectRef{
 										Name: "s1",
 									},
 								},
@@ -371,7 +371,7 @@ func TestGetCombinations(t *testing.T) {
 							Spec: configurationv1alpha1.KongRouteSpec{
 								ServiceRef: &configurationv1alpha1.ServiceRef{
 									Type: configurationv1alpha1.ServiceRefNamespacedRef,
-									NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+									NamespacedRef: &configurationv1alpha1.KongObjectRef{
 										Name: "s1",
 									},
 								},
@@ -417,7 +417,7 @@ func TestGetCombinations(t *testing.T) {
 							Spec: configurationv1alpha1.KongRouteSpec{
 								ServiceRef: &configurationv1alpha1.ServiceRef{
 									Type: configurationv1alpha1.ServiceRefNamespacedRef,
-									NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+									NamespacedRef: &configurationv1alpha1.KongObjectRef{
 										Name: "s1",
 									},
 								},
@@ -653,7 +653,7 @@ func TestGroupByControlPlane(t *testing.T) {
 							Spec: configurationv1alpha1.KongRouteSpec{
 								ServiceRef: &configurationv1alpha1.ServiceRef{
 									Type: configurationv1alpha1.ServiceRefNamespacedRef,
-									NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+									NamespacedRef: &configurationv1alpha1.KongObjectRef{
 										Name: "s1",
 									},
 								},
@@ -695,7 +695,7 @@ func TestGroupByControlPlane(t *testing.T) {
 							Spec: configurationv1alpha1.KongRouteSpec{
 								ServiceRef: &configurationv1alpha1.ServiceRef{
 									Type: configurationv1alpha1.ServiceRefNamespacedRef,
-									NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+									NamespacedRef: &configurationv1alpha1.KongObjectRef{
 										Name: "s1",
 									},
 								},

--- a/controller/konnect/reconciler_serviceref_test.go
+++ b/controller/konnect/reconciler_serviceref_test.go
@@ -125,7 +125,7 @@ func TestHandleServiceRef(t *testing.T) {
 				Spec: configurationv1alpha1.KongRouteSpec{
 					ServiceRef: &configurationv1alpha1.ServiceRef{
 						Type: configurationv1alpha1.ServiceRefNamespacedRef,
-						NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+						NamespacedRef: &configurationv1alpha1.KongObjectRef{
 							Name: "svc-ok",
 						},
 					},
@@ -173,7 +173,7 @@ func TestHandleServiceRef(t *testing.T) {
 				Spec: configurationv1alpha1.KongRouteSpec{
 					ServiceRef: &configurationv1alpha1.ServiceRef{
 						Type: configurationv1alpha1.ServiceRefNamespacedRef,
-						NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+						NamespacedRef: &configurationv1alpha1.KongObjectRef{
 							Name: "svc-ok",
 						},
 					},
@@ -196,7 +196,7 @@ func TestHandleServiceRef(t *testing.T) {
 				Spec: configurationv1alpha1.KongRouteSpec{
 					ServiceRef: &configurationv1alpha1.ServiceRef{
 						Type: configurationv1alpha1.ServiceRefNamespacedRef,
-						NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+						NamespacedRef: &configurationv1alpha1.KongObjectRef{
 							Name: "svc-not-programmed",
 						},
 					},
@@ -235,7 +235,7 @@ func TestHandleServiceRef(t *testing.T) {
 				Spec: configurationv1alpha1.KongRouteSpec{
 					ServiceRef: &configurationv1alpha1.ServiceRef{
 						Type: configurationv1alpha1.ServiceRefNamespacedRef,
-						NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+						NamespacedRef: &configurationv1alpha1.KongObjectRef{
 							Name: "svc-with-cp-ref-unprogrammed",
 						},
 					},

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1134,19 +1134,18 @@ _Appears in:_
 #### KongObjectRef
 
 
-KongObjectRef is a reference to another object representing a Kong entity with deterministic type.<br /><br />
-TODO: https://github.com/Kong/kubernetes-configuration/issues/96
-change other types to use the generic `KongObjectRef` and move it to a common package to prevent possible import cycles.
+KongObjectRef is a reference to another object representing a Kong entity with deterministic type.
 
 
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name is the name of the entity.<br /><br /> NOTE: the `Required` validation rule does not reject empty strings so we use `MinLength` to reject empty string here. |
+| `name` _string_ | Name is the name of the entity. |
 
 
 _Appears in:_
 - [KongSNISpec](#kongsnispec)
+- [ServiceRef](#serviceref)
 
 #### KongPluginBindingSpec
 
@@ -1600,22 +1599,6 @@ Namespace refers to a Kubernetes namespace. It must be a RFC 1123 label.
 _Appears in:_
 - [ControllerReference](#controllerreference)
 
-#### NamespacedServiceRef
-
-
-NamespacedServiceRef is a namespaced reference to a KongService.<br /><br />
-NOTE: currently cross namespace references are not supported.
-
-
-
-| Field | Description |
-| --- | --- |
-| `name` _string_ |  |
-
-
-_Appears in:_
-- [ServiceRef](#serviceref)
-
 #### ObjectName
 _Underlying type:_ `string`
 
@@ -1673,7 +1656,7 @@ ServiceRef is a reference to a KongService.
 | Field | Description |
 | --- | --- |
 | `type` _string_ | Type can be one of: - namespacedRef |
-| `namespacedRef` _[NamespacedServiceRef](#namespacedserviceref)_ | NamespacedRef is a reference to a KongService. |
+| `namespacedRef` _[KongObjectRef](#kongobjectref)_ | NamespacedRef is a reference to a KongService. |
 
 
 _Appears in:_

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/kong/gateway-operator
 
-go 1.22.7
-
-toolchain go1.23.2
+go 1.23.2
 
 // 1.2.2 was released on main branch with a breaking change that was not
 // intended to be released in 1.2.x:
@@ -17,7 +15,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-containerregistry v0.20.2
 	github.com/google/uuid v1.6.0
-	github.com/kong/kubernetes-configuration v0.0.41
+	github.com/kong/kubernetes-configuration v0.0.43
 	github.com/kong/kubernetes-telemetry v0.1.7
 	github.com/kong/kubernetes-testing-framework v0.47.2
 	github.com/kong/semver/v4 v4.0.1

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kong/go-kong v0.59.1 h1:AJZtyCD+Zyqe/mF/m+x3/qN/GPVxAH7jq9zGJTHRfjc=
 github.com/kong/go-kong v0.59.1/go.mod h1:8Vt6HmtgLNgL/7bSwAlz3DIWqBtzG7qEt9+OnMiQOa0=
-github.com/kong/kubernetes-configuration v0.0.41 h1:ELdPFCpN8+VmWU2eEL8kj+8PzaMYYAlKfVJDXA13pTw=
-github.com/kong/kubernetes-configuration v0.0.41/go.mod h1:zo835UJG2Rd9M8OcdkrbbelHLXsjh8fg71P77PZX2iU=
+github.com/kong/kubernetes-configuration v0.0.43 h1:CzMP38+aMjhRTsE+xwAbq2I3nXgWvLlxhcoUZ4BQ+LY=
+github.com/kong/kubernetes-configuration v0.0.43/go.mod h1:ym++Oygj/wZjaCanK8a+mjZ1jttPF7gPP1OBV0aqI00=
 github.com/kong/kubernetes-telemetry v0.1.7 h1:R4NUpvbF5uZ+5kgSQsIcf/oulRBGQCHsffFRDE4wxV4=
 github.com/kong/kubernetes-telemetry v0.1.7/go.mod h1:USy5pcD1+Mm9NtKuz3Pb/rSx71VN76gHCFhdbAB4/lg=
 github.com/kong/kubernetes-testing-framework v0.47.2 h1:+2Z9anTpbV/hwNeN+NFQz53BMU+g3QJydkweBp3tULo=

--- a/hack/generators/go.mod
+++ b/hack/generators/go.mod
@@ -1,8 +1,6 @@
 module github.com/kong/gateway-operator/hack/generators
 
-go 1.22.7
-
-toolchain go1.23.2
+go 1.23.2
 
 replace github.com/kong/gateway-operator => ../../
 

--- a/pkg/utils/test/setup_helpers.go
+++ b/pkg/utils/test/setup_helpers.go
@@ -234,7 +234,7 @@ func DeployCRDs(ctx context.Context, crdPath string, operatorClient *operatorcli
 	}
 	// Then install CRDs from the module found in `$GOPATH`.
 	kongCRDPath := filepath.Join(build.Default.GOPATH, "pkg", "mod", "github.com", "kong",
-		"kubernetes-configuration@"+kongCRDVersion, "config", "crd")
+		"kubernetes-configuration@"+kongCRDVersion, "config", "crd", "gateway-operator")
 	fmt.Printf("INFO: deploying Kong (kubernetes-configuration) CRDs: %s\n", kongCRDPath)
 	if err := clusters.KustomizeDeployForCluster(ctx, env.Cluster(), kongCRDPath); err != nil {
 		return err

--- a/test/envtest/setup.go
+++ b/test/envtest/setup.go
@@ -55,7 +55,7 @@ func Setup(t *testing.T, ctx context.Context, scheme *k8sruntime.Scheme) (*rest.
 	kongConfVersion, err := testutil.ExtractModuleVersion(testutil.KubernetesConfigurationModuleName)
 	require.NoError(t, err)
 	kongCRDPath := filepath.Join(build.Default.GOPATH, "pkg", "mod", "github.com", "kong", "kubernetes-configuration@"+kongConfVersion, "config", "crd")
-	kongBaseCRDPath := kongCRDPath + "/bases"
+	kongBaseCRDPath := kongCRDPath + "/gateway-operator"
 	// we do not deal with incubator resources here, so we only install base CRDs.
 	t.Logf("install Kong CRDs from path %s", kongCRDPath)
 	_, err = envtest.InstallCRDs(cfg, envtest.CRDInstallOptions{

--- a/test/helpers/deploy/deploy_resources.go
+++ b/test/helpers/deploy/deploy_resources.go
@@ -267,7 +267,7 @@ func KongRouteAttachedToService(
 			},
 			ServiceRef: &configurationv1alpha1.ServiceRef{
 				Type: configurationv1alpha1.ServiceRefNamespacedRef,
-				NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+				NamespacedRef: &configurationv1alpha1.KongObjectRef{
 					Name: kongService.Name,
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps `kong/kubernetes-configuration` dependency to v0.0.43 which introduced separate channels for KIC and KGO.
