### PR TITLE
tests: fix envtest TestKongService

### DIFF
--- a/test/envtest/konnect_entities_kongservice_test.go
+++ b/test/envtest/konnect_entities_kongservice_test.go
@@ -94,12 +94,13 @@ func TestKongService(t *testing.T) {
 				s.Spec.KongServiceAPISpec.Host = host
 			},
 		)
-		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for Service to be programmed and get Konnect ID")
 		watchFor(t, ctx, w, apiwatch.Modified, func(kt *configurationv1alpha1.KongService) bool {
 			return kt.GetKonnectID() == serviceID && k8sutils.IsProgrammed(kt)
 		}, "KongService didn't get Programmed status condition or didn't get the correct (service-12345) Konnect ID assigned")
+
+		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on Service update")
 		sdk.ServicesSDK.EXPECT().


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix failures like: https://github.com/Kong/gateway-operator/actions/runs/13549338147/job/37915254505?pr=1241#step:5:329

```
   konnect_entities_kongservice_test.go:90: deployed new KongService test-vvk56/kongservice-45297e37 resource
    konnect_entities_kongservice_test.go:97: Checking *mocks.MockServicesSDK SDK expectations
    assert.go:56: FAIL:	CreateService(string,string,mock.argumentMatcher)
        		at: [/home/runner/work/gateway-operator/gateway-operator/controller/konnect/ops/sdk/mocks/zz_generated.kongservice_mock.go:76 /home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_kongservice_test.go:73]
    assert.go:56: FAIL: 0 out of 1 expectation(s) were met.
        	The code you are testing needs to make 1 more call(s).
        	at: [/home/runner/work/gateway-operator/gateway-operator/test/envtest/assert.go:56 /opt/hostedtoolcache/go/1.24.0/x64/src/runtime/asm_amd64.s:1700]
    assert.go:56: FAIL:	CreateService(string,string,mock.argumentMatcher)
        		at: [/home/runner/work/gateway-operator/gateway-operator/controller/konnect/ops/sdk/mocks/zz_generated.kongservice_mock.go:76 /home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_kongservice_test.go:73]
    assert.go:56: FAIL: 0 out of 1 expectation(s) were met.
        	The code you are testing needs to make 1 more call(s).
        	at: [/home/runner/work/gateway-operator/gateway-operator/test/envtest/assert.go:56 /opt/hostedtoolcache/go/1.24.0/x64/src/runtime/asm_amd64.s:1700]
    assert.go:56: FAIL:	CreateService(string,string,mock.argumentMatcher)
        		at: [/home/runner/work/gateway-operator/gateway-operator/controller/konnect/ops/sdk/mocks/zz_generated.kongservice_mock.go:76 /home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_kongservice_test.go:73]
    assert.go:56: FAIL: 0 out of 1 expectation(s) were met.
        	The code you are testing needs to make 1 more call(s).
        	at: [/home/runner/work/gateway-operator/gateway-operator/test/envtest/assert.go:56 /opt/hostedtoolcache/go/1.24.0/x64/src/runtime/asm_amd64.s:1700]
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
