### PR TITLE
fix(konnect): ensure objects have konnect cleanup finalizer set when reattaching to a referenced entity

### DIFF
--- a/controller/pkg/patch/finalizer.go
+++ b/controller/pkg/patch/finalizer.go
@@ -1,0 +1,45 @@
+package patch
+
+import (
+	"context"
+	"fmt"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// WithFinalizer patches the provided object with the provided finalizer.
+// It returns a ctrl.Result and an error.
+func WithFinalizer[
+	T client.Object,
+](
+	ctx context.Context,
+	cl client.Client,
+	ent T,
+	finalizer string,
+) (bool, ctrl.Result, error) {
+	// This check prevents a deep copy of the object when the finalizer is already added.
+	// Since finalizers are typically set on an object in small numbers,
+	// looping over them twice is not a performance issue.
+	if controllerutil.ContainsFinalizer(ent, finalizer) {
+		return false, ctrl.Result{}, nil
+	}
+
+	objWithFinalizer := ent.DeepCopyObject().(client.Object)
+	if !controllerutil.AddFinalizer(objWithFinalizer, finalizer) {
+		return false, ctrl.Result{}, nil
+	}
+
+	if errUpd := cl.Patch(ctx, objWithFinalizer, client.MergeFrom(ent)); errUpd != nil {
+		if k8serrors.IsConflict(errUpd) {
+			return false, ctrl.Result{Requeue: true}, nil
+		}
+		return false, ctrl.Result{}, fmt.Errorf(
+			"failed to update finalizer %s: %w",
+			finalizer, errUpd,
+		)
+	}
+	return true, ctrl.Result{}, nil
+}

--- a/test/envtest/assert.go
+++ b/test/envtest/assert.go
@@ -59,9 +59,7 @@ func eventuallyAssertSDKExpectations(
 
 // assertsAnd returns a function that performs a logical AND of the given asserts.
 func assertsAnd[
-	T interface {
-		client.Object
-	},
+	T client.Object,
 ](
 	asserts ...func(T) bool,
 ) func(objToMatch T) bool {
@@ -73,5 +71,15 @@ func assertsAnd[
 		}
 
 		return true
+	}
+}
+
+func assertNot[
+	T client.Object,
+](
+	assert func(T) bool,
+) func(objToMatch T) bool {
+	return func(objToMatch T) bool {
+		return !assert(objToMatch)
 	}
 }

--- a/test/envtest/asserts_meta.go
+++ b/test/envtest/asserts_meta.go
@@ -1,0 +1,14 @@
+package envtest
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func objectHasFinalizer[
+	T client.Object,
+](finalizer string) func(obj T) bool {
+	return func(obj T) bool {
+		return controllerutil.ContainsFinalizer(obj, finalizer)
+	}
+}

--- a/test/envtest/konnect_entities_kongconsumer_test.go
+++ b/test/envtest/konnect_entities_kongconsumer_test.go
@@ -9,6 +9,7 @@ import (
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
+	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -437,8 +438,8 @@ func TestKongConsumer(t *testing.T) {
 		created := deploy.KongConsumer(t, ctx, clientNamespaced, name,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 			func(obj client.Object) {
-				cert := obj.(*configurationv1.KongConsumer)
-				cert.Username = name
+				c := obj.(*configurationv1.KongConsumer)
+				c.Username = name
 			},
 		)
 
@@ -455,6 +456,103 @@ func TestKongConsumer(t *testing.T) {
 		watchFor(t, ctx, w, apiwatch.Modified,
 			conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			"KongConsumer didn't get Programmed and/or ControlPlaneRefValid status condition set to False",
+		)
+	})
+
+	t.Run("detaching and reattaching the referenced CP correctly removes and readds the konnect cleanup finalizer", func(t *testing.T) {
+		const (
+			id   = "abc-1234567"
+			name = "name-2"
+		)
+
+		t.Log("Creating KonnectAPIAuthConfiguration and KonnectGatewayControlPlane")
+		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
+		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
+
+		w := setupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
+
+		t.Log("Setting up SDK expectations on KongConsumer creation")
+		sdk.ConsumersSDK.EXPECT().
+			CreateConsumer(
+				mock.Anything,
+				cp.GetKonnectID(),
+				mock.MatchedBy(func(req sdkkonnectcomp.ConsumerInput) bool {
+					return req.Username != nil && *req.Username == name
+				}),
+			).
+			Return(
+				&sdkkonnectops.CreateConsumerResponse{
+					Consumer: &sdkkonnectcomp.Consumer{
+						ID:       lo.ToPtr(id),
+						Username: lo.ToPtr(name),
+					},
+				},
+				nil,
+			)
+
+		t.Log("Setting up SDK expectation on KongConsumerGroups listing")
+		sdk.ConsumerGroupSDK.EXPECT().
+			ListConsumerGroupsForConsumer(mock.Anything, sdkkonnectops.ListConsumerGroupsForConsumerRequest{
+				ConsumerID:     id,
+				ControlPlaneID: cp.GetKonnectStatus().GetKonnectID(),
+			}).Return(&sdkkonnectops.ListConsumerGroupsForConsumerResponse{}, nil)
+
+		created := deploy.KongConsumer(t, ctx, clientNamespaced, name,
+			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
+			func(obj client.Object) {
+				c := obj.(*configurationv1.KongConsumer)
+				c.Username = name
+			},
+		)
+
+		t.Log("Waiting for object to be programmed and get Konnect ID")
+		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
+			fmt.Sprintf("Consumer didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
+
+		t.Log("Deleting KonnectGatewayControlPlane")
+		require.NoError(t, clientNamespaced.Delete(ctx, cp))
+
+		t.Log("Waiting for object to be get Programmed and ControlPlaneRefValid conditions with status=False and konnect cleanup finalizer removed")
+		watchFor(t, ctx, w, apiwatch.Modified,
+			assertsAnd(
+				assertNot(objectHasFinalizer[*configurationv1.KongConsumer](konnect.KonnectCleanupFinalizer)),
+				conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
+			),
+			"Object didn't get Programmed and/or ControlPlaneRefValid status condition set to False",
+		)
+
+		id2 := uuid.New().String()
+		t.Log("Setting up SDK expectations on KongConsumer update (after KonnectGatewayControlPlane deletion)")
+		sdk.ConsumersSDK.EXPECT().
+			UpsertConsumer(mock.Anything, mock.MatchedBy(func(r sdkkonnectops.UpsertConsumerRequest) bool {
+				return r.ConsumerID == id
+			})).
+			Return(&sdkkonnectops.UpsertConsumerResponse{
+				Consumer: &sdkkonnectcomp.Consumer{
+					ID: lo.ToPtr(id2),
+				},
+			}, nil)
+
+		cp = deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth,
+			func(obj client.Object) {
+				cpNew := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
+				cpNew.Name = cp.Name
+			},
+		)
+		t.Log("Setting up SDK expectation on KongConsumerGroups listing")
+		sdk.ConsumerGroupSDK.EXPECT().
+			ListConsumerGroupsForConsumer(mock.Anything, sdkkonnectops.ListConsumerGroupsForConsumerRequest{
+				ConsumerID:     id,
+				ControlPlaneID: cp.GetKonnectStatus().GetKonnectID(),
+			}).Return(&sdkkonnectops.ListConsumerGroupsForConsumerResponse{}, nil)
+
+		t.Log("Waiting for object to be get Programmed with status=True and konnect cleanup finalizer re added")
+		watchFor(t, ctx, w, apiwatch.Modified,
+			assertsAnd(
+				objectHasConditionProgrammedSetToTrue[*configurationv1.KongConsumer](),
+				objectHasFinalizer[*configurationv1.KongConsumer](konnect.KonnectCleanupFinalizer),
+			),
+			"Object didn't get Programmed set to True",
 		)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #1290

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
