### PR TITLE
tests: fix envtest sdk assertions

### DIFF
--- a/test/envtest/assert.go
+++ b/test/envtest/assert.go
@@ -58,3 +58,22 @@ func eventuallyAssertSDKExpectations(
 		waitTime, tickTime,
 	)
 }
+
+// assertsAnd returns a function that performs a logical AND of the given asserts.
+func assertsAnd[
+	T interface {
+		client.Object
+	},
+](
+	asserts ...func(T) bool,
+) func(objToMatch T) bool {
+	return func(objToMatch T) bool {
+		for _, f := range asserts {
+			if !f(objToMatch) {
+				return false
+			}
+		}
+
+		return true
+	}
+}

--- a/test/envtest/asserts_conditions.go
+++ b/test/envtest/asserts_conditions.go
@@ -33,7 +33,7 @@ func conditionsAreSetWhenReferencedControlPlaneIsMissing[
 	}
 }
 
-func conditionProgrammedIsSetToTrue[
+func conditionProgrammedIsSetToTrueAndCPRefIsKonnectID[
 	T interface {
 		client.Object
 		k8sutils.ConditionsAware
@@ -48,6 +48,18 @@ func conditionProgrammedIsSetToTrue[
 		if obj.GetControlPlaneRef().Type != commonv1alpha1.ControlPlaneRefKonnectID {
 			return false
 		}
-		return obj.GetKonnectID() == id && k8sutils.IsProgrammed(obj)
+		if obj.GetKonnectID() != id {
+			return false
+		}
+
+		return k8sutils.IsProgrammed(obj)
+	}
+}
+
+func objectHasConditionProgrammedSetToTrue[
+	T k8sutils.ConditionsAware,
+]() func(T) bool {
+	return func(obj T) bool {
+		return k8sutils.IsProgrammed(obj)
 	}
 }

--- a/test/envtest/asserts_cpref.go
+++ b/test/envtest/asserts_cpref.go
@@ -1,0 +1,15 @@
+package envtest
+
+import (
+	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
+)
+
+func objectHasCPRefKonnectID[
+	T interface {
+		GetControlPlaneRef() *commonv1alpha1.ControlPlaneRef
+	},
+]() func(T) bool {
+	return func(obj T) bool {
+		return obj.GetControlPlaneRef().Type == commonv1alpha1.ControlPlaneRefKonnectID
+	}
+}

--- a/test/envtest/asserts_objectmeta.go
+++ b/test/envtest/asserts_objectmeta.go
@@ -1,0 +1,13 @@
+package envtest
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func objectMatchesName[
+	T client.Object,
+](objToMatch T) func(T) bool {
+	return func(obj T) bool {
+		return obj.GetName() == objToMatch.GetName()
+	}
+}

--- a/test/envtest/konnect_entities_kongcacertificate_test.go
+++ b/test/envtest/konnect_entities_kongcacertificate_test.go
@@ -259,7 +259,7 @@ func TestKongCACertificate(t *testing.T) {
 		eventuallyAssertSDKExpectations(t, factory.SDK.CACertificatesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrue(created, id),
+		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
 			fmt.Sprintf("CACertificate didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")

--- a/test/envtest/konnect_entities_kongcertificate_test.go
+++ b/test/envtest/konnect_entities_kongcertificate_test.go
@@ -288,7 +288,7 @@ func TestKongCertificate(t *testing.T) {
 		eventuallyAssertSDKExpectations(t, factory.SDK.CACertificatesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrue(created, id),
+		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
 			fmt.Sprintf("Certificate didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")

--- a/test/envtest/konnect_entities_kongconsumergroup_test.go
+++ b/test/envtest/konnect_entities_kongconsumergroup_test.go
@@ -276,7 +276,7 @@ func TestKongConsumerGroup(t *testing.T) {
 		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrue(created, id),
+		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
 			fmt.Sprintf("ConsumerGroup didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")

--- a/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
+++ b/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
@@ -174,7 +174,7 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 		eventuallyAssertSDKExpectations(t, factory.SDK.DataPlaneCertificatesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrue(created, id),
+		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
 			fmt.Sprintf("DataPlaneClientCertificate didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")

--- a/test/envtest/konnect_entities_kongkey_test.go
+++ b/test/envtest/konnect_entities_kongkey_test.go
@@ -340,7 +340,7 @@ func TestKongKey(t *testing.T) {
 		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrue(created, id),
+		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
 			fmt.Sprintf("Key didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")

--- a/test/envtest/konnect_entities_kongkeyset_test.go
+++ b/test/envtest/konnect_entities_kongkeyset_test.go
@@ -241,7 +241,7 @@ func TestKongKeySet(t *testing.T) {
 		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrue(created, id),
+		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
 			fmt.Sprintf("Key didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")

--- a/test/envtest/konnect_entities_kongservice_test.go
+++ b/test/envtest/konnect_entities_kongservice_test.go
@@ -313,7 +313,7 @@ func TestKongService(t *testing.T) {
 		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrue(created, id),
+		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
 			fmt.Sprintf("KongService didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")

--- a/test/envtest/konnect_entities_kongupstream_test.go
+++ b/test/envtest/konnect_entities_kongupstream_test.go
@@ -216,7 +216,7 @@ func TestKongUpstream(t *testing.T) {
 		eventuallyAssertSDKExpectations(t, factory.SDK.UpstreamsSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrue(created, id),
+		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
 			fmt.Sprintf("KongUpstream didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes failed assertions like: https://github.com/Kong/gateway-operator/actions/runs/13489962603/job/37686539607#step:5:1526

```
    konnect_entities_kongconsumer_test.go:617: FAIL:	CreateBasicAuthWithConsumer(string,mock.argumentMatcher)
        		at: [/home/runner/work/gateway-operator/gateway-operator/controller/konnect/ops/sdk/mocks/zz_generated.credentialbasicauth_mock.go:72 /home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_kongconsumer_test.go:567]
    konnect_entities_kongconsumer_test.go:617: FAIL: 0 out of 1 expectation(s) were met.
        	The code you are testing needs to make 1 more call(s).
        	at: [/home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_kongconsumer_test.go:617 /opt/hostedtoolcache/go/1.24.0/x64/src/runtime/asm_amd64.s:1700]
    konnect_entities_kongconsumer_test.go:617: FAIL:	CreateBasicAuthWithConsumer(string,mock.argumentMatcher)
        		at: [/home/runner/work/gateway-operator/gateway-operator/controller/konnect/ops/sdk/mocks/zz_generated.credentialbasicauth_mock.go:72 /home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_kongconsumer_test.go:567]
    konnect_entities_kongconsumer_test.go:617: FAIL: 0 out of 1 expectation(s) were met.
        	The code you are testing needs to make 1 more call(s).
        	at: [/home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_kongconsumer_test.go:617 /opt/hostedtoolcache/go/1.24.0/x64/src/runtime/asm_amd64.s:1700]
```

The reason for this is that using `AssertExpectations()` checks the expected calls on the mocked SDK and marks the test as failed even if it fails once.

This PR fixes it by first waiting for the observable event (e.g. `KongConsumer` getting programmed) and only asserts the expected calls after. In some cases this is not necessary (the test doesn't check this) so these calls were removed in this PR.

NOTE: generated mocks do call `AssertExpectations` via `t.Cleanup()` anyway (e.g. https://github.com/Kong/gateway-operator/blob/5d0b4b78c138f606b1eb5116e2649f35cf780bdb/controller/konnect/ops/sdk/mocks/zz_generated.controlplane_mock.go#L334) so if not needed, do not call this in your test.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
