### PR TITLE
fix(ci): fix generate kustomize ref

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -152,7 +152,7 @@ jobs:
     - name: Create k8s KinD Cluster
       uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
       with:
-        cluster_name:  ${{ env.CLUSTER_NAME }}
+        cluster_name: ${{ env.CLUSTER_NAME }}
 
     - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
       with:

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?0c2aa5d85cad # Version is auto-updated by the generating script.
+  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=0c2aa5d85cad66ae08f53d0ea3420be1b3b5fa1f # Version is auto-updated by the generating script.

--- a/scripts/generate-crd-kustomize.sh
+++ b/scripts/generate-crd-kustomize.sh
@@ -15,7 +15,8 @@ RAW_VERSION=$(go list -m -f '{{ .Version }}' ${KCONF_PACKAGE})
 if [[ $(echo "${RAW_VERSION}" | tr -cd '-' | wc -c) -ge 2 ]]; then
     # If there are 2 or more hyphens, extract the part after the last hyphen as 
     # that's a git commit hash (e.g. `v1.1.1-0.20250217181409-44e5ddce290d`).
-    KCONF_VERSION=$(echo "${RAW_VERSION}" | rev | cut -d'-' -f1 | rev)
+    SHA_SHORT="$(echo "${RAW_VERSION}" | rev | cut -d'-' -f1 | rev)"
+    KCONF_VERSION="ref=$(curl -s https://api.github.com/repos/Kong/kubernetes-configuration/commits/${SHA_SHORT} | jq -r .sha)"
 else
     KCONF_VERSION="ref=${RAW_VERSION}"
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the `./scripts/generate-crd-kustomize.sh` script by 

- using a `ref` URL param: without it, `kustomize` will just use the default branch's tip
- use a full SHA as `kustomize` doesn't support short SHA in `ref` URL param: https://github.com/kubernetes-sigs/kustomize/blob/447a60903cd142948443a6bd441b2749ad643815/examples/remoteBuild.md?plain=1#L13-L14

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
