### PR TITLE
feat(konnect): Add watch for secret -> KonnectExtension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,10 @@
 - Added support for `KonnectCloudGatewayNetwork` CRD which can manage Konnect
   Cloud Gateway Network entities.
   [#1136](https://github.com/Kong/gateway-operator/pull/1136)
+- Reconcile affected `KonnectExtension`s when the `Secret` used as Dataplane
+  certificate is modified. A secret must has `konghq.com/konnect-dp-cert` label
+  to trigger the reconciliation.
+  [#1250](https://github.com/Kong/gateway-operator/pull/1250)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,8 +93,8 @@
   Cloud Gateway Network entities.
   [#1136](https://github.com/Kong/gateway-operator/pull/1136)
 - Reconcile affected `KonnectExtension`s when the `Secret` used as Dataplane
-  certificate is modified. A secret must has `konghq.com/konnect-dp-cert` label
-  to trigger the reconciliation.
+  certificate is modified. A secret must have the `konghq.com/konnect-dp-cert`
+  label to trigger the reconciliation.
   [#1250](https://github.com/Kong/gateway-operator/pull/1250)
 
 ### Changed

--- a/controller/konnect/index_konnectextension.go
+++ b/controller/konnect/index_konnectextension.go
@@ -9,6 +9,8 @@ import (
 const (
 	// IndexFieldKonnectExtensionOnAPIAuthConfiguration is the index field for KonnectExtension -> APIAuthConfiguration.
 	IndexFieldKonnectExtensionOnAPIAuthConfiguration = "konnectExtensionAPIAuthConfigurationRef"
+	// IndexFieldKonnectExtensionOnSecrets is the index field for KonnectExtension -> Secret.
+	IndexFieldKonnectExtensionOnSecrets = "konnectExtensionSecretRef"
 )
 
 // IndexOptionsForKonnectExtension returns required Index options for KonnectExtension reconciler.
@@ -18,6 +20,11 @@ func IndexOptionsForKonnectExtension() []ReconciliationIndexOption {
 			IndexObject:  &konnectv1alpha1.KonnectExtension{},
 			IndexField:   IndexFieldKonnectExtensionOnAPIAuthConfiguration,
 			ExtractValue: konnectExtensionAPIAuthConfigurationRef,
+		},
+		{
+			IndexObject:  &konnectv1alpha1.KonnectExtension{},
+			IndexField:   IndexFieldKonnectExtensionOnSecrets,
+			ExtractValue: konnectExensionSecertRef,
 		},
 	}
 }
@@ -29,4 +36,18 @@ func konnectExtensionAPIAuthConfigurationRef(object client.Object) []string {
 	}
 
 	return []string{ext.Spec.KonnectConfiguration.APIAuthConfigurationRef.Name}
+}
+
+func konnectExensionSecertRef(obj client.Object) []string {
+	ext, ok := obj.(*konnectv1alpha1.KonnectExtension)
+	if !ok {
+		return nil
+	}
+
+	if ext.Spec.DataPlaneClientAuth == nil ||
+		ext.Spec.DataPlaneClientAuth.CertificateSecret.CertificateSecretRef == nil {
+		return nil
+	}
+
+	return []string{ext.Spec.DataPlaneClientAuth.CertificateSecret.CertificateSecretRef.Name}
 }

--- a/controller/konnect/index_konnectextension.go
+++ b/controller/konnect/index_konnectextension.go
@@ -24,7 +24,7 @@ func IndexOptionsForKonnectExtension() []ReconciliationIndexOption {
 		{
 			IndexObject:  &konnectv1alpha1.KonnectExtension{},
 			IndexField:   IndexFieldKonnectExtensionOnSecrets,
-			ExtractValue: konnectExensionSecertRef,
+			ExtractValue: konnectExtensionSecretRef,
 		},
 	}
 }
@@ -38,7 +38,7 @@ func konnectExtensionAPIAuthConfigurationRef(object client.Object) []string {
 	return []string{ext.Spec.KonnectConfiguration.APIAuthConfigurationRef.Name}
 }
 
-func konnectExensionSecertRef(obj client.Object) []string {
+func konnectExtensionSecretRef(obj client.Object) []string {
 	ext, ok := obj.(*konnectv1alpha1.KonnectExtension)
 	if !ok {
 		return nil

--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -58,6 +58,7 @@ func (r *KonnectExtensionReconciler) SetupWithManager(ctx context.Context, mgr c
 	ls := metav1.LabelSelector{
 		// A secret ust have `konghq.com/konnect-dp-cert` label to be watched by the controller.
 		// This constraint is added to prevent from watching all secrets which may cause high resource consumption.
+		// TODO: https://github.com/Kong/gateway-operator/issues/1255 set label constraints of `Secret`s on manager level if possible.
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{
 				Key:      SecretKonnectDataPlaneCertificateLabel,

--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -11,10 +11,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kong/gateway-operator/controller/konnect/ops"
@@ -53,6 +55,21 @@ func NewKonnectExtensionReconciler(
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KonnectExtensionReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	ls := metav1.LabelSelector{
+		// A secret must has `konghq.com/konnect-dp-cert` label to be watched by the controller.
+		// This constraint is added to prevent from watching all secrets which may cause high resource consumption.
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      SecretKonnectDataPlaneCertificateLabel,
+				Operator: metav1.LabelSelectorOpExists,
+			},
+		},
+	}
+	labelSelectorPredicate, err := predicate.LabelSelectorPredicate(ls)
+	if err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&konnectv1alpha1.KonnectExtension{}).
 		Watches(
@@ -68,7 +85,16 @@ func (r *KonnectExtensionReconciler) SetupWithManager(ctx context.Context, mgr c
 				),
 			),
 		).
-		// TODO: watch secrets https://github.com/Kong/gateway-operator/issues/1210
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(
+				konnectExtensionReconcileRequestsForSecret(mgr.GetClient()),
+			),
+			builder.WithPredicates(
+				labelSelectorPredicate,
+				predicate.NewPredicateFuncs(secretUsedByKonnectExtension(mgr.GetClient())),
+			),
+		).
 		Complete(r)
 }
 

--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -56,7 +56,7 @@ func NewKonnectExtensionReconciler(
 // SetupWithManager sets up the controller with the Manager.
 func (r *KonnectExtensionReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	ls := metav1.LabelSelector{
-		// A secret must has `konghq.com/konnect-dp-cert` label to be watched by the controller.
+		// A secret ust have `konghq.com/konnect-dp-cert` label to be watched by the controller.
 		// This constraint is added to prevent from watching all secrets which may cause high resource consumption.
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{

--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -56,7 +56,7 @@ func NewKonnectExtensionReconciler(
 // SetupWithManager sets up the controller with the Manager.
 func (r *KonnectExtensionReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	ls := metav1.LabelSelector{
-		// A secret ust have `konghq.com/konnect-dp-cert` label to be watched by the controller.
+		// A secret must have `konghq.com/konnect-dp-cert` label to be watched by the controller.
 		// This constraint is added to prevent from watching all secrets which may cause high resource consumption.
 		// TODO: https://github.com/Kong/gateway-operator/issues/1255 set label constraints of `Secret`s on manager level if possible.
 		MatchExpressions: []metav1.LabelSelectorRequirement{
@@ -89,11 +89,10 @@ func (r *KonnectExtensionReconciler) SetupWithManager(ctx context.Context, mgr c
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(
-				konnectExtensionReconcileRequestsForSecret(mgr.GetClient()),
+				enqueueKonnectExtensionsForSecret(mgr.GetClient()),
 			),
 			builder.WithPredicates(
 				labelSelectorPredicate,
-				predicate.NewPredicateFuncs(secretUsedByKonnectExtension(mgr.GetClient())),
 			),
 		).
 		Complete(r)

--- a/controller/konnect/konnectextension_controller_rbac.go
+++ b/controller/konnect/konnectextension_controller_rbac.go
@@ -7,3 +7,5 @@ package konnect
 // +kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=dataplanes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=konnectextensions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=konnectextensions/finalizers,verbs=update;patch
+
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch

--- a/controller/konnect/konnectextension_controller_secrets.go
+++ b/controller/konnect/konnectextension_controller_secrets.go
@@ -2,7 +2,6 @@ package konnect
 
 import (
 	"context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -18,11 +17,7 @@ const (
 	SecretKonnectDataPlaneCertificateLabel = "konghq.com/konnect-dp-cert" //nolint:gosec
 )
 
-func listKonnectExtensionsBySecret(ctx context.Context, cl client.Client, obj client.Object) ([]konnectv1alpha1.KonnectExtension, error) {
-	s, ok := obj.(*corev1.Secret)
-	if !ok {
-		return nil, fmt.Errorf("expect object to be secret, actually %T", obj)
-	}
+func listKonnectExtensionsBySecret(ctx context.Context, cl client.Client, s *corev1.Secret) ([]konnectv1alpha1.KonnectExtension, error) {
 	l := &konnectv1alpha1.KonnectExtensionList{}
 	err := cl.List(
 		ctx, l,
@@ -41,11 +36,11 @@ func listKonnectExtensionsBySecret(ctx context.Context, cl client.Client, obj cl
 
 func enqueueKonnectExtensionsForSecret(cl client.Client) func(context.Context, client.Object) []reconcile.Request {
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		_, ok := obj.(*corev1.Secret)
+		s, ok := obj.(*corev1.Secret)
 		if !ok {
 			return nil
 		}
-		konnectExtensions, err := listKonnectExtensionsBySecret(ctx, cl, obj)
+		konnectExtensions, err := listKonnectExtensionsBySecret(ctx, cl, s)
 		if err != nil {
 			return nil
 		}

--- a/controller/konnect/konnectextension_controller_secrets.go
+++ b/controller/konnect/konnectextension_controller_secrets.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// SecretKonnectDataPlaneCertificateLabel is the label to mark that the secret is used as a Konnect DP certificate.
-	// A secret must has the label to be watched by the KonnectExtension reconciler.
+	// A secret must have the label to be watched by the KonnectExtension reconciler.
 	SecretKonnectDataPlaneCertificateLabel = "konghq.com/konnect-dp-cert" //nolint:gosec
 )
 

--- a/controller/konnect/konnectextension_controller_secrets.go
+++ b/controller/konnect/konnectextension_controller_secrets.go
@@ -1,0 +1,79 @@
+package konnect
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+const (
+	// SecretKonnectDataPlaneCertificateLabel is the label to mark that the secret is used as a Konnect DP certificate.
+	// A secret must has the label to be watched by the KonnectExtension reconciler.
+	SecretKonnectDataPlaneCertificateLabel = "konghq.com/konnect-dp-cert" //nolint:gosec
+)
+
+func listKonnectExtensionsBySecret(ctx context.Context, cl client.Client, obj client.Object) ([]konnectv1alpha1.KonnectExtension, error) {
+	s, ok := obj.(*corev1.Secret)
+	if !ok {
+		return nil, fmt.Errorf("expect object to be secret, actually %T", obj)
+	}
+	l := &konnectv1alpha1.KonnectExtensionList{}
+	err := cl.List(
+		ctx, l,
+		client.InNamespace(s.Namespace),
+		client.MatchingFields{
+			IndexFieldKonnectExtensionOnSecrets: s.Name,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return l.Items, nil
+
+}
+
+func secretUsedByKonnectExtension(cl client.Client) func(obj client.Object) bool {
+	return func(obj client.Object) bool {
+		konnectExtensions, err := listKonnectExtensionsBySecret(context.Background(), cl, obj)
+		if err != nil {
+			return false
+		}
+		return lo.ContainsBy(konnectExtensions, func(ke konnectv1alpha1.KonnectExtension) bool {
+			return ke.Spec.DataPlaneClientAuth != nil &&
+				ke.Spec.DataPlaneClientAuth.CertificateSecret.CertificateSecretRef != nil &&
+				ke.Spec.DataPlaneClientAuth.CertificateSecret.CertificateSecretRef.Name == obj.GetName()
+		})
+	}
+}
+
+func konnectExtensionReconcileRequestsForSecret(cl client.Client) func(context.Context, client.Object) []reconcile.Request {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		konnectExtensions, err := listKonnectExtensionsBySecret(ctx, cl, obj)
+		if err != nil {
+			return nil
+		}
+
+		reqs := make([]reconcile.Request, 0, len(konnectExtensions))
+		for _, ke := range konnectExtensions {
+			if ke.Spec.DataPlaneClientAuth != nil &&
+				ke.Spec.DataPlaneClientAuth.CertificateSecret.CertificateSecretRef != nil &&
+				ke.Spec.DataPlaneClientAuth.CertificateSecret.CertificateSecretRef.Name == obj.GetName() {
+				reqs = append(reqs, reconcile.Request{
+					NamespacedName: k8stypes.NamespacedName{
+						Namespace: ke.Namespace,
+						Name:      ke.Name,
+					},
+				})
+			}
+		}
+		return reqs
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add watch for `Secret` in `KonnectExtension` controller. A `Secret` must have the label `konghq.com/konnect-dp-cert` to be watched.
**Which issue this PR fixes**

Fixes #1210 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
