### PR TITLE
Migrate kcfg conditions - remove the dependency on pkg/consts.

### DIFF
--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -37,6 +37,7 @@ import (
 	gatewayutils "github.com/kong/gateway-operator/pkg/utils/gateway"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
+	kcfgdataplane "github.com/kong/kubernetes-configuration/api/gateway-operator/dataplane"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
 )
 
@@ -403,7 +404,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		log.Trace(logger, "deployment for ControlPlane not ready yet", "deployment", controlplaneDeployment)
 		// Set Ready to false for controlplane as the underlying deployment is not ready.
 		k8sutils.SetCondition(
-			k8sutils.NewCondition(consts.ReadyType, metav1.ConditionFalse, consts.WaitingToBecomeReadyReason, consts.WaitingToBecomeReadyMessage),
+			k8sutils.NewCondition(kcfgdataplane.ReadyType, metav1.ConditionFalse, kcfgdataplane.WaitingToBecomeReadyReason, kcfgdataplane.WaitingToBecomeReadyMessage),
 			cp,
 		)
 

--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -29,6 +29,7 @@ import (
 	k8sreduce "github.com/kong/gateway-operator/pkg/utils/kubernetes/reduce"
 	k8sresources "github.com/kong/gateway-operator/pkg/utils/kubernetes/resources"
 
+	kcfgcontrolplane "github.com/kong/kubernetes-configuration/api/gateway-operator/controlplane"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
 )
 
@@ -43,12 +44,12 @@ const numReplicasWhenNoDataPlane = 0
 func (r *Reconciler) ensureIsMarkedScheduled(
 	cp *operatorv1beta1.ControlPlane,
 ) bool {
-	_, present := k8sutils.GetCondition(ConditionTypeProvisioned, cp)
+	_, present := k8sutils.GetCondition(kcfgcontrolplane.ConditionTypeProvisioned, cp)
 	if !present {
 		condition := k8sutils.NewCondition(
-			ConditionTypeProvisioned,
+			kcfgcontrolplane.ConditionTypeProvisioned,
 			metav1.ConditionFalse,
-			ConditionReasonPodsNotReady,
+			kcfgcontrolplane.ConditionReasonPodsNotReady,
 			"ControlPlane resource is scheduled for provisioning",
 		)
 
@@ -67,19 +68,19 @@ func (r *Reconciler) ensureDataPlaneStatus(
 	dataplane *operatorv1beta1.DataPlane,
 ) (dataplaneIsSet bool) {
 	dataplaneIsSet = cp.Spec.DataPlane != nil && *cp.Spec.DataPlane == dataplane.Name
-	condition, present := k8sutils.GetCondition(ConditionTypeProvisioned, cp)
+	condition, present := k8sutils.GetCondition(kcfgcontrolplane.ConditionTypeProvisioned, cp)
 
 	newCondition := k8sutils.NewCondition(
-		ConditionTypeProvisioned,
+		kcfgcontrolplane.ConditionTypeProvisioned,
 		metav1.ConditionFalse,
-		ConditionReasonNoDataPlane,
+		kcfgcontrolplane.ConditionReasonNoDataPlane,
 		"DataPlane is not set",
 	)
 	if dataplaneIsSet {
 		newCondition = k8sutils.NewCondition(
-			ConditionTypeProvisioned,
+			kcfgcontrolplane.ConditionTypeProvisioned,
 			metav1.ConditionFalse,
-			ConditionReasonPodsNotReady,
+			kcfgcontrolplane.ConditionReasonPodsNotReady,
 			"DataPlane was set, ControlPlane resource is scheduled for provisioning",
 		)
 	}

--- a/controller/controlplane/status_conditions.go
+++ b/controller/controlplane/status_conditions.go
@@ -5,6 +5,7 @@ import (
 
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
+	kcfgcontrolplane "github.com/kong/kubernetes-configuration/api/gateway-operator/controlplane"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
 )
 
@@ -15,9 +16,9 @@ func markAsProvisioned[T *operatorv1beta1.ControlPlane](resource T) {
 	if ok {
 		k8sutils.SetCondition(
 			k8sutils.NewConditionWithGeneration(
-				ConditionTypeProvisioned,
+				kcfgcontrolplane.ConditionTypeProvisioned,
 				metav1.ConditionTrue,
-				ConditionReasonPodsReady,
+				kcfgcontrolplane.ConditionReasonPodsReady,
 				"pods for all Deployments are ready",
 				cp.Generation,
 			),

--- a/controller/controlplane/status_conditions_test.go
+++ b/controller/controlplane/status_conditions_test.go
@@ -7,9 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
+	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
+	kcfgcontrolplane "github.com/kong/kubernetes-configuration/api/gateway-operator/controlplane"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
 )
 
@@ -30,8 +31,8 @@ func TestMarkAsProvisioned(t *testing.T) {
 					return createControlPlane()
 				},
 				expectedCondition: metav1.Condition{
-					Type:    string(ConditionTypeProvisioned),
-					Reason:  string(ConditionReasonPodsReady),
+					Type:    string(kcfgcontrolplane.ConditionTypeProvisioned),
+					Reason:  string(kcfgcontrolplane.ConditionReasonPodsReady),
 					Message: "pods for all Deployments are ready",
 					Status:  metav1.ConditionTrue,
 				},
@@ -44,8 +45,8 @@ func TestMarkAsProvisioned(t *testing.T) {
 					return cp
 				},
 				expectedCondition: metav1.Condition{
-					Type:               string(ConditionTypeProvisioned),
-					Reason:             string(ConditionReasonPodsReady),
+					Type:               string(kcfgcontrolplane.ConditionTypeProvisioned),
+					Reason:             string(kcfgcontrolplane.ConditionReasonPodsReady),
 					Message:            "pods for all Deployments are ready",
 					Status:             metav1.ConditionTrue,
 					ObservedGeneration: 3,
@@ -57,7 +58,7 @@ func TestMarkAsProvisioned(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				dp := tc.controlplane()
 				markAsProvisioned(dp)
-				cond, ok := k8sutils.GetCondition(consts.ConditionType(tc.expectedCondition.Type), dp)
+				cond, ok := k8sutils.GetCondition(kcfgconsts.ConditionType(tc.expectedCondition.Type), dp)
 				require.True(t, ok)
 				assert.Equal(t, cond.Reason, tc.expectedCondition.Reason)
 				assert.Equal(t, cond.Status, tc.expectedCondition.Status)

--- a/controller/dataplane/controller.go
+++ b/controller/dataplane/controller.go
@@ -24,6 +24,7 @@ import (
 	k8sresources "github.com/kong/gateway-operator/pkg/utils/kubernetes/resources"
 
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+	kcfgkonnect "github.com/kong/kubernetes-configuration/api/konnect"
 )
 
 // -----------------------------------------------------------------------------
@@ -184,7 +185,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	// if the dataplane is configured with Konnect, the status/ready endpoint should be set as the readiness probe.
-	if _, konnectApplied := k8sutils.GetCondition(consts.KonnectExtensionAppliedType, dataplane); konnectApplied {
+	if _, konnectApplied := k8sutils.GetCondition(kcfgkonnect.KonnectExtensionAppliedType, dataplane); konnectApplied {
 		deploymentOpts = append(deploymentOpts, statusReadyEndpointDeploymentOpt(dataplane))
 	}
 

--- a/controller/dataplane/controller_test.go
+++ b/controller/dataplane/controller_test.go
@@ -27,6 +27,7 @@ import (
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers"
 
+	kcfgdataplane "github.com/kong/kubernetes-configuration/api/gateway-operator/dataplane"
 	operatorv1alpha1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1alpha1"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
 )
@@ -680,7 +681,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 				nn := types.NamespacedName{Namespace: "default", Name: "dataplane-kong"}
 				err = reconciler.Client.Get(ctx, nn, dp)
 				require.NoError(t, err)
-				c, ok := k8sutils.GetCondition(consts.ReadyType, dp)
+				c, ok := k8sutils.GetCondition(kcfgdataplane.ReadyType, dp)
 				require.True(t, ok, "DataPlane should have a Ready condition set")
 				assert.Equal(t, metav1.ConditionFalse, c.Status, "DataPlane shouldn't be ready just yet")
 				assert.EqualValues(t, 0, dp.Status.ReadyReplicas)
@@ -697,7 +698,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 
 				err = reconciler.Client.Get(ctx, nn, dp)
 				require.NoError(t, err)
-				c, ok = k8sutils.GetCondition(consts.ReadyType, dp)
+				c, ok = k8sutils.GetCondition(kcfgdataplane.ReadyType, dp)
 				require.True(t, ok, "DataPlane should have a Ready condition set")
 				assert.Equal(t, metav1.ConditionTrue, c.Status, "DataPlane should be ready at this point")
 				assert.EqualValues(t, 1, dp.Status.ReadyReplicas)
@@ -842,7 +843,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 				nn := types.NamespacedName{Namespace: "default", Name: "dataplane-kong"}
 				err = reconciler.Client.Get(ctx, nn, dp)
 				require.NoError(t, err)
-				c, ok := k8sutils.GetCondition(consts.ReadyType, dp)
+				c, ok := k8sutils.GetCondition(kcfgdataplane.ReadyType, dp)
 				require.True(t, ok, "DataPlane should have a Ready condition set")
 				assert.Equal(t, metav1.ConditionFalse, c.Status, "DataPlane shouldn't be ready just yet")
 				assert.EqualValues(t, 0, dp.Status.ReadyReplicas)
@@ -859,7 +860,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 
 				err = reconciler.Client.Get(ctx, nn, dp)
 				require.NoError(t, err)
-				c, ok = k8sutils.GetCondition(consts.ReadyType, dp)
+				c, ok = k8sutils.GetCondition(kcfgdataplane.ReadyType, dp)
 				require.True(t, ok, "DataPlane should have a Ready condition set")
 				assert.Equal(t, metav1.ConditionTrue, c.Status, "DataPlane should be ready at this point")
 				assert.Equal(t, c.ObservedGeneration, dp.Generation, "DataPlane Ready condition should have the same generation as the DataPlane")
@@ -882,7 +883,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 				require.NoError(t, err)
 
 				require.NoError(t, reconciler.Client.Get(ctx, nn, dp))
-				c, ok = k8sutils.GetCondition(consts.ReadyType, dp)
+				c, ok = k8sutils.GetCondition(kcfgdataplane.ReadyType, dp)
 				require.True(t, ok, "DataPlane should have a Ready condition set")
 				assert.Equal(t, metav1.ConditionTrue, c.Status, "DataPlane should be ready at this point")
 				assert.Equal(t, c.ObservedGeneration, dp.Generation, "DataPlane Ready condition should have the same generation as the DataPlane")

--- a/controller/dataplane/controller_utils.go
+++ b/controller/dataplane/controller_utils.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
+	kcfgdataplane "github.com/kong/kubernetes-configuration/api/gateway-operator/dataplane"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
 )
 
@@ -144,9 +145,9 @@ func ensureDataPlaneReadyStatus(
 		// Set Ready to false for dataplane as the underlying deployment is not ready.
 		k8sutils.SetCondition(
 			k8sutils.NewConditionWithGeneration(
-				consts.ReadyType,
+				kcfgdataplane.ReadyType,
 				metav1.ConditionFalse,
-				consts.WaitingToBecomeReadyReason,
+				kcfgdataplane.WaitingToBecomeReadyReason,
 				consts.WaitingToBecomeReadyMessage,
 				generation,
 			),
@@ -178,9 +179,9 @@ func ensureDataPlaneReadyStatus(
 		// Set Ready to false for dataplane as the underlying deployment is not ready.
 		k8sutils.SetCondition(
 			k8sutils.NewConditionWithGeneration(
-				consts.ReadyType,
+				kcfgdataplane.ReadyType,
 				metav1.ConditionFalse,
-				consts.WaitingToBecomeReadyReason,
+				kcfgdataplane.WaitingToBecomeReadyReason,
 				fmt.Sprintf("%s: Deployment %s is not ready yet", consts.WaitingToBecomeReadyMessage, deployment.Name),
 				generation,
 			),
@@ -205,9 +206,9 @@ func ensureDataPlaneReadyStatus(
 		// Set Ready to false for dataplane as the Service is not ready yet.
 		k8sutils.SetCondition(
 			k8sutils.NewConditionWithGeneration(
-				consts.ReadyType,
+				kcfgdataplane.ReadyType,
 				metav1.ConditionFalse,
-				consts.WaitingToBecomeReadyReason,
+				kcfgdataplane.WaitingToBecomeReadyReason,
 				consts.WaitingToBecomeReadyMessage,
 				generation,
 			),
@@ -234,9 +235,9 @@ func ensureDataPlaneReadyStatus(
 		// Set Ready to false for dataplane as the Service is not ready yet.
 		k8sutils.SetCondition(
 			k8sutils.NewConditionWithGeneration(
-				consts.ReadyType,
+				kcfgdataplane.ReadyType,
 				metav1.ConditionFalse,
-				consts.WaitingToBecomeReadyReason,
+				kcfgdataplane.WaitingToBecomeReadyReason,
 				fmt.Sprintf("%s: ingress Service %s is not ready yet", consts.WaitingToBecomeReadyMessage, ingressService.Name),
 				generation,
 			),

--- a/controller/dataplane/controller_utils_test.go
+++ b/controller/dataplane/controller_utils_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
+	kcfgdataplane "github.com/kong/kubernetes-configuration/api/gateway-operator/dataplane"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
 )
 
@@ -103,9 +104,9 @@ func TestEnsureDataPlaneReadyStatus(t *testing.T) {
 			expectedDataPlaneStatus: operatorv1beta1.DataPlaneStatus{
 				Conditions: []metav1.Condition{
 					k8sutils.NewConditionWithGeneration(
-						consts.ReadyType,
+						kcfgdataplane.ReadyType,
 						metav1.ConditionFalse,
-						consts.WaitingToBecomeReadyReason,
+						kcfgdataplane.WaitingToBecomeReadyReason,
 						fmt.Sprintf("%s: Deployment %s is not ready yet", consts.WaitingToBecomeReadyMessage, "dataplane-deployment-1"),
 						102,
 					),
@@ -229,9 +230,9 @@ func TestEnsureDataPlaneReadyStatus(t *testing.T) {
 			expectedDataPlaneStatus: operatorv1beta1.DataPlaneStatus{
 				Conditions: []metav1.Condition{
 					k8sutils.NewConditionWithGeneration(
-						consts.ReadyType,
+						kcfgdataplane.ReadyType,
 						metav1.ConditionFalse,
-						consts.WaitingToBecomeReadyReason,
+						kcfgdataplane.WaitingToBecomeReadyReason,
 						fmt.Sprintf("%s: ingress Service %s is not ready yet", consts.WaitingToBecomeReadyMessage, "dataplane-service-1"),
 						102,
 					),
@@ -359,7 +360,7 @@ func TestEnsureDataPlaneReadyStatus(t *testing.T) {
 			expectedDataPlaneStatus: operatorv1beta1.DataPlaneStatus{
 				Conditions: []metav1.Condition{
 					k8sutils.NewConditionWithGeneration(
-						consts.ReadyType,
+						kcfgdataplane.ReadyType,
 						metav1.ConditionTrue,
 						"Ready",
 						"",

--- a/controller/gateway/controller_conditions.go
+++ b/controller/gateway/controller_conditions.go
@@ -1,7 +1,7 @@
 package gateway
 
 import (
-	consts "github.com/kong/gateway-operator/pkg/consts"
+	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
 )
 
 // -----------------------------------------------------------------------------
@@ -10,13 +10,13 @@ import (
 
 const (
 	// GatewayServiceType the Gateway service condition type
-	GatewayServiceType consts.ConditionType = "GatewayService"
+	GatewayServiceType kcfgconsts.ConditionType = "GatewayService"
 
 	// ControlPlaneReadyType the ControlPlane is deployed and Ready
-	ControlPlaneReadyType consts.ConditionType = "ControlPlaneReady"
+	ControlPlaneReadyType kcfgconsts.ConditionType = "ControlPlaneReady"
 
 	// DataPlaneReadyType the DataPlane is deployed and Ready
-	DataPlaneReadyType consts.ConditionType = "DataPlaneReady"
+	DataPlaneReadyType kcfgconsts.ConditionType = "DataPlaneReady"
 )
 
 // -----------------------------------------------------------------------------
@@ -26,10 +26,10 @@ const (
 const (
 	// GatewayReasonServiceError must be used with the GatewayService condition
 	// to express that the Gateway Service is not properly configured.
-	GatewayReasonServiceError consts.ConditionReason = "GatewayServiceError"
+	GatewayReasonServiceError kcfgconsts.ConditionReason = "GatewayServiceError"
 
 	// ListenerReasonTooManyTLSSecrets must be used with the ResolvedRefs condition
 	// to express that more than one TLS secret has been set in the listener
 	// TLS configuration.
-	ListenerReasonTooManyTLSSecrets consts.ConditionReason = "TooManyTLSSecrets"
+	ListenerReasonTooManyTLSSecrets kcfgconsts.ConditionReason = "TooManyTLSSecrets"
 )

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -32,6 +32,7 @@ import (
 	k8sreduce "github.com/kong/gateway-operator/pkg/utils/kubernetes/reduce"
 	k8sresources "github.com/kong/gateway-operator/pkg/utils/kubernetes/resources"
 
+	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
 )
 
@@ -541,15 +542,15 @@ func supportedRoutesByProtocol() map[gatewayv1.ProtocolType]map[gatewayv1.Kind]s
 func (g *gatewayConditionsAndListenersAwareT) initProgrammedAndListenersStatus() {
 	k8sutils.SetCondition(
 		k8sutils.NewConditionWithGeneration(
-			consts.ConditionType(gatewayv1.GatewayConditionProgrammed),
+			kcfgconsts.ConditionType(gatewayv1.GatewayConditionProgrammed),
 			metav1.ConditionFalse,
-			consts.ConditionReason(gatewayv1.GatewayReasonPending),
+			kcfgconsts.ConditionReason(gatewayv1.GatewayReasonPending),
 			consts.DependenciesNotReadyMessage,
 			g.Generation),
 		g)
 	for i := range g.Spec.Listeners {
 		lStatus := listenerConditionsAware(&g.Status.Listeners[i])
-		cond, ok := k8sutils.GetCondition(consts.ConditionType(gatewayv1.ListenerConditionProgrammed), lStatus)
+		cond, ok := k8sutils.GetCondition(kcfgconsts.ConditionType(gatewayv1.ListenerConditionProgrammed), lStatus)
 		if !ok || cond.ObservedGeneration != g.Generation {
 			k8sutils.SetCondition(metav1.Condition{
 				Type:               string(gatewayv1.ListenerConditionProgrammed),
@@ -800,7 +801,7 @@ func (g *gatewayConditionsAndListenersAwareT) setProgrammed() {
 			LastTransitionTime: metav1.Now(),
 		}
 		listenerStatus := listenerConditionsAware(listener)
-		rCond, ok := k8sutils.GetCondition(consts.ConditionType(gatewayv1.ListenerConditionResolvedRefs), listenerStatus)
+		rCond, ok := k8sutils.GetCondition(kcfgconsts.ConditionType(gatewayv1.ListenerConditionResolvedRefs), listenerStatus)
 		if ok && rCond.Status == metav1.ConditionFalse {
 			programmedCondition.Status = metav1.ConditionFalse
 			programmedCondition.Reason = string(gatewayv1.ListenerReasonPending)
@@ -1032,8 +1033,8 @@ func parseKongListenEnv(str string) (kongListenConfig, error) {
 }
 
 func gatewayStatusNeedsUpdate(oldGateway, newGateway gatewayConditionsAndListenersAwareT) bool {
-	oldCondAccepted, okOld := k8sutils.GetCondition(consts.ConditionType(gatewayv1.GatewayConditionAccepted), oldGateway)
-	newCondAccepted, _ := k8sutils.GetCondition(consts.ConditionType(gatewayv1.GatewayConditionAccepted), newGateway)
+	oldCondAccepted, okOld := k8sutils.GetCondition(kcfgconsts.ConditionType(gatewayv1.GatewayConditionAccepted), oldGateway)
+	newCondAccepted, _ := k8sutils.GetCondition(kcfgconsts.ConditionType(gatewayv1.GatewayConditionAccepted), newGateway)
 
 	if !okOld || !areConditionsEqual(oldCondAccepted, newCondAccepted) {
 		return true

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -21,6 +21,7 @@ import (
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers"
 
+	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
 )
 
@@ -499,7 +500,7 @@ func TestSetAcceptedOnGateway(t *testing.T) {
 			}
 
 			k8sutils.SetAcceptedConditionOnGateway(gateway)
-			acceptedCondition, found := k8sutils.GetCondition(consts.ConditionType(gatewayv1.GatewayConditionAccepted), gateway)
+			acceptedCondition, found := k8sutils.GetCondition(kcfgconsts.ConditionType(gatewayv1.GatewayConditionAccepted), gateway)
 			require.True(t, found)
 			// force the lastTransitionTime to be equal to properly compare the two conditions
 			tc.expectedAcceptedCondition.LastTransitionTime = acceptedCondition.LastTransitionTime

--- a/controller/gateway/controller_test.go
+++ b/controller/gateway/controller_test.go
@@ -27,6 +27,8 @@ import (
 	k8sresources "github.com/kong/gateway-operator/pkg/utils/kubernetes/resources"
 	"github.com/kong/gateway-operator/pkg/vars"
 
+	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
+	kcfgdataplane "github.com/kong/kubernetes-configuration/api/gateway-operator/dataplane"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
 )
 
@@ -185,7 +187,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 					},
 					Status: operatorv1beta1.DataPlaneStatus{
 						Conditions: []metav1.Condition{
-							k8sutils.NewCondition(consts.ReadyType, metav1.ConditionTrue, consts.ResourceReadyReason, ""),
+							k8sutils.NewCondition(kcfgdataplane.ReadyType, metav1.ConditionTrue, kcfgdataplane.ResourceReadyReason, ""),
 						},
 					},
 				},
@@ -202,7 +204,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 					},
 					Status: operatorv1beta1.ControlPlaneStatus{
 						Conditions: []metav1.Condition{
-							k8sutils.NewCondition(consts.ReadyType, metav1.ConditionTrue, consts.ResourceReadyReason, ""),
+							k8sutils.NewCondition(kcfgdataplane.ReadyType, metav1.ConditionTrue, kcfgdataplane.ResourceReadyReason, ""),
 						},
 					},
 				},
@@ -278,7 +280,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 				condition, found := k8sutils.GetCondition(GatewayServiceType, gatewayConditionsAndListenersAware(&currentGateway))
 				require.True(t, found)
 				require.Equal(t, metav1.ConditionFalse, condition.Status)
-				require.Equal(t, GatewayReasonServiceError, consts.ConditionReason(condition.Reason))
+				require.Equal(t, GatewayReasonServiceError, kcfgconsts.ConditionReason(condition.Reason))
 				require.Empty(t, currentGateway.Status.Addresses)
 
 				t.Log("adding a ClusterIP to the dataplane service")
@@ -297,7 +299,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 				condition, found = k8sutils.GetCondition(GatewayServiceType, gatewayConditionsAndListenersAware(&currentGateway))
 				require.True(t, found)
 				require.Equal(t, metav1.ConditionTrue, condition.Status)
-				require.Equal(t, consts.ResourceReadyReason, consts.ConditionReason(condition.Reason))
+				require.Equal(t, kcfgdataplane.ResourceReadyReason, kcfgconsts.ConditionReason(condition.Reason))
 				require.Equal(t,
 					[]gwtypes.GatewayStatusAddress{
 						{
@@ -331,7 +333,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 				condition, found = k8sutils.GetCondition(GatewayServiceType, gatewayConditionsAndListenersAware(&currentGateway))
 				require.True(t, found)
 				require.Equal(t, metav1.ConditionTrue, condition.Status)
-				require.Equal(t, consts.ResourceReadyReason, consts.ConditionReason(condition.Reason))
+				require.Equal(t, kcfgdataplane.ResourceReadyReason, kcfgconsts.ConditionReason(condition.Reason))
 				require.Equal(t,
 					[]gwtypes.GatewayStatusAddress{
 						{
@@ -364,7 +366,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 				condition, found = k8sutils.GetCondition(GatewayServiceType, gatewayConditionsAndListenersAware(&currentGateway))
 				require.True(t, found)
 				require.Equal(t, metav1.ConditionTrue, condition.Status)
-				require.Equal(t, consts.ResourceReadyReason, consts.ConditionReason(condition.Reason))
+				require.Equal(t, kcfgdataplane.ResourceReadyReason, kcfgconsts.ConditionReason(condition.Reason))
 				require.Equal(t, []gwtypes.GatewayStatusAddress{
 					{
 						Type:  lo.ToPtr(gatewayv1.HostnameAddressType),
@@ -386,7 +388,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 				condition, found = k8sutils.GetCondition(GatewayServiceType, gatewayConditionsAndListenersAware(&currentGateway))
 				require.True(t, found)
 				require.Equal(t, metav1.ConditionFalse, condition.Status)
-				require.Equal(t, GatewayReasonServiceError, consts.ConditionReason(condition.Reason))
+				require.Equal(t, GatewayReasonServiceError, kcfgconsts.ConditionReason(condition.Reason))
 				require.Empty(t, currentGateway.Status.Addresses)
 			},
 		},

--- a/controller/gatewayclass/controller_reconciler_utils.go
+++ b/controller/gatewayclass/controller_reconciler_utils.go
@@ -16,6 +16,7 @@ import (
 	gatewayapipkg "github.com/kong/gateway-operator/pkg/gatewayapi"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
+	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
 )
 
@@ -59,9 +60,9 @@ func getAcceptedCondition(ctx context.Context, cl client.Client, gwc *gatewayv1.
 	}
 
 	acceptedCondition := k8sutils.NewConditionWithGeneration(
-		consts.ConditionType(gatewayv1.GatewayClassConditionStatusAccepted),
+		kcfgconsts.ConditionType(gatewayv1.GatewayClassConditionStatusAccepted),
 		status,
-		consts.ConditionReason(reason),
+		kcfgconsts.ConditionReason(reason),
 		strings.Join(messages, ". "),
 		gwc.GetGeneration(),
 	)

--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
+	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
 	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
 	operatorv1alpha1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1alpha1"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
@@ -187,9 +188,9 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		cond.ObservedGeneration != ext.GetGeneration() {
 		if res, err := patch.StatusWithCondition(
 			ctx, r.Client, &ext,
-			consts.ConditionType(konnectv1alpha1.KonnectExtensionReadyConditionType),
+			kcfgconsts.ConditionType(konnectv1alpha1.KonnectExtensionReadyConditionType),
 			metav1.ConditionFalse,
-			consts.ConditionReason(konnectv1alpha1.KonnectExtensionReadyReasonProvisioning),
+			kcfgconsts.ConditionReason(konnectv1alpha1.KonnectExtensionReadyReasonProvisioning),
 			"provisioning in progress",
 		); err != nil || !res.IsZero() {
 			return res, err
@@ -245,9 +246,9 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if err != nil {
 			_, errPatch := patch.StatusWithCondition(
 				ctx, r.Client, &ext,
-				consts.ConditionType(konnectv1alpha1.ControlPlaneRefValidConditionType),
+				kcfgconsts.ConditionType(konnectv1alpha1.ControlPlaneRefValidConditionType),
 				metav1.ConditionFalse,
-				consts.ConditionReason(konnectv1alpha1.ControlPlaneRefReasonInvalid),
+				kcfgconsts.ConditionReason(konnectv1alpha1.ControlPlaneRefReasonInvalid),
 				err.Error(),
 			)
 			return ctrl.Result{}, errPatch
@@ -259,9 +260,9 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}) {
 			_, errPatch := patch.StatusWithCondition(
 				ctx, r.Client, &ext,
-				consts.ConditionType(konnectv1alpha1.ControlPlaneRefValidConditionType),
+				kcfgconsts.ConditionType(konnectv1alpha1.ControlPlaneRefValidConditionType),
 				metav1.ConditionFalse,
-				consts.ConditionReason(konnectv1alpha1.ControlPlaneRefReasonInvalid),
+				kcfgconsts.ConditionReason(konnectv1alpha1.ControlPlaneRefReasonInvalid),
 				fmt.Sprintf("Konnect control plane %s/%s not programmed yet", cpNamepace, cpRef.Name),
 			)
 			// Update of KonnectGatewayControlPlane will trigger reconciliation of KonnectExtension.
@@ -276,18 +277,18 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if err != nil {
 		_, err := patch.StatusWithCondition(
 			ctx, r.Client, &ext,
-			consts.ConditionType(konnectv1alpha1.ControlPlaneRefValidConditionType),
+			kcfgconsts.ConditionType(konnectv1alpha1.ControlPlaneRefValidConditionType),
 			metav1.ConditionFalse,
-			consts.ConditionReason(konnectv1alpha1.ControlPlaneRefReasonInvalid),
+			kcfgconsts.ConditionReason(konnectv1alpha1.ControlPlaneRefReasonInvalid),
 			err.Error(),
 		)
 		return ctrl.Result{}, err
 	}
 	if res, err := patch.StatusWithCondition(
 		ctx, r.Client, &ext,
-		consts.ConditionType(konnectv1alpha1.ControlPlaneRefValidConditionType),
+		kcfgconsts.ConditionType(konnectv1alpha1.ControlPlaneRefValidConditionType),
 		metav1.ConditionTrue,
-		consts.ConditionReason(konnectv1alpha1.ControlPlaneRefReasonValid),
+		kcfgconsts.ConditionReason(konnectv1alpha1.ControlPlaneRefReasonValid),
 		"ControlPlaneRef is valid",
 	); err != nil || !res.IsZero() {
 		return res, err
@@ -297,18 +298,18 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if err != nil {
 		_, err := patch.StatusWithCondition(
 			ctx, r.Client, &ext,
-			consts.ConditionType(konnectv1alpha1.DataPlaneCertificateProvisionedConditionType),
+			kcfgconsts.ConditionType(konnectv1alpha1.DataPlaneCertificateProvisionedConditionType),
 			metav1.ConditionFalse,
-			consts.ConditionReason(konnectv1alpha1.DataPlaneCertificateProvisionedReasonRefNotFound),
+			kcfgconsts.ConditionReason(konnectv1alpha1.DataPlaneCertificateProvisionedReasonRefNotFound),
 			err.Error(),
 		)
 		return ctrl.Result{}, err
 	}
 	if res, err := patch.StatusWithCondition(
 		ctx, r.Client, &ext,
-		consts.ConditionType(konnectv1alpha1.DataPlaneCertificateProvisionedConditionType),
+		kcfgconsts.ConditionType(konnectv1alpha1.DataPlaneCertificateProvisionedConditionType),
 		metav1.ConditionTrue,
-		consts.ConditionReason(konnectv1alpha1.DataPlaneCertificateProvisionedReasonProvisioned),
+		kcfgconsts.ConditionReason(konnectv1alpha1.DataPlaneCertificateProvisionedReasonProvisioned),
 		"DataPlane client certificate is provisioned",
 	); err != nil || !res.IsZero() {
 		return res, err
@@ -335,9 +336,9 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	if res, err := patch.StatusWithCondition(
 		ctx, r.Client, &ext,
-		consts.ConditionType(konnectv1alpha1.KonnectExtensionReadyConditionType),
+		kcfgconsts.ConditionType(konnectv1alpha1.KonnectExtensionReadyConditionType),
 		metav1.ConditionTrue,
-		consts.ConditionReason(konnectv1alpha1.KonnectExtensionReadyReasonReady),
+		kcfgconsts.ConditionReason(konnectv1alpha1.KonnectExtensionReadyReasonReady),
 		"KonnectExtension is ready",
 	); err != nil || !res.IsZero() {
 		return res, err

--- a/controller/konnect/ops/conditions.go
+++ b/controller/konnect/ops/conditions.go
@@ -4,9 +4,9 @@ import (
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
+	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
@@ -33,7 +33,7 @@ func SetKonnectEntityProgrammedCondition(
 // to false on the provided object.
 func SetKonnectEntityProgrammedConditionFalse(
 	obj entityType,
-	reason consts.ConditionReason,
+	reason kcfgconsts.ConditionReason,
 	msg string,
 ) {
 	_setKonnectEntityProgrammedConditon(
@@ -47,7 +47,7 @@ func SetKonnectEntityProgrammedConditionFalse(
 func _setKonnectEntityProgrammedConditon(
 	obj entityType,
 	status metav1.ConditionStatus,
-	reason consts.ConditionReason,
+	reason kcfgconsts.ConditionReason,
 	msg string,
 ) {
 	k8sutils.SetCondition(
@@ -68,13 +68,13 @@ const (
 	ControlPlaneGroupMembersReferenceResolvedConditionType = "MembersReferenceResolved"
 	// ControlPlaneGroupMembersReferenceResolvedReasonResolved indicates that all members of the control plane group
 	// are created and attached to the group in Konnect.
-	ControlPlaneGroupMembersReferenceResolvedReasonResolved consts.ConditionReason = "Resolved"
+	ControlPlaneGroupMembersReferenceResolvedReasonResolved kcfgconsts.ConditionReason = "Resolved"
 	// ControlPlaneGroupMembersReferenceResolvedReasonPartialNotResolved indicates that some members of the control plane group
 	// are not resolved (not found or not created in Konnect).
-	ControlPlaneGroupMembersReferenceResolvedReasonPartialNotResolved consts.ConditionReason = "SomeMemberNotResolved"
+	ControlPlaneGroupMembersReferenceResolvedReasonPartialNotResolved kcfgconsts.ConditionReason = "SomeMemberNotResolved"
 	// ControlPlaneGroupMembersReferenceResolvedReasonFailedToSet indicates that error happened on setting control plane as
 	// member of the control plane.
-	ControlPlaneGroupMembersReferenceResolvedReasonFailedToSet consts.ConditionReason = "SetGroupMemberFailed"
+	ControlPlaneGroupMembersReferenceResolvedReasonFailedToSet kcfgconsts.ConditionReason = "SetGroupMemberFailed"
 )
 
 // SetControlPlaneGroupMembersReferenceResolvedCondition sets MembersReferenceResolved condition of control plane to True.
@@ -92,7 +92,7 @@ func SetControlPlaneGroupMembersReferenceResolvedCondition(
 // SetControlPlaneGroupMembersReferenceResolvedConditionFalse sets MembersReferenceResolved condition of control plane to False.
 func SetControlPlaneGroupMembersReferenceResolvedConditionFalse(
 	cpGroup *konnectv1alpha1.KonnectGatewayControlPlane,
-	reason consts.ConditionReason,
+	reason kcfgconsts.ConditionReason,
 	msg string,
 ) {
 	_setControlPlaneGroupMembersReferenceResolvedCondition(
@@ -106,7 +106,7 @@ func SetControlPlaneGroupMembersReferenceResolvedConditionFalse(
 func _setControlPlaneGroupMembersReferenceResolvedCondition(
 	cpGroup *konnectv1alpha1.KonnectGatewayControlPlane,
 	status metav1.ConditionStatus,
-	reason consts.ConditionReason,
+	reason kcfgconsts.ConditionReason,
 	msg string,
 ) {
 	if cpGroup.Spec.ClusterType == nil || *cpGroup.Spec.ClusterType != sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup {

--- a/controller/konnect/ops/errors.go
+++ b/controller/konnect/ops/errors.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 
 	"github.com/kong/gateway-operator/controller/konnect/constraints"
-	"github.com/kong/gateway-operator/pkg/consts"
+
+	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
 )
 
 // FailedKonnectOpError is an error type that is returned when an operation against
@@ -31,7 +32,7 @@ func (e FailedKonnectOpError[T]) Unwrap() error {
 // to create relations to the entity fail.
 type KonnectEntityCreatedButRelationsFailedError struct {
 	KonnectID string
-	Reason    consts.ConditionReason
+	Reason    kcfgconsts.ConditionReason
 	Err       error
 }
 

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -17,12 +17,12 @@ import (
 	sdkops "github.com/kong/gateway-operator/controller/konnect/ops/sdk"
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/internal/metrics"
-	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
 	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	configurationv1beta1 "github.com/kong/kubernetes-configuration/api/configuration/v1beta1"
+	kcfgkonnect "github.com/kong/kubernetes-configuration/api/konnect"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
@@ -183,17 +183,17 @@ func Create[
 			if errGet != nil {
 				err = fmt.Errorf("trying to find a matching Konnect entity matching the ID failed: %w, %w", errGet, err)
 			}
-			SetKonnectEntityProgrammedConditionFalse(e, consts.KonnectEntitiesFailedToCreateReason, err.Error())
+			SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToCreateReason, err.Error())
 		}
 
 	case errors.As(err, &errSDK):
 		statusCode = errSDK.StatusCode
-		SetKonnectEntityProgrammedConditionFalse(e, consts.KonnectEntitiesFailedToCreateReason, errSDK.Error())
+		SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToCreateReason, errSDK.Error())
 	case errors.As(err, &errRelationsFailed):
 		e.SetKonnectID(errRelationsFailed.KonnectID)
 		SetKonnectEntityProgrammedConditionFalse(e, errRelationsFailed.Reason, errRelationsFailed.Err.Error())
 	case err != nil:
-		SetKonnectEntityProgrammedConditionFalse(e, consts.KonnectEntitiesFailedToCreateReason, err.Error())
+		SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToCreateReason, err.Error())
 	default:
 		SetKonnectEntityProgrammedCondition(e)
 	}
@@ -448,12 +448,12 @@ func Update[
 	switch {
 	case errors.As(err, &errSDK):
 		statusCode = errSDK.StatusCode
-		SetKonnectEntityProgrammedConditionFalse(e, consts.KonnectEntitiesFailedToUpdateReason, errSDK.Body)
+		SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToUpdateReason, errSDK.Body)
 	case errors.As(err, &errRelationsFailed):
 		e.SetKonnectID(errRelationsFailed.KonnectID)
 		SetKonnectEntityProgrammedConditionFalse(e, errRelationsFailed.Reason, err.Error())
 	case err != nil:
-		SetKonnectEntityProgrammedConditionFalse(e, consts.KonnectEntitiesFailedToUpdateReason, err.Error())
+		SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToUpdateReason, err.Error())
 	default:
 		SetKonnectEntityProgrammedCondition(e)
 	}

--- a/controller/konnect/ops/ops_controlplane_test.go
+++ b/controller/konnect/ops/ops_controlplane_test.go
@@ -22,8 +22,8 @@ import (
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
 	"github.com/kong/gateway-operator/internal/metrics"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
-	"github.com/kong/gateway-operator/pkg/consts"
 
+	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
@@ -645,7 +645,7 @@ func TestSetGroupMembers(t *testing.T) {
 		sdk                     func(t *testing.T) *sdkmocks.MockControlPlaneGroupSDK
 		expectedErr             bool
 		memberRefResolvedStatus metav1.ConditionStatus
-		memberRefResolvedReason consts.ConditionReason
+		memberRefResolvedReason kcfgconsts.ConditionReason
 	}{
 		{
 			name: "no members",

--- a/controller/konnect/ops/ops_kongconsumer.go
+++ b/controller/konnect/ops/ops_kongconsumer.go
@@ -16,11 +16,11 @@ import (
 
 	sdkops "github.com/kong/gateway-operator/controller/konnect/ops/sdk"
 	"github.com/kong/gateway-operator/controller/pkg/log"
-	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
 	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1beta1 "github.com/kong/kubernetes-configuration/api/configuration/v1beta1"
+	kcfgkonnect "github.com/kong/kubernetes-configuration/api/konnect"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
@@ -56,7 +56,7 @@ func createConsumer(
 	if err = handleConsumerGroupAssignments(ctx, consumer, cl, cgSDK, cpID); err != nil {
 		return KonnectEntityCreatedButRelationsFailedError{
 			KonnectID: id,
-			Reason:    consts.FailedToAttachConsumerToConsumerGroupReason,
+			Reason:    kcfgkonnect.FailedToAttachConsumerToConsumerGroupReason,
 			Err:       err,
 		}
 	}
@@ -95,7 +95,7 @@ func updateConsumer(
 	if err = handleConsumerGroupAssignments(ctx, consumer, cl, cgSDK, cpID); err != nil {
 		return KonnectEntityCreatedButRelationsFailedError{
 			KonnectID: id,
-			Reason:    consts.FailedToAttachConsumerToConsumerGroupReason,
+			Reason:    kcfgkonnect.FailedToAttachConsumerToConsumerGroupReason,
 			Err:       err,
 		}
 	}

--- a/controller/konnect/reconciler_generic_type_specific.go
+++ b/controller/konnect/reconciler_generic_type_specific.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect/constraints"
 	"github.com/kong/gateway-operator/controller/pkg/patch"
-	"github.com/kong/gateway-operator/pkg/consts"
 
+	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
 	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 )
 
@@ -72,7 +72,7 @@ func handleKongConsumerSpecific(
 			c,
 			configurationv1.ConditionKongConsumerCredentialSecretRefsValid,
 			metav1.ConditionTrue,
-			consts.ConditionReason(configurationv1.ReasonKongConsumerCredentialSecretRefsValid),
+			kcfgconsts.ConditionReason(configurationv1.ReasonKongConsumerCredentialSecretRefsValid),
 			"",
 		)
 
@@ -83,7 +83,7 @@ func handleKongConsumerSpecific(
 		c,
 		configurationv1.ConditionKongConsumerCredentialSecretRefsValid,
 		metav1.ConditionFalse,
-		consts.ConditionReason(configurationv1.ReasonKongConsumerCredentialSecretRefInvalid),
+		kcfgconsts.ConditionReason(configurationv1.ReasonKongConsumerCredentialSecretRefInvalid),
 		errors.Join(errs...).Error(),
 	)
 

--- a/controller/pkg/extensions/apply.go
+++ b/controller/pkg/extensions/apply.go
@@ -13,11 +13,12 @@ import (
 	extensionserrors "github.com/kong/gateway-operator/controller/pkg/extensions/errors"
 	"github.com/kong/gateway-operator/controller/pkg/extensions/konnect"
 	"github.com/kong/gateway-operator/controller/pkg/patch"
-	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
+	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
 	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+	kcfgkonnect "github.com/kong/kubernetes-configuration/api/konnect"
 )
 
 // ExtendableT is the interface implemented by the objects which implementation
@@ -53,9 +54,9 @@ func ApplyExtensions[t ExtendableT](ctx context.Context, cl client.Client, logge
 		ctx,
 		cl,
 		o,
-		consts.ConditionType(extensionsCondition.Type),
+		kcfgconsts.ConditionType(extensionsCondition.Type),
 		extensionsCondition.Status,
-		consts.ConditionReason(extensionsCondition.Reason),
+		kcfgconsts.ConditionReason(extensionsCondition.Reason),
 		extensionsCondition.Message,
 	); err != nil || !res.IsZero() {
 		return true, res, err
@@ -70,7 +71,7 @@ func ApplyExtensions[t ExtendableT](ctx context.Context, cl client.Client, logge
 	}
 
 	// in case the extensionsCondition is true, let's apply the extensions.
-	konnectExtensionApplied := k8sutils.NewConditionWithGeneration(consts.KonnectExtensionAppliedType, metav1.ConditionTrue, consts.KonnectExtensionAppliedReason, "The Konnect extension has been successsfully applied", o.GetGeneration())
+	konnectExtensionApplied := k8sutils.NewConditionWithGeneration(kcfgkonnect.KonnectExtensionAppliedType, metav1.ConditionTrue, kcfgkonnect.KonnectExtensionAppliedReason, "The Konnect extension has been successsfully applied", o.GetGeneration())
 	if extensionsCondition.Status == metav1.ConditionTrue {
 		var (
 			extensionRefFound bool
@@ -89,19 +90,19 @@ func ApplyExtensions[t ExtendableT](ctx context.Context, cl client.Client, logge
 			switch {
 			case errors.Is(err, extensionserrors.ErrCrossNamespaceReference):
 				konnectExtensionApplied.Status = metav1.ConditionFalse
-				konnectExtensionApplied.Reason = string(consts.RefNotPermittedReason)
+				konnectExtensionApplied.Reason = string(kcfgkonnect.RefNotPermittedReason)
 				konnectExtensionApplied.Message = strings.ReplaceAll(err.Error(), "\n", " - ")
 			case errors.Is(err, extensionserrors.ErrKonnectExtensionNotFound):
 				konnectExtensionApplied.Status = metav1.ConditionFalse
-				konnectExtensionApplied.Reason = string(consts.InvalidExtensionRefReason)
+				konnectExtensionApplied.Reason = string(kcfgkonnect.InvalidExtensionRefReason)
 				konnectExtensionApplied.Message = strings.ReplaceAll(err.Error(), "\n", " - ")
 			case errors.Is(err, extensionserrors.ErrClusterCertificateNotFound):
 				konnectExtensionApplied.Status = metav1.ConditionFalse
-				konnectExtensionApplied.Reason = string(consts.InvalidSecretRefReason)
+				konnectExtensionApplied.Reason = string(kcfgkonnect.InvalidSecretRefReason)
 				konnectExtensionApplied.Message = strings.ReplaceAll(err.Error(), "\n", " - ")
 			case errors.Is(err, extensionserrors.ErrKonnectExtensionNotReady):
 				konnectExtensionApplied.Status = metav1.ConditionFalse
-				konnectExtensionApplied.Reason = string(consts.KonnectExtensionNotReadyReason)
+				konnectExtensionApplied.Reason = string(kcfgkonnect.KonnectExtensionNotReadyReason)
 				konnectExtensionApplied.Message = strings.ReplaceAll(err.Error(), "\n", " - ")
 			default:
 				return true, ctrl.Result{}, err
@@ -116,9 +117,9 @@ func ApplyExtensions[t ExtendableT](ctx context.Context, cl client.Client, logge
 		ctx,
 		cl,
 		o,
-		consts.ConditionType(konnectExtensionApplied.Type),
+		kcfgconsts.ConditionType(konnectExtensionApplied.Type),
 		konnectExtensionApplied.Status,
-		consts.ConditionReason(konnectExtensionApplied.Reason),
+		kcfgconsts.ConditionReason(konnectExtensionApplied.Reason),
 		konnectExtensionApplied.Message,
 	); err != nil || !res.IsZero() {
 		return true, res, err

--- a/controller/pkg/patch/statuscondition.go
+++ b/controller/pkg/patch/statuscondition.go
@@ -9,8 +9,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
+
+	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
 )
 
 // SetStatusWithConditionIfDifferent sets the status of the provided object with the
@@ -21,9 +22,9 @@ func SetStatusWithConditionIfDifferent[T interface {
 	k8sutils.ConditionsAware
 }](
 	ent T,
-	conditionType consts.ConditionType,
+	conditionType kcfgconsts.ConditionType,
 	conditionStatus metav1.ConditionStatus,
-	conditionReason consts.ConditionReason,
+	conditionReason kcfgconsts.ConditionReason,
 	conditionMessage string,
 ) bool {
 	cond, ok := k8sutils.GetCondition(conditionType, ent)
@@ -61,9 +62,9 @@ func StatusWithCondition[T interface {
 	ctx context.Context,
 	cl client.Client,
 	ent T,
-	conditionType consts.ConditionType,
+	conditionType kcfgconsts.ConditionType,
 	conditionStatus metav1.ConditionStatus,
-	conditionReason consts.ConditionReason,
+	conditionReason kcfgconsts.ConditionReason,
 	conditionMessage string,
 ) (ctrl.Result, error) {
 	old := ent.DeepCopyObject().(T)

--- a/controller/pkg/patch/statuscondition_test.go
+++ b/controller/pkg/patch/statuscondition_test.go
@@ -17,7 +17,10 @@ import (
 	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
+	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
+	kcfgdataplane "github.com/kong/kubernetes-configuration/api/gateway-operator/dataplane"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+	kcfgkonnect "github.com/kong/kubernetes-configuration/api/konnect"
 )
 
 func TestPatchStatusWithCondition(t *testing.T) {
@@ -28,9 +31,9 @@ func TestPatchStatusWithCondition(t *testing.T) {
 			GetConditions() []metav1.Condition
 			SetConditions([]metav1.Condition)
 		}
-		conditionType      consts.ConditionType
+		conditionType      kcfgconsts.ConditionType
 		conditionStatus    metav1.ConditionStatus
-		conditionReason    consts.ConditionReason
+		conditionReason    kcfgconsts.ConditionReason
 		conditionMessage   string
 		expectedResult     ctrl.Result
 		expectedConditions []metav1.Condition
@@ -47,25 +50,25 @@ func TestPatchStatusWithCondition(t *testing.T) {
 				Status: operatorv1beta1.DataPlaneStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:               string(consts.ReadyType),
+							Type:               string(kcfgdataplane.ReadyType),
 							Status:             metav1.ConditionTrue,
-							Reason:             string(consts.KonnectExtensionAppliedReason),
+							Reason:             string(kcfgkonnect.KonnectExtensionAppliedReason),
 							Message:            "Resource is available",
 							ObservedGeneration: 1,
 						},
 					},
 				},
 			},
-			conditionType:    consts.ReadyType,
+			conditionType:    kcfgdataplane.ReadyType,
 			conditionStatus:  metav1.ConditionTrue,
-			conditionReason:  consts.KonnectExtensionAppliedReason,
+			conditionReason:  kcfgkonnect.KonnectExtensionAppliedReason,
 			conditionMessage: "Resource is available",
 			expectedResult:   ctrl.Result{},
 			expectedConditions: []metav1.Condition{
 				{
-					Type:               string(consts.ReadyType),
+					Type:               string(kcfgdataplane.ReadyType),
 					Status:             metav1.ConditionTrue,
-					Reason:             string(consts.KonnectExtensionAppliedReason),
+					Reason:             string(kcfgkonnect.KonnectExtensionAppliedReason),
 					Message:            "Resource is available",
 					ObservedGeneration: 1,
 				},
@@ -81,25 +84,25 @@ func TestPatchStatusWithCondition(t *testing.T) {
 				Status: operatorv1beta1.DataPlaneStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:               string(consts.ReadyType),
+							Type:               string(kcfgdataplane.ReadyType),
 							Status:             metav1.ConditionFalse,
-							Reason:             string(consts.KonnectExtensionAppliedReason),
+							Reason:             string(kcfgkonnect.KonnectExtensionAppliedReason),
 							Message:            "",
 							ObservedGeneration: 1,
 						},
 					},
 				},
 			},
-			conditionType:    consts.ReadyType,
+			conditionType:    kcfgdataplane.ReadyType,
 			conditionStatus:  metav1.ConditionTrue,
-			conditionReason:  consts.KonnectExtensionAppliedReason,
+			conditionReason:  kcfgkonnect.KonnectExtensionAppliedReason,
 			conditionMessage: "",
 			expectedResult:   ctrl.Result{},
 			expectedConditions: []metav1.Condition{
 				{
-					Type:               string(consts.ReadyType),
+					Type:               string(kcfgdataplane.ReadyType),
 					Status:             metav1.ConditionTrue,
-					Reason:             string(consts.KonnectExtensionAppliedReason),
+					Reason:             string(kcfgkonnect.KonnectExtensionAppliedReason),
 					Message:            "",
 					ObservedGeneration: 1,
 				},
@@ -115,25 +118,25 @@ func TestPatchStatusWithCondition(t *testing.T) {
 				Status: operatorv1beta1.DataPlaneStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:               string(consts.ReadyType),
+							Type:               string(kcfgdataplane.ReadyType),
 							Status:             metav1.ConditionTrue,
-							Reason:             string(consts.KonnectExtensionAppliedReason),
+							Reason:             string(kcfgkonnect.KonnectExtensionAppliedReason),
 							Message:            "",
 							ObservedGeneration: 1,
 						},
 					},
 				},
 			},
-			conditionType:    consts.ReadyType,
+			conditionType:    kcfgdataplane.ReadyType,
 			conditionStatus:  metav1.ConditionTrue,
-			conditionReason:  consts.KonnectExtensionAppliedReason,
+			conditionReason:  kcfgkonnect.KonnectExtensionAppliedReason,
 			conditionMessage: "",
 			expectedResult:   ctrl.Result{},
 			expectedConditions: []metav1.Condition{
 				{
-					Type:               string(consts.ReadyType),
+					Type:               string(kcfgdataplane.ReadyType),
 					Status:             metav1.ConditionTrue,
-					Reason:             string(consts.KonnectExtensionAppliedReason),
+					Reason:             string(kcfgkonnect.KonnectExtensionAppliedReason),
 					Message:            "",
 					ObservedGeneration: 2,
 				},
@@ -149,7 +152,7 @@ func TestPatchStatusWithCondition(t *testing.T) {
 				Status: operatorv1beta1.DataPlaneStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:               string(consts.ReadyType),
+							Type:               string(kcfgdataplane.ReadyType),
 							Status:             metav1.ConditionFalse,
 							Reason:             string(consts.ResourceReadyReason),
 							Message:            "",
@@ -158,16 +161,16 @@ func TestPatchStatusWithCondition(t *testing.T) {
 					},
 				},
 			},
-			conditionType:    consts.ReadyType,
+			conditionType:    kcfgdataplane.ReadyType,
 			conditionStatus:  metav1.ConditionFalse,
-			conditionReason:  consts.DependenciesNotReadyReason,
+			conditionReason:  kcfgdataplane.DependenciesNotReadyReason,
 			conditionMessage: "",
 			expectedResult:   ctrl.Result{},
 			expectedConditions: []metav1.Condition{
 				{
-					Type:               string(consts.ReadyType),
+					Type:               string(kcfgdataplane.ReadyType),
 					Status:             metav1.ConditionFalse,
-					Reason:             string(consts.DependenciesNotReadyReason),
+					Reason:             string(kcfgdataplane.DependenciesNotReadyReason),
 					Message:            "",
 					ObservedGeneration: 1,
 				},
@@ -182,16 +185,16 @@ func TestPatchStatusWithCondition(t *testing.T) {
 				},
 				Status: operatorv1beta1.DataPlaneStatus{},
 			},
-			conditionType:    consts.ReadyType,
+			conditionType:    kcfgdataplane.ReadyType,
 			conditionStatus:  metav1.ConditionTrue,
-			conditionReason:  consts.KonnectExtensionAppliedReason,
+			conditionReason:  kcfgkonnect.KonnectExtensionAppliedReason,
 			conditionMessage: "Resource is available",
 			expectedResult:   ctrl.Result{},
 			expectedConditions: []metav1.Condition{
 				{
-					Type:               string(consts.ReadyType),
+					Type:               string(kcfgdataplane.ReadyType),
 					Status:             metav1.ConditionTrue,
-					Reason:             string(consts.KonnectExtensionAppliedReason),
+					Reason:             string(kcfgkonnect.KonnectExtensionAppliedReason),
 					Message:            "Resource is available",
 					ObservedGeneration: 1,
 				},
@@ -206,9 +209,9 @@ func TestPatchStatusWithCondition(t *testing.T) {
 				},
 				Status: operatorv1beta1.DataPlaneStatus{},
 			},
-			conditionType:    consts.ReadyType,
+			conditionType:    kcfgdataplane.ReadyType,
 			conditionStatus:  metav1.ConditionTrue,
-			conditionReason:  consts.KonnectExtensionAppliedReason,
+			conditionReason:  kcfgkonnect.KonnectExtensionAppliedReason,
 			conditionMessage: "Resource is available",
 			expectedResult: ctrl.Result{
 				Requeue: true,
@@ -233,9 +236,9 @@ func TestPatchStatusWithCondition(t *testing.T) {
 				},
 				Status: operatorv1beta1.DataPlaneStatus{},
 			},
-			conditionType:    consts.ReadyType,
+			conditionType:    kcfgdataplane.ReadyType,
 			conditionStatus:  metav1.ConditionTrue,
-			conditionReason:  consts.KonnectExtensionAppliedReason,
+			conditionReason:  kcfgkonnect.KonnectExtensionAppliedReason,
 			conditionMessage: "Resource is available",
 			expectedError:    true,
 			interceptorFunc: interceptor.Funcs{
@@ -275,7 +278,7 @@ func TestPatchStatusWithCondition(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, expectedCond := range tt.expectedConditions {
-				actualCond, ok := k8sutils.GetCondition(consts.ConditionType(expectedCond.Type), tt.obj)
+				actualCond, ok := k8sutils.GetCondition(kcfgconsts.ConditionType(expectedCond.Type), tt.obj)
 				if !ok {
 					t.Fatalf("condition %s not found", expectedCond.Type)
 				}

--- a/internal/utils/gatewayclass/decorator.go
+++ b/internal/utils/gatewayclass/decorator.go
@@ -4,9 +4,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/pkg/vars"
+
+	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
 )
 
 // -----------------------------------------------------------------------------
@@ -44,7 +45,7 @@ func DecorateGatewayClass(gwc *gatewayv1.GatewayClass) *Decorator {
 
 // IsAccepted returns true if the GatewayClass has been accepted by the operator.
 func (gwc *Decorator) IsAccepted() bool {
-	if cond, ok := k8sutils.GetCondition(consts.ConditionType(gatewayv1.GatewayClassConditionStatusAccepted), gwc); ok {
+	if cond, ok := k8sutils.GetCondition(kcfgconsts.ConditionType(gatewayv1.GatewayClassConditionStatusAccepted), gwc); ok {
 		return cond.Reason == string(gatewayv1.GatewayClassReasonAccepted) &&
 			cond.ObservedGeneration == gwc.Generation && cond.Status == metav1.ConditionTrue
 	}

--- a/internal/utils/gatewayclass/get.go
+++ b/internal/utils/gatewayclass/get.go
@@ -9,9 +9,10 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	operatorerrors "github.com/kong/gateway-operator/internal/errors"
-	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/pkg/vars"
+
+	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
 )
 
 // Get returns a decorated GatewayClass object for the provided GatewayClass name. If the GatewayClass is
@@ -35,7 +36,7 @@ func Get(ctx context.Context, cl client.Client, gatewayClassName string) (*Decor
 			vars.ControllerName(),
 		))
 	}
-	acceptedCondition, found := k8sutils.GetCondition(consts.ConditionType(gatewayv1.GatewayClassConditionStatusAccepted), gwc)
+	acceptedCondition, found := k8sutils.GetCondition(kcfgconsts.ConditionType(gatewayv1.GatewayClassConditionStatusAccepted), gwc)
 	if !found || acceptedCondition.Status != metav1.ConditionTrue {
 		return nil, operatorerrors.NewErrNotAcceptedGatewayClass(gatewayClassName, acceptedCondition)
 	}

--- a/pkg/consts/dataplane_bluegreen_conditions.go
+++ b/pkg/consts/dataplane_bluegreen_conditions.go
@@ -1,9 +1,11 @@
 package consts
 
+import kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
+
 const (
 	// DataPlaneConditionTypeRolledOut is a condition type indicating whether or
 	// not, DataPlane's rollout has been successful or not.
-	DataPlaneConditionTypeRolledOut ConditionType = "RolledOut"
+	DataPlaneConditionTypeRolledOut kcfgconsts.ConditionType = "RolledOut"
 )
 
 const (
@@ -12,32 +14,32 @@ const (
 	// If this Reason is present and no automated rollout is disabled, user can
 	// use the preview services and deployment to inspect the state of those
 	// make a judgement call if the promotion should happen.
-	DataPlaneConditionReasonRolloutAwaitingPromotion ConditionReason = "AwaitingPromotion"
+	DataPlaneConditionReasonRolloutAwaitingPromotion kcfgconsts.ConditionReason = "AwaitingPromotion"
 
 	// DataPlaneConditionReasonRolloutFailed is a reason which indicates a DataPlane
 	// has failed to roll out. This may be caused for example by a Deployment or
 	// a Service failing to get created during a rollout.
-	DataPlaneConditionReasonRolloutFailed ConditionReason = "Failed"
+	DataPlaneConditionReasonRolloutFailed kcfgconsts.ConditionReason = "Failed"
 
 	// DataPlaneConditionReasonRolloutProgressing is a reason which indicates a DataPlane's
 	// new version is being rolled out.
-	DataPlaneConditionReasonRolloutProgressing ConditionReason = "Progressing"
+	DataPlaneConditionReasonRolloutProgressing kcfgconsts.ConditionReason = "Progressing"
 
 	// DataPlaneConditionReasonRolloutWaitingForChange is a reason which indicates a DataPlane
 	// is waiting for a change to trigger new version to be made available before promotion.
-	DataPlaneConditionReasonRolloutWaitingForChange ConditionReason = "WaitingForChange"
+	DataPlaneConditionReasonRolloutWaitingForChange kcfgconsts.ConditionReason = "WaitingForChange"
 
 	// DataPlaneConditionReasonRolloutPromotionInProgress is a reason which
 	// indicates that a promotion is in progress.
-	DataPlaneConditionReasonRolloutPromotionInProgress ConditionReason = "PromotionInProgress"
+	DataPlaneConditionReasonRolloutPromotionInProgress kcfgconsts.ConditionReason = "PromotionInProgress"
 
 	// DataPlaneConditionReasonRolloutPromotionFailed is a reason which indicates
 	// a DataPlane has failed to promote. This may be caused for example by
 	// a failure in updating a live Service.
-	DataPlaneConditionReasonRolloutPromotionFailed ConditionReason = "PromotionFailed"
+	DataPlaneConditionReasonRolloutPromotionFailed kcfgconsts.ConditionReason = "PromotionFailed"
 
 	// DataPlaneConditionReasonRolloutPromotionDone is a reason which indicates that a promotion is done.
-	DataPlaneConditionReasonRolloutPromotionDone ConditionReason = "PromotionDone"
+	DataPlaneConditionReasonRolloutPromotionDone kcfgconsts.ConditionReason = "PromotionDone"
 )
 
 const (

--- a/pkg/utils/kubernetes/status.go
+++ b/pkg/utils/kubernetes/status.go
@@ -6,7 +6,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/kong/gateway-operator/pkg/consts"
+	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
+	kcfgdataplane "github.com/kong/kubernetes-configuration/api/gateway-operator/dataplane"
 )
 
 // ConditionsAndListenerConditionsAndGenerationAware is a CRD type that has Conditions, Generation, and Listener
@@ -61,7 +62,7 @@ func SetCondition(condition metav1.Condition, resource ConditionsAware) {
 }
 
 // GetCondition returns the condition with the given type, if it exists. If the condition does not exists it returns false.
-func GetCondition(cType consts.ConditionType, resource ConditionsAware) (metav1.Condition, bool) {
+func GetCondition(cType kcfgconsts.ConditionType, resource ConditionsAware) (metav1.Condition, bool) {
 	for _, condition := range resource.GetConditions() {
 		if condition.Type == string(cType) {
 			return condition, true
@@ -72,7 +73,7 @@ func GetCondition(cType consts.ConditionType, resource ConditionsAware) (metav1.
 
 // hasConditionWithStatus returns true if the provided resource has a condition
 // with the given type and status.
-func hasConditionWithStatus(cType consts.ConditionType, resource ConditionsAware, status metav1.ConditionStatus) bool {
+func hasConditionWithStatus(cType kcfgconsts.ConditionType, resource ConditionsAware, status metav1.ConditionStatus) bool {
 	for _, condition := range resource.GetConditions() {
 		if condition.Type == string(cType) {
 			return condition.Status == status
@@ -82,24 +83,24 @@ func hasConditionWithStatus(cType consts.ConditionType, resource ConditionsAware
 }
 
 // HasConditionFalse returns true if the condition on the resource has Status set to ConditionFalse, false otherwise.
-func HasConditionFalse(cType consts.ConditionType, resource ConditionsAware) bool {
+func HasConditionFalse(cType kcfgconsts.ConditionType, resource ConditionsAware) bool {
 	return hasConditionWithStatus(cType, resource, metav1.ConditionFalse)
 }
 
 // HasConditionTrue returns true if the condition on the resource has Status set to ConditionTrue, false otherwise.
-func HasConditionTrue(cType consts.ConditionType, resource ConditionsAware) bool {
+func HasConditionTrue(cType kcfgconsts.ConditionType, resource ConditionsAware) bool {
 	return hasConditionWithStatus(cType, resource, metav1.ConditionTrue)
 }
 
 // InitReady initializes the Ready status to False if Ready condition is not
 // yet set on the resource.
 func InitReady(resource ConditionsAndGenerationAware) bool {
-	_, ok := GetCondition(consts.ReadyType, resource)
+	_, ok := GetCondition(kcfgdataplane.ReadyType, resource)
 	if ok {
 		return false
 	}
 	SetCondition(
-		NewConditionWithGeneration(consts.ReadyType, metav1.ConditionFalse, consts.DependenciesNotReadyReason, consts.DependenciesNotReadyMessage, resource.GetGeneration()),
+		NewConditionWithGeneration(kcfgdataplane.ReadyType, metav1.ConditionFalse, kcfgdataplane.DependenciesNotReadyReason, kcfgdataplane.DependenciesNotReadyMessage, resource.GetGeneration()),
 		resource,
 	)
 	return true
@@ -109,18 +110,18 @@ func InitReady(resource ConditionsAndGenerationAware) bool {
 // It uses the provided generation to set the ObservedGeneration field.
 func SetReadyWithGeneration(resource ConditionsAndGenerationAware, generation int64) {
 	ready := metav1.Condition{
-		Type:               string(consts.ReadyType),
+		Type:               string(kcfgdataplane.ReadyType),
 		LastTransitionTime: metav1.Now(),
 		ObservedGeneration: generation,
 	}
 
 	if AreAllConditionsHaveTrueStatus(resource) {
 		ready.Status = metav1.ConditionTrue
-		ready.Reason = string(consts.ResourceReadyReason)
+		ready.Reason = string(kcfgdataplane.ResourceReadyReason)
 	} else {
 		ready.Status = metav1.ConditionFalse
-		ready.Reason = string(consts.DependenciesNotReadyReason)
-		ready.Message = consts.DependenciesNotReadyMessage
+		ready.Reason = string(kcfgdataplane.DependenciesNotReadyReason)
+		ready.Message = kcfgdataplane.DependenciesNotReadyMessage
 	}
 	SetCondition(ready, resource)
 }
@@ -143,8 +144,8 @@ func SetProgrammed(resource ConditionsAndGenerationAware) {
 		programmed.Reason = string(gatewayv1.GatewayReasonProgrammed)
 	} else {
 		programmed.Status = metav1.ConditionFalse
-		programmed.Reason = string(consts.DependenciesNotReadyReason)
-		programmed.Message = consts.DependenciesNotReadyMessage
+		programmed.Reason = string(kcfgdataplane.DependenciesNotReadyReason)
+		programmed.Message = kcfgdataplane.DependenciesNotReadyMessage
 	}
 	SetCondition(programmed, resource)
 }
@@ -201,7 +202,7 @@ func SetAcceptedConditionOnGateway(resource ConditionsAndListenerConditionsAndGe
 func AreAllConditionsHaveTrueStatus(resource ConditionsAware) bool {
 	for _, condition := range resource.GetConditions() {
 		switch condition.Type {
-		case string(consts.ReadyType), string(gatewayv1.GatewayConditionProgrammed):
+		case string(kcfgdataplane.ReadyType), string(gatewayv1.GatewayConditionProgrammed):
 			continue
 		default:
 			if condition.Status != metav1.ConditionTrue {
@@ -227,7 +228,7 @@ func IsAccepted(resource ConditionsAware) bool {
 // that all its conditions are in the True state.
 func IsReady(resource ConditionsAware) bool {
 	for _, condition := range resource.GetConditions() {
-		if condition.Type == string(consts.ReadyType) {
+		if condition.Type == string(kcfgdataplane.ReadyType) {
 			return condition.Status == metav1.ConditionTrue
 		}
 	}
@@ -245,7 +246,7 @@ func IsProgrammed(resource ConditionsAware) bool {
 }
 
 // NewCondition convenience method for creating conditions
-func NewCondition(cType consts.ConditionType, status metav1.ConditionStatus, reason consts.ConditionReason, message string) metav1.Condition {
+func NewCondition(cType kcfgconsts.ConditionType, status metav1.ConditionStatus, reason kcfgconsts.ConditionReason, message string) metav1.Condition {
 	return metav1.Condition{
 		Type:               string(cType),
 		Reason:             string(reason),
@@ -256,7 +257,7 @@ func NewCondition(cType consts.ConditionType, status metav1.ConditionStatus, rea
 }
 
 // NewConditionWithGeneration convenience method for creating conditions with ObservedGeneration set.
-func NewConditionWithGeneration(cType consts.ConditionType, status metav1.ConditionStatus, reason consts.ConditionReason, message string, observedGeneration int64) metav1.Condition {
+func NewConditionWithGeneration(cType kcfgconsts.ConditionType, status metav1.ConditionStatus, reason kcfgconsts.ConditionReason, message string, observedGeneration int64) metav1.Condition {
 	c := NewCondition(cType, status, reason, message)
 	c.ObservedGeneration = observedGeneration
 	return c
@@ -270,7 +271,7 @@ func NeedsUpdate(current, updated ConditionsAware) bool {
 	}
 
 	for _, c := range current.GetConditions() {
-		u, exists := GetCondition(consts.ConditionType(c.Type), updated)
+		u, exists := GetCondition(kcfgconsts.ConditionType(c.Type), updated)
 		if !exists {
 			return true
 		}

--- a/pkg/utils/kubernetes/status_test.go
+++ b/pkg/utils/kubernetes/status_test.go
@@ -7,6 +7,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/gateway-operator/pkg/consts"
+
+	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
 )
 
 type TestResource struct {
@@ -73,7 +75,7 @@ func TestGetCondition(t *testing.T) {
 			resource := &TestResource{
 				Conditions: tt.conditions,
 			}
-			current, exists := GetCondition(consts.ConditionType(tt.condition), resource)
+			current, exists := GetCondition(kcfgconsts.ConditionType(tt.condition), resource)
 			assert.Equal(t, tt.expected, current)
 			assert.Equal(t, tt.expectedFound, exists)
 		})
@@ -332,7 +334,7 @@ func TestIsValidCondition(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			current := HasConditionTrue(consts.ConditionType(tt.input), resource)
+			current := HasConditionTrue(kcfgconsts.ConditionType(tt.input), resource)
 			assert.Equal(t, tt.expected, current)
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request includes several changes to the `controller` package, specifically focusing on updating condition types and reasons to use constants from the `kcfgcontrolplane`, `kcfgdataplane`, and `kcfgkonnect` packages. The changes aim to standardize the use of constants across various controller files and tests.


**Which issue this PR fixes**

part of https://github.com/Kong/kubernetes-configuration/issues/303

**Special notes for your reviewer**:

To facilitate a quick review, I have only made a few minor modifications in this PR. In the subsequent PRs, I will gradually remove the original conditions configuration.


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
