### PR TITLE
fix: ports in `GatewayConfiguration` can be adjusted, enable integration case `verifying DataPlane's NetworkPolicies...`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@
 
 ## Unreleased
 
+### Fixes
+
+- Adjustment of `KONG_PROXY_LISTEN` and `KONG_PORT_MAPS` in `GatewayConfiguration` no longer results in a reconciliation
+  error for a `Gateway`.
+  [#1308](https://github.com/Kong/gateway-operator/pull/1308)
+
 ### Added
 
 - In `KonnectGatewayControlPlane` fields `Status.Endpoints.ControlPlaneEndpoint`


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable `verifying DataPlane's NetworkPolicies get updated after customizing kong proxy listen port through GatewayConfiguration` case from `TestGatewayDataPlaneNetworkPolicy`, because it was declared as resolved

- https://github.com/Kong/gateway-operator/issues/184
- https://github.com/Kong/gateway-operator/pull/609

Simple enablement leads to failing test case due to (controller logs, the same message is set in `Gateway` status):

```log
2025-03-12T15:17:45+01:00	ERROR	gateway	failed to provision dataplane	{"error": "failed patching the dataplane 9b1ebbcd-19ee-4eff-9d0b-d29eef842338-7vhb2: dataplanes.gateway-operator.konghq.com \"9b1ebbcd-19ee-4eff-9d0b-d29eef842338-7vhb2\" is forbidden: ValidatingAdmissionPolicy 'ports.dataplane.gateway-operator.konghq.com' with binding 'binding-ports.dataplane.gateway-operator.konghq.com' denied request: Each port from spec.network.services.ingress.ports has to have an accompanying port in KONG_PORT_MAPS env"}
github.com/kong/gateway-operator/controller/pkg/log.Error
	/Users/jakub.warczarek@konghq.com/Documents/work/gateway-operator/controller/pkg/log/log.go:33
github.com/kong/gateway-operator/controller/gateway.(*Reconciler).Reconcile
```



**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes