### PR TITLE
feat: allow more than 1 replica for ControlPlane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
   [#947](https://github.com/Kong/gateway-operator/pull/947)
 - Support KIC 3.4
   [#972](https://github.com/Kong/gateway-operator/pull/972)
+- Allow more than 1 replica for `ControlPlane`'s `Deployment` to support HA deployments of KIC.
+  [#978](https://github.com/Kong/gateway-operator/pull/978)
 
 ### Fixes
 

--- a/internal/validation/controlplane/validation.go
+++ b/internal/validation/controlplane/validation.go
@@ -33,24 +33,19 @@ func (v *Validator) ValidateDeploymentOptions(opts *operatorv1beta1.ControlPlane
 	if opts == nil || opts.PodTemplateSpec == nil {
 		// Can't use empty DeploymentOptions because we still require users
 		// to provide an image
-		// Related: https://github.com/Kong/gateway-operator/issues/754.
+		// Related: https://github.com/Kong/gateway-operator-archive/issues/754.
 		return errors.New("ControlPlane requires an image")
-	}
-
-	// Ref: https://github.com/Kong/gateway-operator/issues/736
-	if opts.Replicas != nil && *opts.Replicas != 1 {
-		return errors.New("ControlPlane only supports replicas of 1")
 	}
 
 	container := k8sutils.GetPodContainerByName(&opts.PodTemplateSpec.Spec, consts.ControlPlaneControllerContainerName)
 	if container == nil {
 		// We need the controller container for e.g. specifying an image which
 		// is still required.
-		// Ref: https://github.com/Kong/gateway-operator/issues/754.
+		// Ref: https://github.com/Kong/gateway-operator-archive/issues/754.
 		return errors.New("no controller container found in ControlPlane spec")
 	}
 
-	// Ref: https://github.com/Kong/gateway-operator/issues/754.
+	// Ref: https://github.com/Kong/gateway-operator-archive/issues/754.
 	if container.Image == "" {
 		return errors.New("ControlPlane requires an image")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

While going through webhook validations to move to CEL (for #949) I noticed that maximum of 1 replicas is enforced for `ControlPlane`.

This should not be the case as using Gateway discovery has been implemented in https://github.com/Kong/gateway-operator-archive/pull/1261.

This PR remove this restriction.

**Which issue this PR fixes**

Closes #182.

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
