### PR TITLE
chore: add setup watch log to setupWatch

### DIFF
--- a/test/envtest/konnect_entities_kongcacertificate_test.go
+++ b/test/envtest/konnect_entities_kongcacertificate_test.go
@@ -70,7 +70,6 @@ func TestKongCACertificate(t *testing.T) {
 		},
 	}, nil)
 
-	t.Log("Setting up a watch for KongCACertificate events")
 	w := setupWatch[configurationv1alpha1.KongCACertificateList](t, ctx, cl, client.InNamespace(ns.Name))
 
 	t.Log("Creating KongCACertificate")
@@ -236,7 +235,6 @@ func TestKongCACertificate(t *testing.T) {
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-		t.Log("Setting up a watch for KongCACertifcate events")
 		w := setupWatch[configurationv1alpha1.KongCACertificateList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on KongCACertifcate creation")

--- a/test/envtest/konnect_entities_kongcertificate_test.go
+++ b/test/envtest/konnect_entities_kongcertificate_test.go
@@ -83,7 +83,6 @@ func TestKongCertificate(t *testing.T) {
 				Object: &sdkkonnectops.ListCertificateResponseBody{},
 			}, nil)
 
-		t.Log("Setting up a watch for KongCertificate events")
 		w := setupWatch[configurationv1alpha1.KongCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Creating KongCertificate")
@@ -147,8 +146,6 @@ func TestKongCertificate(t *testing.T) {
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 		cpID := cp.GetKonnectStatus().GetKonnectID()
 
-		t.Log("Setup mock SDK for creating certificate and listing certificates by UID")
-
 		w := setupWatch[configurationv1alpha1.KongCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
 		t.Log("Creating a KongCertificate")
 		createdCert := deploy.KongCertificateAttachedToCP(t, ctx, clientNamespaced, cp,
@@ -157,6 +154,7 @@ func TestKongCertificate(t *testing.T) {
 				cert.Spec.Tags = []string{"xconflictx"}
 			},
 		)
+		t.Log("Setup mock SDK for listing certificates by UID")
 		sdk.CertificatesSDK.EXPECT().
 			ListCertificate(
 				mock.Anything,
@@ -262,7 +260,6 @@ func TestKongCertificate(t *testing.T) {
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 		cpID := cp.GetKonnectStatus().GetKonnectID()
 
-		t.Log("Setting up a watch for KongCertifcate events")
 		w := setupWatch[configurationv1alpha1.KongCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on KongCertifcate creation")

--- a/test/envtest/konnect_entities_kongconsumer_test.go
+++ b/test/envtest/konnect_entities_kongconsumer_test.go
@@ -64,7 +64,6 @@ func TestKongConsumer(t *testing.T) {
 	apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 	cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-	t.Log("Setting up a watch for KongConsumer events")
 	cWatch := setupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
 
 	t.Run("should create, update and delete Consumer without ConsumerGroups successfully", func(t *testing.T) {
@@ -162,7 +161,6 @@ func TestKongConsumer(t *testing.T) {
 		}, waitTime, tickTime)
 	})
 
-	t.Log("Setting up a watch for KongConsumerGroup events")
 	cgWatch := setupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, cl, client.InNamespace(ns.Name))
 
 	t.Run("should create, update and delete Consumer with ConsumerGroups successfully", func(t *testing.T) {
@@ -430,7 +428,6 @@ func TestKongConsumer(t *testing.T) {
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-		t.Log("Setting up a watch for KongConsumer events")
 		w := setupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on KongConsumer creation")
@@ -523,7 +520,6 @@ func TestKongConsumerSecretCredentials(t *testing.T) {
 	t.Log("Creating KonnectAPIAuthConfiguration and KonnectGatewayControlPlane")
 	apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 
-	t.Log("Setting up a watch for KongConsumer events")
 	cWatch := setupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
 
 	t.Run("BasicAuth", func(t *testing.T) {
@@ -809,6 +805,5 @@ func TestKongConsumerSecretCredentials(t *testing.T) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.True(c, factory.SDK.KongCredentialsACLSDK.AssertExpectations(t))
 		}, waitTime, tickTime)
-
 	})
 }

--- a/test/envtest/konnect_entities_kongconsumergroup_test.go
+++ b/test/envtest/konnect_entities_kongconsumergroup_test.go
@@ -58,7 +58,6 @@ func TestKongConsumerGroup(t *testing.T) {
 	apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 	cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-	t.Log("Setting up a watch for KongConsumerGroup events")
 	cWatch := setupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, cl, client.InNamespace(ns.Name))
 
 	t.Run("should create, update and delete ConsumerGroup successfully", func(t *testing.T) {
@@ -261,7 +260,6 @@ func TestKongConsumerGroup(t *testing.T) {
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-		t.Log("Setting up a watch for KongConsumerGroup events")
 		w := setupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on KongConsumerGroup creation")

--- a/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
+++ b/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
@@ -66,7 +66,6 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 		},
 	}, nil)
 
-	t.Log("Setting up a watch for KongDataPlaneClientCertificate events")
 	w := setupWatch[configurationv1alpha1.KongDataPlaneClientCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
 
 	t.Log("Creating KongDataPlaneClientCertificate")
@@ -152,7 +151,6 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-		t.Log("Setting up a watch for KongDataPlaneClientCertificate events")
 		w := setupWatch[configurationv1alpha1.KongDataPlaneClientCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on KongDataPlaneClientCertificate creation")

--- a/test/envtest/konnect_entities_kongkey_test.go
+++ b/test/envtest/konnect_entities_kongkey_test.go
@@ -74,7 +74,6 @@ func TestKongKey(t *testing.T) {
 		},
 	}, nil)
 
-	t.Log("Setting up a watch for KongKey events")
 	w := setupWatch[configurationv1alpha1.KongKeyList](t, ctx, cl, client.InNamespace(ns.Name))
 
 	t.Run("without KongKeySet", func(t *testing.T) {
@@ -332,7 +331,6 @@ func TestKongKey(t *testing.T) {
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-		t.Log("Setting up a watch for KongKey events")
 		w := setupWatch[configurationv1alpha1.KongKeyList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on KongKey creation")

--- a/test/envtest/konnect_entities_kongkeyset_test.go
+++ b/test/envtest/konnect_entities_kongkeyset_test.go
@@ -71,7 +71,6 @@ func TestKongKeySet(t *testing.T) {
 		},
 	}, nil)
 
-	t.Log("Setting up a watch for KongKeySet events")
 	w := setupWatch[configurationv1alpha1.KongKeySetList](t, ctx, cl, client.InNamespace(ns.Name))
 
 	t.Log("Creating KongKeySet")
@@ -181,7 +180,6 @@ func TestKongKeySet(t *testing.T) {
 			},
 		}, nil)
 
-		t.Log("Setting up a watch for KongKeySet events")
 		w := setupWatch[configurationv1alpha1.KongKeySetList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Creating KongKeySet with ControlPlaneRef type=konnectID")
@@ -218,7 +216,6 @@ func TestKongKeySet(t *testing.T) {
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-		t.Log("Setting up a watch for KongKeySet events")
 		w := setupWatch[configurationv1alpha1.KongKeySetList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on KongKeySet creation")

--- a/test/envtest/konnect_entities_kongroute_test.go
+++ b/test/envtest/konnect_entities_kongroute_test.go
@@ -57,7 +57,6 @@ func TestKongRoute(t *testing.T) {
 	t.Run("adding, patching and deleting KongRoute", func(t *testing.T) {
 		const routeID = "route-12345"
 
-		t.Log("Setting up a watch for KongRoute events")
 		w := setupWatch[configurationv1alpha1.KongRouteList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on Route creation")

--- a/test/envtest/konnect_entities_kongservice_test.go
+++ b/test/envtest/konnect_entities_kongservice_test.go
@@ -67,7 +67,6 @@ func TestKongService(t *testing.T) {
 		)
 		updateKongUpstreamStatusWithProgrammed(t, ctx, clientNamespaced, upstream, upstreamID, cp.GetKonnectID())
 
-		t.Log("Setting up a watch for KongService events")
 		w := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on Service creation")
@@ -164,7 +163,6 @@ func TestKongService(t *testing.T) {
 		)
 		updateKongUpstreamStatusWithProgrammed(t, ctx, clientNamespaced, upstream, upstreamID, cp.GetKonnectID())
 
-		t.Log("Setting up a watch for KongService events")
 		w := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on Service creation")
@@ -228,7 +226,6 @@ func TestKongService(t *testing.T) {
 		)
 		updateKongUpstreamStatusWithProgrammed(t, ctx, clientNamespaced, upstream, upstreamID, cp.GetKonnectID())
 
-		t.Log("Setting up a watch for KongService events")
 		w := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on Service creation")
@@ -300,7 +297,6 @@ func TestKongService(t *testing.T) {
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-		t.Log("Setting up a watch for KongService events")
 		w := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on Service creation")

--- a/test/envtest/konnect_entities_kongsni_test.go
+++ b/test/envtest/konnect_entities_kongsni_test.go
@@ -72,7 +72,6 @@ func TestKongSNI(t *testing.T) {
 		}
 		require.NoError(t, clientNamespaced.Status().Update(ctx, createdCert))
 
-		t.Log("Setting up a watch for KongSNI events")
 		w := setupWatch[configurationv1alpha1.KongSNIList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK for creating SNI")

--- a/test/envtest/konnect_entities_kongtarget_test.go
+++ b/test/envtest/konnect_entities_kongtarget_test.go
@@ -64,7 +64,6 @@ func TestKongTarget(t *testing.T) {
 		)
 		updateKongUpstreamStatusWithProgrammed(t, ctx, clientNamespaced, upstream, upstreamID, cp.GetKonnectID())
 
-		t.Log("Setting up a watch for KongTarget events")
 		w := setupWatch[configurationv1alpha1.KongTargetList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on Target creation")

--- a/test/envtest/konnect_entities_kongupstream_test.go
+++ b/test/envtest/konnect_entities_kongupstream_test.go
@@ -52,7 +52,6 @@ func TestKongUpstream(t *testing.T) {
 	apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 	cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-	t.Log("Setting up a watch for KongUpstream events")
 	w := setupWatch[configurationv1alpha1.KongUpstreamList](t, ctx, cl, client.InNamespace(ns.Name))
 
 	t.Run("adding, patching and deleting KongUpstream", func(t *testing.T) {
@@ -198,7 +197,6 @@ func TestKongUpstream(t *testing.T) {
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-		t.Log("Setting up a watch for KongUpstream events")
 		w := setupWatch[configurationv1alpha1.KongUpstreamList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on Upstream creation")

--- a/test/envtest/konnect_entities_kongvault_test.go
+++ b/test/envtest/konnect_entities_kongvault_test.go
@@ -54,7 +54,6 @@ func TestKongVault(t *testing.T) {
 	apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 	cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-	t.Log("Setting up a watch for KongVault events")
 	vaultWatch := setupWatch[configurationv1alpha1.KongVaultList](t, ctx, cl)
 
 	t.Run("should create, update and delete vault successfully", func(t *testing.T) {

--- a/test/envtest/watch.go
+++ b/test/envtest/watch.go
@@ -2,6 +2,8 @@ package envtest
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -31,8 +33,15 @@ func setupWatch[
 	cl client.WithWatch,
 	opts ...client.ListOption,
 ) watch.Interface {
-	var tlist TList
-	var list TObjectList = &tlist
+	t.Helper()
+	var (
+		tlist   TList
+		list    TObjectList = &tlist
+		strType             = strings.TrimSuffix(fmt.Sprintf("%T", list), "List")
+	)
+
+	t.Logf("Setting up a watch for %s events", strType)
+
 	w, err := cl.Watch(ctx, list, opts...)
 	require.NoError(t, err)
 	t.Cleanup(func() { w.Stop() })


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactor `setupWatch` and make it log what it's going to watch instead of adding a separate log at each call site.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
