### PR TITLE
ci: ensure actions sha pin

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,15 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  ensure-actions-sha-pin:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: zgosalvez/github-actions-ensure-sha-pinned-actions@c3a2b64f69b7a1542a68f44d9edbd9ec3fc1455e # v3.0.20
+      with:
+        allowlist: |
+          actions/
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -499,6 +508,7 @@ jobs:
   passed:
     runs-on: ubuntu-latest
     needs:
+      - ensure-actions-sha-pin
       - lint
       - verify
       - install-with-kustomize


### PR DESCRIPTION
**What this PR does / why we need it**:

Use https://github.com/zgosalvez/github-actions-ensure-sha-pinned-actions to ensure that actions' versions use SHA pins.

Add `actions/` allowlist.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
