### PR TITLE
chore(tests): enable e2e `TestOperatorLogs`, case `upgrade from nightly to current` and adjustments

### DIFF
--- a/test/e2e/test_operator_logs.go
+++ b/test/e2e/test_operator_logs.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"bufio"
-	"context"
 	"encoding/json"
 	"regexp"
 	"strings"
@@ -65,14 +64,23 @@ var (
 )
 
 func TestOperatorLogs(t *testing.T) {
-	t.Skip() // TODO: https://github.com/kong/gateway-operator-archive/issues/908
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
+	ctx := t.Context()
+	if imageLoad == "" && imageOverride == "" {
+		t.Skipf("No KONG_TEST_GATEWAY_OPERATOR_IMAGE_OVERRIDE nor KONG_TEST_GATEWAY_OPERATOR_IMAGE_LOAD" +
+			" env specified. Please specify the image to upgrade to in order to run this test.")
+	}
+	var image string
+	if imageLoad != "" {
+		t.Logf("KONG_TEST_GATEWAY_OPERATOR_IMAGE_LOAD set to %q, using it to upgrade", imageLoad)
+		image = imageLoad
+	} else {
+		t.Logf("KONG_TEST_GATEWAY_OPERATOR_IMAGE_OVERRIDE set to %q, using it to upgrade", imageOverride)
+		image = imageOverride
+	}
 
 	// createEnvironment will queue up environment cleanup if necessary
 	// and dumping diagnostics if the test fails.
-	e := CreateEnvironment(t, ctx, WithInstallViaKustomize())
+	e := CreateEnvironment(t, ctx, WithOperatorImage(image), WithInstallViaKustomize())
 	clients, testNamespace, cleaner := e.Clients, e.Namespace, e.Cleaner
 
 	t.Log("finding the Pod for the Gateway Operator")
@@ -81,8 +89,8 @@ func TestOperatorLogs(t *testing.T) {
 		"control-plane": "controller-manager",
 	})
 	require.NoError(t, err)
-	require.Eventually(t, func() bool {
-		return len(podList.Items) == 1
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.Len(c, podList.Items, 1)
 	}, time.Minute, time.Second)
 	operatorPod := podList.Items[0]
 
@@ -150,7 +158,7 @@ func TestOperatorLogs(t *testing.T) {
 	cleaner.Add(gatewayClass)
 
 	t.Logf("deploying %d Gateway resourcess", parallelGateways)
-	for i := 0; i < parallelGateways; i++ {
+	for i := range parallelGateways {
 		gatewayNN := types.NamespacedName{
 			Name:      uuid.NewString(),
 			Namespace: testNamespace.Name,
@@ -207,12 +215,12 @@ func TestOperatorLogs(t *testing.T) {
 }
 
 func isReconcilerErrorAllowedByRegexMatch(errorMsg string) bool {
+	// For some reason this sometimes happen on CI. While this might
+	// be an actual issue, this should not fail the test on its own.
+	//
+	// Possibly related upstream issue:
+	// - https://github.com/kubernetes/kubernetes/issues/124347
 	allowedReconcilerErrorRegexes := []string{
-		// For some reason this sometimes happen on CI. While this might be an actual
-		// issue, this should not fail the test on its own.
-		//
-		// Possibly related upstream issue:
-		// - https://github.com/kubernetes-sigs/controller-runtime/issues/1881
 		`Operation cannot be fulfilled on dataplanes.gateway-operator.konghq.com \"[a-z0-9-]*\": StorageError: invalid object, Code: 4.*`,
 	}
 

--- a/test/envtest/konnect_entities_suite_test.go
+++ b/test/envtest/konnect_entities_suite_test.go
@@ -52,8 +52,7 @@ func testNewKonnectEntityReconciler[
 	t.Run(ent.GetTypeName(), func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithCancel(t.Context())
-		defer cancel()
+		ctx := t.Context()
 
 		mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- **for case `upgrade from nightly to current` from `TestHelmUpgrade`**

   Nightly images are available in 

     - [kong/nightly-gateway-operator-oss](https://hub.docker.com/r/kong/nightly-gateway-operator-oss/tags)
     - [kong/nightly-gateway-operator](https://hub.docker.com/r/kong/nightly-gateway-operator/tags)

    so ensure that those registries are used in the enabled test.
    
    Furthermore spotted that `"DataPlane deployment is not patched after operator upgrade"` tried to assert `gatewayDataPlaneDeploymentIsPatched` instead of `gatewayDataPlaneDeploymentIsNotPatched` in two places. 
    Make cleanup logic more robust to ensure that every GWAPI object provisioned before is deleted properly (finalizers need some more time) before uninstalling the Helm chart (otherwise orphaned `ControlPlane` was left and namespace couldn't be deleted)
    
- **`TestOperatorLogs`**
   `TestOperatorLogs` used to be disabled quite long time ago, see
    - https://github.com/kong/gateway-operator-archive/issues/908
    - https://github.com/Kong/gateway-operator-archive/issues/1283#issuecomment-2018318653

   But it is no longer flaky, underlying issues have been addressed, so reenable it. 
   
Replaces https://github.com/Kong/gateway-operator/pull/990