### PR TITLE
fix: add missing KonnectExtension RBAC

### DIFF
--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -384,6 +384,7 @@ rules:
   - konnectapiauthconfigurations
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
+  - konnectextensions
   - konnectgatewaycontrolplanes
   verbs:
   - get
@@ -400,6 +401,7 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations/status
   - konnectcloudgatewaynetworks/finalizers
   - konnectcloudgatewaynetworks/status
+  - konnectextensions/status
   - konnectgatewaycontrolplanes/finalizers
   - konnectgatewaycontrolplanes/status
   verbs:

--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -384,7 +384,6 @@ rules:
   - konnectapiauthconfigurations
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
-  - konnectextensions
   - konnectgatewaycontrolplanes
   verbs:
   - get
@@ -407,6 +406,14 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/controller/dataplane/controller_rbac.go
+++ b/controller/dataplane/controller_rbac.go
@@ -9,6 +9,8 @@ package dataplane
 // +kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=dataplanes/finalizers,verbs=update
 // +kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=konnectextensions,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=konnectextensions/status,verbs=update;patch
+// +kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectextensions,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectextensions/status,verbs=update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=create;get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch

--- a/controller/dataplane/controller_rbac.go
+++ b/controller/dataplane/controller_rbac.go
@@ -9,7 +9,7 @@ package dataplane
 // +kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=dataplanes/finalizers,verbs=update
 // +kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=konnectextensions,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=konnectextensions/status,verbs=update;patch
-// +kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectextensions,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectextensions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectextensions/status,verbs=update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=create;get;list;watch;update;patch;delete

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -35,7 +35,7 @@ WORKDIR /workspace
 
 RUN --mount=type=cache,target=$GOPATH/pkg/mod \
     --mount=type=cache,target=$GOCACHE \
-    go install github.com/go-delve/delve/cmd/dlv@v1.22.1
+    go install github.com/go-delve/delve/cmd/dlv@v1.24.0
 
 # Use cache mounts to cache Go dependencies and bind mounts to avoid unnecessary
 # layers when using COPY instructions for go.mod and go.sum.


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds lacking KonnectExtension RBAC and fixes `make debug.skaffold` by bumping dlv to the latest one.

**Which issue this PR fixes**

Part of https://github.com/Kong/gateway-operator/issues/1233
