### PR TITLE
fix(konnect): fix handling conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,8 @@
   [#1115](https://github.com/Kong/gateway-operator/pull/1115)
 - Fix setting `DataPlane`'s readiness probe using `GatewayConfiguration`.
   [#1118](https://github.com/Kong/gateway-operator/pull/1118)
+- Fix handling Konnect API conflicts.
+  [#1176](https://github.com/Kong/gateway-operator/pull/1176)
 
 ## [v1.4.2]
 

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -58,6 +58,7 @@ func Create[
 		entityType = e.GetTypeName()
 		statusCode int
 	)
+
 	switch ent := any(e).(type) {
 	case *konnectv1alpha1.KonnectGatewayControlPlane:
 		err = createControlPlane(ctx, sdk.GetControlPlaneSDK(), sdk.GetControlPlaneGroupSDK(), cl, ent)

--- a/controller/konnect/ops/ops_errors.go
+++ b/controller/konnect/ops/ops_errors.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"strings"
 
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/go-logr/logr"
@@ -94,7 +95,6 @@ func ParseSDKErrorBody(body string) (sdkErrorBody, error) {
 }
 
 const (
-	dataConstraintMesasge   = "data constraint error"
 	validationErrorMessage  = "validation error"
 	apiErrorOccurredMessage = "API error occurred"
 )
@@ -202,14 +202,20 @@ func SDKErrorIsConflict(sdkError *sdkkonnecterrs.SDKError) bool {
 		return false
 	}
 
-	if sdkErrorBody.Message != dataConstraintMesasge {
-		return false
+	const (
+		dataConstraintMesasge      = "data constraint error"
+		typeUniqueConstraintFailed = "(type: unique) constraint failed"
+	)
+
+	if sdkErrorBody.Message == dataConstraintMesasge ||
+		strings.Contains(sdkErrorBody.Message, typeUniqueConstraintFailed) {
+
+		switch sdkErrorBody.Code {
+		case 3, 6:
+			return true
+		}
 	}
 
-	switch sdkErrorBody.Code {
-	case 3, 6:
-		return true
-	}
 	return false
 }
 

--- a/controller/konnect/ops/ops_errors_test.go
+++ b/controller/konnect/ops/ops_errors_test.go
@@ -140,3 +140,81 @@ func TestErrorIsCreateConflict(t *testing.T) {
 		})
 	}
 }
+
+func TestSDKErrorIsConflict(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *sdkkonnecterrs.SDKError
+		want bool
+	}{
+		{
+			name: "SDKError with data constraint error message and code 3",
+			err: &sdkkonnecterrs.SDKError{
+				Body: `{
+					"code": 3,
+					"message": "data constraint error",
+					"details": []
+				}`,
+			},
+			want: true,
+		},
+		{
+			name: "SDKError with data constraint error message and code 6",
+			err: &sdkkonnecterrs.SDKError{
+				Body: `{
+					"code": 6,
+					"message": "data constraint error",
+					"details": []
+				}`,
+			},
+			want: true,
+		},
+		{
+			name: "SDKError with unique constraint failed message",
+			err: &sdkkonnecterrs.SDKError{
+				Body: `{
+					"code": 3,
+					"message": "name (type: unique) constraint failed",
+					"details": []
+				}`,
+			},
+			want: true,
+		},
+		{
+			name: "SDKError with non-conflict message",
+			err: &sdkkonnecterrs.SDKError{
+				Body: `{
+					"code": 3,
+					"message": "some other error",
+					"details": []
+				}`,
+			},
+			want: false,
+		},
+		{
+			name: "SDKError with conflict message but different code",
+			err: &sdkkonnecterrs.SDKError{
+				Body: `{
+					"code": 4,
+					"message": "data constraint error",
+					"details": []
+				}`,
+			},
+			want: false,
+		},
+		{
+			name: "SDKError with invalid JSON body",
+			err: &sdkkonnecterrs.SDKError{
+				Body: `invalid json`,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SDKErrorIsConflict(tt.err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/controller/konnect/ops/ops_errors_test.go
+++ b/controller/konnect/ops/ops_errors_test.go
@@ -127,6 +127,28 @@ func TestErrorIsCreateConflict(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "error is SDKError with code 6",
+			err: &sdkkonnecterrs.SDKError{
+				Body: `{
+					"code": 6,
+					"message": "already exists",
+					"details": []
+				}`,
+			},
+			want: true,
+		},
+		{
+			name: "error is SDKError with code 7",
+			err: &sdkkonnecterrs.SDKError{
+				Body: `{
+					"code": 7,
+					"message": "other error",
+					"details": []
+				}`,
+			},
+			want: false,
+		},
+		{
 			name: "error is not ConflictError or SDKError",
 			err:  errors.New("some other error"),
 			want: false,


### PR DESCRIPTION
**What this PR does / why we need it**:

- Some conflict errors coming from Konnect contain yet unhandled error message: `(type: unique) constraint failed`. This PR fixes that.

  This error happens when e.g. a route tries to get created with another route already existing in Konnect with the same name.

- This also handles "conflicts" when creating certificates: something changed (not sure what at this stage) and we've started to notice errors in konnect integration tests (documented in #1180). This PR adds a workaround for this by first listing the matching certificates using the UID matching tag before it attempts to create the certificate.

  A long term solution can be implemented as part of #1180.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
