### PR TITLE
fix: delete owner relationship between KongKeys and KongKeyset refs and ControlPlanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,8 @@
   [#1279](https://github.com/Kong/gateway-operator/pull/1279)
 - Remove the owner relationship between `KongCertificate` and `KongSNI`.
   [#1285](https://github.com/Kong/gateway-operator/pull/1285)
+- Remove the owner relationship between `KongKey`s and `KongKeysSet`s and `KonnectGatewayControlPlane`s.
+  [#1291](https://github.com/Kong/gateway-operator/pull/1291)
 - Check whether an error from calling Konnect API is a validation error by
   HTTP status code in Konnect entity controller. If the HTTP status code is
   `400`, we consider the error as a validation error and do not try to requeue

--- a/test/envtest/konnect_entities_kongkey_test.go
+++ b/test/envtest/konnect_entities_kongkey_test.go
@@ -228,13 +228,9 @@ func TestKongKey(t *testing.T) {
 					condition.Status == metav1.ConditionTrue
 			})
 			keySetIDPopulated := c.Status.Konnect != nil && c.Status.Konnect.KeySetID != ""
-			exactlyOneOwnerReference := len(c.GetOwnerReferences()) == 1
-			if !exactlyOneOwnerReference {
-				return false
-			}
+			exactlyZeroOwnerReference := len(c.GetOwnerReferences()) == 0
 
-			hasOwnerRefToKeySet := c.GetOwnerReferences()[0].Name == keySet.GetName()
-			return programmed && associated && keySetIDPopulated && hasOwnerRefToKeySet
+			return programmed && associated && keySetIDPopulated && exactlyZeroOwnerReference
 		}, "KongKey's Programmed and KeySetRefValid conditions should be true eventually")
 
 		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
@@ -255,10 +251,12 @@ func TestKongKey(t *testing.T) {
 			if c.GetName() != createdKey.GetName() {
 				return false
 			}
-			exactlyOneOwnerReference := len(c.GetOwnerReferences()) == 1
-			hasOwnerReferenceToCP := c.GetOwnerReferences()[0].Name == cp.GetName()
 
-			return exactlyOneOwnerReference && hasOwnerReferenceToCP
+			if c.Spec.KeySetRef != nil {
+				return false
+			}
+
+			return len(c.GetOwnerReferences()) == 0
 		}, "KongKey should be deattached from KongKeySet eventually")
 
 		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)


### PR DESCRIPTION
**What this PR does / why we need it**:


**Which issue this PR fixes**

This is the last ownership to fix as part of #788 hence:

Fixes #788

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
