### PR TITLE
chore: fix create-release-branch workflow branch name

### DIFF
--- a/.github/workflows/release-bot.yaml
+++ b/.github/workflows/release-bot.yaml
@@ -130,7 +130,7 @@ jobs:
         with:
           # NOTE: using the full ref name because
           # https://github.com/peterjgrainger/action-create-branch?tab=readme-ov-file#branch
-          branch: 'refs/heads/release/v${{ needs.semver.outputs.major }}.${{ needs.semver.outputs.minor }}.x'
+          branch: 'refs/heads/release/${{ needs.semver.outputs.major }}.${{ needs.semver.outputs.minor }}.x'
           sha: '${{ github.sha }}'
 
   create-cherry-pick-branch-to-main:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the release workflow to follow `release/{major}.{minor}.x` pattern that we've used so far for feature branches.

Closes https://github.com/Kong/gateway-operator/issues/1335. 

To fully fix this issue, we need to adjust `release-branches` ruleset in GH settings:
- Change the naming restriction in `Restrict branch names` - `Metadata restrictions` from `release/[0-9]+\.[0-9]+` to `release/[0-9]+\.[0-9]+\.x`
- Change the `Require status check to pass` - `Do not require status checks on creation` to be ticked

Edit: the adjustments have been done already.


