### PR TITLE
tests: fix envtest TestKongConsumer

### DIFF
--- a/test/envtest/asserts_konnect.go
+++ b/test/envtest/asserts_konnect.go
@@ -13,3 +13,13 @@ func objectHasCPRefKonnectID[
 		return obj.GetControlPlaneRef().Type == commonv1alpha1.ControlPlaneRefKonnectID
 	}
 }
+
+func objectMatchesKonnectID[
+	T interface {
+		GetKonnectID() string
+	},
+](id string) func(T) bool {
+	return func(obj T) bool {
+		return obj.GetKonnectID() == id
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes failures like: https://github.com/Kong/gateway-operator/actions/runs/13517383162/job/37768827124

```
    konnect_entities_kongconsumer_test.go:391: Checking *mocks.MockConsumersSDK SDK expectations
    assert.go:56: FAIL:	CreateConsumer(string,string,mock.argumentMatcher)
        		at: [/home/runner/work/gateway-operator/gateway-operator/controller/konnect/ops/sdk/mocks/zz_generated.kongconsumer_mock.go:76 /home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_kongconsumer_test.go:76]
    assert.go:56: FAIL: 7 out of 8 expectation(s) were met.
        	The code you are testing needs to make 1 more call(s).
        	at: [/home/runner/work/gateway-operator/gateway-operator/test/envtest/assert.go:56 /opt/hostedtoolcache/go/1.24.0/x64/src/runtime/asm_amd64.s:1700]
    assert.go:56: FAIL:	CreateConsumer(string,string,mock.argumentMatcher)
        		at: [/home/runner/work/gateway-operator/gateway-operator/controller/konnect/ops/sdk/mocks/zz_generated.kongconsumer_mock.go:76 /home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_kongconsumer_test.go:76]
```

```
    konnect_entities_kongconsumer_test.go:102: deployed new KongConsumer test-6vgfr/consumer-mjlmr resource
    konnect_entities_kongconsumer_test.go:106: Waiting for KongConsumer to be programmed
    konnect_entities_kongconsumer_test.go:107: 
        	Error Trace:	/home/runner/work/gateway-operator/gateway-operator/test/envtest/watch.go:98
        	            				/home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_kongconsumer_test.go:107
        	Error:      	KongConsumer's Programmed condition should be true eventually
        	Test:       	TestKongConsumer/should_create,_update_and_delete_Consumer_without_ConsumerGroups_successfully
        	Messages:   	Last object received:
...
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
