### PR TITLE
feat(konnect): enqueue KonnectExtension based on KonnectAPIAuthConfiguration changes

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=bc1371ef1d1327d4fc244ba8d3f454d056820d1c # Version is auto-updated by the generating script.
+  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=4662c505b8e7583f81271e8690e4ca959e6b8662 # Version is auto-updated by the generating script.

--- a/controller/konnect/constraints/constraints.go
+++ b/controller/konnect/constraints/constraints.go
@@ -61,22 +61,34 @@ type SupportedKonnectEntityType interface {
 	GetTypeName() string
 }
 
+// EntityTypeObject is an interface that allows non Konnect types to be used
+// in the Konnect reconciler and its helper functions.
+type EntityTypeObject[T any] interface {
+	*T
+
+	// Kubernetes Object methods
+
+	GetObjectMeta() metav1.Object
+	client.Object
+
+	// Additional methods
+
+	GetConditions() []metav1.Condition
+	SetConditions([]metav1.Condition)
+	GetTypeName() string
+}
+
 // EntityType is an interface that all Konnect entity types must implement.
 // Separating this from constraints.SupportedKonnectEntityType allows us to use EntityType
 // where client.Object is required, since it embeds client.Object and uses pointer
 // to refer to the constraints.SupportedKonnectEntityType.
-type EntityType[T SupportedKonnectEntityType] interface {
-	*T
-	// Kubernetes Object methods
-	GetObjectMeta() metav1.Object
-	client.Object
+type EntityType[T any] interface {
+	EntityTypeObject[T]
 
 	// Additional methods which are used in reconciling Konnect entities.
-	GetConditions() []metav1.Condition
-	SetConditions([]metav1.Condition)
-	GetKonnectStatus() *konnectv1alpha1.KonnectEntityStatus
+
 	SetKonnectID(string)
-	GetTypeName() string
+	GetKonnectStatus() *konnectv1alpha1.KonnectEntityStatus
 }
 
 // SupportedKonnectEntityPluginReferenceableType is an interface that all Konnect

--- a/controller/konnect/index_konnectextension.go
+++ b/controller/konnect/index_konnectextension.go
@@ -1,0 +1,32 @@
+package konnect
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+const (
+	// IndexFieldKonnectExtensionOnAPIAuthConfiguration is the index field for KonnectExtension -> APIAuthConfiguration.
+	IndexFieldKonnectExtensionOnAPIAuthConfiguration = "konnectExtensionAPIAuthConfigurationRef"
+)
+
+// IndexOptionsForKonnectExtension returns required Index options for KonnectExtension reconciler.
+func IndexOptionsForKonnectExtension() []ReconciliationIndexOption {
+	return []ReconciliationIndexOption{
+		{
+			IndexObject:  &konnectv1alpha1.KonnectExtension{},
+			IndexField:   IndexFieldKonnectExtensionOnAPIAuthConfiguration,
+			ExtractValue: konnectExtensionAPIAuthConfigurationRef,
+		},
+	}
+}
+
+func konnectExtensionAPIAuthConfigurationRef(object client.Object) []string {
+	ext, ok := object.(*konnectv1alpha1.KonnectExtension)
+	if !ok {
+		return nil
+	}
+
+	return []string{ext.Spec.KonnectConfiguration.APIAuthConfigurationRef.Name}
+}

--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -55,9 +55,20 @@ func NewKonnectExtensionReconciler(
 func (r *KonnectExtensionReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&konnectv1alpha1.KonnectExtension{}).
-		Watches(&operatorv1beta1.DataPlane{}, handler.EnqueueRequestsFromMapFunc(r.listDataPlaneExtensionsReferenced)).
+		Watches(
+			&operatorv1beta1.DataPlane{},
+			handler.EnqueueRequestsFromMapFunc(r.listDataPlaneExtensionsReferenced),
+		).
+		Watches(
+			&konnectv1alpha1.KonnectAPIAuthConfiguration{},
+			handler.EnqueueRequestsFromMapFunc(
+				enqueueObjectsForKonnectAPIAuthConfiguration[konnectv1alpha1.KonnectExtensionList](
+					mgr.GetClient(),
+					IndexFieldKonnectExtensionOnAPIAuthConfiguration,
+				),
+			),
+		).
 		// TODO: watch secrets https://github.com/Kong/gateway-operator/issues/1210
-		// TODO: watch KonnectAPIAuthConfiguration https://github.com/Kong/gateway-operator/issues/1211
 		Complete(r)
 }
 

--- a/controller/konnect/watch_konnectcontrolplane.go
+++ b/controller/konnect/watch_konnectcontrolplane.go
@@ -32,7 +32,10 @@ func KonnectGatewayControlPlaneReconciliationWatchOptions(
 			return b.Watches(
 				&konnectv1alpha1.KonnectAPIAuthConfiguration{},
 				handler.EnqueueRequestsFromMapFunc(
-					enqueueKonnectGatewayControlPlaneForKonnectAPIAuthConfiguration(cl),
+					enqueueObjectsForKonnectAPIAuthConfiguration[konnectv1alpha1.KonnectGatewayControlPlaneList](
+						cl,
+						IndexFieldKonnectGatewayControlPlaneOnAPIAuthConfiguration,
+					),
 				),
 			)
 		},
@@ -67,28 +70,6 @@ func enqueueKonnectGatewayControlPlaneGroupForMembers(
 			return nil
 		}
 
-		return objectListToReconcileRequests(l.Items)
-	}
-}
-
-func enqueueKonnectGatewayControlPlaneForKonnectAPIAuthConfiguration(
-	cl client.Client,
-) func(ctx context.Context, obj client.Object) []reconcile.Request {
-	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		auth, ok := obj.(*konnectv1alpha1.KonnectAPIAuthConfiguration)
-		if !ok {
-			return nil
-		}
-		var l konnectv1alpha1.KonnectGatewayControlPlaneList
-		if err := cl.List(ctx, &l,
-			// TODO: change this when cross namespace refs are allowed.
-			client.InNamespace(auth.GetNamespace()),
-			client.MatchingFields{
-				IndexFieldKonnectGatewayControlPlaneOnAPIAuthConfiguration: auth.Name,
-			},
-		); err != nil {
-			return nil
-		}
 		return objectListToReconcileRequests(l.Items)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/terratest v0.48.2
-	github.com/kong/kubernetes-configuration v1.2.0-rc.1.0.20250225124224-bc1371ef1d13
+	github.com/kong/kubernetes-configuration v1.2.0-rc.1.0.20250225175646-4662c505b8e7
 	github.com/kong/kubernetes-telemetry v0.1.8
 	github.com/kong/kubernetes-testing-framework v0.47.2
 	github.com/kong/semver/v4 v4.0.1

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IX
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/kong/go-kong v0.63.0 h1:8ECLgkgDqON61qCMq/M0gTwZKYxg55Oy692dRDOOBiU=
 github.com/kong/go-kong v0.63.0/go.mod h1:ma9GWnhkxtrXZlLFfED955HjVzmUojYEHet3lm+PDik=
-github.com/kong/kubernetes-configuration v1.2.0-rc.1.0.20250225124224-bc1371ef1d13 h1:7rJiOBvrYIMxLKwmWaCPiJ36UYlcw0r8M+dWkbZrPs4=
-github.com/kong/kubernetes-configuration v1.2.0-rc.1.0.20250225124224-bc1371ef1d13/go.mod h1:ktUCDIijOS9qfjTLfGXMEJmQPQrqCU/0so88d3/Dj5Q=
+github.com/kong/kubernetes-configuration v1.2.0-rc.1.0.20250225175646-4662c505b8e7 h1:Hikm5zpGG7qjJEhbzw31yBz03hYG/8lsmvhT9jzKzIc=
+github.com/kong/kubernetes-configuration v1.2.0-rc.1.0.20250225175646-4662c505b8e7/go.mod h1:ktUCDIijOS9qfjTLfGXMEJmQPQrqCU/0so88d3/Dj5Q=
 github.com/kong/kubernetes-telemetry v0.1.8 h1:nbtUmXW9xkzRO7dgvrgVrJZiRksATk4XHrqX+78g/5k=
 github.com/kong/kubernetes-telemetry v0.1.8/go.mod h1:ZEQY/4DddKoe5XA7UTOIbdI/4d6ZRcrzh2ezRxnuyl0=
 github.com/kong/kubernetes-testing-framework v0.47.2 h1:+2Z9anTpbV/hwNeN+NFQz53BMU+g3QJydkweBp3tULo=

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -713,6 +713,10 @@ func SetupCacheIndicesForKonnectTypes(ctx context.Context, mgr manager.Manager, 
 			Object:       &konnectv1alpha1.KonnectCloudGatewayNetwork{},
 			IndexOptions: konnect.IndexOptionsForKonnectCloudGatewayNetwork(),
 		},
+		{
+			Object:       &konnectv1alpha1.KonnectExtension{},
+			IndexOptions: konnect.IndexOptionsForKonnectExtension(),
+		},
 	}
 
 	for _, t := range types {


### PR DESCRIPTION
**What this PR does / why we need it**:

Enqueue `KonnectExtension` based on `KonnectAPIAuthConfiguration` changes

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

Requires https://github.com/Kong/kubernetes-configuration/pull/316

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
