### PR TITLE
chore: add renovate config for Makefile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,16 @@
       ]
     },
     {
+      "description": "Match dependencies in Makefile that are properly annotated with `# renovate: datasource={} depName={}.`",
+      "customType": "regex",
+      "fileMatch": [
+        "Makefile"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.+=\\s*(?<currentValue>.*)\\n"
+      ]
+    },
+    {
       "description": "Match versions in selected *.go files that are properly annotated with `// renovate: datasource={} depName={}.`",
       "customType": "regex",
       "datasourceTemplate": "docker",


### PR DESCRIPTION
**What this PR does / why we need it**:

Tested locally:

```
docker run --rm -it -v $PWD/renovate.json:/usr/src/app/renovate.json -v /tmp:/tmp -v $(pwd):/tmp/workdir -w /tmp/workdir -e LOG_LEVEL=debug -e GITHUB_COM_TOKEN=${GITHUB_TOKEN} renovate/renovate --platform local --base-dir /tmp/ --enabled-managers custom.regex
...

           {
             "deps": [
               {
                 "depName": "mikefarah/yq",
                 "currentValue": "4.43.1",
                 "datasource": "github-releases",
                 "replaceString": "# renovate: datasource=github-releases depName=mikefarah/yq\nYQ_VERSION = 4.43.1\n",
                 "updates": [
                   {
                     "bucket": "minor",
                     "newVersion": "v4.45.1",
                     "newValue": "4.45.1",
                     "releaseTimestamp": "2025-01-12T03:42:17.000Z",
                     "newVersionAgeInDays": 10,
                     "newMajor": 4,
                     "newMinor": 45,
                     "newPatch": 1,
                     "updateType": "minor",
                     "branchName": "renovate/mikefarah-yq-4.x"
                   }
                 ],
                 "packageName": "mikefarah/yq",
                 "versioning": "semver-coerced",
                 "warnings": [],
                 "sourceUrl": "https://github.com/mikefarah/yq",
                 "registryUrl": "https://github.com",
                 "currentVersion": "v4.43.1",
                 "currentVersionTimestamp": "2024-03-24T00:17:31.000Z",
                 "currentVersionAgeInDays": 304,
                 "isSingleVersion": true,
                 "fixedVersion": "4.43.1"
               }
             ],
             "matchStrings": [
               "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.+=\\s*(?<currentValue>.*)\\n"
             ],
             "packageFile": "Makefile"
           },

```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
