### PR TITLE
ci: add govulncheck on push

### DIFF
--- a/.github/workflows/__govulncheck.yaml
+++ b/.github/workflows/__govulncheck.yaml
@@ -1,0 +1,38 @@
+name: Reusable govulncheck
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git reference to check out'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+    - name: Checkout repository
+      id: checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        ref: ${{ inputs.ref }}
+        
+    - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+      with:
+        repo-checkout: false
+        output-format: sarif
+        output-file: results_${{ steps.checkout.outputs.commit }}.sarif
+
+    - name: Upload SARIF file
+      uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3.28.10
+      with:
+        sarif_file: results_${{ steps.checkout.outputs.commit }}.sarif
+        ref: refs/heads/${{ inputs.ref }}
+        sha: ${{ steps.checkout.outputs.commit }}
+        category: govulncheck

--- a/.github/workflows/govulncheck-cron.yaml
+++ b/.github/workflows/govulncheck-cron.yaml
@@ -1,4 +1,4 @@
-name: govulncheck
+name: govulncheck schedule
 
 concurrency:
   # Run only for most recent commit in PRs but for all tags and commits on main
@@ -7,10 +7,8 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - main
-      - release/*
+  schedule:
+    - cron: '42 1 * * *'
   workflow_dispatch: {}
 
 permissions:
@@ -22,9 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        branch:
+        - main
+        - release/1.4.x
     steps:
     - uses: ./.github/workflows/__govulncheck.yaml
       with:
-        ref: ${{ github.event.inputs.ref || github.ref }}
-
-
+        ref: ${{ matrix.branch }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `govulncheck` on `push` to `main` and any release branch.

The current `govulncheck` workflow that is triggered on schedule will remain working as before. We can't just add the `push` event to the existing workflow as that would trigger the workflow run for all the specified branches which is not what we'd want.

The reason to make this change is to ensure up to date results at https://github.com/Kong/gateway-operator/security/code-scanning

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
