### PR TITLE
feat: populate CP and DP refs in KonnectExtension status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,9 @@
   [#1254](https://github.com/Kong/gateway-operator/pull/1254)
 - Added support for `KonnectExtension`s on `ControlPlane`s.
   [#1262](https://github.com/Kong/gateway-operator/pull/1262)
+- Added support for `KonnectExtension`'s `status` `controlPlaneRefs` and `dataPlaneRefs`
+  fields.
+  [#1297](https://github.com/Kong/gateway-operator/pull/1297)
 
 ### Changed
 

--- a/config/samples/controlplane-konnect-extension.yaml
+++ b/config/samples/controlplane-konnect-extension.yaml
@@ -1,6 +1,5 @@
 # Ensure that you create a secret containing your cluster certificate before applying this
 # kubectl create secret tls konnect-client-tls -n kong --cert=./tls.crt --key=./tls.key
-# ---
 # apiVersion: v1
 # kind: Secret
 # metadata:
@@ -9,15 +8,13 @@
 # stringData:
 #   tls.crt: |
 #     -----BEGIN CERTIFICATE-----
-#     MIIDhDCCAm6gAwIBAgIBATALBgkqhkiG9w0BAQ0wLDEqMAkGA1UEBhMCVVMwHQYD...
-#     zy5lW2IG5AjNDV8VBCthVj5j1UENTVi4rLhu8j/kfb9gNhvqaN8UcA==
+#     ...
 #     -----END CERTIFICATE-----
 #   tls.key: |
 #     -----BEGIN PRIVATE KEY-----
-#     MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQChCERwsegdWSnS...
-#     WSK9kndNKpFI4vPvuw6j2JJl
+#     ...
 #     -----END PRIVATE KEY-----
-# ---
+---
 kind: KonnectAPIAuthConfiguration
 apiVersion: konnect.konghq.com/v1alpha1
 metadata:
@@ -25,7 +22,7 @@ metadata:
   namespace: default
 spec:
   type: token
-  token: kpat_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+  token: kpat_XXXXXXXXX
   serverURL: us.api.konghq.com
 ---
 kind: KonnectExtension
@@ -33,11 +30,13 @@ apiVersion: konnect.konghq.com/v1alpha1
 metadata:
   name: my-konnect-config
   namespace: default
+  annotations:
+    konghq.com/override: "true"
 spec:
   konnectControlPlane:
     controlPlaneRef:
       type: konnectID
-      konnectID: a6554c4c-79a6-4db7-b7a4-201c0cf746ba 
+      konnectID: c846c30c-77da-40e6-b0c8-66ed7e16c497
   dataPlaneClientAuth:
     certificateSecret:
       provisioning: Manual
@@ -52,7 +51,11 @@ kind: ControlPlane
 metadata:
   name: controlplane-example
 spec:
-  dataplane: dataplane-example
+  extensions:
+    - kind: KonnectExtension
+      name: my-konnect-config
+      group: konnect.konghq.com
+  dataplane: konnect-extension-example
   gatewayClass: kong
   deployment:
     podTemplateSpec:
@@ -74,4 +77,29 @@ spec:
             limits:
               memory: "1024Mi"
               cpu: "1000m"
-
+---
+apiVersion: gateway-operator.konghq.com/v1beta1
+kind: DataPlane
+metadata:
+  name: konnect-extension-example
+spec:
+  extensions:
+    - kind: KonnectExtension
+      name: my-konnect-config
+      group: konnect.konghq.com
+  deployment:
+    replicas: 3
+    podTemplateSpec:
+      metadata:
+        labels:
+          dataplane-pod-label: example
+        annotations:
+          dataplane-pod-annotation: example
+      spec:
+        containers:
+          - name: proxy
+            # renovate: datasource=docker versioning=docker
+            image: kong/kong-gateway:3.9
+            readinessProbe:
+              initialDelaySeconds: 1
+              periodSeconds: 1

--- a/config/samples/controlplane-konnect-extension.yaml
+++ b/config/samples/controlplane-konnect-extension.yaml
@@ -1,3 +1,7 @@
+# This example will create a ControlPlane and a DataPlane configured by the ControlPlane with KonnectExtension attached
+# to them. It means that both ControlPlane and DataPlane will communicate with Konnect Control Plane specified in the
+# KonnectExtension spec.
+#
 # Ensure that you create a secret containing your cluster certificate before applying this
 # kubectl create secret tls konnect-client-tls -n kong --cert=./tls.crt --key=./tls.key
 # apiVersion: v1

--- a/config/samples/dataplane-konnect-extension.yaml
+++ b/config/samples/dataplane-konnect-extension.yaml
@@ -1,6 +1,5 @@
 # Ensure that you create a secret containing your cluster certificate before applying this
 # kubectl create secret tls konnect-client-tls -n kong --cert=./tls.crt --key=./tls.key
-# ---
 # apiVersion: v1
 # kind: Secret
 # metadata:
@@ -9,15 +8,13 @@
 # stringData:
 #   tls.crt: |
 #     -----BEGIN CERTIFICATE-----
-#     MIIDhDCCAm6gAwIBAgIBATALBgkqhkiG9w0BAQ0wLDEqMAkGA1UEBhMCVVMwHQYD...
-#     zy5lW2IG5AjNDV8VBCthVj5j1UENTVi4rLhu8j/kfb9gNhvqaN8UcA==
+#     ...
 #     -----END CERTIFICATE-----
 #   tls.key: |
 #     -----BEGIN PRIVATE KEY-----
-#     MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQChCERwsegdWSnS...
-#     WSK9kndNKpFI4vPvuw6j2JJl
+#     ...
 #     -----END PRIVATE KEY-----
-# ---
+---
 kind: KonnectAPIAuthConfiguration
 apiVersion: konnect.konghq.com/v1alpha1
 metadata:
@@ -55,7 +52,7 @@ spec:
   extensions:
   - kind: KonnectExtension
     name: my-konnect-config
-    group: gateway-operator.konghq.com
+    group: konnect.konghq.com
   deployment:
     replicas: 3
     podTemplateSpec:

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -290,7 +290,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	_ = controlplane.SetDefaults(
 		&cp.Spec.ControlPlaneOptions,
 		defaultArgs)
-	stop, result, err := extensions.ApplyExtensions(ctx, r.Client, logger, cp, r.KonnectEnabled)
+	stop, result, err := extensions.ApplyExtensions(ctx, r.Client, cp, r.KonnectEnabled)
 	if err != nil {
 		if extensionserrors.IsKonnectExtensionError(err) {
 			log.Debug(logger, "failed to apply extensions", "err", err)

--- a/controller/dataplane/bluegreen_controller.go
+++ b/controller/dataplane/bluegreen_controller.go
@@ -147,7 +147,7 @@ func (r *BlueGreenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// customize the dataplane with the extensions field
 	log.Trace(logger, "applying extensions")
-	stop, result, err := extensions.ApplyExtensions(ctx, r.Client, logger, &dataplane, r.KonnectEnabled)
+	stop, result, err := extensions.ApplyExtensions(ctx, r.Client, &dataplane, r.KonnectEnabled)
 	if err != nil {
 		if extensionserrors.IsKonnectExtensionError(err) {
 			log.Debug(logger, "failed to apply extensions", "err", err)

--- a/controller/dataplane/controller.go
+++ b/controller/dataplane/controller.go
@@ -84,7 +84,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	log.Trace(logger, "applying extensions")
-	stop, result, err := extensions.ApplyExtensions(ctx, r.Client, logger, dataplane, r.KonnectEnabled)
+	stop, result, err := extensions.ApplyExtensions(ctx, r.Client, dataplane, r.KonnectEnabled)
 	if err != nil {
 		if extensionserrors.IsKonnectExtensionError(err) {
 			log.Debug(logger, "failed to apply extensions", "err", err)

--- a/controller/konnect/konnectextension_controller_utils.go
+++ b/controller/konnect/konnectextension_controller_utils.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,6 +23,8 @@ import (
 	"github.com/kong/gateway-operator/controller/pkg/patch"
 
 	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+	"github.com/kong/kubernetes-configuration/api/konnect"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
@@ -132,6 +136,72 @@ func (r *KonnectExtensionReconciler) getKonnectControlPlane(
 	}
 
 	return konnectCP, ctrl.Result{}, err
+}
+
+// ensureExtendablesReferencesInStatus ensures that the KonnectExtension references to DataPlane and ControlPlane are up-to-date.
+// Only DataPlanes and ControlPlanes with the condition KonnectExtensionApplied=True are added to the status.
+func (r *KonnectExtensionReconciler) ensureExtendablesReferencesInStatus(
+	ctx context.Context,
+	ext *konnectv1alpha1.KonnectExtension,
+	dps operatorv1beta1.DataPlaneList,
+	cps operatorv1beta1.ControlPlaneList,
+) (ctrl.Result, error) {
+	sortRefs := func(refs []commonv1alpha1.NamespacedRef) {
+		refToStr := func(ref commonv1alpha1.NamespacedRef) string {
+			// We can safely assume that the namespace is not nil, as we fill it when mapping refs.
+			return fmt.Sprintf("%s/%s", *ref.Namespace, ref.Name)
+		}
+		sort.Slice(refs, func(i, j int) bool {
+			return refToStr(refs[i]) < refToStr(refs[j])
+		})
+	}
+	hasExetensionAppliedCondition := func(conditions []metav1.Condition) bool {
+		return lo.ContainsBy(conditions, func(cond metav1.Condition) bool {
+			return cond.Type == string(konnect.KonnectExtensionAppliedType) &&
+				cond.Status == metav1.ConditionTrue
+		})
+	}
+
+	extOld := ext.DeepCopy()
+
+	// Ensure DataPlaneRefs are up-to-date.
+	var dpRefs []commonv1alpha1.NamespacedRef
+	for _, dp := range dps.Items {
+		// Only add DataPlanes with the KonnectExtensionApplied condition set to true.
+		if !hasExetensionAppliedCondition(dp.Status.Conditions) {
+			continue
+		}
+		dpRefs = append(dpRefs, commonv1alpha1.NamespacedRef{
+			Name:      dp.Name,
+			Namespace: &dp.Namespace,
+		})
+	}
+	sortRefs(dpRefs)
+	ext.Status.DataPlaneRefs = dpRefs
+
+	// Ensure ControlPlaneRefs are up-to-date.
+	var cpRefs []commonv1alpha1.NamespacedRef
+	for _, cp := range cps.Items {
+		// Only add ControlPlanes with the KonnectExtensionApplied condition set to true.
+		if !hasExetensionAppliedCondition(cp.Status.Conditions) {
+			continue
+		}
+		cpRefs = append(cpRefs, commonv1alpha1.NamespacedRef{
+			Name:      cp.Name,
+			Namespace: &cp.Namespace,
+		})
+	}
+	sortRefs(cpRefs)
+	ext.Status.ControlPlaneRefs = cpRefs
+
+	if shouldUpdate := !cmp.Equal(ext.Status, extOld.Status); !shouldUpdate {
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.Client.Status().Update(ctx, ext); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update KonnectExtension ControlPlane and DataPlane references in status: %w", err)
+	}
+	return ctrl.Result{Requeue: true}, nil
 }
 
 func getKonnectAPIAuthRefNN(ctx context.Context, cl client.Client, ext *konnectv1alpha1.KonnectExtension) (types.NamespacedName, error) {

--- a/controller/pkg/extensions/apply.go
+++ b/controller/pkg/extensions/apply.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,14 +35,14 @@ type withExtensions interface {
 	GetExtensions() []commonv1alpha1.ExtensionRef
 }
 
-// applyExtensions patches the dataplane or controlplane spec by taking into account customizations from the referenced extensions.
+// ApplyExtensions patches the dataplane or controlplane spec by taking into account customizations from the referenced extensions.
 // In case any extension is referenced, it adds a resolvedRefs condition to the dataplane, indicating the status of the
 // extension reference. it returns 3 values:
 //   - stop: a boolean indicating if the caller must return. It's true when the dataplane status has been patched.
 //   - res: a ctrl.Result indicating if the dataplane should be requeued. If the error was unexpected (e.g., because of API server error), the dataplane should be requeued.
 //     In case the error is related to a misconfiguration, the dataplane does not need to be requeued, and feedback is provided into the dataplane status.
 //   - err: an error in case of failure.
-func ApplyExtensions[t ExtendableT](ctx context.Context, cl client.Client, logger logr.Logger, o t, konnectEnabled bool) (stop bool, res ctrl.Result, err error) {
+func ApplyExtensions[t ExtendableT](ctx context.Context, cl client.Client, o t, konnectEnabled bool) (stop bool, res ctrl.Result, err error) {
 	// extensionsCondition can be nil. In that case, no extensions are referenced by the object.
 	extensionsCondition := validateExtensions(o)
 	if extensionsCondition == nil {

--- a/controller/pkg/patch/patch.go
+++ b/controller/pkg/patch/patch.go
@@ -45,7 +45,7 @@ func ApplyPatchIfNotEmpty[
 		return op.Noop, existingResource, nil
 	}
 
-	if err := cl.Patch(ctx, existingResource, client.MergeFrom(oldExistingResource)); err != nil {
+	if err := cl.Patch(ctx, existingResource, patch); err != nil {
 		var t T
 		return op.Noop, t, fmt.Errorf("failed patching %s %s: %w", kind, existingResource.GetName(), err)
 	}

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -35,7 +35,7 @@ WORKDIR /workspace
 
 RUN --mount=type=cache,target=$GOPATH/pkg/mod \
     --mount=type=cache,target=$GOCACHE \
-    go install github.com/go-delve/delve/cmd/dlv@v1.22.1
+    go install github.com/go-delve/delve/cmd/dlv@v1.24.0
 
 # Use cache mounts to cache Go dependencies and bind mounts to avoid unnecessary
 # layers when using COPY instructions for go.mod and go.sum.

--- a/internal/utils/index/index.go
+++ b/internal/utils/index/index.go
@@ -81,7 +81,7 @@ func KongPluginInstallationsOnDataPlane(ctx context.Context, c cache.Cache) erro
 
 // ExtendableOnKonnectExtension indexes the Object .spec.extensions field
 // on the "KonnectExtension" key.
-func ExtendableOnKonnectExtension[t extensions.ExtendableT](ctx context.Context, c cache.Cache, obj t) error {
+func ExtendableOnKonnectExtension[T extensions.ExtendableT](ctx context.Context, c cache.Cache, obj T) error {
 	if _, err := c.GetInformer(ctx, obj); err != nil {
 		if meta.IsNoMatchError(err) {
 			return nil
@@ -93,8 +93,12 @@ func ExtendableOnKonnectExtension[t extensions.ExtendableT](ctx context.Context,
 		obj,
 		KonnectExtensionIndex,
 		func(o client.Object) []string {
+			obj, ok := o.(T)
+			if !ok {
+				return nil
+			}
+
 			result := []string{}
-			obj := o.(t)
 			if len(obj.GetExtensions()) > 0 {
 				for _, ext := range obj.GetExtensions() {
 					namespace := obj.GetNamespace()


### PR DESCRIPTION
**What this PR does / why we need it**:

Starts populating `KonnectExtension`'s `status.controlPlaneRefs` and `status.dataPlaneRefs` fields with references to all CPs and DPs that refer a given KonnectExtension and have a `KonnectExtensionApplied` condition `True`.

**Which issue this PR fixes**

Fixes https://github.com/Kong/gateway-operator/issues/1233.

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
