### PR TITLE
chore: set default `spec.serverHostname` in CRD `KonnectExtension` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@
 
 ## Unreleased
 
+### Changed
+
+- `KonnectExtension` does not require `spec.serverHostname` to be set by a user
+  anymore - default is set to `konghq.com`.
+  [#947](https://github.com/Kong/gateway-operator/pull/947)
+
 ## [v1.4.1]
 
 > Release date: 2024-11-28

--- a/api/v1alpha1/konnect_extension_types.go
+++ b/api/v1alpha1/konnect_extension_types.go
@@ -35,7 +35,7 @@ const (
 // +kubebuilder:subresource:status
 
 // KonnectExtension is the Schema for the KonnectExtension API,
-// and is intended to be referenced as extension by the dataplane API.
+// and is intended to be referenced as extension by the DataPlane API.
 // If a DataPlane successfully refers a KonnectExtension, the DataPlane
 // deployment spec gets customized to include the konnect-related configuration.
 // +kubebuilder:validation:XValidation:rule="oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable."
@@ -74,15 +74,16 @@ type KonnectExtensionSpec struct {
 	// +kubebuilder:validation:Required
 	ControlPlaneRegion string `json:"controlPlaneRegion"`
 
-	// ServerHostname is the fully qualified domain name of the konnect server. This
-	// matches the RFC 1123 definition of a hostname with 1 notable exception that
-	// numeric IP addresses are not allowed.
+	// ServerHostname is the fully qualified domain name of the Konnect server.
+	// For typical operation a default value doesn't need to be adjusted.
+	// It matches the RFC 1123 definition of a hostname with 1 notable exception
+	// that numeric IP addresses are not allowed.
 	//
 	// Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
 	// alphanumeric characters or '-', and must start and end with an alphanumeric
 	// character. No other punctuation is allowed.
 	//
-	// +kubebuilder:example:=foo.example.com
+	// +kubebuilder:default:=konghq.com
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`

--- a/config/crd/bases/gateway-operator.konghq.com_konnectextensions.yaml
+++ b/config/crd/bases/gateway-operator.konghq.com_konnectextensions.yaml
@@ -22,7 +22,7 @@ spec:
       openAPIV3Schema:
         description: |-
           KonnectExtension is the Schema for the KonnectExtension API,
-          and is intended to be referenced as extension by the dataplane API.
+          and is intended to be referenced as extension by the DataPlane API.
           If a DataPlane successfully refers a KonnectExtension, the DataPlane
           deployment spec gets customized to include the konnect-related configuration.
         properties:
@@ -145,15 +145,16 @@ spec:
                 - clusterCertificateSecretRef
                 type: object
               serverHostname:
+                default: konghq.com
                 description: |-
-                  ServerHostname is the fully qualified domain name of the konnect server. This
-                  matches the RFC 1123 definition of a hostname with 1 notable exception that
-                  numeric IP addresses are not allowed.
+                  ServerHostname is the fully qualified domain name of the Konnect server.
+                  For typical operation a default value doesn't need to be adjusted.
+                  It matches the RFC 1123 definition of a hostname with 1 notable exception
+                  that numeric IP addresses are not allowed.
 
                   Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
                   alphanumeric characters or '-', and must start and end with an alphanumeric
                   character. No other punctuation is allowed.
-                example: foo.example.com
                 maxLength: 253
                 minLength: 1
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$

--- a/config/samples/dataplane-konnect-extension.yaml
+++ b/config/samples/dataplane-konnect-extension.yaml
@@ -26,7 +26,6 @@ spec:
   controlPlaneRef:
     type: konnectID
     konnectID: <YOUR-CP-KONNECT-ID>
-  serverHostname: your.konnect.server
   controlPlaneRegion: eu
   konnectControlPlaneAPIAuthConfiguration:
     clusterCertificateSecretRef:

--- a/controller/dataplane/konnectextension_test.go
+++ b/controller/dataplane/konnectextension_test.go
@@ -30,14 +30,14 @@ func TestApplyKonnectExtension(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		dataplane     *operatorv1beta1.DataPlane
+		dataPlane     *operatorv1beta1.DataPlane
 		konnectExt    *operatorv1alpha1.KonnectExtension
 		secret        *corev1.Secret
 		expectedError error
 	}{
 		{
 			name: "no extensions",
-			dataplane: &operatorv1beta1.DataPlane{
+			dataPlane: &operatorv1beta1.DataPlane{
 				Spec: operatorv1beta1.DataPlaneSpec{
 					DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
 						Extensions: []operatorv1alpha1.ExtensionRef{},
@@ -47,7 +47,7 @@ func TestApplyKonnectExtension(t *testing.T) {
 		},
 		{
 			name: "cross-namespace reference",
-			dataplane: &operatorv1beta1.DataPlane{
+			dataPlane: &operatorv1beta1.DataPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 				},
@@ -93,7 +93,7 @@ func TestApplyKonnectExtension(t *testing.T) {
 		},
 		{
 			name: "Extension not found",
-			dataplane: &operatorv1beta1.DataPlane{
+			dataPlane: &operatorv1beta1.DataPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 				},
@@ -120,7 +120,7 @@ func TestApplyKonnectExtension(t *testing.T) {
 		},
 		{
 			name: "Extension properly referenced, secret not found",
-			dataplane: &operatorv1beta1.DataPlane{
+			dataPlane: &operatorv1beta1.DataPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 				},
@@ -165,7 +165,7 @@ func TestApplyKonnectExtension(t *testing.T) {
 		},
 		{
 			name: "Extension properly referenced, no deployment Options set.",
-			dataplane: &operatorv1beta1.DataPlane{
+			dataPlane: &operatorv1beta1.DataPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 				},
@@ -215,7 +215,7 @@ func TestApplyKonnectExtension(t *testing.T) {
 		},
 		{
 			name: "Extension properly referenced, with deployment Options set.",
-			dataplane: &operatorv1beta1.DataPlane{
+			dataPlane: &operatorv1beta1.DataPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 				},
@@ -281,7 +281,7 @@ func TestApplyKonnectExtension(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			objs := []runtime.Object{tt.dataplane}
+			objs := []runtime.Object{tt.dataPlane}
 			if tt.konnectExt != nil {
 				objs = append(objs, tt.konnectExt)
 			}
@@ -290,15 +290,15 @@ func TestApplyKonnectExtension(t *testing.T) {
 			}
 			cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
-			dataplane := tt.dataplane.DeepCopy()
+			dataplane := tt.dataPlane.DeepCopy()
 			err := applyKonnectExtension(context.Background(), cl, dataplane)
 			if tt.expectedError != nil {
 				require.ErrorIs(t, err, tt.expectedError)
 			} else {
 				require.NoError(t, err)
 				requiredEnv := []corev1.EnvVar{}
-				if tt.dataplane.Spec.Deployment.PodTemplateSpec != nil {
-					if container := k8sutils.GetPodContainerByName(&tt.dataplane.Spec.Deployment.PodTemplateSpec.Spec, consts.DataPlaneProxyContainerName); container != nil {
+				if tt.dataPlane.Spec.Deployment.PodTemplateSpec != nil {
+					if container := k8sutils.GetPodContainerByName(&tt.dataPlane.Spec.Deployment.PodTemplateSpec.Spec, consts.DataPlaneProxyContainerName); container != nil {
 						requiredEnv = container.Env
 					}
 				}

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -2,7 +2,7 @@
 # Debug image
 # ------------------------------------------------------------------------------
 
-FROM --platform=$BUILDPLATFORM golang:1.23.4 as debug
+FROM --platform=$BUILDPLATFORM golang:1.23.4 AS debug
 
 ARG GOPATH
 ARG GOCACHE

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1824,7 +1824,7 @@ and configured with KongPlugin CRD.
 
 
 KonnectExtension is the Schema for the KonnectExtension API,
-and is intended to be referenced as extension by the dataplane API.
+and is intended to be referenced as extension by the DataPlane API.
 If a DataPlane successfully refers a KonnectExtension, the DataPlane
 deployment spec gets customized to include the konnect-related configuration.
 
@@ -2107,7 +2107,7 @@ KonnectExtensionSpec defines the desired state of KonnectExtension.
 | --- | --- |
 | `controlPlaneRef` _[ControlPlaneRef](#controlplaneref)_ | ControlPlaneRef is a reference to a ControlPlane this KonnectExtension is associated with. |
 | `controlPlaneRegion` _string_ | ControlPlaneRegion is the region of the Konnect Control Plane. |
-| `serverHostname` _string_ | ServerHostname is the fully qualified domain name of the konnect server. This matches the RFC 1123 definition of a hostname with 1 notable exception that numeric IP addresses are not allowed.<br /><br /> Note that as per RFC1035 and RFC1123, a *label* must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character. No other punctuation is allowed. |
+| `serverHostname` _string_ | ServerHostname is the fully qualified domain name of the Konnect server. For typical operation a default value doesn't need to be adjusted. It matches the RFC 1123 definition of a hostname with 1 notable exception that numeric IP addresses are not allowed.<br /><br /> Note that as per RFC1035 and RFC1123, a *label* must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character. No other punctuation is allowed. |
 | `konnectControlPlaneAPIAuthConfiguration` _[KonnectControlPlaneAPIAuthConfiguration](#konnectcontrolplaneapiauthconfiguration)_ | AuthConfiguration must be used to configure the Konnect API authentication. |
 | `clusterDataPlaneLabels` _object (keys:string, values:string)_ | ClusterDataPlaneLabels is a set of labels that will be applied to the Konnect DataPlane. |
 

--- a/internal/utils/dataplane/env.go
+++ b/internal/utils/dataplane/env.go
@@ -60,7 +60,7 @@ type KongInKonnectParams struct {
 	Server       string
 }
 
-// KongInKonnectDefaults returnes the map of Konnect-related env vars properly configured.
+// KongInKonnectDefaults returns the map of Konnect-related env vars properly configured.
 func KongInKonnectDefaults(params KongInKonnectParams) map[string]string {
 	newEnvSet := make(map[string]string, len(kongInKonnectDefaultsTemplate))
 	for k, v := range kongInKonnectDefaultsTemplate {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request includes setting default value of `spec.serverHostname` to `konghq.com` (this is the only address used by customers) in the `KonnectExtension` configuration as well as some minor code and test adjustments.

**Which issue this PR fixes**

Part of https://github.com/Kong/gateway-operator/issues/936


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
