### PR TITLE
feat(ke): set `ControlPlaneRefValid` condition to false

### DIFF
--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -260,6 +260,17 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return res, err
 		}
 	}
+
+	// get the Konnect Control Plane ID. Set the ControlPlaneRefValid condition accordingly.
+	_, res, err := r.getKonnectControlPlaneID(ctx, ext, readyCondition)
+	if err != nil || !res.IsZero() {
+		// don't return the error here to avoid noise. Status condition is properly set.
+		log.Debug(logger, "controlPlane reference has not properly resolved", "error", err)
+		return res, nil
+	}
+
+	log.Debug(logger, "controlPlane reference validity checked")
+
 	apiAuthRef, err := getKonnectAPIAuthRefNN(ctx, r.Client, &ext)
 	if err != nil {
 		if client.IgnoreNotFound(err) != nil {
@@ -325,8 +336,6 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		log.Debug(logger, "controlPlane not ready yet")
 		return res, nil
 	}
-
-	log.Debug(logger, "controlPlane reference validity checked")
 
 	certProvisionedCond := metav1.Condition{
 		Type:    konnectv1alpha1.DataPlaneCertificateProvisionedConditionType,

--- a/test/helpers/conditions.go
+++ b/test/helpers/conditions.go
@@ -9,9 +9,14 @@ import (
 	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
 )
 
+// ConditionsChecker is a function type that checks the conditions of a resource.
+// It takes a resource of type k8sutils.ConditionsAware and a variadic number of condition types.
+// It returns a boolean indicating whether all specified conditions are met and a string message.
+type ConditionsChecker func(resource k8sutils.ConditionsAware, conditionTypes ...kcfgconsts.ConditionType) (bool, string)
+
 // CheckAllConditionsTrue returns true if all the conditions with given type in `conditionTypes` are set to `True` in the given resource.
 // If it returns `false`, the second return value contains a message to tell what conditions are not `True`.
-func CheckAllConditionsTrue(resource k8sutils.ConditionsAware, conditionTypes []kcfgconsts.ConditionType) (bool, string) {
+func CheckAllConditionsTrue(resource k8sutils.ConditionsAware, conditionTypes ...kcfgconsts.ConditionType) (bool, string) {
 	var failedConditions []string
 	for _, conditionType := range conditionTypes {
 		if !k8sutils.HasConditionTrue(conditionType, resource) {
@@ -21,6 +26,22 @@ func CheckAllConditionsTrue(resource k8sutils.ConditionsAware, conditionTypes []
 
 	if len(failedConditions) > 0 {
 		return false, fmt.Sprintf("condition(s) %s not set to True", strings.Join(failedConditions, ", "))
+	}
+	return true, ""
+}
+
+// CheckAllConditionsFalse returns true if all the conditions with given type in `conditionTypes` are set to `False` in the given resource.
+// If it returns `false`, the second return value contains a message to tell what conditions are not `False`.
+func CheckAllConditionsFalse(resource k8sutils.ConditionsAware, conditionTypes ...kcfgconsts.ConditionType) (bool, string) {
+	var failedConditions []string
+	for _, conditionType := range conditionTypes {
+		if k8sutils.HasConditionTrue(conditionType, resource) {
+			failedConditions = append(failedConditions, string(conditionType))
+		}
+	}
+
+	if len(failedConditions) > 0 {
+		return false, fmt.Sprintf("condition(s) %s not set to False", strings.Join(failedConditions, ", "))
 	}
 	return true, ""
 }

--- a/test/integration/zz_generated.registered_testcases.go
+++ b/test/integration/zz_generated.registered_testcases.go
@@ -31,6 +31,7 @@ func init() {
 		TestKongPluginInstallationEssentials,
 		TestKonnectEntities,
 		TestKonnectExtension,
+		TestKonnectExtensionKonnectControlPlaneNotFound,
 		TestManualGatewayUpgradesAndDowngrades,
 		TestScalingDataPlaneThroughGatewayConfiguration,
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:

If the `KonnectExtension` references the KE by `NamespacedRef`, but the CP does not exist, the `KonnectExtension` `ControlPlaneRefValid` condition is not properly set. This PR fixes that.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
