### PR TITLE
fix: fix ReadinessProbe not setting the HTTPGet endpoint when other fields are customized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@
   `KonnectAPIAuthConfiguration` instead of using a hardcoded `eu` value.
   [#1409](https://github.com/Kong/gateway-operator/pull/1409)
 
+### Fixes
+
+- Fix setting the defaults for `GatewayConfiguration`'s `ReadinessProbe when only
+  timeouts and/or delays are specified. Now the HTTPGet field is set to `/status/ready`
+  as expected with the `Gateway` scenario.
+  [#1395](https://github.com/Kong/gateway-operator/pull/1395)
+
 ## [v1.5.1]
 
 > Release date: 2025-04-01

--- a/controller/gateway/controller_test.go
+++ b/controller/gateway/controller_test.go
@@ -681,6 +681,58 @@ func Test_setDataPlaneOptionsDefaults(t *testing.T) {
 			},
 		},
 		{
+			name: "providing more options",
+			input: operatorv1beta1.DataPlaneOptions{
+				Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+					DeploymentOptions: operatorv1beta1.DeploymentOptions{
+						Replicas: lo.ToPtr(int32(10)),
+						PodTemplateSpec: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  consts.DataPlaneProxyContainerName,
+										Image: "image:v1",
+										ReadinessProbe: &corev1.Probe{
+											InitialDelaySeconds: 1,
+											TimeoutSeconds:      1,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: operatorv1beta1.DataPlaneOptions{
+				Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+					DeploymentOptions: operatorv1beta1.DeploymentOptions{
+						Replicas: lo.ToPtr(int32(10)),
+						PodTemplateSpec: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  consts.DataPlaneProxyContainerName,
+										Image: "image:v1",
+										ReadinessProbe: &corev1.Probe{
+											InitialDelaySeconds: 1,
+											TimeoutSeconds:      1,
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path:   consts.DataPlaneStatusReadyEndpoint,
+													Port:   intstr.FromInt(consts.DataPlaneMetricsPort),
+													Scheme: corev1.URISchemeHTTP,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "defining scaling strategy should not set default replicas",
 			input: operatorv1beta1.DataPlaneOptions{
 				Deployment: operatorv1beta1.DataPlaneDeploymentOptions{

--- a/test/e2e/test_helm_install_upgrade.go
+++ b/test/e2e/test_helm_install_upgrade.go
@@ -271,7 +271,9 @@ func TestHelmUpgrade(t *testing.T) {
 				{
 					Name: "DataPlane deployment is not patched after operator upgrade",
 					Func: func(c *assert.CollectT, cl *testutils.K8sClients) {
-						gatewayDataPlaneDeploymentIsNotPatched("gw-upgrade-nightly-to-current=true")(ctx, c, cl.MgrClient)
+						// https://github.com/Kong/gateway-operator/pull/1395 makes the operator patch
+						// the readiness probe when it's customized but without setting a handler.
+						gatewayDataPlaneDeploymentIsPatched("gw-upgrade-nightly-to-current=true")(ctx, c, cl.MgrClient)
 					},
 				},
 				{


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue where `ReadinessProbe` would get customized by only setting e.g. the timeouts and initial delay like so:

```
kind: GatewayConfiguration
apiVersion: gateway-operator.konghq.com/v1beta1
metadata:
  name: kong
spec:
  dataPlaneOptions:
    deployment:
      podTemplateSpec:
        spec:
          containers:
          - name: proxy
            image: kong/kong-gateway:3.9
            readinessProbe:
              initialDelaySeconds: 1
              periodSeconds: 1
```

The logic in `setDataPlaneOptionsDefaults` prevented the defaults to be correctly filled because the probe was only compared against a `nil` value. This caused the default `/status` endpoint to be used (set in [here](https://github.com/Kong/gateway-operator/blob/7f3e3eaf83dded52f8a06de14d064db5f17a6466/pkg/utils/kubernetes/resources/deployments.go#L344)).

**Which issue this PR fixes**

Related:

- https://github.com/Kong/docs.konghq.com/pull/8609
- https://kongstrong.slack.com/archives/CA42V003B/p1742569562245049

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
