### PR TITLE
Feat(konnect): adopt existing konnect entities

### DIFF
--- a/controller/konnect/annotations.go
+++ b/controller/konnect/annotations.go
@@ -1,0 +1,14 @@
+package konnect
+
+const (
+	// AnnotationKeyAdoptEntity is the annotation key to adopt an existing Konnect entity.
+	AnnotationKeyAdoptEntity = "konnect.konghq.com/adopt"
+)
+
+// getAdoptEntityID gets the Konnect ID of the adopted entity in the value of the annotation.
+func getAdoptEntityID(annotations map[string]string) string {
+	if annotations == nil {
+		return ""
+	}
+	return annotations[AnnotationKeyAdoptEntity]
+}

--- a/controller/konnect/ops/ops_controlplane.go
+++ b/controller/konnect/ops/ops_controlplane.go
@@ -239,3 +239,13 @@ func getControlPlaneForUID(
 
 	return id, nil
 }
+
+// getControlPlaneByID gets Konnect gateway control plane by ID and returns the error in getting.
+func getControlPlaneByID(
+	ctx context.Context,
+	sdk sdkops.ControlPlaneSDK,
+	id string,
+) error {
+	_, err := sdk.GetControlPlane(ctx, id)
+	return err
+}

--- a/controller/konnect/ops/sdk/controlplane.go
+++ b/controller/konnect/ops/sdk/controlplane.go
@@ -13,4 +13,5 @@ type ControlPlaneSDK interface {
 	DeleteControlPlane(ctx context.Context, id string, opts ...sdkkonnectops.Option) (*sdkkonnectops.DeleteControlPlaneResponse, error)
 	UpdateControlPlane(ctx context.Context, id string, req sdkkonnectcomp.UpdateControlPlaneRequest, opts ...sdkkonnectops.Option) (*sdkkonnectops.UpdateControlPlaneResponse, error)
 	ListControlPlanes(ctx context.Context, request sdkkonnectops.ListControlPlanesRequest, opts ...sdkkonnectops.Option) (*sdkkonnectops.ListControlPlanesResponse, error)
+	GetControlPlane(ctx context.Context, id string, opts ...sdkkonnectops.Option) (*sdkkonnectops.GetControlPlaneResponse, error)
 }

--- a/controller/konnect/ops/sdk/mocks/zz_generated.controlplane_mock.go
+++ b/controller/konnect/ops/sdk/mocks/zz_generated.controlplane_mock.go
@@ -173,6 +173,80 @@ func (_c *MockControlPlaneSDK_DeleteControlPlane_Call) RunAndReturn(run func(con
 	return _c
 }
 
+// GetControlPlane provides a mock function with given fields: ctx, id, opts
+func (_m *MockControlPlaneSDK) GetControlPlane(ctx context.Context, id string, opts ...operations.Option) (*operations.GetControlPlaneResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, id)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetControlPlane")
+	}
+
+	var r0 *operations.GetControlPlaneResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...operations.Option) (*operations.GetControlPlaneResponse, error)); ok {
+		return rf(ctx, id, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...operations.Option) *operations.GetControlPlaneResponse); ok {
+		r0 = rf(ctx, id, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*operations.GetControlPlaneResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...operations.Option) error); ok {
+		r1 = rf(ctx, id, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockControlPlaneSDK_GetControlPlane_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetControlPlane'
+type MockControlPlaneSDK_GetControlPlane_Call struct {
+	*mock.Call
+}
+
+// GetControlPlane is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+//   - opts ...operations.Option
+func (_e *MockControlPlaneSDK_Expecter) GetControlPlane(ctx interface{}, id interface{}, opts ...interface{}) *MockControlPlaneSDK_GetControlPlane_Call {
+	return &MockControlPlaneSDK_GetControlPlane_Call{Call: _e.mock.On("GetControlPlane",
+		append([]interface{}{ctx, id}, opts...)...)}
+}
+
+func (_c *MockControlPlaneSDK_GetControlPlane_Call) Run(run func(ctx context.Context, id string, opts ...operations.Option)) *MockControlPlaneSDK_GetControlPlane_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]operations.Option, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(operations.Option)
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockControlPlaneSDK_GetControlPlane_Call) Return(_a0 *operations.GetControlPlaneResponse, _a1 error) *MockControlPlaneSDK_GetControlPlane_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockControlPlaneSDK_GetControlPlane_Call) RunAndReturn(run func(context.Context, string, ...operations.Option) (*operations.GetControlPlaneResponse, error)) *MockControlPlaneSDK_GetControlPlane_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListControlPlanes provides a mock function with given fields: ctx, request, opts
 func (_m *MockControlPlaneSDK) ListControlPlanes(ctx context.Context, request operations.ListControlPlanesRequest, opts ...operations.Option) (*operations.ListControlPlanesResponse, error) {
 	_va := make([]interface{}, len(opts))

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -21,10 +21,11 @@ type KonnectEntityOperation string
 const (
 	// KonnectServerURLKey is the key for the Konnect server URL which accepts the requests of entity opertions.
 	KonnectServerURLKey = "server_url"
-	// KonnectEntityOperationTypeKey is the key for the opertion type:  `create`, `update`, or `delete`.
+	// KonnectEntityOperationTypeKey is the key for the opertion type:  `create`, `update`, `get`, or `delete`.
 	KonnectEntityOperationTypeKey                        = "operation_type"
 	KonnectEntityOperationCreate  KonnectEntityOperation = "create"
 	KonnectEntityOperationUpdate  KonnectEntityOperation = "update"
+	KonnectEntityOpertionGet      KonnectEntityOperation = "get"
 	KonnectEntityOperationDelete  KonnectEntityOperation = "delete"
 	// KonnectEntityTypeKey indicates the type of the operated Konnect entity.
 	KonnectEntityTypeKey = "entity_type"

--- a/pkg/consts/status.go
+++ b/pkg/consts/status.go
@@ -64,6 +64,9 @@ const (
 	// KonnectEntitiesFailedToUpdateReason is the reason assigned to Konnect entities that failed to get updated.
 	// It must be used when Programmed condition is set to False.
 	KonnectEntitiesFailedToUpdateReason ConditionReason = "FailedToUpdate"
+	// KonnectEntitiesFailedToAdoptReason is the reason assigned to Konnect entities that failed to adopt existing entity.
+	// It must be used when Programmed condition is set to False.
+	KonnectEntitiesFailedToAdoptReason ConditionReason = "FailedToAdopt"
 	// FailedToAttachConsumerToConsumerGroupReason is the reason assigned to KonnConsumers when failed to attach it to any consumer group.
 	// It must be used when Programmed condition is set to False.
 	FailedToAttachConsumerToConsumerGroupReason ConditionReason = "FailedToAttachConsumerToConsumerGroup"

--- a/test/envtest/konnect_entities_gatewaycontrolplane_adopt_test.go
+++ b/test/envtest/konnect_entities_gatewaycontrolplane_adopt_test.go
@@ -1,0 +1,82 @@
+package envtest
+
+import (
+	"context"
+	"testing"
+
+	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/gateway-operator/controller/konnect"
+	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/scheme"
+	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
+	"github.com/kong/gateway-operator/test/helpers/deploy"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+func TestKongGatewayControlPlaneAdopt(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := Context(t, context.Background())
+	defer cancel()
+	cfg, ns := Setup(t, ctx, scheme.Get())
+
+	t.Log("Setting up the manager with reconcilers")
+	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+	factory := sdkmocks.NewMockSDKFactory(t)
+	sdk := factory.SDK
+	StartReconcilers(ctx, t, mgr, logs,
+		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+			konnect.WithKonnectEntitySyncPeriod[konnectv1alpha1.KonnectGatewayControlPlane](konnectInfiniteSyncTime),
+		),
+	)
+
+	t.Log("Setting up clients")
+	cl, err := client.NewWithWatch(mgr.GetConfig(), client.Options{
+		Scheme: scheme.Get(),
+	})
+	require.NoError(t, err)
+	clientNamespaced := client.NewNamespacedClient(mgr.GetClient(), ns.Name)
+
+	t.Log("Creating KonnectAPIAuthConfiguration")
+	apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
+	testCPID := "test-12345"
+
+	t.Log("Setting up SDK expectations on KonnectGatewayControlPlane getting")
+	sdk.ControlPlaneSDK.EXPECT().GetControlPlane(
+		mock.Anything,
+		testCPID,
+		mock.Anything,
+	).Return(
+		&sdkkonnectops.GetControlPlaneResponse{},
+		nil,
+	)
+
+	t.Log("Setting up a watch for KonnectGatewayControlPlane events")
+	w := setupWatch[konnectv1alpha1.KonnectGatewayControlPlaneList](t, ctx, cl, client.InNamespace(ns.Name))
+
+	t.Log("Creating KonnectGatewayControlPlane")
+	cp := deploy.KonnectGatewayControlPlane(t, ctx, clientNamespaced, apiAuth, deploy.WithAnnotation(
+		konnect.AnnotationKeyAdoptEntity, testCPID,
+	))
+
+	t.Log("Waiting for Get of KonnectGatewayControlPlane in SDK")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.True(c, factory.SDK.ControlPlaneSDK.AssertExpectations(t))
+	}, waitTime, tickTime)
+
+	t.Log("Watching for KonnectGatewayControlPlane to verify that the KonnectID, finalizer, and programmend conditions are set")
+	watchFor(t, ctx, w, watch.Modified, func(c *konnectv1alpha1.KonnectGatewayControlPlane) bool {
+		if c.GetName() != cp.GetName() {
+			return false
+		}
+		return c.GetKonnectID() == testCPID && k8sutils.IsProgrammed(c) && lo.Contains(c.Finalizers, konnect.KonnectCleanupFinalizer)
+	}, "KonnectGatewayControlPlane should be programmed, has finalizer, and have the ID same as in the adopt annotation")
+
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Support adopting existing konnect entity by annotation `konnect.konghq.com/adopt`.
**Which issue this PR fixes**

Fixes #460

**Special notes for your reviewer**:
This PR starts from `KonnectGatewayControlPlane`. The following work in mainly on adding functions to implement `GetByID` for other types of entities.
**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
