### PR TITLE
fix: set DataPlane's extensions through GatewayConfiguration

### DIFF
--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -137,6 +137,7 @@ func gatewayConfigDataPlaneOptionsToDataPlaneOptions(
 
 	dataPlaneOptions := &operatorv1beta1.DataPlaneOptions{
 		Deployment:       opts.Deployment,
+		Extensions:       opts.Extensions,
 		PluginsToInstall: pluginsToInstall,
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

#453 missed configuring extensions for `Gateway`'s `DataPlane` so this is adding the missing bit.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

This requires tests to be added.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
