### PR TITLE
tests(conformance): disable rate limiting

### DIFF
--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -125,6 +125,7 @@ func TestGatewayConformance(t *testing.T) {
 	opts.ConformanceProfiles = sets.New(
 		suite.GatewayHTTPConformanceProfileName,
 	)
+	opts.RestConfig.QPS = -1
 	opts.SupportedFeatures = supportedFeatures
 	opts.Implementation = conformancev1.Implementation{
 		Organization: metadata.Organization,


### PR DESCRIPTION
**What this PR does / why we need it**:

Disable rate limiting in conformance tests to prevent errors like: https://github.com/Kong/gateway-operator/actions/runs/12934130245/job/36074402999?pr=1066

```
    helpers.go:77: 
        	Error Trace:	/home/runner/go/pkg/mod/sigs.k8s.io/gateway-api@v1.2.1/conformance/utils/kubernetes/helpers.go:110
        	            				/home/runner/go/pkg/mod/sigs.k8s.io/gateway-api@v1.2.1/conformance/utils/kubernetes/helpers.go:77
        	            				/home/runner/go/pkg/mod/sigs.k8s.io/gateway-api@v1.2.1/conformance/utils/suite/suite.go:347
        	            				/home/runner/go/pkg/mod/sigs.k8s.io/gateway-api@v1.2.1/conformance/conformance.go:129
        	            				/home/runner/work/gateway-operator/gateway-operator/test/conformance/conformance_test.go:140
        	Error:      	Received unexpected error:
        	            	error fetching GatewayClass: client rate limiter Wait returned an error: context deadline exceeded
        	Test:       	TestGatewayConformance
        	Messages:   	error waiting for kgo-gwclass-conformance-ksjfx GatewayClass to have Accepted condition to be set: error fetching GatewayClass: client rate limiter Wait returned an error: context deadline exceeded

```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
