### PR TITLE
build: pin all dependencies by SHA

### DIFF
--- a/.github/actions/redhat-certification-action/Dockerfile
+++ b/.github/actions/redhat-certification-action/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10
+FROM docker:20.10@sha256:2967f0819c84dd589ed0a023b9d25dcfe7a3c123d5bf784ffbb77edf55335f0c
 
 RUN apk add bash
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,6 +27,19 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: zgosalvez/github-actions-ensure-sha-pinned-actions@c3a2b64f69b7a1542a68f44d9edbd9ec3fc1455e # v3.0.20
 
+  ossf-scorecard:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    # Ref: https://github.com/ossf/scorecard
+    # TODO: add other checks as needed
+    - run: |
+        docker run --rm --env GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} gcr.io/openssf/scorecard:stable \
+          --repo=github.com/${{ github.repository }} \
+          --commit ${{ github.sha }} \
+          --show-details \
+          --checks=Pinned-Dependencies
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -537,6 +550,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - ensure-actions-sha-pin
+      - ossf-scorecard
       - lint
       - verify
       - install-with-kustomize

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -2,7 +2,7 @@
 # Debug image
 # ------------------------------------------------------------------------------
 
-FROM --platform=$BUILDPLATFORM golang:1.23.4 AS debug
+FROM --platform=$BUILDPLATFORM golang:1.23.4@sha256:7ea4c9dcb2b97ff8ee80a67db3d44f98c8ffa0d191399197007d8459c1453041 AS debug
 
 ARG GOPATH
 ARG GOCACHE

--- a/hack/plugin-images/invalid-size-combined.Dockerfile
+++ b/hack/plugin-images/invalid-size-combined.Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox:1.31.1 AS builder
+FROM busybox:1.31.1@sha256:999f1137906d82f896a70c18ed63d2797a1562cd7d4d2c1907f681b35c30459d AS builder
 
 RUN mkdir myheader &&\
     dd if=/dev/urandom of=/myheader/handler.lua bs=512k count=1 &&\

--- a/hack/plugin-images/invalid-size-one.Dockerfile
+++ b/hack/plugin-images/invalid-size-one.Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox:1.31.1 AS builder
+FROM busybox:1.31.1@sha256:999f1137906d82f896a70c18ed63d2797a1562cd7d4d2c1907f681b35c30459d AS builder
 
 COPY myheader/schema.lua /myheader/
 RUN dd if=/dev/urandom of=/myheader/handler.lua bs=1M count=2

--- a/hack/plugin-images/myheader-2.Dockerfile
+++ b/hack/plugin-images/myheader-2.Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox:1.31.1 AS builder
+FROM busybox:1.31.1@sha256:999f1137906d82f896a70c18ed63d2797a1562cd7d4d2c1907f681b35c30459d AS builder
 
 COPY myheader /myheader/
 RUN sed -i 's/"myheader"/"newheader"/g' /myheader/**


### PR DESCRIPTION
**What this PR does / why we need it**:

Pin all dependencies (in Dockerfiles) by SHA and run [`scorecard`](https://github.com/ossf/scorecard) on CI in `tests/ossf-scorecard` job.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
