### PR TITLE
ci: add merge_queue workflow event trigger

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  merge_group:
+    branches:
+      - 'main'
   pull_request:
     branches:
       - '*'


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent CI from stalling (as seen in https://github.com/Kong/gateway-operator/pull/1057, https://github.com/Kong/gateway-operator/queue/main)

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
