### PR TITLE
ci: fix DockerHub nightly push

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,10 +12,10 @@ jobs:
   build-push-images:
     uses: ./.github/workflows/__build-workflow.yaml
     secrets:
-      dockerhub-token: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
+      dockerhub-token: ${{ secrets.DOCKERHUB_PUSH_TOKEN_NIGHTLY }}
       gh-pat: ${{ secrets.PAT_GITHUB }}
     with:
-      username: ${{ vars.DOCKERHUB_PUSH_USERNAME }}
+      username: ${{ vars.DOCKERHUB_PUSH_USERNAME_NIGHTLY }}
       registry: docker.io
       image-name: ${{ vars.DOCKERHUB_IMAGE_NAME_NIGHTLY }}
       push: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Nightly pushes have started failing: https://github.com/Kong/gateway-operator/actions/runs/14371791126/job/40296110046

```
Error: Error response from daemon: Get "https://registry-1.docker.io/v2/": unauthorized: personal access token is expired
```

This PR fixes it by changing the token name for DockerHub image pushing for nightlies but also:

- set usernames in variables (previously `teamk8s` pushed images)
    
    ```
    gh variable set DOCKERHUB_PUSH_USERNAME --body kong                                                                              
    gh variable set DOCKERHUB_PUSH_USERNAME_NIGHTLY --body kong                                                                      
    ```

- set tokens

    ```
    gh secret set --app actions DOCKERHUB_PUSH_TOKEN --body XXXXXX
    gh secret set --app actions DOCKERHUB_PUSH_TOKEN_NIGHTLY --body XXXXXX
    ```


**Special notes for your reviewer**:

Nightly workflow run triggered from this branch: https://github.com/Kong/gateway-operator/actions/runs/14404171291/job/40396509012

Successfully pushed images:

- https://hub.docker.com/layers/kong/nightly-gateway-operator-oss/sha-5466994-arm64/images/sha256-c7e43adec18c85b26f29b50d675195c4fb8c89a2af01127fb09fad3a4b181891
- https://hub.docker.com/layers/kong/nightly-gateway-operator-oss/sha-5466994-amd64/images/sha256-89b40176e561af4af709cf3a19d73ed1251513600b2294b5ca98359e64fb7a3a

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
