### PR TITLE
Fix(konnect): check if error is validation error by HTTP status code 400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,11 @@
   [#1099](https://github.com/Kong/gateway-operator/pull/1099)
 - Remove the owner relationship between `KongService` and `KongRoute`.
   [#1178](https://github.com/Kong/gateway-operator/pull/1178)
+- Check whether an error from calling Konnect API is a validation error by
+  HTTP status code in Konnect entity controller. If the HTTP status code is
+  `400`, we consider the error as a validation error and do not try to requeue
+  the Konnect entity.
+  [#1226](https://github.com/Kong/gateway-operator/pull/1226)
 
 [kubebuilder_3907]: https://github.com/kubernetes-sigs/kubebuilder/discussions/3907
 


### PR DESCRIPTION
**What this PR does / why we need it**:

As suggested by the koko team, an `SDKError` with status code `400` should indicate a validation error. So we check if the error is a validation error by http code `400` here.
**Which issue this PR fixes**

Fixes #774 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
