### PR TITLE
chore(refactor): accept only what is needed in `DeployCRDs` and `InstallKubernetesConfigurationCRDs`

### DIFF
--- a/pkg/utils/test/setup_helpers.go
+++ b/pkg/utils/test/setup_helpers.go
@@ -212,27 +212,27 @@ func ExtractModuleVersion(moduleName string) (string, error) {
 }
 
 // DeployCRDs deploys the CRDs commonly used in tests.
-func DeployCRDs(ctx context.Context, crdPath string, operatorClient *operatorclient.Clientset, env environments.Environment) error {
-	// CRDs for stable features
+func DeployCRDs(ctx context.Context, crdPath string, operatorClient *operatorclient.Clientset, cluster clusters.Cluster) error {
+	// CRDs for stable features.
 	kubectlFlags := []string{"--server-side", "-v5"}
 	fmt.Printf("INFO: deploying KGO CRDs: %s\n", crdPath)
-	if err := clusters.KustomizeDeployForCluster(ctx, env.Cluster(), crdPath, kubectlFlags...); err != nil {
+	if err := clusters.KustomizeDeployForCluster(ctx, cluster, crdPath, kubectlFlags...); err != nil {
 		return err
 	}
 
-	// CRDs for gateway APIs
+	// CRDs for gateway APIs.
 	fmt.Printf("INFO: deploying Gateway API CRDs: %s\n", GatewayStandardCRDsKustomizeURL)
-	if err := clusters.KustomizeDeployForCluster(ctx, env.Cluster(), GatewayStandardCRDsKustomizeURL); err != nil {
+	if err := clusters.KustomizeDeployForCluster(ctx, cluster, GatewayStandardCRDsKustomizeURL); err != nil {
 		return err
 	}
 
-	if err := InstallKubernetesConfigurationCRDs(ctx, env); err != nil {
+	if err := InstallKubernetesConfigurationCRDs(ctx, cluster); err != nil {
 		return err
 	}
 
-	// CRDs for alpha/experimental features
+	// CRDs for alpha/experimental features.
 	fmt.Printf("INFO: deploying KGO AIGateway CRD: %s\n", crdPath)
-	if err := clusters.ApplyManifestByURL(ctx, env.Cluster(), path.Join(crdPath, AIGatewayCRDPath)); err != nil {
+	if err := clusters.ApplyManifestByURL(ctx, cluster, path.Join(crdPath, AIGatewayCRDPath)); err != nil {
 		return err
 	}
 
@@ -246,8 +246,8 @@ func DeployCRDs(ctx context.Context, crdPath string, operatorClient *operatorcli
 
 // InstallKubernetesConfigurationCRDs installs the Kong CRDs from the `kong/kubernetes-configuration` module.
 // The version is extracted using ExtractModuleVersion from go.mod.
-func InstallKubernetesConfigurationCRDs(ctx context.Context, env environments.Environment) error {
-	// First extract version of `kong/kubernetes-configuration` module used
+func InstallKubernetesConfigurationCRDs(ctx context.Context, cluster clusters.Cluster) error {
+	// First extract version of `kong/kubernetes-configuration` module used.
 	kongCRDVersion, err := ExtractModuleVersion(KubernetesConfigurationModuleName)
 	if err != nil {
 		return fmt.Errorf("failed to extract Kong CRDs (%s) module's version: %w", KubernetesConfigurationModuleName, err)
@@ -262,7 +262,7 @@ func InstallKubernetesConfigurationCRDs(ctx context.Context, env environments.En
 			"kubernetes-configuration@"+kongCRDVersion, "config", "crd", crdDirName,
 		)
 		fmt.Printf("INFO: deploying kubernetes-configuration CRDs: %s\n", kongCRDPath)
-		if err := clusters.KustomizeDeployForCluster(ctx, env.Cluster(), kongCRDPath); err != nil {
+		if err := clusters.KustomizeDeployForCluster(ctx, cluster, kongCRDPath); err != nil {
 			return fmt.Errorf("failed installing kubernetes-configurations (%s) CRDs: %w", kongCRDPath, err)
 		}
 	}

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -109,7 +109,7 @@ func TestMain(m *testing.M) {
 	exitOnErr(err)
 
 	fmt.Println("INFO: deploying CRDs to test cluster")
-	exitOnErr(testutils.DeployCRDs(ctx, path.Join(configPath, "/crd"), clients.OperatorClient, env))
+	exitOnErr(testutils.DeployCRDs(ctx, path.Join(configPath, "/crd"), clients.OperatorClient, env.Cluster()))
 
 	fmt.Println("INFO: starting the operator's controller manager")
 	// startControllerManager will spawn the controller manager in a separate

--- a/test/integration/suite.go
+++ b/test/integration/suite.go
@@ -157,7 +157,7 @@ func TestMain(
 	exitOnErr(err)
 
 	fmt.Println("INFO: deploying CRDs to test cluster")
-	exitOnErr(testutils.DeployCRDs(GetCtx(), path.Join(configPath, "/crd"), GetClients().OperatorClient, GetEnv()))
+	exitOnErr(testutils.DeployCRDs(GetCtx(), path.Join(configPath, "/crd"), GetClients().OperatorClient, GetEnv().Cluster()))
 
 	var ca, cert, key []byte // Certificate generated for tests used by webhook.
 	if webhookEnabled {


### PR DESCRIPTION
**What this PR does / why we need it**:

Both functions `DeployCRDs` and `InstallKubernetesConfigurationCRDs` don't need the whole `environments.Environment` that returns `clusters.Cluster` when the method `Cluster()` is called. They can accept `clusters.Cluster` directly

**Which issue this PR fixes**

Spotted during work on unlocking 

- https://github.com/Kong/gateway-operator-enterprise/pull/389

it's basically kind of the boy-scout rule improvement

