### PR TITLE
chore: adjust for kubernetes-configuration object ref type changes

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=0d8bf77197cc9e6ee26743e87f1e638c75e4d160 # Version is auto-updated by the generating script.
+  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=b0d55d9a7f4f6b8ebcc2b1badda26e10ab3c42cc # Version is auto-updated by the generating script.

--- a/controller/konnect/konnectextension_controller_utils.go
+++ b/controller/konnect/konnectextension_controller_utils.go
@@ -70,7 +70,6 @@ func (r *KonnectExtensionReconciler) getKonnectControlPlane(
 			Namespace: cpNamepace,
 			Name:      cpRef.Name,
 		}, kgcp)
-
 		// set the controlPlaneRefValidCond to false in case the KonnectGatewayControlPlane is not found
 		if err != nil {
 			controlPlaneRefValidCond.Status = metav1.ConditionFalse

--- a/controller/konnect/reconciler_keysetref.go
+++ b/controller/konnect/reconciler_keysetref.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kong/gateway-operator/controller/pkg/patch"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
+	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -62,7 +63,7 @@ func handleKongKeySetRef[T constraints.SupportedKonnectEntityType, TEnt constrai
 		return ctrl.Result{}, nil
 	}
 
-	if keySetRef.Type != configurationv1alpha1.KeySetRefNamespacedRef {
+	if keySetRef.Type != commonv1alpha1.ObjectRefTypeNamespacedRef {
 		ctrllog.FromContext(ctx).Error(fmt.Errorf("unsupported KeySet ref type %q", keySetRef.Type), "unsupported KeySet ref type", "entity", ent)
 		return ctrl.Result{}, nil
 	}
@@ -154,14 +155,14 @@ func handleKongKeySetRef[T constraints.SupportedKonnectEntityType, TEnt constrai
 
 func getKeySetRef[T constraints.SupportedKonnectEntityType, TEnt constraints.EntityType[T]](
 	e TEnt,
-) mo.Option[configurationv1alpha1.KeySetRef] {
+) mo.Option[commonv1alpha1.ObjectRef] {
 	switch e := any(e).(type) {
 	case *configurationv1alpha1.KongKey:
 		if e.Spec.KeySetRef == nil {
-			return mo.None[configurationv1alpha1.KeySetRef]()
+			return mo.None[commonv1alpha1.ObjectRef]()
 		}
 		return mo.Some(*e.Spec.KeySetRef)
 	default:
-		return mo.None[configurationv1alpha1.KeySetRef]()
+		return mo.None[commonv1alpha1.ObjectRef]()
 	}
 }

--- a/controller/konnect/reconciler_keysetref_test.go
+++ b/controller/konnect/reconciler_keysetref_test.go
@@ -181,9 +181,9 @@ func TestHandleKeySetRef(t *testing.T) {
 				ObjectMeta: commonKeyMeta,
 				Spec: configurationv1alpha1.KongKeySpec{
 					ControlPlaneRef: cpRef,
-					KeySetRef: &configurationv1alpha1.KeySetRef{
-						Type: configurationv1alpha1.KeySetRefNamespacedRef,
-						NamespacedRef: &configurationv1alpha1.KeySetNamespacedRef{
+					KeySetRef: &commonv1alpha1.ObjectRef{
+						Type: commonv1alpha1.ObjectRefTypeNamespacedRef,
+						NamespacedRef: &commonv1alpha1.NamespacedRef{
 							Name: "key-set-1",
 						},
 					},
@@ -202,9 +202,9 @@ func TestHandleKeySetRef(t *testing.T) {
 				ObjectMeta: commonKeyMeta,
 				Spec: configurationv1alpha1.KongKeySpec{
 					ControlPlaneRef: cpRef,
-					KeySetRef: &configurationv1alpha1.KeySetRef{
-						Type: configurationv1alpha1.KeySetRefNamespacedRef,
-						NamespacedRef: &configurationv1alpha1.KeySetNamespacedRef{
+					KeySetRef: &commonv1alpha1.ObjectRef{
+						Type: commonv1alpha1.ObjectRefTypeNamespacedRef,
+						NamespacedRef: &commonv1alpha1.NamespacedRef{
 							Name: keySetDuringDeletion.Name,
 						},
 					},
@@ -223,9 +223,9 @@ func TestHandleKeySetRef(t *testing.T) {
 				ObjectMeta: commonKeyMeta,
 				Spec: configurationv1alpha1.KongKeySpec{
 					ControlPlaneRef: cpRef,
-					KeySetRef: &configurationv1alpha1.KeySetRef{
-						Type: configurationv1alpha1.KeySetRefNamespacedRef,
-						NamespacedRef: &configurationv1alpha1.KeySetNamespacedRef{
+					KeySetRef: &commonv1alpha1.ObjectRef{
+						Type: commonv1alpha1.ObjectRefTypeNamespacedRef,
+						NamespacedRef: &commonv1alpha1.NamespacedRef{
 							Name: notProgrammedKeySet.Name,
 						},
 					},
@@ -244,9 +244,9 @@ func TestHandleKeySetRef(t *testing.T) {
 				ObjectMeta: commonKeyMeta,
 				Spec: configurationv1alpha1.KongKeySpec{
 					ControlPlaneRef: cpRef,
-					KeySetRef: &configurationv1alpha1.KeySetRef{
-						Type: configurationv1alpha1.KeySetRefNamespacedRef,
-						NamespacedRef: &configurationv1alpha1.KeySetNamespacedRef{
+					KeySetRef: &commonv1alpha1.ObjectRef{
+						Type: commonv1alpha1.ObjectRefTypeNamespacedRef,
+						NamespacedRef: &commonv1alpha1.NamespacedRef{
 							Name: programmedKeySet.Name,
 						},
 					},

--- a/controller/pkg/extensions/merge_test.go
+++ b/controller/pkg/extensions/merge_test.go
@@ -18,42 +18,48 @@ func TestMergeExtensions(t *testing.T) {
 		{
 			name: "no overlap",
 			defaultExtensions: []commonv1alpha1.ExtensionRef{
-				{Group: "group1",
-					Kind: "kind1",
+				{
+					Group: "group1",
+					Kind:  "kind1",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "name1",
 					},
 				},
-				{Group: "group2",
-					Kind: "kind2",
+				{
+					Group: "group2",
+					Kind:  "kind2",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "name2",
 					},
 				},
 			},
 			extensions: []commonv1alpha1.ExtensionRef{
-				{Group: "group3",
-					Kind: "kind3",
+				{
+					Group: "group3",
+					Kind:  "kind3",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "name3",
 					},
 				},
 			},
 			expected: []commonv1alpha1.ExtensionRef{
-				{Group: "group1",
-					Kind: "kind1",
+				{
+					Group: "group1",
+					Kind:  "kind1",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "name1",
 					},
 				},
-				{Group: "group2",
-					Kind: "kind2",
+				{
+					Group: "group2",
+					Kind:  "kind2",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "name2",
 					},
 				},
-				{Group: "group3",
-					Kind: "kind3",
+				{
+					Group: "group3",
+					Kind:  "kind3",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "name3",
 					},
@@ -63,48 +69,55 @@ func TestMergeExtensions(t *testing.T) {
 		{
 			name: "with overlap",
 			defaultExtensions: []commonv1alpha1.ExtensionRef{
-				{Group: "group1",
-					Kind: "kind1",
+				{
+					Group: "group1",
+					Kind:  "kind1",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "name1",
 					},
 				},
-				{Group: "group2",
-					Kind: "kind2",
+				{
+					Group: "group2",
+					Kind:  "kind2",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "name2",
 					},
 				},
 			},
 			extensions: []commonv1alpha1.ExtensionRef{
-				{Group: "group3",
-					Kind: "kind3",
+				{
+					Group: "group3",
+					Kind:  "kind3",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "name3",
 					},
 				},
-				{Group: "group2",
-					Kind: "kind2",
+				{
+					Group: "group2",
+					Kind:  "kind2",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "nameB",
 					},
 				},
 			},
 			expected: []commonv1alpha1.ExtensionRef{
-				{Group: "group1",
-					Kind: "kind1",
+				{
+					Group: "group1",
+					Kind:  "kind1",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "name1",
 					},
 				},
-				{Group: "group3",
-					Kind: "kind3",
+				{
+					Group: "group3",
+					Kind:  "kind3",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "name3",
 					},
 				},
-				{Group: "group2",
-					Kind: "kind2",
+				{
+					Group: "group2",
+					Kind:  "kind2",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "nameB",
 					},
@@ -114,14 +127,16 @@ func TestMergeExtensions(t *testing.T) {
 		{
 			name: "only default extensions",
 			defaultExtensions: []commonv1alpha1.ExtensionRef{
-				{Group: "group1",
-					Kind: "kind1",
+				{
+					Group: "group1",
+					Kind:  "kind1",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "name1",
 					},
 				},
-				{Group: "group2",
-					Kind: "kind2",
+				{
+					Group: "group2",
+					Kind:  "kind2",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "name2",
 					},
@@ -129,14 +144,16 @@ func TestMergeExtensions(t *testing.T) {
 			},
 			extensions: []commonv1alpha1.ExtensionRef{},
 			expected: []commonv1alpha1.ExtensionRef{
-				{Group: "group1",
-					Kind: "kind1",
+				{
+					Group: "group1",
+					Kind:  "kind1",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "name1",
 					},
 				},
-				{Group: "group2",
-					Kind: "kind2",
+				{
+					Group: "group2",
+					Kind:  "kind2",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "name2",
 					},
@@ -147,28 +164,32 @@ func TestMergeExtensions(t *testing.T) {
 			name:              "only user extensions",
 			defaultExtensions: []commonv1alpha1.ExtensionRef{},
 			extensions: []commonv1alpha1.ExtensionRef{
-				{Group: "group1",
-					Kind: "kind1",
+				{
+					Group: "group1",
+					Kind:  "kind1",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "name1",
 					},
 				},
-				{Group: "group2",
-					Kind: "kind2",
+				{
+					Group: "group2",
+					Kind:  "kind2",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "name2",
 					},
 				},
 			},
 			expected: []commonv1alpha1.ExtensionRef{
-				{Group: "group1",
-					Kind: "kind1",
+				{
+					Group: "group1",
+					Kind:  "kind1",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "name1",
 					},
 				},
-				{Group: "group2",
-					Kind: "kind2",
+				{
+					Group: "group2",
+					Kind:  "kind2",
 					NamespacedRef: commonv1alpha1.NamespacedRef{
 						Name: "name2",
 					},

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/terratest v0.48.2
-	github.com/kong/kubernetes-configuration v1.2.1-0.20250321113930-0d8bf77197cc
+	github.com/kong/kubernetes-configuration v1.2.1-0.20250328125410-b0d55d9a7f4f
 	github.com/kong/kubernetes-telemetry v0.1.9
 	github.com/kong/kubernetes-testing-framework v0.47.2
 	github.com/kong/semver/v4 v4.0.1
@@ -155,7 +155,7 @@ require (
 	github.com/jmoiron/sqlx v1.3.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kong/go-kong v0.64.1 // indirect
+	github.com/kong/go-kong v0.65.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -307,10 +307,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
-github.com/kong/go-kong v0.64.1 h1:HQssErFchbyYoDVQL7kR8x2naaY9mFgmDu/dXF0NZSo=
-github.com/kong/go-kong v0.64.1/go.mod h1:sqdysTKrXIJ6mpxHwTwjgZhLW7jR1/puczTXHLUwJaE=
-github.com/kong/kubernetes-configuration v1.2.1-0.20250321113930-0d8bf77197cc h1:PhuyHfTix95hWN6BZe1wekWMqoez0jKV/NMRaMX5xtw=
-github.com/kong/kubernetes-configuration v1.2.1-0.20250321113930-0d8bf77197cc/go.mod h1:Vxn67CHjQN6yaeaB8VkCl75X/cDTaJLMW/zkveq67vI=
+github.com/kong/go-kong v0.65.0 h1:dZT+hiMhy7CQsrc9W5nHv3cFJGBGTrwlZhC5MLuf9H8=
+github.com/kong/go-kong v0.65.0/go.mod h1:sqdysTKrXIJ6mpxHwTwjgZhLW7jR1/puczTXHLUwJaE=
+github.com/kong/kubernetes-configuration v1.2.1-0.20250328125410-b0d55d9a7f4f h1:UNKIDzrsTWJkWNgmJMFGqtnxXMNeohQrPmGhXieBcn4=
+github.com/kong/kubernetes-configuration v1.2.1-0.20250328125410-b0d55d9a7f4f/go.mod h1:NIFesd18MIy5pb7+6tk9lQeA28kHeG5ue4DAEsecTks=
 github.com/kong/kubernetes-telemetry v0.1.9 h1:XbDMZjZZclHO4oyJGW1mmZ6bzbTnANjcRAYsBg+jpno=
 github.com/kong/kubernetes-telemetry v0.1.9/go.mod h1:lBSbaQdJkoMMO0d+cJWopoJiJ+QHFBttbhCp5VRibJ8=
 github.com/kong/kubernetes-testing-framework v0.47.2 h1:+2Z9anTpbV/hwNeN+NFQz53BMU+g3QJydkweBp3tULo=

--- a/internal/utils/index/kongkey.go
+++ b/internal/utils/index/kongkey.go
@@ -3,6 +3,7 @@ package index
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
 
@@ -38,7 +39,7 @@ func kongKeySetRefFromKongKey(obj client.Object) []string {
 	}
 
 	if key.Spec.KeySetRef == nil ||
-		key.Spec.KeySetRef.Type != configurationv1alpha1.KeySetRefNamespacedRef ||
+		key.Spec.KeySetRef.Type != commonv1alpha1.ObjectRefTypeNamespacedRef ||
 		key.Spec.KeySetRef.NamespacedRef == nil {
 		return nil
 	}

--- a/test/envtest/konnect_entities_kongkey_test.go
+++ b/test/envtest/konnect_entities_kongkey_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
 
+	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -175,9 +176,9 @@ func TestKongKey(t *testing.T) {
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 			func(obj client.Object) {
 				key := obj.(*configurationv1alpha1.KongKey)
-				key.Spec.KeySetRef = &configurationv1alpha1.KeySetRef{
-					Type: configurationv1alpha1.KeySetRefNamespacedRef,
-					NamespacedRef: lo.ToPtr(configurationv1alpha1.KeySetNamespacedRef{
+				key.Spec.KeySetRef = &commonv1alpha1.ObjectRef{
+					Type: commonv1alpha1.ObjectRefTypeNamespacedRef,
+					NamespacedRef: lo.ToPtr(commonv1alpha1.NamespacedRef{
 						Name: keySetName,
 					}),
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adjust for https://github.com/Kong/kubernetes-configuration/pull/369.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
