### PR TITLE
chore(ci): add nightly CI var for pushing images

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,7 +12,7 @@ jobs:
       dockerhub-token: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
       gh-pat: ${{ secrets.PAT_GITHUB }}
     with:
-      username: ${{ vars.DOCKERHUB_PUSH_USERNAME  }}
+      username: ${{ vars.DOCKERHUB_PUSH_USERNAME }}
       registry: docker.io
-      image-name: ${{ vars.DOCKERHUB_IMAGE_NAME }}
+      image-name: ${{ vars.DOCKERHUB_IMAGE_NAME_NIGHTLY }}
       push: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Add GH var for a separate image repository name for nightlies.

Already set to:

```
gh variable set DOCKERHUB_IMAGE_NAME_NIGHTLY --body kong/nightly-gateway-operator-oss
✓ Created variable DOCKERHUB_IMAGE_NAME_NIGHTLY for Kong/gateway-operator
```

Pushing to: https://hub.docker.com/r/kong/nightly-gateway-operator-oss/tags

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
