### PR TITLE
fix: fix setting DataPlane readiness probe using GatewayConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,8 @@
 - Fix unexpected error logs caused by passing an odd number of arguments to the logger
   in the `KongConsumer` reconciler.
   [#983](https://github.com/Kong/gateway-operator/pull/983)
+- Fix setting `DataPlane`'s readiness probe using `GatewayConfiguration`.
+  [#1118](https://github.com/Kong/gateway-operator/pull/1118)
 
 ### Added
 

--- a/config/samples/gateway-with-gatewayconfiguration.yaml
+++ b/config/samples/gateway-with-gatewayconfiguration.yaml
@@ -18,9 +18,9 @@ spec:
           - name: proxy
             # renovate: datasource=docker versioning=docker
             image: kong/kong-gateway:3.9
-            readinessProbe:
-              initialDelaySeconds: 1
-              periodSeconds: 1
+            # readinessProbe:
+            #   initialDelaySeconds: 7
+            #   periodSeconds: 8
     network:
       services:
         ingress:

--- a/config/samples/gateway-with-gatewayconfiguration.yaml
+++ b/config/samples/gateway-with-gatewayconfiguration.yaml
@@ -18,9 +18,9 @@ spec:
           - name: proxy
             # renovate: datasource=docker versioning=docker
             image: kong/kong-gateway:3.9
-            # readinessProbe:
-            #   initialDelaySeconds: 7
-            #   periodSeconds: 8
+            readinessProbe:
+              initialDelaySeconds: 1
+              periodSeconds: 1
     network:
       services:
         ingress:

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -656,7 +656,11 @@ func setDataPlaneOptionsDefaults(opts *operatorv1beta1.DataPlaneOptions, default
 		if container.Image == "" {
 			container.Image = defaultImage
 		}
-		container.ReadinessProbe = k8sresources.GenerateDataPlaneReadinessProbe(consts.DataPlaneStatusReadyEndpoint)
+		if container.ReadinessProbe == nil {
+			// For Gateway we set DataPlane's readiness probe to /status/ready so that
+			// it's only marked ready when it receives the configuration from the ControlPlane.
+			container.ReadinessProbe = k8sresources.GenerateDataPlaneReadinessProbe(consts.DataPlaneStatusReadyEndpoint)
+		}
 	} else {
 		// Because we currently require image to be specified for DataPlanes
 		// we need to add it here. After #20 gets resolved this won't be needed

--- a/controller/gateway/controller_test.go
+++ b/controller/gateway/controller_test.go
@@ -13,6 +13,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	controllerruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -704,6 +705,94 @@ func Test_setDataPlaneOptionsDefaults(t *testing.T) {
 										Name:           consts.DataPlaneProxyContainerName,
 										Image:          consts.DefaultDataPlaneImage,
 										ReadinessProbe: resources.GenerateDataPlaneReadinessProbe(consts.DataPlaneStatusReadyEndpoint),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "not providing the readiness probe sets it to default",
+			input: operatorv1beta1.DataPlaneOptions{
+				Deployment: operatorv1beta1.DataPlaneDeploymentOptions{},
+			},
+			expected: operatorv1beta1.DataPlaneOptions{
+				Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+					DeploymentOptions: operatorv1beta1.DeploymentOptions{
+						Replicas: lo.ToPtr(int32(1)),
+						PodTemplateSpec: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:           consts.DataPlaneProxyContainerName,
+										Image:          consts.DefaultDataPlaneImage,
+										ReadinessProbe: resources.GenerateDataPlaneReadinessProbe(consts.DataPlaneStatusReadyEndpoint),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "providing the readiness probe sets it as expected",
+			input: operatorv1beta1.DataPlaneOptions{
+				Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+					DeploymentOptions: operatorv1beta1.DeploymentOptions{
+						PodTemplateSpec: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  consts.DataPlaneProxyContainerName,
+										Image: consts.DefaultDataPlaneImage,
+										ReadinessProbe: &corev1.Probe{
+											FailureThreshold:    6,
+											InitialDelaySeconds: 7,
+											PeriodSeconds:       8,
+											SuccessThreshold:    8,
+											TimeoutSeconds:      9,
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path:   "/endpoint",
+													Port:   intstr.FromInt(4567),
+													Scheme: corev1.URISchemeHTTP,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: operatorv1beta1.DataPlaneOptions{
+				Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+					DeploymentOptions: operatorv1beta1.DeploymentOptions{
+						Replicas: lo.ToPtr(int32(1)),
+						PodTemplateSpec: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  consts.DataPlaneProxyContainerName,
+										Image: consts.DefaultDataPlaneImage,
+										ReadinessProbe: &corev1.Probe{
+											FailureThreshold:    6,
+											InitialDelaySeconds: 7,
+											PeriodSeconds:       8,
+											SuccessThreshold:    8,
+											TimeoutSeconds:      9,
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path:   "/endpoint",
+													Port:   intstr.FromInt(4567),
+													Scheme: corev1.URISchemeHTTP,
+												},
+											},
+										},
 									},
 								},
 							},


### PR DESCRIPTION
**What this PR does / why we need it**:

Setting the readiness probe using `GatewayConfiguration` was broken due to invalid check in `setDataPlaneOptionsDefaults`.

This PR fixes it by checking if the readiness probe is set at all and only if it's not then overrides it with a default (which uses `/status/ready` for `Gateway` use case).

**Which issue this PR fixes**

Part of #1117 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
