### PR TITLE
feat(konnect): add KonnectDataPlaneGroupConfiguration reconciler

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -142,7 +142,9 @@ linters-settings:
           - go.uber.org/zap/zapcore
   forbidigo:
     forbid:
-      - p: ^.*Dataplane.*$
+      # Add DataplaneG (for DataplaneGroup since there's no lookahead support here)
+      # exception as that's coming from the sdk and we have no control over it.
+      - p: ^.*Dataplane[^G].*$
         msg: "Please use camel case 'DataPlane' instead of 'Dataplane'"
       - p: ^.*Controlplane.*$
         msg: "Please use camel case 'ControlPlane' instead of 'Controlplane'"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,9 @@
 - When the `DataPlane` is configured in Konnect, the `/status/ready` endpoint
   is set as the readiness probe.
   [#1235](https://github.com/Kong/gateway-operator/pull/1253)
+- Added support for `KonnectDataPlaneGroupConfiguration` CRD which can manage Konnect
+  Cloud Gateway DataPlane Group configurations entities.
+  [#1186](https://github.com/Kong/gateway-operator/pull/1186)
 
 ### Changed
 

--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -382,6 +382,7 @@ rules:
   - konnect.konghq.com
   resources:
   - konnectapiauthconfigurations
+  - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectgatewaycontrolplanes
   verbs:
@@ -395,6 +396,8 @@ rules:
   resources:
   - konnectapiauthconfigurations/finalizers
   - konnectapiauthconfigurations/status
+  - konnectcloudgatewaydataplanegroupconfigurations/finalizers
+  - konnectcloudgatewaydataplanegroupconfigurations/status
   - konnectcloudgatewaynetworks/finalizers
   - konnectcloudgatewaynetworks/status
   - konnectgatewaycontrolplanes/finalizers

--- a/config/samples/konnect_control_plane_cg.yaml
+++ b/config/samples/konnect_control_plane_cg.yaml
@@ -1,0 +1,66 @@
+kind: KonnectAPIAuthConfiguration
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: konnect-api-auth-1
+  namespace: default
+spec:
+  type: token
+  token: kpat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  # For complete list of available API URLs see: https://docs.konghq.com/konnect/network/
+  serverURL: eu.api.konghq.com
+---
+kind: KonnectGatewayControlPlane
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: cp-cloud-gateway-test1
+  namespace: default
+spec:
+  cloud_gateway: true
+  cluster_type: CLUSTER_TYPE_CONTROL_PLANE
+  name: cp-cloud-gateway-test1
+  labels:
+    app: test1
+    key1: test1
+  konnect:
+    authRef:
+      name: konnect-api-auth-1
+---
+# NOTE:
+# Data Plane Group Configuration will override any other configuration
+# that is applied outside of this configuration.
+# Using more than 1 configuration will result in configurations overriding each other.
+apiVersion: konnect.konghq.com/v1alpha1
+kind: KonnectCloudGatewayDataPlaneGroupConfiguration
+metadata:
+  name: eu-central-1
+spec:
+  api_access: private+public
+  version: "3.9"
+  dataplane_groups:
+    - provider: aws
+      region: eu-central-1
+      networkRef:
+        type: konnectID
+        konnectID: "222222222222222222222222222222222222"
+      autoscale:
+        type: ConfigurationDataPlaneGroupAutoscaleStatic
+        static:
+          instance_type: small
+          requested_instances: 2
+      environment:
+        - name: KONG_LOG_LEVEL
+          value: debug
+    - provider: aws
+      region: ap-northeast-1
+      networkRef:
+        type: konnectID
+        konnectID: "111111111111111111111111111111111111"
+      autoscale:
+        type: ConfigurationDataPlaneGroupAutoscaleStatic
+        static:
+          instance_type: small
+          requested_instances: 2
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: cp-cloud-gateway-test1

--- a/config/samples/konnect_control_plane_cg.yaml
+++ b/config/samples/konnect_control_plane_cg.yaml
@@ -43,7 +43,7 @@ spec:
         type: konnectID
         konnectID: "222222222222222222222222222222222222"
       autoscale:
-        type: ConfigurationDataPlaneGroupAutoscaleStatic
+        type: static
         static:
           instance_type: small
           requested_instances: 2
@@ -56,7 +56,7 @@ spec:
         type: konnectID
         konnectID: "111111111111111111111111111111111111"
       autoscale:
-        type: ConfigurationDataPlaneGroupAutoscaleStatic
+        type: static
         static:
           instance_type: small
           requested_instances: 2

--- a/config/samples/konnect_control_plane_cg.yaml
+++ b/config/samples/konnect_control_plane_cg.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   type: token
   token: kpat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-  # For complete list of available API URLs see: https://docs.konghq.com/konnect/network/
+  # For a complete list of available API URLs see:https://docs.konghq.com/konnect/network/#kong-gateway-hostnames
   serverURL: eu.api.konghq.com
 ---
 kind: KonnectGatewayControlPlane

--- a/controller/konnect/constraints/constraints.go
+++ b/controller/konnect/constraints/constraints.go
@@ -36,6 +36,7 @@ type KongCredential[T SupportedCredentialType] interface {
 type SupportedKonnectEntityType interface {
 	konnectv1alpha1.KonnectGatewayControlPlane |
 		konnectv1alpha1.KonnectCloudGatewayNetwork |
+		konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration |
 		configurationv1alpha1.KongService |
 		configurationv1alpha1.KongRoute |
 		configurationv1.KongConsumer |

--- a/controller/konnect/index_konnectcloudgatewaydataplanegroupconfiguration.go
+++ b/controller/konnect/index_konnectcloudgatewaydataplanegroupconfiguration.go
@@ -1,0 +1,25 @@
+package konnect
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+const (
+	// IndexFieldKonnectCloudGatewayDataPlaneGroupConfigurationOnAPIAuthConfiguration is the index field for KonnectCloudGatewayDataPlaneGroupConfiguration -> APIAuthConfiguration.
+	IndexFieldKonnectCloudGatewayDataPlaneGroupConfigurationOnAPIAuthConfiguration = "konnectCloudGatewayDataPlaneGroupConfigurationAPIAuthConfigurationRef"
+	// IndexFieldKonnectCloudGatewayDataPlaneGroupConfigurationOnKonnectGatewayControlPlane is the index field for KonnectCloudGatewayDataPlaneGroupConfiguration -> KonnectGatewayControlPlane.
+	IndexFieldKonnectCloudGatewayDataPlaneGroupConfigurationOnKonnectGatewayControlPlane = "konnectCloudGatewayDataPlaneGroupConfigurationOnKonnectGatewayControlPlaneRef"
+)
+
+// IndexOptionsForKonnectCloudGatewayDataPlaneGroupConfiguration returns required Index options for KonnectCloudGatewayDataPlaneGroupConfiguration reconciler.
+func IndexOptionsForKonnectCloudGatewayDataPlaneGroupConfiguration(cl client.Client) []ReconciliationIndexOption {
+	return []ReconciliationIndexOption{
+		{
+			IndexObject:  &konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration{},
+			IndexField:   IndexFieldKonnectCloudGatewayDataPlaneGroupConfigurationOnKonnectGatewayControlPlane,
+			ExtractValue: indexKonnectGatewayControlPlaneRef[konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration](cl),
+		},
+	}
+}

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -125,7 +125,7 @@ func Create[
 		case *konnectv1alpha1.KonnectCloudGatewayNetwork:
 			// NOTE: since Cloud Gateways resource do not support labels/tags,
 			// we can't reliably get the Konnect ID for a Cloud Gateway Network
-			// given a k8s object UID.
+			// given a K8s object UID.
 			// For now this code uses a list, using a name filter, to get the Konnect ID.
 			id, err = getKonnectNetworkMatchingSpecName(ctx, sdk.GetCloudGatewaysSDK(), ent)
 		case *konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration:

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -64,6 +64,8 @@ func Create[
 		err = createControlPlane(ctx, sdk.GetControlPlaneSDK(), sdk.GetControlPlaneGroupSDK(), cl, ent)
 	case *konnectv1alpha1.KonnectCloudGatewayNetwork:
 		err = createKonnectNetwork(ctx, sdk.GetCloudGatewaysSDK(), ent)
+	case *konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration:
+		err = createKonnectDataPlaneGroupConfiguration(ctx, sdk.GetCloudGatewaysSDK(), ent)
 	case *configurationv1alpha1.KongService:
 		err = createService(ctx, sdk.GetServicesSDK(), ent)
 	case *configurationv1alpha1.KongRoute:
@@ -121,7 +123,14 @@ func Create[
 		case *konnectv1alpha1.KonnectGatewayControlPlane:
 			id, err = getControlPlaneForUID(ctx, sdk.GetControlPlaneSDK(), sdk.GetControlPlaneGroupSDK(), cl, ent)
 		case *konnectv1alpha1.KonnectCloudGatewayNetwork:
-			id, err = getKonnectNetworkForUID(ctx, sdk.GetCloudGatewaysSDK(), ent)
+			// NOTE: since Cloud Gateways resource do not support labels/tags,
+			// we can't reliably get the Konnect ID for a Cloud Gateway Network
+			// given a k8s object UID.
+			// For now this code uses a list, using a name filter, to get the Konnect ID.
+			id, err = getKonnectNetworkMatchingSpecName(ctx, sdk.GetCloudGatewaysSDK(), ent)
+		case *konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration:
+			// TODO: can't get the ID for a DataPlaneGroupConfiguration
+			// as this resource type does not support labels/tags.
 		case *configurationv1alpha1.KongService:
 			id, err = getKongServiceForUID(ctx, sdk.GetServicesSDK(), ent)
 		case *configurationv1alpha1.KongRoute:
@@ -235,6 +244,8 @@ func Delete[
 		err = deleteControlPlane(ctx, sdk.GetControlPlaneSDK(), ent)
 	case *konnectv1alpha1.KonnectCloudGatewayNetwork:
 		err = deleteKonnectNetwork(ctx, sdk.GetCloudGatewaysSDK(), ent)
+	case *konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration:
+		err = deleteKonnectDataPlaneGroupConfiguration(ctx, sdk.GetCloudGatewaysSDK(), ent)
 	case *configurationv1alpha1.KongService:
 		err = deleteService(ctx, sdk.GetServicesSDK(), ent)
 	case *configurationv1alpha1.KongRoute:
@@ -379,6 +390,8 @@ func Update[
 		err = updateControlPlane(ctx, sdk.GetControlPlaneSDK(), sdk.GetControlPlaneGroupSDK(), cl, ent)
 	case *konnectv1alpha1.KonnectCloudGatewayNetwork:
 		err = updateKonnectNetwork(ctx, sdk.GetCloudGatewaysSDK(), ent)
+	case *konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration:
+		err = updateKonnectDataPlaneGroupConfiguration(ctx, sdk.GetCloudGatewaysSDK(), ent)
 	case *configurationv1alpha1.KongService:
 		err = updateService(ctx, sdk.GetServicesSDK(), ent)
 	case *configurationv1alpha1.KongRoute:

--- a/controller/konnect/ops/ops_konnectdataplanegroupconfigurations.go
+++ b/controller/konnect/ops/ops_konnectdataplanegroupconfigurations.go
@@ -161,8 +161,8 @@ func cloudGatewayDataPlaneGroupConfigurationToAPIRequest(
 	spec konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationSpec,
 	cpID string,
 ) sdkkonnectcomp.CreateConfigurationRequest {
-	ret := cloudGatewayDataPlaneGroupConfigurationInit(spec, cpID)
-	ret.DataplaneGroups = func() []sdkkonnectcomp.CreateConfigurationDataPlaneGroup {
+	cfgReq := cloudGatewayDataPlaneGroupConfigurationInit(spec, cpID)
+	cfgReq.DataplaneGroups = func() []sdkkonnectcomp.CreateConfigurationDataPlaneGroup {
 		ret := make([]sdkkonnectcomp.CreateConfigurationDataPlaneGroup, 0, len(spec.DataplaneGroups))
 		for _, g := range spec.DataplaneGroups {
 			ret = append(ret, konnectConfigurationDataPlaneGroupToAPIRequest(g))
@@ -170,7 +170,7 @@ func cloudGatewayDataPlaneGroupConfigurationToAPIRequest(
 		return ret
 	}()
 
-	return ret
+	return cfgReq
 }
 
 func konnectConfigurationDataPlaneGroupToAPIRequest(

--- a/controller/konnect/ops/ops_konnectdataplanegroupconfigurations.go
+++ b/controller/konnect/ops/ops_konnectdataplanegroupconfigurations.go
@@ -1,0 +1,246 @@
+package ops
+
+import (
+	"context"
+	"fmt"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+
+	sdkops "github.com/kong/gateway-operator/controller/konnect/ops/sdk"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+// createKonnectDataPlaneGroupConfiguration creates the Konnect DataPlane configuration as specified in provided spec.
+func createKonnectDataPlaneGroupConfiguration(
+	ctx context.Context,
+	sdk sdkops.CloudGatewaysSDK,
+	n *konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration,
+) error {
+	cpID := n.GetControlPlaneID()
+	if cpID == "" {
+		return CantPerformOperationWithoutControlPlaneIDError{Entity: n, Op: CreateOp}
+	}
+
+	req := cloudGatewayDataPlaneGroupConfigurationToAPIRequest(n.Spec, cpID)
+	resp, err := sdk.CreateConfiguration(ctx, req)
+
+	if errWrap := wrapErrIfKonnectOpFailed(err, CreateOp, n); errWrap != nil {
+		return errWrap
+	}
+
+	if resp == nil || resp.ConfigurationManifest == nil || resp.ConfigurationManifest.ID == "" {
+		return fmt.Errorf("failed creating %s: %w", n.GetTypeName(), ErrNilResponse)
+	}
+
+	// At this point, the DataPlaneGroupConfiguration has been created in Konnect.
+	id := resp.ConfigurationManifest.ID
+	n.SetKonnectID(id)
+	n.Status.DataPlaneGroups = dataPlaneGroupsResponseToStatus(resp.ConfigurationManifest.GetDataplaneGroups())
+
+	return nil
+}
+
+// updateKonnectDataPlaneGroupConfiguration updates a Konnect DataPlaneGroupConfiguration.
+func updateKonnectDataPlaneGroupConfiguration(
+	ctx context.Context,
+	sdk sdkops.CloudGatewaysSDK,
+	n *konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration,
+) error {
+	cpID := n.GetControlPlaneID()
+	if cpID == "" {
+		return CantPerformOperationWithoutControlPlaneIDError{Entity: n, Op: UpdateOp}
+	}
+
+	req := cloudGatewayDataPlaneGroupConfigurationToAPIRequest(n.Spec, cpID)
+	resp, err := sdk.CreateConfiguration(ctx, req)
+	if err != nil {
+		var transientError bool
+
+		// NOTE: Cloud Gateways Data Plane group configuration API
+		// https://docs.konghq.com/konnect/api/cloud-gateways/latest/#/Data-Plane%20Group%20Configurations/create-configuration
+		// is not idempotent and will return a 409 Conflict error if the configuration
+		// is the same as the previous one. In this case, we ignore the error and
+		// perform a lookup to get the current configuration.
+		if errorIsDataPlaneGroupConflictProposedConfigIsTheSame(err) {
+			transientError = true
+		}
+
+		// NOTE: Cloud Gateways Data Plane group configuration API
+		// https://docs.konghq.com/konnect/api/cloud-gateways/latest/#/Data-Plane%20Group%20Configurations/create-configuration
+		// is not idempotent and will return a 409 Conflict error if the previous
+		// configuration is not finished provisioning. In this case, we ignore the
+		// error and perform a lookup to get the current configuration.
+		if errorIsDataPlaneGroupBadRequestPreviousConfigNotFinishedProvisioning(err) {
+			transientError = true
+		}
+
+		if transientError {
+			id := n.GetKonnectID()
+			resp, err := sdk.GetConfiguration(ctx, id)
+			if errWrap := wrapErrIfKonnectOpFailed(err, GetOp, n); errWrap != nil {
+				return errWrap
+			}
+			if resp == nil || resp.ConfigurationManifest == nil {
+				return fmt.Errorf("failed getting %s: %w", n.GetTypeName(), ErrNilResponse)
+			}
+			n.SetKonnectID(resp.ConfigurationManifest.ID)
+			n.Status.DataPlaneGroups = dataPlaneGroupsResponseToStatus(resp.ConfigurationManifest.GetDataplaneGroups())
+			return nil
+		}
+
+		// If there was an error which wasn't a conflict, complaining about submitting
+		// the same configuration, wrap it and return it.
+		if errWrap := wrapErrIfKonnectOpFailed(err, CreateOp, n); errWrap != nil {
+			return errWrap
+		}
+	}
+
+	if resp == nil || resp.ConfigurationManifest == nil || resp.ConfigurationManifest.ID == "" {
+		return fmt.Errorf("failed updating %s: %w", n.GetTypeName(), ErrNilResponse)
+	}
+
+	// At this point, the DataPlaneGroupConfiguration has been created in Konnect.
+	id := resp.ConfigurationManifest.ID
+	n.SetKonnectID(id)
+	n.Status.DataPlaneGroups = dataPlaneGroupsResponseToStatus(resp.ConfigurationManifest.GetDataplaneGroups())
+
+	// sdk.ListConfigurations(ctx, sdkkonnectops.ListConfigurationsRequest{
+	// 	Filter: &sdkkonnectcomp.ConfigurationsFilterParameters{
+	// 		ControlPlaneID:  *sdkkonnectcomp.IDFieldFilter,
+	// 		ControlPlaneGeo: *sdkkonnectcomp.ControlPlaneGeoFieldFilter,
+	// 	},
+	// })
+
+	return nil
+}
+
+// deleteKonnectDataPlaneGroupConfiguration deletes a Konnect DataPlaneGroupConfiguration.
+// It is assumed that the Konnect DataPlaneGroupConfiguration has a Konnect ID.
+func deleteKonnectDataPlaneGroupConfiguration(
+	ctx context.Context,
+	sdk sdkops.CloudGatewaysSDK,
+	n *konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration,
+) error {
+	cpID := n.GetControlPlaneID()
+	if cpID == "" {
+		return CantPerformOperationWithoutControlPlaneIDError{Entity: n, Op: DeleteOp}
+	}
+	// NOTE: we delete the data plane group configuration by "creating" (using PUT)
+	// a new configuration with the same ID and the same version, but with an empty
+	// list of data plane groups.
+	req := cloudGatewayDataPlaneGroupConfigurationInit(n.Spec, cpID)
+	resp, err := sdk.CreateConfiguration(ctx, req)
+
+	if errWrap := wrapErrIfKonnectOpFailed(err, CreateOp, n); errWrap != nil {
+		return errWrap
+	}
+
+	if resp == nil || resp.ConfigurationManifest == nil || resp.ConfigurationManifest.ID == "" {
+		return fmt.Errorf("failed deleting %s: %w", n.GetTypeName(), ErrNilResponse)
+	}
+
+	return nil
+}
+
+func cloudGatewayDataPlaneGroupConfigurationInit(
+	spec konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationSpec,
+	cpID string,
+) sdkkonnectcomp.CreateConfigurationRequest {
+	return sdkkonnectcomp.CreateConfigurationRequest{
+		ControlPlaneID: cpID,
+		Version:        spec.Version,
+		APIAccess:      spec.APIAccess,
+		// TODO deduct CP geo
+		ControlPlaneGeo: sdkkonnectcomp.ControlPlaneGeoEu,
+		DataplaneGroups: []sdkkonnectcomp.CreateConfigurationDataPlaneGroup{},
+	}
+}
+
+func cloudGatewayDataPlaneGroupConfigurationToAPIRequest(
+	spec konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationSpec,
+	cpID string,
+) sdkkonnectcomp.CreateConfigurationRequest {
+	ret := cloudGatewayDataPlaneGroupConfigurationInit(spec, cpID)
+	ret.DataplaneGroups = func() []sdkkonnectcomp.CreateConfigurationDataPlaneGroup {
+		ret := make([]sdkkonnectcomp.CreateConfigurationDataPlaneGroup, 0, len(spec.DataplaneGroups))
+		for _, g := range spec.DataplaneGroups {
+			ret = append(ret, konnectConfigurationDataPlaneGroupToAPIRequest(g))
+		}
+		return ret
+	}()
+
+	return ret
+}
+
+func konnectConfigurationDataPlaneGroupToAPIRequest(
+	spec konnectv1alpha1.KonnectConfigurationDataPlaneGroup,
+) sdkkonnectcomp.CreateConfigurationDataPlaneGroup {
+	return sdkkonnectcomp.CreateConfigurationDataPlaneGroup{
+		Provider: spec.Provider,
+		Region:   spec.Region,
+		Environment: func() []sdkkonnectcomp.ConfigurationDataPlaneGroupEnvironmentField {
+			ret := make([]sdkkonnectcomp.ConfigurationDataPlaneGroupEnvironmentField, 0, len(spec.Environment))
+			for _, e := range spec.Environment {
+				ret = append(ret, sdkkonnectcomp.ConfigurationDataPlaneGroupEnvironmentField{
+					Name:  e.Name,
+					Value: e.Value,
+				})
+			}
+			return ret
+		}(),
+		CloudGatewayNetworkID: func() string {
+			switch spec.NetworkRef.Type {
+			case konnectv1alpha1.NetworkRefKonnectID:
+				return *spec.NetworkRef.KonnectID
+			default:
+				panic(fmt.Sprintf("unknown network ref type: %s", spec.NetworkRef.Type))
+			}
+		}(),
+		Autoscale: func() sdkkonnectcomp.ConfigurationDataPlaneGroupAutoscale {
+			switch spec.Autoscale.Type {
+			case konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleTypeAutopilot:
+				return sdkkonnectcomp.ConfigurationDataPlaneGroupAutoscale{
+					Type: sdkkonnectcomp.ConfigurationDataPlaneGroupAutoscaleTypeConfigurationDataPlaneGroupAutoscaleAutopilot,
+					ConfigurationDataPlaneGroupAutoscaleAutopilot: &sdkkonnectcomp.ConfigurationDataPlaneGroupAutoscaleAutopilot{
+						Kind:    sdkkonnectcomp.ConfigurationDataPlaneGroupAutoscaleAutopilotKindAutopilot,
+						BaseRps: spec.Autoscale.Autopilot.BaseRps,
+						MaxRps:  spec.Autoscale.Autopilot.MaxRps,
+					},
+				}
+			case konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleTypeStatic:
+				return sdkkonnectcomp.ConfigurationDataPlaneGroupAutoscale{
+					Type: sdkkonnectcomp.ConfigurationDataPlaneGroupAutoscaleTypeConfigurationDataPlaneGroupAutoscaleStatic,
+					ConfigurationDataPlaneGroupAutoscaleStatic: &sdkkonnectcomp.ConfigurationDataPlaneGroupAutoscaleStatic{
+						Kind:               sdkkonnectcomp.KindStatic,
+						InstanceType:       spec.Autoscale.Static.InstanceType,
+						RequestedInstances: spec.Autoscale.Static.RequestedInstances,
+					},
+				}
+			default:
+				panic(fmt.Sprintf("unknown autoscale type: %s", spec.Autoscale.Type))
+			}
+		}(),
+	}
+}
+
+func dataPlaneGroupsResponseToStatus(
+	r []sdkkonnectcomp.ConfigurationDataPlaneGroup,
+) []konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationStatusGroup {
+	ret := make([]konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationStatusGroup, 0, len(r))
+	for _, g := range r {
+		ret = append(
+			ret,
+			konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationStatusGroup{
+				ID:                    g.ID,
+				State:                 string(g.State),
+				CloudGatewayNetworkID: g.CloudGatewayNetworkID,
+				PrivateIPAddresses:    g.PrivateIPAddresses,
+				EgressIPAddresses:     g.EgressIPAddresses,
+				Provider:              g.Provider,
+				Region:                g.Region,
+			},
+		)
+	}
+	return ret
+}

--- a/controller/konnect/ops/ops_konnectdataplanegroupconfigurations.go
+++ b/controller/konnect/ops/ops_konnectdataplanegroupconfigurations.go
@@ -105,13 +105,6 @@ func updateKonnectDataPlaneGroupConfiguration(
 	n.SetKonnectID(id)
 	n.Status.DataPlaneGroups = dataPlaneGroupsResponseToStatus(resp.ConfigurationManifest.GetDataplaneGroups())
 
-	// sdk.ListConfigurations(ctx, sdkkonnectops.ListConfigurationsRequest{
-	// 	Filter: &sdkkonnectcomp.ConfigurationsFilterParameters{
-	// 		ControlPlaneID:  *sdkkonnectcomp.IDFieldFilter,
-	// 		ControlPlaneGeo: *sdkkonnectcomp.ControlPlaneGeoFieldFilter,
-	// 	},
-	// })
-
 	return nil
 }
 

--- a/controller/konnect/ops/ops_konnectnetwork.go
+++ b/controller/konnect/ops/ops_konnectnetwork.go
@@ -78,9 +78,9 @@ func deleteKonnectNetwork(
 	return nil
 }
 
-// getKonnectNetworkForUID returns the Konnect ID of the Konnect Network
-// that matches the UID of the provided Konnect Network.
-func getKonnectNetworkForUID(
+// getKonnectNetworkMatchingSpecName returns the Konnect ID of the Konnect Network
+// that matches the name of the provided Konnect Network.
+func getKonnectNetworkMatchingSpecName(
 	ctx context.Context,
 	sdk sdkops.CloudGatewaysSDK,
 	n *konnectv1alpha1.KonnectCloudGatewayNetwork,

--- a/controller/konnect/ops/sdk/dedicatedcloudgateways.go
+++ b/controller/konnect/ops/sdk/dedicatedcloudgateways.go
@@ -14,4 +14,8 @@ type CloudGatewaysSDK interface {
 	ListNetworks(ctx context.Context, request sdkkonnectops.ListNetworksRequest, opts ...sdkkonnectops.Option) (*sdkkonnectops.ListNetworksResponse, error)
 	UpdateNetwork(ctx context.Context, networkID string, patchNetworkRequest sdkkonnectcomp.PatchNetworkRequest, opts ...sdkkonnectops.Option) (*sdkkonnectops.UpdateNetworkResponse, error)
 	DeleteNetwork(ctx context.Context, networkID string, opts ...sdkkonnectops.Option) (*sdkkonnectops.DeleteNetworkResponse, error)
+
+	CreateConfiguration(ctx context.Context, request sdkkonnectcomp.CreateConfigurationRequest, opts ...sdkkonnectops.Option) (*sdkkonnectops.CreateConfigurationResponse, error)
+	GetConfiguration(ctx context.Context, configurationID string, opts ...sdkkonnectops.Option) (*sdkkonnectops.GetConfigurationResponse, error)
+	ListConfigurations(ctx context.Context, request sdkkonnectops.ListConfigurationsRequest, opts ...sdkkonnectops.Option) (*sdkkonnectops.ListConfigurationsResponse, error)
 }

--- a/controller/konnect/ops/sdk/mocks/sdkfactory_mock.go
+++ b/controller/konnect/ops/sdk/mocks/sdkfactory_mock.go
@@ -40,6 +40,7 @@ func NewMockSDKWrapperWithT(t *testing.T) *MockSDKWrapper {
 	return &MockSDKWrapper{
 		ControlPlaneSDK:             NewMockControlPlaneSDK(t),
 		ControlPlaneGroupSDK:        NewMockControlPlaneGroupSDK(t),
+		CloudGatewaysSDK:            NewMockCloudGatewaysSDK(t),
 		ServicesSDK:                 NewMockServicesSDK(t),
 		RoutesSDK:                   NewMockRoutesSDK(t),
 		ConsumersSDK:                NewMockConsumersSDK(t),

--- a/controller/konnect/ops/sdk/mocks/zz_generated.dedicatedcloudgateways_mock.go
+++ b/controller/konnect/ops/sdk/mocks/zz_generated.dedicatedcloudgateways_mock.go
@@ -25,6 +25,80 @@ func (_m *MockCloudGatewaysSDK) EXPECT() *MockCloudGatewaysSDK_Expecter {
 	return &MockCloudGatewaysSDK_Expecter{mock: &_m.Mock}
 }
 
+// CreateConfiguration provides a mock function with given fields: ctx, request, opts
+func (_m *MockCloudGatewaysSDK) CreateConfiguration(ctx context.Context, request components.CreateConfigurationRequest, opts ...operations.Option) (*operations.CreateConfigurationResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, request)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateConfiguration")
+	}
+
+	var r0 *operations.CreateConfigurationResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, components.CreateConfigurationRequest, ...operations.Option) (*operations.CreateConfigurationResponse, error)); ok {
+		return rf(ctx, request, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, components.CreateConfigurationRequest, ...operations.Option) *operations.CreateConfigurationResponse); ok {
+		r0 = rf(ctx, request, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*operations.CreateConfigurationResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, components.CreateConfigurationRequest, ...operations.Option) error); ok {
+		r1 = rf(ctx, request, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockCloudGatewaysSDK_CreateConfiguration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateConfiguration'
+type MockCloudGatewaysSDK_CreateConfiguration_Call struct {
+	*mock.Call
+}
+
+// CreateConfiguration is a helper method to define mock.On call
+//   - ctx context.Context
+//   - request components.CreateConfigurationRequest
+//   - opts ...operations.Option
+func (_e *MockCloudGatewaysSDK_Expecter) CreateConfiguration(ctx interface{}, request interface{}, opts ...interface{}) *MockCloudGatewaysSDK_CreateConfiguration_Call {
+	return &MockCloudGatewaysSDK_CreateConfiguration_Call{Call: _e.mock.On("CreateConfiguration",
+		append([]interface{}{ctx, request}, opts...)...)}
+}
+
+func (_c *MockCloudGatewaysSDK_CreateConfiguration_Call) Run(run func(ctx context.Context, request components.CreateConfigurationRequest, opts ...operations.Option)) *MockCloudGatewaysSDK_CreateConfiguration_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]operations.Option, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(operations.Option)
+			}
+		}
+		run(args[0].(context.Context), args[1].(components.CreateConfigurationRequest), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockCloudGatewaysSDK_CreateConfiguration_Call) Return(_a0 *operations.CreateConfigurationResponse, _a1 error) *MockCloudGatewaysSDK_CreateConfiguration_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockCloudGatewaysSDK_CreateConfiguration_Call) RunAndReturn(run func(context.Context, components.CreateConfigurationRequest, ...operations.Option) (*operations.CreateConfigurationResponse, error)) *MockCloudGatewaysSDK_CreateConfiguration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateNetwork provides a mock function with given fields: ctx, request, opts
 func (_m *MockCloudGatewaysSDK) CreateNetwork(ctx context.Context, request components.CreateNetworkRequest, opts ...operations.Option) (*operations.CreateNetworkResponse, error) {
 	_va := make([]interface{}, len(opts))
@@ -173,6 +247,80 @@ func (_c *MockCloudGatewaysSDK_DeleteNetwork_Call) RunAndReturn(run func(context
 	return _c
 }
 
+// GetConfiguration provides a mock function with given fields: ctx, configurationID, opts
+func (_m *MockCloudGatewaysSDK) GetConfiguration(ctx context.Context, configurationID string, opts ...operations.Option) (*operations.GetConfigurationResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, configurationID)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetConfiguration")
+	}
+
+	var r0 *operations.GetConfigurationResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...operations.Option) (*operations.GetConfigurationResponse, error)); ok {
+		return rf(ctx, configurationID, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...operations.Option) *operations.GetConfigurationResponse); ok {
+		r0 = rf(ctx, configurationID, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*operations.GetConfigurationResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...operations.Option) error); ok {
+		r1 = rf(ctx, configurationID, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockCloudGatewaysSDK_GetConfiguration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetConfiguration'
+type MockCloudGatewaysSDK_GetConfiguration_Call struct {
+	*mock.Call
+}
+
+// GetConfiguration is a helper method to define mock.On call
+//   - ctx context.Context
+//   - configurationID string
+//   - opts ...operations.Option
+func (_e *MockCloudGatewaysSDK_Expecter) GetConfiguration(ctx interface{}, configurationID interface{}, opts ...interface{}) *MockCloudGatewaysSDK_GetConfiguration_Call {
+	return &MockCloudGatewaysSDK_GetConfiguration_Call{Call: _e.mock.On("GetConfiguration",
+		append([]interface{}{ctx, configurationID}, opts...)...)}
+}
+
+func (_c *MockCloudGatewaysSDK_GetConfiguration_Call) Run(run func(ctx context.Context, configurationID string, opts ...operations.Option)) *MockCloudGatewaysSDK_GetConfiguration_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]operations.Option, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(operations.Option)
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockCloudGatewaysSDK_GetConfiguration_Call) Return(_a0 *operations.GetConfigurationResponse, _a1 error) *MockCloudGatewaysSDK_GetConfiguration_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockCloudGatewaysSDK_GetConfiguration_Call) RunAndReturn(run func(context.Context, string, ...operations.Option) (*operations.GetConfigurationResponse, error)) *MockCloudGatewaysSDK_GetConfiguration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetNetwork provides a mock function with given fields: ctx, networkID, opts
 func (_m *MockCloudGatewaysSDK) GetNetwork(ctx context.Context, networkID string, opts ...operations.Option) (*operations.GetNetworkResponse, error) {
 	_va := make([]interface{}, len(opts))
@@ -243,6 +391,80 @@ func (_c *MockCloudGatewaysSDK_GetNetwork_Call) Return(_a0 *operations.GetNetwor
 }
 
 func (_c *MockCloudGatewaysSDK_GetNetwork_Call) RunAndReturn(run func(context.Context, string, ...operations.Option) (*operations.GetNetworkResponse, error)) *MockCloudGatewaysSDK_GetNetwork_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListConfigurations provides a mock function with given fields: ctx, request, opts
+func (_m *MockCloudGatewaysSDK) ListConfigurations(ctx context.Context, request operations.ListConfigurationsRequest, opts ...operations.Option) (*operations.ListConfigurationsResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, request)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListConfigurations")
+	}
+
+	var r0 *operations.ListConfigurationsResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, operations.ListConfigurationsRequest, ...operations.Option) (*operations.ListConfigurationsResponse, error)); ok {
+		return rf(ctx, request, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, operations.ListConfigurationsRequest, ...operations.Option) *operations.ListConfigurationsResponse); ok {
+		r0 = rf(ctx, request, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*operations.ListConfigurationsResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, operations.ListConfigurationsRequest, ...operations.Option) error); ok {
+		r1 = rf(ctx, request, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockCloudGatewaysSDK_ListConfigurations_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListConfigurations'
+type MockCloudGatewaysSDK_ListConfigurations_Call struct {
+	*mock.Call
+}
+
+// ListConfigurations is a helper method to define mock.On call
+//   - ctx context.Context
+//   - request operations.ListConfigurationsRequest
+//   - opts ...operations.Option
+func (_e *MockCloudGatewaysSDK_Expecter) ListConfigurations(ctx interface{}, request interface{}, opts ...interface{}) *MockCloudGatewaysSDK_ListConfigurations_Call {
+	return &MockCloudGatewaysSDK_ListConfigurations_Call{Call: _e.mock.On("ListConfigurations",
+		append([]interface{}{ctx, request}, opts...)...)}
+}
+
+func (_c *MockCloudGatewaysSDK_ListConfigurations_Call) Run(run func(ctx context.Context, request operations.ListConfigurationsRequest, opts ...operations.Option)) *MockCloudGatewaysSDK_ListConfigurations_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]operations.Option, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(operations.Option)
+			}
+		}
+		run(args[0].(context.Context), args[1].(operations.ListConfigurationsRequest), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockCloudGatewaysSDK_ListConfigurations_Call) Return(_a0 *operations.ListConfigurationsResponse, _a1 error) *MockCloudGatewaysSDK_ListConfigurations_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockCloudGatewaysSDK_ListConfigurations_Call) RunAndReturn(run func(context.Context, operations.ListConfigurationsRequest, ...operations.Option) (*operations.ListConfigurationsResponse, error)) *MockCloudGatewaysSDK_ListConfigurations_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/controller/konnect/reconciler_controlplaneref.go
+++ b/controller/konnect/reconciler_controlplaneref.go
@@ -18,9 +18,6 @@ import (
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
 	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
-	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
-	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
-	configurationv1beta1 "github.com/kong/kubernetes-configuration/api/configuration/v1beta1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
@@ -28,67 +25,16 @@ func getControlPlaneRef[T constraints.SupportedKonnectEntityType, TEnt constrain
 	e TEnt,
 ) mo.Option[commonv1alpha1.ControlPlaneRef] {
 	none := mo.None[commonv1alpha1.ControlPlaneRef]()
-	switch e := any(e).(type) {
-	case *configurationv1.KongConsumer:
-		if e.Spec.ControlPlaneRef == nil {
-			return none
-		}
-		return mo.Some(*e.Spec.ControlPlaneRef)
-	case *configurationv1beta1.KongConsumerGroup:
-		if e.Spec.ControlPlaneRef == nil {
-			return none
-		}
-		return mo.Some(*e.Spec.ControlPlaneRef)
-	case *configurationv1alpha1.KongRoute:
-		if e.Spec.ControlPlaneRef == nil {
-			return none
-		}
-		return mo.Some(*e.Spec.ControlPlaneRef)
-	case *configurationv1alpha1.KongService:
-		if e.Spec.ControlPlaneRef == nil {
-			return none
-		}
-		return mo.Some(*e.Spec.ControlPlaneRef)
-	case *configurationv1alpha1.KongPluginBinding:
-		return mo.Some(e.Spec.ControlPlaneRef)
-	case *configurationv1alpha1.KongUpstream:
-		if e.Spec.ControlPlaneRef == nil {
-			return none
-		}
-		return mo.Some(*e.Spec.ControlPlaneRef)
-	case *configurationv1alpha1.KongCACertificate:
-		if e.Spec.ControlPlaneRef == nil {
-			return none
-		}
-		return mo.Some(*e.Spec.ControlPlaneRef)
-	case *configurationv1alpha1.KongCertificate:
-		if e.Spec.ControlPlaneRef == nil {
-			return none
-		}
-		return mo.Some(*e.Spec.ControlPlaneRef)
-	case *configurationv1alpha1.KongVault:
-		if e.Spec.ControlPlaneRef == nil {
-			return none
-		}
-		return mo.Some(*e.Spec.ControlPlaneRef)
-	case *configurationv1alpha1.KongKey:
-		if e.Spec.ControlPlaneRef == nil {
-			return none
-		}
-		return mo.Some(*e.Spec.ControlPlaneRef)
-	case *configurationv1alpha1.KongKeySet:
-		if e.Spec.ControlPlaneRef == nil {
-			return none
-		}
-		return mo.Some(*e.Spec.ControlPlaneRef)
-	case *configurationv1alpha1.KongDataPlaneClientCertificate:
-		if e.Spec.ControlPlaneRef == nil {
-			return none
-		}
-		return mo.Some(*e.Spec.ControlPlaneRef)
-	default:
-		return none
+	type GetControlPlaneRef interface {
+		GetControlPlaneRef() *commonv1alpha1.ControlPlaneRef
 	}
+	var empty commonv1alpha1.ControlPlaneRef
+	if eGetter, ok := any(e).(GetControlPlaneRef); ok {
+		if cpRef := eGetter.GetControlPlaneRef(); cpRef != nil && *cpRef != empty {
+			return mo.Some(*cpRef)
+		}
+	}
+	return none
 }
 
 // handleControlPlaneRef handles the ControlPlaneRef for the given entity.

--- a/controller/konnect/reconciler_controlplaneref.go
+++ b/controller/konnect/reconciler_controlplaneref.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/samber/lo"
 	"github.com/samber/mo"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,9 +29,9 @@ func getControlPlaneRef[T constraints.SupportedKonnectEntityType, TEnt constrain
 	type GetControlPlaneRef interface {
 		GetControlPlaneRef() *commonv1alpha1.ControlPlaneRef
 	}
-	var empty commonv1alpha1.ControlPlaneRef
+
 	if eGetter, ok := any(e).(GetControlPlaneRef); ok {
-		if cpRef := eGetter.GetControlPlaneRef(); cpRef != nil && *cpRef != empty {
+		if cpRef := eGetter.GetControlPlaneRef(); lo.IsNotEmpty(cpRef) {
 			return mo.Some(*cpRef)
 		}
 	}

--- a/controller/konnect/reconciler_controlplaneref_test.go
+++ b/controller/konnect/reconciler_controlplaneref_test.go
@@ -331,7 +331,7 @@ func TestGetControlPlaneRef(t *testing.T) {
 				},
 				Spec: konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationSpec{},
 			},
-			mo.None[commonv1alpha1.ControlPlaneRef](),
+			mo.Some(commonv1alpha1.ControlPlaneRef{}),
 		),
 		testGetControlPlaneRef(
 			"control plane ref for KonnectCloudGatewayDataPlaneGroupConfiguration",

--- a/controller/konnect/reconciler_generic_rbac.go
+++ b/controller/konnect/reconciler_generic_rbac.go
@@ -8,6 +8,10 @@ package konnect
 //+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectgatewaycontrolplanes/status,verbs=update;patch
 //+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectgatewaycontrolplanes/finalizers,verbs=update;patch
 
+//+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectcloudgatewaydataplanegroupconfigurations,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectcloudgatewaydataplanegroupconfigurations/status,verbs=update;patch
+//+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectcloudgatewaydataplanegroupconfigurations/finalizers,verbs=update;patch
+
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongconsumers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongconsumers/status,verbs=get;update;patch
 

--- a/controller/konnect/watch.go
+++ b/controller/konnect/watch.go
@@ -43,6 +43,8 @@ func ReconciliationWatchOptionsForEntity[
 		return KonnectGatewayControlPlaneReconciliationWatchOptions(cl)
 	case *konnectv1alpha1.KonnectCloudGatewayNetwork:
 		return KonnectCloudGatewayNetworkReconciliationWatchOptions(cl)
+	case *konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration:
+		return KonnectCloudGatewayDataPlaneGroupConfigurationReconciliationWatchOptions(cl)
 	case *configurationv1alpha1.KongPluginBinding:
 		return KongPluginBindingReconciliationWatchOptions(cl)
 	case *configurationv1alpha1.KongUpstream:

--- a/controller/konnect/watch_konnectcloudgatewaydataplanegroupconfiguration.go
+++ b/controller/konnect/watch_konnectcloudgatewaydataplanegroupconfiguration.go
@@ -1,0 +1,39 @@
+package konnect
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+// TODO(pmalek): this can be extracted and used in reconciler.go
+// as every Konnect entity will have a reference to the KonnectAPIAuthConfiguration.
+// This would require:
+// - mapping function from non List types to List types
+// - a function on each Konnect entity type to get the API Auth configuration
+//   reference from the object
+// - lists have their items stored in Items field, not returned via a method
+
+// KonnectCloudGatewayDataPlaneGroupConfigurationReconciliationWatchOptions returns
+// the watch options for the KonnectCloudGatewayDataPlaneGroupConfiguration.
+func KonnectCloudGatewayDataPlaneGroupConfigurationReconciliationWatchOptions(
+	cl client.Client,
+) []func(*ctrl.Builder) *ctrl.Builder {
+	return []func(*ctrl.Builder) *ctrl.Builder{
+		func(b *ctrl.Builder) *ctrl.Builder {
+			return b.For(&konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration{})
+		},
+		func(b *ctrl.Builder) *ctrl.Builder {
+			return b.Watches(
+				&konnectv1alpha1.KonnectGatewayControlPlane{},
+				handler.EnqueueRequestsFromMapFunc(
+					enqueueObjectForKonnectGatewayControlPlane[konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationList](
+						cl, IndexFieldKonnectCloudGatewayDataPlaneGroupConfigurationOnKonnectGatewayControlPlane,
+					),
+				),
+			)
+		},
+	}
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3039,6 +3039,7 @@ _Appears in:_
 Package v1alpha1 contains API Schema definitions for the konnect.konghq.com v1alpha1 API group.
 
 - [KonnectAPIAuthConfiguration](#konnectapiauthconfiguration)
+- [KonnectCloudGatewayDataPlaneGroupConfiguration](#konnectcloudgatewaydataplanegroupconfiguration)
 - [KonnectCloudGatewayNetwork](#konnectcloudgatewaynetwork)
 - [KonnectExtension](#konnectextension)
 - [KonnectGatewayControlPlane](#konnectgatewaycontrolplane)
@@ -3056,6 +3057,23 @@ KonnectAPIAuthConfiguration is the Schema for the Konnect configuration type.
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `spec` _[KonnectAPIAuthConfigurationSpec](#konnectapiauthconfigurationspec)_ | Spec is the specification of the KonnectAPIAuthConfiguration resource. |
 | `status` _[KonnectAPIAuthConfigurationStatus](#konnectapiauthconfigurationstatus)_ | Status is the status of the KonnectAPIAuthConfiguration resource. |
+
+
+
+### KonnectCloudGatewayDataPlaneGroupConfiguration
+
+
+KonnectCloudGatewayDataPlaneGroupConfiguration is the Schema for the Konnect Network API.
+
+<!-- konnect_cloud_gateway_data_plane_group_configuration description placeholder -->
+
+| Field | Description |
+| --- | --- |
+| `apiVersion` _string_ | `konnect.konghq.com/v1alpha1`
+| `kind` _string_ | `KonnectCloudGatewayDataPlaneGroupConfiguration`
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `spec` _[KonnectCloudGatewayDataPlaneGroupConfigurationSpec](#konnectcloudgatewaydataplanegroupconfigurationspec)_ | Spec defines the desired state of KonnectCloudGatewayDataPlaneGroupConfiguration. |
+| `status` _[KonnectCloudGatewayDataPlaneGroupConfigurationStatus](#konnectcloudgatewaydataplanegroupconfigurationstatus)_ | Status defines the observed state of KonnectCloudGatewayDataPlaneGroupConfiguration. |
 
 
 
@@ -3178,6 +3196,44 @@ KonnectAPIAuthType is the type of authentication used to authenticate with the K
 _Appears in:_
 - [KonnectAPIAuthConfigurationSpec](#konnectapiauthconfigurationspec)
 
+#### KonnectCloudGatewayDataPlaneGroupConfigurationSpec
+
+
+KonnectCloudGatewayDataPlaneGroupConfigurationSpec defines the desired state of KonnectCloudGatewayDataPlaneGroupConfiguration.
+
+
+
+| Field | Description |
+| --- | --- |
+| `version` _string_ | Version specifies the desired Kong Gateway version. |
+| `dataplane_groups` _[KonnectConfigurationDataPlaneGroup](#konnectconfigurationdataplanegroup) array_ | DataplaneGroups is a list of desired data-plane groups that describe where to deploy instances, along with how many instances. |
+| `api_access` _[APIAccess](#apiaccess)_ | APIAccess is the desired type of API access for data-plane groups. |
+| `controlPlaneRef` _[ControlPlaneRef](#controlplaneref)_ | ControlPlaneRef is a reference to a ControlPlane which DataPlanes from this configuration will connect to. |
+
+
+_Appears in:_
+- [KonnectCloudGatewayDataPlaneGroupConfiguration](#konnectcloudgatewaydataplanegroupconfiguration)
+
+#### KonnectCloudGatewayDataPlaneGroupConfigurationStatus
+
+
+KonnectCloudGatewayDataPlaneGroupConfigurationStatus defines the observed state of KonnectCloudGatewayDataPlaneGroupConfiguration.
+
+
+
+| Field | Description |
+| --- | --- |
+| `id` _string_ | ID is the unique identifier of the Konnect entity as assigned by Konnect API. If it's unset (empty string), it means the Konnect entity hasn't been created yet. |
+| `serverURL` _string_ | ServerURL is the URL of the Konnect server in which the entity exists. |
+| `organizationID` _string_ | OrgID is ID of Konnect Org that this entity has been created in. |
+| `controlPlaneID` _string_ | ControlPlaneID is the Konnect ID of the ControlPlane this Route is associated with. |
+| `dataplane_groups` _[KonnectCloudGatewayDataPlaneGroupConfigurationStatusGroup](#konnectcloudgatewaydataplanegroupconfigurationstatusgroup) array_ | DataPlaneGroups is a list of deployed data-plane groups. |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ | Conditions describe the current conditions of the KonnectCloudGatewayDataPlaneGroupConfiguration.<br /><br /> Known condition types are:<br /><br /> * "Programmed" |
+
+
+_Appears in:_
+- [KonnectCloudGatewayDataPlaneGroupConfiguration](#konnectcloudgatewaydataplanegroupconfiguration)
+
 #### KonnectCloudGatewayNetworkSpec
 
 
@@ -3250,6 +3306,7 @@ KonnectEntityStatus represents the status of a Konnect entity.
 
 
 _Appears in:_
+- [KonnectCloudGatewayDataPlaneGroupConfigurationStatus](#konnectcloudgatewaydataplanegroupconfigurationstatus)
 - [KonnectCloudGatewayNetworkStatus](#konnectcloudgatewaynetworkstatus)
 - [KonnectEntityStatusWithControlPlaneAndCertificateRefs](#konnectentitystatuswithcontrolplaneandcertificaterefs)
 - [KonnectEntityStatusWithControlPlaneAndConsumerRefs](#konnectentitystatuswithcontrolplaneandconsumerrefs)
@@ -3269,7 +3326,23 @@ _Appears in:_
 
 
 
+#### KonnectEntityStatusWithControlPlaneRef
 
+
+KonnectEntityStatusWithControlPlaneRef represents the status of a Konnect entity with a reference to a ControlPlane.
+
+
+
+| Field | Description |
+| --- | --- |
+| `id` _string_ | ID is the unique identifier of the Konnect entity as assigned by Konnect API. If it's unset (empty string), it means the Konnect entity hasn't been created yet. |
+| `serverURL` _string_ | ServerURL is the URL of the Konnect server in which the entity exists. |
+| `organizationID` _string_ | OrgID is ID of Konnect Org that this entity has been created in. |
+| `controlPlaneID` _string_ | ControlPlaneID is the Konnect ID of the ControlPlane this Route is associated with. |
+
+
+_Appears in:_
+- [KonnectCloudGatewayDataPlaneGroupConfigurationStatus](#konnectcloudgatewaydataplanegroupconfigurationstatus)
 
 #### KonnectGatewayControlPlaneSpec
 
@@ -3312,4 +3385,21 @@ KonnectGatewayControlPlaneStatus defines the observed state of KonnectGatewayCon
 
 _Appears in:_
 - [KonnectGatewayControlPlane](#konnectgatewaycontrolplane)
+
+#### NetworkRef
+
+
+NetworkRef is the schema for the NetworkRef type.
+It is used to reference a Network entity.
+
+
+
+| Field | Description |
+| --- | --- |
+| `type` _string_ | Type indicates the type of the control plane being referenced. |
+| `konnectID` _string_ | KonnectID is the schema for the KonnectID type. This field is required when the Type is konnectID. |
+
+
+_Appears in:_
+- [KonnectConfigurationDataPlaneGroup](#konnectconfigurationdataplanegroup)
 

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -68,6 +68,8 @@ const (
 	KonnectGatewayControlPlaneControllerName = "KonnectGatewayControlPlane"
 	// KonnectCloudGatewayNetworkControllerName is the name of the KonnectCloudGatewayNetwork controller.
 	KonnectCloudGatewayNetworkControllerName = "KonnectCloudGatewayNetwork"
+	// KonnectCloudGatewayDataPlaneGroupConfigurationControllerName is the name of the KonnectCloudGatewayDataPlaneGroupConfiguration controller.
+	KonnectCloudGatewayDataPlaneGroupConfigurationControllerName = "KonnectCloudGatewayDataPlaneGroupConfiguration"
 	// KongServiceControllerName is the name of the KongService controller.
 	KongServiceControllerName = "KongService"
 	// KongRouteControllerName is the name of the KongRoute controller.
@@ -580,27 +582,28 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 			KongConsumerGroupPluginBindingFinalizerControllerName: newKonnectPluginController[configurationv1beta1.KongConsumerGroup](controllerFactory),
 
 			// Controllers responsible for creating, updating and deleting Konnect entities.
-			KonnectGatewayControlPlaneControllerName:     newKonnectEntityController[konnectv1alpha1.KonnectGatewayControlPlane](controllerFactory),
-			KonnectCloudGatewayNetworkControllerName:     newKonnectEntityController[konnectv1alpha1.KonnectCloudGatewayNetwork](controllerFactory),
-			KongServiceControllerName:                    newKonnectEntityController[configurationv1alpha1.KongService](controllerFactory),
-			KongRouteControllerName:                      newKonnectEntityController[configurationv1alpha1.KongRoute](controllerFactory),
-			KongConsumerControllerName:                   newKonnectEntityController[configurationv1.KongConsumer](controllerFactory),
-			KongConsumerGroupControllerName:              newKonnectEntityController[configurationv1beta1.KongConsumerGroup](controllerFactory),
-			KongUpstreamControllerName:                   newKonnectEntityController[configurationv1alpha1.KongUpstream](controllerFactory),
-			KongCACertificateControllerName:              newKonnectEntityController[configurationv1alpha1.KongCACertificate](controllerFactory),
-			KongCertificateControllerName:                newKonnectEntityController[configurationv1alpha1.KongCertificate](controllerFactory),
-			KongTargetControllerName:                     newKonnectEntityController[configurationv1alpha1.KongTarget](controllerFactory),
-			KongPluginBindingControllerName:              newKonnectEntityController[configurationv1alpha1.KongPluginBinding](controllerFactory),
-			KongCredentialBasicAuthControllerName:        newKonnectEntityController[configurationv1alpha1.KongCredentialBasicAuth](controllerFactory),
-			KongCredentialAPIKeyControllerName:           newKonnectEntityController[configurationv1alpha1.KongCredentialAPIKey](controllerFactory),
-			KongCredentialACLControllerName:              newKonnectEntityController[configurationv1alpha1.KongCredentialACL](controllerFactory),
-			KongCredentialHMACControllerName:             newKonnectEntityController[configurationv1alpha1.KongCredentialHMAC](controllerFactory),
-			KongCredentialJWTControllerName:              newKonnectEntityController[configurationv1alpha1.KongCredentialJWT](controllerFactory),
-			KongKeyControllerName:                        newKonnectEntityController[configurationv1alpha1.KongKey](controllerFactory),
-			KongKeySetControllerName:                     newKonnectEntityController[configurationv1alpha1.KongKeySet](controllerFactory),
-			KongDataPlaneClientCertificateControllerName: newKonnectEntityController[configurationv1alpha1.KongDataPlaneClientCertificate](controllerFactory),
-			KongVaultControllerName:                      newKonnectEntityController[configurationv1alpha1.KongVault](controllerFactory),
-			KongSNIControllerName:                        newKonnectEntityController[configurationv1alpha1.KongSNI](controllerFactory),
+			KonnectGatewayControlPlaneControllerName:                     newKonnectEntityController[konnectv1alpha1.KonnectGatewayControlPlane](controllerFactory),
+			KonnectCloudGatewayNetworkControllerName:                     newKonnectEntityController[konnectv1alpha1.KonnectCloudGatewayNetwork](controllerFactory),
+			KonnectCloudGatewayDataPlaneGroupConfigurationControllerName: newKonnectEntityController[konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration](controllerFactory),
+			KongServiceControllerName:                                    newKonnectEntityController[configurationv1alpha1.KongService](controllerFactory),
+			KongRouteControllerName:                                      newKonnectEntityController[configurationv1alpha1.KongRoute](controllerFactory),
+			KongConsumerControllerName:                                   newKonnectEntityController[configurationv1.KongConsumer](controllerFactory),
+			KongConsumerGroupControllerName:                              newKonnectEntityController[configurationv1beta1.KongConsumerGroup](controllerFactory),
+			KongUpstreamControllerName:                                   newKonnectEntityController[configurationv1alpha1.KongUpstream](controllerFactory),
+			KongCACertificateControllerName:                              newKonnectEntityController[configurationv1alpha1.KongCACertificate](controllerFactory),
+			KongCertificateControllerName:                                newKonnectEntityController[configurationv1alpha1.KongCertificate](controllerFactory),
+			KongTargetControllerName:                                     newKonnectEntityController[configurationv1alpha1.KongTarget](controllerFactory),
+			KongPluginBindingControllerName:                              newKonnectEntityController[configurationv1alpha1.KongPluginBinding](controllerFactory),
+			KongCredentialBasicAuthControllerName:                        newKonnectEntityController[configurationv1alpha1.KongCredentialBasicAuth](controllerFactory),
+			KongCredentialAPIKeyControllerName:                           newKonnectEntityController[configurationv1alpha1.KongCredentialAPIKey](controllerFactory),
+			KongCredentialACLControllerName:                              newKonnectEntityController[configurationv1alpha1.KongCredentialACL](controllerFactory),
+			KongCredentialHMACControllerName:                             newKonnectEntityController[configurationv1alpha1.KongCredentialHMAC](controllerFactory),
+			KongCredentialJWTControllerName:                              newKonnectEntityController[configurationv1alpha1.KongCredentialJWT](controllerFactory),
+			KongKeyControllerName:                                        newKonnectEntityController[configurationv1alpha1.KongKey](controllerFactory),
+			KongKeySetControllerName:                                     newKonnectEntityController[configurationv1alpha1.KongKeySet](controllerFactory),
+			KongDataPlaneClientCertificateControllerName:                 newKonnectEntityController[configurationv1alpha1.KongDataPlaneClientCertificate](controllerFactory),
+			KongVaultControllerName:                                      newKonnectEntityController[configurationv1alpha1.KongVault](controllerFactory),
+			KongSNIControllerName:                                        newKonnectEntityController[configurationv1alpha1.KongSNI](controllerFactory),
 			// NOTE: Reconcilers for new supported entities should be added here.
 		}
 
@@ -716,6 +719,10 @@ func SetupCacheIndicesForKonnectTypes(ctx context.Context, mgr manager.Manager, 
 		{
 			Object:       &konnectv1alpha1.KonnectExtension{},
 			IndexOptions: konnect.IndexOptionsForKonnectExtension(),
+		},
+		{
+			Object:       &konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration{},
+			IndexOptions: konnect.IndexOptionsForKonnectCloudGatewayDataPlaneGroupConfiguration(cl),
 		},
 	}
 

--- a/test/envtest/konnect_entities_konnectdataplanegroupconfiguration_test.go
+++ b/test/envtest/konnect_entities_konnectdataplanegroupconfiguration_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"testing"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
@@ -24,7 +23,7 @@ import (
 
 func TestKonnectDataPlaneGroupConfiguration(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 	cfg, ns := Setup(t, ctx, scheme.Get())
 

--- a/test/envtest/konnect_entities_konnectdataplanegroupconfiguration_test.go
+++ b/test/envtest/konnect_entities_konnectdataplanegroupconfiguration_test.go
@@ -52,9 +52,7 @@ func TestKonnectDataPlaneGroupConfiguration(t *testing.T) {
 			deploy.KonnectGatewayControlPlaneTypeWithCloudGatewaysEnabled(),
 		)
 
-		const (
-			id = "12345"
-		)
+		const id = "12345"
 
 		t.Log("Setting up a watch for KonnectCloudGatewayDataPlaneGroupConfiguration events")
 		w := setupWatch[konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
@@ -113,7 +111,7 @@ func TestKonnectDataPlaneGroupConfiguration(t *testing.T) {
 		}, waitTime, tickTime)
 
 		t.Log("Waiting for object to be deleted in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.True(c, factory.SDK.CloudGatewaysSDK.AssertExpectations(t))
 		}, waitTime, tickTime)
 	})

--- a/test/envtest/konnect_entities_konnectdataplanegroupconfiguration_test.go
+++ b/test/envtest/konnect_entities_konnectdataplanegroupconfiguration_test.go
@@ -1,0 +1,120 @@
+package envtest
+
+import (
+	"context"
+	"testing"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/gateway-operator/controller/konnect"
+	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/scheme"
+	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
+	"github.com/kong/gateway-operator/test/helpers/deploy"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+func TestKonnectDataPlaneGroupConfiguration(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := Context(t, context.Background())
+	defer cancel()
+	cfg, ns := Setup(t, ctx, scheme.Get())
+
+	t.Log("Setting up the manager with reconcilers")
+	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+	factory := sdkmocks.NewMockSDKFactory(t)
+	sdk := factory.SDK
+	StartReconcilers(ctx, t, mgr, logs,
+		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+			konnect.WithKonnectEntitySyncPeriod[konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration](konnectInfiniteSyncTime),
+		),
+	)
+
+	t.Log("Setting up clients")
+	cl, err := client.NewWithWatch(mgr.GetConfig(), client.Options{
+		Scheme: scheme.Get(),
+	})
+	require.NoError(t, err)
+	clientNamespaced := client.NewNamespacedClient(mgr.GetClient(), ns.Name)
+
+	t.Run("adding and deleting", func(t *testing.T) {
+		t.Log("Creating KonnectAPIAuthConfiguration and KonnectGatewayControlPlane")
+		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
+		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth,
+			deploy.KonnectGatewayControlPlaneTypeWithCloudGatewaysEnabled(),
+		)
+
+		const (
+			id = "12345"
+		)
+
+		t.Log("Setting up a watch for KonnectCloudGatewayDataPlaneGroupConfiguration events")
+		w := setupWatch[konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
+		t.Log("Setting up SDK expectations on creation")
+		sdk.CloudGatewaysSDK.EXPECT().CreateConfiguration(
+			mock.Anything,
+			mock.MatchedBy(func(req sdkkonnectcomp.CreateConfigurationRequest) bool {
+				return req.ControlPlaneID == cp.GetKonnectID()
+			}),
+		).Return(&sdkkonnectops.CreateConfigurationResponse{
+			ConfigurationManifest: &sdkkonnectcomp.ConfigurationManifest{
+				ID:             id,
+				ControlPlaneID: cp.GetKonnectID(),
+			},
+		}, nil)
+
+		t.Log("Creating a KonnectCloudGatewayDataPlaneGroupConfiguration")
+		dpgconf := deploy.KonnectCloudGatewayDataPlaneGroupConfiguration(t, ctx, clientNamespaced,
+			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
+		)
+
+		t.Log("Waiting for KonnectCloudGatewayDataPlaneGroupConfiguration to be programmed and get Konnect ID")
+		watchFor(t, ctx, w, apiwatch.Modified, func(c *konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration) bool {
+			return c.GetKonnectID() == id && k8sutils.IsProgrammed(c)
+		}, "KonnectCloudGatewayDataPlaneGroupConfiguration didn't get Programmed status condition or didn't get the correct (12345) Konnect ID assigned")
+
+		t.Log("Checking SDK operations")
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, factory.SDK.CloudGatewaysSDK.AssertExpectations(t))
+		}, waitTime, tickTime)
+
+		// NOTE: we delete the data plane group configuration by "creating" (using PUT)
+		// because Cloud Gateways DataPlane Group connfiguration API doesn't support
+		// deletion of the configuration directly.
+		t.Log("Setting up SDK expectations on deletion")
+		sdk.CloudGatewaysSDK.EXPECT().CreateConfiguration(
+			mock.Anything,
+			mock.MatchedBy(func(req sdkkonnectcomp.CreateConfigurationRequest) bool {
+				return req.ControlPlaneID == cp.GetKonnectID() &&
+					len(req.DataplaneGroups) == 0
+			}),
+		).Return(&sdkkonnectops.CreateConfigurationResponse{
+			ConfigurationManifest: &sdkkonnectcomp.ConfigurationManifest{
+				ID:             id,
+				ControlPlaneID: cp.GetKonnectID(),
+			},
+		}, nil)
+
+		t.Log("Deleting")
+		require.NoError(t, clientNamespaced.Delete(ctx, dpgconf))
+
+		t.Log("Waiting for object to disappear")
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			err := clientNamespaced.Get(ctx, client.ObjectKeyFromObject(dpgconf), dpgconf)
+			assert.True(c, err != nil && k8serrors.IsNotFound(err))
+		}, waitTime, tickTime)
+
+		t.Log("Waiting for object to be deleted in the SDK")
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, factory.SDK.CloudGatewaysSDK.AssertExpectations(t))
+		}, waitTime, tickTime)
+	})
+}

--- a/test/helpers/deploy/deploy_resources.go
+++ b/test/helpers/deploy/deploy_resources.go
@@ -14,13 +14,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kong/gateway-operator/pkg/consts"
+
 	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
 	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	configurationv1beta1 "github.com/kong/kubernetes-configuration/api/configuration/v1beta1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
-
-	"github.com/kong/gateway-operator/pkg/consts"
 )
 
 const (

--- a/test/helpers/deploy/deploy_resources.go
+++ b/test/helpers/deploy/deploy_resources.go
@@ -19,6 +19,8 @@ import (
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	configurationv1beta1 "github.com/kong/kubernetes-configuration/api/configuration/v1beta1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+
+	"github.com/kong/gateway-operator/pkg/consts"
 )
 
 const (
@@ -269,7 +271,7 @@ func KonnectCloudGatewayDataPlaneGroupConfiguration(
 			Name: "data-plane-group-configuration-" + uuid.NewString()[:8],
 		},
 		Spec: konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationSpec{
-			Version:   "3.9",
+			Version:   consts.DefaultDataPlaneTag,
 			APIAccess: lo.ToPtr(sdkkonnectcomp.APIAccessPrivatePlusPublic),
 			DataplaneGroups: []konnectv1alpha1.KonnectConfigurationDataPlaneGroup{
 				{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for `KonnectDataPlaneGroupConfiguration` CRD (added in https://github.com/Kong/kubernetes-configuration/pull/307)

Some notes:

- cloud gateway network ID is only allowed to be provided via Konnect
  - this is planned to be expanded upon demand to support namespaced ref
- the API (https://docs.konghq.com/konnect/api/cloud-gateways/latest/#/Data-Plane%20Group%20Configurations/create-configuration) uses a PUT verb and enforces a single configuration against a Cloud Gateway. This means that only 1 `KonnectCloudGatewayDataPlaneGroupConfiguration` can be applied to be effective, as using more than 1 against a single Control Plane will result in configurations overriding each other
  - unless the API changes this is not planned to change

**Which issue this PR fixes**

Fixes #1114 

**Special notes for your reviewer**:

Required changes from https://github.com/Kong/kubernetes-configuration/pull/307

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
