### PR TITLE
chore: fix GO-2025-3563 by bumping go to 1.24.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/kong/gateway-operator
 
-go 1.24.0
-
-toolchain go1.24.1
+go 1.24.2
 
 // 1.2.2 was released on main branch with a breaking change that was not
 // intended to be released in 1.2.x:

--- a/hack/generators/go.mod
+++ b/hack/generators/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/gateway-operator/hack/generators
 
-go 1.24.0
+go 1.24.2
 
 replace github.com/kong/gateway-operator => ../../
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix https://pkg.go.dev/vuln/GO-2025-3563 by bumping the minimum go and toolchain versions to 1.24.2.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
