### PR TITLE
fix: allow `DataPlaneMetricsExtension`

### DIFF
--- a/controller/pkg/extensions/validate.go
+++ b/controller/pkg/extensions/validate.go
@@ -6,6 +6,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
+	operatorv1alpha1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1alpha1"
 	kcfgkonnect "github.com/kong/kubernetes-configuration/api/konnect"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -27,7 +29,7 @@ func validateExtensions[t ExtendableT](obj t) *metav1.Condition {
 	}
 	var messageBuilder strings.Builder
 	for i, ext := range obj.GetExtensions() {
-		if ext.Group != konnectv1alpha1.SchemeGroupVersion.Group || ext.Kind != konnectv1alpha1.KonnectExtensionKind {
+		if !(isKonnectExtension(ext) || isDataPlaneMetricsExtension(ext)) {
 			buildMessage(&messageBuilder, fmt.Sprintf("Extension %s/%s is not supported", ext.Group, ext.Kind))
 			continue
 		}
@@ -56,4 +58,12 @@ func buildMessage(messageBuilder *strings.Builder, message string) {
 		messageBuilder.WriteString(" - ")
 	}
 	messageBuilder.WriteString(message)
+}
+
+func isKonnectExtension(ext commonv1alpha1.ExtensionRef) bool {
+	return ext.Group == konnectv1alpha1.SchemeGroupVersion.Group && ext.Kind == konnectv1alpha1.KonnectExtensionKind
+}
+
+func isDataPlaneMetricsExtension(ext commonv1alpha1.ExtensionRef) bool {
+	return ext.Group == operatorv1alpha1.SchemeGroupVersion.Group && ext.Kind == operatorv1alpha1.DataPlaneMetricsExtensionKind
 }

--- a/controller/pkg/extensions/validate_test.go
+++ b/controller/pkg/extensions/validate_test.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
+	operatorv1alpha1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1alpha1"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
 	kcfgkonnect "github.com/kong/kubernetes-configuration/api/konnect"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
@@ -34,6 +35,10 @@ func TestValidateExtensions(t *testing.T) {
 							{
 								Group: konnectv1alpha1.SchemeGroupVersion.Group,
 								Kind:  konnectv1alpha1.KonnectExtensionKind,
+							},
+							{
+								Group: operatorv1alpha1.SchemeGroupVersion.Group,
+								Kind:  operatorv1alpha1.DataPlaneMetricsExtensionKind,
 							},
 						},
 					},

--- a/test/helpers/deploy/deploy_resources.go
+++ b/test/helpers/deploy/deploy_resources.go
@@ -1034,8 +1034,8 @@ func KonnectExtension(
 	return ke
 }
 
-// KonnectExtensionRefencingKonnectGatewayControlPlane deploys a KonnectExtension attached to a Konnect CP represented by the given KonnectGatewayControlPlane.
-func KonnectExtensionRefencingKonnectGatewayControlPlane(
+// KonnectExtensionReferencingKonnectGatewayControlPlane deploys a KonnectExtension attached to a Konnect CP represented by the given KonnectGatewayControlPlane.
+func KonnectExtensionReferencingKonnectGatewayControlPlane(
 	t *testing.T,
 	ctx context.Context,
 	cl client.Client,

--- a/test/integration/test_konnect_extension.go
+++ b/test/integration/test_konnect_extension.go
@@ -54,14 +54,14 @@ func TestKonnectExtensionKonnectGatewayControlPlaneNamespacedRef(t *testing.T) {
 	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
 	t.Logf("Creating a KonnectExtension")
-	ke := deploy.KonnectExtensionRefencingKonnectGatewayControlPlane(
+	ke := deploy.KonnectExtensionReferencingKonnectGatewayControlPlane(
 		t, ctx,
 		clientNamespaced,
 		cp,
 	)
 	t.Cleanup(deleteObjectAndWaitForDeletionFn(t, ke.DeepCopy()))
 
-	t.Logf("Waiting for KonnectExtension %s/%s to have ControlPlaneRefValid contition set to True", ke.Namespace, ke.Name)
+	t.Logf("Waiting for KonnectExtension %s/%s to have ControlPlaneRefValid condition set to True", ke.Namespace, ke.Name)
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		err := GetClients().MgrClient.Get(GetCtx(), types.NamespacedName{Name: ke.Name, Namespace: ke.Namespace}, ke)
 		require.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-up for https://github.com/Kong/kubernetes-configuration/pull/341 to make possible to update KGO OSS in KGO EE, see https://github.com/Kong/gateway-operator-enterprise/pull/430 (this change makes test related this resource pass)

