### PR TITLE
tests: make watch in envtest type safe

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -54,6 +54,8 @@ linters-settings:
         alias: ${1}${2}
       - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
         alias: metav1
+      - pkg: k8s.io/apimachinery/pkg/watch
+        alias: apiwatch
 
       - pkg: sigs.k8s.io/gateway-api/apis/(v[\w\d]+)
         alias: gateway${1}

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ab0c168ea1c7 # Version is auto-updated by the generating script.
+  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?0c2aa5d85cad # Version is auto-updated by the generating script.

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/terratest v0.48.2
-	github.com/kong/kubernetes-configuration v1.1.1-0.20250220111603-ab0c168ea1c7
+	github.com/kong/kubernetes-configuration v1.1.1-0.20250224133355-0c2aa5d85cad
 	github.com/kong/kubernetes-telemetry v0.1.8
 	github.com/kong/kubernetes-testing-framework v0.47.2
 	github.com/kong/semver/v4 v4.0.1

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IX
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/kong/go-kong v0.63.0 h1:8ECLgkgDqON61qCMq/M0gTwZKYxg55Oy692dRDOOBiU=
 github.com/kong/go-kong v0.63.0/go.mod h1:ma9GWnhkxtrXZlLFfED955HjVzmUojYEHet3lm+PDik=
-github.com/kong/kubernetes-configuration v1.1.1-0.20250220111603-ab0c168ea1c7 h1:/1bHPk0kszefYZiLSvm8TIeiZfD1xZoORZhfx1FbqAE=
-github.com/kong/kubernetes-configuration v1.1.1-0.20250220111603-ab0c168ea1c7/go.mod h1:MSXL0ljNNW8OPiFHTwh1MfhfbyD76c7WPRTzKIzKQKY=
+github.com/kong/kubernetes-configuration v1.1.1-0.20250224133355-0c2aa5d85cad h1:T309QVfBpDbdHl7XNe4XKd4LaNQ7fl3JgS+AmUXAbfA=
+github.com/kong/kubernetes-configuration v1.1.1-0.20250224133355-0c2aa5d85cad/go.mod h1:ktUCDIijOS9qfjTLfGXMEJmQPQrqCU/0so88d3/Dj5Q=
 github.com/kong/kubernetes-telemetry v0.1.8 h1:nbtUmXW9xkzRO7dgvrgVrJZiRksATk4XHrqX+78g/5k=
 github.com/kong/kubernetes-telemetry v0.1.8/go.mod h1:ZEQY/4DddKoe5XA7UTOIbdI/4d6ZRcrzh2ezRxnuyl0=
 github.com/kong/kubernetes-testing-framework v0.47.2 h1:+2Z9anTpbV/hwNeN+NFQz53BMU+g3QJydkweBp3tULo=

--- a/test/envtest/kongconsumercredential_acl_test.go
+++ b/test/envtest/kongconsumercredential_acl_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
@@ -211,7 +211,7 @@ func TestKongConsumerCredential_ACL(t *testing.T) {
 		created := deploy.KongCredentialACL(t, ctx, clientNamespaced, consumer.Name, aclGroup)
 
 		t.Log("Waiting for KongCredentialACL to be programmed")
-		watchFor(t, ctx, w, watch.Modified, func(k *configurationv1alpha1.KongCredentialACL) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongCredentialACL) bool {
 			return k.GetName() == created.GetName() && k8sutils.IsProgrammed(k)
 		}, "KongCredentialACL's Programmed condition should be true eventually")
 

--- a/test/envtest/kongconsumercredential_apikey_test.go
+++ b/test/envtest/kongconsumercredential_apikey_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
@@ -211,7 +211,7 @@ func TestKongConsumerCredential_APIKey(t *testing.T) {
 		created := deploy.KongCredentialAPIKey(t, ctx, clientNamespaced, consumer.Name)
 
 		t.Log("Waiting for KongCredentialAPIKey to be programmed")
-		watchFor(t, ctx, w, watch.Modified, func(k *configurationv1alpha1.KongCredentialAPIKey) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongCredentialAPIKey) bool {
 			return k.GetName() == created.GetName() && k8sutils.IsProgrammed(k)
 		}, "KongCredentialAPIKey's Programmed condition should be true eventually")
 

--- a/test/envtest/kongconsumercredential_basicauth_test.go
+++ b/test/envtest/kongconsumercredential_basicauth_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
@@ -213,7 +213,7 @@ func TestKongConsumerCredential_BasicAuth(t *testing.T) {
 		created := deploy.KongCredentialBasicAuth(t, ctx, clientNamespaced, consumer.Name, "username", "password")
 
 		t.Log("Waiting for KongCredentialBasicAuth to be programmed")
-		watchFor(t, ctx, w, watch.Modified, func(k *configurationv1alpha1.KongCredentialBasicAuth) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongCredentialBasicAuth) bool {
 			return k.GetName() == created.GetName() && k8sutils.IsProgrammed(k)
 		}, "KongCredentialBasicAuth's Programmed condition should be true eventually")
 

--- a/test/envtest/kongconsumercredential_hmac_test.go
+++ b/test/envtest/kongconsumercredential_hmac_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
@@ -209,7 +209,7 @@ func TestKongConsumerCredential_HMAC(t *testing.T) {
 		created := deploy.KongCredentialHMAC(t, ctx, clientNamespaced, consumer.Name)
 
 		t.Log("Waiting for KongCredentialHMAC to be programmed")
-		watchFor(t, ctx, w, watch.Modified, func(k *configurationv1alpha1.KongCredentialHMAC) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongCredentialHMAC) bool {
 			return k.GetName() == created.GetName() && k8sutils.IsProgrammed(k)
 		}, "KongCredentialHMAC's Programmed condition should be true eventually")
 

--- a/test/envtest/kongconsumercredential_jwt_test.go
+++ b/test/envtest/kongconsumercredential_jwt_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
@@ -212,7 +212,7 @@ func TestKongConsumerCredential_JWT(t *testing.T) {
 		created := deploy.KongCredentialJWT(t, ctx, clientNamespaced, consumer.Name)
 
 		t.Log("Waiting for KongCredentialJWT to be programmed")
-		watchFor(t, ctx, w, watch.Modified, func(k *configurationv1alpha1.KongCredentialJWT) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongCredentialJWT) bool {
 			return k.GetName() == created.GetName() && k8sutils.IsProgrammed(k)
 		}, "KongCredentialJWT's Programmed condition should be true eventually")
 

--- a/test/envtest/kongpluginbinding_managed_test.go
+++ b/test/envtest/kongpluginbinding_managed_test.go
@@ -14,7 +14,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -119,7 +119,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
 
 		t.Logf("waiting for KongPluginBinding to be created")
-		kongPluginBinding := watchFor(t, ctx, wKongPluginBinding, watch.Added,
+		kongPluginBinding := watchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				targets := kpb.Spec.Targets
 				return targets.ServiceReference != nil &&
@@ -132,7 +132,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			"checking that managed KongPlugin %s gets plugin-in-use finalizer added",
 			client.ObjectKeyFromObject(rateLimitingkongPlugin),
 		)
-		_ = watchFor(t, ctx, wKongPlugin, watch.Modified,
+		_ = watchFor(t, ctx, wKongPlugin, apiwatch.Modified,
 			func(kp *configurationv1.KongPlugin) bool {
 				return kp.Name == rateLimitingkongPlugin.Name &&
 					controllerutil.ContainsFinalizer(kp, consts.PluginInUseFinalizer)
@@ -142,7 +142,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 
 		t.Logf("delete managed kongPluginBinding %s, then check it gets recreated", client.ObjectKeyFromObject(kongPluginBinding))
 		require.NoError(t, clientNamespaced.Delete(ctx, kongPluginBinding))
-		kongPluginBinding = watchFor(t, ctx, wKongPluginBinding, watch.Added,
+		kongPluginBinding = watchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				svcRef := kpb.Spec.Targets.ServiceReference
 				return svcRef != nil &&
@@ -178,7 +178,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		wKongPlugin = setupWatch[configurationv1.KongPluginList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
 		delete(kongService.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongService))
-		_ = watchFor(t, ctx, wKongPlugin, watch.Modified,
+		_ = watchFor(t, ctx, wKongPlugin, apiwatch.Modified,
 			func(kp *configurationv1.KongPlugin) bool {
 				return kp.Name == rateLimitingkongPlugin.Name &&
 					!controllerutil.ContainsFinalizer(kp, consts.PluginInUseFinalizer)
@@ -224,7 +224,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		updateKongRouteStatusWithProgrammed(t, ctx, clientNamespaced, kongRoute, routeID, cp.GetKonnectStatus().GetKonnectID(), serviceID)
 
 		t.Logf("waiting for KongPluginBinding to be created")
-		kongPluginBinding := watchFor(t, ctx, wKongPluginBinding, watch.Added,
+		kongPluginBinding := watchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				rRef := kpb.Spec.Targets.RouteReference
 				return rRef != nil &&
@@ -237,7 +237,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			"checking that managed KongPlugin %s gets plugin-in-use finalizer added",
 			client.ObjectKeyFromObject(rateLimitingkongPlugin),
 		)
-		_ = watchFor(t, ctx, wKongPlugin, watch.Modified,
+		_ = watchFor(t, ctx, wKongPlugin, apiwatch.Modified,
 			func(kp *configurationv1.KongPlugin) bool {
 				return kp.Name == rateLimitingkongPlugin.Name &&
 					controllerutil.ContainsFinalizer(kp, consts.PluginInUseFinalizer)
@@ -247,7 +247,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 
 		t.Logf("delete managed kongPluginBinding %s, then check it gets recreated", client.ObjectKeyFromObject(kongPluginBinding))
 		require.NoError(t, clientNamespaced.Delete(ctx, kongPluginBinding))
-		kongPluginBinding = watchFor(t, ctx, wKongPluginBinding, watch.Added,
+		kongPluginBinding = watchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				rRef := kpb.Spec.Targets.RouteReference
 				return rRef != nil &&
@@ -282,7 +282,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		)
 		delete(kongRoute.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongRoute))
-		_ = watchFor(t, ctx, wKongPlugin, watch.Modified,
+		_ = watchFor(t, ctx, wKongPlugin, apiwatch.Modified,
 			func(kp *configurationv1.KongPlugin) bool {
 				return kp.Name == rateLimitingkongPlugin.Name &&
 					!controllerutil.ContainsFinalizer(kp, consts.PluginInUseFinalizer)
@@ -330,7 +330,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 
 		t.Logf("waiting for 2 KongPluginBindings to be created")
 		var kpbRoute, kpbService *configurationv1alpha1.KongPluginBinding
-		watchFor(t, ctx, wKongPluginBinding, watch.Added,
+		watchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				if kpb.Spec.PluginReference.Name != rateLimitingkongPlugin.Name {
 					return false
@@ -354,7 +354,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			"checking that managed KongPlugin %s gets plugin-in-use finalizer added",
 			client.ObjectKeyFromObject(rateLimitingkongPlugin),
 		)
-		_ = watchFor(t, ctx, wKongPlugin, watch.Modified,
+		_ = watchFor(t, ctx, wKongPlugin, apiwatch.Modified,
 			func(kp *configurationv1.KongPlugin) bool {
 				return kp.Name == rateLimitingkongPlugin.Name &&
 					controllerutil.ContainsFinalizer(kp, consts.PluginInUseFinalizer)
@@ -365,7 +365,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		deleteKongPluginBinding(t, ctx, clientNamespaced, kpbRoute, kongRoute)
 		deleteKongPluginBinding(t, ctx, clientNamespaced, kpbService, kongService)
 
-		watchFor(t, ctx, wKongPluginBinding, watch.Added,
+		watchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				if kpb.Spec.PluginReference.Name != rateLimitingkongPlugin.Name {
 					return false
@@ -465,7 +465,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 
 		t.Logf("waiting for 2 KongPluginBindings to be created")
 		var kpbRoute, kpbService *configurationv1alpha1.KongPluginBinding
-		watchFor(t, ctx, wKongPluginBinding, watch.Added,
+		watchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				if kpb.Spec.PluginReference.Name != rateLimitingkongPlugin.Name {
 					return false
@@ -493,7 +493,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			"checking that managed KongPlugin %s gets plugin-in-use finalizer added",
 			client.ObjectKeyFromObject(rateLimitingkongPlugin),
 		)
-		_ = watchFor(t, ctx, wKongPlugin, watch.Modified,
+		_ = watchFor(t, ctx, wKongPlugin, apiwatch.Modified,
 			func(kp *configurationv1.KongPlugin) bool {
 				return kp.Name == rateLimitingkongPlugin.Name &&
 					controllerutil.ContainsFinalizer(kp, consts.PluginInUseFinalizer)
@@ -504,7 +504,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		deleteKongPluginBinding(t, ctx, clientNamespaced, kpbRoute, kongRoute)
 		deleteKongPluginBinding(t, ctx, clientNamespaced, kpbService, kongService)
 
-		watchFor(t, ctx, wKongPluginBinding, watch.Added,
+		watchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				if kpb.Spec.PluginReference.Name != rateLimitingkongPlugin.Name {
 					return false
@@ -581,7 +581,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		delete(kongService.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongService))
 
-		watchFor(t, ctx, wKongPluginBinding, watch.Added,
+		watchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				if kpb.Spec.PluginReference.Name != rateLimitingkongPlugin.Name {
 					return false
@@ -613,7 +613,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		delete(kongConsumer.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongConsumer))
 
-		watchFor(t, ctx, wKongPluginBinding, watch.Deleted,
+		watchFor(t, ctx, wKongPluginBinding, apiwatch.Deleted,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				if kpb.Spec.PluginReference.Name != rateLimitingkongPlugin.Name {
 					return false
@@ -664,7 +664,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 
 		t.Logf("waiting for 2 KongPluginBindings to be created")
 		var kpbRoute, kpbService *configurationv1alpha1.KongPluginBinding
-		watchFor(t, ctx, wKongPluginBinding, watch.Added,
+		watchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				if kpb.Spec.PluginReference.Name != rateLimitingkongPlugin.Name {
 					return false
@@ -692,7 +692,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			"checking that managed KongPlugin %s gets plugin-in-use finalizer added",
 			client.ObjectKeyFromObject(rateLimitingkongPlugin),
 		)
-		_ = watchFor(t, ctx, wKongPlugin, watch.Modified,
+		_ = watchFor(t, ctx, wKongPlugin, apiwatch.Modified,
 			func(kp *configurationv1.KongPlugin) bool {
 				return kp.Name == rateLimitingkongPlugin.Name &&
 					controllerutil.ContainsFinalizer(kp, consts.PluginInUseFinalizer)
@@ -703,7 +703,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		deleteKongPluginBinding(t, ctx, clientNamespaced, kpbRoute, kongRoute)
 		deleteKongPluginBinding(t, ctx, clientNamespaced, kpbService, kongService)
 
-		watchFor(t, ctx, wKongPluginBinding, watch.Added,
+		watchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				if kpb.Spec.PluginReference.Name != rateLimitingkongPlugin.Name {
 					return false
@@ -780,7 +780,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		delete(kongService.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongService))
 
-		watchFor(t, ctx, wKongPluginBinding, watch.Added,
+		watchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				if kpb.Spec.PluginReference.Name != rateLimitingkongPlugin.Name {
 					return false
@@ -812,7 +812,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		delete(kongConsumerGroup.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongConsumerGroup))
 
-		watchFor(t, ctx, wKongPluginBinding, watch.Deleted,
+		watchFor(t, ctx, wKongPluginBinding, apiwatch.Deleted,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				if kpb.Spec.PluginReference.Name != rateLimitingkongPlugin.Name {
 					return false

--- a/test/envtest/kongplugincleanupfinalizer_test.go
+++ b/test/envtest/kongplugincleanupfinalizer_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
@@ -63,7 +63,7 @@ func TestKongPluginFinalizer(t *testing.T) {
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
 		)
 
-		_ = watchFor(t, ctx, wKongService, watch.Modified,
+		_ = watchFor(t, ctx, wKongService, apiwatch.Modified,
 			func(svc *configurationv1alpha1.KongService) bool {
 				return svc.Name == kongService.Name &&
 					slices.Contains(svc.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
@@ -74,7 +74,7 @@ func TestKongPluginFinalizer(t *testing.T) {
 		old := kongService.DeepCopy()
 		kongService.Annotations = nil
 		require.NoError(t, clientNamespaced.Patch(ctx, kongService, client.MergeFrom(old)))
-		_ = watchFor(t, ctx, wKongService, watch.Modified,
+		_ = watchFor(t, ctx, wKongService, apiwatch.Modified,
 			func(svc *configurationv1alpha1.KongService) bool {
 				return svc.Name == kongService.Name &&
 					!slices.Contains(svc.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
@@ -97,7 +97,7 @@ func TestKongPluginFinalizer(t *testing.T) {
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
 		)
 
-		_ = watchFor(t, ctx, wKongRoute, watch.Modified,
+		_ = watchFor(t, ctx, wKongRoute, apiwatch.Modified,
 			func(route *configurationv1alpha1.KongRoute) bool {
 				return route.Name == kongRoute.Name &&
 					slices.Contains(route.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
@@ -108,7 +108,7 @@ func TestKongPluginFinalizer(t *testing.T) {
 		old := kongRoute.DeepCopy()
 		kongRoute.Annotations = nil
 		require.NoError(t, clientNamespaced.Patch(ctx, kongRoute, client.MergeFrom(old)))
-		_ = watchFor(t, ctx, wKongRoute, watch.Modified,
+		_ = watchFor(t, ctx, wKongRoute, apiwatch.Modified,
 			func(route *configurationv1alpha1.KongRoute) bool {
 				return route.Name == kongRoute.Name &&
 					!slices.Contains(route.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
@@ -129,7 +129,7 @@ func TestKongPluginFinalizer(t *testing.T) {
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
 		)
 
-		_ = watchFor(t, ctx, wKongConsumer, watch.Modified,
+		_ = watchFor(t, ctx, wKongConsumer, apiwatch.Modified,
 			func(c *configurationv1.KongConsumer) bool {
 				return c.Name == kongConsumer.Name &&
 					slices.Contains(c.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
@@ -140,7 +140,7 @@ func TestKongPluginFinalizer(t *testing.T) {
 		old := kongConsumer.DeepCopy()
 		kongConsumer.Annotations = nil
 		require.NoError(t, clientNamespaced.Patch(ctx, kongConsumer, client.MergeFrom(old)))
-		_ = watchFor(t, ctx, wKongConsumer, watch.Modified,
+		_ = watchFor(t, ctx, wKongConsumer, apiwatch.Modified,
 			func(c *configurationv1.KongConsumer) bool {
 				return c.Name == kongConsumer.Name &&
 					!slices.Contains(c.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
@@ -161,7 +161,7 @@ func TestKongPluginFinalizer(t *testing.T) {
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
 		)
 
-		_ = watchFor(t, ctx, wKongConsumerGroup, watch.Modified,
+		_ = watchFor(t, ctx, wKongConsumerGroup, apiwatch.Modified,
 			func(cg *configurationv1beta1.KongConsumerGroup) bool {
 				return cg.Name == kongConsumerGroup.Name &&
 					slices.Contains(cg.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
@@ -172,7 +172,7 @@ func TestKongPluginFinalizer(t *testing.T) {
 		old := kongConsumerGroup.DeepCopy()
 		kongConsumerGroup.Annotations = nil
 		require.NoError(t, clientNamespaced.Patch(ctx, kongConsumerGroup, client.MergeFrom(old)))
-		_ = watchFor(t, ctx, wKongConsumerGroup, watch.Modified,
+		_ = watchFor(t, ctx, wKongConsumerGroup, apiwatch.Modified,
 			func(cg *configurationv1beta1.KongConsumerGroup) bool {
 				return cg.Name == kongConsumerGroup.Name &&
 					!slices.Contains(cg.GetFinalizers(), consts.CleanupPluginBindingFinalizer)

--- a/test/envtest/konnect_entities_kongcacertificate_test.go
+++ b/test/envtest/konnect_entities_kongcacertificate_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
@@ -80,7 +80,7 @@ func TestKongCACertificate(t *testing.T) {
 	)
 
 	t.Log("Waiting for KongCACertificate to be programmed")
-	watchFor(t, ctx, w, watch.Modified, func(c *configurationv1alpha1.KongCACertificate) bool {
+	watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCACertificate) bool {
 		if c.GetName() != createdCert.GetName() {
 			return false
 		}
@@ -171,7 +171,7 @@ func TestKongCACertificate(t *testing.T) {
 		)
 
 		t.Log("Watching for KongCACertificates to verify the created KongCACertificate gets programmed")
-		watchFor(t, ctx, w, watch.Modified, func(c *configurationv1alpha1.KongCACertificate) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCACertificate) bool {
 			return c.GetKonnectID() == certID && k8sutils.IsProgrammed(c)
 		}, "KongCACertificate should be programmed and have ID in status after handling conflict")
 
@@ -201,7 +201,7 @@ func TestKongCACertificate(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongCACertificate to be programmed")
-		watchFor(t, ctx, w, watch.Modified, func(c *configurationv1alpha1.KongCACertificate) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCACertificate) bool {
 			if c.GetName() != createdCert.GetName() {
 				return false
 			}
@@ -258,14 +258,14 @@ func TestKongCACertificate(t *testing.T) {
 		eventuallyAssertSDKExpectations(t, factory.SDK.CACertificatesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
+		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
 			fmt.Sprintf("CACertificate didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
 		t.Log("Waiting for CACert to be get Programmed and ControlPlaneRefValid conditions with status=False")
-		watchFor(t, ctx, w, watch.Modified,
+		watchFor(t, ctx, w, apiwatch.Modified,
 			conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			"KongCACertificate didn't get Programmed and/or ControlPlaneRefValid status condition set to False",
 		)

--- a/test/envtest/konnect_entities_kongcertificate_test.go
+++ b/test/envtest/konnect_entities_kongcertificate_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
@@ -93,7 +93,7 @@ func TestKongCertificate(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongCertificate to be programmed")
-		watchFor(t, ctx, w, watch.Modified, func(c *configurationv1alpha1.KongCertificate) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCertificate) bool {
 			if c.GetName() != createdCert.GetName() {
 				return false
 			}
@@ -166,7 +166,7 @@ func TestKongCertificate(t *testing.T) {
 			)
 
 		t.Log("Watching for KongCertificates to verify the created KongCertificate gets programmed")
-		watchFor(t, ctx, w, watch.Modified, func(c *configurationv1alpha1.KongCertificate) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCertificate) bool {
 			if c.GetName() != createdCert.GetName() {
 				return false
 			}
@@ -221,7 +221,7 @@ func TestKongCertificate(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongCertificate to be programmed")
-		watchFor(t, ctx, w, watch.Modified, func(c *configurationv1alpha1.KongCertificate) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCertificate) bool {
 			if c.GetName() != createdCert.GetName() {
 				return false
 			}
@@ -287,14 +287,14 @@ func TestKongCertificate(t *testing.T) {
 		eventuallyAssertSDKExpectations(t, factory.SDK.CACertificatesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
+		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
 			fmt.Sprintf("Certificate didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
 		t.Log("Waiting for CACert to be get Programmed and ControlPlaneRefValid conditions with status=False")
-		watchFor(t, ctx, w, watch.Modified,
+		watchFor(t, ctx, w, apiwatch.Modified,
 			conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			"KongCACertificate didn't get Programmed and/or ControlPlaneRefValid status condition set to False",
 		)

--- a/test/envtest/konnect_entities_kongconsumergroup_test.go
+++ b/test/envtest/konnect_entities_kongconsumergroup_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
@@ -88,7 +88,7 @@ func TestKongConsumerGroup(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongConsumerGroup to be programmed")
-		watchFor(t, ctx, cWatch, watch.Modified, func(c *configurationv1beta1.KongConsumerGroup) bool {
+		watchFor(t, ctx, cWatch, apiwatch.Modified, func(c *configurationv1beta1.KongConsumerGroup) bool {
 			if c.GetName() != cg.GetName() {
 				return false
 			}
@@ -182,7 +182,7 @@ func TestKongConsumerGroup(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongConsumerGroup to be programmed")
-		watchFor(t, ctx, cWatch, watch.Modified, func(c *configurationv1beta1.KongConsumerGroup) bool {
+		watchFor(t, ctx, cWatch, apiwatch.Modified, func(c *configurationv1beta1.KongConsumerGroup) bool {
 			return c.GetKonnectID() == cgID && k8sutils.IsProgrammed(c)
 		}, "KongConsumerGroup's Programmed condition should be true eventually")
 
@@ -218,7 +218,7 @@ func TestKongConsumerGroup(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongConsumerGroup to be programmed")
-		watchFor(t, ctx, cWatch, watch.Modified, func(c *configurationv1beta1.KongConsumerGroup) bool {
+		watchFor(t, ctx, cWatch, apiwatch.Modified, func(c *configurationv1beta1.KongConsumerGroup) bool {
 			if c.GetName() != cg.GetName() {
 				return false
 			}
@@ -275,14 +275,14 @@ func TestKongConsumerGroup(t *testing.T) {
 		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
+		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
 			fmt.Sprintf("ConsumerGroup didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
 		t.Log("Waiting for KongConsumerGroup to be get Programmed and ControlPlaneRefValid conditions with status=False")
-		watchFor(t, ctx, w, watch.Modified,
+		watchFor(t, ctx, w, apiwatch.Modified,
 			conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			"KongConsumerGroup didn't get Programmed and/or ControlPlaneRefValid status condition set to False",
 		)

--- a/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
+++ b/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
@@ -73,7 +73,7 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 	)
 
 	t.Log("Waiting for KongDataPlaneClientCertificate to be programmed")
-	watchFor(t, ctx, w, watch.Modified, func(c *configurationv1alpha1.KongDataPlaneClientCertificate) bool {
+	watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongDataPlaneClientCertificate) bool {
 		if c.GetName() != createdCert.GetName() {
 			return false
 		}
@@ -122,7 +122,7 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongDataPlaneClientCertificate to be programmed")
-		watchFor(t, ctx, w, watch.Modified, func(c *configurationv1alpha1.KongDataPlaneClientCertificate) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongDataPlaneClientCertificate) bool {
 			if c.GetName() != createdCert.GetName() {
 				return false
 			}
@@ -173,14 +173,14 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 		eventuallyAssertSDKExpectations(t, factory.SDK.DataPlaneCertificatesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
+		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
 			fmt.Sprintf("DataPlaneClientCertificate didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
 		t.Log("Waiting for DataPlaneClientCertificate to be get Programmed and ControlPlaneRefValid conditions with status=False")
-		watchFor(t, ctx, w, watch.Modified,
+		watchFor(t, ctx, w, apiwatch.Modified,
 			conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			"KongDataPlaneClientCertificate didn't get Programmed and/or ControlPlaneRefValid status condition set to False",
 		)

--- a/test/envtest/konnect_entities_kongkey_test.go
+++ b/test/envtest/konnect_entities_kongkey_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
@@ -81,7 +81,7 @@ func TestKongKey(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongKey to be programmed")
-		watchFor(t, ctx, w, watch.Modified, func(c *configurationv1alpha1.KongKey) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongKey) bool {
 			if c.GetName() != createdKey.GetName() {
 				return false
 			}
@@ -156,7 +156,7 @@ func TestKongKey(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongKey to be programmed")
-		watchFor(t, ctx, w, watch.Modified, func(k *configurationv1alpha1.KongKey) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongKey) bool {
 			if k.GetName() != createdKey.GetName() {
 				return false
 			}
@@ -185,7 +185,7 @@ func TestKongKey(t *testing.T) {
 		)
 
 		t.Log("Waiting for KeySetRefValid condition to be false")
-		watchFor(t, ctx, w, watch.Modified, func(c *configurationv1alpha1.KongKey) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongKey) bool {
 			if c.GetName() != createdKey.GetName() {
 				return false
 			}
@@ -215,7 +215,7 @@ func TestKongKey(t *testing.T) {
 		updateKongKeySetStatusWithProgrammed(t, ctx, clientNamespaced, keySet, keySetID, cp.GetKonnectStatus().GetKonnectID())
 
 		t.Log("Waiting for KongKey to be programmed and associated with KongKeySet")
-		watchFor(t, ctx, w, watch.Modified, func(c *configurationv1alpha1.KongKey) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongKey) bool {
 			if c.GetName() != createdKey.GetName() {
 				return false
 			}
@@ -251,7 +251,7 @@ func TestKongKey(t *testing.T) {
 		require.NoError(t, clientNamespaced.Patch(ctx, keyToPatch, client.MergeFrom(createdKey)))
 
 		t.Log("Waiting for KongKey to be deattached from KongKeySet")
-		watchFor(t, ctx, w, watch.Modified, func(c *configurationv1alpha1.KongKey) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongKey) bool {
 			if c.GetName() != createdKey.GetName() {
 				return false
 			}
@@ -283,7 +283,7 @@ func TestKongKey(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongKey to be programmed")
-		watchFor(t, ctx, w, watch.Modified, func(c *configurationv1alpha1.KongKey) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongKey) bool {
 			if c.GetName() != createdKey.GetName() {
 				return false
 			}
@@ -339,14 +339,14 @@ func TestKongKey(t *testing.T) {
 		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
+		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
 			fmt.Sprintf("Key didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
 		t.Log("Waiting for KongKey to be get Programmed and ControlPlaneRefValid conditions with status=False")
-		watchFor(t, ctx, w, watch.Modified,
+		watchFor(t, ctx, w, apiwatch.Modified,
 			conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			"KongKey didn't get Programmed and/or ControlPlaneRefValid status condition set to False",
 		)

--- a/test/envtest/konnect_entities_kongkeyset_test.go
+++ b/test/envtest/konnect_entities_kongkeyset_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
@@ -78,7 +78,7 @@ func TestKongKeySet(t *testing.T) {
 	)
 
 	t.Log("Waiting for KongKeySet to be programmed")
-	watchFor(t, ctx, w, watch.Modified, func(c *configurationv1alpha1.KongKeySet) bool {
+	watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongKeySet) bool {
 		if c.GetName() != createdKeySet.GetName() {
 			return false
 		}
@@ -157,7 +157,7 @@ func TestKongKeySet(t *testing.T) {
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 		)
 		t.Log("Watching for KeySet to verify the created KeySet programmed")
-		watchFor(t, ctx, w, watch.Modified, func(c *configurationv1alpha1.KongKeySet) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongKeySet) bool {
 			return c.GetKonnectID() == keySetID && k8sutils.IsProgrammed(c)
 		}, "KeySet should be programmed and have ID in status after handling conflict")
 
@@ -184,7 +184,7 @@ func TestKongKeySet(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongKeySet to be programmed")
-		watchFor(t, ctx, w, watch.Modified, func(c *configurationv1alpha1.KongKeySet) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongKeySet) bool {
 			if c.GetName() != createdKeySet.GetName() {
 				return false
 			}
@@ -240,14 +240,14 @@ func TestKongKeySet(t *testing.T) {
 		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
+		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
 			fmt.Sprintf("Key didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
 		t.Log("Waiting for KongKeySet to be get Programmed and ControlPlaneRefValid conditions with status=False")
-		watchFor(t, ctx, w, watch.Modified,
+		watchFor(t, ctx, w, apiwatch.Modified,
 			conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			"KongKeySet didn't get Programmed and/or ControlPlaneRefValid status condition set to False",
 		)

--- a/test/envtest/konnect_entities_kongroute_test.go
+++ b/test/envtest/konnect_entities_kongroute_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
@@ -87,7 +87,7 @@ func TestKongRoute(t *testing.T) {
 		)
 
 		t.Log("Waiting for Route to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, func(r *configurationv1alpha1.KongRoute) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(r *configurationv1alpha1.KongRoute) bool {
 			if r.GetName() != createdRoute.GetName() {
 				return false
 			}

--- a/test/envtest/konnect_entities_kongservice_test.go
+++ b/test/envtest/konnect_entities_kongservice_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
@@ -97,7 +97,7 @@ func TestKongService(t *testing.T) {
 		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for Service to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, func(kt *configurationv1alpha1.KongService) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(kt *configurationv1alpha1.KongService) bool {
 			return kt.GetKonnectID() == serviceID && k8sutils.IsProgrammed(kt)
 		}, "KongService didn't get Programmed status condition or didn't get the correct (service-12345) Konnect ID assigned")
 
@@ -185,7 +185,7 @@ func TestKongService(t *testing.T) {
 		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for Service to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, func(kt *configurationv1alpha1.KongService) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(kt *configurationv1alpha1.KongService) bool {
 			if kt.GetName() != createdService.GetName() {
 				return false
 			}
@@ -252,7 +252,7 @@ func TestKongService(t *testing.T) {
 		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for Service to get the Programmed condition set to False")
-		watchFor(t, ctx, w, watch.Modified, func(kt *configurationv1alpha1.KongService) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(kt *configurationv1alpha1.KongService) bool {
 			if kt.GetName() != createdService.GetName() {
 				return false
 			}
@@ -312,14 +312,14 @@ func TestKongService(t *testing.T) {
 		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
+		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
 			fmt.Sprintf("KongService didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
 		t.Log("Waiting for Service to be get Programmed and ControlPlaneRefValid conditions with status=False")
-		watchFor(t, ctx, w, watch.Modified,
+		watchFor(t, ctx, w, apiwatch.Modified,
 			conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			"KongService didn't get Programmed and/or ControlPlaneRefValid status condition set to False")
 	})

--- a/test/envtest/konnect_entities_kongsni_test.go
+++ b/test/envtest/konnect_entities_kongsni_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
@@ -95,7 +95,7 @@ func TestKongSNI(t *testing.T) {
 		)
 
 		t.Log("Waiting for SNI to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, func(s *configurationv1alpha1.KongSNI) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(s *configurationv1alpha1.KongSNI) bool {
 			return s.GetKonnectID() == "sni-12345" && k8sutils.IsProgrammed(s)
 		}, "SNI didn't get Programmed status condition or didn't get the correct (sni-12345) Konnect ID assigned")
 

--- a/test/envtest/konnect_entities_kongtarget_test.go
+++ b/test/envtest/konnect_entities_kongtarget_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
@@ -87,7 +87,7 @@ func TestKongTarget(t *testing.T) {
 		)
 
 		t.Log("Waiting for Target to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, func(kt *configurationv1alpha1.KongTarget) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(kt *configurationv1alpha1.KongTarget) bool {
 			return kt.GetKonnectID() == targetID && k8sutils.IsProgrammed(kt)
 		}, "KongTarget didn't get Programmed status condition or didn't get the correct (target-12345) Konnect ID assigned")
 

--- a/test/envtest/konnect_entities_kongupstream_test.go
+++ b/test/envtest/konnect_entities_kongupstream_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -84,7 +84,7 @@ func TestKongUpstream(t *testing.T) {
 		)
 
 		t.Log("Waiting for Upstream to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, func(r *configurationv1alpha1.KongUpstream) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(r *configurationv1alpha1.KongUpstream) bool {
 			return r.GetKonnectID() == upstreamID && k8sutils.IsProgrammed(r)
 		}, "KongUpstream didn't get Programmed status condition or didn't get the correct (upstream-12345) Konnect ID assigned")
 
@@ -162,7 +162,7 @@ func TestKongUpstream(t *testing.T) {
 		)
 
 		t.Log("Waiting for Upstream to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, func(r *configurationv1alpha1.KongUpstream) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(r *configurationv1alpha1.KongUpstream) bool {
 			if r.GetName() != createdUpstream.GetName() {
 				return false
 			}
@@ -215,14 +215,14 @@ func TestKongUpstream(t *testing.T) {
 		eventuallyAssertSDKExpectations(t, factory.SDK.UpstreamsSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, watch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
+		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectID(created, id),
 			fmt.Sprintf("KongUpstream didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
 		t.Log("Waiting for Service to be get Programmed and ControlPlaneRefValid conditions with status=False")
-		watchFor(t, ctx, w, watch.Modified,
+		watchFor(t, ctx, w, apiwatch.Modified,
 			conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			"KongUpstream didn't get Programmed and/or ControlPlaneRefValid status condition set to False")
 	})

--- a/test/envtest/konnect_entities_kongvault_test.go
+++ b/test/envtest/konnect_entities_kongvault_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
@@ -76,7 +76,7 @@ func TestKongVault(t *testing.T) {
 		vault := deploy.KongVaultAttachedToCP(t, ctx, cl, vaultBackend, vaultPrefix, []byte(vaultRawConfig), cp)
 
 		t.Log("Waiting for KongVault to be programmed")
-		watchFor(t, ctx, vaultWatch, watch.Modified, func(v *configurationv1alpha1.KongVault) bool {
+		watchFor(t, ctx, vaultWatch, apiwatch.Modified, func(v *configurationv1alpha1.KongVault) bool {
 			return v.GetKonnectID() == vaultID && k8sutils.IsProgrammed(v)
 		}, "KongVault didn't get Programmed status condition or didn't get the correct (vault-12345) Konnect ID assigned")
 
@@ -154,7 +154,7 @@ func TestKongVault(t *testing.T) {
 		vault := deploy.KongVaultAttachedToCP(t, ctx, cl, vaultBackend, vaultPrefix, []byte(vaultRawConfig), cp)
 
 		t.Log("Waiting for KongVault to be programmed")
-		watchFor(t, ctx, vaultWatch, watch.Modified, func(v *configurationv1alpha1.KongVault) bool {
+		watchFor(t, ctx, vaultWatch, apiwatch.Modified, func(v *configurationv1alpha1.KongVault) bool {
 			if v.GetName() != vault.GetName() {
 				return false
 			}
@@ -191,7 +191,7 @@ func TestKongVault(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongVault to be programmed")
-		watchFor(t, ctx, vaultWatch, watch.Modified, func(v *configurationv1alpha1.KongVault) bool {
+		watchFor(t, ctx, vaultWatch, apiwatch.Modified, func(v *configurationv1alpha1.KongVault) bool {
 			if vault.GetName() != v.GetName() {
 				return false
 			}

--- a/test/envtest/konnect_entities_konnectapiauthconfiguration_test.go
+++ b/test/envtest/konnect_entities_konnectapiauthconfiguration_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/watch"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
@@ -62,7 +62,7 @@ func TestKonnectAPIAuthConfiguration(t *testing.T) {
 		t.Cleanup(func() { assert.NoError(t, cl.Delete(ctx, apiAuth)) })
 
 		t.Log("Waiting for KonnectAPIAuthConfiguration to be APIAuthValid=true")
-		watchFor(t, ctx, w, watch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
 			return client.ObjectKeyFromObject(r) == client.ObjectKeyFromObject(apiAuth) &&
 				r.Status.OrganizationID == "12345" &&
 				k8sutils.HasConditionTrue("APIAuthValid", r)
@@ -87,7 +87,7 @@ func TestKonnectAPIAuthConfiguration(t *testing.T) {
 		t.Cleanup(func() { assert.NoError(t, cl.Delete(ctx, apiAuth)) })
 
 		t.Log("Waiting for KonnectAPIAuthConfiguration to be APIAuthValid=true")
-		watchFor(t, ctx, w, watch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
 			return client.ObjectKeyFromObject(r) == client.ObjectKeyFromObject(apiAuth) &&
 				k8sutils.HasConditionFalse("APIAuthValid", r)
 		}, "KonnectAPIAuthConfiguration didn't get APIAuthValid status condition set to false")
@@ -109,7 +109,7 @@ func TestKonnectAPIAuthConfiguration(t *testing.T) {
 		t.Cleanup(func() { assert.NoError(t, cl.Delete(ctx, apiAuth)) })
 
 		t.Log("Waiting for KonnectAPIAuthConfiguration to be APIAuthValid=false")
-		watchFor(t, ctx, w, watch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
 			return client.ObjectKeyFromObject(r) == client.ObjectKeyFromObject(apiAuth) &&
 				k8sutils.HasConditionFalse("APIAuthValid", r)
 		}, "KonnectAPIAuthConfiguration didn't get APIAuthValid status condition set to false")
@@ -131,7 +131,7 @@ func TestKonnectAPIAuthConfiguration(t *testing.T) {
 		t.Cleanup(func() { assert.NoError(t, cl.Delete(ctx, apiAuth)) })
 
 		t.Log("Waiting for KonnectAPIAuthConfiguration to be APIAuthValid=false")
-		watchFor(t, ctx, w, watch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
 			return client.ObjectKeyFromObject(r) == client.ObjectKeyFromObject(apiAuth) &&
 				k8sutils.HasConditionFalse("APIAuthValid", r)
 		}, "KonnectAPIAuthConfiguration didn't get APIAuthValid status condition set to false")
@@ -151,7 +151,7 @@ func TestKonnectAPIAuthConfiguration(t *testing.T) {
 		t.Cleanup(func() { assert.NoError(t, cl.Delete(ctx, apiAuth)) })
 
 		t.Log("Waiting for KonnectAPIAuthConfiguration to be APIAuthValid=false")
-		watchFor(t, ctx, w, watch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
+		watchFor(t, ctx, w, apiwatch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
 			return client.ObjectKeyFromObject(r) == client.ObjectKeyFromObject(apiAuth) &&
 				k8sutils.HasConditionFalse("APIAuthValid", r)
 		}, "KonnectAPIAuthConfiguration didn't get APIAuthValid status condition set to false")

--- a/test/envtest/watch_test.go
+++ b/test/envtest/watch_test.go
@@ -1,0 +1,35 @@
+package envtest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kong/gateway-operator/modules/manager/scheme"
+
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
+)
+
+func TestWatch(t *testing.T) {
+	var (
+		ctx = t.Context()
+		cl  = fakectrlruntimeclient.NewClientBuilder().
+			WithScheme(scheme.Get()).
+			Build()
+		consumer = &configurationv1.KongConsumer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-consumer",
+			},
+		}
+	)
+
+	wConsumer := setupWatch[configurationv1.KongConsumerList](t, ctx, cl)
+	require.NoError(t, cl.Create(ctx, consumer))
+	watchFor(t, ctx, wConsumer, apiwatch.Added,
+		objectMatchesName(consumer),
+		"error",
+	)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds some more type safety to `setupWatch` and `weatchFor`.

So now the following will not compile:

```
	wConsumerGroup := setupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, cl)
	watchFor(t, ctx, wConsumerGroup, apiwatch.Added,
		func(c *configurationv1.KongConsumer) bool {
			return true
		},
		"error",
	)
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
