### PR TITLE
chore(linter): add `usetesting` and fix reported issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -32,6 +32,7 @@ linters:
   - unconvert
   - unparam
   - unused
+  - usetesting
   - wastedassign
   - loggercheck
 linters-settings:
@@ -143,6 +144,8 @@ linters-settings:
         msg: "Please use camel case 'DataPlane' instead of 'Dataplane'"
       - p: ^.*Controlplane.*$
         msg: "Please use camel case 'ControlPlane' instead of 'Controlplane'"
+  usetesting:
+    os-temp-dir: true
 issues:
   max-same-issues: 0
   fix: true

--- a/controller/controlplane/controller_reconciler_utils_test.go
+++ b/controller/controlplane/controller_reconciler_utils_test.go
@@ -1,7 +1,6 @@
 package controlplane
 
 import (
-	"context"
 	"testing"
 
 	"github.com/samber/lo"
@@ -72,7 +71,7 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 			},
 			testBody: func(t *testing.T, r *Reconciler, cp *operatorv1beta1.ControlPlane) {
 				var (
-					ctx      = context.Background()
+					ctx      = t.Context()
 					webhooks admregv1.ValidatingWebhookConfigurationList
 				)
 				require.NoError(t, r.Client.List(ctx, &webhooks))
@@ -138,7 +137,7 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 			},
 			testBody: func(t *testing.T, r *Reconciler, cp *operatorv1beta1.ControlPlane) {
 				var (
-					ctx      = context.Background()
+					ctx      = t.Context()
 					webhooks admregv1.ValidatingWebhookConfigurationList
 				)
 				require.NoError(t, r.Client.List(ctx, &webhooks))

--- a/controller/controlplane/controller_test.go
+++ b/controller/controlplane/controller_test.go
@@ -1,7 +1,6 @@
 package controlplane
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -232,7 +231,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			testBody: func(t *testing.T, reconciler Reconciler, controlplaneReq reconcile.Request) {
-				ctx := context.Background()
+				ctx := t.Context()
 
 				// first reconcile loop to allow the reconciler to set the controlplane defaults
 				_, err := reconciler.Reconcile(ctx, controlplaneReq)
@@ -414,7 +413,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			testBody: func(t *testing.T, reconciler Reconciler, controlplaneReq reconcile.Request) {
-				ctx := context.Background()
+				ctx := t.Context()
 
 				_, err := reconciler.Reconcile(ctx, controlplaneReq)
 				require.EqualError(t, err, "unsupported ControlPlane image kong/kubernetes-ingress-controller:1.0")

--- a/controller/controlplane/controlplane_controller_reconciler_utils_test.go
+++ b/controller/controlplane/controlplane_controller_reconciler_utils_test.go
@@ -1,7 +1,6 @@
 package controlplane
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -126,7 +125,7 @@ func TestEnsureClusterRole(t *testing.T) {
 		}
 
 		t.Run(tc.Name, func(t *testing.T) {
-			createdOrUpdated, generatedClusterRole, err := r.ensureClusterRole(context.Background(), &tc.controlplane)
+			createdOrUpdated, generatedClusterRole, err := r.ensureClusterRole(t.Context(), &tc.controlplane)
 			require.Equal(t, tc.err, err)
 			require.Equal(t, tc.createdorUpdated, createdOrUpdated)
 			require.Equal(t, tc.expectedClusterRole.Rules, generatedClusterRole.Rules)
@@ -264,7 +263,7 @@ func TestEnsureClusterRoleBinding(t *testing.T) {
 		}
 
 		t.Run(tc.name, func(t *testing.T) {
-			createdOrUpdated, generatedCRB, err := r.ensureClusterRoleBinding(context.Background(), controlPlane, testServiceAccount, testClusterRole)
+			createdOrUpdated, generatedCRB, err := r.ensureClusterRoleBinding(t.Context(), controlPlane, testServiceAccount, testClusterRole)
 			require.Equal(t, tc.err, err)
 			require.Equal(t, tc.createdOrUpdated, createdOrUpdated)
 			// when err == nil, ensureClusterRoleBinding should return a non-nil ClusterRoleBinding with the same metadata, RoleRef

--- a/controller/dataplane/bluegreen_controller_test.go
+++ b/controller/dataplane/bluegreen_controller_test.go
@@ -186,7 +186,7 @@ func TestDataPlaneBlueGreenReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			testBody: func(t *testing.T, reconciler BlueGreenReconciler, dataplaneReq reconcile.Request) {
-				ctx := context.Background()
+				ctx := t.Context()
 
 				_, err := reconciler.Reconcile(ctx, dataplaneReq)
 				require.NoError(t, err)
@@ -563,7 +563,7 @@ func TestEnsurePreviewIngressService(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			fakeClient := fakectrlruntimeclient.
 				NewClientBuilder().
 				WithScheme(scheme.Scheme).

--- a/controller/dataplane/controller_reconciler_utils_test.go
+++ b/controller/dataplane/controller_reconciler_utils_test.go
@@ -1,7 +1,6 @@
 package dataplane
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -79,7 +78,7 @@ func TestDeploymentBuilder(t *testing.T) {
 			},
 			certSecretName: "certificate",
 			testBody: func(t *testing.T, reconciler Reconciler, dataPlane *operatorv1beta1.DataPlane, certSecretName string) {
-				ctx := context.Background()
+				ctx := t.Context()
 				deploymentBuilder := NewDeploymentBuilder(logr.Discard(), reconciler.Client).
 					WithClusterCertificate(certSecretName).
 					WithAdditionalLabels(deploymentLiveLabels)
@@ -144,7 +143,7 @@ func TestDeploymentBuilder(t *testing.T) {
 			},
 			certSecretName: "certificate",
 			testBody: func(t *testing.T, reconciler Reconciler, dataPlane *operatorv1beta1.DataPlane, certSecretName string) {
-				ctx := context.Background()
+				ctx := t.Context()
 
 				deploymentBuilder := NewDeploymentBuilder(logr.Discard(), reconciler.Client).
 					WithClusterCertificate(certSecretName).
@@ -215,7 +214,7 @@ func TestDeploymentBuilder(t *testing.T) {
 			},
 			certSecretName: "certificate",
 			testBody: func(t *testing.T, reconciler Reconciler, dataPlane *operatorv1beta1.DataPlane, certSecretName string) {
-				ctx := context.Background()
+				ctx := t.Context()
 				dataplaneImage, err := generateDataPlaneImage(dataPlane, consts.DefaultDataPlaneImage, versions.IsDataPlaneImageVersionSupported)
 				require.NoError(t, err)
 				// generate the DataPlane as it is supposed to be, change the .spec.strategy field, and create it.
@@ -276,7 +275,7 @@ func TestDeploymentBuilder(t *testing.T) {
 			},
 			certSecretName: "certificate",
 			testBody: func(t *testing.T, reconciler Reconciler, dataPlane *operatorv1beta1.DataPlane, certSecretName string) {
-				ctx := context.Background()
+				ctx := t.Context()
 				dataplaneImage, err := generateDataPlaneImage(dataPlane, consts.DefaultDataPlaneImage, versions.IsDataPlaneImageVersionSupported)
 				require.NoError(t, err)
 				// generate the DataPlane as it is expected to be and create it.
@@ -347,7 +346,7 @@ func TestDeploymentBuilder(t *testing.T) {
 			},
 			certSecretName: "certificate",
 			testBody: func(t *testing.T, reconciler Reconciler, dataPlane *operatorv1beta1.DataPlane, certSecretName string) {
-				ctx := context.Background()
+				ctx := t.Context()
 				dataplaneImage, err := generateDataPlaneImage(dataPlane, consts.DefaultDataPlaneImage, versions.IsDataPlaneImageVersionSupported)
 				// generateDataPlaneImage will set deployment's containers resources
 				// to the ones set in dataplane spec so we set it here to get the
@@ -397,7 +396,7 @@ func TestDeploymentBuilder(t *testing.T) {
 			},
 			certSecretName: "certificate",
 			testBody: func(t *testing.T, reconciler Reconciler, dataPlane *operatorv1beta1.DataPlane, certSecretName string) {
-				ctx := context.Background()
+				ctx := t.Context()
 
 				firstDeploymentBuilder := NewDeploymentBuilder(logr.Discard(), reconciler.Client).
 					WithClusterCertificate(certSecretName).
@@ -461,7 +460,7 @@ func TestDeploymentBuilder(t *testing.T) {
 			},
 			certSecretName: "certificate",
 			testBody: func(t *testing.T, reconciler Reconciler, dataPlane *operatorv1beta1.DataPlane, certSecretName string) {
-				ctx := context.Background()
+				ctx := t.Context()
 
 				firstDeploymentBuilder := NewDeploymentBuilder(logr.Discard(), reconciler.Client).
 					WithClusterCertificate(certSecretName).

--- a/controller/dataplane/controller_test.go
+++ b/controller/dataplane/controller_test.go
@@ -1,7 +1,6 @@
 package dataplane
 
 import (
-	"context"
 	"crypto/x509"
 	"fmt"
 	"os"
@@ -173,7 +172,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			testBody: func(t *testing.T, reconciler Reconciler, dataplaneReq reconcile.Request) {
-				ctx := context.Background()
+				ctx := t.Context()
 
 				// first reconcile loop to allow the reconciler to set the dataplane defaults
 				_, err := reconciler.Reconcile(ctx, dataplaneReq)
@@ -270,7 +269,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			testBody: func(t *testing.T, reconciler Reconciler, dataplaneReq reconcile.Request) {
-				ctx := context.Background()
+				ctx := t.Context()
 
 				// first reconcile loop to allow the reconciler to set the dataplane defaults
 				_, err := reconciler.Reconcile(ctx, dataplaneReq)
@@ -373,7 +372,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			testBody: func(t *testing.T, reconciler Reconciler, dataplaneReq reconcile.Request) {
-				ctx := context.Background()
+				ctx := t.Context()
 
 				// first reconcile loop to allow the reconciler to set the dataplane defaults
 				_, err := reconciler.Reconcile(ctx, dataplaneReq)
@@ -505,7 +504,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			testBody: func(t *testing.T, reconciler Reconciler, dataplaneReq reconcile.Request) {
-				ctx := context.Background()
+				ctx := t.Context()
 
 				_, err := reconciler.Reconcile(ctx, dataplaneReq)
 				require.NoError(t, err)
@@ -660,7 +659,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			testBody: func(t *testing.T, reconciler Reconciler, dataplaneReq reconcile.Request) {
-				ctx := context.Background()
+				ctx := t.Context()
 
 				_, err := reconciler.Reconcile(ctx, dataplaneReq)
 				require.NoError(t, err)
@@ -822,7 +821,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			testBody: func(t *testing.T, reconciler Reconciler, dataplaneReq reconcile.Request) {
-				ctx := context.Background()
+				ctx := t.Context()
 
 				_, err := reconciler.Reconcile(ctx, dataplaneReq)
 				require.NoError(t, err)

--- a/controller/dataplane/controller_utils_test.go
+++ b/controller/dataplane/controller_utils_test.go
@@ -1,7 +1,6 @@
 package dataplane
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -390,7 +389,7 @@ func TestEnsureDataPlaneReadyStatus(t *testing.T) {
 				WithLists(tc.objectLists...).
 				Build()
 
-			res, err := ensureDataPlaneReadyStatus(context.Background(), fakeClient, logr.Discard(), tc.dataPlane, tc.dataPlane.Generation)
+			res, err := ensureDataPlaneReadyStatus(t.Context(), fakeClient, logr.Discard(), tc.dataPlane, tc.dataPlane.Generation)
 			if tc.expectedError {
 				assert.Error(t, err)
 				return

--- a/controller/dataplane/dynamic_test.go
+++ b/controller/dataplane/dynamic_test.go
@@ -405,7 +405,7 @@ func TestCallbackRun(t *testing.T) {
 			for _, cb := range tc.callbacks {
 				require.NoError(t, manager.Register(cb.Callback, cb.Name))
 			}
-			errs := runner.For(tc.dataplane).Modifies(tc.modifies).Runs(manager).Do(context.Background(), tc.subject)
+			errs := runner.For(tc.dataplane).Modifies(tc.modifies).Runs(manager).Do(t.Context(), tc.subject)
 			errSort := func(a, b error) int {
 				A := a.Error()
 				B := b.Error()

--- a/controller/dataplane/konnectextension_test.go
+++ b/controller/dataplane/konnectextension_test.go
@@ -1,7 +1,6 @@
 package dataplane
 
 import (
-	"context"
 	"sort"
 	"testing"
 
@@ -292,7 +291,7 @@ func TestApplyKonnectExtension(t *testing.T) {
 			cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 			dataplane := tt.dataPlane.DeepCopy()
-			err := applyKonnectExtension(context.Background(), cl, dataplane)
+			err := applyKonnectExtension(t.Context(), cl, dataplane)
 			if tt.expectedError != nil {
 				require.ErrorIs(t, err, tt.expectedError)
 			} else {

--- a/controller/dataplane/owned_finalizer_controller_test.go
+++ b/controller/dataplane/owned_finalizer_controller_test.go
@@ -1,7 +1,6 @@
 package dataplane
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -57,7 +56,7 @@ func TestRequestsForDataPlaneOwnedObjects(t *testing.T) {
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "not-owned-diff-ns-secret", Namespace: otherNs}},
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	expectedRequest := func(name string) ctrl.Request {
 		return ctrl.Request{
 			NamespacedName: k8stypes.NamespacedName{

--- a/controller/dataplane/owned_resources_test.go
+++ b/controller/dataplane/owned_resources_test.go
@@ -293,7 +293,7 @@ func TestEnsureIngressServiceForDataPlane(t *testing.T) {
 				WithScheme(scheme.Scheme).
 				Build()
 
-			ctx := context.Background()
+			ctx := t.Context()
 			existingSvc, err := k8sresources.GenerateNewIngressServiceForDataPlane(tc.dataplane)
 			require.NoError(t, err)
 			k8sutils.SetOwnerForObject(existingSvc, tc.dataplane)

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -1124,7 +1123,7 @@ func TestGetSupportedKindsWithResolvedRefsCondition(t *testing.T) {
 
 	for _, tc := range testCases {
 
-		ctx := context.Background()
+		ctx := t.Context()
 		client := fakectrlruntimeclient.
 			NewClientBuilder().
 			WithScheme(scheme.Get()).
@@ -1584,7 +1583,7 @@ func TestCountAttachedRoutesForGatewayListener(t *testing.T) {
 				WithObjects(tc.Objects...).
 				Build()
 
-			ctx := context.Background()
+			ctx := t.Context()
 			for i, listener := range tc.Gateway.Spec.Listeners {
 				routes, err := countAttachedRoutesForGatewayListener(ctx, &tc.Gateway, listener, client)
 				assert.Equal(t, tc.ExpectedRoutes[i], routes, "#%d", i)

--- a/controller/gateway/controller_test.go
+++ b/controller/gateway/controller_test.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -76,7 +75,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			testBody: func(t *testing.T, r Reconciler, gatewayReq reconcile.Request) {
-				ctx := context.Background()
+				ctx := t.Context()
 				_, err := r.Reconcile(ctx, gatewayReq)
 				require.Error(t, err)
 			},
@@ -124,7 +123,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			testBody: func(t *testing.T, r Reconciler, gatewayReq reconcile.Request) {
-				ctx := context.Background()
+				ctx := t.Context()
 				res, err := r.Reconcile(ctx, gatewayReq)
 				require.NoError(t, err, "reconciliation should not return an error")
 				require.Equal(t, res, reconcile.Result{}, "reconciliation should not return a requeue")
@@ -240,7 +239,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			testBody: func(t *testing.T, reconciler Reconciler, gatewayReq reconcile.Request) {
-				ctx := context.Background()
+				ctx := t.Context()
 
 				// These addresses are just placeholders, their value doesn't matter. No check is performed in the Gateway-controller,
 				// apart from the existence of an address.
@@ -868,7 +867,7 @@ func BenchmarkGatewayReconciler_Reconcile(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, err := reconciler.Reconcile(context.Background(), gatewayReq)
+		_, err := reconciler.Reconcile(b.Context(), gatewayReq)
 		if err != nil {
 			b.Error(err)
 		}

--- a/controller/gatewayclass/controller_reconciler_utils_test.go
+++ b/controller/gatewayclass/controller_reconciler_utils_test.go
@@ -1,7 +1,6 @@
 package gatewayclass
 
 import (
-	"context"
 	"testing"
 
 	"github.com/samber/lo"
@@ -118,7 +117,7 @@ func TestGetAcceptedCondition(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			cl := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithRuntimeObjects(tt.existingObjs...).
@@ -254,7 +253,7 @@ func TestGetRouterFlavor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			cl := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithRuntimeObjects(tt.existingObjs...).

--- a/controller/gatewayclass/controller_test.go
+++ b/controller/gatewayclass/controller_test.go
@@ -1,7 +1,6 @@
 package gatewayclass
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -60,7 +59,7 @@ func TestGatewayClassReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			testBody: func(t *testing.T, reconciler Reconciler, gatewayClassReq reconcile.Request, gatewayClass *gatewayv1.GatewayClass) {
-				ctx := context.Background()
+				ctx := t.Context()
 				_, err := reconciler.Reconcile(ctx, gatewayClassReq)
 				require.NoError(t, err)
 				gwc := gatewayclass.NewDecorator()
@@ -85,7 +84,7 @@ func TestGatewayClassReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			testBody: func(t *testing.T, reconciler Reconciler, gatewayClassReq reconcile.Request, gatewayClass *gatewayv1.GatewayClass) {
-				ctx := context.Background()
+				ctx := t.Context()
 				_, err := reconciler.Reconcile(ctx, gatewayClassReq)
 				require.NoError(t, err)
 				gwc := gatewayclass.NewDecorator()

--- a/controller/kongplugininstallation/image/image_test.go
+++ b/controller/kongplugininstallation/image/image_test.go
@@ -1,7 +1,6 @@
 package image_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,7 +14,7 @@ func TestFetchPluginContent(t *testing.T) {
 	t.Log("This test accesses container registries on public internet")
 
 	t.Run("invalid image URL", func(t *testing.T) {
-		_, err := image.FetchPlugin(context.Background(), "foo bar", nil)
+		_, err := image.FetchPlugin(t.Context(), "foo bar", nil)
 		require.ErrorContains(t, err, "unexpected format of image url: could not parse reference: foo bar")
 	})
 
@@ -25,7 +24,7 @@ func TestFetchPluginContent(t *testing.T) {
 	// Source: hack/plugin-images/myheader.Dockerfile.
 	t.Run("valid image (Docker format)", func(t *testing.T) {
 		plugin, err := image.FetchPlugin(
-			context.Background(), registryUrl+"plugin-example/valid:0.1.0", nil,
+			t.Context(), registryUrl+"plugin-example/valid:0.1.0", nil,
 		)
 		require.NoError(t, err)
 		requireExpectedContent(t, plugin)
@@ -35,7 +34,7 @@ func TestFetchPluginContent(t *testing.T) {
 	// Instead of Docker Podman or Buildah is used to build the image.
 	t.Run("valid image (OCI format)", func(t *testing.T) {
 		plugin, err := image.FetchPlugin(
-			context.Background(), registryUrl+"plugin-example/valid-oci:0.1.0", nil,
+			t.Context(), registryUrl+"plugin-example/valid-oci:0.1.0", nil,
 		)
 		require.NoError(t, err)
 		requireExpectedContent(t, plugin)
@@ -52,7 +51,7 @@ func TestFetchPluginContent(t *testing.T) {
 		require.NoError(t, err)
 
 		plugin, err := image.FetchPlugin(
-			context.Background(), registryUrl+"plugin-example-private/valid:0.1.0", credsStore,
+			t.Context(), registryUrl+"plugin-example-private/valid:0.1.0", credsStore,
 		)
 		require.NoError(t, err)
 		requireExpectedContentPrivate(t, plugin)
@@ -61,7 +60,7 @@ func TestFetchPluginContent(t *testing.T) {
 	// Source: hack/plugin-images/invalid-layers.Dockerfile.
 	t.Run("invalid image - too many layers", func(t *testing.T) {
 		_, err := image.FetchPlugin(
-			context.Background(), registryUrl+"plugin-example/invalid-layers", nil,
+			t.Context(), registryUrl+"plugin-example/invalid-layers", nil,
 		)
 		require.ErrorContains(t, err, "expected exactly one layer with plugin, found 2 layers")
 	})
@@ -69,7 +68,7 @@ func TestFetchPluginContent(t *testing.T) {
 	// Source: hack/plugin-images/invalid-name.Dockerfile.
 	t.Run("invalid image - invalid names of files", func(t *testing.T) {
 		_, err := image.FetchPlugin(
-			context.Background(), registryUrl+"plugin-example/invalid-name", nil,
+			t.Context(), registryUrl+"plugin-example/invalid-name", nil,
 		)
 		require.ErrorContains(t, err, `file "add-header.lua" is unexpected, required files are handler.lua and schema.lua`)
 	})
@@ -77,7 +76,7 @@ func TestFetchPluginContent(t *testing.T) {
 	// Source: hack/plugin-images/missing-file.Dockerfile.
 	t.Run("invalid image - missing file", func(t *testing.T) {
 		_, err := image.FetchPlugin(
-			context.Background(), registryUrl+"plugin-example/missing-file", nil,
+			t.Context(), registryUrl+"plugin-example/missing-file", nil,
 		)
 		require.ErrorContains(t, err, `required files not found in the image: schema.lua`)
 	})
@@ -85,7 +84,7 @@ func TestFetchPluginContent(t *testing.T) {
 	// Source: hack/plugin-images/invalid-size-one.Dockerfile.
 	t.Run("invalid image - invalid too big plugin (size of single file)", func(t *testing.T) {
 		_, err := image.FetchPlugin(
-			context.Background(), registryUrl+"plugin-example/invalid-size-one", nil,
+			t.Context(), registryUrl+"plugin-example/invalid-size-one", nil,
 		)
 		require.ErrorContains(t, err, "plugin size limit of 1.00 MiB exceeded")
 	})
@@ -93,7 +92,7 @@ func TestFetchPluginContent(t *testing.T) {
 	// Source: hack/plugin-images/invalid-size-combined.Dockerfile.
 	t.Run("invalid image - invalid too big plugin (size of files combined)", func(t *testing.T) {
 		_, err := image.FetchPlugin(
-			context.Background(), registryUrl+"plugin-example/invalid-size-combined", nil,
+			t.Context(), registryUrl+"plugin-example/invalid-size-combined", nil,
 		)
 		require.ErrorContains(t, err, "plugin size limit of 1.00 MiB exceeded")
 	})

--- a/controller/konnect/ops/ops_controlplane_test.go
+++ b/controller/konnect/ops/ops_controlplane_test.go
@@ -1,7 +1,6 @@
 package ops
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -33,7 +32,7 @@ func TestCreateControlPlane(t *testing.T) {
 		cpID  = "cp-id"
 		cpgID = "cpg-id"
 	)
-	ctx := context.Background()
+	ctx := t.Context()
 	testCases := []struct {
 		name                string
 		mockCPTuple         func(*testing.T) (*sdkmocks.MockControlPlaneSDK, *sdkmocks.MockControlPlaneGroupSDK, *konnectv1alpha1.KonnectGatewayControlPlane)
@@ -275,7 +274,7 @@ func TestCreateControlPlane(t *testing.T) {
 }
 
 func TestDeleteControlPlane(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testCases := []struct {
 		name        string
 		mockCPPair  func(*testing.T) (*sdkmocks.MockControlPlaneSDK, *konnectv1alpha1.KonnectGatewayControlPlane)
@@ -403,7 +402,7 @@ func TestDeleteControlPlane(t *testing.T) {
 }
 
 func TestUpdateControlPlane(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testCases := []struct {
 		name        string
 		mockCPTuple func(*testing.T) (*sdkmocks.MockControlPlaneSDK, *sdkmocks.MockControlPlaneGroupSDK, *konnectv1alpha1.KonnectGatewayControlPlane)
@@ -577,7 +576,7 @@ func TestUpdateControlPlane(t *testing.T) {
 
 func TestCreateAndUpdateControlPlane_KubernetesMetadataConsistency(t *testing.T) {
 	var (
-		ctx = context.Background()
+		ctx = t.Context()
 		cp  = &konnectv1alpha1.KonnectGatewayControlPlane{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "KonnectGatewayControlPlane",
@@ -901,7 +900,7 @@ func TestSetGroupMembers(t *testing.T) {
 				Build()
 
 			sdk := tc.sdk(t)
-			err := setGroupMembers(context.Background(), fakeClient, tc.group, "cpg-12345", sdk)
+			err := setGroupMembers(t.Context(), fakeClient, tc.group, "cpg-12345", sdk)
 			if tc.expectedErr {
 				assert.Error(t, err)
 				return

--- a/controller/konnect/ops/ops_kongpluginbinding_test.go
+++ b/controller/konnect/ops/ops_kongpluginbinding_test.go
@@ -1,7 +1,6 @@
 package ops
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/uuid"
@@ -20,7 +19,7 @@ import (
 )
 
 func TestKongPluginBindingToSDKPluginInput_Tags(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	pb := &configurationv1alpha1.KongPluginBinding{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "KongPluginBinding",

--- a/controller/konnect/ops/ops_kongservice_test.go
+++ b/controller/konnect/ops/ops_kongservice_test.go
@@ -1,7 +1,6 @@
 package ops
 
 import (
-	"context"
 	"testing"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
@@ -22,7 +21,7 @@ import (
 )
 
 func TestCreateKongService(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testCases := []struct {
 		name                string
 		mockServicePair     func(*testing.T) (*sdkmocks.MockServicesSDK, *configurationv1alpha1.KongService)
@@ -200,7 +199,7 @@ func TestCreateKongService(t *testing.T) {
 }
 
 func TestDeleteKongService(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testCases := []struct {
 		name            string
 		mockServicePair func(*testing.T) (*sdkmocks.MockServicesSDK, *configurationv1alpha1.KongService)
@@ -329,7 +328,7 @@ func TestDeleteKongService(t *testing.T) {
 }
 
 func TestUpdateKongService(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testCases := []struct {
 		name            string
 		mockServicePair func(*testing.T) (*sdkmocks.MockServicesSDK, *configurationv1alpha1.KongService)

--- a/controller/konnect/ops/ops_kongupstream_test.go
+++ b/controller/konnect/ops/ops_kongupstream_test.go
@@ -1,7 +1,6 @@
 package ops
 
 import (
-	"context"
 	"testing"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
@@ -22,7 +21,7 @@ import (
 )
 
 func TestCreateKongUpstream(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testCases := []struct {
 		name             string
 		mockUpstreamPair func(*testing.T) (*sdkmocks.MockUpstreamsSDK, *configurationv1alpha1.KongUpstream)
@@ -153,7 +152,7 @@ func TestCreateKongUpstream(t *testing.T) {
 }
 
 func TestDeleteKongUpstream(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testCases := []struct {
 		name             string
 		mockUpstreamPair func(*testing.T) (*sdkmocks.MockUpstreamsSDK, *configurationv1alpha1.KongUpstream)
@@ -282,7 +281,7 @@ func TestDeleteKongUpstream(t *testing.T) {
 }
 
 func TestUpdateKongUpstream(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testCases := []struct {
 		name             string
 		mockUpstreamPair func(*testing.T) (*sdkmocks.MockUpstreamsSDK, *configurationv1alpha1.KongUpstream)

--- a/controller/konnect/ops/ops_kongvault_test.go
+++ b/controller/konnect/ops/ops_kongvault_test.go
@@ -1,7 +1,6 @@
 package ops
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -139,7 +138,7 @@ func TestCreateKongVault(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			sdk, vault := tc.mockVaultPair(t)
-			err := createVault(context.Background(), sdk, vault)
+			err := createVault(t.Context(), sdk, vault)
 			tc.assertions(t, vault)
 
 			if tc.expectedErr {
@@ -251,7 +250,7 @@ func TestUpdateKongVault(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			sdk, vault := tc.mockVaultPair(t)
-			err := updateVault(context.Background(), sdk, vault)
+			err := updateVault(t.Context(), sdk, vault)
 			tc.assertions(t, vault)
 
 			if tc.expectedErr {
@@ -352,7 +351,7 @@ func TestDeleteKongVault(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			sdk, vault := tc.mockVaultPair(t)
-			err := deleteVault(context.Background(), sdk, vault)
+			err := deleteVault(t.Context(), sdk, vault)
 			if tc.expectedErr {
 				assert.Error(t, err)
 				return

--- a/controller/konnect/ops/ops_test.go
+++ b/controller/konnect/ops/ops_test.go
@@ -1,7 +1,6 @@
 package ops
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"testing"
@@ -238,7 +237,7 @@ func testCreate[
 				sdk = tc.sdkFunc(t, sdk)
 			}
 
-			_, err := Create(context.Background(), sdk, fakeClient, &metrics.MockRecorder{}, tc.entity)
+			_, err := Create(t.Context(), sdk, fakeClient, &metrics.MockRecorder{}, tc.entity)
 			if tc.expectedErrorContains != "" {
 				require.ErrorContains(t, err, tc.expectedErrorContains)
 			} else {
@@ -346,7 +345,7 @@ func testDelete[
 				sdk = tc.sdkFunc(t, sdk)
 			}
 
-			err := Delete(context.Background(), sdk, fakeClient, &metrics.MockRecorder{}, tc.entity)
+			err := Delete(t.Context(), sdk, fakeClient, &metrics.MockRecorder{}, tc.entity)
 			if tc.expectedError != "" {
 				require.ErrorContains(t, err, tc.expectedError)
 				return

--- a/controller/konnect/reconciler_certificateref_test.go
+++ b/controller/konnect/reconciler_certificateref_test.go
@@ -1,7 +1,6 @@
 package konnect
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -376,12 +375,12 @@ func testHandleCertificateRef[T constraints.SupportedKonnectEntityType, TEnt con
 				WithObjects(tc.ent).WithObjects(tc.objects...).
 				// WithStatusSubresource is required for updating status of handled entity.
 				WithStatusSubresource(tc.ent).Build()
-			require.NoError(t, fakeClient.SubResource("status").Update(context.Background(), tc.ent))
+			require.NoError(t, fakeClient.SubResource("status").Update(t.Context(), tc.ent))
 
-			res, err := handleKongCertificateRef(context.Background(), fakeClient, tc.ent)
+			res, err := handleKongCertificateRef(t.Context(), fakeClient, tc.ent)
 
 			var updatedEnt TEnt = tc.ent.DeepCopyObject().(TEnt)
-			require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(tc.ent), updatedEnt))
+			require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKeyFromObject(tc.ent), updatedEnt))
 			for _, assertion := range tc.updatedEntAssertions {
 				ok, msg := assertion(updatedEnt)
 				require.True(t, ok, msg)

--- a/controller/konnect/reconciler_controlplaneref_test.go
+++ b/controller/konnect/reconciler_controlplaneref_test.go
@@ -1,7 +1,6 @@
 package konnect
 
 import (
-	"context"
 	"testing"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
@@ -264,12 +263,12 @@ func testHandleControlPlaenRef[
 				// WithStatusSubresource is required for updating status of handled entity.
 				WithStatusSubresource(tc.ent).
 				Build()
-			require.NoError(t, fakeClient.SubResource("status").Update(context.Background(), tc.ent))
+			require.NoError(t, fakeClient.SubResource("status").Update(t.Context(), tc.ent))
 
-			res, err := handleControlPlaneRef(context.Background(), fakeClient, tc.ent)
+			res, err := handleControlPlaneRef(t.Context(), fakeClient, tc.ent)
 
 			var updatedEnt TEnt = tc.ent.DeepCopyObject().(TEnt)
-			require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(tc.ent), updatedEnt))
+			require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKeyFromObject(tc.ent), updatedEnt))
 			for _, assertion := range tc.updatedEntAssertions {
 				ok, msg := assertion(updatedEnt)
 				require.True(t, ok, msg)

--- a/controller/konnect/reconciler_credential_secrets_test.go
+++ b/controller/konnect/reconciler_credential_secrets_test.go
@@ -1,7 +1,6 @@
 package konnect
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -261,7 +260,7 @@ func TestEnsureExistingCredential(t *testing.T) {
 					WithScheme(scheme.Get()).
 					WithObjects(tt.cred).
 					Build()
-				_, err := ensureExistingCredential(context.Background(), client, tt.cred, tt.secret, tt.consumer)
+				_, err := ensureExistingCredential(t.Context(), client, tt.cred, tt.secret, tt.consumer)
 				if (err != nil) != tt.wantError {
 					t.Errorf("ensureExistingCredential() error = %v, wantError %v", err, tt.wantError)
 				}
@@ -356,7 +355,7 @@ func TestEnsureExistingCredential(t *testing.T) {
 					WithScheme(scheme.Get()).
 					WithObjects(tt.cred).
 					Build()
-				_, err := ensureExistingCredential(context.Background(), client, tt.cred, tt.secret, tt.consumer)
+				_, err := ensureExistingCredential(t.Context(), client, tt.cred, tt.secret, tt.consumer)
 				if (err != nil) != tt.wantError {
 					t.Errorf("ensureExistingCredential() error = %v, wantError %v", err, tt.wantError)
 				}
@@ -452,7 +451,7 @@ func TestEnsureExistingCredential(t *testing.T) {
 					WithScheme(scheme.Get()).
 					WithObjects(tt.cred).
 					Build()
-				_, err := ensureExistingCredential(context.Background(), client, tt.cred, tt.secret, tt.consumer)
+				_, err := ensureExistingCredential(t.Context(), client, tt.cred, tt.secret, tt.consumer)
 				if (err != nil) != tt.wantError {
 					t.Errorf("ensureExistingCredential() error = %v, wantError %v", err, tt.wantError)
 				}

--- a/controller/konnect/reconciler_keysetref_test.go
+++ b/controller/konnect/reconciler_keysetref_test.go
@@ -1,7 +1,6 @@
 package konnect
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -351,12 +350,12 @@ func testHandleKeySetRef[T constraints.SupportedKonnectEntityType, TEnt constrai
 				// WithStatusSubresource is required for updating status of handled entity.
 				WithStatusSubresource(tc.ent).
 				Build()
-			require.NoError(t, fakeClient.Status().Update(context.Background(), tc.ent))
+			require.NoError(t, fakeClient.Status().Update(t.Context(), tc.ent))
 
-			res, err := handleKongKeySetRef(context.Background(), fakeClient, tc.ent)
+			res, err := handleKongKeySetRef(t.Context(), fakeClient, tc.ent)
 
 			updatedEnt := tc.ent.DeepCopyObject().(TEnt)
-			require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(tc.ent), updatedEnt))
+			require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKeyFromObject(tc.ent), updatedEnt))
 			for _, assertion := range tc.updatedEntAssertions {
 				ok, msg := assertion(updatedEnt)
 				require.True(t, ok, msg)

--- a/controller/konnect/reconciler_kongplugin_combinations_test.go
+++ b/controller/konnect/reconciler_kongplugin_combinations_test.go
@@ -1,7 +1,6 @@
 package konnect
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -816,7 +815,7 @@ func TestGroupByControlPlane(t *testing.T) {
 				WithScheme(scheme.Get()).
 				WithObjects(objects...).
 				Build()
-			got, err := tt.args.relations.GroupByControlPlane(context.Background(), cl)
+			got, err := tt.args.relations.GroupByControlPlane(t.Context(), cl)
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 		})

--- a/controller/konnect/reconciler_konnectapiauth_test.go
+++ b/controller/konnect/reconciler_konnectapiauth_test.go
@@ -1,7 +1,6 @@
 package konnect
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -149,7 +148,7 @@ func TestGetTokenFromKonnectAPIAuthConfiguration(t *testing.T) {
 			cl := clientBuilder.Build()
 
 			// Call the function under test
-			token, err := getTokenFromKonnectAPIAuthConfiguration(context.Background(), cl, tt.apiAuth)
+			token, err := getTokenFromKonnectAPIAuthConfiguration(t.Context(), cl, tt.apiAuth)
 			if tt.expectedError {
 				assert.NotNil(t, err)
 				return

--- a/controller/konnect/reconciler_serviceref_test.go
+++ b/controller/konnect/reconciler_serviceref_test.go
@@ -1,7 +1,6 @@
 package konnect
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -297,12 +296,12 @@ func testHandleServiceRef[
 				// WithStatusSubresource is required for updating status of handled entity.
 				WithStatusSubresource(tc.ent).
 				Build()
-			require.NoError(t, fakeClient.SubResource("status").Update(context.Background(), tc.ent))
+			require.NoError(t, fakeClient.SubResource("status").Update(t.Context(), tc.ent))
 
-			res, err := handleKongServiceRef(context.Background(), fakeClient, tc.ent)
+			res, err := handleKongServiceRef(t.Context(), fakeClient, tc.ent)
 
 			var updatedEnt TEnt = tc.ent.DeepCopyObject().(TEnt)
-			require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(tc.ent), updatedEnt))
+			require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKeyFromObject(tc.ent), updatedEnt))
 			for _, assertion := range tc.updatedEntAssertions {
 				ok, msg := assertion(updatedEnt)
 				require.True(t, ok, msg)

--- a/controller/konnect/reconciler_upstreamref_test.go
+++ b/controller/konnect/reconciler_upstreamref_test.go
@@ -1,7 +1,6 @@
 package konnect
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -404,12 +403,12 @@ func testHandleUpstreamRef[T constraints.SupportedKonnectEntityType, TEnt constr
 				WithObjects(tc.ent).WithObjects(tc.objects...).
 				// WithStatusSubresource is required for updating status of handled entity.
 				WithStatusSubresource(tc.ent).Build()
-			require.NoError(t, fakeClient.SubResource("status").Update(context.Background(), tc.ent))
+			require.NoError(t, fakeClient.SubResource("status").Update(t.Context(), tc.ent))
 
-			res, err := handleKongUpstreamRef(context.Background(), fakeClient, tc.ent)
+			res, err := handleKongUpstreamRef(t.Context(), fakeClient, tc.ent)
 
 			var updatedEnt TEnt = tc.ent.DeepCopyObject().(TEnt)
-			require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(tc.ent), updatedEnt))
+			require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKeyFromObject(tc.ent), updatedEnt))
 			for _, assertion := range tc.updatedEntAssertions {
 				ok, msg := assertion(updatedEnt)
 				require.True(t, ok, msg)

--- a/controller/konnect/watch_test.go
+++ b/controller/konnect/watch_test.go
@@ -1,7 +1,6 @@
 package konnect
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -205,7 +204,7 @@ func TestEnqueueObjectForKonnectGatewayControlPlane(t *testing.T) {
 				require.NotNil(t, cl)
 
 				f := enqueueObjectForKonnectGatewayControlPlane[configurationv1.KongConsumerList](cl, tt.index)
-				requests := f(context.Background(), cp)
+				requests := f(t.Context(), cp)
 				require.Len(t, requests, len(tt.expected))
 				require.Equal(t, tt.expected, requests)
 			})

--- a/controller/pkg/patch/patch_test.go
+++ b/controller/pkg/patch/patch_test.go
@@ -1,7 +1,6 @@
 package patch
 
 import (
-	"context"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -183,7 +182,7 @@ func TestApplyPatchIfNonEmpty(t *testing.T) {
 				WithObjects(tc.dataPlane, hpa).
 				Build()
 
-			result, _, err := ApplyPatchIfNotEmpty(context.Background(), fakeClient, log, hpa, old, tc.updated)
+			result, _, err := ApplyPatchIfNotEmpty(t.Context(), fakeClient, log, hpa, old, tc.updated)
 			if tc.wantErr {
 				require.Error(t, err)
 				return

--- a/controller/pkg/patch/statuscondition_test.go
+++ b/controller/pkg/patch/statuscondition_test.go
@@ -253,7 +253,7 @@ func TestPatchStatusWithCondition(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			cl := fake.NewClientBuilder().
 				WithObjects(tt.obj).
 				WithStatusSubresource(tt.obj).

--- a/controller/pkg/secrets/cert_test.go
+++ b/controller/pkg/secrets/cert_test.go
@@ -2,7 +2,6 @@ package secrets
 
 import (
 	"bytes"
-	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -340,7 +339,7 @@ func TestMaybeCreateCertificateSecret(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 
 			scheme := runtime.NewScheme()
 			require.NoError(t, corev1.AddToScheme(scheme))

--- a/controller/pkg/secrets/ref/ref_test.go
+++ b/controller/pkg/secrets/ref/ref_test.go
@@ -1,7 +1,6 @@
 package ref
 
 import (
-	"context"
 	"testing"
 
 	"github.com/samber/lo"
@@ -203,7 +202,7 @@ func TestCheckReferenceGrantForSecret(t *testing.T) {
 			})...)
 			assert.NoError(t, gatewayv1beta1.Install(cl.Scheme()))
 			_, granted, err := CheckReferenceGrantForSecret(
-				context.Background(), cl,
+				t.Context(), cl,
 				tc.forObj,
 				gatewayv1.SecretObjectReference{
 					Namespace: lo.ToPtr(gatewayv1.Namespace("default")),

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,6 @@ github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IX
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/kong/go-kong v0.63.0 h1:8ECLgkgDqON61qCMq/M0gTwZKYxg55Oy692dRDOOBiU=
 github.com/kong/go-kong v0.63.0/go.mod h1:ma9GWnhkxtrXZlLFfED955HjVzmUojYEHet3lm+PDik=
-github.com/kong/kubernetes-configuration v1.1.1-0.20250219125458-b45dead920d4 h1:cKGIpPM55LOJ2YEbbuKDj/OyJ4Zvz38c/gUJ/zi/JT8=
-github.com/kong/kubernetes-configuration v1.1.1-0.20250219125458-b45dead920d4/go.mod h1:bTJv/IsSCE9Ux+9RY9fEMCU9yehBWAvrSXc8iWx7OGo=
 github.com/kong/kubernetes-configuration v1.1.1-0.20250220111603-ab0c168ea1c7 h1:/1bHPk0kszefYZiLSvm8TIeiZfD1xZoORZhfx1FbqAE=
 github.com/kong/kubernetes-configuration v1.1.1-0.20250220111603-ab0c168ea1c7/go.mod h1:MSXL0ljNNW8OPiFHTwh1MfhfbyD76c7WPRTzKIzKQKY=
 github.com/kong/kubernetes-telemetry v0.1.8 h1:nbtUmXW9xkzRO7dgvrgVrJZiRksATk4XHrqX+78g/5k=

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -509,7 +509,7 @@ func TestCreateManager(t *testing.T) {
 
 			t.Log("trigger a report...")
 			require.NoError(t, m.Start())
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 			defer cancel()
 			require.NoError(t, m.TriggerExecute(ctx, "test-signal"), "failed triggering signal execution")
 
@@ -662,14 +662,14 @@ func TestTelemetryUpdates(t *testing.T) {
 
 			t.Log("trigger a report...")
 			require.NoError(t, m.Start())
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 			defer cancel()
 			require.NoError(t, m.TriggerExecute(ctx, "test-signal"), "failed triggering signal execution")
 
 			t.Log("checking received report...")
 			requireReportContainsValuesEventually(t, ch, tc.expectedReportParts...)
 
-			tc.action(t, context.Background(), dyn)
+			tc.action(t, t.Context(), dyn)
 
 			require.NoError(t, m.TriggerExecute(ctx, "test-signal"), "failed triggering signal execution")
 

--- a/internal/utils/gatewayclass/get_test.go
+++ b/internal/utils/gatewayclass/get_test.go
@@ -1,7 +1,6 @@
 package gatewayclass_test
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -124,7 +123,7 @@ func TestGet(t *testing.T) {
 				WithObjects(tc.objectsToAdd...).
 				Build()
 
-			gwc, err := gatewayclass.Get(context.Background(), fakeClient, tc.gatewayClassName)
+			gwc, err := gatewayclass.Get(t.Context(), fakeClient, tc.gatewayClassName)
 			if tc.expectedError != nil {
 				require.ErrorContains(t, err, tc.expectedError.Error())
 				require.IsType(t, tc.expectedError, err)

--- a/pkg/utils/gateway/ownerrefs_test.go
+++ b/pkg/utils/gateway/ownerrefs_test.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"context"
 	"testing"
 
 	"github.com/samber/lo"
@@ -258,7 +257,7 @@ func TestListHTTPRoutesForGateway(t *testing.T) {
 				WithObjects(tc.gateway).
 				WithObjects(tc.httpRoutes...).
 				Build()
-			routes, err := ListHTTPRoutesForGateway(context.Background(), cl, tc.gateway)
+			routes, err := ListHTTPRoutesForGateway(t.Context(), cl, tc.gateway)
 			if tc.expectedErr {
 				require.Error(t, err)
 			} else {

--- a/pkg/utils/kubernetes/envvars_test.go
+++ b/pkg/utils/kubernetes/envvars_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"context"
 	"encoding/base64"
 	"testing"
 
@@ -291,7 +290,7 @@ func TestGetEnvValueFromContainer(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			c := b.Build()
-			value, found, err := GetEnvValueFromContainer(context.Background(), tc.container, "default", tc.key, c)
+			value, found, err := GetEnvValueFromContainer(t.Context(), tc.container, "default", tc.key, c)
 			if tc.hasError {
 				require.Error(t, err)
 				return

--- a/pkg/utils/kubernetes/lists_test.go
+++ b/pkg/utils/kubernetes/lists_test.go
@@ -1,7 +1,6 @@
 package kubernetes_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,7 +15,7 @@ import (
 )
 
 func TestListValidatingWebhookConfigurationsForOwner(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testCases := []struct {
 		name          string
 		objects       []runtime.Object

--- a/pkg/utils/kubernetes/referencegrant_test.go
+++ b/pkg/utils/kubernetes/referencegrant_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"context"
 	"testing"
 
 	"github.com/samber/lo"
@@ -288,7 +287,7 @@ func TestAllowedByReferenceGrants(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cl := fake.NewFakeClient(tc.objs...)
 			require.NoError(t, gatewayv1beta1.Install(cl.Scheme()))
-			allow, err := AllowedByReferenceGrants(context.Background(), cl, tc.from, tc.targetNamespace, tc.to)
+			allow, err := AllowedByReferenceGrants(t.Context(), cl, tc.from, tc.targetNamespace, tc.to)
 			require.NoError(t, err)
 			require.Equal(t, tc.allow, allow)
 		})

--- a/pkg/utils/test/predicates.go
+++ b/pkg/utils/test/predicates.go
@@ -710,7 +710,7 @@ func GatewayClassIsAccepted(t *testing.T, ctx context.Context, gatewayClassName 
 	gatewayClasses := clients.GatewayClient.GatewayV1().GatewayClasses()
 
 	return func() bool {
-		gwc, err := gatewayClasses.Get(context.Background(), gatewayClassName, metav1.GetOptions{})
+		gwc, err := gatewayClasses.Get(t.Context(), gatewayClassName, metav1.GetOptions{})
 		if err != nil {
 			return false
 		}

--- a/test/crdsvalidation/controlplane_test.go
+++ b/test/crdsvalidation/controlplane_test.go
@@ -1,7 +1,6 @@
 package crdsvalidation
 
 import (
-	"context"
 	"testing"
 
 	"github.com/samber/lo"
@@ -17,7 +16,7 @@ import (
 
 func TestControlPlane(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg, ns := envtest.Setup(t, ctx, scheme.Get())
 
 	t.Run("spec", func(t *testing.T) {

--- a/test/crdsvalidation/dataplane_test.go
+++ b/test/crdsvalidation/dataplane_test.go
@@ -1,7 +1,6 @@
 package crdsvalidation
 
 import (
-	"context"
 	"testing"
 
 	"github.com/samber/lo"
@@ -18,7 +17,7 @@ import (
 
 func TestDataPlane(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg, ns := envtest.Setup(t, ctx, scheme.Get())
 
 	commonObjectMeta := metav1.ObjectMeta{

--- a/test/crdsvalidation/dataplane_validatingadmissionpolicy_test.go
+++ b/test/crdsvalidation/dataplane_validatingadmissionpolicy_test.go
@@ -1,7 +1,6 @@
 package crdsvalidation
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -32,7 +31,7 @@ func TestDataPlaneValidatingAdmissionPolicy(t *testing.T) {
 	t.Parallel()
 
 	var (
-		ctx              = context.Background()
+		ctx              = t.Context()
 		scheme           = scheme.Get()
 		cfg, ns          = envtest.Setup(t, ctx, scheme)
 		commonObjectMeta = metav1.ObjectMeta{

--- a/test/e2e/environment.go
+++ b/test/e2e/environment.go
@@ -196,7 +196,7 @@ func CreateEnvironment(t *testing.T, ctx context.Context, opts ...TestEnvOption)
 
 	t.Cleanup(func() {
 		if opt.InstallViaKustomize {
-			cleanupEnvironment(t, context.Background(), env, kustomizeDir.Tests())
+			cleanupEnvironment(t, t.Context(), env, kustomizeDir.Tests())
 		}
 	})
 
@@ -341,7 +341,7 @@ func waitForOperatorDeployment(
 			logOperatorPodLogs(t, ctx, k8sClient, ns)
 			return fmt.Errorf("timed out waiting for operator deployment in namespace %s", ns)
 		case <-ctx.Done():
-			logOperatorPodLogs(t, context.Background(), k8sClient, ns)
+			logOperatorPodLogs(t, t.Context(), k8sClient, ns)
 			return ctx.Err()
 		case <-pollTimer.C:
 			listOpts := metav1.ListOptions{

--- a/test/e2e/environment.go
+++ b/test/e2e/environment.go
@@ -196,7 +196,7 @@ func CreateEnvironment(t *testing.T, ctx context.Context, opts ...TestEnvOption)
 
 	t.Cleanup(func() {
 		if opt.InstallViaKustomize {
-			cleanupEnvironment(t, t.Context(), env, kustomizeDir.Tests())
+			cleanupEnvironment(t, context.Background(), env, kustomizeDir.Tests()) //nolint:usetesting
 		}
 	})
 

--- a/test/e2e/test_helm_install_upgrade.go
+++ b/test/e2e/test_helm_install_upgrade.go
@@ -41,7 +41,7 @@ func TestHelmUpgrade(t *testing.T) {
 		waitTime = 3 * time.Minute
 	)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	// createEnvironment will queue up environment cleanup if necessary

--- a/test/e2e/test_operator_logs.go
+++ b/test/e2e/test_operator_logs.go
@@ -67,7 +67,7 @@ var (
 func TestOperatorLogs(t *testing.T) {
 	t.Skip() // TODO: https://github.com/kong/gateway-operator-archive/issues/908
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	// createEnvironment will queue up environment cleanup if necessary

--- a/test/e2e/test_upgrade.go
+++ b/test/e2e/test_upgrade.go
@@ -68,7 +68,7 @@ func TestDeployAndUpgradeFromLatestTagToOverride(t *testing.T) {
 	fromImage := fmt.Sprintf("%s:%s", ktests.Images[0].NewName, ktests.Images[0].NewTag)
 
 	t.Logf("got latest tag %q from %q", fromImage, kustomizeTests)
-	testManifestsUpgrade(t, context.Background(), upgradeTestParams{
+	testManifestsUpgrade(t, t.Context(), upgradeTestParams{
 		fromImage: fromImage,
 		toImage:   image,
 	})

--- a/test/envtest/kongconsumercredential_acl_test.go
+++ b/test/envtest/kongconsumercredential_acl_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"slices"
 	"strings"
 	"testing"
@@ -33,7 +32,7 @@ import (
 
 func TestKongConsumerCredential_ACL(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 
 	// Setup up the envtest environment.

--- a/test/envtest/kongconsumercredential_apikey_test.go
+++ b/test/envtest/kongconsumercredential_apikey_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"slices"
 	"strings"
 	"testing"
@@ -33,7 +32,7 @@ import (
 
 func TestKongConsumerCredential_APIKey(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 
 	// Setup up the envtest environment.

--- a/test/envtest/kongconsumercredential_basicauth_test.go
+++ b/test/envtest/kongconsumercredential_basicauth_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"slices"
 	"strings"
 	"testing"
@@ -33,7 +32,7 @@ import (
 
 func TestKongConsumerCredential_BasicAuth(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 
 	// Setup up the envtest environment.

--- a/test/envtest/kongconsumercredential_hmac_test.go
+++ b/test/envtest/kongconsumercredential_hmac_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"slices"
 	"strings"
 	"testing"
@@ -33,7 +32,7 @@ import (
 
 func TestKongConsumerCredential_HMAC(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 
 	// Setup up the envtest environment.

--- a/test/envtest/kongconsumercredential_jwt_test.go
+++ b/test/envtest/kongconsumercredential_jwt_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"slices"
 	"strings"
 	"testing"
@@ -33,7 +32,7 @@ import (
 
 func TestKongConsumerCredential_JWT(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 
 	// Setup up the envtest environment.

--- a/test/envtest/kongpluginbinding_managed_test.go
+++ b/test/envtest/kongpluginbinding_managed_test.go
@@ -38,7 +38,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 	// KongPluginBindings.
 
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 
 	// Setup up the envtest environment.

--- a/test/envtest/kongpluginbinding_unmanaged_test.go
+++ b/test/envtest/kongpluginbinding_unmanaged_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"testing"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
@@ -25,7 +24,7 @@ import (
 
 func TestKongPluginBindingUnmanaged(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 
 	// Setup up the envtest environment.

--- a/test/envtest/kongplugincleanupfinalizer_test.go
+++ b/test/envtest/kongplugincleanupfinalizer_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"fmt"
 	"slices"
 	"testing"
@@ -24,7 +23,7 @@ import (
 
 func TestKongPluginFinalizer(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 
 	// Setup up the envtest environment.

--- a/test/envtest/konnect_entities_gatewaycontrolplane_test.go
+++ b/test/envtest/konnect_entities_gatewaycontrolplane_test.go
@@ -393,7 +393,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 					mock.Anything,
 					mock.MatchedBy(func(r sdkkonnectops.ListControlPlanesRequest) bool {
 						var cp konnectv1alpha1.KonnectGatewayControlPlane
-						require.NoError(t, cl.Get(context.Background(), client.ObjectKey{Name: "cp-4"}, &cp))
+						require.NoError(t, cl.Get(t.Context(), client.ObjectKey{Name: "cp-4"}, &cp))
 						// On conflict, we list cps by UID and check if there is already one created.
 						return r.Labels != nil && *r.Labels == ops.KubernetesUIDLabelKey+":"+string(cp.UID)
 					}),
@@ -491,7 +491,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 					mock.Anything,
 					mock.MatchedBy(func(r sdkkonnectops.ListControlPlanesRequest) bool {
 						var cp konnectv1alpha1.KonnectGatewayControlPlane
-						require.NoError(t, cl.Get(context.Background(), client.ObjectKey{Name: "cp-group-1"}, &cp))
+						require.NoError(t, cl.Get(t.Context(), client.ObjectKey{Name: "cp-group-1"}, &cp))
 						// On conflict, we list cps by UID and check if there is already one created.
 						return r.Labels != nil && *r.Labels == ops.KubernetesUIDLabelKey+":"+string(cp.UID)
 					}),

--- a/test/envtest/konnect_entities_kongcacertificate_test.go
+++ b/test/envtest/konnect_entities_kongcacertificate_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"fmt"
 	"slices"
 	"testing"
@@ -29,7 +28,7 @@ import (
 
 func TestKongCACertificate(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 	cfg, ns := Setup(t, ctx, scheme.Get())
 	const (

--- a/test/envtest/konnect_entities_kongcertificate_test.go
+++ b/test/envtest/konnect_entities_kongcertificate_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -29,7 +28,7 @@ import (
 
 func TestKongCertificate(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 	cfg, ns := Setup(t, ctx, scheme.Get())
 

--- a/test/envtest/konnect_entities_kongconsumer_test.go
+++ b/test/envtest/konnect_entities_kongconsumer_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -34,7 +33,7 @@ import (
 
 func TestKongConsumer(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 	cfg, ns := Setup(t, ctx, scheme.Get())
 
@@ -462,7 +461,7 @@ func TestKongConsumer(t *testing.T) {
 
 func TestKongConsumerSecretCredentials(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 	cfg, ns := Setup(t, ctx, scheme.Get())
 

--- a/test/envtest/konnect_entities_kongconsumergroup_test.go
+++ b/test/envtest/konnect_entities_kongconsumergroup_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -32,7 +31,7 @@ import (
 
 func TestKongConsumerGroup(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 	cfg, ns := Setup(t, ctx, scheme.Get())
 

--- a/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
+++ b/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -26,7 +25,7 @@ import (
 
 func TestKongDataPlaneClientCertificate(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 	cfg, ns := Setup(t, ctx, scheme.Get())
 

--- a/test/envtest/konnect_entities_kongkey_test.go
+++ b/test/envtest/konnect_entities_kongkey_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -36,7 +35,7 @@ func TestKongKey(t *testing.T) {
 		keySetID   = "key-set-id"
 	)
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 	cfg, ns := Setup(t, ctx, scheme.Get())
 

--- a/test/envtest/konnect_entities_kongkeyset_test.go
+++ b/test/envtest/konnect_entities_kongkeyset_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -35,7 +34,7 @@ func TestKongKeySet(t *testing.T) {
 	)
 
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 	cfg, ns := Setup(t, ctx, scheme.Get())
 

--- a/test/envtest/konnect_entities_kongroute_test.go
+++ b/test/envtest/konnect_entities_kongroute_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"slices"
 	"testing"
 
@@ -26,7 +25,7 @@ import (
 
 func TestKongRoute(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 	cfg, ns := Setup(t, ctx, scheme.Get())
 

--- a/test/envtest/konnect_entities_kongservice_test.go
+++ b/test/envtest/konnect_entities_kongservice_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -28,7 +27,7 @@ import (
 
 func TestKongService(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 	cfg, ns := Setup(t, ctx, scheme.Get())
 

--- a/test/envtest/konnect_entities_kongsni_test.go
+++ b/test/envtest/konnect_entities_kongsni_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"testing"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
@@ -27,7 +26,7 @@ import (
 
 func TestKongSNI(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 	cfg, ns := Setup(t, ctx, scheme.Get())
 

--- a/test/envtest/konnect_entities_kongtarget_test.go
+++ b/test/envtest/konnect_entities_kongtarget_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"testing"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
@@ -25,7 +24,7 @@ import (
 
 func TestKongTarget(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 	cfg, ns := Setup(t, ctx, scheme.Get())
 

--- a/test/envtest/konnect_entities_kongupstream_test.go
+++ b/test/envtest/konnect_entities_kongupstream_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -27,7 +26,7 @@ import (
 
 func TestKongUpstream(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 	cfg, ns := Setup(t, ctx, scheme.Get())
 

--- a/test/envtest/konnect_entities_kongvault_test.go
+++ b/test/envtest/konnect_entities_kongvault_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -27,7 +26,7 @@ import (
 
 func TestKongVault(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 	cfg, ns := Setup(t, ctx, scheme.Get())
 

--- a/test/envtest/konnect_entities_konnectapiauthconfiguration_test.go
+++ b/test/envtest/konnect_entities_konnectapiauthconfiguration_test.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"context"
 	"testing"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
@@ -25,7 +24,7 @@ import (
 
 func TestKonnectAPIAuthConfiguration(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, context.Background())
+	ctx, cancel := Context(t, t.Context())
 	defer cancel()
 	cfg, ns := Setup(t, ctx, scheme.Get())
 

--- a/test/envtest/konnect_entities_suite_test.go
+++ b/test/envtest/konnect_entities_suite_test.go
@@ -23,7 +23,7 @@ import (
 // TestKonnectEntityReconcilers tests Konnect entity reconcilers. The test cases are run against a real Kubernetes API
 // server provided by the envtest package and a mock Konnect SDK.
 func TestKonnectEntityReconcilers(t *testing.T) {
-	cfg, _ := Setup(t, context.Background(), scheme.Get())
+	cfg, _ := Setup(t, t.Context(), scheme.Get())
 
 	testNewKonnectEntityReconciler(t, cfg, konnectv1alpha1.KonnectGatewayControlPlane{}, konnectGatewayControlPlaneTestCases)
 }
@@ -52,7 +52,7 @@ func testNewKonnectEntityReconciler[
 	t.Run(ent.GetTypeName(), func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
 		mgr, logs := NewManager(t, ctx, cfg, scheme.Get())

--- a/test/helpers/setup.go
+++ b/test/helpers/setup.go
@@ -36,7 +36,7 @@ func SetupTestEnv(t *testing.T, ctx context.Context, env environments.Environmen
 		t.Helper()
 
 		t.Log("performing test cleanup")
-		ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+		ctx, cancel := context.WithTimeout(t.Context(), time.Minute*5)
 		defer cancel()
 		assert.NoError(t, cleaner.Cleanup(ctx))
 	})
@@ -49,7 +49,7 @@ func SetupTestEnv(t *testing.T, ctx context.Context, env environments.Environmen
 
 	t.Cleanup(func() {
 		if t.Failed() {
-			output, err := env.Cluster().DumpDiagnostics(context.Background(), t.Name())
+			output, err := env.Cluster().DumpDiagnostics(t.Context(), t.Name())
 			assert.NoError(t, err)
 			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
 		}

--- a/test/helpers/setup.go
+++ b/test/helpers/setup.go
@@ -36,7 +36,7 @@ func SetupTestEnv(t *testing.T, ctx context.Context, env environments.Environmen
 		t.Helper()
 
 		t.Log("performing test cleanup")
-		ctx, cancel := context.WithTimeout(t.Context(), time.Minute*5)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5) //nolint:usetesting
 		defer cancel()
 		assert.NoError(t, cleaner.Cleanup(ctx))
 	})
@@ -49,7 +49,7 @@ func SetupTestEnv(t *testing.T, ctx context.Context, env environments.Environmen
 
 	t.Cleanup(func() {
 		if t.Failed() {
-			output, err := env.Cluster().DumpDiagnostics(t.Context(), t.Name())
+			output, err := env.Cluster().DumpDiagnostics(context.Background(), t.Name()) //nolint:usetesting
 			assert.NoError(t, err)
 			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Inspired by 

- https://github.com/Kong/kubernetes-ingress-controller/pull/7145

enable `usetesting` in the KGO too to keep linter configs aligned and fix all reported issues. Basically, all of them are to use `t.Context()` instead of `context.Background()` in tests that is a good practice, because it ensures context cancelation before test cleanup.

