### PR TITLE
test: let kustomize workflow use actual code for testing

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -98,6 +98,10 @@ jobs:
 
   install-with-kustomize:
     runs-on: ubuntu-latest
+    env:
+      IMG: gateway-operator
+      TAG: e2e-${{ github.sha }}
+      CLUSTER_NAME: install-with-kustomize
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -107,8 +111,13 @@ jobs:
       with:
         go-version-file: go.mod
 
+    - name: build docker image
+      run: make docker.build
+
     - name: Create k8s KinD Cluster
       uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+      with:
+        cluster_name:  ${{ env.CLUSTER_NAME }}
 
     - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
       with:
@@ -117,7 +126,13 @@ jobs:
     - name: Verify installing CRDs via kustomize works
       run: make install
 
+    - name: Load image to kind cluster
+      run: kind load docker-image gateway-operator:e2e-${{ github.sha }} --name $CLUSTER_NAME
+
     - name: Verify deploying operator via kustomize works
+      env:
+        IMG: gateway-operator
+        VERSION: e2e-${{ github.sha }}
       run: make deploy
 
     - name: Verify that undeploying operator via kustomize works


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request includes updates to the GitHub Actions workflow for testing. The changes focus on building and loading a Docker image for the `gateway-operator` and ensuring it is used in the Kubernetes KinD cluster.

Updates to GitHub Actions workflow:

* [`.github/workflows/tests.yaml`](diffhunk://#diff-95557d53bf91069e59d82b9d8fcfaf52ec84a762858983edd5ef3c9b3e4c8191R110-R115): Added steps to build a Docker image for `gateway-operator` and tag it with the current commit SHA.
* [`.github/workflows/tests.yaml`](diffhunk://#diff-95557d53bf91069e59d82b9d8fcfaf52ec84a762858983edd5ef3c9b3e4c8191R126-R132): Added a step to load the Docker image into the KinD cluster.
* [`.github/workflows/tests.yaml`](diffhunk://#diff-95557d53bf91069e59d82b9d8fcfaf52ec84a762858983edd5ef3c9b3e4c8191R126-R132): Updated the environment variables for the deploy step to use the newly built Docker image.

**Which issue this PR fixes**

Fixes https://github.com/Kong/gateway-operator/issues/993

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes~
