### PR TITLE
fix(konnect): fix EnqueueRequestsFromMapFunc predicates for konnect entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fix watch predicates for types shared between KGO and KIC.
+  [#948](https://github.com/Kong/gateway-operator/pull/948)
+
 ### Changed
 
 - `KonnectExtension` does not require `spec.serverHostname` to be set by a user

--- a/controller/konnect/reconciler_kongplugin.go
+++ b/controller/konnect/reconciler_kongplugin.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/pkg/consts"
@@ -59,6 +60,7 @@ func (r *KongPluginReconciler) SetupWithManager(_ context.Context, mgr ctrl.Mana
 			handler.EnqueueRequestsFromMapFunc(mapPluginsFromAnnotation[configurationv1alpha1.KongService](r.developmentMode)),
 			builder.WithPredicates(
 				kongPluginsAnnotationChangedPredicate,
+				predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1alpha1.KongService]),
 			),
 		).
 		Watches(
@@ -66,6 +68,7 @@ func (r *KongPluginReconciler) SetupWithManager(_ context.Context, mgr ctrl.Mana
 			handler.EnqueueRequestsFromMapFunc(mapPluginsFromAnnotation[configurationv1alpha1.KongRoute](r.developmentMode)),
 			builder.WithPredicates(
 				kongPluginsAnnotationChangedPredicate,
+				predicate.NewPredicateFuncs(kongRouteRefersToKonnectGatewayControlPlane(r.client)),
 			),
 		).
 		Watches(
@@ -73,6 +76,7 @@ func (r *KongPluginReconciler) SetupWithManager(_ context.Context, mgr ctrl.Mana
 			handler.EnqueueRequestsFromMapFunc(mapPluginsFromAnnotation[configurationv1.KongConsumer](r.developmentMode)),
 			builder.WithPredicates(
 				kongPluginsAnnotationChangedPredicate,
+				predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1.KongConsumer]),
 			),
 		).
 		Watches(
@@ -80,6 +84,7 @@ func (r *KongPluginReconciler) SetupWithManager(_ context.Context, mgr ctrl.Mana
 			handler.EnqueueRequestsFromMapFunc(mapPluginsFromAnnotation[configurationv1beta1.KongConsumerGroup](r.developmentMode)),
 			builder.WithPredicates(
 				kongPluginsAnnotationChangedPredicate,
+				predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1beta1.KongConsumerGroup]),
 			),
 		).
 		Complete(r)

--- a/controller/konnect/watch_credentialacl.go
+++ b/controller/konnect/watch_credentialacl.go
@@ -46,6 +46,9 @@ func kongCredentialACLReconciliationWatchOptions(
 				handler.EnqueueRequestsFromMapFunc(
 					kongCredentialACLForKongConsumer(cl),
 				),
+				builder.WithPredicates(
+					predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1.KongConsumer]),
+				),
 			)
 		},
 		func(b *ctrl.Builder) *ctrl.Builder {

--- a/controller/konnect/watch_credentialapikey.go
+++ b/controller/konnect/watch_credentialapikey.go
@@ -46,6 +46,9 @@ func kongCredentialAPIKeyReconciliationWatchOptions(
 				handler.EnqueueRequestsFromMapFunc(
 					kongCredentialAPIKeyForKongConsumer(cl),
 				),
+				builder.WithPredicates(
+					predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1.KongConsumer]),
+				),
 			)
 		},
 		func(b *ctrl.Builder) *ctrl.Builder {

--- a/controller/konnect/watch_credentialbasicauth.go
+++ b/controller/konnect/watch_credentialbasicauth.go
@@ -46,6 +46,9 @@ func kongCredentialBasicAuthReconciliationWatchOptions(
 				handler.EnqueueRequestsFromMapFunc(
 					kongCredentialBasicAuthForKongConsumer(cl),
 				),
+				builder.WithPredicates(
+					predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1.KongConsumer]),
+				),
 			)
 		},
 		func(b *ctrl.Builder) *ctrl.Builder {

--- a/controller/konnect/watch_credentialhmac.go
+++ b/controller/konnect/watch_credentialhmac.go
@@ -46,6 +46,9 @@ func kongCredentialHMACReconciliationWatchOptions(
 				handler.EnqueueRequestsFromMapFunc(
 					kongCredentialHMACForKongConsumer(cl),
 				),
+				builder.WithPredicates(
+					predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1.KongConsumer]),
+				),
 			)
 		},
 		func(b *ctrl.Builder) *ctrl.Builder {

--- a/controller/konnect/watch_credentialjwt.go
+++ b/controller/konnect/watch_credentialjwt.go
@@ -46,6 +46,9 @@ func kongCredentialJWTReconciliationWatchOptions(
 				handler.EnqueueRequestsFromMapFunc(
 					kongCredentialJWTForKongConsumer(cl),
 				),
+				builder.WithPredicates(
+					predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1.KongConsumer]),
+				),
 			)
 		},
 		func(b *ctrl.Builder) *ctrl.Builder {

--- a/controller/konnect/watch_kongconsumer.go
+++ b/controller/konnect/watch_kongconsumer.go
@@ -66,6 +66,9 @@ func KongConsumerReconciliationWatchOptions(
 				handler.EnqueueRequestsFromMapFunc(
 					enqueueKongConsumerForKongConsumerGroup(cl),
 				),
+				builder.WithPredicates(
+					predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1beta1.KongConsumerGroup]),
+				),
 			)
 		},
 	}

--- a/controller/konnect/watch_kongpluginbinding.go
+++ b/controller/konnect/watch_kongpluginbinding.go
@@ -80,6 +80,9 @@ func KongPluginBindingReconciliationWatchOptions(
 				handler.EnqueueRequestsFromMapFunc(
 					enqueueKongPluginBindingFor[configurationv1alpha1.KongService](cl),
 				),
+				builder.WithPredicates(
+					predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1alpha1.KongService]),
+				),
 			)
 		},
 		func(b *ctrl.Builder) *ctrl.Builder {
@@ -87,6 +90,9 @@ func KongPluginBindingReconciliationWatchOptions(
 				&configurationv1alpha1.KongRoute{},
 				handler.EnqueueRequestsFromMapFunc(
 					enqueueKongPluginBindingFor[configurationv1alpha1.KongRoute](cl),
+				),
+				builder.WithPredicates(
+					predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1alpha1.KongRoute]),
 				),
 			)
 		},
@@ -96,6 +102,9 @@ func KongPluginBindingReconciliationWatchOptions(
 				handler.EnqueueRequestsFromMapFunc(
 					enqueueKongPluginBindingFor[configurationv1.KongConsumer](cl),
 				),
+				builder.WithPredicates(
+					predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1.KongConsumer]),
+				),
 			)
 		},
 		func(b *ctrl.Builder) *ctrl.Builder {
@@ -103,6 +112,9 @@ func KongPluginBindingReconciliationWatchOptions(
 				&configurationv1beta1.KongConsumerGroup{},
 				handler.EnqueueRequestsFromMapFunc(
 					enqueueKongPluginBindingFor[configurationv1beta1.KongConsumerGroup](cl),
+				),
+				builder.WithPredicates(
+					predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1beta1.KongConsumerGroup]),
 				),
 			)
 		},

--- a/controller/konnect/watch_kongroute.go
+++ b/controller/konnect/watch_kongroute.go
@@ -45,6 +45,9 @@ func KongRouteReconciliationWatchOptions(
 				handler.EnqueueRequestsFromMapFunc(
 					enqueueKongRouteForKongService(cl),
 				),
+				builder.WithPredicates(
+					predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1alpha1.KongService]),
+				),
 			)
 		},
 	}

--- a/controller/konnect/watch_kongsni.go
+++ b/controller/konnect/watch_kongsni.go
@@ -32,6 +32,9 @@ func KongSNIReconciliationWatchOptions(cl client.Client,
 			return b.Watches(
 				&configurationv1alpha1.KongCertificate{},
 				handler.EnqueueRequestsFromMapFunc(enqueueKongSNIForKongCertificate(cl)),
+				builder.WithPredicates(
+					predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1alpha1.KongCertificate]),
+				),
 			)
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue with missing `EnqueueRequestsFromMapFunc` predicates for types that are shared between KGO and KIC.

When some objects change, we need to check if that object should trigger the dependents to be enqueued. For instance `KongConsumerGroup` changes should only trigger a reconciliation for `KongConsumer`s in that group then the group is bound to a `KonnectGatewayControlPlane`.

Otherwise we assume that's a group reconciled by KIC.

**Which issue this PR fixes**

Fixes #939

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
