### PR TITLE
feat: set GWC accepted condition properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,13 +67,12 @@
 - Move `DataPlane` promotion in progress validation to CRD CEL validation expressions.
   This is relevant for `DataPlane`s with BlueGreen rollouts enabled only.
   [#1054](https://github.com/Kong/gateway-operator/pull/1054)
-- The `GatewayClass` Accepted Condition is set to False with reason `InvalidParameters`
+- The `GatewayClass` Accepted Condition is set to `False` with reason `InvalidParameters`
   in case the `.spec.parametersRef` field is not a valid reference to an existing
   `GatewayConfiguration` object.
   [#1021](https://github.com/Kong/gateway-operator/pull/1021)
 
 [kubebuilder_3907]: https://github.com/kubernetes-sigs/kubebuilder/discussions/3907
-
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,13 @@
 - Move `DataPlane` promotion in progress validation to CRD CEL validation expressions.
   This is relevant for `DataPlane`s with BlueGreen rollouts enabled only.
   [#1054](https://github.com/Kong/gateway-operator/pull/1054)
+- The `GatewayClass` Accepted Condition is set to False with reason `InvalidParameters`
+  in case the `.spec.parametersRef` field is not a valid reference to an existing
+  `GatewayConfiguration` object.
+  [#1021](https://github.com/Kong/gateway-operator/pull/1021)
 
 [kubebuilder_3907]: https://github.com/kubernetes-sigs/kubebuilder/discussions/3907
+
 
 ### Fixes
 

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -123,9 +123,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	log.Trace(logger, "checking gatewayclass")
 	gwc, err := gatewayclass.Get(ctx, r.Client, string(gateway.Spec.GatewayClassName))
 	if err != nil {
-		if errors.As(err, &operatorerrors.ErrUnsupportedGatewayClass{}) {
+		switch {
+		case errors.As(err, &operatorerrors.ErrUnsupportedGatewayClass{}):
 			log.Debug(logger, "resource not supported, ignoring",
 				"expectedGatewayClass", vars.ControllerName(),
+				"gatewayClass", gateway.Spec.GatewayClassName,
+				"reason", err.Error(),
+			)
+			return ctrl.Result{}, nil
+		case errors.As(err, &operatorerrors.ErrNotAcceptedGatewayClass{}):
+			log.Debug(logger, "GatewayClass not accepted, ignoring",
 				"gatewayClass", gateway.Spec.GatewayClassName,
 				"reason", err.Error(),
 			)

--- a/controller/gatewayclass/controller.go
+++ b/controller/gatewayclass/controller.go
@@ -59,10 +59,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get accepted condition: %w", err)
 	}
-	k8sutils.SetCondition(
-		*condition,
-		gwc,
-	)
+	k8sutils.SetCondition(*condition, gwc)
 
 	if err := r.Status().Patch(ctx, gwc.GatewayClass, client.MergeFrom(oldGwc)); err != nil {
 		if k8serrors.IsConflict(err) {

--- a/controller/gatewayclass/controller.go
+++ b/controller/gatewayclass/controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -16,7 +15,6 @@ import (
 	"github.com/kong/gateway-operator/controller"
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/internal/utils/gatewayclass"
-	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 )
 
@@ -55,29 +53,26 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	if !gwc.IsAccepted() {
-		oldGwc := gwc.DeepCopy()
+	oldGwc := gwc.DeepCopy()
 
-		k8sutils.SetCondition(
-			k8sutils.NewConditionWithGeneration(
-				consts.ConditionType(gatewayv1.GatewayClassConditionStatusAccepted),
-				metav1.ConditionTrue,
-				consts.ConditionReason(gatewayv1.GatewayClassReasonAccepted),
-				"the gatewayclass has been accepted by the operator",
-				gwc.GetGeneration(),
-			),
-			gwc,
-		)
-		if err := r.Status().Patch(ctx, gwc.GatewayClass, client.MergeFrom(oldGwc)); err != nil {
-			if k8serrors.IsConflict(err) {
-				log.Debug(logger, "conflict found when updating GatewayClass, retrying")
-				return ctrl.Result{
-					Requeue:      true,
-					RequeueAfter: controller.RequeueWithoutBackoff,
-				}, nil
-			}
-			return ctrl.Result{}, fmt.Errorf("failed patching GatewayClass: %w", err)
+	condition, err := getAcceptedCondition(ctx, r.Client, gwc.GatewayClass)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get accepted condition: %w", err)
+	}
+	k8sutils.SetCondition(
+		*condition,
+		gwc,
+	)
+
+	if err := r.Status().Patch(ctx, gwc.GatewayClass, client.MergeFrom(oldGwc)); err != nil {
+		if k8serrors.IsConflict(err) {
+			log.Debug(logger, "conflict found when updating GatewayClass, retrying")
+			return ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: controller.RequeueWithoutBackoff,
+			}, nil
 		}
+		return ctrl.Result{}, fmt.Errorf("failed patching GatewayClass: %w", err)
 	}
 
 	return ctrl.Result{}, nil

--- a/controller/gatewayclass/controller_reconciler_utils.go
+++ b/controller/gatewayclass/controller_reconciler_utils.go
@@ -17,22 +17,22 @@ import (
 // getAcceptedCondition returns the accepted condition for the GatewayClass, with
 // the proper status, reason and message.
 func getAcceptedCondition(ctx context.Context, cl client.Client, gwc *gatewayv1.GatewayClass) (*metav1.Condition, error) {
-	reason := string(gatewayv1.GatewayClassReasonAccepted)
-	message := []string{}
+	reason := gatewayv1.GatewayClassReasonAccepted
+	messages := []string{}
 	status := metav1.ConditionFalse
 
 	if gwc.Spec.ParametersRef != nil {
 		validRef := true
 		if gwc.Spec.ParametersRef.Group != gatewayv1.Group(operatorv1beta1.SchemeGroupVersion.Group) ||
 			gwc.Spec.ParametersRef.Kind != "GatewayConfiguration" {
-			reason = string(gatewayv1.GatewayClassReasonInvalidParameters)
-			message = append(message, "ParametersRef must reference a gateway-operator.konghq.com/GatewayConfiguration")
+			reason = gatewayv1.GatewayClassReasonInvalidParameters
+			messages = append(messages, "ParametersRef must reference a gateway-operator.konghq.com/GatewayConfiguration")
 			validRef = false
 		}
 
 		if gwc.Spec.ParametersRef.Namespace == nil {
-			reason = string(gatewayv1.GatewayClassReasonInvalidParameters)
-			message = append(message, "ParametersRef must reference a namespaced resource")
+			reason = gatewayv1.GatewayClassReasonInvalidParameters
+			messages = append(messages, "ParametersRef must reference a namespaced resource")
 			validRef = false
 		}
 
@@ -43,21 +43,21 @@ func getAcceptedCondition(ctx context.Context, cl client.Client, gwc *gatewayv1.
 				return nil, err
 			}
 			if k8serrors.IsNotFound(err) {
-				reason = string(gatewayv1.GatewayClassReasonInvalidParameters)
-				message = append(message, "The referenced GatewayConfiguration does not exist")
+				reason = gatewayv1.GatewayClassReasonInvalidParameters
+				messages = append(messages, "The referenced GatewayConfiguration does not exist")
 			}
 		}
 	}
-	if reason == string(gatewayv1.GatewayClassReasonAccepted) {
+	if reason == gatewayv1.GatewayClassReasonAccepted {
 		status = metav1.ConditionTrue
-		message = []string{"GatewayClass is accepted"}
+		messages = []string{"GatewayClass is accepted"}
 	}
 
 	acceptedCondition := k8sutils.NewConditionWithGeneration(
 		consts.ConditionType(gatewayv1.GatewayClassConditionStatusAccepted),
 		status,
 		consts.ConditionReason(reason),
-		strings.Join(message, ". "),
+		strings.Join(messages, ". "),
 		gwc.GetGeneration(),
 	)
 

--- a/controller/gatewayclass/controller_reconciler_utils.go
+++ b/controller/gatewayclass/controller_reconciler_utils.go
@@ -1,0 +1,65 @@
+package gatewayclass
+
+import (
+	"context"
+	"strings"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	operatorv1beta1 "github.com/kong/gateway-operator/api/v1beta1"
+	"github.com/kong/gateway-operator/pkg/consts"
+	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
+)
+
+// getAcceptedCondition returns the accepted condition for the GatewayClass, with
+// the proper status, reason and message.
+func getAcceptedCondition(ctx context.Context, cl client.Client, gwc *gatewayv1.GatewayClass) (*metav1.Condition, error) {
+	reason := string(gatewayv1.GatewayClassReasonAccepted)
+	message := []string{}
+	status := metav1.ConditionFalse
+
+	if gwc.Spec.ParametersRef != nil {
+		validRef := true
+		if gwc.Spec.ParametersRef.Group != gatewayv1.Group(operatorv1beta1.SchemeGroupVersion.Group) ||
+			gwc.Spec.ParametersRef.Kind != "GatewayConfiguration" {
+			reason = string(gatewayv1.GatewayClassReasonInvalidParameters)
+			message = append(message, "ParametersRef must reference a gateway-operator.konghq.com/GatewayConfiguration")
+			validRef = false
+		}
+
+		if gwc.Spec.ParametersRef.Namespace == nil {
+			reason = string(gatewayv1.GatewayClassReasonInvalidParameters)
+			message = append(message, "ParametersRef must reference a namespaced resource")
+			validRef = false
+		}
+
+		if validRef {
+			gatewayConfig := operatorv1beta1.GatewayConfiguration{}
+			err := cl.Get(ctx, client.ObjectKey{Name: gwc.Spec.ParametersRef.Name, Namespace: string(*gwc.Spec.ParametersRef.Namespace)}, &gatewayConfig)
+			if client.IgnoreNotFound(err) != nil {
+				return nil, err
+			}
+			if k8serrors.IsNotFound(err) {
+				reason = string(gatewayv1.GatewayClassReasonInvalidParameters)
+				message = append(message, "The referenced GatewayConfiguration does not exist")
+			}
+		}
+	}
+	if reason == string(gatewayv1.GatewayClassReasonAccepted) {
+		status = metav1.ConditionTrue
+		message = []string{"GatewayClass is accepted"}
+	}
+
+	acceptedCondition := k8sutils.NewConditionWithGeneration(
+		consts.ConditionType(gatewayv1.GatewayClassConditionStatusAccepted),
+		status,
+		consts.ConditionReason(reason),
+		strings.Join(message, ". "),
+		gwc.GetGeneration(),
+	)
+
+	return &acceptedCondition, nil
+}

--- a/controller/gatewayclass/controller_reconciler_utils_test.go
+++ b/controller/gatewayclass/controller_reconciler_utils_test.go
@@ -1,0 +1,131 @@
+package gatewayclass
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	operatorv1beta1 "github.com/kong/gateway-operator/api/v1beta1"
+)
+
+func TestGetAcceptedCondition(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, gatewayv1.Install(scheme))
+	assert.NoError(t, operatorv1beta1.AddToScheme(scheme))
+
+	tests := []struct {
+		name           string
+		gwc            *gatewayv1.GatewayClass
+		existingObjs   []runtime.Object
+		expectedStatus metav1.ConditionStatus
+		expectedReason string
+		expectedMsg    string
+	}{
+		{
+			name: "ParametersRef is nil",
+			gwc: &gatewayv1.GatewayClass{
+				Spec: gatewayv1.GatewayClassSpec{
+					ParametersRef: nil,
+				},
+			},
+			expectedStatus: metav1.ConditionTrue,
+			expectedReason: string(gatewayv1.GatewayClassReasonAccepted),
+			expectedMsg:    "GatewayClass is accepted",
+		},
+		{
+			name: "Invalid ParametersRef Group and kind",
+			gwc: &gatewayv1.GatewayClass{
+				Spec: gatewayv1.GatewayClassSpec{
+
+					ParametersRef: &gatewayv1.ParametersReference{
+						Group:     "invalid.group",
+						Kind:      "InvalidKind",
+						Namespace: lo.ToPtr(gatewayv1.Namespace("default")),
+						Name:      "invalid",
+					},
+				},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: string(gatewayv1.GatewayClassReasonInvalidParameters),
+			expectedMsg:    "ParametersRef must reference a gateway-operator.konghq.com/GatewayConfiguration",
+		},
+		{
+			name: "ParametersRef Namespace is nil",
+			gwc: &gatewayv1.GatewayClass{
+				Spec: gatewayv1.GatewayClassSpec{
+					ParametersRef: &gatewayv1.ParametersReference{
+						Group: gatewayv1.Group(operatorv1beta1.SchemeGroupVersion.Group),
+						Kind:  "GatewayConfiguration",
+						Name:  "no-namespace",
+					},
+				},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: string(gatewayv1.GatewayClassReasonInvalidParameters),
+			expectedMsg:    "ParametersRef must reference a namespaced resource",
+		},
+		{
+			name: "GatewayConfiguration does not exist",
+			gwc: &gatewayv1.GatewayClass{
+				Spec: gatewayv1.GatewayClassSpec{
+					ParametersRef: &gatewayv1.ParametersReference{
+						Group:     gatewayv1.Group(operatorv1beta1.SchemeGroupVersion.Group),
+						Kind:      "GatewayConfiguration",
+						Name:      "nonexistent",
+						Namespace: lo.ToPtr(gatewayv1.Namespace("default")),
+					},
+				},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: string(gatewayv1.GatewayClassReasonInvalidParameters),
+			expectedMsg:    "The referenced GatewayConfiguration does not exist",
+		},
+		{
+			name: "Valid ParametersRef",
+			gwc: &gatewayv1.GatewayClass{
+				Spec: gatewayv1.GatewayClassSpec{
+					ParametersRef: &gatewayv1.ParametersReference{
+						Group:     gatewayv1.Group(operatorv1beta1.SchemeGroupVersion.Group),
+						Kind:      "GatewayConfiguration",
+						Name:      "valid-config",
+						Namespace: lo.ToPtr(gatewayv1.Namespace("default")),
+					},
+				},
+			},
+			existingObjs: []runtime.Object{
+				&operatorv1beta1.GatewayConfiguration{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "valid-config",
+						Namespace: "default",
+					},
+				},
+			},
+			expectedStatus: metav1.ConditionTrue,
+			expectedReason: string(gatewayv1.GatewayClassReasonAccepted),
+			expectedMsg:    "GatewayClass is accepted",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.existingObjs...).
+				Build()
+
+			condition, err := getAcceptedCondition(ctx, cl, tt.gwc)
+			assert.NoError(t, err)
+			assert.NotNil(t, condition)
+			assert.Equal(t, tt.expectedStatus, condition.Status)
+			assert.Equal(t, tt.expectedReason, condition.Reason)
+			assert.Equal(t, tt.expectedMsg, condition.Message)
+		})
+	}
+}

--- a/controller/gatewayclass/controller_reconciler_utils_test.go
+++ b/controller/gatewayclass/controller_reconciler_utils_test.go
@@ -114,7 +114,7 @@ func TestGetAcceptedCondition(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			ctx := context.Background()
 			cl := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithRuntimeObjects(tt.existingObjs...).

--- a/controller/specialized/aigateway_controller_watch.go
+++ b/controller/specialized/aigateway_controller_watch.go
@@ -37,7 +37,8 @@ func (r *AIGatewayReconciler) aiGatewayHasMatchingGatewayClass(obj client.Object
 		// class as well. If we fail here it's most likely because of some failure
 		// of the Kubernetes API and it's technically better to enqueue the object
 		// than to drop it for eventual consistency during cluster outages.
-		return !errors.As(err, &operatorerrors.ErrUnsupportedGatewayClass{})
+		return !errors.As(err, &operatorerrors.ErrUnsupportedGatewayClass{}) &&
+			!errors.As(err, &operatorerrors.ErrNotAcceptedGatewayClass{})
 	}
 
 	return true

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -3,6 +3,8 @@ package errors
 import (
 	"errors"
 	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // -----------------------------------------------------------------------------
@@ -29,6 +31,21 @@ func NewErrUnsupportedGateway(reason string) ErrUnsupportedGatewayClass {
 
 func (e ErrUnsupportedGatewayClass) Error() string {
 	return fmt.Sprintf("unsupported gateway class: %s", e.reason)
+}
+
+// ErrNotAcceptedGatewayClass is an error which indicates that a provided GatewayClass
+// is not accepted.
+type ErrNotAcceptedGatewayClass struct {
+	gatewayClass string
+	condition    metav1.Condition
+}
+
+func NewErrNotAcceptedGatewayClass(gatewayClass string, condition metav1.Condition) ErrNotAcceptedGatewayClass {
+	return ErrNotAcceptedGatewayClass{gatewayClass: gatewayClass, condition: condition}
+}
+
+func (e ErrNotAcceptedGatewayClass) Error() string {
+	return fmt.Sprintf("gateway class %s not accepted; reason: %s, message: %s", e.gatewayClass, e.condition.Reason, e.condition.Message)
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -25,10 +25,12 @@ type ErrUnsupportedGatewayClass struct {
 	reason string
 }
 
+// NewErrUnsupportedGateway creates a new ErrUnsupportedGatewayClass error
 func NewErrUnsupportedGateway(reason string) ErrUnsupportedGatewayClass {
 	return ErrUnsupportedGatewayClass{reason: reason}
 }
 
+// Error returns the error message for the ErrUnsupportedGatewayClass error
 func (e ErrUnsupportedGatewayClass) Error() string {
 	return fmt.Sprintf("unsupported gateway class: %s", e.reason)
 }
@@ -40,10 +42,12 @@ type ErrNotAcceptedGatewayClass struct {
 	condition    metav1.Condition
 }
 
+// NewErrNotAcceptedGatewayClass creates a new ErrNotAcceptedGatewayClass error
 func NewErrNotAcceptedGatewayClass(gatewayClass string, condition metav1.Condition) ErrNotAcceptedGatewayClass {
 	return ErrNotAcceptedGatewayClass{gatewayClass: gatewayClass, condition: condition}
 }
 
+// Error returns the error message for the ErrNotAcceptedGatewayClass error
 func (e ErrNotAcceptedGatewayClass) Error() string {
 	return fmt.Sprintf("gateway class %s not accepted; reason: %s, message: %s", e.gatewayClass, e.condition.Reason, e.condition.Message)
 }

--- a/internal/utils/gatewayclass/get.go
+++ b/internal/utils/gatewayclass/get.go
@@ -36,7 +36,7 @@ func Get(ctx context.Context, cl client.Client, gatewayClassName string) (*Decor
 		))
 	}
 	acceptedCondition, found := k8sutils.GetCondition(consts.ConditionType(gatewayv1.GatewayClassConditionStatusAccepted), gwc)
-	if acceptedCondition.Status != metav1.ConditionTrue || !found {
+	if !found || acceptedCondition.Status != metav1.ConditionTrue {
 		return nil, operatorerrors.NewErrNotAcceptedGatewayClass(gatewayClassName, acceptedCondition)
 	}
 

--- a/internal/utils/gatewayclass/get.go
+++ b/internal/utils/gatewayclass/get.go
@@ -4,14 +4,19 @@ import (
 	"context"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	operatorerrors "github.com/kong/gateway-operator/internal/errors"
+	"github.com/kong/gateway-operator/pkg/consts"
+	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/pkg/vars"
 )
 
 // Get returns a decorated GatewayClass object for the provided GatewayClass name. If the GatewayClass is
 // not found or is not supported, an `ErrUnsupportedGatewayClass` error is returned with a descriptive message.
+// If the GatewayClass is not accepted, an `ErrNotAcceptedGatewayClass` error is returned with a descriptive message.
 func Get(ctx context.Context, cl client.Client, gatewayClassName string) (*Decorator, error) {
 	if gatewayClassName == "" {
 		return nil, operatorerrors.NewErrUnsupportedGateway("no GatewayClassName provided")
@@ -29,6 +34,10 @@ func Get(ctx context.Context, cl client.Client, gatewayClassName string) (*Decor
 			gwc.Spec.ControllerName,
 			vars.ControllerName(),
 		))
+	}
+	acceptedCondition, found := k8sutils.GetCondition(consts.ConditionType(gatewayv1.GatewayClassConditionStatusAccepted), gwc)
+	if acceptedCondition.Status != metav1.ConditionTrue || !found {
+		return nil, operatorerrors.NewErrNotAcceptedGatewayClass(gatewayClassName, acceptedCondition)
 	}
 
 	return gwc, nil

--- a/internal/utils/gatewayclass/get_test.go
+++ b/internal/utils/gatewayclass/get_test.go
@@ -57,16 +57,61 @@ func TestGet(t *testing.T) {
 			),
 		},
 		{
-			name:             "gateway class supported",
+			name:             "gateway class supported but not accepted",
+			gatewayClassName: "gateway-class-not-accepted",
+			objectsToAdd: []client.Object{
+				&gatewayv1.GatewayClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gateway-class-not-accepted",
+					},
+					Spec: gatewayv1.GatewayClassSpec{
+						ControllerName: gatewayv1.GatewayController(vars.ControllerName()),
+					},
+					Status: gatewayv1.GatewayClassStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:    string(gatewayv1.GatewayClassConditionStatusAccepted),
+								Status:  metav1.ConditionFalse,
+								Reason:  string(gatewayv1.GatewayClassReasonInvalidParameters),
+								Message: "ParametersRef must reference a gateway-operator.konghq.com/GatewayConfiguration",
+							},
+						},
+					},
+				},
+			},
+			expectedError: operatorerrors.NewErrNotAcceptedGatewayClass(
+				"gateway-class-not-accepted",
+				metav1.Condition{
+					Type:    string(gatewayv1.GatewayClassConditionStatusAccepted),
+					Status:  metav1.ConditionFalse,
+					Reason:  string(gatewayv1.GatewayClassReasonInvalidParameters),
+					Message: "ParametersRef must reference a gateway-operator.konghq.com/GatewayConfiguration",
+				},
+			),
+		},
+		{
+			name:             "gateway class supported and accepted",
 			gatewayClassName: "gateway-class-2",
-			objectsToAdd: []client.Object{&gatewayv1.GatewayClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "gateway-class-2",
+			objectsToAdd: []client.Object{
+				&gatewayv1.GatewayClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gateway-class-2",
+					},
+					Spec: gatewayv1.GatewayClassSpec{
+						ControllerName: gatewayv1.GatewayController(vars.ControllerName()),
+					},
+					Status: gatewayv1.GatewayClassStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:    string(gatewayv1.GatewayClassConditionStatusAccepted),
+								Status:  metav1.ConditionTrue,
+								Reason:  string(gatewayv1.GatewayClassReasonAccepted),
+								Message: "GatewayClass is accepted",
+							},
+						},
+					},
 				},
-				Spec: gatewayv1.GatewayClassSpec{
-					ControllerName: gatewayv1.GatewayController(vars.ControllerName()),
-				},
-			}},
+			},
 			expectedError: nil,
 		},
 	}

--- a/pkg/utils/kubernetes/status.go
+++ b/pkg/utils/kubernetes/status.go
@@ -45,7 +45,12 @@ func SetCondition(condition metav1.Condition, resource ConditionsAware) {
 		if conditions[i].Type != condition.Type {
 			newConditions = append(newConditions, conditions[i])
 		} else {
-			newConditions = append(newConditions, condition)
+			oldCondition := conditions[i]
+			if conditionNeedsUpdate(oldCondition, condition) {
+				newConditions = append(newConditions, condition)
+			} else {
+				newConditions = append(newConditions, oldCondition)
+			}
 			conditionFound = true
 		}
 	}
@@ -264,9 +269,13 @@ func NeedsUpdate(current, updated ConditionsAware) bool {
 		if !exists {
 			return true
 		}
-		if u.Reason != c.Reason || u.Message != c.Message || u.Status != c.Status || u.ObservedGeneration != c.ObservedGeneration {
+		if conditionNeedsUpdate(c, u) {
 			return true
 		}
 	}
 	return false
+}
+
+func conditionNeedsUpdate(current, updated metav1.Condition) bool {
+	return updated.Reason != current.Reason || updated.Message != current.Message || updated.Status != current.Status || updated.ObservedGeneration != current.ObservedGeneration
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The GWC accepted condition is now properly set to False with reason InvalidParameters in case the ParametersRef field of the GatewayClass spec is not a valid GatewayConfiguration. 

**Which issue this PR fixes**

Fixes #982 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
