### PR TITLE
fix: delete owner relationship between KongCertificates and KongSNIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,8 @@
   [#1178](https://github.com/Kong/gateway-operator/pull/1178)
 - Remove the owner relationship between `KongTarget` and `KongUpstream`.
   [#1279](https://github.com/Kong/gateway-operator/pull/1279)
+- Remove the owner relationship between `KongCertificate` and `KongSNI`.
+  [#1285](https://github.com/Kong/gateway-operator/pull/1285)
 - Check whether an error from calling Konnect API is a validation error by
   HTTP status code in Konnect entity controller. If the HTTP status code is
   `400`, we consider the error as a validation error and do not try to requeue

--- a/controller/konnect/reconciler_certificateref.go
+++ b/controller/konnect/reconciler_certificateref.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kong/gateway-operator/controller/konnect/constraints"
@@ -93,16 +92,9 @@ func handleKongCertificateRef[T constraints.SupportedKonnectEntityType, TEnt con
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	// Set owner reference of referenced KongCertificate and the reconciled entity.
-	old := ent.DeepCopyObject().(TEnt)
-	if err := controllerutil.SetOwnerReference(cert, ent, cl.Scheme(), controllerutil.WithBlockOwnerDeletion(true)); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to set owner reference: %w", err)
-	}
-	if err := cl.Patch(ctx, ent, client.MergeFrom(old)); err != nil {
-		if k8serrors.IsConflict(err) {
-			return ctrl.Result{Requeue: true}, nil
-		}
-		return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
+	res, err := RemoveOwnerRefIfSet(ctx, cl, ent, cert)
+	if err != nil || !res.IsZero() {
+		return res, err
 	}
 
 	// TODO: make this more generic.

--- a/controller/konnect/reconciler_certificateref_test.go
+++ b/controller/konnect/reconciler_certificateref_test.go
@@ -201,9 +201,9 @@ func TestHandleCertificateRef(t *testing.T) {
 					}), "KongSNI does not have ControlPlaneRefValid condition set to True"
 				},
 				func(ks *configurationv1alpha1.KongSNI) (bool, string) {
-					return lo.ContainsBy(ks.OwnerReferences, func(o metav1.OwnerReference) bool {
+					return !lo.ContainsBy(ks.OwnerReferences, func(o metav1.OwnerReference) bool {
 						return o.Kind == "KongCertificate" && o.Name == "cert-ok"
-					}), "OwnerReference of KongSNI is not set"
+					}), "OwnerReference of KongSNI is set but shouldn't"
 				},
 			},
 		},

--- a/controller/konnect/reconciler_consumerref.go
+++ b/controller/konnect/reconciler_consumerref.go
@@ -2,18 +2,15 @@ package konnect
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/samber/mo"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kong/gateway-operator/controller/konnect/constraints"
@@ -195,41 +192,4 @@ func handleKongConsumerRef[T constraints.SupportedKonnectEntityType, TEnt constr
 	}
 
 	return ctrl.Result{}, nil
-}
-
-func objectHasDeletedKongConsumerOwner(
-	obj client.Object,
-	scheme *runtime.Scheme,
-	err error,
-) (bool, error) {
-	var (
-		nn                types.NamespacedName
-		errDoesNotExist   ReferencedKongConsumerDoesNotExist
-		errIsBeingDeleted ReferencedKongConsumerIsBeingDeleted
-	)
-
-	switch {
-	case errors.As(err, &errDoesNotExist):
-		nn = errDoesNotExist.Reference
-	case errors.As(err, &errIsBeingDeleted):
-		nn = errIsBeingDeleted.Reference
-	default:
-		return false, nil
-	}
-
-	c := configurationv1.KongConsumer{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "KongConsumer",
-			APIVersion: "configuration.konghq.com/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      nn.Name,
-			Namespace: nn.Namespace,
-		},
-	}
-	ok, err := controllerutil.HasOwnerReference(obj.GetOwnerReferences(), &c, scheme)
-	if err != nil {
-		return false, err
-	}
-	return ok, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Also
- fix the missed ownership setting block in `controller/konnect/reconciler_upstreamref.go` (in #1279)
- fix the deleted consumer check (we don't set the ownership anymore so just check if the referenced consumer doesn't exist), in which case delete the finalizer

**Which issue this PR fixes**

Part of #788 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
