### PR TITLE
tests: add eventuallyAssertSDKExpectations and refactor envtests to use it

### DIFF
--- a/test/envtest/assert.go
+++ b/test/envtest/assert.go
@@ -3,8 +3,11 @@ package envtest
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -32,4 +35,26 @@ func assertCollectObjectExistsAndHasKonnectID(
 		}
 		assert.Equal(c, konnectID, obj.GetKonnectID())
 	}
+}
+
+// eventuallyAssertSDKExpectations waits for the SDK to have all its expectations met.
+// This is useful to ensure that all expected calls to the SDK have been made up
+// to a certain point in the test.
+func eventuallyAssertSDKExpectations(
+	t *testing.T,
+	sdk interface {
+		AssertExpectations(mock.TestingT) bool
+	},
+	waitTime time.Duration, //nolint:unparam
+	tickTime time.Duration, //nolint:unparam
+) {
+	t.Helper()
+	t.Logf("Checking %T SDK expectations", sdk)
+
+	require.EventuallyWithT(t,
+		func(c *assert.CollectT) {
+			assert.True(c, sdk.AssertExpectations(t))
+		},
+		waitTime, tickTime,
+	)
 }

--- a/test/envtest/kongconsumercredential_acl_test.go
+++ b/test/envtest/kongconsumercredential_acl_test.go
@@ -133,9 +133,7 @@ func TestKongConsumerCredential_ACL(t *testing.T) {
 		"KongCredentialACL wasn't created",
 	)
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.True(c, sdk.AssertExpectations(t))
-	}, waitTime, tickTime)
+	eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
 
 	sdk.EXPECT().
 		DeleteACLWithConsumer(
@@ -163,9 +161,7 @@ func TestKongConsumerCredential_ACL(t *testing.T) {
 		"KongCredentialACL wasn't deleted but it should have been",
 	)
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.True(c, sdk.AssertExpectations(t))
-	}, waitTime, tickTime)
+	eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
 
 	t.Run("conflict on creation should be handled successfully", func(t *testing.T) {
 		t.Log("Setting up SDK expectations on creation with conflict")
@@ -221,8 +217,6 @@ func TestKongConsumerCredential_ACL(t *testing.T) {
 		}, "KongCredentialACL's Programmed condition should be true eventually")
 
 		t.Log("Checking SDK KongCredentialACL operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
 	})
 }

--- a/test/envtest/kongconsumercredential_apikey_test.go
+++ b/test/envtest/kongconsumercredential_apikey_test.go
@@ -133,9 +133,7 @@ func TestKongConsumerCredential_APIKey(t *testing.T) {
 		"KongCredentialAPIKey wasn't created",
 	)
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.True(c, sdk.AssertExpectations(t))
-	}, waitTime, tickTime)
+	eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
 
 	sdk.EXPECT().
 		DeleteKeyAuthWithConsumer(
@@ -164,9 +162,7 @@ func TestKongConsumerCredential_APIKey(t *testing.T) {
 		"KongCredentialAPIKey wasn't deleted but it should have been",
 	)
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.True(c, sdk.AssertExpectations(t))
-	}, waitTime, tickTime)
+	eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
 
 	t.Run("conflict on creation should be handled successfully", func(t *testing.T) {
 		t.Log("Setting up SDK expectations on creation with conflict")
@@ -220,9 +216,6 @@ func TestKongConsumerCredential_APIKey(t *testing.T) {
 			return k.GetName() == created.GetName() && k8sutils.IsProgrammed(k)
 		}, "KongCredentialAPIKey's Programmed condition should be true eventually")
 
-		t.Log("Checking SDK KongCredentialAPIKey operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
 	})
 }

--- a/test/envtest/kongconsumercredential_basicauth_test.go
+++ b/test/envtest/kongconsumercredential_basicauth_test.go
@@ -136,9 +136,7 @@ func TestKongConsumerCredential_BasicAuth(t *testing.T) {
 		"KongCredentialBasicAuth wasn't created",
 	)
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.True(c, sdk.AssertExpectations(t))
-	}, waitTime, tickTime)
+	eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
 
 	sdk.EXPECT().
 		DeleteBasicAuthWithConsumer(
@@ -166,9 +164,7 @@ func TestKongConsumerCredential_BasicAuth(t *testing.T) {
 		"KongCredentialBasicAuth wasn't deleted but it should have been",
 	)
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.True(c, factory.SDK.KongCredentialsBasicAuthSDK.AssertExpectations(t))
-	}, waitTime, tickTime)
+	eventuallyAssertSDKExpectations(t, factory.SDK.KongCredentialsBasicAuthSDK, waitTime, tickTime)
 
 	t.Run("conflict on creation should be handled successfully", func(t *testing.T) {
 		t.Log("Setting up SDK expectations on creation with conflict")
@@ -222,9 +218,6 @@ func TestKongConsumerCredential_BasicAuth(t *testing.T) {
 			return k.GetName() == created.GetName() && k8sutils.IsProgrammed(k)
 		}, "KongCredentialBasicAuth's Programmed condition should be true eventually")
 
-		t.Log("Checking SDK KongCredentialBasicAuth operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
 	})
 }

--- a/test/envtest/kongconsumercredential_hmac_test.go
+++ b/test/envtest/kongconsumercredential_hmac_test.go
@@ -132,9 +132,7 @@ func TestKongConsumerCredential_HMAC(t *testing.T) {
 		"KongCredentialHMAC wasn't created",
 	)
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.True(c, sdk.AssertExpectations(t))
-	}, waitTime, tickTime)
+	eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
 
 	sdk.EXPECT().
 		DeleteHmacAuthWithConsumer(
@@ -162,9 +160,7 @@ func TestKongConsumerCredential_HMAC(t *testing.T) {
 		"KongCredentialHMAC wasn't deleted but it should have been",
 	)
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.True(c, sdk.AssertExpectations(t))
-	}, waitTime, tickTime)
+	eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
 
 	t.Run("conflict on creation should be handled successfully", func(t *testing.T) {
 		t.Log("Setting up SDK expectations on creation with conflict")
@@ -218,9 +214,6 @@ func TestKongConsumerCredential_HMAC(t *testing.T) {
 			return k.GetName() == created.GetName() && k8sutils.IsProgrammed(k)
 		}, "KongCredentialHMAC's Programmed condition should be true eventually")
 
-		t.Log("Checking SDK KongCredentialHMAC operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
 	})
 }

--- a/test/envtest/kongconsumercredential_jwt_test.go
+++ b/test/envtest/kongconsumercredential_jwt_test.go
@@ -134,9 +134,7 @@ func TestKongConsumerCredential_JWT(t *testing.T) {
 		"KongCredentialJWT wasn't created",
 	)
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.True(c, sdk.AssertExpectations(t))
-	}, waitTime, tickTime)
+	eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
 
 	sdk.EXPECT().
 		DeleteJwtWithConsumer(
@@ -165,9 +163,7 @@ func TestKongConsumerCredential_JWT(t *testing.T) {
 		"KongCredentialJWT wasn't deleted but it should have been",
 	)
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.True(c, sdk.AssertExpectations(t))
-	}, waitTime, tickTime)
+	eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
 
 	t.Run("conflict on creation should be handled successfully", func(t *testing.T) {
 		t.Log("Setting up SDK expectations on creation with conflict")
@@ -221,9 +217,6 @@ func TestKongConsumerCredential_JWT(t *testing.T) {
 			return k.GetName() == created.GetName() && k8sutils.IsProgrammed(k)
 		}, "KongCredentialJWT's Programmed condition should be true eventually")
 
-		t.Log("Checking SDK KongCredentialJWT operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
 	})
 }

--- a/test/envtest/kongpluginbinding_managed_test.go
+++ b/test/envtest/kongpluginbinding_managed_test.go
@@ -152,9 +152,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			"KongPluginBinding wasn't recreated",
 		)
 
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.PluginSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
 
 		t.Logf(
 			"remove annotation from KongService %s and check that managed KongPluginBinding %s gets deleted, "+
@@ -201,9 +199,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			"KongPluginBinding wasn't deleted after removing annotation from KongService",
 		)
 
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.PluginSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
 	})
 
 	t.Run("binding to KongRoute", func(t *testing.T) {
@@ -261,9 +257,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			"KongPluginBinding wasn't recreated",
 		)
 
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.PluginSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
 
 		t.Logf(
 			"remove annotation from KongRoute %s and check that managed KongPluginBinding %s gets deleted, "+
@@ -309,9 +303,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			"KongPluginBinding wasn't deleted after removing annotation from KongRoute",
 		)
 
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.PluginSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
 	})
 
 	t.Run("binding to KongService and KongRoute", func(t *testing.T) {
@@ -437,9 +429,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			"KongPluginBinding bound to Service wasn't deleted after removing annotation from KongService",
 		)
 
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.PluginSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
 	})
 
 	t.Run("binding to KongConsumer, KongService and KongRoute", func(t *testing.T) {
@@ -638,9 +628,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			"KongConsumer bound KongPluginBinding wasn't deleted",
 		)
 
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.PluginSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
 	})
 
 	t.Run("binding to KongConsumerGroup, KongService and KongRoute", func(t *testing.T) {
@@ -839,8 +827,6 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			"KongConsumerGroup bound KongPluginBinding wasn't deleted",
 		)
 
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.PluginSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
 	})
 }

--- a/test/envtest/kongpluginbinding_unmanaged_test.go
+++ b/test/envtest/kongpluginbinding_unmanaged_test.go
@@ -120,9 +120,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			))
 		}, waitTime, tickTime)
 
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.PluginSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
 	})
 	t.Run("binding to KongRoute", func(t *testing.T) {
 		proxyCacheKongPlugin := deploy.ProxyCachePlugin(t, ctx, clientNamespaced)
@@ -198,9 +196,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			))
 		}, waitTime, tickTime)
 
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.PluginSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
 	})
 
 	t.Run("binding to KongService and KongRoute", func(t *testing.T) {
@@ -282,9 +278,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			))
 		}, waitTime, tickTime)
 
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.PluginSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
 	})
 
 	t.Run("binding to KongService and KongConsumer", func(t *testing.T) {
@@ -375,9 +369,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			))
 		}, waitTime, tickTime)
 
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.PluginSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
 	})
 
 	t.Run("binding to KongService and KongConsumerGroup", func(t *testing.T) {
@@ -461,9 +453,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			))
 		}, waitTime, tickTime)
 
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.PluginSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
 	})
 
 	t.Run("binding globally", func(t *testing.T) {
@@ -521,8 +511,6 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			))
 		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
 
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.PluginSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
 	})
 }

--- a/test/envtest/konnect_entities_kongcacertificate_test.go
+++ b/test/envtest/konnect_entities_kongcacertificate_test.go
@@ -176,10 +176,7 @@ func TestKongCACertificate(t *testing.T) {
 			return c.GetKonnectID() == certID && k8sutils.IsProgrammed(c)
 		}, "KongCACertificate should be programmed and have ID in status after handling conflict")
 
-		t.Log("Ensuring that the SDK's create and list methods are called")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.CACertificatesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk.CACertificatesSDK, waitTime, tickTime)
 	})
 
 	t.Run("should handle konnectID control plane reference", func(t *testing.T) {
@@ -218,10 +215,7 @@ func TestKongCACertificate(t *testing.T) {
 			})
 		}, "KongCACertificate's Programmed condition should be true eventually")
 
-		t.Log("Waiting for KongCACertificate to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.CACertificatesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.CACertificatesSDK, waitTime, tickTime)
 	})
 
 	t.Run("removing referenced CP sets the status conditions properly", func(t *testing.T) {
@@ -262,10 +256,7 @@ func TestKongCACertificate(t *testing.T) {
 				cert.Spec.Tags = tags
 			},
 		)
-		t.Log("Checking SDK CACertificate operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.CACertificatesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.CACertificatesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
 		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrue(created, id),

--- a/test/envtest/konnect_entities_kongcertificate_test.go
+++ b/test/envtest/konnect_entities_kongcertificate_test.go
@@ -10,7 +10,6 @@ import (
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -105,10 +104,7 @@ func TestKongCertificate(t *testing.T) {
 			})
 		}, "KongCertificate's Programmed condition should be true eventually")
 
-		t.Log("Waiting for KongCertificate to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.CertificatesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.CertificatesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on KongCertificate update")
 		sdk.CertificatesSDK.EXPECT().UpsertCertificate(mock.Anything, mock.MatchedBy(func(r sdkkonnectops.UpsertCertificateRequest) bool {
@@ -122,9 +118,7 @@ func TestKongCertificate(t *testing.T) {
 		require.NoError(t, clientNamespaced.Patch(ctx, certToPatch, client.MergeFrom(createdCert)))
 
 		t.Log("Waiting for KongCertificate to be updated in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.CertificatesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.CertificatesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on KongCertificate deletion")
 		sdk.CertificatesSDK.EXPECT().DeleteCertificate(mock.Anything, cpID, "cert-12345").
@@ -133,10 +127,7 @@ func TestKongCertificate(t *testing.T) {
 		t.Log("Deleting KongCertificate")
 		require.NoError(t, cl.Delete(ctx, createdCert))
 
-		t.Log("Waiting for KongCertificate to be deleted in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.CertificatesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.CertificatesSDK, waitTime, tickTime)
 	})
 
 	t.Run("should handle conflict in creation correctly", func(t *testing.T) {
@@ -187,9 +178,7 @@ func TestKongCertificate(t *testing.T) {
 		}, "KongCertificate should be programmed and have ID in status after handling conflict")
 
 		t.Log("Ensuring that the SDK's create and list methods are called")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, sdk.CertificatesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, sdk.CertificatesSDK, waitTime, tickTime)
 	})
 
 	t.Run("should handle konnectID control plane reference", func(t *testing.T) {
@@ -246,10 +235,7 @@ func TestKongCertificate(t *testing.T) {
 			})
 		}, "KongCertificate's Programmed condition should be true eventually")
 
-		t.Log("Waiting for KongCertificate to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.CertificatesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.CertificatesSDK, waitTime, tickTime)
 	})
 
 	t.Run("removing referenced CP sets the status conditions properly", func(t *testing.T) {
@@ -299,10 +285,7 @@ func TestKongCertificate(t *testing.T) {
 				cert.Spec.Tags = []string{"tag3"}
 			},
 		)
-		t.Log("Checking SDK Certificate operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.CACertificatesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.CACertificatesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
 		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrue(created, id),

--- a/test/envtest/konnect_entities_kongconsumer_test.go
+++ b/test/envtest/konnect_entities_kongconsumer_test.go
@@ -115,10 +115,7 @@ func TestKongConsumer(t *testing.T) {
 			})
 		}, "KongConsumer's Programmed condition should be true eventually")
 
-		t.Log("Waiting for KongConsumer to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ConsumersSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on KongConsumer update")
 		sdk.ConsumersSDK.EXPECT().
@@ -134,10 +131,7 @@ func TestKongConsumer(t *testing.T) {
 		consumerToPatch.Username = updatedUsername
 		require.NoError(t, clientNamespaced.Patch(ctx, consumerToPatch, client.MergeFrom(createdConsumer)))
 
-		t.Log("Waiting for KongConsumer to be updated in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ConsumersSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on KongConsumer deletion")
 		sdk.ConsumersSDK.EXPECT().
@@ -155,10 +149,7 @@ func TestKongConsumer(t *testing.T) {
 			}, waitTime, tickTime,
 		)
 
-		t.Log("Waiting for KongConsumer to be deleted in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ConsumersSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
 	})
 
 	cgWatch := setupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, cl, client.InNamespace(ns.Name))
@@ -260,10 +251,7 @@ func TestKongConsumer(t *testing.T) {
 			})
 		}, "KongConsumerGroup's Programmed condition should be true eventually")
 
-		t.Log("Waiting for SDK expectations to be met")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ConsumersSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on KongConsumer update with ConsumerGroup")
 		sdk.ConsumersSDK.EXPECT().
@@ -308,9 +296,7 @@ func TestKongConsumer(t *testing.T) {
 		require.NoError(t, clientNamespaced.Patch(ctx, consumerToPatch, client.MergeFrom(createdConsumer)))
 
 		t.Log("Waiting for SDK expectations to be met")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ConsumerGroupSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
 	})
 
 	t.Run("should handle conflict in creation correctly", func(t *testing.T) {
@@ -354,10 +340,7 @@ func TestKongConsumer(t *testing.T) {
 			return c.GetKonnectID() == consumerID && k8sutils.IsProgrammed(c)
 		}, "KongConsumer should be programmed and have ID in status after handling conflict")
 
-		t.Log("Ensuring that the SDK's create and list methods are called")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ConsumersSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
 	})
 
 	t.Run("should handle konnectID control plane reference", func(t *testing.T) {
@@ -412,10 +395,7 @@ func TestKongConsumer(t *testing.T) {
 			})
 		}, "KongConsumer's Programmed condition should be true eventually")
 
-		t.Log("Waiting for KongConsumer to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ConsumersSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
 	})
 
 	t.Run("removing referenced CP sets the status conditions properly", func(t *testing.T) {
@@ -463,10 +443,7 @@ func TestKongConsumer(t *testing.T) {
 				cert.Username = name
 			},
 		)
-		t.Log("Checking SDK Consumer operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ConsumersSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
 		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrue(created, id),
@@ -608,14 +585,8 @@ func TestKongConsumerSecretCredentials(t *testing.T) {
 			})
 		}, "KongConsumer's Programmed condition should be true eventually")
 
-		t.Log("Waiting for KongConsumer to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ConsumersSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
-		t.Log("Waiting for KongCredentialBasicAuth to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.KongCredentialsBasicAuthSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.KongCredentialsBasicAuthSDK, waitTime, tickTime)
 	})
 
 	t.Run("APIKey", func(t *testing.T) {
@@ -702,14 +673,8 @@ func TestKongConsumerSecretCredentials(t *testing.T) {
 			})
 		}, "KongConsumer's Programmed condition should be true eventually")
 
-		t.Log("Waiting for KongConsumer to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ConsumersSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
-		t.Log("Waiting for KongCredentialAPIKey to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.KongCredentialsAPIKeySDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.KongCredentialsAPIKeySDK, waitTime, tickTime)
 	})
 
 	t.Run("ACL", func(t *testing.T) {
@@ -796,14 +761,7 @@ func TestKongConsumerSecretCredentials(t *testing.T) {
 			})
 		}, "KongConsumer's Programmed condition should be true eventually")
 
-		t.Log("Waiting for KongConsumer to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ConsumersSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
-
-		t.Log("Waiting for KongCredentialACL to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.KongCredentialsACLSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.KongCredentialsACLSDK, waitTime, tickTime)
 	})
 }

--- a/test/envtest/konnect_entities_kongconsumergroup_test.go
+++ b/test/envtest/konnect_entities_kongconsumergroup_test.go
@@ -99,10 +99,7 @@ func TestKongConsumerGroup(t *testing.T) {
 			})
 		}, "KongConsumerGroup's Programmed condition should be true eventually")
 
-		t.Log("Waiting for KongConsumerGroup to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ConsumerGroupSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on KongConsumerGroup update")
 		sdk.ConsumerGroupSDK.EXPECT().
@@ -116,10 +113,7 @@ func TestKongConsumerGroup(t *testing.T) {
 		cgToPatch.Spec.Name = updatedCGName
 		require.NoError(t, clientNamespaced.Patch(ctx, cgToPatch, client.MergeFrom(cg)))
 
-		t.Log("Waiting for KongConsumerGroup to be updated in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ConsumerGroupSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on KongConsumerGroup deletion")
 		sdk.ConsumerGroupSDK.EXPECT().
@@ -137,10 +131,7 @@ func TestKongConsumerGroup(t *testing.T) {
 			}, waitTime, tickTime,
 		)
 
-		t.Log("Waiting for KongConsumerGroup to be deleted in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ConsumerGroupSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
 	})
 
 	t.Run("should create ConsumerGroup successfully on conflict when ConsumerGroup with matching uid tag exists", func(t *testing.T) {
@@ -196,10 +187,7 @@ func TestKongConsumerGroup(t *testing.T) {
 			return c.GetKonnectID() == cgID && k8sutils.IsProgrammed(c)
 		}, "KongConsumerGroup's Programmed condition should be true eventually")
 
-		t.Log("Waiting for KongConsumerGroup to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ConsumerGroupSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
 	})
 
 	t.Run("should handle konnectID control plane reference", func(t *testing.T) {
@@ -244,10 +232,7 @@ func TestKongConsumerGroup(t *testing.T) {
 			})
 		}, "KongConsumerGroup's Programmed condition should be true eventually")
 
-		t.Log("Waiting for KongConsumerGroup to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ConsumerGroupSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
 	})
 
 	t.Run("removing referenced CP sets the status conditions properly", func(t *testing.T) {
@@ -288,10 +273,7 @@ func TestKongConsumerGroup(t *testing.T) {
 				cg.Spec.Name = name
 			},
 		)
-		t.Log("Checking SDK ConsumerGroup operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ConsumerGroupSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
 		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrue(created, id),

--- a/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
+++ b/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
@@ -136,10 +136,7 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 			})
 		}, "KongDataPlaneClientCertificate's Programmed condition should be true eventually")
 
-		t.Log("Waiting for KongDataPlaneClientCertificate to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.CACertificatesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.CACertificatesSDK, waitTime, tickTime)
 	})
 
 	t.Run("removing referenced CP sets the status conditions properly", func(t *testing.T) {
@@ -174,10 +171,7 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 		created := deploy.KongDataPlaneClientCertificateAttachedToCP(t, ctx, clientNamespaced,
 			deploy.WithKonnectIDControlPlaneRef(cp),
 		)
-		t.Log("Checking SDK DataPlaneClientCertificate operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.DataPlaneCertificatesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.DataPlaneCertificatesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
 		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrue(created, id),

--- a/test/envtest/konnect_entities_kongkey_test.go
+++ b/test/envtest/konnect_entities_kongkey_test.go
@@ -11,7 +11,6 @@ import (
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -93,10 +92,7 @@ func TestKongKey(t *testing.T) {
 			})
 		}, "KongKey's Programmed condition should be true eventually")
 
-		t.Log("Checking SDK KongKey operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.KeysSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on KongKey update")
 		sdk.KeysSDK.EXPECT().UpsertKey(mock.Anything, mock.MatchedBy(func(r sdkkonnectops.UpsertKeyRequest) bool {
@@ -109,10 +105,7 @@ func TestKongKey(t *testing.T) {
 		certToPatch.Spec.Tags = append(certToPatch.Spec.Tags, "addedTag")
 		require.NoError(t, clientNamespaced.Patch(ctx, certToPatch, client.MergeFrom(createdKey)))
 
-		t.Log("Waiting for KongKey to be updated in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.KeysSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on KongKey deletion")
 		sdk.KeysSDK.EXPECT().DeleteKey(mock.Anything, cp.GetKonnectStatus().GetKonnectID(), keyID).
@@ -121,10 +114,7 @@ func TestKongKey(t *testing.T) {
 		t.Log("Deleting KongKey")
 		require.NoError(t, cl.Delete(ctx, createdKey))
 
-		t.Log("Waiting for KongKey to be deleted in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.KeysSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 	})
 
 	t.Run("without KongKeySet but with conflict response", func(t *testing.T) {
@@ -177,10 +167,7 @@ func TestKongKey(t *testing.T) {
 			})
 		}, "KongKey's Programmed condition should be true eventually")
 
-		t.Log("Checking SDK KongKey operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.KeysSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 	})
 
 	t.Run("with KongKeySet", func(t *testing.T) {
@@ -251,10 +238,7 @@ func TestKongKey(t *testing.T) {
 			return programmed && associated && keySetIDPopulated && hasOwnerRefToKeySet
 		}, "KongKey's Programmed and KeySetRefValid conditions should be true eventually")
 
-		t.Log("Waiting for KongKey to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.KeysSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on KongKeySet deattachment")
 		sdk.KeysSDK.EXPECT().UpsertKey(mock.Anything, mock.MatchedBy(func(r sdkkonnectops.UpsertKeyRequest) bool {
@@ -278,10 +262,7 @@ func TestKongKey(t *testing.T) {
 			return exactlyOneOwnerReference && hasOwnerReferenceToCP
 		}, "KongKey should be deattached from KongKeySet eventually")
 
-		t.Log("Waiting for KongKey to be deattached from KongKeySet in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.KeysSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 	})
 
 	t.Run("should handle konnectID control plane reference", func(t *testing.T) {
@@ -316,10 +297,7 @@ func TestKongKey(t *testing.T) {
 			})
 		}, "KongKey's Programmed condition should be true eventually")
 
-		t.Log("Checking SDK KongKey operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.KeysSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 	})
 
 	t.Run("removing referenced CP sets the status conditions properly", func(t *testing.T) {
@@ -359,10 +337,7 @@ func TestKongKey(t *testing.T) {
 				cg.Spec.Tags = append(cg.Spec.Tags, "test-1")
 			},
 		)
-		t.Log("Checking SDK Key operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.KeysSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
 		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrue(created, id),

--- a/test/envtest/konnect_entities_kongkeyset_test.go
+++ b/test/envtest/konnect_entities_kongkeyset_test.go
@@ -162,10 +162,7 @@ func TestKongKeySet(t *testing.T) {
 			return c.GetKonnectID() == keySetID && k8sutils.IsProgrammed(c)
 		}, "KeySet should be programmed and have ID in status after handling conflict")
 
-		t.Log("Ensuring that the SDK's create and list methods are called")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ConsumersSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
 	})
 
 	t.Run("should handle konnectID control plane reference", func(t *testing.T) {
@@ -201,10 +198,7 @@ func TestKongKeySet(t *testing.T) {
 			})
 		}, "KongKeySet's Programmed condition should be true eventually")
 
-		t.Log("Waiting for KongKeySet to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.KeySetsSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.KeySetsSDK, waitTime, tickTime)
 	})
 
 	t.Run("removing referenced CP sets the status conditions properly", func(t *testing.T) {
@@ -244,10 +238,7 @@ func TestKongKeySet(t *testing.T) {
 				cg.Spec.Tags = append(cg.Spec.Tags, "test-1")
 			},
 		)
-		t.Log("Checking SDK Key operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.KeysSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
 		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrue(created, id),

--- a/test/envtest/konnect_entities_kongroute_test.go
+++ b/test/envtest/konnect_entities_kongroute_test.go
@@ -95,10 +95,7 @@ func TestKongRoute(t *testing.T) {
 			return r.GetKonnectID() == routeID && k8sutils.IsProgrammed(r)
 		}, "KongRoute didn't get Programmed status condition or didn't get the correct (route-12345) Konnect ID assigned")
 
-		t.Log("Checking SDK KongRoute operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.RoutesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.RoutesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on Route update")
 		sdk.RoutesSDK.EXPECT().
@@ -117,10 +114,7 @@ func TestKongRoute(t *testing.T) {
 		routeToPatch.Spec.PreserveHost = lo.ToPtr(true)
 		require.NoError(t, clientNamespaced.Patch(ctx, routeToPatch, client.MergeFrom(createdRoute)))
 
-		t.Log("Waiting for Route to be updated in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.RoutesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.RoutesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on Route deletion")
 		sdk.RoutesSDK.EXPECT().
@@ -140,9 +134,6 @@ func TestKongRoute(t *testing.T) {
 			assert.True(c, err != nil && k8serrors.IsNotFound(err))
 		}, waitTime, tickTime)
 
-		t.Log("Waiting for Route to be deleted in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.RoutesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.RoutesSDK, waitTime, tickTime)
 	})
 }

--- a/test/envtest/konnect_entities_kongservice_test.go
+++ b/test/envtest/konnect_entities_kongservice_test.go
@@ -95,10 +95,7 @@ func TestKongService(t *testing.T) {
 				s.Spec.KongServiceAPISpec.Host = host
 			},
 		)
-		t.Log("Checking SDK KongService operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ServicesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for Service to be programmed and get Konnect ID")
 		watchFor(t, ctx, w, watch.Modified, func(kt *configurationv1alpha1.KongService) bool {
@@ -120,10 +117,7 @@ func TestKongService(t *testing.T) {
 		serviceToPatch.Spec.Port = port
 		require.NoError(t, clientNamespaced.Patch(ctx, serviceToPatch, client.MergeFrom(createdService)))
 
-		t.Log("Waiting for Service to be updated in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ServicesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on Service deletion")
 		sdk.ServicesSDK.EXPECT().
@@ -143,10 +137,7 @@ func TestKongService(t *testing.T) {
 			assert.True(c, err != nil && k8serrors.IsNotFound(err))
 		}, waitTime, tickTime)
 
-		t.Log("Waiting for Service to be deleted in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ServicesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 	})
 
 	t.Run("should handle konnectID control plane references", func(t *testing.T) {
@@ -192,10 +183,7 @@ func TestKongService(t *testing.T) {
 			},
 			deploy.WithKonnectIDControlPlaneRef(cp),
 		)
-		t.Log("Checking SDK KongService operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ServicesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for Service to be programmed and get Konnect ID")
 		watchFor(t, ctx, w, watch.Modified, func(kt *configurationv1alpha1.KongService) bool {
@@ -262,10 +250,7 @@ func TestKongService(t *testing.T) {
 				s.Spec.KongServiceAPISpec.Host = host
 			},
 		)
-		t.Log("Checking SDK KongService operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ServicesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for Service to get the Programmed condition set to False")
 		watchFor(t, ctx, w, watch.Modified, func(kt *configurationv1alpha1.KongService) bool {
@@ -325,10 +310,7 @@ func TestKongService(t *testing.T) {
 				s.Spec.KongServiceAPISpec.Host = host
 			},
 		)
-		t.Log("Checking SDK KongService operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ServicesSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
 		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrue(created, id),

--- a/test/envtest/konnect_entities_kongsni_test.go
+++ b/test/envtest/konnect_entities_kongsni_test.go
@@ -115,10 +115,7 @@ func TestKongSNI(t *testing.T) {
 		sniToPatch.Spec.KongSNIAPISpec.Name = "test2.kong-sni.example.com"
 		require.NoError(t, clientNamespaced.Patch(ctx, sniToPatch, client.MergeFrom(createdSNI)))
 
-		t.Log("Waiting for KongSNI to be updated in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.SNIsSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.SNIsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK for deleting SNI")
 		sdk.SNIsSDK.EXPECT().DeleteSniWithCertificate(
@@ -141,9 +138,6 @@ func TestKongSNI(t *testing.T) {
 			"KongSNI was not deleted",
 		)
 
-		t.Log("Waiting for SNI to be deleted in SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.SNIsSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.SNIsSDK, waitTime, tickTime)
 	})
 }

--- a/test/envtest/konnect_entities_kongtarget_test.go
+++ b/test/envtest/konnect_entities_kongtarget_test.go
@@ -92,10 +92,7 @@ func TestKongTarget(t *testing.T) {
 			return kt.GetKonnectID() == targetID && k8sutils.IsProgrammed(kt)
 		}, "KongTarget didn't get Programmed status condition or didn't get the correct (target-12345) Konnect ID assigned")
 
-		t.Log("Checking SDK KongTarget operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.TargetsSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.TargetsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on Target update")
 		sdk.TargetsSDK.EXPECT().UpsertTargetWithUpstream(
@@ -110,10 +107,7 @@ func TestKongTarget(t *testing.T) {
 		targetToPatch.Spec.Weight = 200
 		require.NoError(t, clientNamespaced.Patch(ctx, targetToPatch, client.MergeFrom(createdTarget)))
 
-		t.Log("Waiting for Target to be updated in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.TargetsSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.TargetsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on Target deletion")
 		sdk.TargetsSDK.EXPECT().DeleteTargetWithUpstream(
@@ -132,9 +126,6 @@ func TestKongTarget(t *testing.T) {
 			assert.True(c, err != nil && k8serrors.IsNotFound(err))
 		}, waitTime, tickTime)
 
-		t.Log("Waiting for Target to be deleted in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.TargetsSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.TargetsSDK, waitTime, tickTime)
 	})
 }

--- a/test/envtest/konnect_entities_kongupstream_test.go
+++ b/test/envtest/konnect_entities_kongupstream_test.go
@@ -89,10 +89,7 @@ func TestKongUpstream(t *testing.T) {
 			return r.GetKonnectID() == upstreamID && k8sutils.IsProgrammed(r)
 		}, "KongUpstream didn't get Programmed status condition or didn't get the correct (upstream-12345) Konnect ID assigned")
 
-		t.Log("Checking SDK KongUpstream operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.UpstreamsSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.UpstreamsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on Upstream update")
 		sdk.UpstreamsSDK.EXPECT().
@@ -112,10 +109,7 @@ func TestKongUpstream(t *testing.T) {
 		upstreamToPatch.Spec.HashFallbackHeader = lo.ToPtr("X-Hash-Header")
 		require.NoError(t, clientNamespaced.Patch(ctx, upstreamToPatch, client.MergeFrom(createdUpstream)))
 
-		t.Log("Waiting for Upstream to be updated in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.UpstreamsSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.UpstreamsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on Upstream deletion")
 		sdk.UpstreamsSDK.EXPECT().
@@ -135,10 +129,7 @@ func TestKongUpstream(t *testing.T) {
 			assert.True(c, err != nil && k8serrors.IsNotFound(err))
 		}, waitTime, tickTime)
 
-		t.Log("Waiting for Upstream to be deleted in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.UpstreamsSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.UpstreamsSDK, waitTime, tickTime)
 	})
 
 	t.Run("should handle konnectID control plane reference", func(t *testing.T) {
@@ -182,10 +173,7 @@ func TestKongUpstream(t *testing.T) {
 			return r.GetKonnectID() == upstreamID && k8sutils.IsProgrammed(r)
 		}, "KongUpstream didn't get Programmed status condition or didn't get the correct (upstream-12345) Konnect ID assigned")
 
-		t.Log("Checking SDK KongUpstream operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.UpstreamsSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.UpstreamsSDK, waitTime, tickTime)
 	})
 
 	t.Run("removing referenced CP sets the status conditions properly", func(t *testing.T) {
@@ -225,10 +213,7 @@ func TestKongUpstream(t *testing.T) {
 				s.Spec.Tags = append(s.Spec.Tags, "test-1")
 			},
 		)
-		t.Log("Checking SDK KongUpstream operations")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.UpstreamsSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.UpstreamsSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
 		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrue(created, id),

--- a/test/envtest/konnect_entities_kongvault_test.go
+++ b/test/envtest/konnect_entities_kongvault_test.go
@@ -9,7 +9,6 @@ import (
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -82,10 +81,7 @@ func TestKongVault(t *testing.T) {
 			return v.GetKonnectID() == vaultID && k8sutils.IsProgrammed(v)
 		}, "KongVault didn't get Programmed status condition or didn't get the correct (vault-12345) Konnect ID assigned")
 
-		t.Log("Waiting for KongVault to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.VaultSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.VaultSDK, waitTime, tickTime)
 
 		t.Log("Setting up mock SDK for vault update")
 		sdk.VaultSDK.EXPECT().UpsertVault(mock.Anything, mock.MatchedBy(func(r sdkkonnectops.UpsertVaultRequest) bool {
@@ -99,10 +95,7 @@ func TestKongVault(t *testing.T) {
 		vaultToPatch.Spec.Description = vaultDespription
 		require.NoError(t, clientNamespaced.Patch(ctx, vaultToPatch, client.MergeFrom(vault)))
 
-		t.Log("Waiting for KongVault to be updated in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.ConsumersSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
 
 		t.Log("Setting up mock SDK for vault deletion")
 		sdk.VaultSDK.EXPECT().DeleteVault(mock.Anything, cp.GetKonnectStatus().GetKonnectID(), vaultID).
@@ -111,10 +104,7 @@ func TestKongVault(t *testing.T) {
 		t.Log("Deleting KongVault")
 		require.NoError(t, cl.Delete(ctx, vault))
 
-		t.Log("Waiting for vault to be deleted in the SDK")
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.VaultSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.VaultSDK, waitTime, tickTime)
 	})
 
 	t.Run("should correctly handle conflict on create", func(t *testing.T) {
@@ -176,10 +166,7 @@ func TestKongVault(t *testing.T) {
 			})
 		}, "KongVault's Programmed condition should be true eventually")
 
-		t.Log("Waiting for KongVault to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.VaultSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.VaultSDK, waitTime, tickTime)
 	})
 
 	t.Run("should handle konnectID control plane reference", func(t *testing.T) {
@@ -215,9 +202,6 @@ func TestKongVault(t *testing.T) {
 			return v.GetKonnectID() == vaultID && k8sutils.IsProgrammed(v)
 		}, "KongVault didn't get Programmed status condition or didn't get the correct (vault-12345) Konnect ID assigned")
 
-		t.Log("Waiting for KongVault to be created in the SDK")
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, factory.SDK.VaultSDK.AssertExpectations(t))
-		}, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.VaultSDK, waitTime, tickTime)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`eventuallyAssertSDKExpectations` and use it in `envtest` suite to minimize code duplication when waiting for mock assertions to be satisfied.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
