### PR TITLE
chore: split development mode flag into granular ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@
   [#1415](https://github.com/Kong/gateway-operator/pull/1415)
 - Add `namespacedRef` support for referencing networks in `KonnectCloudGatewayDataPlaneGroupConfiguration`
   [#1423](https://github.com/Kong/gateway-operator/pull/1423)
+- Introduced new CLI flags:
+  - `--logging-mode` (or `GATEWAY_OPERATOR_LOGGING_MODE` env var) to set the logging mode (`development` can be set
+    for simplified logging).
+  - `--validate-images` (or `GATEWAY_OPERATOR_VALIDATE_IMAGES` env var) to enable ControlPlane and DataPlane image 
+    validation (it's set by default to `true`).
+  [#1435](https://github.com/Kong/gateway-operator/pull/1435)
 
 ### Changes
 

--- a/Makefile
+++ b/Makefile
@@ -550,7 +550,8 @@ KUBECONFIG ?= $(HOME)/.kube/config
 .PHONY: _run
 _run:
 	KUBECONFIG=$(KUBECONFIG) \
-		GATEWAY_OPERATOR_DEVELOPMENT_MODE=true \
+		GATEWAY_OPERATOR_ANONYMOUS_REPORTS=false \
+		GATEWAY_OPERATOR_LOGGING_MODE=development \
 		go run ./cmd/main.go \
 		--no-leader-election \
 		-cluster-ca-secret-namespace kong-system \
@@ -592,7 +593,9 @@ run.skaffold:
 
 .PHONY: debug
 debug: manifests generate install.all _ensure-kong-system-namespace
-	GATEWAY_OPERATOR_DEVELOPMENT_MODE=true dlv debug ./cmd/main.go -- \
+	GATEWAY_OPERATOR_ANONYMOUS_REPORTS=false \
+	GATEWAY_OPERATOR_LOGGING_MODE=development \
+		dlv debug ./cmd/main.go -- \
 		--no-leader-election \
 		-cluster-ca-secret-namespace kong-system \
 		--enable-controller-aigateway \

--- a/config/debug/manager_debug.yaml
+++ b/config/debug/manager_debug.yaml
@@ -35,8 +35,8 @@ spec:
             - -enable-controller-konnect
           name: manager
           env:
-            - name: GATEWAY_OPERATOR_DEVELOPMENT_MODE
-              value: "true"
+            - name: GATEWAY_OPERATOR_ANONYMOUS_REPORTS
+              value: "false"
           resources:
             limits:
               cpu: 1000m

--- a/config/dev/manager_dev.yaml
+++ b/config/dev/manager_dev.yaml
@@ -27,8 +27,8 @@ spec:
             - -enable-controller-konnect
           name: manager
           env:
-          - name: GATEWAY_OPERATOR_DEVELOPMENT_MODE
-            value: "true"
+            - name: GATEWAY_OPERATOR_ANONYMOUS_REPORTS
+              value: "false"
           resources:
             limits:
               cpu: 1000m

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -56,7 +56,7 @@ type Reconciler struct {
 	ClusterCAKeyConfig        secrets.KeyConfig
 	KonnectEnabled            bool
 	EnforceConfig             bool
-	LoggingMode               logging.LoggingMode
+	LoggingMode               logging.Mode
 	ValidateControlPlaneImage bool
 	AnonymousReportsEnabled   bool
 }

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -36,6 +36,7 @@ import (
 	operatorerrors "github.com/kong/gateway-operator/internal/errors"
 	"github.com/kong/gateway-operator/internal/utils/index"
 	"github.com/kong/gateway-operator/internal/versions"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/pkg/consts"
 	gatewayutils "github.com/kong/gateway-operator/pkg/utils/gateway"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
@@ -49,13 +50,15 @@ import (
 // Reconciler reconciles a ControlPlane object
 type Reconciler struct {
 	client.Client
-	Scheme                   *runtime.Scheme
-	ClusterCASecretName      string
-	ClusterCASecretNamespace string
-	ClusterCAKeyConfig       secrets.KeyConfig
-	DevelopmentMode          bool
-	KonnectEnabled           bool
-	EnforceConfig            bool
+	Scheme                    *runtime.Scheme
+	ClusterCASecretName       string
+	ClusterCASecretNamespace  string
+	ClusterCAKeyConfig        secrets.KeyConfig
+	KonnectEnabled            bool
+	EnforceConfig             bool
+	LoggingMode               logging.LoggingMode
+	ValidateControlPlaneImage bool
+	AnonymousReportsEnabled   bool
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -145,7 +148,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 
 // Reconcile moves the current state of an object to the intended state.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.GetLogger(ctx, "controlplane", r.DevelopmentMode)
+	logger := log.GetLogger(ctx, "controlplane", r.LoggingMode)
 
 	log.Trace(logger, "reconciling ControlPlane resource")
 	cp := new(operatorv1beta1.ControlPlane)
@@ -293,7 +296,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	log.Trace(logger, "validating ControlPlane configuration")
-	if err := validateControlPlane(cp, r.DevelopmentMode); err != nil {
+	if err := validateControlPlane(cp, r.ValidateControlPlaneImage); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -304,7 +307,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		ControlPlaneName:            cp.Name,
 		DataPlaneIngressServiceName: dataplaneIngressServiceName,
 		DataPlaneAdminServiceName:   dataplaneAdminServiceName,
-		AnonymousReportsEnabled:     controlplane.DeduceAnonymousReportsEnabled(r.DevelopmentMode, &cp.Spec.ControlPlaneOptions),
+		AnonymousReportsEnabled:     controlplane.DeduceAnonymousReportsEnabled(r.AnonymousReportsEnabled, &cp.Spec.ControlPlaneOptions),
 	}
 	for _, owner := range cp.OwnerReferences {
 		if strings.HasPrefix(owner.APIVersion, gatewayv1.GroupName) && owner.Kind == "Gateway" {
@@ -473,9 +476,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 }
 
 // validateControlPlane validates the control plane.
-func validateControlPlane(controlPlane *operatorv1beta1.ControlPlane, devMode bool) error {
+func validateControlPlane(controlPlane *operatorv1beta1.ControlPlane, validateControlPlaneImage bool) error {
 	versionValidationOptions := make([]versions.VersionValidationOption, 0)
-	if !devMode {
+	if validateControlPlaneImage {
 		versionValidationOptions = append(versionValidationOptions, versions.IsControlPlaneImageVersionSupported)
 	}
 	_, err := controlplane.GenerateImage(&controlPlane.Spec.ControlPlaneOptions, versionValidationOptions...)

--- a/controller/controlplane/controller_test.go
+++ b/controller/controlplane/controller_test.go
@@ -456,10 +456,11 @@ func TestReconciler_Reconcile(t *testing.T) {
 				Build()
 
 			reconciler := Reconciler{
-				Client:                   fakeClient,
-				Scheme:                   scheme.Scheme,
-				ClusterCASecretName:      mtlsSecret.Name,
-				ClusterCASecretNamespace: mtlsSecret.Namespace,
+				Client:                    fakeClient,
+				Scheme:                    scheme.Scheme,
+				ClusterCASecretName:       mtlsSecret.Name,
+				ClusterCASecretNamespace:  mtlsSecret.Namespace,
+				ValidateControlPlaneImage: true,
 			}
 
 			tc.testBody(t, reconciler, tc.controlplaneReq)

--- a/controller/dataplane/bluegreen_controller.go
+++ b/controller/dataplane/bluegreen_controller.go
@@ -73,7 +73,7 @@ type BlueGreenReconciler struct {
 
 	EnforceConfig          bool
 	ValidateDataPlaneImage bool
-	LoggingMode            logging.LoggingMode
+	LoggingMode            logging.Mode
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controller/dataplane/controller.go
+++ b/controller/dataplane/controller.go
@@ -45,7 +45,7 @@ type Reconciler struct {
 	DefaultImage             string
 	KonnectEnabled           bool
 	EnforceConfig            bool
-	LoggingMode              logging.LoggingMode
+	LoggingMode              logging.Mode
 	ValidateDataPlaneImage   bool
 }
 

--- a/controller/dataplane/controller_reconciler_utils_test.go
+++ b/controller/dataplane/controller_reconciler_utils_test.go
@@ -58,8 +58,8 @@ func TestDeploymentBuilder(t *testing.T) {
 	}
 
 	const (
-		developmentMode = false
-		enforceConfig   = true
+		validateDataPlaneImage = true
+		enforceConfig          = true
 	)
 	deploymentLiveLabels := client.MatchingLabels{
 		consts.DataPlaneDeploymentStateLabel: consts.DataPlaneStateLabelValueLive,
@@ -86,7 +86,7 @@ func TestDeploymentBuilder(t *testing.T) {
 					WithClusterCertificate(certSecretName).
 					WithAdditionalLabels(deploymentLiveLabels)
 
-				deployment, res, err := deploymentBuilder.BuildAndDeploy(ctx, dataPlane, enforceConfig, developmentMode)
+				deployment, res, err := deploymentBuilder.BuildAndDeploy(ctx, dataPlane, enforceConfig, validateDataPlaneImage)
 				require.NoError(t, err)
 				require.Equal(t, op.Created, res)
 				require.NotNil(t, deployment)
@@ -152,7 +152,7 @@ func TestDeploymentBuilder(t *testing.T) {
 					WithClusterCertificate(certSecretName).
 					WithAdditionalLabels(deploymentLiveLabels)
 
-				deployment, res, err := deploymentBuilder.BuildAndDeploy(ctx, dataPlane, enforceConfig, developmentMode)
+				deployment, res, err := deploymentBuilder.BuildAndDeploy(ctx, dataPlane, enforceConfig, validateDataPlaneImage)
 				require.NoError(t, err)
 				require.Equal(t, op.Created, res)
 				require.Len(t, deployment.Spec.Template.Spec.Volumes, 2)
@@ -234,7 +234,7 @@ func TestDeploymentBuilder(t *testing.T) {
 					WithClusterCertificate(certSecretName).
 					WithAdditionalLabels(client.MatchingLabels{})
 
-				deployment, res, err := deploymentBuilder.BuildAndDeploy(ctx, dataPlane, enforceConfig, developmentMode)
+				deployment, res, err := deploymentBuilder.BuildAndDeploy(ctx, dataPlane, enforceConfig, validateDataPlaneImage)
 				require.NoError(t, err)
 
 				assert.Equal(t, op.Updated, res, "the DataPlane deployment should be updated with the original strategy")
@@ -297,7 +297,7 @@ func TestDeploymentBuilder(t *testing.T) {
 					WithClusterCertificate(certSecretName).
 					WithAdditionalLabels(client.MatchingLabels{})
 
-				deployment, res, err := deploymentBuilder.BuildAndDeploy(ctx, dataPlane, enforceConfig, developmentMode)
+				deployment, res, err := deploymentBuilder.BuildAndDeploy(ctx, dataPlane, enforceConfig, validateDataPlaneImage)
 				require.NoError(t, err)
 
 				assert.Equal(t, op.Updated, res, "the DataPlane deployment should be updated to get the resources set to defaults")
@@ -368,7 +368,7 @@ func TestDeploymentBuilder(t *testing.T) {
 					WithClusterCertificate(certSecretName).
 					WithAdditionalLabels(client.MatchingLabels{})
 
-				deployment, res, err := deploymentBuilder.BuildAndDeploy(ctx, dataPlane, enforceConfig, developmentMode)
+				deployment, res, err := deploymentBuilder.BuildAndDeploy(ctx, dataPlane, enforceConfig, validateDataPlaneImage)
 				require.NoError(t, err)
 
 				assert.Equal(t, op.Updated, res, "the DataPlane deployment should be updated to get the affinity set to the dataplane's spec")
@@ -405,7 +405,7 @@ func TestDeploymentBuilder(t *testing.T) {
 					WithClusterCertificate(certSecretName).
 					WithAdditionalLabels(deploymentLiveLabels)
 
-				existingDeployment, res, err := firstDeploymentBuilder.BuildAndDeploy(ctx, dataPlane, enforceConfig, developmentMode)
+				existingDeployment, res, err := firstDeploymentBuilder.BuildAndDeploy(ctx, dataPlane, enforceConfig, validateDataPlaneImage)
 				require.NoError(t, err)
 				require.Equal(t, op.Created, res)
 
@@ -433,7 +433,7 @@ func TestDeploymentBuilder(t *testing.T) {
 					WithClusterCertificate(certSecretName).
 					WithAdditionalLabels(deploymentLiveLabels)
 
-				deployment, res, err := secondDeploymentBuilder.BuildAndDeploy(ctx, dataPlane, enforceConfig, developmentMode)
+				deployment, res, err := secondDeploymentBuilder.BuildAndDeploy(ctx, dataPlane, enforceConfig, validateDataPlaneImage)
 				require.NoError(t, err)
 				assert.Equal(t, op.Updated, res, "the DataPlane deployment should be updated to get the affinity removed")
 				require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
@@ -469,7 +469,7 @@ func TestDeploymentBuilder(t *testing.T) {
 					WithClusterCertificate(certSecretName).
 					WithAdditionalLabels(deploymentLiveLabels)
 
-				existingDeployment, res, err := firstDeploymentBuilder.BuildAndDeploy(ctx, dataPlane, enforceConfig, developmentMode)
+				existingDeployment, res, err := firstDeploymentBuilder.BuildAndDeploy(ctx, dataPlane, enforceConfig, validateDataPlaneImage)
 
 				require.NoError(t, err)
 				require.Equal(t, op.Created, res)
@@ -498,7 +498,7 @@ func TestDeploymentBuilder(t *testing.T) {
 					WithClusterCertificate(certSecretName).
 					WithAdditionalLabels(deploymentLiveLabels)
 
-				deployment, res, err := secondDeploymentBuilder.BuildAndDeploy(ctx, dataPlane, enforceConfig, developmentMode)
+				deployment, res, err := secondDeploymentBuilder.BuildAndDeploy(ctx, dataPlane, enforceConfig, validateDataPlaneImage)
 
 				require.NoError(t, err)
 				assert.Equal(t, op.Updated, res, "the DataPlane deployment should be updated to get the affinity removed")

--- a/controller/dataplane/controller_test.go
+++ b/controller/dataplane/controller_test.go
@@ -916,6 +916,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 				Client:                   fakeClient,
 				ClusterCASecretName:      mtlsSecret.Name,
 				ClusterCASecretNamespace: mtlsSecret.Namespace,
+				ValidateDataPlaneImage:   true,
 				ClusterCAKeyConfig: secrets.KeyConfig{
 					Type: x509.ECDSA,
 				},

--- a/controller/dataplane/owned_deployment.go
+++ b/controller/dataplane/owned_deployment.go
@@ -90,7 +90,7 @@ func (d *DeploymentBuilder) BuildAndDeploy(
 	ctx context.Context,
 	dataplane *operatorv1beta1.DataPlane,
 	enforceConfig bool,
-	developmentMode bool,
+	validateDataPlaneImage bool,
 ) (*appsv1.Deployment, op.Result, error) {
 	// run any preparatory callbacks
 	beforeDeploymentCallbacks := NewCallbackRunner(d.client)
@@ -112,7 +112,7 @@ func (d *DeploymentBuilder) BuildAndDeploy(
 	}
 
 	// generate the initial Deployment struct
-	desiredDeployment, err := generateDataPlaneDeployment(developmentMode, dataplane, d.defaultImage, d.additionalLabels, d.opts...)
+	desiredDeployment, err := generateDataPlaneDeployment(validateDataPlaneImage, dataplane, d.defaultImage, d.additionalLabels, d.opts...)
 	if err != nil {
 		return nil, op.Noop, fmt.Errorf("could not generate Deployment: %w", err)
 	}
@@ -160,7 +160,7 @@ func (d *DeploymentBuilder) BuildAndDeploy(
 // generateDataPlaneDeployment generates the base Deployment for a DataPlane. It determines the image to use and
 // generates an opt transform function to add additional labels before invoking the generator utility.
 func generateDataPlaneDeployment(
-	developmentMode bool,
+	validateDataPlaneImage bool,
 	dataplane *operatorv1beta1.DataPlane,
 	defaultImage string,
 	additionalDeploymentLabels client.MatchingLabels,
@@ -171,7 +171,7 @@ func generateDataPlaneDeployment(
 	}
 
 	versionValidationOptions := make([]versions.VersionValidationOption, 0)
-	if !developmentMode {
+	if validateDataPlaneImage {
 		versionValidationOptions = append(versionValidationOptions, versions.IsDataPlaneImageVersionSupported)
 	}
 	dataplaneImage, err := generateDataPlaneImage(dataplane, defaultImage, versionValidationOptions...)

--- a/controller/dataplane/owned_finalizer_controller.go
+++ b/controller/dataplane/owned_finalizer_controller.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/kong/gateway-operator/controller/pkg/log"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
@@ -63,8 +64,8 @@ type DeepCopier[T DataPlaneOwnedResource, PT ClientObjectPointer[T]] interface {
 // This is a stop gap solution until we implement proper self-healing for the DataPlane resources, see:
 // https://github.com/Kong/gateway-operator/issues/1028
 type DataPlaneOwnedResourceFinalizerReconciler[T DataPlaneOwnedResource, PT DataPlaneOwnedResourcePointer[T, PT]] struct {
-	Client          client.Client
-	DevelopmentMode bool
+	Client      client.Client
+	LoggingMode logging.LoggingMode
 }
 
 // NewDataPlaneOwnedResourceFinalizerReconciler returns a new DataPlaneOwnedResourceFinalizerReconciler for a type passed
@@ -78,11 +79,11 @@ type DataPlaneOwnedResourceFinalizerReconciler[T DataPlaneOwnedResource, PT Data
 //	NewDataPlaneOwnedResourceFinalizerReconciler[corev1.Service, *corev1.Service](...).
 func NewDataPlaneOwnedResourceFinalizerReconciler[T DataPlaneOwnedResource, PT DataPlaneOwnedResourcePointer[T, PT]](
 	client client.Client,
-	developmentMode bool,
+	loggingMode logging.LoggingMode,
 ) *DataPlaneOwnedResourceFinalizerReconciler[T, PT] {
 	return &DataPlaneOwnedResourceFinalizerReconciler[T, PT]{
-		Client:          client,
-		DevelopmentMode: developmentMode,
+		Client:      client,
+		LoggingMode: loggingMode,
 	}
 }
 
@@ -119,7 +120,7 @@ func (r DataPlaneOwnedResourceFinalizerReconciler[T, PT]) Reconcile(ctx context.
 		return ctrl.Result{}, fmt.Errorf("failed to get %s %s/%s: %w", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName(), err)
 	}
 
-	logger := log.GetLogger(ctx, obj.GetObjectKind().GroupVersionKind().Kind, r.DevelopmentMode)
+	logger := log.GetLogger(ctx, obj.GetObjectKind().GroupVersionKind().Kind, r.LoggingMode)
 
 	// If the object is not being deleted, we don't need to do anything.
 	if obj.GetDeletionTimestamp().IsZero() {

--- a/controller/dataplane/owned_finalizer_controller.go
+++ b/controller/dataplane/owned_finalizer_controller.go
@@ -65,7 +65,7 @@ type DeepCopier[T DataPlaneOwnedResource, PT ClientObjectPointer[T]] interface {
 // https://github.com/Kong/gateway-operator/issues/1028
 type DataPlaneOwnedResourceFinalizerReconciler[T DataPlaneOwnedResource, PT DataPlaneOwnedResourcePointer[T, PT]] struct {
 	Client      client.Client
-	LoggingMode logging.LoggingMode
+	LoggingMode logging.Mode
 }
 
 // NewDataPlaneOwnedResourceFinalizerReconciler returns a new DataPlaneOwnedResourceFinalizerReconciler for a type passed
@@ -79,7 +79,7 @@ type DataPlaneOwnedResourceFinalizerReconciler[T DataPlaneOwnedResource, PT Data
 //	NewDataPlaneOwnedResourceFinalizerReconciler[corev1.Service, *corev1.Service](...).
 func NewDataPlaneOwnedResourceFinalizerReconciler[T DataPlaneOwnedResource, PT DataPlaneOwnedResourcePointer[T, PT]](
 	client client.Client,
-	loggingMode logging.LoggingMode,
+	loggingMode logging.Mode,
 ) *DataPlaneOwnedResourceFinalizerReconciler[T, PT] {
 	return &DataPlaneOwnedResourceFinalizerReconciler[T, PT]{
 		Client:      client,

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -34,6 +34,7 @@ import (
 	operatorerrors "github.com/kong/gateway-operator/internal/errors"
 	gwtypes "github.com/kong/gateway-operator/internal/types"
 	"github.com/kong/gateway-operator/internal/utils/gatewayclass"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/pkg/consts"
 	gatewayutils "github.com/kong/gateway-operator/pkg/utils/gateway"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
@@ -56,10 +57,11 @@ import (
 // Reconciler reconciles a Gateway object.
 type Reconciler struct {
 	client.Client
-	Scheme                *runtime.Scheme
-	DevelopmentMode       bool
-	DefaultDataPlaneImage string
-	KonnectEnabled        bool
+	Scheme                  *runtime.Scheme
+	DefaultDataPlaneImage   string
+	KonnectEnabled          bool
+	AnonymousReportsEnabled bool
+	LoggingMode             logging.LoggingMode
 }
 
 // provisionDataPlaneFailRequeueAfter is the time duration after which we retry provisioning
@@ -125,7 +127,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 
 // Reconcile moves the current state of an object to the intended state.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.GetLogger(ctx, "gateway", r.DevelopmentMode)
+	logger := log.GetLogger(ctx, "gateway", r.LoggingMode)
 
 	log.Trace(logger, "reconciling gateway resource")
 	var gateway gwtypes.Gateway

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -61,7 +61,7 @@ type Reconciler struct {
 	DefaultDataPlaneImage   string
 	KonnectEnabled          bool
 	AnonymousReportsEnabled bool
-	LoggingMode             logging.LoggingMode
+	LoggingMode             logging.Mode
 }
 
 // provisionDataPlaneFailRequeueAfter is the time duration after which we retry provisioning

--- a/controller/gateway/controller_watch.go
+++ b/controller/gateway/controller_watch.go
@@ -372,7 +372,7 @@ func (r *Reconciler) setControlPlaneGatewayConfigDefaults(gateway *gwtypes.Gatew
 			DataPlaneAdminServiceName:   dataplaneAdminServiceName,
 			OwnedByGateway:              gateway.Name,
 			ControlPlaneName:            controlPlaneName,
-			AnonymousReportsEnabled:     controlplane.DeduceAnonymousReportsEnabled(r.DevelopmentMode, gatewayConfig.Spec.ControlPlaneOptions),
+			AnonymousReportsEnabled:     controlplane.DeduceAnonymousReportsEnabled(r.AnonymousReportsEnabled, gatewayConfig.Spec.ControlPlaneOptions),
 		},
 	)
 }

--- a/controller/gatewayclass/controller.go
+++ b/controller/gatewayclass/controller.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kong/gateway-operator/controller"
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/internal/utils/gatewayclass"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 )
 
@@ -27,7 +28,7 @@ import (
 type Reconciler struct {
 	client.Client
 	Scheme                        *runtime.Scheme
-	DevelopmentMode               bool
+	LoggingMode                   logging.LoggingMode
 	GatewayAPIExperimentalEnabled bool
 }
 
@@ -41,7 +42,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 
 // Reconcile moves the current state of an object to the intended state.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.GetLogger(ctx, "gatewayclass", r.DevelopmentMode)
+	logger := log.GetLogger(ctx, "gatewayclass", r.LoggingMode)
 
 	log.Trace(logger, "reconciling gatewayclass resource")
 

--- a/controller/gatewayclass/controller.go
+++ b/controller/gatewayclass/controller.go
@@ -28,7 +28,7 @@ import (
 type Reconciler struct {
 	client.Client
 	Scheme                        *runtime.Scheme
-	LoggingMode                   logging.LoggingMode
+	LoggingMode                   logging.Mode
 	GatewayAPIExperimentalEnabled bool
 }
 

--- a/controller/kongplugininstallation/controller.go
+++ b/controller/kongplugininstallation/controller.go
@@ -39,7 +39,7 @@ const kindKongPluginInstallation = gatewayv1.Kind("KongPluginInstallation")
 type Reconciler struct {
 	client.Client
 	Scheme      *runtime.Scheme
-	LoggingMode logging.LoggingMode
+	LoggingMode logging.Mode
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controller/kongplugininstallation/controller.go
+++ b/controller/kongplugininstallation/controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kong/gateway-operator/controller/kongplugininstallation/image"
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/controller/pkg/secrets/ref"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	k8sresources "github.com/kong/gateway-operator/pkg/utils/kubernetes/resources"
 
@@ -37,8 +38,8 @@ const kindKongPluginInstallation = gatewayv1.Kind("KongPluginInstallation")
 // Reconciler reconciles a KongPluginInstallation object.
 type Reconciler struct {
 	client.Client
-	Scheme          *runtime.Scheme
-	DevelopmentMode bool
+	Scheme      *runtime.Scheme
+	LoggingMode logging.LoggingMode
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -86,7 +87,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 
 // Reconcile moves the current state of an object to the intended state.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.GetLogger(ctx, "kongplugininstallation", r.DevelopmentMode)
+	logger := log.GetLogger(ctx, "kongplugininstallation", r.LoggingMode)
 
 	log.Trace(logger, "reconciling KongPluginInstallation resource")
 	var kpi operatorv1alpha1.KongPluginInstallation

--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -44,7 +44,7 @@ import (
 // KonnectExtensionReconciler reconciles a KonnectExtension object.
 type KonnectExtensionReconciler struct {
 	client.Client
-	LoggingMode              logging.LoggingMode
+	LoggingMode              logging.Mode
 	SdkFactory               sdkops.SDKFactory
 	SyncPeriod               time.Duration
 	ClusterCASecretName      string

--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kong/gateway-operator/controller/pkg/patch"
 	"github.com/kong/gateway-operator/controller/pkg/secrets"
 	"github.com/kong/gateway-operator/internal/utils/index"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/pkg/consts"
 	konnectresource "github.com/kong/gateway-operator/pkg/utils/konnect/resources"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
@@ -43,7 +44,7 @@ import (
 // KonnectExtensionReconciler reconciles a KonnectExtension object.
 type KonnectExtensionReconciler struct {
 	client.Client
-	DevelopmentMode          bool
+	LoggingMode              logging.LoggingMode
 	SdkFactory               sdkops.SDKFactory
 	SyncPeriod               time.Duration
 	ClusterCASecretName      string
@@ -142,7 +143,7 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	logger := log.GetLogger(ctx, konnectv1alpha1.KonnectExtensionKind, r.DevelopmentMode).WithValues("konnectExtension", req.NamespacedName)
+	logger := log.GetLogger(ctx, konnectv1alpha1.KonnectExtensionKind, r.LoggingMode).WithValues("konnectExtension", req.NamespacedName)
 
 	var (
 		dataPlaneList    operatorv1beta1.DataPlaneList

--- a/controller/konnect/reconciler_credential_secrets.go
+++ b/controller/konnect/reconciler_credential_secrets.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	operatorerrors "github.com/kong/gateway-operator/internal/errors"
 	"github.com/kong/gateway-operator/internal/utils/index"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/pkg/clientops"
 	k8sreduce "github.com/kong/gateway-operator/pkg/utils/kubernetes/reduce"
 
@@ -70,21 +71,21 @@ const (
 
 // KongCredentialSecretReconciler reconciles a KongPlugin object.
 type KongCredentialSecretReconciler struct {
-	developmentMode bool
-	client          client.Client
-	scheme          *runtime.Scheme
+	loggingMode logging.LoggingMode
+	client      client.Client
+	scheme      *runtime.Scheme
 }
 
 // NewKongCredentialSecretReconciler creates a new KongCredentialSecretReconciler.
 func NewKongCredentialSecretReconciler(
-	developmentMode bool,
+	loggingMode logging.LoggingMode,
 	client client.Client,
 	scheme *runtime.Scheme,
 ) *KongCredentialSecretReconciler {
 	return &KongCredentialSecretReconciler{
-		developmentMode: developmentMode,
-		client:          client,
-		scheme:          scheme,
+		loggingMode: loggingMode,
+		client:      client,
+		scheme:      scheme,
 	}
 }
 
@@ -196,7 +197,7 @@ func (r *KongCredentialSecretReconciler) Reconcile(ctx context.Context, req ctrl
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	logger := log.GetLogger(ctx, "Secret", r.developmentMode)
+	logger := log.GetLogger(ctx, "Secret", r.loggingMode)
 	log.Debug(logger, "reconciling")
 
 	if !secret.GetDeletionTimestamp().IsZero() {

--- a/controller/konnect/reconciler_credential_secrets.go
+++ b/controller/konnect/reconciler_credential_secrets.go
@@ -71,14 +71,14 @@ const (
 
 // KongCredentialSecretReconciler reconciles a KongPlugin object.
 type KongCredentialSecretReconciler struct {
-	loggingMode logging.LoggingMode
+	loggingMode logging.Mode
 	client      client.Client
 	scheme      *runtime.Scheme
 }
 
 // NewKongCredentialSecretReconciler creates a new KongCredentialSecretReconciler.
 func NewKongCredentialSecretReconciler(
-	loggingMode logging.LoggingMode,
+	loggingMode logging.Mode,
 	client client.Client,
 	scheme *runtime.Scheme,
 ) *KongCredentialSecretReconciler {

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kong/gateway-operator/controller/pkg/op"
 	"github.com/kong/gateway-operator/controller/pkg/patch"
 	"github.com/kong/gateway-operator/internal/metrics"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
@@ -40,7 +41,7 @@ const (
 // It uses the generic type constraints to constrain the supported types.
 type KonnectEntityReconciler[T constraints.SupportedKonnectEntityType, TEnt constraints.EntityType[T]] struct {
 	sdkFactory              sdkops.SDKFactory
-	DevelopmentMode         bool
+	LoggingMode             logging.LoggingMode
 	Client                  client.Client
 	SyncPeriod              time.Duration
 	MaxConcurrentReconciles uint
@@ -88,13 +89,13 @@ func NewKonnectEntityReconciler[
 	TEnt constraints.EntityType[T],
 ](
 	sdkFactory sdkops.SDKFactory,
-	developmentMode bool,
+	loggingMode logging.LoggingMode,
 	client client.Client,
 	opts ...KonnectEntityReconcilerOption[T, TEnt],
 ) *KonnectEntityReconciler[T, TEnt] {
 	r := &KonnectEntityReconciler[T, TEnt]{
 		sdkFactory:              sdkFactory,
-		DevelopmentMode:         developmentMode,
+		LoggingMode:             loggingMode,
 		Client:                  client,
 		SyncPeriod:              consts.DefaultKonnectSyncPeriod,
 		MaxConcurrentReconciles: consts.DefaultKonnectMaxConcurrentReconciles,
@@ -134,7 +135,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 ) (ctrl.Result, error) {
 	var (
 		entityTypeName = constraints.EntityTypeName[T]()
-		logger         = log.GetLogger(ctx, entityTypeName, r.DevelopmentMode)
+		logger         = log.GetLogger(ctx, entityTypeName, r.LoggingMode)
 	)
 
 	var (

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -41,7 +41,7 @@ const (
 // It uses the generic type constraints to constrain the supported types.
 type KonnectEntityReconciler[T constraints.SupportedKonnectEntityType, TEnt constraints.EntityType[T]] struct {
 	sdkFactory              sdkops.SDKFactory
-	LoggingMode             logging.LoggingMode
+	LoggingMode             logging.Mode
 	Client                  client.Client
 	SyncPeriod              time.Duration
 	MaxConcurrentReconciles uint
@@ -89,7 +89,7 @@ func NewKonnectEntityReconciler[
 	TEnt constraints.EntityType[T],
 ](
 	sdkFactory sdkops.SDKFactory,
-	loggingMode logging.LoggingMode,
+	loggingMode logging.Mode,
 	client client.Client,
 	opts ...KonnectEntityReconcilerOption[T, TEnt],
 ) *KonnectEntityReconciler[T, TEnt] {

--- a/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
+++ b/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
@@ -33,7 +33,7 @@ type KonnectEntityPluginBindingFinalizerReconciler[
 	T constraints.SupportedKonnectEntityPluginReferenceableType,
 	TEnt constraints.EntityType[T],
 ] struct {
-	LoggingMode logging.LoggingMode
+	LoggingMode logging.Mode
 	Client      client.Client
 }
 
@@ -43,7 +43,7 @@ func NewKonnectEntityPluginReconciler[
 	T constraints.SupportedKonnectEntityPluginReferenceableType,
 	TEnt constraints.EntityType[T],
 ](
-	loggingMode logging.LoggingMode,
+	loggingMode logging.Mode,
 	client client.Client,
 ) *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt] {
 	r := &KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]{

--- a/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
+++ b/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kong/gateway-operator/controller/konnect/constraints"
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/internal/utils/index"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/pkg/clientops"
 	"github.com/kong/gateway-operator/pkg/consts"
 
@@ -32,8 +33,8 @@ type KonnectEntityPluginBindingFinalizerReconciler[
 	T constraints.SupportedKonnectEntityPluginReferenceableType,
 	TEnt constraints.EntityType[T],
 ] struct {
-	DevelopmentMode bool
-	Client          client.Client
+	LoggingMode logging.LoggingMode
+	Client      client.Client
 }
 
 // NewKonnectEntityPluginReconciler returns a new KonnectEntityPluginReconciler
@@ -42,12 +43,12 @@ func NewKonnectEntityPluginReconciler[
 	T constraints.SupportedKonnectEntityPluginReferenceableType,
 	TEnt constraints.EntityType[T],
 ](
-	developmentMode bool,
+	loggingMode logging.LoggingMode,
 	client client.Client,
 ) *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt] {
 	r := &KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]{
-		DevelopmentMode: developmentMode,
-		Client:          client,
+		LoggingMode: loggingMode,
+		Client:      client,
 	}
 	return r
 }
@@ -150,7 +151,7 @@ func (r *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]) Reconcile(
 ) (ctrl.Result, error) {
 	var (
 		entityTypeName = constraints.EntityTypeName[T]()
-		logger         = log.GetLogger(ctx, entityTypeName, r.DevelopmentMode)
+		logger         = log.GetLogger(ctx, entityTypeName, r.LoggingMode)
 	)
 
 	var (

--- a/controller/konnect/reconciler_kongplugin.go
+++ b/controller/konnect/reconciler_kongplugin.go
@@ -36,13 +36,13 @@ import (
 
 // KongPluginReconciler reconciles a KongPlugin object.
 type KongPluginReconciler struct {
-	loggingMode logging.LoggingMode
+	loggingMode logging.Mode
 	client      client.Client
 }
 
 // NewKongPluginReconciler creates a new KongPluginReconciler.
 func NewKongPluginReconciler(
-	loggingMode logging.LoggingMode,
+	loggingMode logging.Mode,
 	client client.Client,
 ) *KongPluginReconciler {
 	return &KongPluginReconciler{

--- a/controller/konnect/reconciler_kongplugin.go
+++ b/controller/konnect/reconciler_kongplugin.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/controller/pkg/patch"
 	"github.com/kong/gateway-operator/internal/utils/index"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/pkg/consts"
 	k8sreduce "github.com/kong/gateway-operator/pkg/utils/kubernetes/reduce"
 
@@ -35,18 +36,18 @@ import (
 
 // KongPluginReconciler reconciles a KongPlugin object.
 type KongPluginReconciler struct {
-	developmentMode bool
-	client          client.Client
+	loggingMode logging.LoggingMode
+	client      client.Client
 }
 
 // NewKongPluginReconciler creates a new KongPluginReconciler.
 func NewKongPluginReconciler(
-	developmentMode bool,
+	loggingMode logging.LoggingMode,
 	client client.Client,
 ) *KongPluginReconciler {
 	return &KongPluginReconciler{
-		developmentMode: developmentMode,
-		client:          client,
+		loggingMode: loggingMode,
+		client:      client,
 	}
 }
 
@@ -61,7 +62,7 @@ func (r *KongPluginReconciler) SetupWithManager(_ context.Context, mgr ctrl.Mana
 		).
 		Watches(
 			&configurationv1alpha1.KongService{},
-			handler.EnqueueRequestsFromMapFunc(mapPluginsFromAnnotation[configurationv1alpha1.KongService](r.developmentMode)),
+			handler.EnqueueRequestsFromMapFunc(mapPluginsFromAnnotation[configurationv1alpha1.KongService](r.loggingMode)),
 			builder.WithPredicates(
 				kongPluginsAnnotationChangedPredicate,
 				predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1alpha1.KongService]),
@@ -69,7 +70,7 @@ func (r *KongPluginReconciler) SetupWithManager(_ context.Context, mgr ctrl.Mana
 		).
 		Watches(
 			&configurationv1alpha1.KongRoute{},
-			handler.EnqueueRequestsFromMapFunc(mapPluginsFromAnnotation[configurationv1alpha1.KongRoute](r.developmentMode)),
+			handler.EnqueueRequestsFromMapFunc(mapPluginsFromAnnotation[configurationv1alpha1.KongRoute](r.loggingMode)),
 			builder.WithPredicates(
 				kongPluginsAnnotationChangedPredicate,
 				predicate.NewPredicateFuncs(kongRouteRefersToKonnectGatewayControlPlane(r.client)),
@@ -77,7 +78,7 @@ func (r *KongPluginReconciler) SetupWithManager(_ context.Context, mgr ctrl.Mana
 		).
 		Watches(
 			&configurationv1.KongConsumer{},
-			handler.EnqueueRequestsFromMapFunc(mapPluginsFromAnnotation[configurationv1.KongConsumer](r.developmentMode)),
+			handler.EnqueueRequestsFromMapFunc(mapPluginsFromAnnotation[configurationv1.KongConsumer](r.loggingMode)),
 			builder.WithPredicates(
 				kongPluginsAnnotationChangedPredicate,
 				predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1.KongConsumer]),
@@ -85,7 +86,7 @@ func (r *KongPluginReconciler) SetupWithManager(_ context.Context, mgr ctrl.Mana
 		).
 		Watches(
 			&configurationv1beta1.KongConsumerGroup{},
-			handler.EnqueueRequestsFromMapFunc(mapPluginsFromAnnotation[configurationv1beta1.KongConsumerGroup](r.developmentMode)),
+			handler.EnqueueRequestsFromMapFunc(mapPluginsFromAnnotation[configurationv1beta1.KongConsumerGroup](r.loggingMode)),
 			builder.WithPredicates(
 				kongPluginsAnnotationChangedPredicate,
 				predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1beta1.KongConsumerGroup]),
@@ -100,7 +101,7 @@ func (r *KongPluginReconciler) SetupWithManager(_ context.Context, mgr ctrl.Mana
 func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var (
 		entityTypeName = "KongPlugin"
-		logger         = log.GetLogger(ctx, entityTypeName, r.developmentMode)
+		logger         = log.GetLogger(ctx, entityTypeName, r.loggingMode)
 	)
 
 	// Fetch the KongPlugin instance

--- a/controller/konnect/reconciler_konnectapiauth.go
+++ b/controller/konnect/reconciler_konnectapiauth.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kong/gateway-operator/controller/konnect/server"
 	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/controller/pkg/patch"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
@@ -28,9 +29,9 @@ import (
 
 // KonnectAPIAuthConfigurationReconciler reconciles a KonnectAPIAuthConfiguration object.
 type KonnectAPIAuthConfigurationReconciler struct {
-	sdkFactory      sdkops.SDKFactory
-	developmentMode bool
-	client          client.Client
+	sdkFactory  sdkops.SDKFactory
+	client      client.Client
+	loggingMode logging.LoggingMode
 }
 
 const (
@@ -47,13 +48,13 @@ const (
 // NewKonnectAPIAuthConfigurationReconciler creates a new KonnectAPIAuthConfigurationReconciler.
 func NewKonnectAPIAuthConfigurationReconciler(
 	sdkFactory sdkops.SDKFactory,
-	developmentMode bool,
+	loggingMode logging.LoggingMode,
 	client client.Client,
 ) *KonnectAPIAuthConfigurationReconciler {
 	return &KonnectAPIAuthConfigurationReconciler{
-		sdkFactory:      sdkFactory,
-		developmentMode: developmentMode,
-		client:          client,
+		sdkFactory:  sdkFactory,
+		loggingMode: loggingMode,
+		client:      client,
 	}
 }
 
@@ -95,7 +96,7 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 
 	var (
 		entityTypeName = "KonnectAPIAuthConfiguration"
-		logger         = log.GetLogger(ctx, entityTypeName, r.developmentMode)
+		logger         = log.GetLogger(ctx, entityTypeName, r.loggingMode)
 	)
 
 	log.Debug(logger, "reconciling")

--- a/controller/konnect/reconciler_konnectapiauth.go
+++ b/controller/konnect/reconciler_konnectapiauth.go
@@ -31,7 +31,7 @@ import (
 type KonnectAPIAuthConfigurationReconciler struct {
 	sdkFactory  sdkops.SDKFactory
 	client      client.Client
-	loggingMode logging.LoggingMode
+	loggingMode logging.Mode
 }
 
 const (
@@ -48,7 +48,7 @@ const (
 // NewKonnectAPIAuthConfigurationReconciler creates a new KonnectAPIAuthConfigurationReconciler.
 func NewKonnectAPIAuthConfigurationReconciler(
 	sdkFactory sdkops.SDKFactory,
-	loggingMode logging.LoggingMode,
+	loggingMode logging.Mode,
 	client client.Client,
 ) *KonnectAPIAuthConfigurationReconciler {
 	return &KonnectAPIAuthConfigurationReconciler{

--- a/controller/konnect/watch_kongplugin.go
+++ b/controller/konnect/watch_kongplugin.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect/constraints"
 	"github.com/kong/gateway-operator/controller/pkg/log"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 
 	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
@@ -28,12 +29,12 @@ func mapPluginsFromAnnotation[
 			configurationv1beta1.KongConsumerGroup
 		GetTypeName() string
 	},
-](devMode bool) func(ctx context.Context, obj client.Object) []ctrl.Request {
+](loggingMode logging.LoggingMode) func(ctx context.Context, obj client.Object) []ctrl.Request {
 	return func(ctx context.Context, obj client.Object) []ctrl.Request {
 		_, ok := any(obj).(*T)
 		if !ok {
 			entityTypeName := constraints.EntityTypeName[T]()
-			logger := log.GetLogger(ctx, entityTypeName, devMode)
+			logger := log.GetLogger(ctx, entityTypeName, loggingMode)
 			log.Error(logger,
 				fmt.Errorf("cannot cast object to %s", entityTypeName),
 				fmt.Sprintf("%s mapping handler", entityTypeName),
@@ -61,7 +62,7 @@ func mapPluginsFromAnnotation[
 
 // mapKongPluginBindings enqueue requests for KongPlugins referenced by KongPluginBindings in their .spec.pluginRef field.
 func (r *KongPluginReconciler) mapKongPluginBindings(ctx context.Context, obj client.Object) []ctrl.Request {
-	logger := log.GetLogger(ctx, "KongPlugin", r.developmentMode)
+	logger := log.GetLogger(ctx, "KongPlugin", r.loggingMode)
 	kongPluginBinding, ok := obj.(*configurationv1alpha1.KongPluginBinding)
 	if !ok {
 		log.Error(logger,

--- a/controller/konnect/watch_kongplugin.go
+++ b/controller/konnect/watch_kongplugin.go
@@ -29,7 +29,7 @@ func mapPluginsFromAnnotation[
 			configurationv1beta1.KongConsumerGroup
 		GetTypeName() string
 	},
-](loggingMode logging.LoggingMode) func(ctx context.Context, obj client.Object) []ctrl.Request {
+](loggingMode logging.Mode) func(ctx context.Context, obj client.Object) []ctrl.Request {
 	return func(ctx context.Context, obj client.Object) []ctrl.Request {
 		_, ok := any(obj).(*T)
 		if !ok {

--- a/controller/pkg/controlplane/controlplane.go
+++ b/controller/pkg/controlplane/controlplane.go
@@ -259,15 +259,15 @@ func SpecDeepEqual(spec1, spec2 *operatorv1beta1.ControlPlaneOptions, envVarsToI
 //
 // This allows users to override the setting that is a derivative of the operator development mode
 // using the environment variable `CONTROLLER_ANONYMOUS_REPORTS` in the control plane pod template spec.
-func DeduceAnonymousReportsEnabled(developmentMode bool, cpOpts *operatorv1beta1.ControlPlaneOptions) bool {
+func DeduceAnonymousReportsEnabled(anonymousReportsEnabled bool, cpOpts *operatorv1beta1.ControlPlaneOptions) bool {
 	pts := cpOpts.Deployment.PodTemplateSpec
 	if pts == nil {
-		return !developmentMode
+		return anonymousReportsEnabled
 	}
 
 	container := k8sutils.GetPodContainerByName(&pts.Spec, consts.ControlPlaneControllerContainerName)
 	if container == nil {
-		return !developmentMode
+		return anonymousReportsEnabled
 	}
 
 	env := k8sutils.EnvValueByName(container.Env, "CONTROLLER_ANONYMOUS_REPORTS")
@@ -275,5 +275,5 @@ func DeduceAnonymousReportsEnabled(developmentMode bool, cpOpts *operatorv1beta1
 		return v
 	}
 
-	return !developmentMode
+	return anonymousReportsEnabled
 }

--- a/controller/pkg/controlplane/controplane_test.go
+++ b/controller/pkg/controlplane/controplane_test.go
@@ -13,26 +13,26 @@ import (
 
 func TestDeduceAnonymousReportsEnabled(t *testing.T) {
 	tests := []struct {
-		name            string
-		developmentMode bool
-		cpOpts          *operatorv1beta1.ControlPlaneOptions
-		expected        bool
+		name                    string
+		anonymousReportsEnabled bool
+		cpOpts                  *operatorv1beta1.ControlPlaneOptions
+		expected                bool
 	}{
 		{
-			name:            "Anonymous reports not set, development mode enabled",
-			developmentMode: true,
-			cpOpts:          &operatorv1beta1.ControlPlaneOptions{},
-			expected:        false,
+			name:                    "CP opts anonymous reports not set, anonymous reports disabled",
+			anonymousReportsEnabled: false,
+			cpOpts:                  &operatorv1beta1.ControlPlaneOptions{},
+			expected:                false,
 		},
 		{
-			name:            "Anonymous reports not set, development mode disabled",
-			developmentMode: true,
-			expected:        false,
-			cpOpts:          &operatorv1beta1.ControlPlaneOptions{},
+			name:                    "CP opts anonymous reports not set, anonymous reports disabled",
+			anonymousReportsEnabled: false,
+			expected:                false,
+			cpOpts:                  &operatorv1beta1.ControlPlaneOptions{},
 		},
 		{
-			name:            "Anonymous reports disabled",
-			developmentMode: false,
+			name:                    "CP opts anonymous reports disabled",
+			anonymousReportsEnabled: true,
 			cpOpts: &operatorv1beta1.ControlPlaneOptions{
 				Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{
 					PodTemplateSpec: &corev1.PodTemplateSpec{
@@ -55,8 +55,8 @@ func TestDeduceAnonymousReportsEnabled(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:            "Anonymous reports enabled, development mode disabled",
-			developmentMode: false,
+			name:                    "CP opts anonymous reports enabled, anonymous reports enabled",
+			anonymousReportsEnabled: true,
 			cpOpts: &operatorv1beta1.ControlPlaneOptions{
 				Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{
 					PodTemplateSpec: &corev1.PodTemplateSpec{
@@ -79,8 +79,8 @@ func TestDeduceAnonymousReportsEnabled(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:            "Anonymous reports enabled, development mode",
-			developmentMode: true,
+			name:                    "CP opts anonymous reports enabled, anonymous reports disabled",
+			anonymousReportsEnabled: false,
 			cpOpts: &operatorv1beta1.ControlPlaneOptions{
 				Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{
 					PodTemplateSpec: &corev1.PodTemplateSpec{
@@ -105,7 +105,7 @@ func TestDeduceAnonymousReportsEnabled(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ret := DeduceAnonymousReportsEnabled(tt.developmentMode, tt.cpOpts)
+			ret := DeduceAnonymousReportsEnabled(tt.anonymousReportsEnabled, tt.cpOpts)
 			require.Equal(t, tt.expected, ret)
 		})
 	}

--- a/controller/pkg/log/log.go
+++ b/controller/pkg/log/log.go
@@ -51,7 +51,7 @@ func oddKeyValues(logger logr.Logger, msg string, keysAndValues ...interface{}) 
 }
 
 // GetLogger returns a configured instance of logger.
-func GetLogger(ctx context.Context, controllerName string, loggingMode logging.LoggingMode) logr.Logger {
+func GetLogger(ctx context.Context, controllerName string, loggingMode logging.Mode) logr.Logger {
 	// if development mode is active, do not add the context to the log line, as we want
 	// to have a lighter logging structure
 	if loggingMode == logging.DevelopmentMode {

--- a/controller/pkg/log/log.go
+++ b/controller/pkg/log/log.go
@@ -51,10 +51,10 @@ func oddKeyValues(logger logr.Logger, msg string, keysAndValues ...interface{}) 
 }
 
 // GetLogger returns a configured instance of logger.
-func GetLogger(ctx context.Context, controllerName string, developmentMode bool) logr.Logger {
+func GetLogger(ctx context.Context, controllerName string, loggingMode logging.LoggingMode) logr.Logger {
 	// if development mode is active, do not add the context to the log line, as we want
 	// to have a lighter logging structure
-	if developmentMode {
+	if loggingMode == logging.DevelopmentMode {
 		return ctrllog.Log.WithName(controllerName)
 	}
 	return ctrllog.FromContext(ctx).WithName(controllerName)

--- a/controller/specialized/aigateway_controller.go
+++ b/controller/specialized/aigateway_controller.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kong/gateway-operator/controller/pkg/watch"
 	operatorerrors "github.com/kong/gateway-operator/internal/errors"
 	"github.com/kong/gateway-operator/internal/utils/gatewayclass"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/pkg/vars"
 
@@ -32,8 +33,8 @@ import (
 type AIGatewayReconciler struct {
 	client.Client
 
-	Scheme          *runtime.Scheme
-	DevelopmentMode bool
+	Scheme      *runtime.Scheme
+	LoggingMode logging.LoggingMode
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -61,7 +62,7 @@ func (r *AIGatewayReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 
 // Reconcile reconciles the AIGateway resource.
 func (r *AIGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.GetLogger(ctx, "aigateway", r.DevelopmentMode)
+	logger := log.GetLogger(ctx, "aigateway", r.LoggingMode)
 
 	var aigateway operatorv1alpha1.AIGateway
 	if err := r.Get(ctx, req.NamespacedName, &aigateway); err != nil {

--- a/controller/specialized/aigateway_controller.go
+++ b/controller/specialized/aigateway_controller.go
@@ -34,7 +34,7 @@ type AIGatewayReconciler struct {
 	client.Client
 
 	Scheme      *runtime.Scheme
-	LoggingMode logging.LoggingMode
+	LoggingMode logging.Mode
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/hack/generators/kic/role-generator/templates.go
+++ b/hack/generators/kic/role-generator/templates.go
@@ -122,7 +122,7 @@ var ErrControlPlaneVersionNotSupported = fmt.Errorf("version not supported")
 // GenerateNewClusterRoleForControlPlane is a helper function that extract
 // the version from the tag, and returns the ClusterRole with all the needed
 // permissions.
-func GenerateNewClusterRoleForControlPlane(controlplaneName string, image string, devMode bool) (*rbacv1.ClusterRole, error) {
+func GenerateNewClusterRoleForControlPlane(controlplaneName string, image string, validateControlPlaneImage bool) (*rbacv1.ClusterRole, error) {
 	versionToUse := versions.DefaultControlPlaneVersion
 	var constraint *semver.Constraints
 
@@ -131,15 +131,15 @@ func GenerateNewClusterRoleForControlPlane(controlplaneName string, image string
 		// of the controlplane. When an invalid or unsupported image is used in dev mode,
 		// the clusterRole associated to the default ControlPlane image is used instead.
 		v, err := versions.FromImage(image)
-		if err != nil && !devMode {
+		if err != nil && validateControlPlaneImage {
 				return nil, err
 		}
 
 		supported, err := versions.IsControlPlaneImageVersionSupported(image)
-		if err != nil && !devMode {
+		if err != nil && validateControlPlaneImage {
 			return nil, err
 		}
-		if devMode {
+		if !validateControlPlaneImage {
 			if !supported {
 				v, err = semverv4.Parse(versions.DefaultControlPlaneVersion)
 				if err != nil {

--- a/hack/generators/kic/webhook-config-generator/templates.go
+++ b/hack/generators/kic/webhook-config-generator/templates.go
@@ -100,7 +100,7 @@ import (
 // GenerateValidatingWebhookConfigurationForControlPlane generates a ValidatingWebhookConfiguration for a control plane
 // based on the control plane version. It also overrides all webhooks' client configurations with the provided service
 // details.
-func GenerateValidatingWebhookConfigurationForControlPlane(webhookName string, image string, devMode bool, clientConfig admregv1.WebhookClientConfig) (*admregv1.ValidatingWebhookConfiguration, error) {
+func GenerateValidatingWebhookConfigurationForControlPlane(webhookName string, image string, validateControlPlaneImage bool, clientConfig admregv1.WebhookClientConfig) (*admregv1.ValidatingWebhookConfiguration, error) {
 	if webhookName == "" {
 		return nil, fmt.Errorf("webhook name is required")
 	}
@@ -112,18 +112,18 @@ func GenerateValidatingWebhookConfigurationForControlPlane(webhookName string, i
 	// of the controlplane. When an invalid or unsupported image is used in dev mode,
 	// the clusterRole associated to the default ControlPlane image is used instead.
 	v, err := versions.FromImage(image)
-	if err != nil && !devMode {
+	if err != nil && validateControlPlaneImage {
 		return nil, err
 	}
 
 	supported, err := versions.IsControlPlaneImageVersionSupported(image)
-	if err != nil && !devMode {
+	if err != nil && validateControlPlaneImage {
 		return nil, err
 	}
-	if !devMode && !supported {
+	if validateControlPlaneImage && !supported {
 		return nil, ErrControlPlaneVersionNotSupported
 	}
-	if devMode && !supported {
+	if !validateControlPlaneImage && !supported {
 		v, err = semverv4.Parse(versions.DefaultControlPlaneVersion)
 		if err != nil {
 			return nil, fmt.Errorf("error when creating semver from the default controlplane version: %w", err)

--- a/modules/cli/cli.go
+++ b/modules/cli/cli.go
@@ -30,7 +30,7 @@ func New(m metadata.Info) *CLI {
 	var deferCfg flagsForFurtherEvaluation
 
 	flagSet.BoolVar(&cfg.ValidateImages, "validate-images", true, "Validate the images set in ControlPlane and DataPlane specifications.")
-	flagSet.Var(NewValidatedValue[logging.LoggingMode](&cfg.LoggingMode, logging.NewLoggingMode, WithDefault(logging.ProductionMode)), "logging-mode", "Logging mode to use. Possible values: production, development.")
+	flagSet.Var(NewValidatedValue[logging.Mode](&cfg.LoggingMode, logging.NewMode, WithDefault(logging.ProductionMode)), "logging-mode", "Logging mode to use. Possible values: production, development.")
 
 	flagSet.BoolVar(&cfg.AnonymousReports, "anonymous-reports", true, "Send anonymized usage data to help improve Kong.")
 	flagSet.StringVar(&cfg.APIServerPath, "apiserver-host", "", "The Kubernetes API server URL. If not set, the operator will use cluster config discovery.")

--- a/modules/cli/cli_test.go
+++ b/modules/cli/cli_test.go
@@ -40,22 +40,23 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
-			name: "no command line arguments, many environment variables",
+			name: "no command line arguments, logging mode is set to development, anonymous reports off",
 			args: []string{},
 			envVars: map[string]string{
-				"POD_NAMESPACE":                     "test",
-				"GATEWAY_OPERATOR_DEVELOPMENT_MODE": "true",
+				"POD_NAMESPACE":                      "test",
+				"GATEWAY_OPERATOR_LOGGING_MODE":      "development",
+				"GATEWAY_OPERATOR_ANONYMOUS_REPORTS": "false",
 			},
 			expectedCfg: func() manager.Config {
 				cfg := expectedDefaultCfg()
 				cfg.LeaderElectionNamespace = "test"
 				cfg.ClusterCASecretNamespace = "test"
 				cfg.ControllerNamespace = "test"
-				// All the below config changes are the result of GATEWAY_OPERATOR_DEVELOPMENT_MODE=true.
-				cfg.DevelopmentMode = true
+				// All the below config changes are the result of GATEWAY_OPERATOR_LOGGING_MODE=development.
+				cfg.LoggingMode = logging.DevelopmentMode
 				loggerOpts := manager.DefaultConfig().LoggerOpts
 				loggerOpts.Development = true
-				cfg.LoggerOpts = logging.SetupLogEncoder(true, loggerOpts)
+				cfg.LoggerOpts = logging.SetupLogEncoder(logging.DevelopmentMode, loggerOpts)
 				cfg.AnonymousReports = false
 				return cfg
 			},
@@ -169,7 +170,8 @@ func expectedDefaultCfg() manager.Config {
 		ProbeAddr:                               ":8081",
 		LeaderElection:                          true,
 		LeaderElectionNamespace:                 "kong-system",
-		DevelopmentMode:                         false,
+		LoggingMode:                             logging.ProductionMode,
+		ValidateImages:                          true,
 		EnforceConfig:                           true,
 		ControllerName:                          "",
 		ControllerNamespace:                     "kong-system",

--- a/modules/cli/validated.go
+++ b/modules/cli/validated.go
@@ -1,0 +1,85 @@
+package cli
+
+import "fmt"
+
+// ValidatedValueOpt is a function that modifies a ValidatedValue.
+type ValidatedValueOpt[T any] func(*ValidatedValue[T])
+
+// WithDefault sets the default value for the validated variable.
+func WithDefault[T any](defaultValue T) ValidatedValueOpt[T] {
+	return func(v *ValidatedValue[T]) {
+		*v.variable = defaultValue
+
+		// Assign origin which is used in ValidatedValue[T]'s String() string
+		// func so that we get a pretty printed default.
+		v.origin = stringFromAny(defaultValue)
+	}
+}
+
+func stringFromAny(s any) string {
+	switch ss := s.(type) {
+	case string:
+		return ss
+	case fmt.Stringer:
+		return fmt.Sprintf("%q", ss.String())
+	default:
+		panic(fmt.Errorf("unknown type %T", s))
+	}
+}
+
+// WithTypeNameOverride overrides the type name that's printed in the help message.
+func WithTypeNameOverride[T any](typeName string) ValidatedValueOpt[T] {
+	return func(v *ValidatedValue[T]) {
+		v.typeName = typeName
+	}
+}
+
+// ValidatedValue implements `pflag.Value` interface. It can be used for hooking up arbitrary validation logic to any type.
+// It should be passed to `pflag.FlagSet.Var()`.
+type ValidatedValue[T any] struct {
+	origin      string
+	variable    *T
+	constructor func(string) (T, error)
+	typeName    string
+}
+
+// NewValidatedValue creates a validated variable of type T. Constructor should validate the input and return an error
+// in case of any failures. If validation passes, constructor should return a value that's to be set in the variable.
+// The constructor accepts a flagValue that is raw input from user's command line (or an env variable that was bind to
+// the flag, see: bindEnvVars).
+// It accepts a variadic list of options that can be used e.g. to set the default value or override the type name.
+func NewValidatedValue[T any](variable *T, constructor func(flagValue string) (T, error), opts ...ValidatedValueOpt[T]) ValidatedValue[T] {
+	v := ValidatedValue[T]{
+		constructor: constructor,
+		variable:    variable,
+	}
+	for _, opt := range opts {
+		opt(&v)
+	}
+	return v
+}
+
+func (v ValidatedValue[T]) String() string {
+	return v.origin
+}
+
+// Set sets the value of the variable. It uses the constructor to validate the input and set the value.
+func (v ValidatedValue[T]) Set(s string) error {
+	value, err := v.constructor(s)
+	if err != nil {
+		return err
+	}
+
+	*v.variable = value
+	return nil
+}
+
+// Type returns the type of the variable. If the type name is overridden, it returns that.
+func (v ValidatedValue[T]) Type() string {
+	if v.typeName != "" {
+		return v.typeName
+	}
+
+	var t T
+	return fmt.Sprintf("%T", t)
+}

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -658,7 +658,7 @@ func SetupControllers(mgr manager.Manager, c *Config) (map[string]ControllerDef,
 
 type konnectControllerFactory struct {
 	sdkFactory              sdkops.SDKFactory
-	loggingMode             logging.LoggingMode
+	loggingMode             logging.Mode
 	client                  client.Client
 	syncPeriod              time.Duration
 	maxConcurrentReconciles uint

--- a/modules/manager/logging/encoding.go
+++ b/modules/manager/logging/encoding.go
@@ -30,7 +30,7 @@ var (
 // SetupLogEncoder sets additional logger configuration options when development mode is enabled.
 // In this way, the log structure is lighter and more human-friendly when the development mode
 // is enabled.
-func SetupLogEncoder(loggingMode LoggingMode, options *zap.Options) *zap.Options {
+func SetupLogEncoder(loggingMode Mode, options *zap.Options) *zap.Options {
 	if loggingMode == DevelopmentMode {
 		options.Development = true
 		options.TimeEncoder = defaultDevTimeEncoder

--- a/modules/manager/logging/encoding.go
+++ b/modules/manager/logging/encoding.go
@@ -30,8 +30,9 @@ var (
 // SetupLogEncoder sets additional logger configuration options when development mode is enabled.
 // In this way, the log structure is lighter and more human-friendly when the development mode
 // is enabled.
-func SetupLogEncoder(developmentMode bool, options *zap.Options) *zap.Options {
-	if developmentMode {
+func SetupLogEncoder(loggingMode LoggingMode, options *zap.Options) *zap.Options {
+	if loggingMode == DevelopmentMode {
+		options.Development = true
 		options.TimeEncoder = defaultDevTimeEncoder
 		options.EncoderConfigOptions = []zap.EncoderConfigOption{
 			func(ec *zapcore.EncoderConfig) {

--- a/modules/manager/logging/mode.go
+++ b/modules/manager/logging/mode.go
@@ -2,22 +2,22 @@ package logging
 
 import "fmt"
 
-// LoggingMode is the type for the logging mode.
-type LoggingMode string
+// Mode is the type for the logging mode.
+type Mode string
 
-func (l LoggingMode) String() string {
+func (l Mode) String() string {
 	return string(l)
 }
 
 const (
 	// DevelopmentMode is the development logging mode.
-	DevelopmentMode LoggingMode = "development"
+	DevelopmentMode Mode = "development"
 	// ProductionMode is the production logging mode.
-	ProductionMode LoggingMode = "production"
+	ProductionMode Mode = "production"
 )
 
-// NewLoggingMode creates a new LoggingMode from a string.
-func NewLoggingMode(mode string) (LoggingMode, error) {
+// NewMode creates a new Mode from a string.
+func NewMode(mode string) (Mode, error) {
 	switch mode {
 	case string(DevelopmentMode):
 		return DevelopmentMode, nil

--- a/modules/manager/logging/mode.go
+++ b/modules/manager/logging/mode.go
@@ -1,0 +1,29 @@
+package logging
+
+import "fmt"
+
+// LoggingMode is the type for the logging mode.
+type LoggingMode string
+
+func (l LoggingMode) String() string {
+	return string(l)
+}
+
+const (
+	// DevelopmentMode is the development logging mode.
+	DevelopmentMode LoggingMode = "development"
+	// ProductionMode is the production logging mode.
+	ProductionMode LoggingMode = "production"
+)
+
+// NewLoggingMode creates a new LoggingMode from a string.
+func NewLoggingMode(mode string) (LoggingMode, error) {
+	switch mode {
+	case string(DevelopmentMode):
+		return DevelopmentMode, nil
+	case string(ProductionMode):
+		return ProductionMode, nil
+	default:
+		return "", fmt.Errorf("invalid logging mode: %s", mode)
+	}
+}

--- a/pkg/utils/kubernetes/resources/clusterrole_helpers_test.go
+++ b/pkg/utils/kubernetes/resources/clusterrole_helpers_test.go
@@ -13,11 +13,11 @@ import (
 
 func TestClusterroleHelpers(t *testing.T) {
 	testCases := []struct {
-		controlplane        string
-		image               string
-		devMode             bool
-		expectedClusterRole func() *rbacv1.ClusterRole
-		expectedError       error
+		controlplane              string
+		image                     string
+		validateControlPlaneImage bool
+		expectedClusterRole       func() *rbacv1.ClusterRole
+		expectedError             error
 	}{
 		{
 			controlplane: "test_3.1.2",
@@ -29,9 +29,9 @@ func TestClusterroleHelpers(t *testing.T) {
 			},
 		},
 		{
-			controlplane: "test_3.1_dev",
-			image:        "kong/kubernetes-ingress-controller:3.1",
-			devMode:      true,
+			controlplane:              "test_3.1_dev",
+			image:                     "kong/kubernetes-ingress-controller:3.1",
+			validateControlPlaneImage: false,
 			expectedClusterRole: func() *rbacv1.ClusterRole {
 				cr := clusterroles.GenerateNewClusterRoleForControlPlane_ge3_4("test_3.1_dev")
 				k8sresources.LabelObjectAsControlPlaneManaged(cr)
@@ -39,14 +39,15 @@ func TestClusterroleHelpers(t *testing.T) {
 			},
 		},
 		{
-			controlplane:  "test_3.0",
-			image:         "kong/kubernetes-ingress-controller:3.0.0",
-			expectedError: k8sresources.ErrControlPlaneVersionNotSupported,
+			controlplane:              "test_3.0",
+			image:                     "kong/kubernetes-ingress-controller:3.0.0",
+			validateControlPlaneImage: true,
+			expectedError:             k8sresources.ErrControlPlaneVersionNotSupported,
 		},
 		{
-			controlplane: "test_3.0_dev",
-			image:        "kong/kubernetes-ingress-controller:3.0.0",
-			devMode:      true,
+			controlplane:              "test_3.0_dev",
+			image:                     "kong/kubernetes-ingress-controller:3.0.0",
+			validateControlPlaneImage: false,
 			expectedClusterRole: func() *rbacv1.ClusterRole {
 				cr := clusterroles.GenerateNewClusterRoleForControlPlane_ge3_4("test_3.0_dev")
 				k8sresources.LabelObjectAsControlPlaneManaged(cr)
@@ -54,14 +55,15 @@ func TestClusterroleHelpers(t *testing.T) {
 			},
 		},
 		{
-			controlplane:  "test_unsupported",
-			image:         "kong/kubernetes-ingress-controller:1.0",
-			expectedError: k8sresources.ErrControlPlaneVersionNotSupported,
+			controlplane:              "test_unsupported",
+			image:                     "kong/kubernetes-ingress-controller:1.0",
+			validateControlPlaneImage: true,
+			expectedError:             k8sresources.ErrControlPlaneVersionNotSupported,
 		},
 		{
-			controlplane: "test_unsupported_dev",
-			image:        "kong/kubernetes-ingress-controller:1.0",
-			devMode:      true,
+			controlplane:              "test_unsupported_dev",
+			image:                     "kong/kubernetes-ingress-controller:1.0",
+			validateControlPlaneImage: false,
 			expectedClusterRole: func() *rbacv1.ClusterRole {
 				cr := clusterroles.GenerateNewClusterRoleForControlPlane_ge3_4("test_unsupported_dev")
 				k8sresources.LabelObjectAsControlPlaneManaged(cr)
@@ -69,14 +71,15 @@ func TestClusterroleHelpers(t *testing.T) {
 			},
 		},
 		{
-			controlplane:  "test_invalid_tag",
-			image:         "test/development:main",
-			expectedError: kgoerrors.ErrInvalidSemverVersion,
+			controlplane:              "test_invalid_tag",
+			image:                     "test/development:main",
+			validateControlPlaneImage: true,
+			expectedError:             kgoerrors.ErrInvalidSemverVersion,
 		},
 		{
-			controlplane: "test_invalid_tag_dev",
-			image:        "test/development:main",
-			devMode:      true,
+			controlplane:              "test_invalid_tag_dev",
+			image:                     "test/development:main",
+			validateControlPlaneImage: false,
 			expectedClusterRole: func() *rbacv1.ClusterRole {
 				cr := clusterroles.GenerateNewClusterRoleForControlPlane_ge3_4("test_invalid_tag_dev")
 				k8sresources.LabelObjectAsControlPlaneManaged(cr)
@@ -84,9 +87,9 @@ func TestClusterroleHelpers(t *testing.T) {
 			},
 		},
 		{
-			controlplane: "cp-3-2-0",
-			image:        "kong/kubernetes-ingress-controller:3.2.0",
-			devMode:      false,
+			controlplane:              "cp-3-2-0",
+			image:                     "kong/kubernetes-ingress-controller:3.2.0",
+			validateControlPlaneImage: true,
 			expectedClusterRole: func() *rbacv1.ClusterRole {
 				cr := clusterroles.GenerateNewClusterRoleForControlPlane_ge3_2_lt3_3("cp-3-2-0")
 				k8sresources.LabelObjectAsControlPlaneManaged(cr)
@@ -94,9 +97,9 @@ func TestClusterroleHelpers(t *testing.T) {
 			},
 		},
 		{
-			controlplane: "cp-3-3-0",
-			image:        "kong/kubernetes-ingress-controller:3.3.0",
-			devMode:      false,
+			controlplane:              "cp-3-3-0",
+			image:                     "kong/kubernetes-ingress-controller:3.3.0",
+			validateControlPlaneImage: true,
 			expectedClusterRole: func() *rbacv1.ClusterRole {
 				cr := clusterroles.GenerateNewClusterRoleForControlPlane_ge3_3_lt3_4("cp-3-3-0")
 				k8sresources.LabelObjectAsControlPlaneManaged(cr)
@@ -104,9 +107,9 @@ func TestClusterroleHelpers(t *testing.T) {
 			},
 		},
 		{
-			controlplane: "cp-3-4-1",
-			image:        "kong/kubernetes-ingress-controller:3.4.1",
-			devMode:      false,
+			controlplane:              "cp-3-4-1",
+			image:                     "kong/kubernetes-ingress-controller:3.4.1",
+			validateControlPlaneImage: true,
 			expectedClusterRole: func() *rbacv1.ClusterRole {
 				cr := clusterroles.GenerateNewClusterRoleForControlPlane_ge3_4("cp-3-4-1")
 				k8sresources.LabelObjectAsControlPlaneManaged(cr)
@@ -117,7 +120,7 @@ func TestClusterroleHelpers(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.controlplane, func(t *testing.T) {
-			clusterRole, err := k8sresources.GenerateNewClusterRoleForControlPlane(tc.controlplane, tc.image, tc.devMode)
+			clusterRole, err := k8sresources.GenerateNewClusterRoleForControlPlane(tc.controlplane, tc.image, tc.validateControlPlaneImage)
 			if tc.expectedError != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tc.expectedError)

--- a/pkg/utils/kubernetes/resources/kic_validatingwebhookconfig_test.go
+++ b/pkg/utils/kubernetes/resources/kic_validatingwebhookconfig_test.go
@@ -13,27 +13,30 @@ import (
 
 func TestGenerateValidatingWebhookConfigurationForControlPlane(t *testing.T) {
 	testCases := []struct {
-		image         string
-		expectedError error
-		devMode       bool
+		image                     string
+		expectedError             error
+		validateControlPlaneImage bool
 	}{
 		{
-			image: "kong/kubernetes-ingress-controller:3.2.0",
+			image:                     "kong/kubernetes-ingress-controller:3.2.0",
+			validateControlPlaneImage: true,
 		},
 		{
-			image: "kong/kubernetes-ingress-controller:3.1.2",
+			image:                     "kong/kubernetes-ingress-controller:3.1.2",
+			validateControlPlaneImage: true,
 		},
 		{
-			image:         "kong/kubernetes-ingress-controller:3.0.0",
-			expectedError: k8sresources.ErrControlPlaneVersionNotSupported,
+			image:                     "kong/kubernetes-ingress-controller:3.0.0",
+			validateControlPlaneImage: true,
+			expectedError:             k8sresources.ErrControlPlaneVersionNotSupported,
 		},
 		{
-			image:   "kong/kubernetes-ingress-controller:febecdfe",
-			devMode: true,
+			image:                     "kong/kubernetes-ingress-controller:febecdfe",
+			validateControlPlaneImage: false,
 		},
 		{
-			image:   "kong/nightly-ingress-controller:nightly",
-			devMode: true,
+			image:                     "kong/nightly-ingress-controller:nightly",
+			validateControlPlaneImage: false,
 		},
 	}
 	for _, tc := range testCases {
@@ -41,7 +44,7 @@ func TestGenerateValidatingWebhookConfigurationForControlPlane(t *testing.T) {
 			cfg, err := k8sresources.GenerateValidatingWebhookConfigurationForControlPlane(
 				"webhook",
 				tc.image,
-				tc.devMode,
+				tc.validateControlPlaneImage,
 				admregv1.WebhookClientConfig{
 					Service: &admregv1.ServiceReference{
 						Name:      "svc",

--- a/pkg/utils/kubernetes/resources/zz_generated.clusterrole_helpers.go
+++ b/pkg/utils/kubernetes/resources/zz_generated.clusterrole_helpers.go
@@ -22,7 +22,7 @@ var ErrControlPlaneVersionNotSupported = fmt.Errorf("version not supported")
 // GenerateNewClusterRoleForControlPlane is a helper function that extract
 // the version from the tag, and returns the ClusterRole with all the needed
 // permissions.
-func GenerateNewClusterRoleForControlPlane(controlplaneName string, image string, devMode bool) (*rbacv1.ClusterRole, error) {
+func GenerateNewClusterRoleForControlPlane(controlplaneName string, image string, validateControlPlaneImage bool) (*rbacv1.ClusterRole, error) {
 	versionToUse := versions.DefaultControlPlaneVersion
 	var constraint *semver.Constraints
 
@@ -31,15 +31,15 @@ func GenerateNewClusterRoleForControlPlane(controlplaneName string, image string
 		// of the controlplane. When an invalid or unsupported image is used in dev mode,
 		// the clusterRole associated to the default ControlPlane image is used instead.
 		v, err := versions.FromImage(image)
-		if err != nil && !devMode {
+		if err != nil && validateControlPlaneImage {
 			return nil, err
 		}
 
 		supported, err := versions.IsControlPlaneImageVersionSupported(image)
-		if err != nil && !devMode {
+		if err != nil && validateControlPlaneImage {
 			return nil, err
 		}
-		if devMode {
+		if !validateControlPlaneImage {
 			if !supported {
 				v, err = semverv4.Parse(versions.DefaultControlPlaneVersion)
 				if err != nil {

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kong/gateway-operator/config"
 	"github.com/kong/gateway-operator/modules/manager"
 	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/metadata"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	testutils "github.com/kong/gateway-operator/pkg/utils/test"
@@ -163,7 +164,7 @@ func exitOnErr(err error) {
 func startControllerManager(metadata metadata.Info) <-chan struct{} {
 	cfg := manager.DefaultConfig()
 	cfg.LeaderElection = false
-	cfg.DevelopmentMode = true
+	cfg.LoggingMode = logging.DevelopmentMode
 	cfg.ControllerName = "konghq.com/gateway-operator-integration-tests"
 	cfg.GatewayControllerEnabled = true
 	cfg.ControlPlaneControllerEnabled = true

--- a/test/envtest/dataplane_konnectextensions_test.go
+++ b/test/envtest/dataplane_konnectextensions_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
 	"github.com/kong/gateway-operator/controller/pkg/secrets"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	"github.com/kong/gateway-operator/pkg/consts"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
@@ -67,13 +68,14 @@ func TestDataPlaneKonnectExtension(t *testing.T) {
 		ClusterCASecretNamespace: ns.Name,
 		ClusterCAKeyConfig:       clusterCAKeyConfig,
 		DefaultImage:             consts.DefaultDataPlaneImage,
-		DevelopmentMode:          true,
+		LoggingMode:              logging.DevelopmentMode,
+		ValidateDataPlaneImage:   true,
 		KonnectEnabled:           true,
 		EnforceConfig:            true,
 	}
 	konnectExtensionReconciler := &konnect.KonnectExtensionReconciler{
 		Client:                   cl,
-		DevelopmentMode:          true,
+		LoggingMode:              logging.DevelopmentMode,
 		SdkFactory:               factory,
 		SyncPeriod:               time.Hour * 24, // To ensure we don't resync in test. Reconciler will be called automatically on changes.
 		ClusterCASecretName:      clusterCASecretName,

--- a/test/envtest/kongconsumercredential_acl_test.go
+++ b/test/envtest/kongconsumercredential_acl_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -117,7 +118,7 @@ func TestKongConsumerCredential_ACL(t *testing.T) {
 		)
 
 	reconcilers := []Reconciler{
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialACL](konnectInfiniteSyncTime),
 		),
 	}

--- a/test/envtest/kongconsumercredential_apikey_test.go
+++ b/test/envtest/kongconsumercredential_apikey_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -117,7 +118,7 @@ func TestKongConsumerCredential_APIKey(t *testing.T) {
 		)
 
 	reconcilers := []Reconciler{
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialAPIKey](konnectInfiniteSyncTime),
 		),
 	}

--- a/test/envtest/kongconsumercredential_basicauth_test.go
+++ b/test/envtest/kongconsumercredential_basicauth_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -120,7 +121,7 @@ func TestKongConsumerCredential_BasicAuth(t *testing.T) {
 		)
 
 	reconcilers := []Reconciler{
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialBasicAuth](konnectInfiniteSyncTime),
 		),
 	}

--- a/test/envtest/kongconsumercredential_hmac_test.go
+++ b/test/envtest/kongconsumercredential_hmac_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -116,7 +117,7 @@ func TestKongConsumerCredential_HMAC(t *testing.T) {
 		)
 
 	reconcilers := []Reconciler{
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialHMAC](konnectInfiniteSyncTime),
 		),
 	}

--- a/test/envtest/kongconsumercredential_jwt_test.go
+++ b/test/envtest/kongconsumercredential_jwt_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -118,7 +119,7 @@ func TestKongConsumerCredential_JWT(t *testing.T) {
 		)
 
 	reconcilers := []Reconciler{
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialJWT](konnectInfiniteSyncTime),
 		),
 	}

--- a/test/envtest/kongpluginbinding_managed_test.go
+++ b/test/envtest/kongpluginbinding_managed_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
 	"github.com/kong/gateway-operator/internal/utils/index"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	"github.com/kong/gateway-operator/pkg/consts"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -59,8 +60,8 @@ func TestKongPluginBindingManaged(t *testing.T) {
 	sdk := factory.SDK
 
 	reconcilers := []Reconciler{
-		konnect.NewKongPluginReconciler(false, mgr.GetClient()),
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKongPluginReconciler(logging.DevelopmentMode, mgr.GetClient()),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongPluginBinding](konnectInfiniteSyncTime),
 		),
 	}

--- a/test/envtest/kongpluginbinding_unmanaged_test.go
+++ b/test/envtest/kongpluginbinding_unmanaged_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
 
@@ -40,7 +41,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 	sdk := factory.SDK
 
 	reconcilers := []Reconciler{
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongPluginBinding](konnectInfiniteSyncTime),
 		),
 	}

--- a/test/envtest/kongplugincleanupfinalizer_test.go
+++ b/test/envtest/kongplugincleanupfinalizer_test.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/controller/konnect"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	"github.com/kong/gateway-operator/pkg/consts"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -41,11 +42,11 @@ func TestKongPluginFinalizer(t *testing.T) {
 	cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
 	StartReconcilers(ctx, t, mgr, logs,
-		konnect.NewKonnectEntityPluginReconciler[configurationv1alpha1.KongService](false, cl),
-		konnect.NewKonnectEntityPluginReconciler[configurationv1alpha1.KongRoute](false, cl),
-		konnect.NewKonnectEntityPluginReconciler[configurationv1.KongConsumer](false, cl),
-		konnect.NewKonnectEntityPluginReconciler[configurationv1beta1.KongConsumerGroup](false, cl),
-		konnect.NewKongPluginReconciler(false, cl),
+		konnect.NewKonnectEntityPluginReconciler[configurationv1alpha1.KongService](logging.DevelopmentMode, cl),
+		konnect.NewKonnectEntityPluginReconciler[configurationv1alpha1.KongRoute](logging.DevelopmentMode, cl),
+		konnect.NewKonnectEntityPluginReconciler[configurationv1.KongConsumer](logging.DevelopmentMode, cl),
+		konnect.NewKonnectEntityPluginReconciler[configurationv1beta1.KongConsumerGroup](logging.DevelopmentMode, cl),
+		konnect.NewKongPluginReconciler(logging.DevelopmentMode, cl),
 	)
 
 	t.Run("KongService", func(t *testing.T) {

--- a/test/envtest/konnect_entities_kongcacertificate_test.go
+++ b/test/envtest/konnect_entities_kongcacertificate_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -41,7 +42,7 @@ func TestKongCACertificate(t *testing.T) {
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
 	StartReconcilers(ctx, t, mgr, logs,
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCACertificate](konnectInfiniteSyncTime),
 		),
 	)

--- a/test/envtest/konnect_entities_kongcertificate_test.go
+++ b/test/envtest/konnect_entities_kongcertificate_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kong/gateway-operator/controller/konnect"
 	"github.com/kong/gateway-operator/controller/konnect/ops"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -37,7 +38,7 @@ func TestKongCertificate(t *testing.T) {
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
 	StartReconcilers(ctx, t, mgr, logs,
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCertificate](konnectInfiniteSyncTime),
 		),
 	)

--- a/test/envtest/konnect_entities_kongconsumer_test.go
+++ b/test/envtest/konnect_entities_kongconsumer_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -43,13 +44,13 @@ func TestKongConsumer(t *testing.T) {
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
 	reconcilers := []Reconciler{
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1.KongConsumer](konnectInfiniteSyncTime),
 		),
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1beta1.KongConsumerGroup](konnectInfiniteSyncTime),
 		),
-		konnect.NewKongCredentialSecretReconciler(false, mgr.GetClient(), mgr.GetScheme()),
+		konnect.NewKongCredentialSecretReconciler(logging.DevelopmentMode, mgr.GetClient(), mgr.GetScheme()),
 	}
 	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
 
@@ -568,25 +569,25 @@ func TestKongConsumerSecretCredentials(t *testing.T) {
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
 	reconcilers := []Reconciler{
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1.KongConsumer](konnectInfiniteSyncTime),
 		),
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialBasicAuth](konnectInfiniteSyncTime),
 		),
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialAPIKey](konnectInfiniteSyncTime),
 		),
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialACL](konnectInfiniteSyncTime),
 		),
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialJWT](konnectInfiniteSyncTime),
 		),
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialHMAC](konnectInfiniteSyncTime),
 		),
-		konnect.NewKongCredentialSecretReconciler(false, mgr.GetClient(), mgr.GetScheme()),
+		konnect.NewKongCredentialSecretReconciler(logging.DevelopmentMode, mgr.GetClient(), mgr.GetScheme()),
 	}
 	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
 

--- a/test/envtest/konnect_entities_kongconsumergroup_test.go
+++ b/test/envtest/konnect_entities_kongconsumergroup_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kong/gateway-operator/controller/konnect"
 	"github.com/kong/gateway-operator/controller/konnect/ops"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -40,7 +41,7 @@ func TestKongConsumerGroup(t *testing.T) {
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
 	reconcilers := []Reconciler{
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1beta1.KongConsumerGroup](konnectInfiniteSyncTime),
 		),
 	}

--- a/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
+++ b/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
 
@@ -34,7 +35,7 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
 	StartReconcilers(ctx, t, mgr, logs,
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongDataPlaneClientCertificate](konnectInfiniteSyncTime),
 		),
 	)

--- a/test/envtest/konnect_entities_kongkey_test.go
+++ b/test/envtest/konnect_entities_kongkey_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
 
@@ -44,7 +45,7 @@ func TestKongKey(t *testing.T) {
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
 	StartReconcilers(ctx, t, mgr, logs,
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongKey](konnectInfiniteSyncTime),
 		),
 	)

--- a/test/envtest/konnect_entities_kongkeyset_test.go
+++ b/test/envtest/konnect_entities_kongkeyset_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -44,7 +45,7 @@ func TestKongKeySet(t *testing.T) {
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
 	StartReconcilers(ctx, t, mgr, logs,
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongKeySet](konnectInfiniteSyncTime),
 		),
 	)

--- a/test/envtest/konnect_entities_kongroute_test.go
+++ b/test/envtest/konnect_entities_kongroute_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -33,7 +34,7 @@ func TestKongRoute(t *testing.T) {
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
 	StartReconcilers(ctx, t, mgr, logs,
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongRoute](konnectInfiniteSyncTime),
 		),
 	)

--- a/test/envtest/konnect_entities_kongservice_test.go
+++ b/test/envtest/konnect_entities_kongservice_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -37,7 +38,7 @@ func TestKongService(t *testing.T) {
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
 	StartReconcilers(ctx, t, mgr, logs,
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongService](konnectInfiniteSyncTime),
 		),
 	)

--- a/test/envtest/konnect_entities_kongsni_test.go
+++ b/test/envtest/konnect_entities_kongsni_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -35,7 +36,7 @@ func TestKongSNI(t *testing.T) {
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
 	StartReconcilers(ctx, t, mgr, logs,
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongSNI](konnectInfiniteSyncTime),
 		),
 	)

--- a/test/envtest/konnect_entities_kongtarget_test.go
+++ b/test/envtest/konnect_entities_kongtarget_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -32,7 +33,7 @@ func TestKongTarget(t *testing.T) {
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
 	StartReconcilers(ctx, t, mgr, logs,
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongTarget](konnectInfiniteSyncTime),
 		),
 	)

--- a/test/envtest/konnect_entities_kongupstream_test.go
+++ b/test/envtest/konnect_entities_kongupstream_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -34,7 +35,7 @@ func TestKongUpstream(t *testing.T) {
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
 	StartReconcilers(ctx, t, mgr, logs,
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongUpstream](konnectInfiniteSyncTime),
 		),
 	)

--- a/test/envtest/konnect_entities_kongvault_test.go
+++ b/test/envtest/konnect_entities_kongvault_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -35,7 +36,7 @@ func TestKongVault(t *testing.T) {
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
 	reconcilers := []Reconciler{
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongVault](konnectInfiniteSyncTime),
 		),
 	}

--- a/test/envtest/konnect_entities_konnectapiauthconfiguration_test.go
+++ b/test/envtest/konnect_entities_konnectapiauthconfiguration_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -33,7 +34,7 @@ func TestKonnectAPIAuthConfiguration(t *testing.T) {
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
 	StartReconcilers(ctx, t, mgr, logs,
-		konnect.NewKonnectAPIAuthConfigurationReconciler(factory, false, mgr.GetClient()),
+		konnect.NewKonnectAPIAuthConfigurationReconciler(factory, logging.DevelopmentMode, mgr.GetClient()),
 	)
 
 	t.Log("Setting up clients")

--- a/test/envtest/konnect_entities_konnectdataplanegroupconfiguration_test.go
+++ b/test/envtest/konnect_entities_konnectdataplanegroupconfiguration_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kong/gateway-operator/controller/konnect"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
@@ -50,7 +51,7 @@ func TestKonnectDataPlaneGroupConfiguration(t *testing.T) {
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
 	StartReconcilers(ctx, t, mgr, logs,
-		konnect.NewKonnectEntityReconciler(factory, false, mgr.GetClient(),
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 			konnect.WithKonnectEntitySyncPeriod[konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration](konnectInfiniteSyncTime),
 		),
 	)

--- a/test/envtest/konnect_entities_suite_test.go
+++ b/test/envtest/konnect_entities_suite_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kong/gateway-operator/controller/konnect"
 	"github.com/kong/gateway-operator/controller/konnect/constraints"
 	sdkmocks "github.com/kong/gateway-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
@@ -67,7 +68,7 @@ func testNewKonnectEntityReconciler[
 		factory := sdkmocks.NewMockSDKFactory(t)
 		sdk := factory.SDK
 
-		StartReconcilers(ctx, t, mgr, logs, konnect.NewKonnectEntityReconciler[T, TEnt](factory, false, cl))
+		StartReconcilers(ctx, t, mgr, logs, konnect.NewKonnectEntityReconciler[T, TEnt](factory, logging.DevelopmentMode, cl))
 
 		const (
 			wait = time.Second

--- a/test/integration/suite.go
+++ b/test/integration/suite.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kong/gateway-operator/config"
 	"github.com/kong/gateway-operator/modules/manager"
 	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
+	"github.com/kong/gateway-operator/modules/manager/logging"
 	testutils "github.com/kong/gateway-operator/pkg/utils/test"
 	"github.com/kong/gateway-operator/test"
 	"github.com/kong/gateway-operator/test/helpers"
@@ -193,7 +194,7 @@ func exitOnErr(err error) {
 func DefaultControllerConfigForTests() manager.Config {
 	cfg := manager.DefaultConfig()
 	cfg.LeaderElection = false
-	cfg.DevelopmentMode = true
+	cfg.LoggingMode = logging.DevelopmentMode
 	cfg.ControllerName = "konghq.com/gateway-operator-integration-tests"
 	cfg.GatewayControllerEnabled = true
 	cfg.ControlPlaneControllerEnabled = true


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of having a single rule-them-all kind of toggle - `GATEWAY_OPERATOR_DEVELOPMENT_MODE` - introduce granular ones that will allow changing the behavior more precisely depending on a use case needs (e.g., disable image validations in production without changing the logging mode and anonymous reports settings).

Newly introduced flags:

- `--logging-mode` (`GATEWAY_OPERATOR_LOGGING_MODE`) with default `production`
- `--validate-images` (`GATEWAY_OPERATOR_VALIDATE_IMAGES`) with default `true`

**Which issue this PR fixes**

Fixes https://github.com/Kong/gateway-operator/issues/118.

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
