### PR TITLE
fix: odd number of arguments passed to logger in Konnect ops

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,6 +33,7 @@ linters:
   - unparam
   - unused
   - wastedassign
+  - loggercheck
 linters-settings:
   gci:
     sections:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,6 @@
 
 ## Unreleased
 
-### Fixes
-
-- Fix watch predicates for types shared between KGO and KIC.
-  [#948](https://github.com/Kong/gateway-operator/pull/948)
-
 ### Changed
 
 - `KonnectExtension` does not require `spec.serverHostname` to be set by a user
@@ -46,6 +41,11 @@
 - Remove `RunAsUser` specification in jobs to create webhook certificates
   because Openshift does not specifying `RunAsUser` by default.
   [#964](https://github.com/Kong/gateway-operator/pull/964)
+- Fix watch predicates for types shared between KGO and KIC.
+  [#948](https://github.com/Kong/gateway-operator/pull/948)
+- Fix unexpected error logs caused by passing an odd number of arguments to the logger
+  in the `KongConsumer` reconciler.
+  [#983](https://github.com/Kong/gateway-operator/pull/983)
 
 ## [v1.4.1]
 

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -301,7 +301,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			log.Debug(
 				logger,
 				"conflict found when trying to ensure ControlPlane's DataPlane configuration was up to date, retrying",
-				cp,
+				"controlPlane", cp,
 			)
 			return ctrl.Result{Requeue: true, RequeueAfter: controller.RequeueWithoutBackoff}, nil
 		}

--- a/controller/dataplane/watch.go
+++ b/controller/dataplane/watch.go
@@ -102,7 +102,7 @@ func listDataPlanesReferencingKonnectExtension(
 		if err := c.List(ctx, &dataPlaneList, client.MatchingFields{
 			index.KonnectExtensionIndex: ext.Namespace + "/" + ext.Name,
 		}); err != nil {
-			logger.Error(err, "Failed to list DataPlanes in watch", operatorv1alpha1.KonnectExtensionKind)
+			logger.Error(err, "Failed to list DataPlanes in watch", "extensionKind", operatorv1alpha1.KonnectExtensionKind)
 			return nil
 		}
 		return lo.Map(dataPlaneList.Items, func(dp operatorv1beta1.DataPlane, _ int) reconcile.Request {

--- a/controller/konnect/ops/ops_kongconsumer.go
+++ b/controller/konnect/ops/ops_kongconsumer.go
@@ -158,6 +158,8 @@ func reconcileConsumerGroupsWithKonnect(
 	cpID string,
 	consumer *configurationv1.KongConsumer,
 ) error {
+	logger := ctrllog.FromContext(ctx).WithValues("kongconsumer", client.ObjectKeyFromObject(consumer).String())
+
 	// List the ConsumerGroups that the Consumer is assigned to in Konnect.
 	cgsResp, err := cgSDK.ListConsumerGroupsForConsumer(ctx, sdkkonnectops.ListConsumerGroupsForConsumerRequest{
 		ControlPlaneID: cpID,
@@ -177,14 +179,14 @@ func reconcileConsumerGroupsWithKonnect(
 
 	// Calculate the difference between the desired and actual ConsumerGroups.
 	consumerGroupsToBeAddedTo, consumerGroupsToBeRemovedFrom := lo.Difference(desiredConsumerGroupsIDs, actualConsumerGroupsIDs)
-	log.Debug(ctrllog.FromContext(ctx), "reconciling ConsumerGroups for KongConsumer", consumer,
+	log.Debug(logger, "reconciling ConsumerGroups for KongConsumer",
 		"groupsToBeAddedTo", consumerGroupsToBeAddedTo,
 		"groupsToBeRemovedFrom", consumerGroupsToBeRemovedFrom,
 	)
 
 	// Adding consumer to consumer groups that it is not assigned to yet.
 	for _, cgID := range consumerGroupsToBeAddedTo {
-		log.Debug(ctrllog.FromContext(ctx), "adding KongConsumer to group", consumer,
+		log.Debug(ctrllog.FromContext(ctx), "adding KongConsumer to group",
 			"group", cgID,
 		)
 		_, err := cgSDK.AddConsumerToGroup(ctx, sdkkonnectops.AddConsumerToGroupRequest{
@@ -201,7 +203,7 @@ func reconcileConsumerGroupsWithKonnect(
 
 	// Removing consumer from consumer groups that it is not assigned to anymore.
 	for _, cgID := range consumerGroupsToBeRemovedFrom {
-		log.Debug(ctrllog.FromContext(ctx), "removing KongConsumer from group", consumer,
+		log.Debug(logger, "removing KongConsumer from group",
 			"group", cgID,
 		)
 		_, err := cgSDK.RemoveConsumerFromGroup(ctx, sdkkonnectops.RemoveConsumerFromGroupRequest{

--- a/controller/konnect/reconciler_keysetref.go
+++ b/controller/konnect/reconciler_keysetref.go
@@ -68,7 +68,7 @@ func handleKongKeySetRef[T constraints.SupportedKonnectEntityType, TEnt constrai
 	}
 
 	if keySetRef.Type != configurationv1alpha1.KeySetRefNamespacedRef {
-		ctrllog.FromContext(ctx).Error(fmt.Errorf("unsupported KeySet ref type %q", keySetRef.Type), "entity", ent)
+		ctrllog.FromContext(ctx).Error(fmt.Errorf("unsupported KeySet ref type %q", keySetRef.Type), "unsupported KeySet ref type", "entity", ent)
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an odd number of arguments passed to logger:

```text
2025-01-09T11:37:37.477+0100 - ERROR - KONGCONSUMER - reconciling ConsumerGroups for KongConsumer - {"konnect_id": "1b073b9e-ec16-420e-be45-6cccbd72ec13", "error": "log message has odd number of arguments"}
```

Also, enables `loggercheck` linter that should detect similar issues if we use a non-decorated `logr.Logger` (unfortunately, in most cases we use our `log.Debug/Info` wrapper function). 