### PR TITLE
chore: remove redundant dependency `golang.org/x/net`

### DIFF
--- a/test/crdsvalidation/dataplane_test.go
+++ b/test/crdsvalidation/dataplane_test.go
@@ -1,10 +1,10 @@
 package crdsvalidation
 
 import (
+	"context"
 	"testing"
 
 	"github.com/samber/lo"
-	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Redo 

- https://github.com/Kong/gateway-operator/pull/1002

because

- https://github.com/Kong/gateway-operator/pull/999

introduced this again by mistake, [see](https://github.com/Kong/gateway-operator/pull/999/files#diff-0106af3724df5586d4928666ade8185dea56e53cbb0480c2c326552ed1a321faR7)