### PR TITLE
feat: add `-cluster-ca-key-type` and `-cluster-ca-key-size` flags to control the type and size (for rsa) of CA private keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@
   alternative is `GlobalInControlPlane` that will make the plugin apply
   globally in a control plane.
   [#1052](https://github.com/Kong/gateway-operator/pull/1052)
+- Added `-cluster-ca-key-type` and `-cluster-ca-key-size` CLI flags to allow
+  configuring cluster CA private key type and size. Currently allowed values:
+  `rsa` and `ecdsa` (default).
+  [#1081](https://github.com/Kong/gateway-operator/pull/1081)
 
 ### Changed
 

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kong/gateway-operator/controller/pkg/controlplane"
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/controller/pkg/op"
+	"github.com/kong/gateway-operator/controller/pkg/secrets"
 	operatorerrors "github.com/kong/gateway-operator/internal/errors"
 	"github.com/kong/gateway-operator/internal/versions"
 	"github.com/kong/gateway-operator/pkg/consts"
@@ -42,6 +43,7 @@ type Reconciler struct {
 	Scheme                   *runtime.Scheme
 	ClusterCASecretName      string
 	ClusterCASecretNamespace string
+	ClusterCAKeyConfig       secrets.KeyConfig
 	DevelopmentMode          bool
 }
 

--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -435,6 +435,10 @@ func (r *Reconciler) ensureAdminMTLSCertificateSecret(
 			Name:      r.ClusterCASecretName,
 		},
 		usages,
+		secrets.KeyConfig{
+			Type: r.ClusterCAKeyConfig.Type,
+			Size: r.ClusterCAKeyConfig.Size,
+		},
 		r.Client,
 		matchingLabels,
 	)
@@ -486,6 +490,10 @@ func (r *Reconciler) ensureAdmissionWebhookCertificateSecret(
 			Name:      r.ClusterCASecretName,
 		},
 		usages,
+		secrets.KeyConfig{
+			Type: r.ClusterCAKeyConfig.Type,
+			Size: r.ClusterCAKeyConfig.Size,
+		},
 		r.Client,
 		matchingLabels,
 	)
@@ -498,7 +506,6 @@ func (r *Reconciler) ensureOwnedClusterRolesDeleted(
 	ctx context.Context,
 	cp *operatorv1beta1.ControlPlane,
 ) (deletions bool, err error) {
-
 	clusterRoles, err := k8sutils.ListClusterRoles(
 		ctx,
 		r.Client,
@@ -557,7 +564,6 @@ func (r *Reconciler) ensureOwnedClusterRoleBindingsDeleted(
 func (r *Reconciler) ensureOwnedValidatingWebhookConfigurationDeleted(ctx context.Context,
 	cp *operatorv1beta1.ControlPlane,
 ) (deletions bool, err error) {
-
 	validatingWebhookConfigurations, err := k8sutils.ListValidatingWebhookConfigurations(
 		ctx,
 		r.Client,

--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -435,10 +435,7 @@ func (r *Reconciler) ensureAdminMTLSCertificateSecret(
 			Name:      r.ClusterCASecretName,
 		},
 		usages,
-		secrets.KeyConfig{
-			Type: r.ClusterCAKeyConfig.Type,
-			Size: r.ClusterCAKeyConfig.Size,
-		},
+		r.ClusterCAKeyConfig,
 		r.Client,
 		matchingLabels,
 	)
@@ -490,10 +487,7 @@ func (r *Reconciler) ensureAdmissionWebhookCertificateSecret(
 			Name:      r.ClusterCASecretName,
 		},
 		usages,
-		secrets.KeyConfig{
-			Type: r.ClusterCAKeyConfig.Type,
-			Size: r.ClusterCAKeyConfig.Size,
-		},
+		r.ClusterCAKeyConfig,
 		r.Client,
 		matchingLabels,
 	)

--- a/controller/dataplane/bluegreen_controller.go
+++ b/controller/dataplane/bluegreen_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kong/gateway-operator/controller/pkg/dataplane"
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/controller/pkg/op"
+	"github.com/kong/gateway-operator/controller/pkg/secrets"
 	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	k8sresources "github.com/kong/gateway-operator/pkg/utils/kubernetes/resources"
@@ -52,6 +53,7 @@ type BlueGreenReconciler struct {
 	// certificate data which will be used when generating certificates for DataPlane's
 	// Deployment.
 	ClusterCASecretNamespace string
+	ClusterCAKeyConfig       secrets.KeyConfig
 
 	// DevelopmentMode indicates if the controller should run in development mode,
 	// which causes it to e.g. perform less validations.
@@ -175,6 +177,10 @@ func (r *BlueGreenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		types.NamespacedName{
 			Namespace: dataplaneAdminService.Namespace,
 			Name:      dataplaneAdminService.Name,
+		},
+		secrets.KeyConfig{
+			Type: r.ClusterCAKeyConfig.Type,
+			Size: r.ClusterCAKeyConfig.Size,
 		},
 	)
 	if err != nil {

--- a/controller/dataplane/bluegreen_controller.go
+++ b/controller/dataplane/bluegreen_controller.go
@@ -178,10 +178,7 @@ func (r *BlueGreenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			Namespace: dataplaneAdminService.Namespace,
 			Name:      dataplaneAdminService.Name,
 		},
-		secrets.KeyConfig{
-			Type: r.ClusterCAKeyConfig.Type,
-			Size: r.ClusterCAKeyConfig.Size,
-		},
+		r.ClusterCAKeyConfig,
 	)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/controller/dataplane/bluegreen_controller_test.go
+++ b/controller/dataplane/bluegreen_controller_test.go
@@ -2,6 +2,7 @@ package dataplane
 
 import (
 	"context"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"os"
@@ -29,7 +30,6 @@ import (
 	"github.com/kong/gateway-operator/controller/pkg/op"
 	"github.com/kong/gateway-operator/controller/pkg/secrets"
 	dpv "github.com/kong/gateway-operator/internal/validation/dataplane"
-	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
 	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	k8sresources "github.com/kong/gateway-operator/pkg/utils/kubernetes/resources"
@@ -354,7 +354,7 @@ func TestDataPlaneBlueGreenReconciler_Reconcile(t *testing.T) {
 				ClusterCASecretName:      mtlsSecret.Name,
 				ClusterCASecretNamespace: mtlsSecret.Namespace,
 				ClusterCAKeyConfig: secrets.KeyConfig{
-					Type: mgrconfig.ECDSA,
+					Type: x509.ECDSA,
 				},
 				DataPlaneController: &Reconciler{
 					Scheme:                   scheme.Scheme,
@@ -362,7 +362,7 @@ func TestDataPlaneBlueGreenReconciler_Reconcile(t *testing.T) {
 					ClusterCASecretName:      mtlsSecret.Name,
 					ClusterCASecretNamespace: mtlsSecret.Namespace,
 					ClusterCAKeyConfig: secrets.KeyConfig{
-						Type: mgrconfig.ECDSA,
+						Type: x509.ECDSA,
 					},
 					Validator: dpv.NewValidator(fakeClient),
 				},

--- a/controller/dataplane/bluegreen_controller_test.go
+++ b/controller/dataplane/bluegreen_controller_test.go
@@ -27,7 +27,9 @@ import (
 	"github.com/kong/gateway-operator/controller/pkg/builder"
 	"github.com/kong/gateway-operator/controller/pkg/dataplane"
 	"github.com/kong/gateway-operator/controller/pkg/op"
+	"github.com/kong/gateway-operator/controller/pkg/secrets"
 	dpv "github.com/kong/gateway-operator/internal/validation/dataplane"
+	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
 	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	k8sresources "github.com/kong/gateway-operator/pkg/utils/kubernetes/resources"
@@ -351,12 +353,18 @@ func TestDataPlaneBlueGreenReconciler_Reconcile(t *testing.T) {
 				Client:                   fakeClient,
 				ClusterCASecretName:      mtlsSecret.Name,
 				ClusterCASecretNamespace: mtlsSecret.Namespace,
+				ClusterCAKeyConfig: secrets.KeyConfig{
+					Type: mgrconfig.ECDSA,
+				},
 				DataPlaneController: &Reconciler{
 					Scheme:                   scheme.Scheme,
 					Client:                   fakeClient,
 					ClusterCASecretName:      mtlsSecret.Name,
 					ClusterCASecretNamespace: mtlsSecret.Namespace,
-					Validator:                dpv.NewValidator(fakeClient),
+					ClusterCAKeyConfig: secrets.KeyConfig{
+						Type: mgrconfig.ECDSA,
+					},
+					Validator: dpv.NewValidator(fakeClient),
 				},
 			}
 

--- a/controller/dataplane/controller.go
+++ b/controller/dataplane/controller.go
@@ -164,10 +164,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			Namespace: dataplaneAdminService.Namespace,
 			Name:      dataplaneAdminService.Name,
 		},
-		secrets.KeyConfig{
-			Type: r.ClusterCAKeyConfig.Type,
-			Size: r.ClusterCAKeyConfig.Size,
-		},
+		r.ClusterCAKeyConfig,
 	)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/controller/dataplane/controller.go
+++ b/controller/dataplane/controller.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kong/gateway-operator/controller/pkg/ctxinjector"
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/controller/pkg/op"
+	"github.com/kong/gateway-operator/controller/pkg/secrets"
 	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	k8sresources "github.com/kong/gateway-operator/pkg/utils/kubernetes/resources"
@@ -37,6 +38,7 @@ type Reconciler struct {
 	eventRecorder            record.EventRecorder
 	ClusterCASecretName      string
 	ClusterCASecretNamespace string
+	ClusterCAKeyConfig       secrets.KeyConfig
 	DevelopmentMode          bool
 	Validator                dataPlaneValidator
 	Callbacks                DataPlaneCallbacks
@@ -161,6 +163,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		types.NamespacedName{
 			Namespace: dataplaneAdminService.Namespace,
 			Name:      dataplaneAdminService.Name,
+		},
+		secrets.KeyConfig{
+			Type: r.ClusterCAKeyConfig.Type,
+			Size: r.ClusterCAKeyConfig.Size,
 		},
 	)
 	if err != nil {

--- a/controller/dataplane/controller_test.go
+++ b/controller/dataplane/controller_test.go
@@ -2,6 +2,7 @@ package dataplane
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"os"
 	"testing"
@@ -26,7 +27,6 @@ import (
 	operatorv1beta1 "github.com/kong/gateway-operator/api/v1beta1"
 	"github.com/kong/gateway-operator/controller/pkg/secrets"
 	"github.com/kong/gateway-operator/internal/validation/dataplane"
-	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
 	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers"
@@ -917,7 +917,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 				ClusterCASecretName:      mtlsSecret.Name,
 				ClusterCASecretNamespace: mtlsSecret.Namespace,
 				ClusterCAKeyConfig: secrets.KeyConfig{
-					Type: mgrconfig.ECDSA,
+					Type: x509.ECDSA,
 				},
 				Validator: dataplane.NewValidator(fakeClient),
 			}

--- a/controller/dataplane/controller_test.go
+++ b/controller/dataplane/controller_test.go
@@ -24,7 +24,9 @@ import (
 
 	operatorv1alpha1 "github.com/kong/gateway-operator/api/v1alpha1"
 	operatorv1beta1 "github.com/kong/gateway-operator/api/v1beta1"
+	"github.com/kong/gateway-operator/controller/pkg/secrets"
 	"github.com/kong/gateway-operator/internal/validation/dataplane"
+	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
 	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers"
@@ -914,7 +916,10 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 				Client:                   fakeClient,
 				ClusterCASecretName:      mtlsSecret.Name,
 				ClusterCASecretNamespace: mtlsSecret.Namespace,
-				Validator:                dataplane.NewValidator(fakeClient),
+				ClusterCAKeyConfig: secrets.KeyConfig{
+					Type: mgrconfig.ECDSA,
+				},
+				Validator: dataplane.NewValidator(fakeClient),
 			}
 
 			tc.testBody(t, reconciler, tc.dataplaneReq)

--- a/controller/dataplane/owned_resources.go
+++ b/controller/dataplane/owned_resources.go
@@ -46,10 +46,7 @@ func ensureDataPlaneCertificate(
 		fmt.Sprintf("*.%s.%s.svc", adminServiceNN.Name, adminServiceNN.Namespace),
 		clusterCASecretNN,
 		usages,
-		secrets.KeyConfig{
-			Type: keyConfig.Type,
-			Size: keyConfig.Size,
-		},
+		keyConfig,
 		cl,
 		secrets.GetManagedLabelForServiceSecret(adminServiceNN),
 	)

--- a/controller/dataplane/owned_resources.go
+++ b/controller/dataplane/owned_resources.go
@@ -35,6 +35,7 @@ func ensureDataPlaneCertificate(
 	dataplane *operatorv1beta1.DataPlane,
 	clusterCASecretNN types.NamespacedName,
 	adminServiceNN types.NamespacedName,
+	keyConfig secrets.KeyConfig,
 ) (op.Result, *corev1.Secret, error) {
 	usages := []certificatesv1.KeyUsage{
 		certificatesv1.UsageKeyEncipherment,
@@ -45,6 +46,10 @@ func ensureDataPlaneCertificate(
 		fmt.Sprintf("*.%s.%s.svc", adminServiceNN.Name, adminServiceNN.Namespace),
 		clusterCASecretNN,
 		usages,
+		secrets.KeyConfig{
+			Type: keyConfig.Type,
+			Size: keyConfig.Size,
+		},
 		cl,
 		secrets.GetManagedLabelForServiceSecret(adminServiceNN),
 	)

--- a/controller/pkg/secrets/cert.go
+++ b/controller/pkg/secrets/cert.go
@@ -2,8 +2,7 @@ package secrets
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
+	"crypto"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -31,6 +30,7 @@ import (
 	operatorv1beta1 "github.com/kong/gateway-operator/api/v1beta1"
 	"github.com/kong/gateway-operator/controller/pkg/dataplane"
 	"github.com/kong/gateway-operator/controller/pkg/op"
+	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
 	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
@@ -94,14 +94,36 @@ limitations under the License.
 
 // signCertificate takes a CertificateSigningRequest and a TLS Secret and returns a PEM x.509 certificate
 // signed by the certificate in the Secret.
-func signCertificate(csr certificatesv1.CertificateSigningRequest, ca *corev1.Secret) ([]byte, error) {
+func signCertificate(
+	csr certificatesv1.CertificateSigningRequest,
+	ca *corev1.Secret,
+	keyType mgrconfig.KeyType,
+) ([]byte, error) {
 	caKeyBlock, _ := pem.Decode(ca.Data["tls.key"])
 	if caKeyBlock == nil {
 		return nil, fmt.Errorf("failed decoding 'tls.key' data from secret %s", ca.Name)
 	}
-	priv, err := x509.ParseECPrivateKey(caKeyBlock.Bytes)
-	if err != nil {
-		return nil, err
+
+	var (
+		signatureAlgorithm x509.SignatureAlgorithm
+		priv               crypto.Signer
+		err                error
+	)
+	switch keyType {
+	case mgrconfig.ECDSA:
+		priv, err = x509.ParseECPrivateKey(caKeyBlock.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		signatureAlgorithm = x509.ECDSAWithSHA256
+	case mgrconfig.RSA:
+		priv, err = x509.ParsePKCS1PrivateKey(caKeyBlock.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		signatureAlgorithm = x509.SHA256WithRSA
+	default:
+		return nil, fmt.Errorf("unsupported key type: %s", keyType)
 	}
 
 	caCertBlock, _ := pem.Decode(ca.Data["tls.crt"])
@@ -134,7 +156,7 @@ func signCertificate(csr certificatesv1.CertificateSigningRequest, ca *corev1.Se
 			ExpiryString: certExpiryDuration.String(),
 		},
 	}
-	cfs, err := local.NewSigner(priv, caCert, x509.ECDSAWithSHA256, policy)
+	cfs, err := local.NewSigner(priv, caCert, signatureAlgorithm, policy)
 	if err != nil {
 		return nil, err
 	}
@@ -180,6 +202,7 @@ func EnsureCertificate[
 	subject string,
 	mtlsCASecretNN types.NamespacedName,
 	usages []certificatesv1.KeyUsage,
+	keyConfig KeyConfig,
 	cl client.Client,
 	additionalMatchingLabels client.MatchingLabels,
 ) (op.Result, *corev1.Secret, error) {
@@ -209,7 +232,7 @@ func EnsureCertificate[
 
 	// If there are no secrets yet, then create one.
 	if count == 0 {
-		return generateTLSDataSecret(ctx, generatedSecret, owner, subject, mtlsCASecretNN, usages, cl)
+		return generateTLSDataSecret(ctx, generatedSecret, owner, subject, mtlsCASecretNN, usages, keyConfig, cl)
 	}
 
 	// Otherwise there is already 1 certificate matching specified selectors.
@@ -222,7 +245,7 @@ func EnsureCertificate[
 			return op.Noop, nil, err
 		}
 
-		return generateTLSDataSecret(ctx, generatedSecret, owner, subject, mtlsCASecretNN, usages, cl)
+		return generateTLSDataSecret(ctx, generatedSecret, owner, subject, mtlsCASecretNN, usages, keyConfig, cl)
 	}
 
 	// Check if existing certificate is for a different subject.
@@ -236,7 +259,7 @@ func EnsureCertificate[
 			return op.Noop, nil, err
 		}
 
-		return generateTLSDataSecret(ctx, generatedSecret, owner, subject, mtlsCASecretNN, usages, cl)
+		return generateTLSDataSecret(ctx, generatedSecret, owner, subject, mtlsCASecretNN, usages, keyConfig, cl)
 	}
 
 	var updated bool
@@ -305,21 +328,22 @@ func generateTLSDataSecret(
 	subject string,
 	mtlsCASecret types.NamespacedName,
 	usages []certificatesv1.KeyUsage,
+	keyConfig KeyConfig,
 	k8sClient client.Client,
 ) (op.Result, *corev1.Secret, error) {
+	priv, pemBlock, signatureAlgorithm, err := CreatePrivateKey(keyConfig)
+	if err != nil {
+		return op.Noop, nil, err
+	}
+
 	template := x509.CertificateRequest{
 		Subject: pkix.Name{
 			CommonName:   subject,
 			Organization: []string{"Kong, Inc."},
 			Country:      []string{"US"},
 		},
-		SignatureAlgorithm: x509.ECDSAWithSHA256,
+		SignatureAlgorithm: signatureAlgorithm,
 		DNSNames:           []string{subject},
-	}
-
-	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		return op.Noop, nil, err
 	}
 
 	der, err := x509.CreateCertificateRequest(rand.Reader, &template, priv)
@@ -353,17 +377,13 @@ func generateTLSDataSecret(
 		},
 	}
 
-	ca := &corev1.Secret{}
-	err = k8sClient.Get(ctx, mtlsCASecret, ca)
+	var ca corev1.Secret
+	err = k8sClient.Get(ctx, mtlsCASecret, &ca)
 	if err != nil {
 		return op.Noop, nil, err
 	}
 
-	signed, err := signCertificate(csr, ca)
-	if err != nil {
-		return op.Noop, nil, err
-	}
-	privDer, err := x509.MarshalECPrivateKey(priv)
+	signed, err := signCertificate(csr, &ca, keyConfig.Type)
 	if err != nil {
 		return op.Noop, nil, err
 	}
@@ -371,10 +391,7 @@ func generateTLSDataSecret(
 	generatedSecret.Data = map[string][]byte{
 		"ca.crt":  ca.Data["tls.crt"],
 		"tls.crt": signed,
-		"tls.key": pem.EncodeToMemory(&pem.Block{
-			Type:  "EC PRIVATE KEY",
-			Bytes: privDer,
-		}),
+		"tls.key": pem.EncodeToMemory(pemBlock),
 	}
 
 	err = k8sClient.Create(ctx, generatedSecret)

--- a/controller/pkg/secrets/cert.go
+++ b/controller/pkg/secrets/cert.go
@@ -445,7 +445,7 @@ func parsePrivateKey(pemBlock *pem.Block) (crypto.Signer, x509.SignatureAlgorith
 	)
 	switch pemBlock.Type {
 
-	case "EC PRIVATE KEY":
+	case "EC PRIVATE KEY", "ECDSA PRIVATE KEY":
 		priv, err = x509.ParseECPrivateKey(pemBlock.Bytes)
 		if err != nil {
 			return nil, signatureAlgorithm, err

--- a/controller/pkg/secrets/cert.go
+++ b/controller/pkg/secrets/cert.go
@@ -444,21 +444,22 @@ func parsePrivateKey(pemBlock *pem.Block) (crypto.Signer, x509.SignatureAlgorith
 		err                error
 	)
 	switch pemBlock.Type {
+
 	case "EC PRIVATE KEY":
 		priv, err = x509.ParseECPrivateKey(pemBlock.Bytes)
 		if err != nil {
 			return nil, signatureAlgorithm, err
 		}
-		signatureAlgorithm = x509.ECDSAWithSHA256
+		return priv, x509.ECDSAWithSHA256, nil
+
 	case "RSA PRIVATE KEY":
 		priv, err = x509.ParsePKCS1PrivateKey(pemBlock.Bytes)
 		if err != nil {
 			return nil, signatureAlgorithm, err
 		}
-		signatureAlgorithm = x509.SHA256WithRSA
+		return priv, x509.SHA256WithRSA, nil
+
 	default:
 		return nil, signatureAlgorithm, fmt.Errorf("unsupported key type: %s", pemBlock.Type)
 	}
-
-	return priv, signatureAlgorithm, nil
 }

--- a/controller/pkg/secrets/cert_test.go
+++ b/controller/pkg/secrets/cert_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/json"
@@ -31,7 +32,6 @@ import (
 	operatorv1beta1 "github.com/kong/gateway-operator/api/v1beta1"
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/controller/pkg/op"
-	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
 	k8sresources "github.com/kong/gateway-operator/pkg/utils/kubernetes/resources"
 )
 
@@ -235,7 +235,7 @@ func TestMaybeCreateCertificateSecret(t *testing.T) {
 			},
 			additionalMatchingLabels: nil,
 			keyConfig: KeyConfig{
-				Type: mgrconfig.ECDSA,
+				Type: x509.ECDSA,
 			},
 			expectedResult: op.Created,
 			expectedError:  nil,
@@ -250,7 +250,7 @@ func TestMaybeCreateCertificateSecret(t *testing.T) {
 			},
 			additionalMatchingLabels: nil,
 			keyConfig: KeyConfig{
-				Type: mgrconfig.ECDSA,
+				Type: x509.ECDSA,
 			},
 			objectList: &corev1.SecretList{
 				Items: []corev1.Secret{
@@ -288,7 +288,7 @@ func TestMaybeCreateCertificateSecret(t *testing.T) {
 			},
 			additionalMatchingLabels: nil,
 			keyConfig: KeyConfig{
-				Type: mgrconfig.ECDSA,
+				Type: x509.ECDSA,
 			},
 			objectList: &corev1.SecretList{
 				Items: []corev1.Secret{
@@ -449,4 +449,69 @@ func generateCACert(nn types.NamespacedName) (*corev1.Secret, error) {
 	}
 
 	return signedSecret, nil
+}
+
+func Test_parsePrivateKey(t *testing.T) {
+	tests := []struct {
+		name             string
+		keyType          x509.PublicKeyAlgorithm
+		expectedAlg      x509.SignatureAlgorithm
+		expectedKeyType  interface{}
+		expectedErrorMsg string
+	}{
+		{
+			name:            "valid ECDSA private key",
+			keyType:         x509.ECDSA,
+			expectedAlg:     x509.ECDSAWithSHA256,
+			expectedKeyType: &ecdsa.PrivateKey{},
+		},
+		{
+			name:            "valid RSA private key",
+			keyType:         x509.RSA,
+			expectedAlg:     x509.SHA256WithRSA,
+			expectedKeyType: &rsa.PrivateKey{},
+		},
+		{
+			name:             "unsupported key type",
+			keyType:          x509.DSA,
+			expectedErrorMsg: "unsupported key type: DSA PRIVATE KEY",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var privKeyBytes []byte
+			var err error
+
+			switch tt.keyType {
+			case x509.ECDSA:
+				privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				require.NoError(t, err)
+				privKeyBytes, err = x509.MarshalECPrivateKey(privKey)
+				require.NoError(t, err)
+			case x509.RSA:
+				privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+				require.NoError(t, err)
+				privKeyBytes = x509.MarshalPKCS1PrivateKey(privKey)
+			default:
+				privKeyBytes = []byte{}
+			}
+
+			pemBlock := &pem.Block{
+				Type:  tt.keyType.String() + " PRIVATE KEY",
+				Bytes: privKeyBytes,
+			}
+
+			priv, alg, err := parsePrivateKey(pemBlock)
+			if tt.expectedErrorMsg != "" {
+				require.Error(t, err)
+				assert.Equal(t, tt.expectedErrorMsg, err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedAlg, alg)
+			assert.IsType(t, tt.expectedKeyType, priv)
+		})
+	}
 }

--- a/controller/pkg/secrets/cert_test.go
+++ b/controller/pkg/secrets/cert_test.go
@@ -31,6 +31,7 @@ import (
 	operatorv1beta1 "github.com/kong/gateway-operator/api/v1beta1"
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/controller/pkg/op"
+	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
 	k8sresources "github.com/kong/gateway-operator/pkg/utils/kubernetes/resources"
 )
 
@@ -218,6 +219,7 @@ func TestMaybeCreateCertificateSecret(t *testing.T) {
 		dataPlane                *operatorv1beta1.DataPlane
 		subject                  string
 		mtlsCASecretNN           NN
+		keyConfig                KeyConfig
 		additionalMatchingLabels client.MatchingLabels
 		expectedResult           op.Result
 		expectedError            error
@@ -232,8 +234,11 @@ func TestMaybeCreateCertificateSecret(t *testing.T) {
 				Namespace: "ns",
 			},
 			additionalMatchingLabels: nil,
-			expectedResult:           op.Created,
-			expectedError:            nil,
+			keyConfig: KeyConfig{
+				Type: mgrconfig.ECDSA,
+			},
+			expectedResult: op.Created,
+			expectedError:  nil,
 		},
 		{
 			name:      "existing secret certificate gets deleted and re-created with it doesn't have the expected contents",
@@ -244,6 +249,9 @@ func TestMaybeCreateCertificateSecret(t *testing.T) {
 				Namespace: "ns",
 			},
 			additionalMatchingLabels: nil,
+			keyConfig: KeyConfig{
+				Type: mgrconfig.ECDSA,
+			},
 			objectList: &corev1.SecretList{
 				Items: []corev1.Secret{
 					func() corev1.Secret {
@@ -279,6 +287,9 @@ func TestMaybeCreateCertificateSecret(t *testing.T) {
 				Namespace: "ns",
 			},
 			additionalMatchingLabels: nil,
+			keyConfig: KeyConfig{
+				Type: mgrconfig.ECDSA,
+			},
 			objectList: &corev1.SecretList{
 				Items: []corev1.Secret{
 					func() corev1.Secret {
@@ -356,6 +367,7 @@ func TestMaybeCreateCertificateSecret(t *testing.T) {
 				[]certificatesv1.KeyUsage{
 					certificatesv1.UsageServerAuth,
 				},
+				tc.keyConfig,
 				fakeClient,
 				tc.additionalMatchingLabels,
 			)

--- a/controller/pkg/secrets/privkey.go
+++ b/controller/pkg/secrets/privkey.go
@@ -1,0 +1,68 @@
+package secrets
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
+)
+
+// KeyConfig is the configuration for generating a private key.
+type KeyConfig struct {
+	// Type is the type of the key to generate
+	Type mgrconfig.KeyType
+
+	// Size is the size of the key to generate in bits.
+	// This is only used for RSA keys.
+	Size int
+}
+
+// CreatePrivateKey generates a private key based on the provided keyConfig.
+func CreatePrivateKey(
+	keyConfig KeyConfig,
+) (crypto.Signer, *pem.Block, x509.SignatureAlgorithm, error) {
+	var (
+		signatureAlgorithm x509.SignatureAlgorithm = x509.UnknownSignatureAlgorithm
+		priv               crypto.Signer
+		pemBlock           *pem.Block
+	)
+	switch keyConfig.Type {
+	case mgrconfig.ECDSA:
+		signatureAlgorithm = x509.ECDSAWithSHA256
+		ecdsa, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			return nil, nil, signatureAlgorithm, err
+		}
+		privDer, err := x509.MarshalECPrivateKey(ecdsa)
+		if err != nil {
+			return nil, nil, signatureAlgorithm, err
+		}
+		priv = ecdsa
+		pemBlock = &pem.Block{
+			Type:  "EC PRIVATE KEY",
+			Bytes: privDer,
+		}
+	case mgrconfig.RSA:
+		signatureAlgorithm = x509.SHA256WithRSA
+		rsa, err := rsa.GenerateKey(rand.Reader, keyConfig.Size)
+		if err != nil {
+			return nil, nil, signatureAlgorithm, err
+		}
+		privDer := x509.MarshalPKCS1PrivateKey(rsa)
+		priv = rsa
+		pemBlock = &pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: privDer,
+		}
+	default:
+		return nil, nil, signatureAlgorithm, fmt.Errorf("unsupported key type: %s", keyConfig.Type)
+	}
+
+	return priv, pemBlock, signatureAlgorithm, nil
+}

--- a/controller/pkg/secrets/privkey.go
+++ b/controller/pkg/secrets/privkey.go
@@ -9,14 +9,12 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-
-	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
 )
 
 // KeyConfig is the configuration for generating a private key.
 type KeyConfig struct {
 	// Type is the type of the key to generate
-	Type mgrconfig.KeyType
+	Type x509.PublicKeyAlgorithm
 
 	// Size is the size of the key to generate in bits.
 	// This is only used for RSA keys.
@@ -33,7 +31,7 @@ func CreatePrivateKey(
 		pemBlock           *pem.Block
 	)
 	switch keyConfig.Type {
-	case mgrconfig.ECDSA:
+	case x509.ECDSA:
 		signatureAlgorithm = x509.ECDSAWithSHA256
 		ecdsa, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		if err != nil {
@@ -48,7 +46,7 @@ func CreatePrivateKey(
 			Type:  "EC PRIVATE KEY",
 			Bytes: privDer,
 		}
-	case mgrconfig.RSA:
+	case x509.RSA:
 		signatureAlgorithm = x509.SHA256WithRSA
 		rsa, err := rsa.GenerateKey(rand.Reader, keyConfig.Size)
 		if err != nil {

--- a/controller/pkg/secrets/privkey_test.go
+++ b/controller/pkg/secrets/privkey_test.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
 )
 
 func TestCreatePrivateKey(t *testing.T) {
@@ -23,7 +21,7 @@ func TestCreatePrivateKey(t *testing.T) {
 		{
 			name: "Generate ECDSA key",
 			keyConfig: KeyConfig{
-				Type: mgrconfig.ECDSA,
+				Type: x509.ECDSA,
 			},
 			expectErr:            false,
 			expectedPemBlockType: "EC PRIVATE KEY",
@@ -31,7 +29,7 @@ func TestCreatePrivateKey(t *testing.T) {
 		{
 			name: "Generate RSA key with size 2048",
 			keyConfig: KeyConfig{
-				Type: mgrconfig.RSA,
+				Type: x509.RSA,
 				Size: 2048,
 			},
 			expectErr:            false,
@@ -40,7 +38,7 @@ func TestCreatePrivateKey(t *testing.T) {
 		{
 			name: "Unsupported key type",
 			keyConfig: KeyConfig{
-				Type: "unsupported",
+				Type: x509.DSA,
 			},
 			expectErr: true,
 		},

--- a/controller/pkg/secrets/privkey_test.go
+++ b/controller/pkg/secrets/privkey_test.go
@@ -1,0 +1,80 @@
+package secrets
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
+)
+
+func TestCreatePrivateKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		keyConfig KeyConfig
+		expectErr bool
+	}{
+		{
+			name: "Generate ECDSA key",
+			keyConfig: KeyConfig{
+				Type: mgrconfig.ECDSA,
+			},
+			expectErr: false,
+		},
+		{
+			name: "Generate RSA key with size 2048",
+			keyConfig: KeyConfig{
+				Type: mgrconfig.RSA,
+				Size: 2048,
+			},
+			expectErr: false,
+		},
+		{
+			name: "Unsupported key type",
+			keyConfig: KeyConfig{
+				Type: "unsupported",
+			},
+			expectErr: true,
+		},
+		{
+			name:      "Unsupported key type",
+			keyConfig: KeyConfig{},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			priv, pemBlock, sigAlg, err := CreatePrivateKey(tt.keyConfig)
+			if tt.expectErr {
+				assert.Error(t, err)
+				assert.Nil(t, priv)
+				assert.Nil(t, pemBlock)
+				assert.Equal(t, x509.UnknownSignatureAlgorithm, sigAlg)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, priv)
+			require.NotNil(t, pemBlock)
+			require.NotEqual(t, x509.UnknownSignatureAlgorithm, sigAlg)
+
+			// Check PEM block type
+			if tt.keyConfig.Type == mgrconfig.ECDSA {
+				assert.Equal(t, "EC PRIVATE KEY", pemBlock.Type)
+			} else if tt.keyConfig.Type == mgrconfig.RSA {
+				assert.Equal(t, "RSA PRIVATE KEY", pemBlock.Type)
+			}
+
+			// Check if PEM block can be parsed
+			p, rest := pem.Decode(pem.EncodeToMemory(pemBlock))
+			assert.Empty(t, rest)
+			assert.NotNil(t, p)
+		})
+	}
+}

--- a/controller/pkg/secrets/privkey_test.go
+++ b/controller/pkg/secrets/privkey_test.go
@@ -15,16 +15,18 @@ func TestCreatePrivateKey(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		keyConfig KeyConfig
-		expectErr bool
+		name                 string
+		keyConfig            KeyConfig
+		expectErr            bool
+		expectedPemBlockType string
 	}{
 		{
 			name: "Generate ECDSA key",
 			keyConfig: KeyConfig{
 				Type: mgrconfig.ECDSA,
 			},
-			expectErr: false,
+			expectErr:            false,
+			expectedPemBlockType: "EC PRIVATE KEY",
 		},
 		{
 			name: "Generate RSA key with size 2048",
@@ -32,7 +34,8 @@ func TestCreatePrivateKey(t *testing.T) {
 				Type: mgrconfig.RSA,
 				Size: 2048,
 			},
-			expectErr: false,
+			expectErr:            false,
+			expectedPemBlockType: "RSA PRIVATE KEY",
 		},
 		{
 			name: "Unsupported key type",
@@ -42,7 +45,7 @@ func TestCreatePrivateKey(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:      "Unsupported key type",
+			name:      "Empty key type",
 			keyConfig: KeyConfig{},
 			expectErr: true,
 		},
@@ -64,12 +67,7 @@ func TestCreatePrivateKey(t *testing.T) {
 			require.NotNil(t, pemBlock)
 			require.NotEqual(t, x509.UnknownSignatureAlgorithm, sigAlg)
 
-			// Check PEM block type
-			if tt.keyConfig.Type == mgrconfig.ECDSA {
-				assert.Equal(t, "EC PRIVATE KEY", pemBlock.Type)
-			} else if tt.keyConfig.Type == mgrconfig.RSA {
-				assert.Equal(t, "RSA PRIVATE KEY", pemBlock.Type)
-			}
+			assert.Equal(t, tt.expectedPemBlockType, pemBlock.Type)
 
 			// Check if PEM block can be parsed
 			p, rest := pem.Decode(pem.EncodeToMemory(pemBlock))

--- a/modules/cli/cli.go
+++ b/modules/cli/cli.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/kong/gateway-operator/modules/manager"
+	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
 	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/metadata"
 	"github.com/kong/gateway-operator/pkg/consts"
@@ -23,6 +24,8 @@ func New(m metadata.Info) *CLI {
 	cfg := manager.Config{
 		// set default values for MetricsAccessFilter
 		MetricsAccessFilter: manager.MetricsAccessFilterOff,
+		// set default values for ClusterCAKeyType
+		ClusterCAKeyType: mgrconfig.ECDSA,
 	}
 	var deferCfg flagsForFurtherEvaluation
 
@@ -39,6 +42,8 @@ func New(m metadata.Info) *CLI {
 	flagSet.StringVar(&cfg.ControllerName, "controller-name", "", "Controller name to use if other than the default, only needed for multi-tenancy.")
 	flagSet.StringVar(&cfg.ClusterCASecretName, "cluster-ca-secret", "kong-operator-ca", "Name of the Secret containing the cluster CA certificate.")
 	flagSet.StringVar(&deferCfg.ClusterCASecretNamespace, "cluster-ca-secret-namespace", "", "Name of the namespace for Secret containing the cluster CA certificate.")
+	flagSet.Var(&cfg.ClusterCAKeyType, "cluster-ca-key-type", "Type of the key used for the cluster CA certificate (possible values: ecdsa, rsa). Default: ecdsa.")
+	flagSet.IntVar(&cfg.ClusterCAKeySize, "cluster-ca-key-size", mgrconfig.DefaultClusterCAKeySize, "Size (in bits) of the key used for the cluster CA certificate. Only used for RSA keys.")
 
 	// controllers for standard APIs and features
 	flagSet.BoolVar(&cfg.GatewayControllerEnabled, "enable-controller-gateway", true, "Enable the Gateway controller.")

--- a/modules/cli/cli_test.go
+++ b/modules/cli/cli_test.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/kong/gateway-operator/modules/manager"
+	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
 	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/metadata"
 	"github.com/kong/gateway-operator/pkg/consts"
@@ -102,6 +103,19 @@ func TestParse(t *testing.T) {
 				return cfg
 			},
 		},
+		{
+			name: "cluster CA key type argument is set",
+			args: []string{
+				"--cluster-ca-key-type=rsa",
+				"--cluster-ca-key-size=2048",
+			},
+			expectedCfg: func() manager.Config {
+				cfg := expectedDefaultCfg()
+				cfg.ClusterCAKeySize = 2048
+				cfg.ClusterCAKeyType = mgrconfig.RSA
+				return cfg
+			},
+		},
 	}
 
 	for _, tC := range testCases {
@@ -170,6 +184,8 @@ func expectedDefaultCfg() manager.Config {
 		KubeconfigPath:                          "",
 		ClusterCASecretName:                     "kong-operator-ca",
 		ClusterCASecretNamespace:                "kong-system",
+		ClusterCAKeyType:                        mgrconfig.ECDSA,
+		ClusterCAKeySize:                        mgrconfig.DefaultClusterCAKeySize,
 		GatewayControllerEnabled:                true,
 		ControlPlaneControllerEnabled:           true,
 		DataPlaneControllerEnabled:              true,

--- a/modules/manager/config/consts.go
+++ b/modules/manager/config/consts.go
@@ -1,0 +1,4 @@
+package config
+
+// DefaultClusterCAKeySize is the default size of the cluster CA key.
+const DefaultClusterCAKeySize = 4096

--- a/modules/manager/config/types.go
+++ b/modules/manager/config/types.go
@@ -15,6 +15,8 @@ const (
 	ECDSA KeyType = "ecdsa"
 	// RSA is the key type for RSA keys.
 	RSA KeyType = "rsa"
+	// DefaultClusterCAKeyType is the default key type for the cluster CA.
+	DefaultClusterCAKeyType KeyType = ECDSA
 )
 
 // Set implements flag.Value.
@@ -23,8 +25,7 @@ func (kt *KeyType) Set(v string) error {
 	case string(ECDSA), string(RSA):
 		*kt = KeyType(v)
 	case "":
-		// Default to ECDSA.
-		*kt = ECDSA
+		*kt = DefaultClusterCAKeyType
 	default:
 		return fmt.Errorf("invalid value %q for key type", v)
 	}

--- a/modules/manager/config/types.go
+++ b/modules/manager/config/types.go
@@ -1,0 +1,37 @@
+// This package serves to break the cyclic dependency between the manager and
+// packages that import the config types.
+
+package config
+
+import (
+	"fmt"
+)
+
+// KeyType is the type of private key.
+type KeyType string
+
+const (
+	// ECDSA is the key type for ECDSA keys.
+	ECDSA KeyType = "ecdsa"
+	// RSA is the key type for RSA keys.
+	RSA KeyType = "rsa"
+)
+
+// Set implements flag.Value.
+func (kt *KeyType) Set(v string) error {
+	switch v {
+	case string(ECDSA), string(RSA):
+		*kt = KeyType(v)
+	case "":
+		// Default to ECDSA.
+		*kt = ECDSA
+	default:
+		return fmt.Errorf("invalid value %q for key type", v)
+	}
+	return nil
+}
+
+// String implements the String() method from flag.Value interface.
+func (kt *KeyType) String() string {
+	return string(*kt)
+}

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"reflect"
 	"time"
@@ -31,6 +32,7 @@ import (
 	"github.com/kong/gateway-operator/internal/metrics"
 	"github.com/kong/gateway-operator/internal/utils/index"
 	dataplanevalidator "github.com/kong/gateway-operator/internal/validation/dataplane"
+	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
 	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
@@ -380,7 +382,16 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 	}
 
 	clusterCAKeyConfig := secrets.KeyConfig{
-		Type: c.ClusterCAKeyType,
+		Type: func() x509.PublicKeyAlgorithm {
+			switch c.ClusterCAKeyType {
+			case mgrconfig.RSA:
+				return x509.RSA
+			case mgrconfig.ECDSA:
+				return x509.ECDSA
+			default:
+				return x509.UnknownPublicKeyAlgorithm
+			}
+		}(),
 		Size: c.ClusterCAKeySize,
 	}
 

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -379,6 +379,11 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 		}
 	}
 
+	clusterCAKeyConfig := secrets.KeyConfig{
+		Type: c.ClusterCAKeyType,
+		Size: c.ClusterCAKeySize,
+	}
+
 	controllers := map[string]ControllerDef{
 		// GatewayClass controller
 		GatewayClassControllerName: {
@@ -407,11 +412,8 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 				Scheme:                   mgr.GetScheme(),
 				ClusterCASecretName:      c.ClusterCASecretName,
 				ClusterCASecretNamespace: c.ClusterCASecretNamespace,
-				ClusterCAKeyConfig: secrets.KeyConfig{
-					Type: c.ClusterCAKeyType,
-					Size: c.ClusterCAKeySize,
-				},
-				DevelopmentMode: c.DevelopmentMode,
+				ClusterCAKeyConfig:       clusterCAKeyConfig,
+				DevelopmentMode:          c.DevelopmentMode,
 			},
 		},
 		// DataPlane controller
@@ -422,12 +424,9 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 				Scheme:                   mgr.GetScheme(),
 				ClusterCASecretName:      c.ClusterCASecretName,
 				ClusterCASecretNamespace: c.ClusterCASecretNamespace,
-				ClusterCAKeyConfig: secrets.KeyConfig{
-					Type: c.ClusterCAKeyType,
-					Size: c.ClusterCAKeySize,
-				},
-				DevelopmentMode: c.DevelopmentMode,
-				Validator:       dataplanevalidator.NewValidator(mgr.GetClient()),
+				ClusterCAKeyConfig:       clusterCAKeyConfig,
+				DevelopmentMode:          c.DevelopmentMode,
+				Validator:                dataplanevalidator.NewValidator(mgr.GetClient()),
 				Callbacks: dataplane.DataPlaneCallbacks{
 					BeforeDeployment: dataplane.CreateCallbackManager(),
 					AfterDeployment:  dataplane.CreateCallbackManager(),
@@ -444,22 +443,16 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 				DevelopmentMode:          c.DevelopmentMode,
 				ClusterCASecretName:      c.ClusterCASecretName,
 				ClusterCASecretNamespace: c.ClusterCASecretNamespace,
-				ClusterCAKeyConfig: secrets.KeyConfig{
-					Type: c.ClusterCAKeyType,
-					Size: c.ClusterCAKeySize,
-				},
+				ClusterCAKeyConfig:       clusterCAKeyConfig,
 				DataPlaneController: &dataplane.Reconciler{
 					Client:                   mgr.GetClient(),
 					Scheme:                   mgr.GetScheme(),
 					ClusterCASecretName:      c.ClusterCASecretName,
 					ClusterCASecretNamespace: c.ClusterCASecretNamespace,
-					ClusterCAKeyConfig: secrets.KeyConfig{
-						Type: c.ClusterCAKeyType,
-						Size: c.ClusterCAKeySize,
-					},
-					DevelopmentMode: c.DevelopmentMode,
-					Validator:       dataplanevalidator.NewValidator(mgr.GetClient()),
-					DefaultImage:    consts.DefaultDataPlaneImage,
+					ClusterCAKeyConfig:       clusterCAKeyConfig,
+					DevelopmentMode:          c.DevelopmentMode,
+					Validator:                dataplanevalidator.NewValidator(mgr.GetClient()),
+					DefaultImage:             consts.DefaultDataPlaneImage,
 					Callbacks: dataplane.DataPlaneCallbacks{
 						BeforeDeployment: dataplane.CreateCallbackManager(),
 						AfterDeployment:  dataplane.CreateCallbackManager(),

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kong/gateway-operator/controller/konnect/constraints"
 	sdkops "github.com/kong/gateway-operator/controller/konnect/ops/sdk"
 	"github.com/kong/gateway-operator/controller/pkg/log"
+	"github.com/kong/gateway-operator/controller/pkg/secrets"
 	"github.com/kong/gateway-operator/controller/specialized"
 	"github.com/kong/gateway-operator/internal/metrics"
 	"github.com/kong/gateway-operator/internal/utils/index"
@@ -406,7 +407,11 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 				Scheme:                   mgr.GetScheme(),
 				ClusterCASecretName:      c.ClusterCASecretName,
 				ClusterCASecretNamespace: c.ClusterCASecretNamespace,
-				DevelopmentMode:          c.DevelopmentMode,
+				ClusterCAKeyConfig: secrets.KeyConfig{
+					Type: c.ClusterCAKeyType,
+					Size: c.ClusterCAKeySize,
+				},
+				DevelopmentMode: c.DevelopmentMode,
 			},
 		},
 		// DataPlane controller
@@ -417,8 +422,12 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 				Scheme:                   mgr.GetScheme(),
 				ClusterCASecretName:      c.ClusterCASecretName,
 				ClusterCASecretNamespace: c.ClusterCASecretNamespace,
-				DevelopmentMode:          c.DevelopmentMode,
-				Validator:                dataplanevalidator.NewValidator(mgr.GetClient()),
+				ClusterCAKeyConfig: secrets.KeyConfig{
+					Type: c.ClusterCAKeyType,
+					Size: c.ClusterCAKeySize,
+				},
+				DevelopmentMode: c.DevelopmentMode,
+				Validator:       dataplanevalidator.NewValidator(mgr.GetClient()),
 				Callbacks: dataplane.DataPlaneCallbacks{
 					BeforeDeployment: dataplane.CreateCallbackManager(),
 					AfterDeployment:  dataplane.CreateCallbackManager(),
@@ -435,14 +444,22 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 				DevelopmentMode:          c.DevelopmentMode,
 				ClusterCASecretName:      c.ClusterCASecretName,
 				ClusterCASecretNamespace: c.ClusterCASecretNamespace,
+				ClusterCAKeyConfig: secrets.KeyConfig{
+					Type: c.ClusterCAKeyType,
+					Size: c.ClusterCAKeySize,
+				},
 				DataPlaneController: &dataplane.Reconciler{
 					Client:                   mgr.GetClient(),
 					Scheme:                   mgr.GetScheme(),
 					ClusterCASecretName:      c.ClusterCASecretName,
 					ClusterCASecretNamespace: c.ClusterCASecretNamespace,
-					DevelopmentMode:          c.DevelopmentMode,
-					Validator:                dataplanevalidator.NewValidator(mgr.GetClient()),
-					DefaultImage:             consts.DefaultDataPlaneImage,
+					ClusterCAKeyConfig: secrets.KeyConfig{
+						Type: c.ClusterCAKeyType,
+						Size: c.ClusterCAKeySize,
+					},
+					DevelopmentMode: c.DevelopmentMode,
+					Validator:       dataplanevalidator.NewValidator(mgr.GetClient()),
+					DefaultImage:    consts.DefaultDataPlaneImage,
 					Callbacks: dataplane.DataPlaneCallbacks{
 						BeforeDeployment: dataplane.CreateCallbackManager(),
 						AfterDeployment:  dataplane.CreateCallbackManager(),

--- a/modules/manager/keys.go
+++ b/modules/manager/keys.go
@@ -1,0 +1,19 @@
+package manager
+
+import (
+	"crypto/x509"
+	"fmt"
+
+	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
+)
+
+func keyTypeToX509PublicKeyAlgorithm(keyType mgrconfig.KeyType) (x509.PublicKeyAlgorithm, error) {
+	switch keyType {
+	case mgrconfig.RSA:
+		return x509.RSA, nil
+	case mgrconfig.ECDSA:
+		return x509.ECDSA, nil
+	default:
+		return x509.UnknownPublicKeyAlgorithm, fmt.Errorf("unsupported key type: %s", keyType)
+	}
+}

--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -18,8 +18,6 @@ package manager
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -48,7 +46,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"github.com/kong/gateway-operator/controller/pkg/secrets"
 	"github.com/kong/gateway-operator/internal/telemetry"
+	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
 	"github.com/kong/gateway-operator/modules/manager/metadata"
 	"github.com/kong/gateway-operator/pkg/vars"
 )
@@ -78,6 +78,8 @@ type Config struct {
 	KubeconfigPath           string
 	ClusterCASecretName      string
 	ClusterCASecretNamespace string
+	ClusterCAKeyType         mgrconfig.KeyType
+	ClusterCAKeySize         int
 	LoggerOpts               *zap.Options
 
 	// controllers for standard APIs and features
@@ -214,6 +216,10 @@ func Run(
 		client:          mgr.GetClient(),
 		secretName:      cfg.ClusterCASecretName,
 		secretNamespace: cfg.ClusterCASecretNamespace,
+		keyConfig: secrets.KeyConfig{
+			Type: cfg.ClusterCAKeyType,
+			Size: cfg.ClusterCAKeySize,
+		},
 	}
 	if err = mgr.Add(caMgr); err != nil {
 		return fmt.Errorf("unable to start manager: %w", err)
@@ -303,6 +309,7 @@ type caManager struct {
 	client          client.Client
 	secretName      string
 	secretNamespace string
+	keyConfig       secrets.KeyConfig
 }
 
 // Start starts the CA manager.
@@ -319,72 +326,72 @@ func (m *caManager) Start(ctx context.Context) error {
 func (m *caManager) maybeCreateCACertificate(ctx context.Context) error {
 	// TODO https://github.com/Kong/gateway-operator/issues/199 this also needs to check if the CA is expired and
 	// managed, and needs to reissue it (and all issued certificates) if so
-	ca := &corev1.Secret{}
 	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
-	err := m.client.Get(ctx, client.ObjectKey{Namespace: m.secretNamespace, Name: m.secretName}, ca)
-	if k8serrors.IsNotFound(err) {
-		serial, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
-		if err != nil {
-			return err
-		}
-		m.logger.Info(fmt.Sprintf("no CA certificate Secret %s found, generating CA certificate", m.secretName))
-		template := x509.Certificate{
-			Subject: pkix.Name{
-				CommonName:   "Kong Gateway Operator CA",
-				Organization: []string{"Kong, Inc."},
-				Country:      []string{"US"},
-			},
-			SerialNumber:          serial,
-			SignatureAlgorithm:    x509.ECDSAWithSHA256,
-			NotBefore:             time.Now(),
-			NotAfter:              time.Now().Add(time.Second * 315400000),
-			KeyUsage:              x509.KeyUsageCertSign + x509.KeyUsageKeyEncipherment + x509.KeyUsageDigitalSignature,
-			BasicConstraintsValid: true,
-			IsCA:                  true,
+
+	var (
+		ca        corev1.Secret
+		objectKey = client.ObjectKey{Namespace: m.secretNamespace, Name: m.secretName}
+	)
+
+	if err := m.client.Get(ctx, objectKey, &ca); err != nil {
+		if k8serrors.IsNotFound(err) {
+			m.logger.Info(fmt.Sprintf("no CA certificate Secret %s found, generating CA certificate", objectKey))
+			return m.createCACertificate(ctx)
 		}
 
-		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		if err != nil {
-			return err
-		}
-		privDer, err := x509.MarshalECPrivateKey(priv)
-		if err != nil {
-			return err
-		}
-
-		der, err := x509.CreateCertificate(rand.Reader, &template, &template, priv.Public(), priv)
-		if err != nil {
-			return err
-		}
-
-		signedSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: m.secretNamespace,
-				Name:      m.secretName,
-			},
-			Type: corev1.SecretTypeTLS,
-			StringData: map[string]string{
-				"tls.crt": string(pem.EncodeToMemory(&pem.Block{
-					Type:  "CERTIFICATE",
-					Bytes: der,
-				})),
-
-				"tls.key": string(pem.EncodeToMemory(&pem.Block{
-					Type:  "EC PRIVATE KEY",
-					Bytes: privDer,
-				})),
-			},
-		}
-		err = m.client.Create(ctx, signedSecret)
-		if err != nil {
-			return err
-		}
-
-	} else if err != nil {
 		return err
 	}
 	return nil
+}
+
+func (m *caManager) createCACertificate(ctx context.Context) error {
+	serial, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		return err
+	}
+
+	priv, pemBlock, signatureAlgorithm, err := secrets.CreatePrivateKey(m.keyConfig)
+	if err != nil {
+		return err
+	}
+
+	template := x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:   "Kong Gateway Operator CA",
+			Organization: []string{"Kong, Inc."},
+			Country:      []string{"US"},
+		},
+		SerialNumber:          serial,
+		SignatureAlgorithm:    signatureAlgorithm,
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Second * 315400000),
+		KeyUsage:              x509.KeyUsageCertSign + x509.KeyUsageKeyEncipherment + x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, priv.Public(), priv)
+	if err != nil {
+		return err
+	}
+
+	signedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: m.secretNamespace,
+			Name:      m.secretName,
+		},
+		Type: corev1.SecretTypeTLS,
+		StringData: map[string]string{
+			"tls.crt": string(pem.EncodeToMemory(&pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: der,
+			})),
+
+			"tls.key": string(pem.EncodeToMemory(pemBlock)),
+		},
+	}
+	return m.client.Create(ctx, signedSecret)
 }
 
 // setupAnonymousReports sets up and starts the anonymous reporting and returns

--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -211,22 +211,18 @@ func Run(
 		return err
 	}
 
+	keyType, err := keyTypeToX509PublicKeyAlgorithm(cfg.ClusterCAKeyType)
+	if err != nil {
+		return fmt.Errorf("unsupported cluster CA key type: %w", err)
+	}
+
 	caMgr := &caManager{
 		logger:          ctrl.Log.WithName("ca_manager"),
 		client:          mgr.GetClient(),
 		secretName:      cfg.ClusterCASecretName,
 		secretNamespace: cfg.ClusterCASecretNamespace,
 		keyConfig: secrets.KeyConfig{
-			Type: func() x509.PublicKeyAlgorithm {
-				switch cfg.ClusterCAKeyType {
-				case mgrconfig.RSA:
-					return x509.RSA
-				case mgrconfig.ECDSA:
-					return x509.ECDSA
-				default:
-					return x509.UnknownPublicKeyAlgorithm
-				}
-			}(),
+			Type: keyType,
 			Size: cfg.ClusterCAKeySize,
 		},
 	}

--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -217,7 +217,16 @@ func Run(
 		secretName:      cfg.ClusterCASecretName,
 		secretNamespace: cfg.ClusterCASecretNamespace,
 		keyConfig: secrets.KeyConfig{
-			Type: cfg.ClusterCAKeyType,
+			Type: func() x509.PublicKeyAlgorithm {
+				switch cfg.ClusterCAKeyType {
+				case mgrconfig.RSA:
+					return x509.RSA
+				case mgrconfig.ECDSA:
+					return x509.ECDSA
+				default:
+					return x509.UnknownPublicKeyAlgorithm
+				}
+			}(),
 			Size: cfg.ClusterCAKeySize,
 		},
 	}

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kong/gateway-operator/config"
 	"github.com/kong/gateway-operator/modules/admission"
 	"github.com/kong/gateway-operator/modules/manager"
+	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
 	"github.com/kong/gateway-operator/modules/manager/metadata"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	testutils "github.com/kong/gateway-operator/pkg/utils/test"
@@ -172,6 +173,7 @@ func startControllerManager(metadata metadata.Info) <-chan struct{} {
 	cfg.DataPlaneControllerEnabled = true
 	cfg.ValidatingWebhookEnabled = false
 	cfg.AnonymousReports = false
+	cfg.ClusterCAKeyType = mgrconfig.ECDSA
 
 	cfg.NewClientFunc = func(config *rest.Config, options client.Options) (client.Client, error) {
 		// always hijack and impersonate the system service account here so that the manager

--- a/test/integration/suite.go
+++ b/test/integration/suite.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/kong/gateway-operator/config"
 	"github.com/kong/gateway-operator/modules/manager"
+	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
 	testutils "github.com/kong/gateway-operator/pkg/utils/test"
 	"github.com/kong/gateway-operator/test"
 	"github.com/kong/gateway-operator/test/helpers"
@@ -224,6 +225,7 @@ func DefaultControllerConfigForTests() manager.Config {
 	cfg.ValidatingWebhookEnabled = webhookEnabled
 	cfg.AnonymousReports = false
 	cfg.KonnectControllersEnabled = true
+	cfg.ClusterCAKeyType = mgrconfig.ECDSA
 
 	cfg.NewClientFunc = func(config *rest.Config, options client.Options) (client.Client, error) {
 		// always hijack and impersonate the system service account here so that the manager


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `-cluster-ca-key-type` and `-cluster-ca-key-size` flags to allow configuring which private key types to use for cluster CA.

Allowed values: `rsa` and `ecdsa` (default, remains as it was).

**Which issue this PR fixes**

Fixes #

Internal reference: FTI-6433

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
