### PR TITLE
fix(tests): proper serviceaccount impersonation

### DIFF
--- a/pkg/utils/test/consts.go
+++ b/pkg/utils/test/consts.go
@@ -92,3 +92,7 @@ const (
 	// DefaultHTTPPort is the default HTTP port.
 	DefaultHTTPPort = 80
 )
+
+// ServiceAccountToImpersonate is the service account to impersonate when running tests,
+// to ensure that the same RBAC rules as presented in Helm chart are used.
+const ServiceAccountToImpersonate = "system:serviceaccount:kong-system:controller-manager"

--- a/test/integration/suite.go
+++ b/test/integration/suite.go
@@ -14,8 +14,6 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
-	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/config"
 	"github.com/kong/gateway-operator/modules/manager"
@@ -208,14 +206,7 @@ func DefaultControllerConfigForTests() manager.Config {
 	cfg.ClusterCAKeyType = mgrconfig.ECDSA
 	cfg.GatewayAPIExperimentalEnabled = true
 	cfg.EnforceConfig = true
+	cfg.ServiceAccountToImpersonate = testutils.ServiceAccountToImpersonate
 
-	cfg.NewClientFunc = func(config *rest.Config, options client.Options) (client.Client, error) {
-		// always hijack and impersonate the system service account here so that the manager
-		// is testing the RBAC permissions we provide under config/rbac/. This helps alert us
-		// if we break our RBAC configs as the manager will emit permissions errors.
-		config.Impersonate.UserName = "system:serviceaccount:kong-system:controller-manager"
-
-		return client.New(config, options)
-	}
 	return cfg
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The current way of impersonation 

https://github.com/Kong/gateway-operator/blob/b4eb05b587fd6af733b450e1bd0b9347ddc7595a/test/integration/suite.go#L212-L219

does not work at all. It can be easily proven by changing the name to serviceaccount that doesn't exist. Instead of printing in logs e.g.
```
...
W0321 14:42:52.250383     277 reflector.go:569] pkg/mod/k8s.io/client-go@v0.32.3/tools/cache/reflector.go:251: failed to list *v1alpha1.KongUpstream: kongupstreams.configuration.konghq.com is forbidden: User "system:serviceaccount:kong-system:controller-manager2222" cannot list resource "kongupstreams" in API group "configuration.konghq.com" at the cluster scope
E0321 14:42:52.250527     277 reflector.go:166] "Unhandled Error" err="pkg/mod/k8s.io/client-go@v0.32.3/tools/cache/reflector.go:251: Failed to watch *v1alpha1.KongUpstream: failed to list *v1alpha1.KongUpstream: kongupstreams.configuration.konghq.com is forbidden: User \"system:serviceaccount:kong-system:controller-manager2222\" cannot list resource \"kongupstreams\" in API group \"configuration.konghq.com\" at the cluster scope" logger="UnhandledError"
...
```

all tests will pass. 

Hint why does impersonation not work configuring this way maybe in the docs of the field `NewClient` `client.NewClientFunc`

> NOTE: LOW LEVEL PRIMITIVE! Only use a custom NewClient if you know what you are doing.
[src](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.20.3/pkg/manager#Options.NewClient)

So definitely it has to have some caveats. 

This PR makes impersonation work, by configuring it on `*rest.Config` level [the same way as in KIC](https://github.com/Kong/kubernetes-ingress-controller/blob/b89c775e0c816823ee1dccbad1557efe2ea3dc82/internal/manager/config.go#L382-L384) 

**Which issue this PR fixes**

Fixes #748 

**Special notes for your reviewer**:

How to test it? Just change the value of `ServiceAccountToImpersonate` to a nonexistent one, and the errors mentioned above in the PR description will pop out as expected.

