### PR TITLE
chore: fix upgrade test to work with EE

### DIFF
--- a/test/e2e/test_helm_install_upgrade.go
+++ b/test/e2e/test_helm_install_upgrade.go
@@ -120,10 +120,10 @@ func TestHelmUpgrade(t *testing.T) {
 					},
 				},
 				{
-					Name: fmt.Sprintf("DataPlane deployment is patched after operator upgrade (due to change in default Kong image version to %q)", helpers.GetDefaultDataPlaneImagePreviousMinor()),
+					Name: "DataPlane deployment is patched after operator upgrade (due to change in default Kong image version to 3.8)",
 					Func: func(c *assert.CollectT, cl *testutils.K8sClients) {
 						gatewayDataPlaneDeploymentIsPatched("gw-upgrade-onebeforelatestminor-latestminor=true")(ctx, c, cl.MgrClient)
-						gatewayDataPlaneDeploymentHasImageSetTo("gw-upgrade-onebeforelatestminor-latestminor=true", helpers.GetDefaultDataPlaneImagePreviousMinor())(ctx, c, cl.MgrClient)
+						gatewayDataPlaneDeploymentHasImageSetTo("gw-upgrade-onebeforelatestminor-latestminor=true", helpers.GetDefaultDataPlaneBaseImage()+":3.8")(ctx, c, cl.MgrClient)
 					},
 				},
 				{

--- a/test/e2e/test_helm_install_upgrade.go
+++ b/test/e2e/test_helm_install_upgrade.go
@@ -120,10 +120,10 @@ func TestHelmUpgrade(t *testing.T) {
 					},
 				},
 				{
-					Name: "DataPlane deployment is patched after operator upgrade (due to change in default Kong image version to kong:3.8)",
+					Name: fmt.Sprintf("DataPlane deployment is patched after operator upgrade (due to change in default Kong image version to %q)", helpers.GetDefaultDataPlaneImagePreviousMinor()),
 					Func: func(c *assert.CollectT, cl *testutils.K8sClients) {
 						gatewayDataPlaneDeploymentIsPatched("gw-upgrade-onebeforelatestminor-latestminor=true")(ctx, c, cl.MgrClient)
-						gatewayDataPlaneDeploymentHasImageSetTo("gw-upgrade-onebeforelatestminor-latestminor=true", "kong:3.8")(ctx, c, cl.MgrClient)
+						gatewayDataPlaneDeploymentHasImageSetTo("gw-upgrade-onebeforelatestminor-latestminor=true", helpers.GetDefaultDataPlaneImagePreviousMinor())(ctx, c, cl.MgrClient)
 					},
 				},
 				{

--- a/test/helpers/defaults.go
+++ b/test/helpers/defaults.go
@@ -1,9 +1,6 @@
 package helpers
 
 import (
-	"fmt"
-	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/kong/gateway-operator/pkg/consts"
@@ -34,26 +31,6 @@ func GetDefaultDataPlaneImage() string {
 	_defaultDataPlaneImageLock.RLock()
 	defer _defaultDataPlaneImageLock.RUnlock()
 	return _defaultDataPlaneImage
-}
-
-// GetDefaultDataPlaneImagePreviousMinor returns the default data plane image with the previous version.
-func GetDefaultDataPlaneImagePreviousMinor() string {
-	defaultDPImage := GetDefaultDataPlaneImage()
-	s := strings.Split(defaultDPImage, ".")
-	if len(s) != 2 {
-		panic(fmt.Sprintf("invalid default data plane image (more than one '.' in version), %s", defaultDPImage))
-	}
-	v, err := strconv.Atoi(s[1])
-	if err != nil {
-		panic(fmt.Sprintf("invalid default data plane image (after '.' not a number), %s", defaultDPImage))
-	}
-	// NOTICE: Kong Gateway 4.0 rather won't happen in foreseeable future, thus for now it's safe to have it hardcoded this way.
-	previous := v - 1
-	if previous < 0 {
-		panic(fmt.Sprintf("invalid default data plane image (previous version is negative), %s", defaultDPImage))
-	}
-	s[1] = strconv.Itoa(previous)
-	return strings.Join(s, ".")
 }
 
 // SetDefaultDataPlaneImage sets the default data plane image.


### PR DESCRIPTION
**What this PR does / why we need it**:

We should use `helpers.GetDefaultDataPlaneImageBase()` to make this work properly in KGO EE tests (it overrides the default image on its own: https://github.com/Kong/gateway-operator-enterprise/blob/27c99e34d6e6fc6bd3ee99be885be5e8a71ad0c4/test/e2e/run_e2e_test.go#L15).

Should fix https://github.com/Kong/gateway-operator-enterprise/actions/runs/12686258105/job/35358212920?pr=383.