### PR TITLE
chore(ci): fix govulncheck incorrectly reporting ref

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -29,29 +29,26 @@ jobs:
         - release/1.4.x
     steps:
     - name: Checkout repository
+      id: checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: ${{ matrix.branch }}
 
-    - name: Set results file name
-      id: filename
-      run: |
-        echo "result=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-
-    - id: govulncheck
-      uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+    - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
       with:
         # Let the actions/checkout above perform the checkout as this action
         # cannot checkout on custom ref.
         repo-checkout: false
         output-format: sarif
-        output-file: results_${{ steps.filename.result }}.sarif
+        output-file: results_${{ steps.checkout.outputs.commit }}.sarif
 
     - name: Upload SARIF file
       uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3.28.10
       with:
         # Path to SARIF file relative to the root of the repository
-        sarif_file: results_${{ steps.filename.result }}.sarif
+        sarif_file: results_${{ steps.checkout.outputs.commit }}.sarif
+        ref: refs/heads/${{ matrix.branch }}
+        sha: ${{ steps.checkout.outputs.commit }}
         # Optional category for the results
         # Used to differentiate multiple results for one commit
         category: govulncheck


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix `govulncheck` reporting on incorrect refs/sha.

With this PR we'll stop getting reports like: https://github.com/Kong/gateway-operator/security/code-scanning/30 which are constantly flapping between being unsolved (`release/1.4.x` branch) and solved (`main`).

<img width="1029" alt="image" src="https://github.com/user-attachments/assets/9df13bda-0e49-4522-b6e2-a1e4a4998685" />

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
