### PR TITLE
chore: run tests and build on all PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ on:
     - 'main'
   pull_request:
     branches:
-      - '*'
+      - '**'
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ on:
       - 'main'
   pull_request:
     branches:
-      - '*'
+      - '**'
       - 'release/*'
   push:
     branches:


### PR DESCRIPTION
**What this PR does / why we need it**:

We should run tests and build for all PRs despite their branch.

Unblocks https://github.com/Kong/gateway-operator/pull/1177.