### PR TITLE
Fix(konnect): sort dataplane labels before converting to env

### DIFF
--- a/internal/utils/dataplane/env.go
+++ b/internal/utils/dataplane/env.go
@@ -2,6 +2,7 @@ package dataplane
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/samber/lo"
@@ -104,12 +105,11 @@ func sanitizeEndpoint(endpoint string) string {
 }
 
 func clusterDataPlaneLabelStringFromLabels(labels map[string]konnectv1alpha1.DataPlaneLabelValue) string {
-	return strings.Join(
-		lo.MapToSlice(
-			labels, func(k string, v konnectv1alpha1.DataPlaneLabelValue) string {
-				return fmt.Sprintf("%s:%s", k, v)
-			},
-		),
-		",",
+	labelStrings := lo.MapToSlice(
+		labels, func(k string, v konnectv1alpha1.DataPlaneLabelValue) string {
+			return fmt.Sprintf("%s:%s", k, v)
+		},
 	)
+	sort.Strings(labelStrings)
+	return strings.Join(labelStrings, ",")
 }

--- a/internal/utils/dataplane/env_test.go
+++ b/internal/utils/dataplane/env_test.go
@@ -33,7 +33,7 @@ func TestClusterDataPlaneLabelStringFromLabels(t *testing.T) {
 				"environment": "prod",
 				"app":         "gateway",
 			},
-			want: "region:us-west,environment:prod,app:gateway",
+			want: "app:gateway,environment:prod,region:us-west",
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Sort labels of Konnect dataplane to generate a fixed value for env used in generated in `DataPlane`. 
**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
