### PR TITLE
chore(ci): pin 3rd party actions by hashes

### DIFF
--- a/.github/workflows/__build-workflow.yaml
+++ b/.github/workflows/__build-workflow.yaml
@@ -87,7 +87,7 @@ jobs:
       prerelease: ${{ steps.semver_parser.outputs.prerelease }}
 
     steps:
-      - uses: mukunku/tag-exists-action@v1.6.0
+      - uses: mukunku/tag-exists-action@bdad1eaa119ce71b150b952c97351c75025c06a9 # v1.6.0
         id: check-tag
         if: ${{ inputs.tag != '' }}
         name: check if tag already exists
@@ -108,7 +108,7 @@ jobs:
       - name: Parse semver string
         id: semver_parser
         if: ${{ inputs.tag != '' }}
-        uses: booxmedialtd/ws-action-parse-semver@v1.4.7
+        uses: booxmedialtd/ws-action-parse-semver@7784200024d6b3fc01253e617ec0168daf603de3 # v1.4.7
         with:
           input_string: ${{ inputs.tag }}
           version_extractor_regex: 'v(.*)$'
@@ -153,19 +153,19 @@ jobs:
 
       - name: Log in to the Container registry
         if: ${{ inputs.push }}
-        uses: docker/login-action@v3.1.0
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
           registry: ${{ inputs.registry }}
           username: ${{ inputs.username }}
           password: ${{ secrets.dockerhub-token }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.8.0
         with:
           platforms: ${{ matrix.arch }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
 
       - name: Add standard tags
         if: ${{ inputs.tag != '' }}
@@ -184,7 +184,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5.5.1
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           images: |
             ${{ inputs.registry }}/${{ inputs.image-name }}
@@ -199,7 +199,7 @@ jobs:
             ${{ env.TAGS_STANDARD }}${{ env.TAGS_SUPPLEMENTAL }}
           flavor: latest=${{ inputs.latest }},suffix=-${{ matrix.arch  }}
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
 
       # Setup Golang to use go pkg cache which is utilized in Dockerfile's cache mount.
       - name: Setup golang
@@ -212,7 +212,7 @@ jobs:
 
       - name: Build image
         id: build
-        uses: docker/build-push-action@v5.3.0
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
           context: .
           push: ${{ inputs.push }}
@@ -280,7 +280,7 @@ jobs:
         run: git submodule update --init
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
 
       - name: Add standard tags
         if: ${{ inputs.tag != '' }}
@@ -299,7 +299,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5.5.1
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           images: |
             ${{ inputs.registry }}/${{ inputs.image-name }}
@@ -316,7 +316,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: ${{ inputs.push }}
-        uses: docker/login-action@v3.1.0
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
           registry: ${{ inputs.registry }}
           username: ${{ inputs.username }}
@@ -330,7 +330,7 @@ jobs:
       # When building with `inputs.tag` set, `steps.meta.outputs.tags` contains multiple entries, so it cannot be used
       # directly in sources. Instead, the sources are constructed using the `inputs.registry`, `inputs.image-name` and
       # `needs.semver.outputs.fullversion`.
-      - uses: int128/docker-manifest-create-action@v2
+      - uses: int128/docker-manifest-create-action@736aaa0f6ae97b2fb7f43e8dcef3ab47a02ea96e # v2.8.0
         if: ${{ inputs.tag != '' }}
         with:
           tags: ${{ steps.meta.outputs.tags }}
@@ -341,7 +341,7 @@ jobs:
       # When building on schedule, `steps.meta.outputs.tags` contains multiple entries, so it cannot be used
       # directly in sources. Instead, the sources are constructed using the `inputs.registry`, `inputs.image-name` and
       # the current date.
-      - uses: int128/docker-manifest-create-action@v2
+      - uses: int128/docker-manifest-create-action@736aaa0f6ae97b2fb7f43e8dcef3ab47a02ea96e # v2.8.0
         if: ${{ inputs.tag == '' && github.event_name == 'schedule' }}
         with:
           tags: ${{ steps.meta.outputs.tags }}
@@ -351,7 +351,7 @@ jobs:
 
       # When building on push (e.g. on main), `steps.meta.outputs.tags` contains only a single entry, so it can be used
       # directly in sources.
-      - uses: int128/docker-manifest-create-action@v2
+      - uses: int128/docker-manifest-create-action@736aaa0f6ae97b2fb7f43e8dcef3ab47a02ea96e # v2.8.0
         if: ${{ inputs.tag == '' && github.event_name == 'push' }}
         with:
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/__release-workflow.yaml
+++ b/.github/workflows/__release-workflow.yaml
@@ -72,7 +72,7 @@ jobs:
       prerelease: ${{ steps.semver_parser.outputs.prerelease }}
     runs-on: ubuntu-latest
     steps:
-      - uses: mukunku/tag-exists-action@v1.6.0
+      - uses: mukunku/tag-exists-action@bdad1eaa119ce71b150b952c97351c75025c06a9 # v1.6.0
         id: check-tag
         name: Check if tag already exists
         with:
@@ -91,7 +91,7 @@ jobs:
 
       - name: Parse semver string
         id: semver_parser
-        uses: booxmedialtd/ws-action-parse-semver@v1.4.7
+        uses: booxmedialtd/ws-action-parse-semver@7784200024d6b3fc01253e617ec0168daf603de3 # v1.4.7
         with:
           input_string: ${{ inputs.tag }}
           version_extractor_regex: 'v(.*)$'
@@ -136,7 +136,7 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           install: false
 
@@ -168,7 +168,7 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           install: false
 
@@ -229,7 +229,7 @@ jobs:
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
           echo ${VERSION} > VERSION
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         if: ${{ (inputs.base == 'main' && matrix.base == 'main') || (inputs.base != 'main') }}
         with:
           install: false

--- a/.github/workflows/release-bot.yaml
+++ b/.github/workflows/release-bot.yaml
@@ -57,13 +57,13 @@ jobs:
         
       - name: Parse semver string
         id: semver_parser
-        uses: booxmedialtd/ws-action-parse-semver@v1.4.7
+        uses: booxmedialtd/ws-action-parse-semver@7784200024d6b3fc01253e617ec0168daf603de3 # v1.4.7
         with:
           input_string: ${{ env.VERSION }}
           version_extractor_regex: '(.*)$'
 
       - name: check if tag already exists
-        uses: mukunku/tag-exists-action@v1.6.0
+        uses: mukunku/tag-exists-action@bdad1eaa119ce71b150b952c97351c75025c06a9 # v1.6.0
         id: tag_exists
         with:
           tag: ${{ steps.commit_parser.outputs.release_version }}
@@ -81,7 +81,7 @@ jobs:
     if: ${{ needs.look_for_release.outputs.release_found == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: ncipollo/release-action@v1
+      - uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # v1.14.0
         with:
           body: |
             #### Download Kong Gateway Operator ${{ needs.semver.outputs.version }}:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
       with:
         go-version-file: go.mod
 
-    - uses: jdx/mise-action@v2
+    - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
       with:
         install: false
 
@@ -55,7 +55,7 @@ jobs:
       with:
         go-version-file: go.mod
 
-    - uses: jdx/mise-action@v2
+    - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
       with:
         install: false
 
@@ -63,7 +63,7 @@ jobs:
       run: make verify.manifests
 
     - name: Verify generators consistency
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
       with:
         timeout_minutes: 3
         max_attempts: 3
@@ -83,9 +83,9 @@ jobs:
         go-version-file: go.mod
 
     - name: Create k8s KinD Cluster
-      uses: helm/kind-action@v1.9.0
+      uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
 
-    - uses: jdx/mise-action@v2
+    - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
       with:
         install: false
 
@@ -129,7 +129,7 @@ jobs:
       with:
         go-version-file: go.mod
 
-    - uses: jdx/mise-action@v2
+    - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
       with:
         install: false
 
@@ -205,7 +205,7 @@ jobs:
       with:
         go-version-file: go.mod
 
-    - uses: jdx/mise-action@v2
+    - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
       with:
         install: false
 
@@ -258,7 +258,7 @@ jobs:
       with:
         go-version-file: go.mod
 
-    - uses: jdx/mise-action@v2
+    - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
       with:
         install: false
 
@@ -309,7 +309,7 @@ jobs:
       with:
         go-version-file: go.mod
 
-    - uses: jdx/mise-action@v2
+    - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
       with:
         install: false
 
@@ -359,7 +359,7 @@ jobs:
         TAG: e2e-${{ github.sha }}
       run: make docker.build
 
-    - uses: jdx/mise-action@v2
+    - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
       with:
         install: false
 
@@ -409,7 +409,7 @@ jobs:
 
       - name: Upload test results to BuildPulse for flaky test detection
         if: ${{ !cancelled() }}
-        uses: buildpulse/buildpulse-action@v0.11.0
+        uses: buildpulse/buildpulse-action@d0d30f53585cf16b2e01811a5a753fd47968654a # v1.11.0
         with:
           account: 962416
           repository: 477814940


### PR DESCRIPTION
**What this PR does / why we need it**:
Pin 3rd party github actions by hashes for branch `release/1.2.x`.
**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
