### PR TITLE
chore(refactor): in `KonnectExtension` controller do not fetch `KonnectGatewayControlPlane` from Konnect

### DIFF
--- a/controller/konnect/konnectextension_controller_utils.go
+++ b/controller/konnect/konnectextension_controller_utils.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
-	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/samber/lo"
 	certificatesv1 "k8s.io/api/certificates/v1"
@@ -18,14 +17,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kong/gateway-operator/controller/konnect/ops"
-	sdkops "github.com/kong/gateway-operator/controller/konnect/ops/sdk"
 	extensionserrors "github.com/kong/gateway-operator/controller/pkg/extensions/errors"
-	"github.com/kong/gateway-operator/controller/pkg/log"
 	"github.com/kong/gateway-operator/controller/pkg/op"
 	"github.com/kong/gateway-operator/controller/pkg/patch"
 	"github.com/kong/gateway-operator/controller/pkg/secrets"
+	"github.com/kong/gateway-operator/internal/utils/index"
 	"github.com/kong/gateway-operator/pkg/consts"
+	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
 	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
@@ -33,20 +31,64 @@ import (
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
-// getKonnectControlPlane retrieves the Konnect Control Plane based on the provided KonnectExtension specification.
+// getGatewayKonnectControlPlane retrieves the Konnect Control Plane form K8s cluster
+// based on the provided KonnectExtension specification.
 // It supports two types of ControlPlaneRef: KonnectNamespacedRef and KonnectID.
 //
 // Returns:
 // - cp: The retrieved Konnect Control Plane.
 // - res: The result of the controller reconciliation.
 // - err: An error if the retrieval fails.
-func (r *KonnectExtensionReconciler) getKonnectControlPlane(
+func (r *KonnectExtensionReconciler) getGatewayKonnectControlPlane(
 	ctx context.Context,
-	logger logr.Logger,
-	sdk sdkops.ControlPlaneSDK,
 	ext konnectv1alpha1.KonnectExtension,
 	dependingConditions ...metav1.Condition,
-) (cp *sdkkonnectcomp.ControlPlane, res ctrl.Result, err error) {
+) (cp *konnectv1alpha1.KonnectGatewayControlPlane, res ctrl.Result, err error) {
+	// Get respective KonnectGatewayControlPlane from K8s cluster.
+	var errGetFromK8s error
+	switch ext.Spec.Konnect.ControlPlane.Ref.Type {
+	case commonv1alpha1.ControlPlaneRefKonnectNamespacedRef:
+		// TODO: get namespace from cpRef.Namespace when allowed to reference CP from another namespace.
+		cpNN := client.ObjectKey{
+			Name:      ext.Spec.Konnect.ControlPlane.Ref.KonnectNamespacedRef.Name,
+			Namespace: ext.Namespace,
+		}
+		kgcp := &konnectv1alpha1.KonnectGatewayControlPlane{}
+		// Set the controlPlaneRefValidCond to false in case the KonnectGatewayControlPlane is not found.
+		if err := r.Get(ctx, cpNN, kgcp); err != nil {
+			if k8serrors.IsNotFound(err) {
+				errGetFromK8s = err
+			} else {
+				return nil, ctrl.Result{}, err
+			}
+		}
+		cp = kgcp
+	case commonv1alpha1.ControlPlaneRefKonnectID:
+		kgcpList := &konnectv1alpha1.KonnectGatewayControlPlaneList{}
+		if err := r.List(ctx, kgcpList, client.InNamespace(ext.Namespace), client.MatchingFields{
+			index.IndexFieldKonnectGatewayControlPlaneOnKonnectID: *ext.Spec.Konnect.ControlPlane.Ref.KonnectID,
+		}); err != nil {
+			return nil, ctrl.Result{}, err
+		}
+		kgcps := kgcpList.Items
+		switch l := len(kgcps); l {
+		case 0:
+			errGetFromK8s = k8serrors.NewNotFound(
+				konnectv1alpha1.Resource("KonnectGatewayControlPlane"),
+				fmt.Sprintf("with KonnectID %s in namespace %s",
+					*ext.Spec.Konnect.ControlPlane.Ref.KonnectID, ext.Namespace,
+				),
+			)
+		case 1:
+			cp = &kgcps[0]
+		default:
+			return nil, ctrl.Result{}, fmt.Errorf(
+				"multiple KonnectGatewayControlPlanes found %d with the same KonnectID %s",
+				l, *ext.Spec.Konnect.ControlPlane.Ref.KonnectID,
+			)
+		}
+	}
+
 	controlPlaneRefValidCond := metav1.Condition{
 		Type:    konnectv1alpha1.ControlPlaneRefValidConditionType,
 		Status:  metav1.ConditionTrue,
@@ -54,18 +96,11 @@ func (r *KonnectExtensionReconciler) getKonnectControlPlane(
 		Message: "ControlPlaneRef is valid",
 	}
 
-	konnectCPID, res, err := r.getKonnectControlPlaneID(ctx, ext, dependingConditions...)
-	if err != nil || !res.IsZero() {
-		return nil, res, err
-	}
-
-	// get the Konnect Control Plane from Konnect
-	konnectCP, err := ops.GetControlPlaneByID(ctx, sdk, konnectCPID)
-	// set the controlPlaneRefValidCond to false in case the Control Plane is not found in Konnect
-	if err != nil {
+	// Check if the KonnectGatewayControlPlane has been found.
+	if errGetFromK8s != nil {
 		controlPlaneRefValidCond.Status = metav1.ConditionFalse
 		controlPlaneRefValidCond.Reason = konnectv1alpha1.ControlPlaneRefReasonInvalid
-		controlPlaneRefValidCond.Message = err.Error()
+		controlPlaneRefValidCond.Message = errGetFromK8s.Error()
 		if res, _, errPatch := patch.StatusWithConditions(
 			ctx,
 			r.Client,
@@ -74,13 +109,26 @@ func (r *KonnectExtensionReconciler) getKonnectControlPlane(
 		); errPatch != nil || !res.IsZero() {
 			return nil, res, errPatch
 		}
-		log.Debug(logger, "ControlPlane retrieval failed in Konnect")
-		// Setting "Requeue: true" along with RequeueAfter makes the controller bulletproof, as
-		// if the syncPeriod is set to zero, the controller won't requeue.
-		return nil, ctrl.Result{Requeue: true, RequeueAfter: r.SyncPeriod}, nil
+		return nil, ctrl.Result{}, errGetFromK8s
 	}
 
-	// set the controlPlaneRefValidCond to true in case the Control Plane is found in Konnect
+	// Set the controlPlaneRefValidCond to false in case the KonnectGatewayControlPlane is not programmed yet.
+	if !k8sutils.HasConditionTrue(konnectv1alpha1.KonnectEntityProgrammedConditionType, cp) {
+		controlPlaneRefValidCond.Status = metav1.ConditionFalse
+		controlPlaneRefValidCond.Reason = konnectv1alpha1.ControlPlaneRefReasonInvalid
+		controlPlaneRefValidCond.Message = fmt.Sprintf("Konnect control plane %s/%s not programmed yet", cp.Name, cp.Namespace)
+		if res, _, errPatch := patch.StatusWithConditions(
+			ctx,
+			r.Client,
+			&ext,
+			append(dependingConditions, controlPlaneRefValidCond)...,
+		); errPatch != nil || !res.IsZero() {
+			return nil, res, errPatch
+		}
+		return nil, ctrl.Result{}, extensionserrors.ErrKonnectGatewayControlPlaneNotProgrammed
+	}
+
+	// Set the controlPlaneRefValidCond to true in case the ControlPlane is configured properly.
 	if res, _, errPatch := patch.StatusWithConditions(
 		ctx,
 		r.Client,
@@ -90,79 +138,7 @@ func (r *KonnectExtensionReconciler) getKonnectControlPlane(
 		return nil, res, errPatch
 	}
 
-	return konnectCP, ctrl.Result{}, err
-}
-
-func (r *KonnectExtensionReconciler) getKonnectControlPlaneID(
-	ctx context.Context,
-	ext konnectv1alpha1.KonnectExtension,
-	dependingConditions ...metav1.Condition,
-) (id string, res ctrl.Result, err error) {
-	var (
-		konnectCPID string
-		// init the controlPlaneRefValidCond with the assumption that the ControlPlaneRef is valid
-		controlPlaneRefValidCond = metav1.Condition{
-			Type:    konnectv1alpha1.ControlPlaneRefValidConditionType,
-			Status:  metav1.ConditionTrue,
-			Reason:  konnectv1alpha1.ControlPlaneRefReasonValid,
-			Message: "ControlPlaneRef is valid",
-		}
-	)
-
-	switch ext.Spec.Konnect.ControlPlane.Ref.Type {
-	case commonv1alpha1.ControlPlaneRefKonnectNamespacedRef:
-		// in case the ControlPlaneRef is a KonnectNamespacedRef, we fetch the KonnectGatewayControlPlane
-		// and get the KonnectID from `status.konnectID`.
-		cpRef := ext.Spec.Konnect.ControlPlane.Ref.KonnectNamespacedRef
-		cpNamepace := ext.Namespace
-		// TODO: get namespace from cpRef.Namespace when allowed to reference CP from another namespace.
-		kgcp := &konnectv1alpha1.KonnectGatewayControlPlane{}
-		err := r.Get(ctx, client.ObjectKey{
-			Namespace: cpNamepace,
-			Name:      cpRef.Name,
-		}, kgcp)
-
-		// set the controlPlaneRefValidCond to false in case the KonnectGatewayControlPlane is not found
-		if err != nil {
-			controlPlaneRefValidCond.Status = metav1.ConditionFalse
-			controlPlaneRefValidCond.Reason = konnectv1alpha1.ControlPlaneRefReasonInvalid
-			controlPlaneRefValidCond.Message = err.Error()
-			if res, _, errPatch := patch.StatusWithConditions(
-				ctx,
-				r.Client,
-				&ext,
-				append(dependingConditions, controlPlaneRefValidCond)...,
-			); errPatch != nil || !res.IsZero() {
-				return "", res, errPatch
-			}
-			return "", ctrl.Result{}, err
-		}
-
-		// set the controlPlaneRefValidCond to false in case the KonnectGatewayControlPlane is not programmed yet
-		if !lo.ContainsBy(kgcp.Status.Conditions, func(cond metav1.Condition) bool {
-			return cond.Type == konnectv1alpha1.KonnectEntityProgrammedConditionType &&
-				cond.Status == metav1.ConditionTrue
-		}) {
-			controlPlaneRefValidCond.Status = metav1.ConditionFalse
-			controlPlaneRefValidCond.Reason = konnectv1alpha1.ControlPlaneRefReasonInvalid
-			controlPlaneRefValidCond.Message = fmt.Sprintf("Konnect control plane %s/%s not programmed yet", cpNamepace, cpRef.Name)
-			if res, _, errPatch := patch.StatusWithConditions(
-				ctx,
-				r.Client,
-				&ext,
-				append(dependingConditions, controlPlaneRefValidCond)...,
-			); errPatch != nil || !res.IsZero() {
-				return "", res, errPatch
-			}
-			return "", ctrl.Result{}, extensionserrors.ErrKonnectGatewayControlPlaneNotProgrammed
-		}
-		konnectCPID = kgcp.GetKonnectID()
-	case commonv1alpha1.ControlPlaneRefKonnectID:
-		// in case the ControlPlaneRef is a KonnectID, we use it directly.
-		konnectCPID = *ext.Spec.Konnect.ControlPlane.Ref.KonnectID
-	}
-
-	return konnectCPID, ctrl.Result{}, nil
+	return cp, ctrl.Result{}, nil
 }
 
 // ensureExtendablesReferencesInStatus ensures that the KonnectExtension references to DataPlane and ControlPlane are up-to-date.
@@ -317,7 +293,8 @@ func (r *KonnectExtensionReconciler) getCertificateSecret(ctx context.Context, e
 
 func konnectClusterTypeToCRDClusterType(clusterType sdkkonnectcomp.ControlPlaneClusterType) konnectv1alpha1.KonnectExtensionClusterType {
 	switch clusterType {
-	case sdkkonnectcomp.ControlPlaneClusterTypeClusterTypeControlPlane:
+	// When it's not specified by the caller (left empty) in Konnect it's set to CLUSTER_TYPE_CONTROL_PLANE.
+	case sdkkonnectcomp.ControlPlaneClusterTypeClusterTypeControlPlane, "":
 		return konnectv1alpha1.ClusterTypeControlPlane
 	case sdkkonnectcomp.ControlPlaneClusterTypeClusterTypeK8SIngressController:
 		return konnectv1alpha1.ClusterTypeK8sIngressController

--- a/controller/konnect/konnectextension_controller_utils.go
+++ b/controller/konnect/konnectextension_controller_utils.go
@@ -31,7 +31,7 @@ import (
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
-// getGatewayKonnectControlPlane retrieves the Konnect Control Plane form K8s cluster
+// getGatewayKonnectControlPlane retrieves the Konnect Control Plane from K8s cluster
 // based on the provided KonnectExtension specification.
 // It supports two types of ControlPlaneRef: KonnectNamespacedRef and KonnectID.
 //

--- a/test/envtest/dataplane_konnectextensions_test.go
+++ b/test/envtest/dataplane_konnectextensions_test.go
@@ -86,26 +86,6 @@ func TestDataPlaneKonnectExtension(t *testing.T) {
 		konnectExtensionReconciler,
 	)
 
-	t.Logf("Setting up expected ListControlPlanes SDK call returning our control plane")
-	factory.SDK.ControlPlaneSDK.EXPECT().ListControlPlanes(mock.Anything, mock.Anything).
-		Return(
-			&sdkkonnectops.ListControlPlanesResponse{
-				StatusCode: http.StatusOK,
-				ListControlPlanesResponse: &sdkkonnectcomp.ListControlPlanesResponse{
-					Data: []sdkkonnectcomp.ControlPlane{
-						{
-							ID:   konnectControlPlaneID,
-							Name: "konnect-cp",
-							Config: sdkkonnectcomp.Config{
-								ControlPlaneEndpoint: "cp.endpoint",
-								TelemetryEndpoint:    "tp.endpoint",
-								ClusterType:          sdkkonnectcomp.ControlPlaneClusterTypeClusterTypeControlPlane,
-							},
-						},
-					},
-				},
-			}, nil)
-
 	t.Logf("Setting up expected ListDpClientCertificates SDK call returning no certificates")
 	factory.SDK.DataPlaneCertificatesSDK.EXPECT().ListDpClientCertificates(mock.Anything, konnectControlPlaneID).
 		Return(&sdkkonnectops.ListDpClientCertificatesResponse{
@@ -134,6 +114,9 @@ func TestDataPlaneKonnectExtension(t *testing.T) {
 
 	t.Logf("Creating KonnectAPIAuthConfiguration")
 	konnectAPIAuthConfiguration := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, cl)
+
+	t.Logf("Creating and setting expecting status for corresponding KonnectControlPlane with Konnect ID: %s", konnectControlPlaneID)
+	_ = deploy.KonnectGatewayControlPlaneWithID(t, ctx, cl, konnectAPIAuthConfiguration, deploy.WithKonnectID(konnectControlPlaneID))
 
 	t.Logf("Creating KonnectExtension")
 	konnectExtension := konnectv1alpha1.KonnectExtension{

--- a/test/helpers/deploy/deploy_resources.go
+++ b/test/helpers/deploy/deploy_resources.go
@@ -269,6 +269,13 @@ func KonnectGatewayControlPlaneWithID(
 		},
 	}
 	cp.Status.ID = uuid.NewString()[:8]
+	cp.Status.Endpoints = &konnectv1alpha1.KonnectEndpoints{
+		ControlPlaneEndpoint: "cp.endpoint",
+		TelemetryEndpoint:    "tp.endpoint",
+	}
+	for _, opt := range opts {
+		opt(cp)
+	}
 	require.NoError(t, cl.Status().Update(ctx, cp))
 	return cp
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not perform redundant fetches from Konnect API of `KonnectGatewayControlPlane` in `KonnectExtension`. Instead rely on a `KonnectGatewayControlPlane` resource reconciled in K8s, because all needed information is already here. 

**Which issue this PR fixes**

Fixes #1275 

**Special notes for your reviewer**:

`controller/konnect/konnectextension_controller.go:578` is done this way, because for creation of `KonnectGatewayControlPlane` in K8s [it's not required to fill `spec.cluster_type` field](https://github.com/Kong/kubernetes-configuration/blob/68327eadc8d2d88c9924831f4902144a05234a7d/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go#L46). Hence this field may be empty, but such entity when requested from Konnect has it set to `CLUSTER_TYPE_CONTROL_PLANE` (at least it seems to be like that).

~It can be left as it is. Or a new field `clusterType` in `status` can be introduced for `KonnectGatewayControlPlane` and filled in the helper [handleKonnectGatewayControlPlaneSpecific](https://github.com/Kong/gateway-operator/blob/f984148cb41e14492f1b8cced7a1080e8106f39a/controller/konnect/reconciler_generic_type_specific.go#L60-L81) during reconciliation of `KonnectGatewayControlPlane`.  This solution seems to be better, because it does not need any assumption to consider~
> [see the comment](https://github.com/Kong/gateway-operator/pull/1436/files/f984148cb41e14492f1b8cced7a1080e8106f39a#r2026664014) 
