### PR TITLE
chore: fix ValidatingAdmissionPolicy for DataPlane ports

### DIFF
--- a/config/default/validating_policies/dataplane_ports_validating_admission_policy.yaml
+++ b/config/default/validating_policies/dataplane_ports_validating_admission_policy.yaml
@@ -16,18 +16,17 @@ spec:
         resources:
           - "dataplanes"
   variables:
-  - name: network
-    expression: object.spec.network
-  - name: services
-    expression: variables.network.services
   - name: ingressPorts
-    expression: variables.services.ingress.ports
+    expression: object.spec.network.services.ingress.ports
   - name: podTemplateSpec
     expression: object.spec.deployment.podTemplateSpec
+  - name: proxyContainers
+    expression: |
+      variables.podTemplateSpec.spec.containers.filter(c, c.name == 'proxy')
   - name: proxyContainer
     expression: |
-      variables.podTemplateSpec.spec.containers.exists(c, c.name == 'proxy') ?
-        variables.podTemplateSpec.spec.containers.filter(c, c.name == 'proxy')[0] :
+      variables.proxyContainers.size() > 0 ?
+        variables.proxyContainers[0] :
         null
   - name: envFilteredPortMaps
     expression: |
@@ -47,27 +46,35 @@ spec:
     expression: |
       !has(object.spec.network) ||
       !has(object.spec.network.services) ||
-      variables.ingressPorts == null ||
-      variables.envPortMaps == null ||
-      variables.ingressPorts.all(p, variables.envPortMaps.
-                split(",").
-                exists(pm,
-                    pm.split(":")[1].trim() == string(p.targetPort)
-                    )
-                )
+      !has(object.spec.network.services.ingress) ||
+      !has(object.spec.network.services.ingress.ports) ||
+      (
+        has(variables.proxyContainer.env) &&
+        variables.envPortMaps != null &&
+        variables.ingressPorts.all(p, variables.envPortMaps.
+                  split(",").
+                  exists(pm,
+                      pm.split(":")[1].trim() == string(p.targetPort)
+                      )
+                  )
+      )
     reason: Invalid
   - messageExpression: "'Each port from spec.network.services.ingress.ports has to have an accompanying port in KONG_PROXY_LISTEN env'"
     expression: |
       !has(object.spec.network) ||
       !has(object.spec.network.services) ||
-      variables.ingressPorts == null ||
-      variables.envProxyListen == null ||
-      variables.ingressPorts.all(p, variables.envProxyListen.
-                split(",").
-                exists(pm,
-                  pm.trim().split(" ")[0].split(":")[1].trim() == string(p.targetPort)
+      !has(object.spec.network.services.ingress) ||
+      !has(object.spec.network.services.ingress.ports) ||
+      (
+        has(variables.proxyContainer.env) &&
+        variables.envProxyListen != null &&
+        variables.ingressPorts.all(p, variables.envProxyListen.
+                  split(",").
+                  exists(pm,
+                    pm.trim().split(" ")[0].split(":")[1].trim() == string(p.targetPort)
+                    )
                   )
-                )
+      )
     reason: Invalid
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/config/samples/dataplane.yaml
+++ b/config/samples/dataplane.yaml
@@ -15,9 +15,6 @@ spec:
         - name: proxy
           # renovate: datasource=docker versioning=docker
           image: kong/kong-gateway:3.9
-          env:
-          - name: KONG_LOG_LEVEL
-            value: debug
           resources:
             requests:
               memory: "64Mi"
@@ -29,8 +26,3 @@ spec:
             initialDelaySeconds: 1
             periodSeconds: 1
 
-  network:
-    services:
-      ingress:
-        annotations:
-          foo: bar

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/terratest v0.48.1
-	github.com/kong/kubernetes-configuration v1.0.7-0.20250120092720-c985e30e5dd8
+	github.com/kong/kubernetes-configuration v1.1.1-0.20250121180526-63c79b8dd980
 	github.com/kong/kubernetes-telemetry v0.1.8
 	github.com/kong/kubernetes-testing-framework v0.47.2
 	github.com/kong/semver/v4 v4.0.1

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IX
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/kong/go-kong v0.63.0 h1:8ECLgkgDqON61qCMq/M0gTwZKYxg55Oy692dRDOOBiU=
 github.com/kong/go-kong v0.63.0/go.mod h1:ma9GWnhkxtrXZlLFfED955HjVzmUojYEHet3lm+PDik=
-github.com/kong/kubernetes-configuration v1.0.7-0.20250120092720-c985e30e5dd8 h1:SOex4KtF+p+D+hipv461M2Ueu4qQGBf8C5H1cuK1xfo=
-github.com/kong/kubernetes-configuration v1.0.7-0.20250120092720-c985e30e5dd8/go.mod h1:YzSyKf/Dg1TIPkVlzSHofk/RGchuDzpxBivfPDkQ2Do=
+github.com/kong/kubernetes-configuration v1.1.1-0.20250121180526-63c79b8dd980 h1:3sFAu5eGFo2LyzK9pLgygbv+jP6xfdikw0TMEmakbGY=
+github.com/kong/kubernetes-configuration v1.1.1-0.20250121180526-63c79b8dd980/go.mod h1:Z9Yo8DyBe/4zw/cgoSYafqHzuviKINVSq1b8D60F0u8=
 github.com/kong/kubernetes-telemetry v0.1.8 h1:nbtUmXW9xkzRO7dgvrgVrJZiRksATk4XHrqX+78g/5k=
 github.com/kong/kubernetes-telemetry v0.1.8/go.mod h1:ZEQY/4DddKoe5XA7UTOIbdI/4d6ZRcrzh2ezRxnuyl0=
 github.com/kong/kubernetes-testing-framework v0.47.2 h1:+2Z9anTpbV/hwNeN+NFQz53BMU+g3QJydkweBp3tULo=

--- a/test/crdsvalidation/dataplane_validatingadmissionpolicy_test.go
+++ b/test/crdsvalidation/dataplane_validatingadmissionpolicy_test.go
@@ -35,7 +35,7 @@ func TestDataPlaneValidatingAdmissionPolicy(t *testing.T) {
 			Namespace:    ns.Name,
 		}
 		sharedEventuallyConfig = kcfgcrdsvalidation.EventuallyConfig{
-			Timeout: 15 * time.Second,
+			Timeout: 5 * time.Second,
 			Period:  100 * time.Millisecond,
 		}
 	)
@@ -255,6 +255,82 @@ func TestDataPlaneValidatingAdmissionPolicy(t *testing.T) {
 				},
 				ExpectedErrorEventuallyConfig: sharedEventuallyConfig,
 				ExpectedErrorMessage:          lo.ToPtr("is forbidden: ValidatingAdmissionPolicy 'ports.dataplane.gateway-operator.konghq.com' with binding 'binding-ports.dataplane.gateway-operator.konghq.com' denied request: Each port from spec.network.services.ingress.ports has to have an accompanying port in KONG_PORT_MAPS env"),
+			},
+			{
+				Name: "providing network services ingress options without ports does not fail",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: commonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+								DeploymentOptions: operatorv1beta1.DeploymentOptions{
+									PodTemplateSpec: &corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name:  "proxy",
+													Image: "kong:3.9",
+												},
+											},
+										},
+									},
+								},
+							},
+							Network: operatorv1beta1.DataPlaneNetworkOptions{
+								Services: &operatorv1beta1.DataPlaneServices{
+									Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+										ServiceOptions: operatorv1beta1.ServiceOptions{
+											Annotations: map[string]string{
+												"a": "b",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			// TODO: ValidatingAdmissionPolicy rules have to be adjusted for this test case.
+			{
+				Name: "providing network services ingress ports without matching envs should fail",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: commonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+								DeploymentOptions: operatorv1beta1.DeploymentOptions{
+									PodTemplateSpec: &corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name:  "proxy",
+													Image: "kong:3.9",
+												},
+											},
+										},
+									},
+								},
+							},
+							Network: operatorv1beta1.DataPlaneNetworkOptions{
+								Services: &operatorv1beta1.DataPlaneServices{
+									Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+										Ports: []operatorv1beta1.DataPlaneServicePort{
+											{
+												Name: "http",
+												Port: 80,
+												// No matching port in KONG_PORT_MAPS
+												TargetPort: intstr.FromInt(8001),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage:          lo.ToPtr("Each port from spec.network.services.ingress.ports has to have an accompanying port in KONG_PORT_MAPS env"),
+				ExpectedErrorEventuallyConfig: sharedEventuallyConfig,
 			},
 		}.RunWithConfig(t, cfg, scheme)
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix `ValidatingAdmissionPolicy` for `DataPlane` ports. It was missing cases where `spec.network.services.ingress.ports` or `spec.network.services.ingress` were unspecified.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
