### PR TITLE
chore(linter): enable all go-vet rules

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -40,6 +40,11 @@ linters-settings:
       - default
       - prefix(github.com/kong/kubernetes-configuration)
       - prefix(github.com/kong/gateway-operator)
+  govet:
+    enable-all: true # To have checks like e.g. unusedwrite.
+    disable:
+      - fieldalignment
+      - shadow
   importas:
     no-unaliased: true
     alias:

--- a/controller/dataplane/owned_deployment.go
+++ b/controller/dataplane/owned_deployment.go
@@ -331,7 +331,7 @@ func reconcileDataPlaneDeployment(
 			// the replicas to the minReplicas if the existing Deployment replicas
 			// are less than the minReplicas to enforce faster scaling before HPA
 			// kicks in.
-			(scaling != nil && scaling.HorizontalScaling != nil &&
+			(scaling.HorizontalScaling != nil &&
 				scaling.HorizontalScaling.MinReplicas != nil &&
 				existing.Spec.Replicas != nil &&
 				*existing.Spec.Replicas < *scaling.HorizontalScaling.MinReplicas) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Inspired by
- https://github.com/Kong/kubernetes-ingress-controller/pull/6685

enable all Go vet rules to avoid such situations in KGO projects and fix reported redundant condition check.

Checks `fieldalignment` and `shadow` report many issues, therefore decide if it is worth enabling them, and let's do it in separate PRs.
