### PR TITLE
fix: remove runAsUser setting from webhook certificate job spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@
 - Fix `DataPlane`s with `KonnectExtension` and `BlueGreen` settings. Both the Live
   and preview deployments are now customized with Konnect-related settings.
   [#910](https://github.com/Kong/gateway-operator/pull/910)
+- Remove `RunAsUser` specification in jobs to create webhook certificates
+  because Openshift does not specifying `RunAsUser` by default.
+  [#964](https://github.com/Kong/gateway-operator/pull/964)
 
 ## [v1.4.1]
 

--- a/pkg/utils/kubernetes/resources/jobs.go
+++ b/pkg/utils/kubernetes/resources/jobs.go
@@ -82,7 +82,6 @@ func newWebhookCertificateConfigJobCommon(namespace, serviceAccountName string, 
 					ServiceAccountName: serviceAccountName,
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: lo.ToPtr(true),
-						RunAsUser:    lo.ToPtr(int64(2000)),
 					},
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
Do not set `RunAsUser` in jobs to create webhook certificate as openshift does not allow  specifying `runAsUser`.
**Which issue this PR fixes**

Fixes #921

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
