### PR TITLE
chore: enhance KongPluginInstallation example and document tests

### DIFF
--- a/config/samples/gateway-httproute.yaml
+++ b/config/samples/gateway-httproute.yaml
@@ -115,8 +115,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           resources:
-            requests:
-              cpu: 10m
+            limits:
+              cpu: 100m
+              memory: 100Mi
 ---
 kind: GatewayConfiguration
 apiVersion: gateway-operator.konghq.com/v1beta1

--- a/config/samples/gateway-kongplugininstallation-httproute.yaml
+++ b/config/samples/gateway-kongplugininstallation-httproute.yaml
@@ -19,8 +19,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    app: echo
   name: echo
 spec:
   replicas: 1
@@ -42,26 +40,10 @@ spec:
           ports:
             - containerPort: 8080
               name: http
-          env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
           resources:
-            requests:
-              cpu: 10m
+            limits:
+              cpu: 100m
+              memory: 100Mi
 ---
 kind: GatewayConfiguration
 apiVersion: gateway-operator.konghq.com/v1beta1
@@ -142,11 +124,14 @@ spec:
           kind: Service
           port: 80
 ---
+# It adds header "myheader: this-is-extra-header" to the response.
 apiVersion: configuration.konghq.com/v1
 kind: KongPlugin
 metadata:
   name: kong-custom-plugin
 plugin: additional-custom-plugin
+config:
+  header_value: this-is-extra-header
 ---
 kind: KongPluginInstallation
 apiVersion: gateway-operator.konghq.com/v1alpha1
@@ -154,8 +139,10 @@ metadata:
   name: additional-custom-plugin
   namespace: additional
 spec:
-  image: northamerica-northeast1-docker.pkg.dev/k8s-team-playground/plugin-example/myheader
+  # See https://docs.konghq.com/gateway-operator/latest/guides/plugin-distribution/#create-a-custom-plugin
+  image: kong/plugin-example:1.0.0
 ---
+# It adds header "newheader: amazing" to the response.
 apiVersion: configuration.konghq.com/v1
 kind: KongPlugin
 metadata:

--- a/hack/plugin-images/README.md
+++ b/hack/plugin-images/README.md
@@ -1,0 +1,24 @@
+# Plugin Images
+
+Tests
+
+- [test/integration/test_kongplugininstallation.go](../../test/integration/test_kongplugininstallation.go)
+- [controller/kongplugininstallation/image/image_test.go](../../controller/kongplugininstallation/image/image_test.go)
+
+rely on images built with `Dockerfile`s in this directory and pushed to remote registries. Examine them for more details.
+
+The content of the directory `myheader` is based on the official documentation
+[Plugin Distribution - Create a custom plugin](https://docs.konghq.com/gateway-operator/latest/guides/plugin-distribution/#create-a-custom-plugin).
+
+To build the images, run the following command inside this directory:
+
+```shell
+docker build -t <IMAGE_NAME> -f <FILE_NAME>.Dockerfile .
+```
+
+How to configure GCP registries:
+
+- `northamerica-northeast1-docker.pkg.dev/k8s-team-playground/plugin-example` (public)
+- `northamerica-northeast1-docker.pkg.dev/k8s-team-playground/plugin-example-private` (private)
+
+used for tests check [the official GCP documentation](https://cloud.google.com/artifact-registry/docs/docker).

--- a/hack/plugin-images/invalid-layers.Dockerfile
+++ b/hack/plugin-images/invalid-layers.Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+
+COPY myheader /
+
+COPY README.md /

--- a/hack/plugin-images/invalid-name.Dockerfile
+++ b/hack/plugin-images/invalid-name.Dockerfile
@@ -1,0 +1,9 @@
+FROM scratch AS builder
+
+# Rename handler.lua to an invalid name.
+COPY myheader/handler.lua /myheader/add-header.lua
+COPY myheader/schema.lua /myheader/schema.lua
+
+FROM scratch
+
+COPY --from=builder /myheader /

--- a/hack/plugin-images/invalid-size-combined.Dockerfile
+++ b/hack/plugin-images/invalid-size-combined.Dockerfile
@@ -1,0 +1,10 @@
+FROM busybox:1.31.1 AS builder
+
+RUN mkdir myheader &&\
+    dd if=/dev/urandom of=/myheader/handler.lua bs=512k count=1 &&\
+    dd if=/dev/urandom of=/myheader/schema.lua bs=512k count=1
+
+
+FROM scratch
+
+COPY --from=builder /myheader /

--- a/hack/plugin-images/invalid-size-one.Dockerfile
+++ b/hack/plugin-images/invalid-size-one.Dockerfile
@@ -1,0 +1,9 @@
+FROM busybox:1.31.1 AS builder
+
+COPY myheader/schema.lua /myheader/
+RUN dd if=/dev/urandom of=/myheader/handler.lua bs=1M count=2
+
+
+FROM scratch
+
+COPY --from=builder /myheader /

--- a/hack/plugin-images/missing-file.Dockerfile
+++ b/hack/plugin-images/missing-file.Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+
+# File schema.lua will be missing in the final image.
+COPY myheader/handler.lua /

--- a/hack/plugin-images/myheader-2.Dockerfile
+++ b/hack/plugin-images/myheader-2.Dockerfile
@@ -1,0 +1,10 @@
+FROM busybox:1.31.1 AS builder
+
+COPY myheader /myheader/
+RUN sed -i 's/"myheader"/"newheader"/g' /myheader/**
+RUN sed -i 's/"roar"/"amazing"/g' /myheader/**
+
+
+FROM scratch
+
+COPY --from=builder /myheader /

--- a/hack/plugin-images/myheader.Dockerfile
+++ b/hack/plugin-images/myheader.Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+
+COPY myheader /

--- a/hack/plugin-images/myheader/handler.lua
+++ b/hack/plugin-images/myheader/handler.lua
@@ -1,0 +1,12 @@
+local MyHeader = {}
+
+MyHeader.PRIORITY = 1000
+MyHeader.VERSION = "1.0.0"
+
+function MyHeader:header_filter(conf)
+  -- do custom logic here
+  kong.response.set_header("myheader", conf.header_value)
+end
+
+return MyHeader
+

--- a/hack/plugin-images/myheader/schema.lua
+++ b/hack/plugin-images/myheader/schema.lua
@@ -1,0 +1,12 @@
+return {
+  name = "myheader",
+  fields = {
+    { config = {
+        type = "record",
+        fields = {
+          { header_value = { type = "string", default = "roar", }, },
+        },
+    }, },
+  }
+}
+

--- a/test/integration/test_kongplugininstallation.go
+++ b/test/integration/test_kongplugininstallation.go
@@ -34,14 +34,16 @@ import (
 
 func TestKongPluginInstallationEssentials(t *testing.T) {
 	namespace, cleaner := helpers.SetupTestEnv(t, GetCtx(), GetEnv())
+	t.Log("this test accesses container registries on public internet")
 
+	// Learn more how images were build and pushed to the registry in hack/plugin-images/README.md.
 	const registryUrl = "northamerica-northeast1-docker.pkg.dev/k8s-team-playground/"
-
+	// Source: hack/plugin-images/invalid-layers.Dockerfile.
 	const pluginInvalidLayersImage = registryUrl + "plugin-example/invalid-layers"
-
+	// Source: hack/plugin-images/myheader.Dockerfile.
 	const pluginMyHeaderImage = registryUrl + "plugin-example/myheader"
 	expectedHeadersForMyHeader := http.Header{"myheader": {"roar"}}
-
+	// Source: hack/plugin-images/myheader-2.Dockerfile.
 	const pluginMyHeader2Image = registryUrl + "plugin-example-private/myheader-2"
 	expectedHeadersForMyHeader2 := http.Header{"newheader": {"amazing"}}
 

--- a/test/integration/utils.go
+++ b/test/integration/utils.go
@@ -163,6 +163,9 @@ func GetVolumeMountsByVolumeName(volumeMounts []corev1.VolumeMount, name string)
 	return ret
 }
 
+// GetKongPluginImageRegistryCredentialsForTests returns the credentials for the image registry with plugins for tests.
+// The expected format is the same as ~/.docker/config.json, see
+// https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#log-in-to-docker-hub
 func GetKongPluginImageRegistryCredentialsForTests() string {
 	return os.Getenv("KONG_PLUGIN_IMAGE_REGISTRY_CREDENTIALS")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Tests for `KongPluginInstallation` rely on container registries configured in k8s-team's GCP project and images built according to specifications. This PR leaves some description for future us to learn how those were built and what they contain. Moreover, it simplifies and enhances examplar to make it more informative. 

**Which issue this PR fixes**

Closes https://github.com/Kong/gateway-operator/issues/465

**Special notes for your reviewer**:

Building some kind of machinery/scripts for auto bootstrap, etc. seems like an overkill because they won't change often (also, we've already used remote registers in our tests, e.g. KIC image, http-echo, etc.). Furthermore, building and uploading a container image according to the docs is not the hardest / most time-consuming job in the world - [see the cost/saving ratio](https://imgs.xkcd.com/comics/is_it_worth_the_time_2x.png)

> Reviewer [please check](https://console.cloud.google.com/artifacts?pli=1&invt=AbiK-A&inv=1&project=k8s-team-playground) if you have access. As a member of k8s-team you should.

