### PR TITLE
tests: fix helm upgrade e2e test

### DIFF
--- a/test/e2e/test_helm_install_upgrade.go
+++ b/test/e2e/test_helm_install_upgrade.go
@@ -68,7 +68,7 @@ func TestHelmUpgrade(t *testing.T) {
 		{
 			name:        "upgrade from one before latest to latest minor",
 			fromVersion: "1.4.2", // renovate: datasource=docker packageName=kong/gateway-operator-oss depName=kong/gateway-operator-oss@only-patch
-			toVersion:   "1.5.0", // renovate: datasource=docker packageName=kong/gateway-operator-oss
+			toVersion:   "1.5.0", // renovate: datasource=docker packageName=kong/gateway-operator-oss depName=kong/gateway-operator-oss
 			objectsToDeploy: []client.Object{
 				&operatorv1beta1.GatewayConfiguration{
 					ObjectMeta: metav1.ObjectMeta{
@@ -139,7 +139,7 @@ func TestHelmUpgrade(t *testing.T) {
 		},
 		{
 			name:             "upgrade from latest minor to current",
-			fromVersion:      "1.5.0", // renovate: datasource=docker packageName=kong/gateway-operator-oss
+			fromVersion:      "1.5.0", // renovate: datasource=docker packageName=kong/gateway-operator-oss depName=kong/gateway-operator-oss
 			upgradeToCurrent: true,
 			// This is the effective semver of a next release. It's needed for the chart to properly render
 			// semver-conditional templates.
@@ -271,9 +271,7 @@ func TestHelmUpgrade(t *testing.T) {
 				{
 					Name: "DataPlane deployment is not patched after operator upgrade",
 					Func: func(c *assert.CollectT, cl *testutils.K8sClients) {
-						// https://github.com/Kong/gateway-operator/pull/1395 makes the operator patch
-						// the readiness probe when it's customized but without setting a handler.
-						gatewayDataPlaneDeploymentIsPatched("gw-upgrade-nightly-to-current=true")(ctx, c, cl.MgrClient)
+						gatewayDataPlaneDeploymentIsNotPatched("gw-upgrade-nightly-to-current=true")(ctx, c, cl.MgrClient)
 					},
 				},
 				{


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix e2e test failures like this: https://github.com/Kong/gateway-operator/actions/runs/14330657915/job/40165693488

This is a consequence of merging #1395 which makes the operator update the Deployment (this change has already been release in latest nightly and 
`TestE2E/TestHelmUpgrade/upgrade_from_nightly_to_current/after_upgrade/DataPlane_deployment_is_not_patched_after_operator_upgrade` is made to reflect that).

And fix renovate config (`depName` is required via [this rule](https://github.com/Kong/gateway-operator/blob/b72d64ec5f30742d61b0f45848255a2ffca627ad/renovate.json#L58))

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
