### PR TITLE
ci: update workflow to use ubuntu-24.04-arm for tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,13 +28,13 @@ permissions:
 
 jobs:
   ensure-actions-sha-pin:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: zgosalvez/github-actions-ensure-sha-pinned-actions@25ed13d0628a1601b4b44048e63cc4328ed03633 # v3.0.22
 
   ossf-scorecard:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     # Ref: https://github.com/ossf/scorecard
@@ -45,7 +45,7 @@ jobs:
           --show-details
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -66,7 +66,7 @@ jobs:
       run: make lint
 
   govulncheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -78,7 +78,7 @@ jobs:
         repo-checkout: false
 
   verify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -103,7 +103,7 @@ jobs:
         command: make verify.generators
 
   samples:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -132,7 +132,7 @@ jobs:
       run: make ignore-not-found=true uninstall.all
 
   install-with-kustomize:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     env:
       IMG: gateway-operator
       TAG: e2e-${{ github.sha }}
@@ -177,7 +177,7 @@ jobs:
       run: make uninstall
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -192,7 +192,7 @@ jobs:
       run: ./bin/manager -version | ./scripts/verify-version.sh ${{ github.repository }}
 
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
     - name: checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -226,7 +226,7 @@ jobs:
         path: unit-tests.xml
 
   CRDs-validation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -242,7 +242,7 @@ jobs:
       run: make test.crds-validation
   
   envtest-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
     - name: checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -275,7 +275,7 @@ jobs:
         path: envtest-tests.xml
 
   conformance-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:
@@ -326,7 +326,7 @@ jobs:
         path: standard-*-report.yaml
 
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     name: integration-tests
     steps:
     - name: checkout repository
@@ -374,7 +374,7 @@ jobs:
         path: integration-tests.xml
 
   integration-tests-bluegreen:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     name: integration-tests-bluegreen
     steps:
     - name: checkout repository
@@ -419,7 +419,7 @@ jobs:
         path: integration-tests-bluegreen.xml
   
   e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
     - name: checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -471,7 +471,7 @@ jobs:
       - conformance-tests
       - e2e-tests
     if: ${{ always() }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
 
       - name: checkout repository
@@ -499,7 +499,7 @@ jobs:
   # It allows to use this particular job as a required check for PRs.
   # Ref: https://github.com/orgs/community/discussions/26822#discussioncomment-3305794
   passed:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs:
       - ensure-actions-sha-pin
       - ossf-scorecard


### PR DESCRIPTION
**What this PR does / why we need it**:

GHA now provides ARM runners for free

https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/


**Which issue this PR fixes**
- set the runner version to avoid unexpected breaking changes
- trying to accelerate GHA CI

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
