### PR TITLE
fix(konnect): fix endless reconciliation when errors are encountered

### DIFF
--- a/controller/konnect/ops/conditions.go
+++ b/controller/konnect/ops/conditions.go
@@ -34,13 +34,17 @@ func SetKonnectEntityProgrammedCondition(
 func SetKonnectEntityProgrammedConditionFalse(
 	obj entityType,
 	reason kcfgconsts.ConditionReason,
-	msg string,
+	err error,
 ) {
+	// Clear the instance field from the error to avoid requeueing the resource
+	// because of the trace ID in the instance field is different for each request.
+	err = clearInstanceFromError(err)
+
 	_setKonnectEntityProgrammedConditon(
 		obj,
 		metav1.ConditionFalse,
 		reason,
-		msg,
+		err.Error(),
 	)
 }
 

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -183,17 +183,18 @@ func Create[
 			if errGet != nil {
 				err = fmt.Errorf("trying to find a matching Konnect entity matching the ID failed: %w, %w", errGet, err)
 			}
-			SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToCreateReason, err.Error())
+
+			SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToCreateReason, err)
 		}
 
 	case errors.As(err, &errSDK):
 		statusCode = errSDK.StatusCode
-		SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToCreateReason, errSDK.Error())
+		SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToCreateReason, errSDK)
 	case errors.As(err, &errRelationsFailed):
 		e.SetKonnectID(errRelationsFailed.KonnectID)
-		SetKonnectEntityProgrammedConditionFalse(e, errRelationsFailed.Reason, errRelationsFailed.Err.Error())
+		SetKonnectEntityProgrammedConditionFalse(e, errRelationsFailed.Reason, errRelationsFailed.Err)
 	case err != nil:
-		SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToCreateReason, err.Error())
+		SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToCreateReason, err)
 	default:
 		SetKonnectEntityProgrammedCondition(e)
 	}
@@ -315,6 +316,10 @@ func Delete[
 		)
 	}
 	logOpComplete(ctx, start, DeleteOp, ent, err)
+
+	// Clear the instance field from the error to avoid requeueing the resource
+	// because of the trace ID in the instance field is different for each request.
+	err = clearInstanceFromError(err)
 
 	return err
 }
@@ -445,15 +450,16 @@ func Update[
 		errRelationsFailed KonnectEntityCreatedButRelationsFailedError
 		errSDK             *sdkkonnecterrs.SDKError
 	)
+
 	switch {
 	case errors.As(err, &errSDK):
 		statusCode = errSDK.StatusCode
-		SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToUpdateReason, errSDK.Body)
+		SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToUpdateReason, errSDK)
 	case errors.As(err, &errRelationsFailed):
 		e.SetKonnectID(errRelationsFailed.KonnectID)
-		SetKonnectEntityProgrammedConditionFalse(e, errRelationsFailed.Reason, err.Error())
+		SetKonnectEntityProgrammedConditionFalse(e, errRelationsFailed.Reason, err)
 	case err != nil:
-		SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToUpdateReason, err.Error())
+		SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToUpdateReason, err)
 	default:
 		SetKonnectEntityProgrammedCondition(e)
 	}
@@ -619,4 +625,24 @@ func getMatchingEntryFromListResponseData[
 	}
 
 	return id, nil
+}
+
+// clearInstanceFromError clears the instance field from the error.
+// This is needed because the instance field contains the trace ID which changes
+// with each request and makes the reconciliation loop requeue the resource
+// instead of performing the backoff.
+func clearInstanceFromError(err error) error {
+	var errBadRequest *sdkkonnecterrs.BadRequestError
+	if errors.As(err, &errBadRequest) {
+		errBadRequest.Instance = ""
+		return errBadRequest
+	}
+
+	var errConflict *sdkkonnecterrs.ConflictError
+	if errors.As(err, &errConflict) {
+		errConflict.Instance = ""
+		return errConflict
+	}
+
+	return err
 }

--- a/controller/konnect/ops/ops_errors_test.go
+++ b/controller/konnect/ops/ops_errors_test.go
@@ -416,3 +416,53 @@ func TestErrorIsDataPlaneGroupBadRequestPreviousConfigNotFinishedProvisioning(t 
 		})
 	}
 }
+
+func TestErrorIsConflictError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "error is ConflictError with status 409",
+			err: &sdkkonnecterrs.ConflictError{
+				Status: 409.0,
+				Detail: "Key (org_id, name) already exists.",
+			},
+			want: true,
+		},
+		{
+			name: "error is ConflictError with non-409 status",
+			err: &sdkkonnecterrs.ConflictError{
+				Status: 400,
+				Detail: "Some other error",
+			},
+			want: false,
+		},
+		{
+			name: "error is not ConflictError",
+			err:  errors.New("some other error"),
+			want: false,
+		},
+		{
+			name: "error is SDKError",
+			err: &sdkkonnecterrs.SDKError{
+				StatusCode: 409,
+				Body:       "conflict error body",
+			},
+			want: false,
+		},
+		{
+			name: "error is nil",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ErrorIsConflictError(tt.err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/controller/konnect/ops/ops_test.go
+++ b/controller/konnect/ops/ops_test.go
@@ -97,8 +97,8 @@ func TestCreate(t *testing.T) {
 				require.Len(t, ent.Status.Conditions, 1)
 				assert.Equal(t, metav1.ConditionFalse, ent.Status.Conditions[0].Status)
 				assert.EqualValues(t, kcfgkonnect.KonnectEntitiesFailedToCreateReason, ent.Status.Conditions[0].Reason)
-				assert.Equal(t,
-					`failed to create KonnectGatewayControlPlane test-ns/test-cp: {"status":400,"title":"Invalid Request","instance":"","detail":"Invalid Parameters","invalid_parameters":[{"field":"labels","rule":"is_label","reason":"Label value exceeds maximum of 63 characters"}]}`,
+				assert.JSONEq(t,
+					`{"status":400,"title":"Invalid Request","instance":"","detail":"Invalid Parameters","invalid_parameters":[{"field":"labels","rule":"is_label","reason":"Label value exceeds maximum of 63 characters"}]}`,
 					ent.Status.Conditions[0].Message)
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes endless reconciliation when Konnect API errors are encountered by doing 2 things:

- removing the `instance` value from the API response error to prevent endless reconciliation (each response gets a different `instance` value and since we use the message in object status condition and compare the message to make a decision whether status needs to be updated this causes endless reconciliation)
- add Conflict 409 errors to the list of "unrecoverable errors" which should not be returned by the reconciler to prevent endless reconciliation

Exemplar status condition which is set during the above mentioned endless reconciliation:

```
  - lastTransitionTime: "2025-03-18T13:56:11Z"
    message: 'trying to find a matching Konnect entity matching the ID failed: KonnectGatewayControlPlane
      test1 (matching UID 9ab33b5f-490b-43fb-a1d6-bb76f6088792) not found on Konnect,
      failed to create KonnectGatewayControlPlane default/test1: {"status":409,"title":"Conflict","instance":"kong:trace:341630016729690
1026","detail":"Key
      (org_id, name)=(8a6e97b1-b481-4fc2-8399-a59077076af6, test1) already exists."}'
    observedGeneration: 1
    reason: FailedToCreate
    status: "False"
    type: Programmed
```

This is accompanied by the following log:

```json
{
	"level": "error",
	"ts": "2025-03-18T14:56:11.803+0100",
	"logger": "KonnectGatewayControlPlane",
	"msg": "operation in Konnect API failed",
	"controller": "KonnectGatewayControlPlane",
	"controllerGroup": "konnect.konghq.com",
	"controllerKind": "KonnectGatewayControlPlane",
	"KonnectGatewayControlPlane": {
		"name": "test1",
		"namespace": "default"
	},
	"namespace": "default",
	"name": "test1",
	"reconcileID": "15e9494c-d8b6-4af4-b0fe-7c49e713b430",
	"op": "create",
	"duration": "457.273333ms",
	"error": "trying to find a matching Konnect entity matching the ID failed: KonnectGatewayControlPlane test1 (matching UID 9ab33b5f-490b-43fb-a1d6-bb76f6088792) not found on Konnect, failed to create KonnectGatewayControlPlane default/test1: {\"status\":409,\"title\":\"Conflict\",\"instance\":\"kong:trace:3416300167296901026\",\"detail\":\"Key (org_id, name)=(8a6e97b1-b481-4fc2-8399-a59077076af6, test1) already exists.\"}"
}
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
