### PR TITLE
feat: support NodePort as ingress service type for DataPlane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@
 - Deduce `KonnectCloudGatewayDataPlaneGroupConfiguration` region based on the attached
   `KonnectAPIAuthConfiguration` instead of using a hardcoded `eu` value.
   [#1409](https://github.com/Kong/gateway-operator/pull/1409)
+- Support `NodePort` as ingress service type for `DataPlane`
+    [#1430](https://github.com/Kong/gateway-operator/pull/1430)
 
 ## [v1.5.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
   `KonnectAPIAuthConfiguration` instead of using a hardcoded `eu` value.
   [#1409](https://github.com/Kong/gateway-operator/pull/1409)
 - Support `NodePort` as ingress service type for `DataPlane`
-    [#1430](https://github.com/Kong/gateway-operator/pull/1430)
+  [#1430](https://github.com/Kong/gateway-operator/pull/1430)
 
 ## [v1.5.1]
 

--- a/test/integration/zz_generated.registered_testcases.go
+++ b/test/integration/zz_generated.registered_testcases.go
@@ -14,6 +14,7 @@ func init() {
 		TestDataPlaneHorizontalScaling,
 		TestDataPlanePodDisruptionBudget,
 		TestDataPlaneServiceExternalTrafficPolicy,
+		TestDataPlaneServiceTypes,
 		TestDataPlaneSpecifyingServiceName,
 		TestDataPlaneUpdate,
 		TestDataPlaneValidation,


### PR DESCRIPTION
**What this PR does / why we need it**:

feat: support `NodePort` as ingress service type for DataPlane

**Which issue this PR fixes**

Fixes https://github.com/Kong/gateway-operator/issues/1407

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
