### PR TITLE
fix: fix checking status when using a KonnectGatewayControlPlane with KIC CP type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,9 @@
 - Fix unexpected error logs caused by passing an odd number of arguments to the logger
   in the `KongConsumer` reconciler.
   [#983](https://github.com/Kong/gateway-operator/pull/983)
+- Fix checking status when using a `KonnectGatewayControlPlane` with KIC CP type
+  as a `ControlPlaneRef`.
+  [#1115](https://github.com/Kong/gateway-operator/pull/1115)
 
 ### Added
 

--- a/controller/konnect/ops/ops_errors.go
+++ b/controller/konnect/ops/ops_errors.go
@@ -167,7 +167,7 @@ func ErrorIsSDKError403(err error) bool {
 		return false
 	}
 
-	return errSDK.StatusCode == 403 && errSDK.Message == apiErrorOccurredMessage
+	return errSDK.StatusCode == 403
 }
 
 // ErrorIsSDKBadRequestError returns true if the provided error is a BadRequestError.

--- a/controller/konnect/ops/ops_errors_test.go
+++ b/controller/konnect/ops/ops_errors_test.go
@@ -1,0 +1,142 @@
+package ops
+
+import (
+	"errors"
+	"testing"
+
+	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorIsSDKError403(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "error is SDKError with 403 status code",
+			err: &sdkkonnecterrs.SDKError{
+				StatusCode: 403,
+				Body: `{
+					"code": 7,
+					"message": "usage constraint error",
+					"details": [
+						{
+							"@type": "type.googleapis.com/kong.admin.model.v1.ErrorDetail",
+							"messages": [
+								"operation not permitted on KIC cluster"
+							]
+						}
+					]
+				}`,
+			},
+			want: true,
+		},
+		{
+			name: "error is SDKError with non-403 status code",
+			err: &sdkkonnecterrs.SDKError{
+				StatusCode: 404,
+				Body: `{
+					"code": 7,
+					"message": "usage constraint error",
+					"details": [
+						{
+							"@type": "type.googleapis.com/kong.admin.model.v1.ErrorDetail",
+							"messages": [
+								"operation not permitted on KIC cluster"
+							]
+						}
+					]
+				}`,
+			},
+			want: false,
+		},
+		{
+			name: "error is not SDKError",
+			err:  errors.New("some other error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ErrorIsSDKError403(tt.err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestErrorIsSDKBadRequestError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "error is BadRequestError",
+			err:  &sdkkonnecterrs.BadRequestError{},
+			want: true,
+		},
+		{
+			name: "error is not BadRequestError",
+			err:  errors.New("some other error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ErrorIsSDKBadRequestError(tt.err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestErrorIsCreateConflict(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "error is ConflictError",
+			err:  &sdkkonnecterrs.ConflictError{},
+			want: true,
+		},
+		{
+			name: "error is SDKError with conflict message",
+			err: &sdkkonnecterrs.SDKError{
+				Body: `{
+					"code": 3,
+					"message": "data constraint error",
+					"details": []
+				}`,
+			},
+			want: true,
+		},
+		{
+			name: "error is SDKError with non-conflict message",
+			err: &sdkkonnecterrs.SDKError{
+				Body: `{
+					"code": 3,
+					"message": "some other error",
+					"details": []
+				}`,
+			},
+			want: false,
+		},
+		{
+			name: "error is not ConflictError or SDKError",
+			err:  errors.New("some other error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ErrorIsCreateConflict(tt.err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/controller/konnect/reconciler_controlplaneref.go
+++ b/controller/konnect/reconciler_controlplaneref.go
@@ -124,7 +124,7 @@ func handleControlPlaneRef[T constraints.SupportedKonnectEntityType, TEnt constr
 	// The configuration in control plane group type are read only so they are unsupported to attach entities to them:
 	// https://docs.konghq.com/konnect/gateway-manager/control-plane-groups/#limitations
 	if cp.Spec.ClusterType != nil &&
-		*cp.Spec.ClusterType != sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane {
+		*cp.Spec.ClusterType == sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup {
 		if res, errStatus := patch.StatusWithCondition(
 			ctx, cl, ent,
 			konnectv1alpha1.ControlPlaneRefValidConditionType,

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -522,7 +522,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// Regardless of the error reported from Create(), if the Konnect ID has been
 		// set then:
 		// - add the finalizer so that the resource can be cleaned up from Konnect on deletion...
-		if ent.GetKonnectStatus().ID != "" {
+		if status != nil && status.ID != "" {
 			objWithFinalizer := ent.DeepCopyObject().(client.Object)
 			if controllerutil.AddFinalizer(objWithFinalizer, KonnectCleanupFinalizer) {
 				if errUpd := r.Client.Patch(ctx, objWithFinalizer, client.MergeFrom(ent)); errUpd != nil {
@@ -545,7 +545,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 			// ...
 			// - add the Org ID and Server URL to the status so that the resource can be
 			//   cleaned up from Konnect on deletion and also so that the status can
-			//   indicate where the resource is located.
+			//   indicate where the corresponding Konnect entity is located.
 			setServerURLAndOrgID(ent, serverURL, apiAuth.Status.OrganizationID)
 		}
 

--- a/test/envtest/update_status.go
+++ b/test/envtest/update_status.go
@@ -111,7 +111,8 @@ func updateKongUpstreamStatusWithProgrammed(
 	ctx context.Context,
 	cl client.Client,
 	obj *configurationv1alpha1.KongUpstream,
-	id, cpID string,
+	id string,
+	cpID string,
 ) {
 	obj.Status.Konnect = &konnectv1alpha1.KonnectEntityStatusWithControlPlaneRef{
 		ControlPlaneID:      cpID,

--- a/test/helpers/deploy/deploy_resources.go
+++ b/test/helpers/deploy/deploy_resources.go
@@ -161,6 +161,17 @@ func KonnectGatewayControlPlane(
 	return cp
 }
 
+// KonnectGatewayControlPlaneType returns an ObjOption that sets the cluster type on the CP.
+func KonnectGatewayControlPlaneType(typ sdkkonnectcomp.CreateControlPlaneRequestClusterType) ObjOption {
+	return func(obj client.Object) {
+		cp, ok := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
+		if !ok {
+			panic(fmt.Errorf("%T does not implement KonnectGatewayControlPlane", obj))
+		}
+		cp.Spec.CreateControlPlaneRequest.ClusterType = &typ
+	}
+}
+
 // KonnectGatewayControlPlaneWithID deploys a KonnectGatewayControlPlane resource and returns the resource.
 // The Status ID and Programmed condition are set on the CP using status Update() call.
 // It can be useful where the reconciler for KonnectGatewayControlPlane is not started


### PR DESCRIPTION
**What this PR does / why we need it**:

Configuring entities in Konnect's ControlPlane of type KIC is not allowed and yields (equivalent `curl`):

```
curl -s -H "Authorization: Bearer ${KONNECT_TOKEN}" --request POST \
  --url https://eu.api.konghq.com/v2/control-planes/c579dfb7-054f-48fd-9ffc-88520236b310/core-entities/services \
  --header 'Content-Type: application/json' \
  --header 'accept: application/json' \
  --data '{"host":"example.internal","id":"49fd316e-c457-481c-9fc7-8079153e4f3c","name":"example-service","path":"/","port":80,"protocol":"http"}' | jq
{
  "code": 7,
  "message": "usage constraint error",
  "details": [
    {
      "@type": "type.googleapis.com/kong.admin.model.v1.ErrorDetail",
      "messages": [
        "operation not permitted on KIC cluster"
      ]
    }
  ]
}

```

This PR

- changes the check in https://github.com/Kong/gateway-operator/pull/1115/files#diff-5b6aadc0fe9b4d0ba8cfd31756eef41ffdcd65687cd077d3b8d427294dcc81b5R525 to verify if the `status` is `nil` before accessing `status.ID`
- changes the comparison in https://github.com/Kong/gateway-operator/pull/1115/files#diff-40d9e12ec4a0bfa12ba2e0a07890b5d034f2d94bf3c1663151dc4a6e539c5358R127 so that only control plane groups are not allowed (this way we get the `ControlPlaneRefValid` condition on an entity set to `true`) but later on when Programmed condition is set we set it to the error returned from the API
  - I'm open to changing this so that an invalid (KIC) cp type would yield a `ControlPlaneRefValid` with status `False` instead (just like we do for group type)
- add 403 SDKError (with message `API error occurred`) to the unrecoverable set of errors

**Which issue this PR fixes**

Fixes  #1112

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
