### PR TITLE
feat(konnect): add reconciler for secret used as jwt credential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
   - `basic-auth` [#1120](https://github.com/Kong/gateway-operator/pull/1120)
   - `key-auth` [#1168](https://github.com/Kong/gateway-operator/pull/1168)
   - `acl` [#1187](https://github.com/Kong/gateway-operator/pull/1187)
+  - `jwt` [#1208](https://github.com/Kong/gateway-operator/pull/1208)
 - Added prometheus metrics for Konnect entity operations in the metrics server:
   - `gateway_operator_konnect_entity_operation_count` for number of operations.
   - `gateway_operator_konnect_entity_operation_duration_milliseconds` for duration of operations.

--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -123,7 +123,6 @@ rules:
   - kongconsumergroups
   - kongconsumers
   - kongcredentialhmacs
-  - kongcredentialjwts
   - kongdataplaneclientcertificates
   - kongkeys
   - kongkeysets
@@ -202,6 +201,7 @@ rules:
   - kongcredentialacls
   - kongcredentialapikeys
   - kongcredentialbasicauths
+  - kongcredentialjwts
   - kongpluginbindings
   - kongplugins
   verbs:

--- a/config/samples/konnect_kongconsumer_acl_secret.yaml
+++ b/config/samples/konnect_kongconsumer_acl_secret.yaml
@@ -1,0 +1,47 @@
+kind: KonnectAPIAuthConfiguration
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: konnect-api-auth-dev-1
+  namespace: default
+spec:
+  type: token
+  token: kpat_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+  serverURL: us.api.konghq.com
+---
+kind: KonnectGatewayControlPlane
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: test-cp-acl-auth
+  namespace: default
+spec:
+  name: test-cp-acl-auth
+  labels:
+    app: test-cp-acl-auth
+    key1: test-cp-acl-auth
+  konnect:
+    authRef:
+      name: konnect-api-auth-dev-1
+---
+kind: KongConsumer
+apiVersion: configuration.konghq.com/v1
+metadata:
+  name: consumer1
+  namespace: default
+username: consumer1
+spec:
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: test-cp-acl-auth
+credentials:
+- consumer1-acl-1
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: consumer1-acl-1
+  namespace: default
+  labels:
+    konghq.com/credential: acl
+stringData:
+  group: "acl-group"

--- a/config/samples/konnect_kongconsumer_jwt_secret.yaml
+++ b/config/samples/konnect_kongconsumer_jwt_secret.yaml
@@ -1,0 +1,47 @@
+kind: KonnectAPIAuthConfiguration
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: konnect-api-auth-dev-1
+  namespace: default
+spec:
+  type: token
+  token: kpat_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+  serverURL: us.api.konghq.com
+---
+kind: KonnectGatewayControlPlane
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: test-cp-jwt-auth
+  namespace: default
+spec:
+  name: test-cp-jwt-auth
+  labels:
+    app: test-cp-jwt-auth
+  konnect:
+    authRef:
+      name: konnect-api-auth-dev-1
+---
+kind: KongConsumer
+apiVersion: configuration.konghq.com/v1
+metadata:
+  name: consumer-jwt-1
+  namespace: default
+username: consumer1
+spec:
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: test-cp-jwt-auth
+credentials:
+- consumer1-jwt-auth-1
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: consumer1-jwt-auth-1
+  namespace: default
+  labels:
+    konghq.com/credential: jwt
+stringData:
+  algorithm: "HS256"
+  key: "jwt-sign-key"

--- a/controller/konnect/constraints/constraints.go
+++ b/controller/konnect/constraints/constraints.go
@@ -15,10 +15,10 @@ import (
 type SupportedCredentialType interface {
 	configurationv1alpha1.KongCredentialBasicAuth |
 		configurationv1alpha1.KongCredentialAPIKey |
-		configurationv1alpha1.KongCredentialACL
+		configurationv1alpha1.KongCredentialACL |
+		configurationv1alpha1.KongCredentialJWT
 	// TODO: add other credential types
 	// TODO: https://github.com/Kong/gateway-operator/issues/1125
-	// TODO: https://github.com/Kong/gateway-operator/issues/1126
 
 	GetTypeName() string
 }

--- a/controller/konnect/index_credentials_jwt.go
+++ b/controller/konnect/index_credentials_jwt.go
@@ -9,6 +9,8 @@ import (
 const (
 	// IndexFieldKongCredentialJWTReferencesKongConsumer is the index name for KongCredentialJWT -> Consumer.
 	IndexFieldKongCredentialJWTReferencesKongConsumer = "kongCredentialsJWTConsumerRef"
+	// IndexFieldKongCredentialAPIKeyReferencesSecret is the index name for KongCredentialJWT -> Secret.
+	IndexFieldKongCredentialJWTReferencesSecret = "kongCredentialsJWTSecretRef"
 )
 
 // IndexOptionsForCredentialsJWT returns required Index options for KongCredentialJWT.
@@ -18,6 +20,11 @@ func IndexOptionsForCredentialsJWT() []ReconciliationIndexOption {
 			IndexObject:  &configurationv1alpha1.KongCredentialJWT{},
 			IndexField:   IndexFieldKongCredentialJWTReferencesKongConsumer,
 			ExtractValue: kongCredentialJWTReferencesConsumer,
+		},
+		{
+			IndexObject:  &configurationv1alpha1.KongCredentialJWT{},
+			IndexField:   IndexFieldKongCredentialJWTReferencesSecret,
+			ExtractValue: kongCredentialReferencesSecret[configurationv1alpha1.KongCredentialJWT],
 		},
 	}
 }

--- a/controller/konnect/reconciler_credential_secrets.go
+++ b/controller/konnect/reconciler_credential_secrets.go
@@ -781,7 +781,7 @@ func (r KongCredentialSecretReconciler) handleConsumerUsingCredentialSecret(
 			ctx,
 			&l,
 			client.MatchingFields{
-				IndexFieldKongCredentialACLReferencesKongConsumer: consumer.Name,
+				IndexFieldKongCredentialJWTReferencesKongConsumer: consumer.Name,
 			},
 		)
 		if err != nil {

--- a/controller/konnect/reconciler_credential_secrets.go
+++ b/controller/konnect/reconciler_credential_secrets.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +36,9 @@ const (
 	// KongCredentialTypeAPIKey is the type of api-key credential, it's used
 	// as the value for konghq.com/credential label.
 	KongCredentialTypeAPIKey = "key-auth"
+	// KongCredentialTypeJWT is the type of jwt-auth credential.
+	// It's used as the values of konghq.com/credential label.
+	KongCredentialTypeJWT = "jwt"
 	// KongCredentialTypeACL is the type of Access Control Lists(ACLs) managed similar as credentials.
 	// It's used as the value for konghq.com/credential label.
 	KongCredentialTypeACL = "acl"
@@ -45,6 +49,14 @@ const (
 	CredentialSecretKeyNameAPIKeyKey = "key"
 	// CredentialSecretKeyNameACLGroupKey is the credential secret key name for ACL group type.
 	CredentialSecretKeyNameACLGroupKey = "group"
+	// CredentialSecretKeyNameJwtAlgorithmKey is the credential secret key name for JWT algorithm.
+	CredentialSecretKeyNameJwtAlgorithmKey = "algorithm"
+	// CredentualSecretKeyNameJwtKeyKey is the credential secret key name for JWT key.
+	CredentialSecretKeyNameJwtKeyKey = "key"
+	// CredentialSecretKeyNameJwtRSAPublicKeyKey is the credential secret key name for JWT RSA public key.
+	CredentialSecretKeyNameJwtRSAPublicKeyKey = "rsa_public_key" //nolint:gosec
+	// CredentialSecretKeyNameJwtSecretKey is the credentail secret ley name for JWT secret.
+	CredentialSecretKeyNameJwtSecretKey = "secret"
 )
 
 // KongCredentialSecretReconciler reconciles a KongPlugin object.
@@ -109,9 +121,9 @@ func (r *KongCredentialSecretReconciler) SetupWithManager(_ context.Context, mgr
 		Owns(&configurationv1alpha1.KongCredentialBasicAuth{}, builder.MatchEveryOwner).
 		Owns(&configurationv1alpha1.KongCredentialAPIKey{}, builder.MatchEveryOwner).
 		Owns(&configurationv1alpha1.KongCredentialACL{}, builder.MatchEveryOwner).
+		Owns(&configurationv1alpha1.KongCredentialJWT{}, builder.MatchEveryOwner).
 		// TODO: Add more credential types support.
 		// TODO: https://github.com/Kong/gateway-operator/issues/1125
-		// TODO: https://github.com/Kong/gateway-operator/issues/1126
 		Complete(r)
 }
 
@@ -243,7 +255,6 @@ func deleteAllCredentialsUsingSecret(
 ) error {
 	// TODO: Add more credential types support.
 	// TODO: https://github.com/Kong/gateway-operator/issues/1125
-	// TODO: https://github.com/Kong/gateway-operator/issues/1126
 	switch credType {
 
 	// NOTE: To use DeleteAllOf() we need a selectable field added to the CRD.
@@ -285,6 +296,7 @@ func deleteAllCredentialsUsingSecret(
 				)
 			}
 		}
+
 	case KongCredentialTypeACL:
 		var l configurationv1alpha1.KongCredentialACLList
 		err := cl.List(
@@ -300,6 +312,26 @@ func deleteAllCredentialsUsingSecret(
 		for _, cred := range l.Items {
 			if err := cl.Delete(ctx, &cred); err != nil {
 				return fmt.Errorf("failed deleting unused KongCredentialACLs %s: %w",
+					client.ObjectKeyFromObject(&cred), err,
+				)
+			}
+		}
+
+	case KongCredentialTypeJWT:
+		var l configurationv1alpha1.KongCredentialJWTList
+		err := cl.List(
+			ctx, &l,
+			client.MatchingFields{
+				IndexFieldKongCredentialJWTReferencesSecret: secret.Name,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("failed listing unused KongCredentialJWTs: %w", err)
+		}
+
+		for _, cred := range l.Items {
+			if err := cl.Delete(ctx, &cred); err != nil {
+				return fmt.Errorf("failed deleting unused KongCredentialJWTs %s: %w",
 					client.ObjectKeyFromObject(&cred), err,
 				)
 			}
@@ -351,6 +383,15 @@ func ensureExistingCredential[
 			update = true
 		}
 
+	case *configurationv1alpha1.KongCredentialJWT:
+		if cred.Spec.ConsumerRef.Name != consumer.Name ||
+			(cred.Spec.Key != nil && *cred.Spec.Key != string(secret.Data[CredentialSecretKeyNameJwtKeyKey])) {
+
+			cred.Spec.ConsumerRef.Name = consumer.Name
+			setKongCredentialJWTSpec(&cred.Spec, secret)
+			update = true
+		}
+
 	default:
 		// NOTE: Shouldn't happen.
 		panic(fmt.Sprintf("unsupported credential type %T", cred))
@@ -397,6 +438,9 @@ func ensureCredentialExists(
 	case KongCredentialTypeACL:
 		cred = secretToKongCredentialACL(secret, kongConsumer)
 
+	case KongCredentialTypeJWT:
+		cred = secretToKongCredentialJWT(secret, kongConsumer)
+
 	default:
 		return fmt.Errorf("Secret %s used as credential, but has unsupported type %s",
 			nn, credType,
@@ -441,7 +485,6 @@ func validateSecret(
 
 	// TODO: Add more credential types support.
 	// TODO: https://github.com/Kong/gateway-operator/issues/1125
-	// TODO: https://github.com/Kong/gateway-operator/issues/1126
 	switch credType {
 	case KongCredentialTypeBasicAuth:
 		if err := validateSecretForKongCredentialBasicAuth(s); err != nil {
@@ -453,6 +496,10 @@ func validateSecret(
 		}
 	case KongCredentialTypeACL:
 		if err := validateSecretForKongCredentialACL(s); err != nil {
+			return err
+		}
+	case KongCredentialTypeJWT:
+		if err := validateSecretForKongCredentialJWT(s); err != nil {
 			return err
 		}
 	default:
@@ -493,6 +540,75 @@ func validateSecretForKongCredentialACL(s *corev1.Secret) error {
 			client.ObjectKeyFromObject(s), CredentialSecretKeyNameACLGroupKey,
 		)
 	}
+	return nil
+}
+
+// credentialJWTAllowedAlgorithms is the list of Allowed algorithms for JWT.
+var credentialJWTAllowedAlgorithms = lo.SliceToMap(
+	[]string{
+		"HS256",
+		"HS384",
+		"HS512",
+		"RS256",
+		"RS384",
+		"RS512",
+		"ES256",
+		"ES384",
+		"ES512",
+		"PS256",
+		"PS384",
+		"PS512",
+		"EdDSA",
+	},
+	func(s string) (string, struct{}) { return s, struct{}{} },
+)
+
+var credentialJWTAlgorithmsRequiringRSAPublicKey = lo.SliceToMap(
+	[]string{
+		"RS256",
+		"RS384",
+		"RS512",
+		"PS256",
+		"PS384",
+		"PS512",
+		"EdDSA",
+	},
+	func(s string) (string, struct{}) { return s, struct{}{} },
+)
+
+func validateSecretForKongCredentialJWT(s *corev1.Secret) error {
+	// check if 'key' exists.
+	if _, ok := s.Data[CredentialSecretKeyNameJwtKeyKey]; !ok {
+		return fmt.Errorf(
+			"Secret %s used as JWT credential, but lacks %s key",
+			client.ObjectKeyFromObject(s), CredentialSecretKeyNameJwtKeyKey,
+		)
+	}
+	// validate algorithm.
+	algorithm, ok := s.Data[CredentialSecretKeyNameJwtAlgorithmKey]
+	if !ok {
+		return fmt.Errorf(
+			"Secret %s used as JWT credential, but lacks %s key",
+			client.ObjectKeyFromObject(s), CredentialSecretKeyNameJwtAlgorithmKey,
+		)
+	}
+	// check if algorithm is supported.
+	if _, ok := credentialJWTAllowedAlgorithms[string(algorithm)]; !ok {
+		return fmt.Errorf(
+			"Secret %s used as JWT credential, but algorithm '%s' is invalid or not supported",
+			client.ObjectKeyFromObject(s), algorithm,
+		)
+	}
+	// check rsa_public_key if the algorithm requires.
+	if _, ok := credentialJWTAlgorithmsRequiringRSAPublicKey[string(algorithm)]; ok {
+		if _, hasRSAPublicKey := s.Data[CredentialSecretKeyNameJwtRSAPublicKeyKey]; !hasRSAPublicKey {
+			return fmt.Errorf("Secret %s used as JWT credential, but lacks %s key which is required when algorithm is %s",
+				client.ObjectKeyFromObject(s),
+				CredentialSecretKeyNameJwtRSAPublicKeyKey, algorithm,
+			)
+		}
+	}
+
 	return nil
 }
 
@@ -549,6 +665,22 @@ func secretToKongCredentialACL(
 	return cred
 }
 
+func secretToKongCredentialJWT(
+	s *corev1.Secret, c *configurationv1.KongConsumer,
+) *configurationv1alpha1.KongCredentialJWT {
+	cred := &configurationv1alpha1.KongCredentialJWT{
+		ObjectMeta: secretObjectMetaForConsumer(c),
+		Spec: configurationv1alpha1.KongCredentialJWTSpec{
+			ConsumerRef: corev1.LocalObjectReference{
+				Name: c.Name,
+			},
+		},
+	}
+
+	setKongCredentialJWTSpec(&cred.Spec, s)
+	return cred
+}
+
 func setKongCredentialBasicAuthSpec(
 	spec *configurationv1alpha1.KongCredentialBasicAuthSpec, s *corev1.Secret,
 ) {
@@ -568,6 +700,21 @@ func setKongCredentialACLSpec(
 	spec.Group = string(s.Data[CredentialSecretKeyNameACLGroupKey])
 }
 
+func setKongCredentialJWTSpec(
+	spec *configurationv1alpha1.KongCredentialJWTSpec, s *corev1.Secret,
+) {
+	spec.Algorithm = string(s.Data[CredentialSecretKeyNameJwtAlgorithmKey])
+	spec.Key = lo.ToPtr(string(s.Data[CredentialSecretKeyNameJwtKeyKey]))
+
+	if rsaPublicKey, ok := s.Data[CredentialSecretKeyNameJwtRSAPublicKeyKey]; ok {
+		spec.RSAPublicKey = lo.ToPtr(string(rsaPublicKey))
+	}
+
+	if jwtSecret, ok := s.Data[CredentialSecretKeyNameJwtSecretKey]; ok {
+		spec.Secret = lo.ToPtr(string(jwtSecret))
+	}
+}
+
 func (r KongCredentialSecretReconciler) handleConsumerUsingCredentialSecret(
 	ctx context.Context,
 	s *corev1.Secret,
@@ -576,7 +723,6 @@ func (r KongCredentialSecretReconciler) handleConsumerUsingCredentialSecret(
 ) (ctrl.Result, error) {
 	// TODO: add more credentials types support.
 	// TODO: https://github.com/Kong/gateway-operator/issues/1125
-	// TODO: https://github.com/Kong/gateway-operator/issues/1126
 
 	switch credType {
 	case KongCredentialTypeBasicAuth:
@@ -624,6 +770,22 @@ func (r KongCredentialSecretReconciler) handleConsumerUsingCredentialSecret(
 		)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed listing KongCredentialACL: %w", err)
+		}
+		if res, err := handleCreds(ctx, r.client, s, credType, consumer, l.Items, r.scheme); err != nil || !res.IsZero() {
+			return res, err
+		}
+
+	case KongCredentialTypeJWT:
+		var l configurationv1alpha1.KongCredentialJWTList
+		err := r.client.List(
+			ctx,
+			&l,
+			client.MatchingFields{
+				IndexFieldKongCredentialACLReferencesKongConsumer: consumer.Name,
+			},
+		)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed listing KongCrenentialJWT: %w", err)
 		}
 		if res, err := handleCreds(ctx, r.client, s, credType, consumer, l.Items, r.scheme); err != nil || !res.IsZero() {
 			return res, err

--- a/controller/konnect/reconciler_credential_secrets_rbac.go
+++ b/controller/konnect/reconciler_credential_secrets_rbac.go
@@ -5,5 +5,6 @@ package konnect
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialbasicauths,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialapikeys,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialacls,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongcredentialjwts,verbs=get;list;watch;create;update;patch;delete
 
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch

--- a/controller/konnect/reconciler_credential_secrets_test.go
+++ b/controller/konnect/reconciler_credential_secrets_test.go
@@ -3,6 +3,7 @@ package konnect
 import (
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -125,7 +126,7 @@ func TestValidateSecretForKongCredentialAPIKey(t *testing.T) {
 	}
 }
 
-func TestValidateSecertForKongCredentialACL(t *testing.T) {
+func TestValidateSecretForKongCredentialACL(t *testing.T) {
 	tests := []struct {
 		name      string
 		secret    *corev1.Secret
@@ -162,6 +163,93 @@ func TestValidateSecertForKongCredentialACL(t *testing.T) {
 			err := validateSecretForKongCredentialACL(tt.secret)
 			if (err != nil) != tt.wantError {
 				t.Errorf("validateSecretForKongCredentialACL() error = %v, wantError %v", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestValidateSecretForCredentialJWT(t *testing.T) {
+	tests := []struct {
+		name      string
+		secret    *corev1.Secret
+		wantError bool
+	}{
+		{
+			name: "valid secret",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"algorithm":      []byte("RS256"),
+					"key":            []byte("jwt-key"),
+					"rsa_public_key": []byte("rsa-public-key"),
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "missing key",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "missing-key",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{},
+			},
+			wantError: true,
+		},
+		{
+			name: "invalid algorithm",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-algorithm",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"algorithm":      []byte("INVALID"),
+					"key":            []byte("jwt-key"),
+					"rsa_public_key": []byte("rsa-public-key"),
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "missing RSA public key",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "missing-public-key",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"algorithm": []byte("RS256"),
+					"key":       []byte("jwt-key"),
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "algorithm not requiring RSA public key",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "missing-public-key",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"algorithm": []byte("HS512"),
+					"key":       []byte("jwt-key"),
+				},
+			},
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSecretForKongCredentialJWT(tt.secret)
+			if (err != nil) != tt.wantError {
+				t.Errorf("validateSecretForKongCredentialJWT() error = %v, wantError %v", err, tt.wantError)
 			}
 		})
 	}
@@ -452,6 +540,115 @@ func TestEnsureExistingCredential(t *testing.T) {
 					WithObjects(tt.cred).
 					Build()
 				_, err := ensureExistingCredential(t.Context(), client, tt.cred, tt.secret, tt.consumer)
+				if (err != nil) != tt.wantError {
+					t.Errorf("ensureExistingCredential() error = %v, wantError %v", err, tt.wantError)
+				}
+				if tt.assert != nil {
+					tt.assert(t, tt.cred)
+				}
+			})
+		}
+	})
+
+	t.Run("KongCredentialJWT", func(t *testing.T) {
+		testCases := []struct {
+			name      string
+			cred      *configurationv1alpha1.KongCredentialJWT
+			secret    *corev1.Secret
+			consumer  *configurationv1.KongConsumer
+			assert    func(t *testing.T, cred *configurationv1alpha1.KongCredentialJWT)
+			wantError bool
+		}{
+			{
+				name: "credential needs update",
+				cred: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cred",
+						Namespace: "default",
+					},
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Algorithm:    "RS256",
+							Key:          lo.ToPtr("old-key"),
+							RSAPublicKey: lo.ToPtr("old-public-key"),
+						},
+					},
+				},
+				secret: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"algorithm":      []byte("RS256"),
+						"key":            []byte("new-key"),
+						"rsa_public_key": []byte("new-public-key"),
+						"secret":         []byte("jwt-secret"),
+					},
+				},
+				consumer: &configurationv1.KongConsumer{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "consumer",
+						Namespace: "default",
+					},
+				},
+				assert: func(t *testing.T, cred *configurationv1alpha1.KongCredentialJWT) {
+					require.NotNil(t, cred)
+					require.Equal(t, "new-key", *cred.Spec.Key)
+					require.Equal(t, "new-public-key", *cred.Spec.RSAPublicKey)
+					require.Equal(t, "jwt-secret", *cred.Spec.Secret)
+				},
+				wantError: false,
+			},
+			{
+				name: "credential does not need update",
+				cred: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cred",
+						Namespace: "default",
+					},
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Algorithm:    "RS256",
+							Key:          lo.ToPtr("new-key"),
+							RSAPublicKey: lo.ToPtr("new-public-key"),
+						},
+					},
+				},
+				secret: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"algorithm":      []byte("RS256"),
+						"key":            []byte("new-key"),
+						"rsa_public_key": []byte("new-public-key"),
+					},
+				},
+				consumer: &configurationv1.KongConsumer{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "consumer",
+						Namespace: "default",
+					},
+				},
+				wantError: false,
+			},
+		}
+
+		for _, tt := range testCases {
+			t.Run(tt.name, func(t *testing.T) {
+				client := clientfake.NewClientBuilder().
+					WithScheme(scheme.Get()).
+					WithObjects(tt.cred).
+					Build()
+				_, err := ensureExistingCredential(context.Background(), client, tt.cred, tt.secret, tt.consumer)
 				if (err != nil) != tt.wantError {
 					t.Errorf("ensureExistingCredential() error = %v, wantError %v", err, tt.wantError)
 				}

--- a/controller/konnect/reconciler_credential_secrets_test.go
+++ b/controller/konnect/reconciler_credential_secrets_test.go
@@ -648,7 +648,7 @@ func TestEnsureExistingCredential(t *testing.T) {
 					WithScheme(scheme.Get()).
 					WithObjects(tt.cred).
 					Build()
-				_, err := ensureExistingCredential(context.Background(), client, tt.cred, tt.secret, tt.consumer)
+				_, err := ensureExistingCredential(t.Context(), client, tt.cred, tt.secret, tt.consumer)
 				if (err != nil) != tt.wantError {
 					t.Errorf("ensureExistingCredential() error = %v, wantError %v", err, tt.wantError)
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add reconciler for `Secret` used as `jwt` credential.
**Which issue this PR fixes**

Fixes #1126

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
