### PR TITLE
chore: fix release bot cherry-pick

### DIFF
--- a/.github/workflows/release-bot.yaml
+++ b/.github/workflows/release-bot.yaml
@@ -156,7 +156,8 @@ jobs:
 
       - name: Cherry-pick commit
         run: |
-          git checkout -b ${{ env.CHERRYPICK_BRANCH }} main
+          git fetch --all
+          git checkout -b ${{ env.CHERRYPICK_BRANCH }} origin/main
           git cherry-pick ${{ github.sha }}
           # Amend the commit message to avoid infinite loop of this workflow (it's triggered by the commit message).
           git commit --amend -m "chore: cherry-pick ${{ needs.semver.outputs.version }} commit (${{ github.sha }}) onto main"


### PR DESCRIPTION
**What this PR does / why we need it**:

Attempt to fix release bot cherry picking: https://github.com/Kong/gateway-operator/actions/runs/14193700195/job/39763932770

```
Run git checkout -b cherry-pick/a97da752ac065719b6e05b1636cfbb7a02c384d1-to-main main
  git checkout -b cherry-pick/a97da75[2](https://github.com/Kong/gateway-operator/actions/runs/14193700195/job/39763932770#step:4:2)ac065719b6e05b1636cfbb7a02c384d1-to-main main
  git cherry-pick a97da752ac065719b6e05b16[3](https://github.com/Kong/gateway-operator/actions/runs/14193700195/job/39763932770#step:4:3)6cfbb7a02c384d1
  # Amend the commit message to avoid infinite loop of this workflow (it's triggered by the commit message).
  git commit --amend -m "chore: cherry-pick 1.5.1 commit (a97da752ac065719b6e05b1636cfbb7a02c38[4](https://github.com/Kong/gateway-operator/actions/runs/14193700195/job/39763932770#step:4:4)d1) onto main"
  shell: /usr/bin/bash -e {0}
  env:
    CHERRYPICK_BRANCH: cherry-pick/a97da752ac065719b6e0[5](https://github.com/Kong/gateway-operator/actions/runs/14193700195/job/39763932770#step:4:5)b1636cfbb7a02c384d1-to-main
fatal: 'main' is not a commit and a branch 'cherry-pick/a97da752ac065719b6e05b163[6](https://github.com/Kong/gateway-operator/actions/runs/14193700195/job/39763932770#step:4:6)cfbb7a02c384d1-to-main' cannot be created from it
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
