### PR TITLE
feat(konnect): Support `Secrets` used for `KongCredentialACL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
   them in `KongConsumer`s' `credentials` field.
   - `basic-auth` [#1120](https://github.com/Kong/gateway-operator/pull/1120)
   - `key-auth` [#1168](https://github.com/Kong/gateway-operator/pull/1168)
+  - `acl` [#1187](https://github.com/Kong/gateway-operator/pull/1187)
 - Added prometheus metrics for Konnect entity operations in the metrics server:
   - `gateway_operator_konnect_entity_operation_count` for number of operations.
   - `gateway_operator_konnect_entity_operation_duration_milliseconds` for duration of operations.

--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -122,7 +122,6 @@ rules:
   - kongcertificates
   - kongconsumergroups
   - kongconsumers
-  - kongcredentialacls
   - kongcredentialhmacs
   - kongcredentialjwts
   - kongdataplaneclientcertificates
@@ -200,6 +199,7 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
+  - kongcredentialacls
   - kongcredentialapikeys
   - kongcredentialbasicauths
   - kongpluginbindings

--- a/controller/konnect/constraints/constraints.go
+++ b/controller/konnect/constraints/constraints.go
@@ -14,9 +14,9 @@ import (
 // types must implement.
 type SupportedCredentialType interface {
 	configurationv1alpha1.KongCredentialBasicAuth |
-		configurationv1alpha1.KongCredentialAPIKey
+		configurationv1alpha1.KongCredentialAPIKey |
+		configurationv1alpha1.KongCredentialACL
 	// TODO: add other credential types
-	// TODO: https://github.com/Kong/gateway-operator/issues/1124
 	// TODO: https://github.com/Kong/gateway-operator/issues/1125
 	// TODO: https://github.com/Kong/gateway-operator/issues/1126
 

--- a/controller/konnect/index_credentials_acl.go
+++ b/controller/konnect/index_credentials_acl.go
@@ -9,6 +9,8 @@ import (
 const (
 	// IndexFieldKongCredentialACLReferencesKongConsumer is the index name for KongCredentialACL -> Consumer.
 	IndexFieldKongCredentialACLReferencesKongConsumer = "kongCredentialsACLConsumerRef"
+	// IndexFieldKongCredentialACLReferencesKongSecret is the index name for KongCredentialACL -> Secret.
+	IndexFieldKongCredentialACLReferencesKongSecret = "kongCredentialsACLSecretRef"
 )
 
 // IndexOptionsForCredentialsACL returns required Index options for KongCredentialACL.
@@ -18,6 +20,11 @@ func IndexOptionsForCredentialsACL() []ReconciliationIndexOption {
 			IndexObject:  &configurationv1alpha1.KongCredentialACL{},
 			IndexField:   IndexFieldKongCredentialACLReferencesKongConsumer,
 			ExtractValue: kongCredentialACLReferencesConsumer,
+		},
+		{
+			IndexObject:  &configurationv1alpha1.KongCredentialACL{},
+			IndexField:   IndexFieldKongCredentialACLReferencesKongSecret,
+			ExtractValue: kongCredentialReferencesSecret[configurationv1alpha1.KongCredentialACL],
 		},
 	}
 }

--- a/controller/konnect/reconciler_credential_secrets_rbac.go
+++ b/controller/konnect/reconciler_credential_secrets_rbac.go
@@ -4,5 +4,6 @@ package konnect
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialbasicauths,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialapikeys,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialacls,verbs=get;list;watch;create;update;patch;delete
 
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch

--- a/test/envtest/konnect_entities_kongconsumer_test.go
+++ b/test/envtest/konnect_entities_kongconsumer_test.go
@@ -506,6 +506,9 @@ func TestKongConsumerSecretCredentials(t *testing.T) {
 		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialAPIKey](konnectInfiniteSyncTime),
 		),
+		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialACL](konnectInfiniteSyncTime),
+		),
 		konnect.NewKongCredentialSecretReconciler(false, mgr.GetClient(), mgr.GetScheme()),
 	}
 	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
@@ -711,5 +714,101 @@ func TestKongConsumerSecretCredentials(t *testing.T) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.True(c, factory.SDK.KongCredentialsAPIKeySDK.AssertExpectations(t))
 		}, waitTime, tickTime)
+	})
+
+	t.Run("ACL", func(t *testing.T) {
+		consumerID := fmt.Sprintf("consumer-%d", rand.Int31n(1000))
+		username := fmt.Sprintf("user-secret-credentials-%d", rand.Int31n(1000))
+		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
+
+		t.Log("Setting up SDK expectations on KongConsumer creation")
+		sdk.ConsumersSDK.EXPECT().
+			CreateConsumer(mock.Anything, cp.GetKonnectStatus().GetKonnectID(),
+				mock.MatchedBy(func(input sdkkonnectcomp.ConsumerInput) bool {
+					return input.Username != nil && *input.Username == username
+				}),
+			).Return(&sdkkonnectops.CreateConsumerResponse{
+			Consumer: &sdkkonnectcomp.Consumer{
+				ID: lo.ToPtr(consumerID),
+			},
+		}, nil)
+
+		t.Log("Setting up SDK expectation on possibly updating KongConsumer ( due to asynchronous nature of updates between KongConsumer and KongConsumerGroup)")
+		sdk.ConsumersSDK.EXPECT().
+			UpsertConsumer(mock.Anything, mock.MatchedBy(func(r sdkkonnectops.UpsertConsumerRequest) bool {
+				return r.ConsumerID == consumerID
+			})).
+			Return(&sdkkonnectops.UpsertConsumerResponse{}, nil).
+			Maybe()
+
+		t.Log("Setting up SDK expectation on KongConsumerGroups listing")
+		sdk.ConsumerGroupSDK.EXPECT().
+			ListConsumerGroupsForConsumer(mock.Anything, sdkkonnectops.ListConsumerGroupsForConsumerRequest{
+				ConsumerID:     consumerID,
+				ControlPlaneID: cp.GetKonnectStatus().GetKonnectID(),
+			}).Return(&sdkkonnectops.ListConsumerGroupsForConsumerResponse{}, nil)
+
+		s := deploy.Secret(t, ctx, clientNamespaced,
+			map[string][]byte{
+				"group": []byte("acl-group"),
+			},
+			deploy.WithLabel("konghq.com/credential", konnect.KongCredentialTypeACL),
+		)
+
+		t.Log("Setting up SDK expectation on (managed) ACLs credentials creation")
+		sdk.KongCredentialsACLSDK.EXPECT().
+			CreateACLWithConsumer(
+				mock.Anything,
+				mock.MatchedBy(
+					func(r sdkkonnectops.CreateACLWithConsumerRequest) bool {
+						return r.ControlPlaneID == cp.GetKonnectID() &&
+							r.ACLWithoutParents.Group == "acl-group"
+					},
+				),
+			).
+			Return(
+				&sdkkonnectops.CreateACLWithConsumerResponse{
+					ACL: &sdkkonnectcomp.ACL{
+						ID: lo.ToPtr("acl-id"),
+					},
+				},
+				nil,
+			)
+
+		t.Log("Creating KongConsumer with ControlPlaneRef type=konnectID")
+		createdConsumer := deploy.KongConsumer(t, ctx, clientNamespaced, username,
+			deploy.WithKonnectIDControlPlaneRef(cp),
+			func(obj client.Object) {
+				consumer := obj.(*configurationv1.KongConsumer)
+				consumer.Credentials = []string{
+					s.Name,
+				}
+			},
+		)
+
+		t.Log("Waiting for KongConsumer to be programmed")
+		watchFor(t, ctx, cWatch, watch.Modified, func(c *configurationv1.KongConsumer) bool {
+			if c.GetName() != createdConsumer.GetName() {
+				return false
+			}
+			if c.GetControlPlaneRef().Type != configurationv1alpha1.ControlPlaneRefKonnectID {
+				return false
+			}
+			return lo.ContainsBy(c.Status.Conditions, func(condition metav1.Condition) bool {
+				return condition.Type == konnectv1alpha1.KonnectEntityProgrammedConditionType &&
+					condition.Status == metav1.ConditionTrue
+			})
+		}, "KongConsumer's Programmed condition should be true eventually")
+
+		t.Log("Waiting for KongConsumer to be created in the SDK")
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, factory.SDK.ConsumersSDK.AssertExpectations(t))
+		}, waitTime, tickTime)
+
+		t.Log("Waiting for KongCredentialACL to be created in the SDK")
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, factory.SDK.KongCredentialsACLSDK.AssertExpectations(t))
+		}, waitTime, tickTime)
+
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Support watching `Secrets` used as `ACL` credential attached to `KongConsumer` in Konnect entity reconciler.

**Which issue this PR fixes**

Fixes #1124

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
