### PR TITLE
fixes: minor reconciliation fixes in KE controller

### DIFF
--- a/controller/konnect/konnectextension_controller_utils.go
+++ b/controller/konnect/konnectextension_controller_utils.go
@@ -124,7 +124,9 @@ func (r *KonnectExtensionReconciler) getKonnectControlPlane(
 			return nil, res, errPatch
 		}
 		log.Debug(logger, "ControlPlane retrieval failed in Konnect")
-		return nil, ctrl.Result{RequeueAfter: r.syncPeriod}, nil
+		// Setting "Requeue: true" along with RequeueAfter makes the controller bulletproof, as
+		// if the syncPeriod is set to zero, the controller won't requeue.
+		return nil, ctrl.Result{Requeue: true, RequeueAfter: r.syncPeriod}, nil
 	}
 
 	// set the controlPlaneRefValidCond to true in case the Control Plane is found in Konnect


### PR DESCRIPTION
**What this PR does / why we need it**:

Here are some minor fixes to the `KonnectExtension` reconcile, mostly related to avoid missing events related to the watched objects.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
