### PR TITLE
feat(controlplane): split ClusterRole into ClusterRole and Role to separate permissions when watching a list of namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,31 @@
 - Added `spec.watchNamespace` field to `ControlPlane` CRD to allow watching resources
   only in the specified namespace.
   When `spec.watchNamespace.type=list` is used, each specified namespace requires
-  a `ReferenceGrant` in the namespace of the `ControlPlane` that allows the `ControlPlane`
-  to watch resources in the specified namespace.
+  a `ReferenceGrant` that allows the `ControlPlane` to watch resources in the specified namespace.
+  For example:
+
+  ```yaml
+  apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: ReferenceGrant
+  metadata:
+    name: ref
+    namespace: namespace-a
+  spec:
+    from:
+    - group: gateway-operator.konghq.com
+      kind: ControlPlane
+      namespace: controlplane-namespace
+    to:
+    - group: ""
+      kind: Namespace
+      name: namespace-a
+  ```
+
+  Aforementioned list is extended with `ControlPlane`'s own namespace which doesn't
+  require said `ReferenceGrant`.
   [#1388](https://github.com/Kong/gateway-operator/pull/1388)
+  [#1410](https://github.com/Kong/gateway-operator/pull/1410)
+
 - Deduce `KonnectCloudGatewayDataPlaneGroupConfiguration` region based on the attached
   `KonnectAPIAuthConfiguration` instead of using a hardcoded `eu` value.
   [#1409](https://github.com/Kong/gateway-operator/pull/1409)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,31 +57,13 @@
 - Added `spec.watchNamespace` field to `ControlPlane` CRD to allow watching resources
   only in the specified namespace.
   When `spec.watchNamespace.type=list` is used, each specified namespace requires
-  a `ReferenceGrant` that allows the `ControlPlane` to watch resources in the specified namespace.
-  For example:
-
-  ```yaml
-  apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: ReferenceGrant
-  metadata:
-    name: ref
-    namespace: namespace-a
-  spec:
-    from:
-    - group: gateway-operator.konghq.com
-      kind: ControlPlane
-      namespace: controlplane-namespace
-    to:
-    - group: ""
-      kind: Namespace
-      name: namespace-a
-  ```
-
+  a `WatchNamespaceGrant` that allows the `ControlPlane` to watch resources in the specified namespace.
   Aforementioned list is extended with `ControlPlane`'s own namespace which doesn't
-  require said `ReferenceGrant`.
+  require said `WatchNamespaceGrant`.
   [#1388](https://github.com/Kong/gateway-operator/pull/1388)
   [#1410](https://github.com/Kong/gateway-operator/pull/1410)
-
+  <!-- TODO: https://github.com/Kong/gateway-operator/issues/1501 add link to guide from documentation. -->
+  For more information on this please see: https://docs.konghq.com/gateway-operator/latest/
 - Deduce `KonnectCloudGatewayDataPlaneGroupConfiguration` region based on the attached
   `KonnectAPIAuthConfiguration` instead of using a hardcoded `eu` value.
   [#1409](https://github.com/Kong/gateway-operator/pull/1409)

--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -467,6 +467,8 @@ rules:
   resources:
   - clusterrolebindings
   - clusterroles
+  - rolebindings
+  - roles
   verbs:
   - create
   - delete

--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -307,6 +307,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - gateway-operator.konghq.com
+  resources:
+  - watchnamespacegrants
+  verbs:
+  - list
+- apiGroups:
   - gateway.networking.k8s.io
   resources:
   - backendtlspolicies

--- a/config/samples/controlplane-dataplane-watchnamespaces.yaml
+++ b/config/samples/controlplane-dataplane-watchnamespaces.yaml
@@ -2,6 +2,7 @@ apiVersion: gateway-operator.konghq.com/v1beta1
 kind: DataPlane
 metadata:
   name: dataplane-cp-watchnamespace
+  namespace: default
 spec:
   deployment:
     podTemplateSpec:
@@ -27,13 +28,13 @@ spec:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kong-system
+  name: namespace-a
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
   name: ref
-  namespace: kong-system
+  namespace: namespace-a
 spec:
   from:
   - group: gateway-operator.konghq.com
@@ -42,19 +43,45 @@ spec:
   to:
   - group: ""
     kind: Namespace
-    name: kong-system
+    name: namespace-a
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: namespace-b
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: ref
+  namespace: namespace-b
+spec:
+  from:
+  - group: gateway-operator.konghq.com
+    kind: ControlPlane
+    namespace: default
+  to:
+  - group: ""
+    kind: Namespace
+    name: namespace-b
 ---
 apiVersion: gateway-operator.konghq.com/v1beta1
 kind: ControlPlane
 metadata:
   name: controlplane-example
+  namespace: default
 spec:
   dataplane: dataplane-cp-watchnamespace
   gatewayClass: kong
   watchNamespaces:
+    # Using "list" also adds ControlPlane's own namespace to the list
+    # of watched namespaces because that's that KIC does. The reason
+    # for this is the publish service (DataPlane's Service exposed by Kong) by default
+    # would exist in the same namespace as ControlPlane.
     type: list
     list:
-    - kong-system
+    - namespace-a
+    - namespace-b
   deployment:
     podTemplateSpec:
       metadata:
@@ -68,9 +95,6 @@ spec:
           readinessProbe:
             initialDelaySeconds: 1
             periodSeconds: 3
-          env:
-          - name: CONTROLLER_DUMP_CONFIG
-            value: "true"
           resources:
             requests:
               memory: "64Mi"

--- a/config/samples/controlplane-dataplane-watchnamespaces.yaml
+++ b/config/samples/controlplane-dataplane-watchnamespaces.yaml
@@ -30,40 +30,32 @@ kind: Namespace
 metadata:
   name: namespace-a
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: ReferenceGrant
+apiVersion: gateway-operator.konghq.com/v1alpha1
+kind: WatchNamespaceGrant
 metadata:
-  name: ref
+  name: watchnamespacegrant
   namespace: namespace-a
 spec:
   from:
   - group: gateway-operator.konghq.com
     kind: ControlPlane
     namespace: default
-  to:
-  - group: ""
-    kind: Namespace
-    name: namespace-a
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: namespace-b
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: ReferenceGrant
+apiVersion: gateway-operator.konghq.com/v1alpha1
+kind: WatchNamespaceGrant
 metadata:
-  name: ref
+  name: watchnamespacegrant
   namespace: namespace-b
 spec:
   from:
   - group: gateway-operator.konghq.com
     kind: ControlPlane
     namespace: default
-  to:
-  - group: ""
-    kind: Namespace
-    name: namespace-b
 ---
 apiVersion: gateway-operator.konghq.com/v1beta1
 kind: ControlPlane

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -135,12 +135,12 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 		// reconciliation for all supported ControlPlane objects which use this Role.
 		Watches(
 			&rbacv1.Role{},
-			handler.EnqueueRequestsFromMapFunc(r.listControlPlanesForRoles)).
+			handler.EnqueueRequestsFromMapFunc(listControlPlanesFor[*rbacv1.Role])).
 		// Watch for events on RoleBindings, if any RoleBinding event happens, enqueue
 		// reconciliation for all supported ControlPlane objects which use this RoleBinding.
 		Watches(
 			&rbacv1.RoleBinding{},
-			handler.EnqueueRequestsFromMapFunc(r.listControlPlanesForRoleBindings))
+			handler.EnqueueRequestsFromMapFunc(listControlPlanesFor[*rbacv1.RoleBinding]))
 
 	if r.KonnectEnabled {
 		// Watch for changes in KonnectExtension objects that are referenced by ControlPlane objects.

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -131,12 +131,12 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 		Watches(
 			&gatewayv1beta1.ReferenceGrant{},
 			handler.EnqueueRequestsFromMapFunc(r.listControlPlanesForReferenceGrants)).
-		// watch for events on Roles, if any Role event happen, enqueue
+		// Watch for events on Roles, if any Role event happens, enqueue
 		// reconciliation for all supported ControlPlane objects which use this Role.
 		Watches(
 			&rbacv1.Role{},
 			handler.EnqueueRequestsFromMapFunc(r.listControlPlanesForRoles)).
-		// watch for events on RoleBindings, if any RoleBinding event happen, enqueue
+		// Watch for events on RoleBindings, if any RoleBinding event happens, enqueue
 		// reconciliation for all supported ControlPlane objects which use this RoleBinding.
 		Watches(
 			&rbacv1.RoleBinding{},

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -363,18 +363,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	const (
-		ConditionTypeReferenceGrantsValid   = "ReferenceGrantsValid"
-		ConditionReasonReferenceGrantsValid = "ReferenceGrantsValid"
+		ConditionTypeWatchNamespaceGrantsValid   = "WatchNamespaceGrantsValid"
+		ConditionReasonWatchNamespaceGrantsValid = "WatchNamespaceGrantsValid"
 	)
-	log.Trace(logger, "validating ReferenceGrants exist for the ControlPlane")
-	validatedWatchNamespaces, err := r.validateReferenceGrants(ctx, cp)
+	log.Trace(logger, "validating WatchNamespaceGrants exist for the ControlPlane")
+	validatedWatchNamespaces, err := r.validateWatchNamespaceGrants(ctx, cp)
 	if err != nil {
 		k8sutils.SetCondition(
 			k8sutils.NewConditionWithGeneration(
-				ConditionTypeReferenceGrantsValid,
+				ConditionTypeWatchNamespaceGrantsValid,
 				metav1.ConditionFalse,
 				kcfgcontrolplane.ConditionReasonMissingReferenceGrant,
-				fmt.Sprintf("ReferenceGrant(s) are missing for the ControlPlane: %v", err),
+				fmt.Sprintf("WatchNamespaceGrant(s) are missing for the ControlPlane: %v", err),
 				cp.GetGeneration(),
 			),
 			cp,
@@ -386,10 +386,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	} else {
 		k8sutils.SetCondition(
 			k8sutils.NewConditionWithGeneration(
-				ConditionTypeReferenceGrantsValid,
+				ConditionTypeWatchNamespaceGrantsValid,
 				metav1.ConditionTrue,
-				ConditionReasonReferenceGrantsValid,
-				"ReferenceGrant(s) are present and valid",
+				ConditionReasonWatchNamespaceGrantsValid,
+				"WatchNamespaceGrant(s) are present and valid",
 				cp.GetGeneration(),
 			),
 			cp,

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -50,6 +50,7 @@ import (
 // Reconciler reconciles a ControlPlane object
 type Reconciler struct {
 	client.Client
+	DiscoveryClient           *CachedDiscoveryClient
 	Scheme                    *runtime.Scheme
 	ClusterCASecretName       string
 	ClusterCASecretNamespace  string
@@ -129,7 +130,17 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 		// are referenced in a "from" instance.
 		Watches(
 			&gatewayv1beta1.ReferenceGrant{},
-			handler.EnqueueRequestsFromMapFunc(r.listControlPlanesForReferenceGrants))
+			handler.EnqueueRequestsFromMapFunc(r.listControlPlanesForReferenceGrants)).
+		// watch for events on Roles, if any Role event happen, enqueue
+		// reconciliation for all supported ControlPlane objects which use this Role.
+		Watches(
+			&rbacv1.Role{},
+			handler.EnqueueRequestsFromMapFunc(r.listControlPlanesForRoles)).
+		// watch for events on RoleBindings, if any RoleBinding event happen, enqueue
+		// reconciliation for all supported ControlPlane objects which use this RoleBinding.
+		Watches(
+			&rbacv1.RoleBinding{},
+			handler.EnqueueRequestsFromMapFunc(r.listControlPlanesForRoleBindings))
 
 	if r.KonnectEnabled {
 		// Watch for changes in KonnectExtension objects that are referenced by ControlPlane objects.
@@ -351,25 +362,38 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		log.Debug(logger, "DataPlane not set, deployment for ControlPlane will remain dormant")
 	}
 
+	const (
+		ConditionTypeReferenceGrantsValid   = "ReferenceGrantsValid"
+		ConditionReasonReferenceGrantsValid = "ReferenceGrantsValid"
+	)
 	log.Trace(logger, "validating ReferenceGrants exist for the ControlPlane")
 	validatedWatchNamespaces, err := r.validateReferenceGrants(ctx, cp)
 	if err != nil {
 		k8sutils.SetCondition(
-			k8sutils.NewCondition(
-				kcfgdataplane.ReadyType,
+			k8sutils.NewConditionWithGeneration(
+				ConditionTypeReferenceGrantsValid,
 				metav1.ConditionFalse,
 				kcfgcontrolplane.ConditionReasonMissingReferenceGrant,
 				fmt.Sprintf("ReferenceGrant(s) are missing for the ControlPlane: %v", err),
+				cp.GetGeneration(),
 			),
 			cp,
 		)
-		res, err := r.patchStatus(ctx, logger, cp)
-		if err != nil || !res.IsZero() {
-			return res, err
-		}
 		// We do not return here as we want to proceed with reconciling the Deployment.
 		// This will prevent users using the ControlPlane Deployment with previous
 		// WatchNamespaces spec.
+		// We do not patch the status here either because that's done below.
+	} else {
+		k8sutils.SetCondition(
+			k8sutils.NewConditionWithGeneration(
+				ConditionTypeReferenceGrantsValid,
+				metav1.ConditionTrue,
+				ConditionReasonReferenceGrantsValid,
+				"ReferenceGrant(s) are present and valid",
+				cp.GetGeneration(),
+			),
+			cp,
+		)
 	}
 
 	log.Trace(logger, "ensuring ServiceAccount for ControlPlane deployment exists")
@@ -382,7 +406,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil // requeue will be triggered by the creation or update of the owned object
 	}
 
-	res, err := r.ensureRoles(ctx, logger, cp, controlplaneServiceAccount)
+	res, err := r.ensureRolesAndClusterRoles(ctx, logger, cp, controlplaneServiceAccount, validatedWatchNamespaces)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to ensure roles or cluster roles: %w", err)
 	} else if res != op.Noop {

--- a/controller/controlplane/controller_rbac.go
+++ b/controller/controlplane/controller_rbac.go
@@ -9,6 +9,8 @@ package controlplane
 // +kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=controlplanes/finalizers,verbs=update
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create;get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create;get;list;watch;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=create;get;list;watch;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create;get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=create;get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=create;get;list;watch;update;patch;delete

--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -371,7 +371,8 @@ func (r *Reconciler) ensureRolesAndClusterRoles(
 		res, err := r.ensureRoleBindings(ctx, cp, controlplaneServiceAccount, controlplaneRoles)
 		if err != nil {
 			return op.Noop, err
-		} else if res != op.Noop {
+		}
+		if res != op.Noop {
 			log.Debug(logger, "RoleBindings created/updated")
 			return res, nil
 		}
@@ -492,8 +493,7 @@ rolesLoop:
 			return false, nil, err
 		}
 
-		count := len(existingRoles)
-		switch count {
+		switch count := len(existingRoles); count {
 		case 0:
 			if err := r.Create(ctx, generatedRole); err != nil {
 				return false, nil, err
@@ -523,7 +523,7 @@ rolesLoop:
 			if err := k8sreduce.ReduceRoles(ctx, r.Client, existingRoles); err != nil {
 				return false, nil, err
 			}
-			return false, nil, errors.New("number of Roles reduced")
+			return false, nil, fmt.Errorf("number of Roles reduced from: %d to 1", count)
 		}
 
 	}

--- a/controller/controlplane/controlplane_controller_reconciler_utils_test.go
+++ b/controller/controlplane/controlplane_controller_reconciler_utils_test.go
@@ -125,7 +125,8 @@ func TestEnsureClusterRole(t *testing.T) {
 		}
 
 		t.Run(tc.Name, func(t *testing.T) {
-			createdOrUpdated, generatedClusterRole, err := r.ensureClusterRole(t.Context(), &tc.controlplane)
+			// NOTE: we pass in nil as we don't test watch namespaces here.
+			createdOrUpdated, generatedClusterRole, err := r.ensureClusterRole(t.Context(), &tc.controlplane, clusterRole)
 			require.Equal(t, tc.err, err)
 			require.Equal(t, tc.createdorUpdated, createdOrUpdated)
 			require.Equal(t, tc.expectedClusterRole.Rules, generatedClusterRole.Rules)

--- a/controller/controlplane/discovery_client.go
+++ b/controller/controlplane/discovery_client.go
@@ -1,0 +1,56 @@
+package controlplane
+
+import (
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+// CachedDiscoveryClient is a wrapper around the discovery client that caches the API resources
+// for a period of time.
+type CachedDiscoveryClient struct {
+	cl *discovery.DiscoveryClient
+
+	lastLookupTime time.Time
+	period         time.Duration
+	lock           sync.RWMutex
+	apiResourceMap map[schema.GroupVersion]*metav1.APIResourceList
+}
+
+// NewDiscoveryClient creates a new CachedDiscoveryClient.
+func NewDiscoveryClient(cfg *rest.Config, period time.Duration) *CachedDiscoveryClient {
+	return &CachedDiscoveryClient{
+		period: period,
+		cl:     discovery.NewDiscoveryClientForConfigOrDie(cfg),
+	}
+}
+
+// GetAPIResourceListMapping returns the GroupVersion to API resources map.
+func (c *CachedDiscoveryClient) GetAPIResourceListMapping() (map[schema.GroupVersion]*metav1.APIResourceList, error) {
+	c.lock.RLock()
+	isNil := c.apiResourceMap == nil
+	c.lock.RUnlock()
+
+	if isNil || time.Since(c.lastLookupTime) > c.period {
+		if err := c.refresh(); err != nil {
+			return nil, err
+		}
+	}
+	return c.apiResourceMap, nil
+}
+
+func (c *CachedDiscoveryClient) refresh() error {
+	_, s, _, err := c.cl.GroupsAndMaybeResources()
+	if err != nil {
+		return err
+	}
+	c.lock.Lock()
+	c.apiResourceMap = s
+	c.lock.Unlock()
+	c.lastLookupTime = time.Now()
+	return nil
+}

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -453,6 +453,7 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 		ControlPlaneControllerName: {
 			Enabled: c.GatewayControllerEnabled || c.ControlPlaneControllerEnabled,
 			Controller: &controlplane.Reconciler{
+				DiscoveryClient:           controlplane.NewDiscoveryClient(mgr.GetConfig(), time.Minute),
 				Client:                    mgr.GetClient(),
 				Scheme:                    mgr.GetScheme(),
 				ClusterCASecretName:       c.ClusterCASecretName,

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -40,6 +40,12 @@ const (
 	// Kubernetes API.
 	GatewayOperatorManagedByNamespaceLabel = OperatorLabelPrefix + "managed-by-namespace"
 
+	// GatewayOperatorOwnerUIDControlPlane is the label that is used for objects
+	// to indicate a ControlPlane resource is the owner of the object.
+	// The value set for this label is the UID of the ControlPlane resource that
+	// owns the object.
+	GatewayOperatorOwnerUIDControlPlane = OperatorLabelPrefix + "controlplane-owner-uid"
+
 	// GatewayManagedLabelValue indicates that the object's lifecycle is managed by
 	// the gateway controller.
 	GatewayManagedLabelValue = "gateway"

--- a/pkg/utils/kubernetes/lists.go
+++ b/pkg/utils/kubernetes/lists.go
@@ -184,6 +184,27 @@ func ListServiceAccountsForOwner(
 	return serviceAccounts, nil
 }
 
+// ListRoles is a helper function which gets a list of Roles
+// using the provided list options.
+func ListRoles(
+	ctx context.Context,
+	c client.Client,
+	listOpts ...client.ListOption,
+) ([]rbacv1.Role, error) {
+	roleList := &rbacv1.RoleList{}
+
+	err := c.List(
+		ctx,
+		roleList,
+		listOpts...,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return roleList.Items, nil
+}
+
 // ListClusterRoles is a helper function which gets a list of ClusterRoles
 // using the provided list options.
 func ListClusterRoles(
@@ -224,6 +245,27 @@ func ListClusterRoleBindings(
 	}
 
 	return clusterRoleBindingList.Items, nil
+}
+
+// ListRoleBindings is a helper function which gets a list of RoleBindings
+// using the provided list options.
+func ListRoleBindings(
+	ctx context.Context,
+	c client.Client,
+	listOpts ...client.ListOption,
+) ([]rbacv1.RoleBinding, error) {
+	roleBindingList := &rbacv1.RoleBindingList{}
+
+	err := c.List(
+		ctx,
+		roleBindingList,
+		listOpts...,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return roleBindingList.Items, nil
 }
 
 // ListConfigMapsForOwner is a helper function which gets a list of ConfigMaps

--- a/pkg/utils/kubernetes/reduce/filters.go
+++ b/pkg/utils/kubernetes/reduce/filters.go
@@ -114,7 +114,7 @@ func filterRoles(roles []rbacv1.Role) []rbacv1.Role {
 		}
 	}
 
-	return append(roles[:best], roles[best+1:]...)
+	return slices.Delete(roles, best, best+1)
 }
 
 // -----------------------------------------------------------------------------

--- a/pkg/utils/kubernetes/reduce/filters.go
+++ b/pkg/utils/kubernetes/reduce/filters.go
@@ -1,6 +1,8 @@
 package reduce
 
 import (
+	"slices"
+
 	"github.com/samber/lo"
 	admregv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"

--- a/pkg/utils/kubernetes/reduce/filters.go
+++ b/pkg/utils/kubernetes/reduce/filters.go
@@ -121,9 +121,9 @@ func filterRoles(roles []rbacv1.Role) []rbacv1.Role {
 // Filter functions - ClusterRoleBindings
 // -----------------------------------------------------------------------------
 
-// filterBindings filters out the ClusterRoleBinding or RoleBindings to be kept and returns
+// filterRoleBindings filters out the ClusterRoleBinding or RoleBindings to be kept and returns
 // all the objects to be deleted.
-func filterBindings[
+func filterRoleBindings[
 	T interface {
 		rbacv1.ClusterRoleBinding | rbacv1.RoleBinding
 	},

--- a/pkg/utils/kubernetes/reduce/reduce.go
+++ b/pkg/utils/kubernetes/reduce/reduce.go
@@ -72,7 +72,7 @@ func ReduceRoles(ctx context.Context, k8sClient client.Client, roles []rbacv1.Ro
 
 // ReduceClusterRoleBindings detects the best ClusterRoleBinding in the set and deletes all the others.
 func ReduceClusterRoleBindings(ctx context.Context, k8sClient client.Client, clusterRoleBindings []rbacv1.ClusterRoleBinding) error {
-	filteredClusterRoleBindings := filterBindings(clusterRoleBindings)
+	filteredClusterRoleBindings := filterRoleBindings(clusterRoleBindings)
 	return clientops.DeleteAll(ctx, k8sClient, filteredClusterRoleBindings)
 }
 
@@ -80,7 +80,7 @@ func ReduceClusterRoleBindings(ctx context.Context, k8sClient client.Client, clu
 
 // ReduceRoleBindings detects the best RoleBinding in the set and deletes all the others.
 func ReduceRoleBindings(ctx context.Context, k8sClient client.Client, roleBindings []rbacv1.RoleBinding) error {
-	filteredRoleBindings := filterBindings(roleBindings)
+	filteredRoleBindings := filterRoleBindings(roleBindings)
 	return clientops.DeleteAll(ctx, k8sClient, filteredRoleBindings)
 }
 

--- a/pkg/utils/kubernetes/reduce/reduce.go
+++ b/pkg/utils/kubernetes/reduce/reduce.go
@@ -60,12 +60,28 @@ func ReduceClusterRoles(ctx context.Context, k8sClient client.Client, clusterRol
 	return clientops.DeleteAll(ctx, k8sClient, filteredClusterRoles)
 }
 
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=delete
+
+// ReduceRoles detects the best Role in the set and deletes all the others.
+func ReduceRoles(ctx context.Context, k8sClient client.Client, roles []rbacv1.Role) error {
+	filteredRoles := filterRoles(roles)
+	return clientops.DeleteAll(ctx, k8sClient, filteredRoles)
+}
+
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=delete
 
 // ReduceClusterRoleBindings detects the best ClusterRoleBinding in the set and deletes all the others.
 func ReduceClusterRoleBindings(ctx context.Context, k8sClient client.Client, clusterRoleBindings []rbacv1.ClusterRoleBinding) error {
-	filteredCLusterRoleBindings := filterClusterRoleBindings(clusterRoleBindings)
-	return clientops.DeleteAll(ctx, k8sClient, filteredCLusterRoleBindings)
+	filteredClusterRoleBindings := filterBindings(clusterRoleBindings)
+	return clientops.DeleteAll(ctx, k8sClient, filteredClusterRoleBindings)
+}
+
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=delete
+
+// ReduceRoleBindings detects the best RoleBinding in the set and deletes all the others.
+func ReduceRoleBindings(ctx context.Context, k8sClient client.Client, roleBindings []rbacv1.RoleBinding) error {
+	filteredRoleBindings := filterBindings(roleBindings)
+	return clientops.DeleteAll(ctx, k8sClient, filteredRoleBindings)
 }
 
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=delete

--- a/pkg/utils/kubernetes/reduce/reduce_test.go
+++ b/pkg/utils/kubernetes/reduce/reduce_test.go
@@ -1,0 +1,159 @@
+package reduce_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kong/gateway-operator/pkg/consts"
+	"github.com/kong/gateway-operator/pkg/utils/kubernetes/reduce"
+)
+
+func TestReduceClusterRoleBindings(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		clusterRoleBindings    []rbacv1.ClusterRoleBinding
+		expectedDeletedCount   int
+		expectedRemainingNames []string
+	}{
+		{
+			name:                   "empty list returns no error",
+			clusterRoleBindings:    []rbacv1.ClusterRoleBinding{},
+			expectedDeletedCount:   0,
+			expectedRemainingNames: []string{},
+		},
+		{
+			name: "single ClusterRoleBinding is preserved",
+			clusterRoleBindings: []rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "crb-1",
+					},
+				},
+			},
+			expectedDeletedCount:   0,
+			expectedRemainingNames: []string{"crb-1"},
+		},
+		{
+			name: "multiple ClusterRoleBindings with different creation timestamps - oldest is preserved",
+			clusterRoleBindings: []rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "crb-1",
+						CreationTimestamp: metav1.NewTime(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "crb-2",
+						CreationTimestamp: metav1.NewTime(time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC)),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "crb-3",
+						CreationTimestamp: metav1.NewTime(time.Date(2022, 12, 30, 0, 0, 0, 0, time.UTC)),
+					},
+				},
+			},
+			expectedDeletedCount:   2,
+			expectedRemainingNames: []string{"crb-3"},
+		},
+		{
+			name: "multiple ClusterRoleBindings, one with managed by label remains",
+			clusterRoleBindings: []rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "crb-1",
+						CreationTimestamp: metav1.NewTime(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "crb-2",
+						CreationTimestamp: metav1.NewTime(time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC)),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "crb-3",
+						CreationTimestamp: metav1.NewTime(time.Date(2022, 12, 30, 0, 0, 0, 0, time.UTC)),
+						Labels: map[string]string{
+							consts.GatewayOperatorManagedByLabel: consts.ControlPlaneManagedLabelValue,
+						},
+					},
+				},
+			},
+			expectedDeletedCount:   2,
+			expectedRemainingNames: []string{"crb-3"},
+		},
+		{
+			name: "multiple ClusterRoleBindings, one with managed by label remains",
+			clusterRoleBindings: []rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "crb-1",
+						CreationTimestamp: metav1.NewTime(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "crb-2",
+						CreationTimestamp: metav1.NewTime(time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC)),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "crb-3",
+						CreationTimestamp: metav1.NewTime(time.Date(2022, 12, 30, 0, 0, 0, 0, time.UTC)),
+						Labels: map[string]string{
+							consts.GatewayOperatorManagedByLabel: consts.ControlPlaneManagedLabelValue,
+						},
+					},
+				},
+			},
+			expectedDeletedCount:   2,
+			expectedRemainingNames: []string{"crb-3"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			objs := []client.Object{}
+			for i := range tc.clusterRoleBindings {
+				objs = append(objs, &tc.clusterRoleBindings[i])
+			}
+
+			cl := fake.NewClientBuilder().WithObjects(objs...).Build()
+			err := reduce.ReduceClusterRoleBindings(t.Context(), cl, tc.clusterRoleBindings)
+			require.NoError(t, err)
+
+			// Verify which ClusterRoleBindings remain
+			var remainingBindings rbacv1.ClusterRoleBindingList
+			require.NoError(t, cl.List(t.Context(), &remainingBindings))
+
+			require.Len(t, remainingBindings.Items, len(tc.expectedRemainingNames))
+
+			// Check the expected ClusterRoleBinding(s) remain
+			for _, name := range tc.expectedRemainingNames {
+				remaining := false
+				for _, crb := range remainingBindings.Items {
+					if crb.Name == name {
+						remaining = true
+						break
+					}
+				}
+				assert.True(t, remaining, "Expected ClusterRoleBinding %s to remain but it was deleted", name)
+			}
+
+			// Also verify expected number of deleted ClusterRoleBindings
+			assert.Equal(t, tc.expectedDeletedCount, len(tc.clusterRoleBindings)-len(remainingBindings.Items))
+		})
+	}
+}

--- a/pkg/utils/kubernetes/resources/controlplane_role.go
+++ b/pkg/utils/kubernetes/resources/controlplane_role.go
@@ -1,0 +1,32 @@
+package resources
+
+import (
+	"fmt"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
+
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+)
+
+// GenerateNewRoleForControlPlane generates a new Role in provided namespace for
+// provided ControlPlane.
+func GenerateNewRoleForControlPlane(
+	cp *operatorv1beta1.ControlPlane, namespace string, rules []rbacv1.PolicyRule,
+) *rbacv1.Role {
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: k8sutils.TrimGenerateName(fmt.Sprintf("%s-", cp.GetName())),
+			Namespace:    namespace,
+			Labels: map[string]string{
+				"app": cp.GetName(),
+			},
+		},
+		Rules: rules,
+	}
+
+	LabelObjectAsControlPlaneManaged(role)
+	return role
+}

--- a/pkg/utils/kubernetes/resources/controlplane_role_test.go
+++ b/pkg/utils/kubernetes/resources/controlplane_role_test.go
@@ -1,0 +1,95 @@
+package resources
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
+
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+)
+
+func TestGenerateNewRoleForControlPlane(t *testing.T) {
+	cp := &operatorv1beta1.ControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-controlplane",
+			UID:  "12345",
+		},
+	}
+
+	testCases := []struct {
+		name             string
+		controlplaneName string
+		namespace        string
+		rules            []rbacv1.PolicyRule
+		expectedRole     *rbacv1.Role
+	}{
+		{
+			name:             "generates role with empty rules",
+			controlplaneName: "test-controlplane",
+			namespace:        "test-namespace",
+			rules:            []rbacv1.PolicyRule{},
+			expectedRole: &rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: k8sutils.TrimGenerateName(fmt.Sprintf("%s-", "test-controlplane")),
+					Namespace:    "test-namespace",
+					Labels: map[string]string{
+						"app":                                    "test-controlplane",
+						"gateway-operator.konghq.com/managed-by": "controlplane",
+					},
+				},
+				Rules: []rbacv1.PolicyRule{},
+			},
+		},
+		{
+			name:             "generates role with multiple rules",
+			controlplaneName: "cp-with-rules",
+			namespace:        "default",
+			rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+				{
+					APIGroups: []string{"apps"},
+					Resources: []string{"deployments"},
+					Verbs:     []string{"get", "update"},
+				},
+			},
+			expectedRole: &rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: k8sutils.TrimGenerateName(fmt.Sprintf("%s-", "test-controlplane")),
+					Namespace:    "default",
+					Labels: map[string]string{
+						"app":                                    "test-controlplane",
+						"gateway-operator.konghq.com/managed-by": "controlplane",
+					},
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"pods"},
+						Verbs:     []string{"get", "list", "watch"},
+					},
+					{
+						APIGroups: []string{"apps"},
+						Resources: []string{"deployments"},
+						Verbs:     []string{"get", "update"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			role := GenerateNewRoleForControlPlane(cp, tc.namespace, tc.rules)
+			require.Equal(t, tc.expectedRole, role)
+		})
+	}
+}

--- a/pkg/utils/kubernetes/resources/labels.go
+++ b/pkg/utils/kubernetes/resources/labels.go
@@ -14,47 +14,36 @@ import (
 // provided object to signal that it's owned by a DataPlane resource
 // and that its lifecycle is managed by this operator.
 func LabelObjectAsDataPlaneManaged(obj metav1.Object) {
-	labels := obj.GetLabels()
-	if labels == nil {
-		labels = make(map[string]string)
-	}
-	labels[consts.GatewayOperatorManagedByLabel] = consts.DataPlaneManagedLabelValue
-	obj.SetLabels(labels)
+	setLabel(obj, consts.GatewayOperatorManagedByLabel, consts.DataPlaneManagedLabelValue)
 }
 
 // LabelObjectAsKongPluginInstallationManaged ensures that labels are set on the
 // provided object to signal that it's owned by a KongPluginInstallation
 // resource and that its lifecycle is managed by this operator.
 func LabelObjectAsKongPluginInstallationManaged(obj metav1.Object) {
-	labels := obj.GetLabels()
-	if labels == nil {
-		labels = make(map[string]string)
-	}
-	labels[consts.GatewayOperatorManagedByLabel] = consts.KongPluginInstallationManagedLabelValue
-	obj.SetLabels(labels)
+	setLabel(obj, consts.GatewayOperatorManagedByLabel, consts.KongPluginInstallationManagedLabelValue)
 }
 
 // LabelObjectAsKonnectExtensionManaged ensures that labels are set on the
 // provided object to signal that it's owned by a KonnectExtension resource
 // and that its lifecycle is managed by this operator.
 func LabelObjectAsKonnectExtensionManaged(obj metav1.Object) {
-	labels := obj.GetLabels()
-	if labels == nil {
-		labels = make(map[string]string)
-	}
-	labels[consts.GatewayOperatorManagedByLabel] = consts.KonnectExtensionManagedByLabelValue
-	obj.SetLabels(labels)
+	setLabel(obj, consts.GatewayOperatorManagedByLabel, consts.KonnectExtensionManagedByLabelValue)
 }
 
 // LabelObjectAsControlPlaneManaged ensures that labels are set on the
 // provided object to signal that it's owned by a ControlPlane resource and that its
 // lifecycle is managed by this operator.
 func LabelObjectAsControlPlaneManaged(obj metav1.Object) {
+	setLabel(obj, consts.GatewayOperatorManagedByLabel, consts.ControlPlaneManagedLabelValue)
+}
+
+func setLabel(obj metav1.Object, key string, value string) { //nolint:unparam
 	labels := obj.GetLabels()
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	labels[consts.GatewayOperatorManagedByLabel] = consts.ControlPlaneManagedLabelValue
+	labels[key] = value
 	obj.SetLabels(labels)
 }
 

--- a/pkg/utils/kubernetes/resources/rolebindings.go
+++ b/pkg/utils/kubernetes/resources/rolebindings.go
@@ -1,0 +1,66 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/samber/lo"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/kong/gateway-operator/pkg/consts"
+	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
+
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+)
+
+// -----------------------------------------------------------------------------
+// RoleBinding generators
+// -----------------------------------------------------------------------------
+
+// GenerateNewRoleBindingForControlPlane is a helper to generate a RoleBinding
+// resource to bind roles to the service account used by the controlplane deployment.
+func GenerateNewRoleBindingForControlPlane(
+	cp *operatorv1beta1.ControlPlane,
+	serviceAccountName string,
+	roleNN k8stypes.NamespacedName,
+) *rbacv1.RoleBinding {
+	crb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: k8sutils.TrimGenerateName(fmt.Sprintf("%s-%s-", consts.ControlPlanePrefix, cp.GetName())),
+			Namespace:    roleNN.Namespace,
+			Labels: map[string]string{
+				"app": cp.GetName(),
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     roleNN.Name,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      serviceAccountName,
+				Namespace: cp.GetNamespace(),
+			},
+		},
+	}
+	LabelObjectAsControlPlaneManaged(crb)
+	return crb
+}
+
+// CompareRoleName compares RoleRef in RoleBinding with given cluster role name.
+// It returns true if the referenced role is the cluster role with the given name.
+func CompareRoleName(existingRoleBinding *rbacv1.RoleBinding, roleName string) bool {
+	return existingRoleBinding.RoleRef.APIGroup == "rbac.authorization.k8s.io" &&
+		existingRoleBinding.RoleRef.Kind == "Role" &&
+		existingRoleBinding.RoleRef.Name == roleName
+}
+
+// RoleBindingContainsServiceAccount returns true if the subjects of the RoleBinding contains given service account.
+func RoleBindingContainsServiceAccount(existingRoleBinding *rbacv1.RoleBinding, namespace string, serviceAccountName string) bool {
+	return lo.ContainsBy(existingRoleBinding.Subjects, func(s rbacv1.Subject) bool {
+		return s.Kind == "ServiceAccount" && s.Namespace == namespace && s.Name == serviceAccountName
+	})
+}

--- a/test/e2e/test_helm_install_upgrade.go
+++ b/test/e2e/test_helm_install_upgrade.go
@@ -141,9 +141,9 @@ func TestHelmUpgrade(t *testing.T) {
 			name:             "upgrade from latest minor to current",
 			fromVersion:      "1.5.1", // renovate: datasource=docker packageName=kong/gateway-operator-oss depName=kong/gateway-operator-oss
 			upgradeToCurrent: true,
-			// This is the effective semver of a next release. It's needed for the chart to properly render
-			// semver-conditional templates.
-			upgradeToEffectiveSemver: "1.5.0",
+			// This is the effective semver of a next release.
+			// It's needed for the chart to properly render semver-conditional templates.
+			upgradeToEffectiveSemver: "1.6.0",
 			objectsToDeploy: []client.Object{
 				&operatorv1beta1.GatewayConfiguration{
 					ObjectMeta: metav1.ObjectMeta{
@@ -215,6 +215,9 @@ func TestHelmUpgrade(t *testing.T) {
 			name:             "upgrade from nightly to current",
 			fromVersion:      "nightly",
 			upgradeToCurrent: true,
+			// This is the effective semver of a next release.
+			// It's needed for the chart to properly render semver-conditional templates.
+			upgradeToEffectiveSemver: "1.6.0",
 			objectsToDeploy: []client.Object{
 				&operatorv1beta1.GatewayConfiguration{
 					ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PRs adds splitting of `ControlPlane`'s `ClusterRole` into `Role`s and a `ClusterRole` when `spec.watchNamespaces` is specified and `type` is `list` or `own`.

Along with the `Role`s, the operator will also create appropriate `RoleBinding`s.

**Which issue this PR fixes**

Fixes #1347

**Special notes for your reviewer**:

Adding integration tests is tracked in #1482 to prevent this PR getting out of hand and becoming too big to review.

Chart changes (granting `Role` and `RoleBinding` policy rules) are done in https://github.com/Kong/charts/pull/1295.

Updated API (`WatchNamespaceGrant`): https://github.com/Kong/kubernetes-configuration/pull/403

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
