### PR TITLE
fix: prevent panic in KE controller when dereferencing not existing secret

### DIFF
--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -205,10 +205,11 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			}, nil
 		}
 
-		certificateSecret, certExists, err := getCertificateSecret(ctx, r.Client, ext)
+		certificateSecret, err := getCertificateSecret(ctx, r.Client, ext)
 		if client.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, err
 		}
+		certExists := !k8serrors.IsNotFound(err)
 
 		// if the certificate exists and the cleanup in Konnect has been performed, we can remove the secret-in-use finalizer from the secret.
 		if certExists && !controllerutil.ContainsFinalizer(certificateSecret, KonnectCleanupFinalizer) {
@@ -335,7 +336,7 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	// get the Kubernetes secret holding the certificate.
-	certificateSecret, _, err := getCertificateSecret(ctx, r.Client, ext)
+	certificateSecret, err := getCertificateSecret(ctx, r.Client, ext)
 	if err != nil {
 		certProvisionedCond.Status = metav1.ConditionFalse
 		certProvisionedCond.Reason = konnectv1alpha1.DataPlaneCertificateProvisionedReasonRefNotFound

--- a/controller/konnect/konnectextension_controller_utils.go
+++ b/controller/konnect/konnectextension_controller_utils.go
@@ -238,7 +238,7 @@ func getKonnectAPIAuthRefNN(ctx context.Context, cl client.Client, ext *konnectv
 	}, nil
 }
 
-func getCertificateSecret(ctx context.Context, cl client.Client, ext konnectv1alpha1.KonnectExtension) (*corev1.Secret, error) {
+func getCertificateSecret(ctx context.Context, cl client.Client, ext konnectv1alpha1.KonnectExtension) (secret *corev1.Secret, exists bool, err error) {
 	var certificateSecret corev1.Secret
 	switch *ext.Spec.DataPlaneClientAuth.CertificateSecret.Provisioning {
 	case konnectv1alpha1.ManualSecretProvisioning:
@@ -247,12 +247,12 @@ func getCertificateSecret(ctx context.Context, cl client.Client, ext konnectv1al
 			Namespace: ext.Namespace,
 			Name:      ext.Spec.DataPlaneClientAuth.CertificateSecret.CertificateSecretRef.Name,
 		}, &certificateSecret); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	default:
-		return nil, errors.New("automatic secret provisioning not supported yet")
+		return nil, false, errors.New("automatic secret provisioning not supported yet")
 	}
-	return &certificateSecret, nil
+	return &certificateSecret, true, nil
 }
 
 func konnectClusterTypeToCRDClusterType(clusterType sdkkonnectcomp.ControlPlaneClusterType) konnectv1alpha1.KonnectExtensionClusterType {

--- a/controller/konnect/konnectextension_controller_utils.go
+++ b/controller/konnect/konnectextension_controller_utils.go
@@ -238,7 +238,7 @@ func getKonnectAPIAuthRefNN(ctx context.Context, cl client.Client, ext *konnectv
 	}, nil
 }
 
-func getCertificateSecret(ctx context.Context, cl client.Client, ext konnectv1alpha1.KonnectExtension) (secret *corev1.Secret, exists bool, err error) {
+func getCertificateSecret(ctx context.Context, cl client.Client, ext konnectv1alpha1.KonnectExtension) (*corev1.Secret, error) {
 	var certificateSecret corev1.Secret
 	switch *ext.Spec.DataPlaneClientAuth.CertificateSecret.Provisioning {
 	case konnectv1alpha1.ManualSecretProvisioning:
@@ -247,12 +247,12 @@ func getCertificateSecret(ctx context.Context, cl client.Client, ext konnectv1al
 			Namespace: ext.Namespace,
 			Name:      ext.Spec.DataPlaneClientAuth.CertificateSecret.CertificateSecretRef.Name,
 		}, &certificateSecret); err != nil {
-			return nil, false, err
+			return nil, err
 		}
 	default:
-		return nil, false, errors.New("automatic secret provisioning not supported yet")
+		return nil, errors.New("automatic secret provisioning not supported yet")
 	}
-	return &certificateSecret, true, nil
+	return &certificateSecret, nil
 }
 
 func konnectClusterTypeToCRDClusterType(clusterType sdkkonnectcomp.ControlPlaneClusterType) konnectv1alpha1.KonnectExtensionClusterType {


### PR DESCRIPTION
**What this PR does / why we need it**:

In the KE controller, when dereferencing a secret to remove its finalizer, ensure the secret actually exists.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
