### PR TITLE
fix(aigateway): check reference grant aigateway credential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 ### Breaking Changes
 
 - Added check of whether using `Secret` in another namespace in `AIGateway`'s
-  `spec.cloudProviderCredentials`. If the `AIGateway` and the `Secret`
+  `spec.cloudProviderCredentials` is allowed. If the `AIGateway` and the `Secret`
   referenced in `spec.cloudProviderCredentials` are not in the same namespace,
   there MUST be a `ReferenceGrant` in the namespace of the `Secret` that allows
   the `AIGateway`s to reference the `Secret`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- Added check of whether using `Secret` in another namespace in `AIGateway`'s
+  `spec.cloudProviderCredentials`. If the `AIGateway` and the `Secret`
+  referenced in `spec.cloudProviderCredentials` are not in the same namespace,
+  there MUST be a `ReferenceGrant` in the namespace of the `Secret` that allows
+  the `AIGateway`s to reference the `Secret`.
+  This may break usage of `AIGateway`s that is already using `Secret` in
+  other namespaces as AI cloud provider credentials.
+  [#1161](https://github.com/Kong/gateway-operator/pull/1161)
+
 ### Added
 
 - Added `Name` field in `ServiceOptions` to allow specifying name of the

--- a/controller/pkg/secrets/ref/ref.go
+++ b/controller/pkg/secrets/ref/ref.go
@@ -98,7 +98,7 @@ func CheckReferenceGrantForSecret(
 		},
 	)
 	if err != nil {
-		return "", false, fmt.Errorf("Failed to check if Secret  %s/%s is allowed by ReferenceGrants: %w",
+		return "", false, fmt.Errorf("failed to check if Secret %s/%s is allowed by ReferenceGrants: %w",
 			*secretRef.Namespace, secretRef.Name, err)
 	}
 	if !allowed {

--- a/controller/specialized/aigateway_controller.go
+++ b/controller/specialized/aigateway_controller.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/gateway-operator/api/v1alpha1"
 	"github.com/kong/gateway-operator/controller/pkg/log"
@@ -45,6 +46,11 @@ func (r *AIGatewayReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 			&gatewayv1.GatewayClass{},
 			handler.EnqueueRequestsFromMapFunc(r.listAIGatewaysForGatewayClass),
 			builder.WithPredicates(predicate.NewPredicateFuncs(watch.GatewayClassMatchesController)),
+		).
+		Watches(
+			&gatewayv1beta1.ReferenceGrant{},
+			handler.EnqueueRequestsFromMapFunc(r.listAIGatewaysForReferenceGrants),
+			builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantReferencesAIGateway)),
 		).
 		// TODO watch on Gateways, KongPlugins, e.t.c.
 		//

--- a/controller/specialized/aigateway_controller_rbac.go
+++ b/controller/specialized/aigateway_controller_rbac.go
@@ -10,4 +10,6 @@ package specialized
 
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;update;patch;delete
 
+//+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=referencegrants,verbs=get;list;watch
+
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete

--- a/controller/specialized/aigateway_controller_reconciler_owned_resources.go
+++ b/controller/specialized/aigateway_controller_reconciler_owned_resources.go
@@ -198,6 +198,7 @@ func (r *AIGatewayReconciler) configurePlugins(
 		credentialSecretNamespace = *aiGateway.Spec.CloudProviderCredentials.Namespace
 	}
 
+	// check if referencing the credential secret is allowed by referencegrants.
 	if !r.secretReferenceAllowedByReferenceGrants(ctx, logger, aiGateway, credentialSecretNamespace, credentialSecretName) {
 		log.Info(logger, "Referencing Secret is not allowed by ReferenceGrants",
 			"secret_namespace", credentialSecretNamespace, "secret_name", credentialSecretName)
@@ -275,6 +276,8 @@ func (r *AIGatewayReconciler) configurePlugins(
 	return changes, nil
 }
 
+// secretReferenceAllowedByReferenceGrants returns true if the AIGateway is allowed to references the Secret `secretNamespace/secretName`.
+// Returns true if they are in the same namespace, or there is any RefernceGrant allowing it.
 func (r *AIGatewayReconciler) secretReferenceAllowedByReferenceGrants(
 	ctx context.Context,
 	logger logr.Logger,

--- a/controller/specialized/aigateway_controller_watch.go
+++ b/controller/specialized/aigateway_controller_watch.go
@@ -10,10 +10,12 @@ import (
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/gateway-operator/api/v1alpha1"
 	operatorerrors "github.com/kong/gateway-operator/internal/errors"
 	"github.com/kong/gateway-operator/internal/utils/gatewayclass"
+	"github.com/samber/lo"
 )
 
 // -----------------------------------------------------------------------------
@@ -77,4 +79,55 @@ func (r *AIGatewayReconciler) listAIGatewaysForGatewayClass(ctx context.Context,
 	}
 
 	return
+}
+
+func (r *AIGatewayReconciler) listAIGatewaysForReferenceGrants(ctx context.Context, obj client.Object) []reconcile.Request {
+	referenceGrant, ok := obj.(*gatewayv1beta1.ReferenceGrant)
+	if !ok {
+		ctrllog.FromContext(ctx).Error(
+			operatorerrors.ErrUnexpectedObject,
+			"failed to run map funcs",
+			"expected", "ReferenceGrant", "found", reflect.TypeOf(obj),
+		)
+		return nil
+	}
+
+	namespaces := []string{}
+	for _, from := range referenceGrant.Spec.From {
+		if from.Group != gatewayv1beta1.Group(v1alpha1.SchemeGroupVersion.Group) || from.Kind != gatewayv1beta1.Kind("AIGateway") {
+			continue
+		}
+		ns := string(from.Namespace)
+		namespaces = append(namespaces, ns)
+	}
+
+	namespaces = lo.Uniq(namespaces)
+	reqs := []reconcile.Request{}
+	for _, ns := range namespaces {
+		aigateways := new(v1alpha1.AIGatewayList)
+		namespacedClient := client.NewNamespacedClient(r.Client, ns)
+		if err := namespacedClient.List(ctx, aigateways); err != nil {
+			ctrllog.FromContext(ctx).Error(err, "could not list aigateways in namespace", "namespace", ns)
+			return nil
+		}
+		for _, aigateway := range aigateways.Items {
+			reqs = append(reqs, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: aigateway.Namespace,
+					Name:      aigateway.Name,
+				},
+			})
+		}
+	}
+	return reqs
+}
+
+func referenceGrantReferencesAIGateway(obj client.Object) bool {
+	referenceGrant, ok := obj.(*gatewayv1beta1.ReferenceGrant)
+	if !ok {
+		return false
+	}
+	return lo.ContainsBy(referenceGrant.Spec.From, func(from gatewayv1beta1.ReferenceGrantFrom) bool {
+		return from.Group == gatewayv1beta1.Group(v1alpha1.SchemeGroupVersion.Group) && from.Kind == gatewayv1beta1.Kind("AIGateway")
+	})
 }

--- a/controller/specialized/aigateway_controller_watch.go
+++ b/controller/specialized/aigateway_controller_watch.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"reflect"
 
+	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -15,7 +16,6 @@ import (
 	"github.com/kong/gateway-operator/api/v1alpha1"
 	operatorerrors "github.com/kong/gateway-operator/internal/errors"
 	"github.com/kong/gateway-operator/internal/utils/gatewayclass"
-	"github.com/samber/lo"
 )
 
 // -----------------------------------------------------------------------------
@@ -81,6 +81,8 @@ func (r *AIGatewayReconciler) listAIGatewaysForGatewayClass(ctx context.Context,
 	return
 }
 
+// listAIGatewaysForReferenceGrants lists AIGateways whose group, kind and namespace appeared in `spec.from` of ReferenceGrants.
+// The listed AIGateways in are allowed to reference the resources in the `spec.to` of the ReferenceGrant.
 func (r *AIGatewayReconciler) listAIGatewaysForReferenceGrants(ctx context.Context, obj client.Object) []reconcile.Request {
 	referenceGrant, ok := obj.(*gatewayv1beta1.ReferenceGrant)
 	if !ok {
@@ -122,6 +124,8 @@ func (r *AIGatewayReconciler) listAIGatewaysForReferenceGrants(ctx context.Conte
 	return reqs
 }
 
+// referenceGrantReferencesAIGateway is the predicate function for watching ReferenceGrants.
+// It returns true if `AIGateway` type is included in the `spec.from`.
 func referenceGrantReferencesAIGateway(obj client.Object) bool {
 	referenceGrant, ok := obj.(*gatewayv1beta1.ReferenceGrant)
 	if !ok {

--- a/pkg/utils/kubernetes/referencegrant.go
+++ b/pkg/utils/kubernetes/referencegrant.go
@@ -26,6 +26,7 @@ func AllowedByReferenceGrants(
 	err := namespacedClient.List(
 		ctx,
 		&referenceGrantList,
+		// TODO: Add field selector to filter ReferenceGrants having given `from` to limit the listing scope here.
 	)
 	if err != nil {
 		return false, err

--- a/pkg/utils/kubernetes/referencegrant.go
+++ b/pkg/utils/kubernetes/referencegrant.go
@@ -1,0 +1,65 @@
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/samber/lo"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+// AllowedByReferenceGrants checks if the reference from the input `from` to the object(s)
+// in namespace `targetNamespace` with group, kind, name given in the input `to` is allowed by any ReferenceGrant.
+func AllowedByReferenceGrants(
+	ctx context.Context,
+	cl client.Client,
+	from gatewayv1beta1.ReferenceGrantFrom,
+	targetNamespace string,
+	to gatewayv1beta1.ReferenceGrantTo,
+) (bool, error) {
+	// Same namespace is always allowed.
+	if from.Namespace == gatewayv1beta1.Namespace(targetNamespace) {
+		return true, nil
+	}
+	referenceGrantList := gatewayv1beta1.ReferenceGrantList{}
+	namespacedClient := client.NewNamespacedClient(cl, targetNamespace)
+	err := namespacedClient.List(
+		ctx,
+		&referenceGrantList,
+	)
+	if err != nil {
+		return false, err
+	}
+	for _, referenceGrant := range referenceGrantList.Items {
+		// If the `spec.from` does not contain the input `from`, we skip the ReferenceGrant
+		// becuase it is impossible to grant the reference to the input `from`.
+		if !lo.ContainsBy(referenceGrant.Spec.From, func(refGrantFrom gatewayv1beta1.ReferenceGrantFrom) bool {
+			return isSameGroup(refGrantFrom.Group, from.Group) &&
+				refGrantFrom.Kind == from.Kind &&
+				refGrantFrom.Namespace == from.Namespace
+		}) {
+			continue
+		}
+		// If the ReferenceGrant contains the input `from` in `spec.from`, and contains the referenced target in `to`,
+		// we return true because it allows the reference.
+		if lo.ContainsBy(referenceGrant.Spec.To, func(refGrantTo gatewayv1beta1.ReferenceGrantTo) bool {
+			return isSameGroup(refGrantTo.Group, to.Group) &&
+				refGrantTo.Kind == to.Kind &&
+				(refGrantTo.Name == nil || (to.Name != nil && *refGrantTo.Name == *to.Name))
+		}) {
+			return true, nil
+		}
+	}
+	// If we did not find one ReferenceGrant that allows the reference, return false.
+	return false, nil
+}
+
+func isSameGroup(group1, group2 gatewayv1beta1.Group) bool {
+	if group1 == gatewayv1beta1.Group("core") {
+		group1 = gatewayv1beta1.Group("")
+	}
+	if group2 == gatewayv1beta1.Group("core") {
+		group2 = gatewayv1beta1.Group("")
+	}
+	return group1 == group2
+}

--- a/pkg/utils/kubernetes/referencegrant.go
+++ b/pkg/utils/kubernetes/referencegrant.go
@@ -32,7 +32,7 @@ func AllowedByReferenceGrants(
 	}
 	for _, referenceGrant := range referenceGrantList.Items {
 		// If the `spec.from` does not contain the input `from`, we skip the ReferenceGrant
-		// becuase it is impossible to grant the reference to the input `from`.
+		// because it is impossible to grant the reference to the input `from`.
 		if !lo.ContainsBy(referenceGrant.Spec.From, func(refGrantFrom gatewayv1beta1.ReferenceGrantFrom) bool {
 			return isSameGroup(refGrantFrom.Group, from.Group) &&
 				refGrantFrom.Kind == from.Kind &&
@@ -45,6 +45,7 @@ func AllowedByReferenceGrants(
 		if lo.ContainsBy(referenceGrant.Spec.To, func(refGrantTo gatewayv1beta1.ReferenceGrantTo) bool {
 			return isSameGroup(refGrantTo.Group, to.Group) &&
 				refGrantTo.Kind == to.Kind &&
+				// check if the name matches: allow if `spec.to` has no name, or they both have name and equal.
 				(refGrantTo.Name == nil || (to.Name != nil && *refGrantTo.Name == *to.Name))
 		}) {
 			return true, nil
@@ -54,6 +55,7 @@ func AllowedByReferenceGrants(
 	return false, nil
 }
 
+// isSameGroup returns true if the two `Group`s are the same. `core` and empty are equivalent.
 func isSameGroup(group1, group2 gatewayv1beta1.Group) bool {
 	if group1 == gatewayv1beta1.Group("core") {
 		group1 = gatewayv1beta1.Group("")

--- a/pkg/utils/kubernetes/referencegrant_test.go
+++ b/pkg/utils/kubernetes/referencegrant_test.go
@@ -1,0 +1,297 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+var referenceGrantTypeMeta = metav1.TypeMeta{
+	APIVersion: gatewayv1beta1.GroupVersion.String(),
+	Kind:       "ReferenceGrant",
+}
+
+func TestAllowedByReferenceGrants(t *testing.T) {
+	testCases := []struct {
+		name            string
+		from            gatewayv1beta1.ReferenceGrantFrom
+		targetNamespace string
+		to              gatewayv1beta1.ReferenceGrantTo
+		objs            []runtime.Object
+		allow           bool
+	}{
+		{
+			name: "should allow for same namespace",
+			from: gatewayv1beta1.ReferenceGrantFrom{
+				Group:     "some-group.k8s.io",
+				Kind:      "SomeKind",
+				Namespace: "ns-1",
+			},
+			to: gatewayv1beta1.ReferenceGrantTo{
+				Group: "another-group.k8s.io",
+				Kind:  "AnotherKind",
+			},
+			targetNamespace: "ns-1",
+			allow:           true,
+		},
+		{
+			name: "should allow if one of `spec.from` and `spec.to` matches in the ReferenceGrant in the target namespace",
+			from: gatewayv1beta1.ReferenceGrantFrom{
+				Group:     "some-group.k8s.io",
+				Kind:      "SomeKind",
+				Namespace: "source-namespace",
+			},
+			to: gatewayv1beta1.ReferenceGrantTo{
+				Group: "another-group.k8s.io",
+				Kind:  "AnotherKind",
+			},
+			targetNamespace: "target-namespace",
+			objs: []runtime.Object{
+				&gatewayv1beta1.ReferenceGrant{
+					TypeMeta: referenceGrantTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "target-namespace",
+						Name:      "ref-grant-1",
+					},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{
+							{
+								Group:     "some-group.k8s.io",
+								Kind:      "SomeKind",
+								Namespace: "source-namespace",
+							},
+							{
+								Group:     "some-group.k8s.io",
+								Kind:      "AnotherKind",
+								Namespace: "source-namespace",
+							},
+						},
+						To: []gatewayv1beta1.ReferenceGrantTo{
+							{
+								Group: "another-group.k8s.io",
+								Kind:  "AnotherKind",
+							},
+						},
+					},
+				},
+			},
+			allow: true,
+		},
+		{
+			name: "should not allow if no ReferenceGrant allows",
+			from: gatewayv1beta1.ReferenceGrantFrom{
+				Group:     "some-group.k8s.io",
+				Kind:      "SomeKind",
+				Namespace: "source-namespace",
+			},
+			to: gatewayv1beta1.ReferenceGrantTo{
+				Group: "another-group.k8s.io",
+				Kind:  "AnotherKind",
+			},
+			targetNamespace: "target-namespace",
+			allow:           false,
+		},
+		{
+			name: "should process 'core' group correctly",
+			from: gatewayv1beta1.ReferenceGrantFrom{
+				Group:     "core",
+				Kind:      "Service",
+				Namespace: "source-namespace",
+			},
+			to: gatewayv1beta1.ReferenceGrantTo{
+				Group: "",
+				Kind:  "Secret",
+			},
+			targetNamespace: "target-namespace",
+			objs: []runtime.Object{
+				&gatewayv1beta1.ReferenceGrant{
+					TypeMeta: referenceGrantTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "target-namespace",
+						Name:      "ref-grant-1",
+					},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{
+							{
+								Group:     "",
+								Kind:      "Service",
+								Namespace: "source-namespace",
+							},
+							{
+								Group:     "some-group.k8s.io",
+								Kind:      "AnotherKind",
+								Namespace: "source-namespace",
+							},
+						},
+						To: []gatewayv1beta1.ReferenceGrantTo{
+							{
+								Group: "core",
+								Kind:  "Secret",
+							},
+						},
+					},
+				},
+			},
+			allow: true,
+		},
+		{
+			name: "should allow if name matches",
+			from: gatewayv1beta1.ReferenceGrantFrom{
+				Group:     "some-group.k8s.io",
+				Kind:      "SomeKind",
+				Namespace: "source-namespace",
+			},
+			to: gatewayv1beta1.ReferenceGrantTo{
+				Group: "another-group.k8s.io",
+				Kind:  "AnotherKind",
+				Name:  lo.ToPtr(gatewayv1beta1.ObjectName("some-name")),
+			},
+			targetNamespace: "target-namespace",
+			objs: []runtime.Object{
+				&gatewayv1beta1.ReferenceGrant{
+					TypeMeta: referenceGrantTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "target-namespace",
+						Name:      "ref-grant-1",
+					},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{
+							{
+								Group:     "some-group.k8s.io",
+								Kind:      "SomeKind",
+								Namespace: "source-namespace",
+							},
+						},
+						To: []gatewayv1beta1.ReferenceGrantTo{
+							{
+								Group: "another-group.k8s.io",
+								Kind:  "AnotherKind",
+								Name:  lo.ToPtr(gatewayv1beta1.ObjectName("some-name")),
+							},
+						},
+					},
+				},
+			},
+			allow: true,
+		},
+		{
+			name: "should not allow if name does not match",
+			from: gatewayv1beta1.ReferenceGrantFrom{
+				Group:     "some-group.k8s.io",
+				Kind:      "SomeKind",
+				Namespace: "source-namespace",
+			},
+			to: gatewayv1beta1.ReferenceGrantTo{
+				Group: "another-group.k8s.io",
+				Kind:  "AnotherKind",
+				Name:  lo.ToPtr(gatewayv1beta1.ObjectName("some-name")),
+			},
+			targetNamespace: "target-namespace",
+			objs: []runtime.Object{
+				&gatewayv1beta1.ReferenceGrant{
+					TypeMeta: referenceGrantTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "target-namespace",
+						Name:      "ref-grant-1",
+					},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{
+							{
+								Group:     "some-group.k8s.io",
+								Kind:      "SomeKind",
+								Namespace: "source-namespace",
+							},
+						},
+						To: []gatewayv1beta1.ReferenceGrantTo{
+							{
+								Group: "another-group.k8s.io",
+								Kind:  "AnotherKind",
+								Name:  lo.ToPtr(gatewayv1beta1.ObjectName("another-name")),
+							},
+						},
+					},
+				},
+				&gatewayv1beta1.ReferenceGrant{
+					TypeMeta: referenceGrantTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "target-namespace",
+						Name:      "ref-grant-2",
+					},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{
+							{
+								Group:     "some-group.k8s.io",
+								Kind:      "AnotherKind",
+								Namespace: "source-namespace",
+							},
+						},
+						To: []gatewayv1beta1.ReferenceGrantTo{
+							{
+								Group: "another-group.k8s.io",
+								Kind:  "AnotherKind",
+								Name:  lo.ToPtr(gatewayv1beta1.ObjectName("some-name")),
+							},
+						},
+					},
+				},
+			},
+			allow: false,
+		},
+		{
+			name: "should allow if input specifies name and ReferenceGrant does not",
+			from: gatewayv1beta1.ReferenceGrantFrom{
+				Group:     "some-group.k8s.io",
+				Kind:      "SomeKind",
+				Namespace: "source-namespace",
+			},
+			to: gatewayv1beta1.ReferenceGrantTo{
+				Group: "another-group.k8s.io",
+				Kind:  "AnotherKind",
+				Name:  lo.ToPtr(gatewayv1beta1.ObjectName("some-name")),
+			},
+			targetNamespace: "target-namespace",
+			objs: []runtime.Object{
+				&gatewayv1beta1.ReferenceGrant{
+					TypeMeta: referenceGrantTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "target-namespace",
+						Name:      "ref-grant-1",
+					},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{
+							{
+								Group:     "some-group.k8s.io",
+								Kind:      "SomeKind",
+								Namespace: "source-namespace",
+							},
+						},
+						To: []gatewayv1beta1.ReferenceGrantTo{
+							{
+								Group: "another-group.k8s.io",
+								Kind:  "AnotherKind",
+							},
+						},
+					},
+				},
+			},
+			allow: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cl := fake.NewFakeClient(tc.objs...)
+			require.NoError(t, gatewayv1beta1.Install(cl.Scheme()))
+			allow, err := AllowedByReferenceGrants(context.Background(), cl, tc.from, tc.targetNamespace, tc.to)
+			require.NoError(t, err)
+			require.Equal(t, tc.allow, allow)
+		})
+	}
+
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Checks if `AIGateway` using a `Secret` as AI cloud provider credential is allowed by `ReferenceGrant`.
**Which issue this PR fixes**

Fixes #1150

**Special notes for your reviewer**:
This may break the current usage of using `Secret` in the different namespace with `AIGateway`. So I listed it in `Breaking Changes` in the CHANGELOG.
**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
