### PR TITLE
refactor: add enqueueObjectForAPIAuthThroughControlPlaneRef

### DIFF
--- a/controller/konnect/watch_kongcacertificate.go
+++ b/controller/konnect/watch_kongcacertificate.go
@@ -1,21 +1,12 @@
 package konnect
 
 import (
-	"context"
-	"fmt"
-
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/kong/gateway-operator/modules/manager/logging"
-
-	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -34,7 +25,9 @@ func KongCACertificateReconciliationWatchOptions(cl client.Client) []func(*ctrl.
 			return b.Watches(
 				&konnectv1alpha1.KonnectAPIAuthConfiguration{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueKongCACertificateForKonnectAPIAuthConfiguration(cl),
+					enqueueObjectForAPIAuthThroughControlPlaneRef[configurationv1alpha1.KongCACertificateList](
+						cl, IndexFieldKongCACertificateOnKonnectGatewayControlPlane,
+					),
 				),
 			)
 		},
@@ -48,78 +41,5 @@ func KongCACertificateReconciliationWatchOptions(cl client.Client) []func(*ctrl.
 				),
 			)
 		},
-	}
-}
-
-func enqueueKongCACertificateForKonnectAPIAuthConfiguration(cl client.Client) handler.MapFunc {
-	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		auth, ok := obj.(*konnectv1alpha1.KonnectAPIAuthConfiguration)
-		if !ok {
-			return nil
-		}
-		var l configurationv1alpha1.KongCACertificateList
-		if err := cl.List(ctx, &l, &client.ListOptions{
-			// TODO: change this when cross namespace refs are allowed.
-			Namespace: auth.GetNamespace(),
-		}); err != nil {
-			return nil
-		}
-
-		var ret []reconcile.Request
-		for _, cert := range l.Items {
-			cpRef, ok := getControlPlaneRef(&cert).Get()
-			if !ok {
-				continue
-			}
-
-			switch cpRef.Type {
-			case commonv1alpha1.ControlPlaneRefKonnectNamespacedRef:
-				nn := types.NamespacedName{
-					Name:      cpRef.KonnectNamespacedRef.Name,
-					Namespace: cert.Namespace,
-				}
-				// TODO: change this when cross namespace refs are allowed.
-				if nn.Namespace != auth.Namespace {
-					continue
-				}
-				var cp konnectv1alpha1.KonnectGatewayControlPlane
-				if err := cl.Get(ctx, nn, &cp); err != nil {
-					ctrllog.FromContext(ctx).Error(
-						err,
-						"failed to get KonnectControlPlane",
-						"KonnectControlPlane", nn,
-					)
-					continue
-				}
-
-				// TODO: change this when cross namespace refs are allowed.
-				if cp.GetKonnectAPIAuthConfigurationRef().Name != auth.Name {
-					continue
-				}
-
-				ret = append(ret, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Namespace: cert.Namespace,
-						Name:      cert.Name,
-					},
-				})
-
-			case commonv1alpha1.ControlPlaneRefKonnectID:
-				ctrllog.FromContext(ctx).Error(
-					fmt.Errorf("unimplemented ControlPlaneRef type %q", cpRef.Type),
-					"unimplemented ControlPlaneRef for KongCACertificate",
-					"KongCACertificate", cert, "refType", cpRef.Type,
-				)
-				continue
-
-			default:
-				ctrllog.FromContext(ctx).V(logging.DebugLevel.Value()).Info(
-					"unsupported ControlPlaneRef for KongCACertificate",
-					"KongCACertificate", cert, "refType", cpRef.Type,
-				)
-				continue
-			}
-		}
-		return ret
 	}
 }

--- a/controller/konnect/watch_kongcertificate.go
+++ b/controller/konnect/watch_kongcertificate.go
@@ -1,21 +1,12 @@
 package konnect
 
 import (
-	"context"
-	"fmt"
-
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/kong/gateway-operator/modules/manager/logging"
-
-	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -34,7 +25,9 @@ func KongCertificateReconciliationWatchOptions(cl client.Client) []func(*ctrl.Bu
 			return b.Watches(
 				&konnectv1alpha1.KonnectAPIAuthConfiguration{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueKongCertificateForKonnectAPIAuthConfiguration(cl),
+					enqueueObjectForAPIAuthThroughControlPlaneRef[configurationv1alpha1.KongCertificateList](
+						cl, IndexFieldKongCertificateOnKonnectGatewayControlPlane,
+					),
 				),
 			)
 		},
@@ -48,78 +41,5 @@ func KongCertificateReconciliationWatchOptions(cl client.Client) []func(*ctrl.Bu
 				),
 			)
 		},
-	}
-}
-
-func enqueueKongCertificateForKonnectAPIAuthConfiguration(cl client.Client) handler.MapFunc {
-	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		auth, ok := obj.(*konnectv1alpha1.KonnectAPIAuthConfiguration)
-		if !ok {
-			return nil
-		}
-		var l configurationv1alpha1.KongCertificateList
-		if err := cl.List(ctx, &l, &client.ListOptions{
-			// TODO: change this when cross namespace refs are allowed.
-			Namespace: auth.GetNamespace(),
-		}); err != nil {
-			return nil
-		}
-
-		var ret []reconcile.Request
-		for _, cert := range l.Items {
-			cpRef, ok := getControlPlaneRef(&cert).Get()
-			if !ok {
-				continue
-			}
-
-			switch cpRef.Type {
-			case commonv1alpha1.ControlPlaneRefKonnectNamespacedRef:
-				nn := types.NamespacedName{
-					Name:      cpRef.KonnectNamespacedRef.Name,
-					Namespace: cert.Namespace,
-				}
-				// TODO: change this when cross namespace refs are allowed.
-				if nn.Namespace != auth.Namespace {
-					continue
-				}
-				var cp konnectv1alpha1.KonnectGatewayControlPlane
-				if err := cl.Get(ctx, nn, &cp); err != nil {
-					ctrllog.FromContext(ctx).Error(
-						err,
-						"failed to get KonnectControlPlane",
-						"KonnectControlPlane", nn,
-					)
-					continue
-				}
-
-				// TODO: change this when cross namespace refs are allowed.
-				if cp.GetKonnectAPIAuthConfigurationRef().Name != auth.Name {
-					continue
-				}
-
-				ret = append(ret, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Namespace: cert.Namespace,
-						Name:      cert.Name,
-					},
-				})
-
-			case commonv1alpha1.ControlPlaneRefKonnectID:
-				ctrllog.FromContext(ctx).Error(
-					fmt.Errorf("unimplemented ControlPlaneRef type %q", cpRef.Type),
-					"unimplemented ControlPlaneRef for KongCertificate",
-					"KongCertificate", cert, "refType", cpRef.Type,
-				)
-				continue
-
-			default:
-				ctrllog.FromContext(ctx).V(logging.DebugLevel.Value()).Info(
-					"unsupported ControlPlaneRef for KongCertificate",
-					"KongCertificate", cert, "refType", cpRef.Type,
-				)
-				continue
-			}
-		}
-		return ret
 	}
 }

--- a/controller/konnect/watch_kongdataplanecertificate.go
+++ b/controller/konnect/watch_kongdataplanecertificate.go
@@ -1,21 +1,12 @@
 package konnect
 
 import (
-	"context"
-	"fmt"
-
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/kong/gateway-operator/modules/manager/logging"
-
-	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -34,7 +25,9 @@ func KongDataPlaneClientCertificateReconciliationWatchOptions(cl client.Client) 
 			return b.Watches(
 				&konnectv1alpha1.KonnectAPIAuthConfiguration{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueKongDataPlaneClientCertificateForKonnectAPIAuthConfiguration(cl),
+					enqueueObjectForAPIAuthThroughControlPlaneRef[configurationv1alpha1.KongDataPlaneClientCertificateList](
+						cl, IndexFieldKongDataPlaneClientCertificateOnKonnectGatewayControlPlane,
+					),
 				),
 			)
 		},
@@ -48,80 +41,5 @@ func KongDataPlaneClientCertificateReconciliationWatchOptions(cl client.Client) 
 				),
 			)
 		},
-	}
-}
-
-func enqueueKongDataPlaneClientCertificateForKonnectAPIAuthConfiguration(
-	cl client.Client,
-) func(ctx context.Context, obj client.Object) []reconcile.Request {
-	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		auth, ok := obj.(*konnectv1alpha1.KonnectAPIAuthConfiguration)
-		if !ok {
-			return nil
-		}
-		var l configurationv1alpha1.KongDataPlaneClientCertificateList
-		if err := cl.List(ctx, &l, &client.ListOptions{
-			// TODO: change this when cross namespace refs are allowed.
-			Namespace: auth.GetNamespace(),
-		}); err != nil {
-			return nil
-		}
-
-		var ret []reconcile.Request
-		for _, dpCert := range l.Items {
-			cpRef, ok := getControlPlaneRef(&dpCert).Get()
-			if !ok {
-				continue
-			}
-
-			switch cpRef.Type {
-			case commonv1alpha1.ControlPlaneRefKonnectNamespacedRef:
-				nn := types.NamespacedName{
-					Name:      cpRef.KonnectNamespacedRef.Name,
-					Namespace: dpCert.Namespace,
-				}
-				// TODO: change this when cross namespace refs are allowed.
-				if nn.Namespace != auth.Namespace {
-					continue
-				}
-				var cp konnectv1alpha1.KonnectGatewayControlPlane
-				if err := cl.Get(ctx, nn, &cp); err != nil {
-					ctrllog.FromContext(ctx).Error(
-						err,
-						"failed to get KonnectGatewayControlPlane",
-						"KonnectGatewayControlPlane", nn,
-					)
-					continue
-				}
-
-				// TODO: change this when cross namespace refs are allowed.
-				if cp.GetKonnectAPIAuthConfigurationRef().Name != auth.Name {
-					continue
-				}
-
-				ret = append(ret, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Namespace: dpCert.Namespace,
-						Name:      dpCert.Name,
-					},
-				})
-
-			case commonv1alpha1.ControlPlaneRefKonnectID:
-				ctrllog.FromContext(ctx).Error(
-					fmt.Errorf("unimplemented ControlPlaneRef type %q", cpRef.Type),
-					"unimplemented ControlPlaneRef for KongDataPlaneClientCertificate",
-					"KongDataPlaneClientCertificate", dpCert, "refType", cpRef.Type,
-				)
-				continue
-
-			default:
-				ctrllog.FromContext(ctx).V(logging.DebugLevel.Value()).Info(
-					"unsupported ControlPlaneRef for KongDataPlaneClientCertificate",
-					"KongDataPlaneClientCertificate", dpCert, "refType", cpRef.Type,
-				)
-				continue
-			}
-		}
-		return ret
 	}
 }

--- a/controller/konnect/watch_kongkey.go
+++ b/controller/konnect/watch_kongkey.go
@@ -2,20 +2,14 @@ package konnect
 
 import (
 	"context"
-	"fmt"
 
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/kong/gateway-operator/modules/manager/logging"
-
-	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -42,7 +36,9 @@ func KongKeyReconciliationWatchOptions(cl client.Client) []func(*ctrl.Builder) *
 			return b.Watches(
 				&konnectv1alpha1.KonnectAPIAuthConfiguration{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueKongKeyForKonnectAPIAuthConfiguration(cl),
+					enqueueObjectForAPIAuthThroughControlPlaneRef[configurationv1alpha1.KongKeyList](
+						cl, IndexFieldKongKeyOnKonnectGatewayControlPlane,
+					),
 				),
 			)
 		},
@@ -56,79 +52,7 @@ func KongKeyReconciliationWatchOptions(cl client.Client) []func(*ctrl.Builder) *
 				),
 			)
 		},
-	}
-}
-
-func enqueueKongKeyForKonnectAPIAuthConfiguration(cl client.Client) handler.MapFunc {
-	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		auth, ok := obj.(*konnectv1alpha1.KonnectAPIAuthConfiguration)
-		if !ok {
-			return nil
-		}
-		var l configurationv1alpha1.KongKeyList
-		if err := cl.List(ctx, &l, &client.ListOptions{
-			// TODO: change this when cross namespace refs are allowed.
-			Namespace: auth.GetNamespace(),
-		}); err != nil {
-			return nil
-		}
-
-		var ret []reconcile.Request
-		for _, key := range l.Items {
-			cpRef, ok := getControlPlaneRef(&key).Get()
-			if !ok {
-				continue
-			}
-
-			switch cpRef.Type {
-			case commonv1alpha1.ControlPlaneRefKonnectNamespacedRef:
-				nn := types.NamespacedName{
-					Name:      cpRef.KonnectNamespacedRef.Name,
-					Namespace: key.Namespace,
-				}
-				// TODO: change this when cross namespace refs are allowed.
-				if nn.Namespace != auth.Namespace {
-					continue
-				}
-				var cp konnectv1alpha1.KonnectGatewayControlPlane
-				if err := cl.Get(ctx, nn, &cp); err != nil {
-					ctrllog.FromContext(ctx).Error(
-						err,
-						"failed to get KonnectControlPlane",
-						"KonnectControlPlane", nn,
-					)
-					continue
-				}
-
-				// TODO: change this when cross namespace refs are allowed.
-				if cp.GetKonnectAPIAuthConfigurationRef().Name != auth.Name {
-					continue
-				}
-
-				ret = append(ret, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Namespace: key.Namespace,
-						Name:      key.Name,
-					},
-				})
-
-			case commonv1alpha1.ControlPlaneRefKonnectID:
-				ctrllog.FromContext(ctx).Error(
-					fmt.Errorf("unimplemented ControlPlaneRef type %q", cpRef.Type),
-					"unimplemented ControlPlaneRef for KongKey",
-					"KongKey", key, "refType", cpRef.Type,
-				)
-				continue
-
-			default:
-				ctrllog.FromContext(ctx).V(logging.DebugLevel.Value()).Info(
-					"unsupported ControlPlaneRef for KongKey",
-					"KongKey", key, "refType", cpRef.Type,
-				)
-				continue
-			}
-		}
-		return ret
+		// TODO: add watch for KonnectGatewayControlPlane through KeySet reference.
 	}
 }
 

--- a/controller/konnect/watch_kongkeyset.go
+++ b/controller/konnect/watch_kongkeyset.go
@@ -1,21 +1,12 @@
 package konnect
 
 import (
-	"context"
-	"fmt"
-
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/kong/gateway-operator/modules/manager/logging"
-
-	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -34,7 +25,9 @@ func KongKeySetReconciliationWatchOptions(cl client.Client) []func(*ctrl.Builder
 			return b.Watches(
 				&konnectv1alpha1.KonnectAPIAuthConfiguration{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueKongKeySetForKonnectAPIAuthConfiguration(cl),
+					enqueueObjectForAPIAuthThroughControlPlaneRef[configurationv1alpha1.KongKeySetList](
+						cl, IndexFieldKongKeySetOnKonnectGatewayControlPlane,
+					),
 				),
 			)
 		},
@@ -48,78 +41,5 @@ func KongKeySetReconciliationWatchOptions(cl client.Client) []func(*ctrl.Builder
 				),
 			)
 		},
-	}
-}
-
-func enqueueKongKeySetForKonnectAPIAuthConfiguration(cl client.Client) handler.MapFunc {
-	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		auth, ok := obj.(*konnectv1alpha1.KonnectAPIAuthConfiguration)
-		if !ok {
-			return nil
-		}
-		var l configurationv1alpha1.KongKeySetList
-		if err := cl.List(ctx, &l, &client.ListOptions{
-			// TODO: change this when cross namespace refs are allowed.
-			Namespace: auth.GetNamespace(),
-		}); err != nil {
-			return nil
-		}
-
-		var ret []reconcile.Request
-		for _, keySet := range l.Items {
-			cpRef, ok := getControlPlaneRef(&keySet).Get()
-			if !ok {
-				continue
-			}
-
-			switch cpRef.Type {
-			case commonv1alpha1.ControlPlaneRefKonnectNamespacedRef:
-				nn := types.NamespacedName{
-					Name:      cpRef.KonnectNamespacedRef.Name,
-					Namespace: keySet.Namespace,
-				}
-				// TODO: change this when cross namespace refs are allowed.
-				if nn.Namespace != auth.Namespace {
-					continue
-				}
-				var cp konnectv1alpha1.KonnectGatewayControlPlane
-				if err := cl.Get(ctx, nn, &cp); err != nil {
-					ctrllog.FromContext(ctx).Error(
-						err,
-						"failed to get KonnectControlPlane",
-						"KonnectControlPlane", nn,
-					)
-					continue
-				}
-
-				// TODO: change this when cross namespace refs are allowed.
-				if cp.GetKonnectAPIAuthConfigurationRef().Name != auth.Name {
-					continue
-				}
-
-				ret = append(ret, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Namespace: keySet.Namespace,
-						Name:      keySet.Name,
-					},
-				})
-
-			case commonv1alpha1.ControlPlaneRefKonnectID:
-				ctrllog.FromContext(ctx).Error(
-					fmt.Errorf("unimplemented ControlPlaneRef type %q", cpRef.Type),
-					"unimplemented ControlPlaneRef for KongKeySet",
-					"KongKeySet", keySet, "refType", cpRef.Type,
-				)
-				continue
-
-			default:
-				ctrllog.FromContext(ctx).V(logging.DebugLevel.Value()).Info(
-					"unsupported ControlPlaneRef for KongKeySet",
-					"KongKeySet", keySet, "refType", cpRef.Type,
-				)
-				continue
-			}
-		}
-		return ret
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `enqueueObjectForAPIAuthThroughControlPlaneRef`, as a for of generic way to enqueue resources that bind to control planes that use the provided `KonnectAPIAuthConfiguration`.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
