### PR TITLE
fix(konnectExtension): don't trigger error when CP is not programmed

### DIFF
--- a/controller/konnect/konnectextension_controller_utils.go
+++ b/controller/konnect/konnectextension_controller_utils.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect/ops"
 	sdkops "github.com/kong/gateway-operator/controller/konnect/ops/sdk"
+	extensionserrors "github.com/kong/gateway-operator/controller/pkg/extensions/errors"
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/controller/pkg/patch"
 
@@ -80,7 +81,7 @@ func (r *KonnectExtensionReconciler) getKonnectControlPlane(
 			); errPatch != nil || !res.IsZero() {
 				return nil, res, errPatch
 			}
-			return nil, ctrl.Result{}, nil
+			return nil, ctrl.Result{}, err
 		}
 
 		// set the controlPlaneRefValidCond to false in case the KonnectGatewayControlPlane is not programmed yet
@@ -99,7 +100,7 @@ func (r *KonnectExtensionReconciler) getKonnectControlPlane(
 			); errPatch != nil || !res.IsZero() {
 				return nil, res, errPatch
 			}
-			return nil, ctrl.Result{}, nil
+			return nil, ctrl.Result{}, extensionserrors.ErrKonnectGatewayControlPlaneNotProgrammed
 		}
 		konnectCPID = kgcp.GetKonnectID()
 	case commonv1alpha1.ControlPlaneRefKonnectID:

--- a/controller/pkg/extensions/errors/errors.go
+++ b/controller/pkg/extensions/errors/errors.go
@@ -1,6 +1,8 @@
 package errors
 
-import "errors"
+import (
+	"errors"
+)
 
 var (
 	// ErrCrossNamespaceReference is returned when a Konnect extension references a different namespace.
@@ -13,6 +15,9 @@ var (
 	ErrKonnectExtensionNotReady = errors.New("konnect extension is not ready")
 	// ErrInvalidExtensions is returned when an invalid extension is referenced.
 	ErrInvalidExtensions = errors.New("invalid extensions")
+
+	// ErrKonnectGatewayControlPlaneNotProgrammed is returned when a control plane is not programmed.
+	ErrKonnectGatewayControlPlaneNotProgrammed = errors.New("konnect control plane is not programmed yet")
 )
 
 // IsKonnectExtensionError returns true if the error is a Konnect extension error.


### PR DESCRIPTION
**What this PR does / why we need it**:

In the `KonnectExtension` controller, if the `KonnectGatewayControlPlane` is not programmed, don't raise an error.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
