### PR TITLE
chore(konnect): bump kubernetes-configuration and update namespacedRef fields

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=97a38355409a782a415e80e6f7cba4edfb022b0a # Version is auto-updated by the generating script.
+  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=7dde593f190e9516679ab8fdd7b5d9c56a1b3817 # Version is auto-updated by the generating script.

--- a/controller/konnect/ops/ops_kongroute_test.go
+++ b/controller/konnect/ops/ops_kongroute_test.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
+	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 	"github.com/kong/kubernetes-configuration/pkg/metadata"
@@ -31,7 +32,7 @@ func TestKongRouteToSDKRouteInput_Tags(t *testing.T) {
 		Spec: configurationv1alpha1.KongRouteSpec{
 			ServiceRef: &configurationv1alpha1.ServiceRef{
 				Type: configurationv1alpha1.ServiceRefNamespacedRef,
-				NamespacedRef: &configurationv1alpha1.KongObjectRef{
+				NamespacedRef: &commonv1alpha1.NameRef{
 					Name: "service-1",
 				},
 			},

--- a/controller/konnect/reconciler_certificateref.go
+++ b/controller/konnect/reconciler_certificateref.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kong/gateway-operator/controller/pkg/patch"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
+	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -24,13 +25,13 @@ import (
 // getKongCertificateRef gets the reference of KongCertificate.
 func getKongCertificateRef[T constraints.SupportedKonnectEntityType, TEnt constraints.EntityType[T]](
 	e TEnt,
-) mo.Option[configurationv1alpha1.KongObjectRef] {
+) mo.Option[commonv1alpha1.NameRef] {
 	switch e := any(e).(type) {
 	case *configurationv1alpha1.KongSNI:
 		// Since certificateRef is required for KongSNI, we directly return spec.CertificateRef here.
 		return mo.Some(e.Spec.CertificateRef)
 	default:
-		return mo.None[configurationv1alpha1.KongObjectRef]()
+		return mo.None[commonv1alpha1.NameRef]()
 	}
 }
 

--- a/controller/konnect/reconciler_certificateref_test.go
+++ b/controller/konnect/reconciler_certificateref_test.go
@@ -178,7 +178,7 @@ func TestHandleCertificateRef(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: configurationv1alpha1.KongSNISpec{
-					CertificateRef: configurationv1alpha1.KongObjectRef{
+					CertificateRef: commonv1alpha1.NameRef{
 						Name: "cert-ok",
 					},
 				},
@@ -215,7 +215,7 @@ func TestHandleCertificateRef(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: configurationv1alpha1.KongSNISpec{
-					CertificateRef: configurationv1alpha1.KongObjectRef{
+					CertificateRef: commonv1alpha1.NameRef{
 						Name: "cert-nonexist",
 					},
 				},
@@ -238,7 +238,7 @@ func TestHandleCertificateRef(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: configurationv1alpha1.KongSNISpec{
-					CertificateRef: configurationv1alpha1.KongObjectRef{
+					CertificateRef: commonv1alpha1.NameRef{
 						Name: "cert-not-programmed",
 					},
 				},
@@ -266,7 +266,7 @@ func TestHandleCertificateRef(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: configurationv1alpha1.KongSNISpec{
-					CertificateRef: configurationv1alpha1.KongObjectRef{
+					CertificateRef: commonv1alpha1.NameRef{
 						Name: "cert-no-cp-ref",
 					},
 				},
@@ -293,7 +293,7 @@ func TestHandleCertificateRef(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: configurationv1alpha1.KongSNISpec{
-					CertificateRef: configurationv1alpha1.KongObjectRef{
+					CertificateRef: commonv1alpha1.NameRef{
 						Name: "cert-being-deleted",
 					},
 				},
@@ -312,7 +312,7 @@ func TestHandleCertificateRef(t *testing.T) {
 					Name:      "sni-cp-ref-not-found",
 				},
 				Spec: configurationv1alpha1.KongSNISpec{
-					CertificateRef: configurationv1alpha1.KongObjectRef{
+					CertificateRef: commonv1alpha1.NameRef{
 						Name: "cert-cpref-not-found",
 					},
 				},
@@ -333,7 +333,7 @@ func TestHandleCertificateRef(t *testing.T) {
 					Name:      "sni-cp-ref-not-programmed",
 				},
 				Spec: configurationv1alpha1.KongSNISpec{
-					CertificateRef: configurationv1alpha1.KongObjectRef{
+					CertificateRef: commonv1alpha1.NameRef{
 						Name: "cert-cpref-not-programmed",
 					},
 				},

--- a/controller/konnect/reconciler_keysetref_test.go
+++ b/controller/konnect/reconciler_keysetref_test.go
@@ -183,7 +183,7 @@ func TestHandleKeySetRef(t *testing.T) {
 					ControlPlaneRef: cpRef,
 					KeySetRef: &configurationv1alpha1.KeySetRef{
 						Type: configurationv1alpha1.KeySetRefNamespacedRef,
-						NamespacedRef: &configurationv1alpha1.KeySetNamespacedRef{
+						NamespacedRef: &commonv1alpha1.NameRef{
 							Name: "key-set-1",
 						},
 					},
@@ -204,7 +204,7 @@ func TestHandleKeySetRef(t *testing.T) {
 					ControlPlaneRef: cpRef,
 					KeySetRef: &configurationv1alpha1.KeySetRef{
 						Type: configurationv1alpha1.KeySetRefNamespacedRef,
-						NamespacedRef: &configurationv1alpha1.KeySetNamespacedRef{
+						NamespacedRef: &commonv1alpha1.NameRef{
 							Name: keySetDuringDeletion.Name,
 						},
 					},
@@ -225,7 +225,7 @@ func TestHandleKeySetRef(t *testing.T) {
 					ControlPlaneRef: cpRef,
 					KeySetRef: &configurationv1alpha1.KeySetRef{
 						Type: configurationv1alpha1.KeySetRefNamespacedRef,
-						NamespacedRef: &configurationv1alpha1.KeySetNamespacedRef{
+						NamespacedRef: &commonv1alpha1.NameRef{
 							Name: notProgrammedKeySet.Name,
 						},
 					},
@@ -246,7 +246,7 @@ func TestHandleKeySetRef(t *testing.T) {
 					ControlPlaneRef: cpRef,
 					KeySetRef: &configurationv1alpha1.KeySetRef{
 						Type: configurationv1alpha1.KeySetRefNamespacedRef,
-						NamespacedRef: &configurationv1alpha1.KeySetNamespacedRef{
+						NamespacedRef: &commonv1alpha1.NameRef{
 							Name: programmedKeySet.Name,
 						},
 					},

--- a/controller/konnect/reconciler_kongplugin_combinations_test.go
+++ b/controller/konnect/reconciler_kongplugin_combinations_test.go
@@ -146,7 +146,7 @@ func TestGetCombinations(t *testing.T) {
 							Spec: configurationv1alpha1.KongRouteSpec{
 								ServiceRef: &configurationv1alpha1.ServiceRef{
 									Type: configurationv1alpha1.ServiceRefNamespacedRef,
-									NamespacedRef: &configurationv1alpha1.KongObjectRef{
+									NamespacedRef: &commonv1alpha1.NameRef{
 										Name: "s1",
 									},
 								},
@@ -303,7 +303,7 @@ func TestGetCombinations(t *testing.T) {
 							Spec: configurationv1alpha1.KongRouteSpec{
 								ServiceRef: &configurationv1alpha1.ServiceRef{
 									Type: configurationv1alpha1.ServiceRefNamespacedRef,
-									NamespacedRef: &configurationv1alpha1.KongObjectRef{
+									NamespacedRef: &commonv1alpha1.NameRef{
 										Name: "s1",
 									},
 								},
@@ -372,7 +372,7 @@ func TestGetCombinations(t *testing.T) {
 							Spec: configurationv1alpha1.KongRouteSpec{
 								ServiceRef: &configurationv1alpha1.ServiceRef{
 									Type: configurationv1alpha1.ServiceRefNamespacedRef,
-									NamespacedRef: &configurationv1alpha1.KongObjectRef{
+									NamespacedRef: &commonv1alpha1.NameRef{
 										Name: "s1",
 									},
 								},
@@ -418,7 +418,7 @@ func TestGetCombinations(t *testing.T) {
 							Spec: configurationv1alpha1.KongRouteSpec{
 								ServiceRef: &configurationv1alpha1.ServiceRef{
 									Type: configurationv1alpha1.ServiceRefNamespacedRef,
-									NamespacedRef: &configurationv1alpha1.KongObjectRef{
+									NamespacedRef: &commonv1alpha1.NameRef{
 										Name: "s1",
 									},
 								},
@@ -662,7 +662,7 @@ func TestGroupByControlPlane(t *testing.T) {
 							Spec: configurationv1alpha1.KongRouteSpec{
 								ServiceRef: &configurationv1alpha1.ServiceRef{
 									Type: configurationv1alpha1.ServiceRefNamespacedRef,
-									NamespacedRef: &configurationv1alpha1.KongObjectRef{
+									NamespacedRef: &commonv1alpha1.NameRef{
 										Name: "s1",
 									},
 								},
@@ -704,7 +704,7 @@ func TestGroupByControlPlane(t *testing.T) {
 							Spec: configurationv1alpha1.KongRouteSpec{
 								ServiceRef: &configurationv1alpha1.ServiceRef{
 									Type: configurationv1alpha1.ServiceRefNamespacedRef,
-									NamespacedRef: &configurationv1alpha1.KongObjectRef{
+									NamespacedRef: &commonv1alpha1.NameRef{
 										Name: "s1",
 									},
 								},

--- a/controller/konnect/reconciler_serviceref_test.go
+++ b/controller/konnect/reconciler_serviceref_test.go
@@ -128,7 +128,7 @@ func TestHandleServiceRef(t *testing.T) {
 				Spec: configurationv1alpha1.KongRouteSpec{
 					ServiceRef: &configurationv1alpha1.ServiceRef{
 						Type: configurationv1alpha1.ServiceRefNamespacedRef,
-						NamespacedRef: &configurationv1alpha1.KongObjectRef{
+						NamespacedRef: &commonv1alpha1.NameRef{
 							Name: "svc-ok",
 						},
 					},
@@ -175,7 +175,7 @@ func TestHandleServiceRef(t *testing.T) {
 				Spec: configurationv1alpha1.KongRouteSpec{
 					ServiceRef: &configurationv1alpha1.ServiceRef{
 						Type: configurationv1alpha1.ServiceRefNamespacedRef,
-						NamespacedRef: &configurationv1alpha1.KongObjectRef{
+						NamespacedRef: &commonv1alpha1.NameRef{
 							Name: "svc-ok",
 						},
 					},
@@ -198,7 +198,7 @@ func TestHandleServiceRef(t *testing.T) {
 				Spec: configurationv1alpha1.KongRouteSpec{
 					ServiceRef: &configurationv1alpha1.ServiceRef{
 						Type: configurationv1alpha1.ServiceRefNamespacedRef,
-						NamespacedRef: &configurationv1alpha1.KongObjectRef{
+						NamespacedRef: &commonv1alpha1.NameRef{
 							Name: "svc-not-programmed",
 						},
 					},
@@ -237,7 +237,7 @@ func TestHandleServiceRef(t *testing.T) {
 				Spec: configurationv1alpha1.KongRouteSpec{
 					ServiceRef: &configurationv1alpha1.ServiceRef{
 						Type: configurationv1alpha1.ServiceRefNamespacedRef,
-						NamespacedRef: &configurationv1alpha1.KongObjectRef{
+						NamespacedRef: &commonv1alpha1.NameRef{
 							Name: "svc-with-cp-ref-unprogrammed",
 						},
 					},

--- a/controller/konnect/reconciler_upstreamref.go
+++ b/controller/konnect/reconciler_upstreamref.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kong/gateway-operator/controller/pkg/patch"
 	k8sutils "github.com/kong/gateway-operator/pkg/utils/kubernetes"
 
+	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -23,13 +24,13 @@ import (
 // getKongUpstreamRef gets the reference of KongUpstream.
 func getKongUpstreamRef[T constraints.SupportedKonnectEntityType, TEnt constraints.EntityType[T]](
 	e TEnt,
-) mo.Option[configurationv1alpha1.TargetRef] {
+) mo.Option[commonv1alpha1.NameRef] {
 	switch e := any(e).(type) {
 	case *configurationv1alpha1.KongTarget:
 		// Since upstreamRef is required for KongTarget, we directly return spec.UpstreamRef here.
 		return mo.Some(e.Spec.UpstreamRef)
 	default:
-		return mo.None[configurationv1alpha1.TargetRef]()
+		return mo.None[commonv1alpha1.NameRef]()
 	}
 }
 

--- a/controller/konnect/reconciler_upstreamref_test.go
+++ b/controller/konnect/reconciler_upstreamref_test.go
@@ -214,7 +214,7 @@ func TestHandleUpstreamRef(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: configurationv1alpha1.KongTargetSpec{
-					UpstreamRef: configurationv1alpha1.TargetRef{
+					UpstreamRef: commonv1alpha1.NameRef{
 						Name: "upstream-ok",
 					},
 				},
@@ -251,7 +251,7 @@ func TestHandleUpstreamRef(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: configurationv1alpha1.KongTargetSpec{
-					UpstreamRef: configurationv1alpha1.TargetRef{
+					UpstreamRef: commonv1alpha1.NameRef{
 						Name: "upstream-nonexist",
 					},
 				},
@@ -274,7 +274,7 @@ func TestHandleUpstreamRef(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: configurationv1alpha1.KongTargetSpec{
-					UpstreamRef: configurationv1alpha1.TargetRef{
+					UpstreamRef: commonv1alpha1.NameRef{
 						Name: "upstream-not-programmed",
 					},
 				},
@@ -300,7 +300,7 @@ func TestHandleUpstreamRef(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: configurationv1alpha1.KongTargetSpec{
-					UpstreamRef: configurationv1alpha1.TargetRef{
+					UpstreamRef: commonv1alpha1.NameRef{
 						Name: "upstream-no-cp-ref",
 					},
 				},
@@ -325,7 +325,7 @@ func TestHandleUpstreamRef(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: configurationv1alpha1.KongTargetSpec{
-					UpstreamRef: configurationv1alpha1.TargetRef{
+					UpstreamRef: commonv1alpha1.NameRef{
 						Name: "upstream-being-deleted",
 					},
 				},
@@ -342,7 +342,7 @@ func TestHandleUpstreamRef(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: configurationv1alpha1.KongTargetSpec{
-					UpstreamRef: configurationv1alpha1.TargetRef{
+					UpstreamRef: commonv1alpha1.NameRef{
 						Name: "upstream-cpref-not-found",
 					},
 				},
@@ -361,7 +361,7 @@ func TestHandleUpstreamRef(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: configurationv1alpha1.KongTargetSpec{
-					UpstreamRef: configurationv1alpha1.TargetRef{
+					UpstreamRef: commonv1alpha1.NameRef{
 						Name: "upstream-cpref-not-programmed",
 					},
 				},

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ go 1.24.2
 retract v1.2.2
 
 require (
-	github.com/Kong/sdk-konnect-go v0.2.25
+	github.com/Kong/sdk-konnect-go v0.2.26
 	github.com/Masterminds/semver v1.5.0
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/go-logr/logr v1.4.2
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/terratest v0.48.2
-	github.com/kong/kubernetes-configuration v1.3.2-0.20250407143758-97a38355409a
+	github.com/kong/kubernetes-configuration v1.3.2-0.20250411121302-7dde593f190e
 	github.com/kong/kubernetes-telemetry v0.1.9
 	github.com/kong/kubernetes-testing-framework v0.47.2
 	github.com/kong/semver/v4 v4.0.1
@@ -159,7 +159,7 @@ require (
 	github.com/jmoiron/sqlx v1.3.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kong/go-kong v0.65.0 // indirect
+	github.com/kong/go-kong v0.65.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/Kong/sdk-konnect-go v0.2.25 h1:1n3CLoPbSQAA2YBMuklZqeJqxfyPWuMIhWH/Z+I3qLw=
-github.com/Kong/sdk-konnect-go v0.2.25/go.mod h1:xsmTIkBbmVyUh1nRFjQMOhxYIPDl+sMfmRmPuZHtwLE=
+github.com/Kong/sdk-konnect-go v0.2.26 h1:39zLa4oExkvY4GS/TIU1i40tUjSxoe+EyH9SuWECKP8=
+github.com/Kong/sdk-konnect-go v0.2.26/go.mod h1:xsmTIkBbmVyUh1nRFjQMOhxYIPDl+sMfmRmPuZHtwLE=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -307,10 +307,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
-github.com/kong/go-kong v0.65.0 h1:dZT+hiMhy7CQsrc9W5nHv3cFJGBGTrwlZhC5MLuf9H8=
-github.com/kong/go-kong v0.65.0/go.mod h1:sqdysTKrXIJ6mpxHwTwjgZhLW7jR1/puczTXHLUwJaE=
-github.com/kong/kubernetes-configuration v1.3.2-0.20250407143758-97a38355409a h1:Ff6NfW4N/LcTS42V+HAxEhMuT5VOUv+BXgDxzYZk46c=
-github.com/kong/kubernetes-configuration v1.3.2-0.20250407143758-97a38355409a/go.mod h1:HLTUw06SiSlGeDByfP3NeibT/dQIzbzvBHZj2yN1APo=
+github.com/kong/go-kong v0.65.1 h1:CM+8NlF+VbJckTxP2hGmSPKhA1GMliitXjQ7vJiPkaE=
+github.com/kong/go-kong v0.65.1/go.mod h1:sqdysTKrXIJ6mpxHwTwjgZhLW7jR1/puczTXHLUwJaE=
+github.com/kong/kubernetes-configuration v1.3.2-0.20250411121302-7dde593f190e h1:7UJfOI5LFtAtIjQWm9DSZaoGV7O68u1fkHsG6F2wHUE=
+github.com/kong/kubernetes-configuration v1.3.2-0.20250411121302-7dde593f190e/go.mod h1:+HRrz0eeoy7d5YJYiCkk736xaSq3y9fbV5SvucYo/tY=
 github.com/kong/kubernetes-telemetry v0.1.9 h1:XbDMZjZZclHO4oyJGW1mmZ6bzbTnANjcRAYsBg+jpno=
 github.com/kong/kubernetes-telemetry v0.1.9/go.mod h1:lBSbaQdJkoMMO0d+cJWopoJiJ+QHFBttbhCp5VRibJ8=
 github.com/kong/kubernetes-testing-framework v0.47.2 h1:+2Z9anTpbV/hwNeN+NFQz53BMU+g3QJydkweBp3tULo=

--- a/test/envtest/konnect_entities_kongkey_test.go
+++ b/test/envtest/konnect_entities_kongkey_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	"github.com/kong/gateway-operator/test/helpers/deploy"
 
+	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -178,7 +179,7 @@ func TestKongKey(t *testing.T) {
 				key := obj.(*configurationv1alpha1.KongKey)
 				key.Spec.KeySetRef = &configurationv1alpha1.KeySetRef{
 					Type: configurationv1alpha1.KeySetRefNamespacedRef,
-					NamespacedRef: lo.ToPtr(configurationv1alpha1.KeySetNamespacedRef{
+					NamespacedRef: lo.ToPtr(commonv1alpha1.NameRef{
 						Name: keySetName,
 					}),
 				}

--- a/test/helpers/deploy/deploy_resources.go
+++ b/test/helpers/deploy/deploy_resources.go
@@ -458,7 +458,7 @@ func KongRouteAttachedToService(
 			},
 			ServiceRef: &configurationv1alpha1.ServiceRef{
 				Type: configurationv1alpha1.ServiceRefNamespacedRef,
-				NamespacedRef: &configurationv1alpha1.KongObjectRef{
+				NamespacedRef: &commonv1alpha1.NameRef{
 					Name: kongService.Name,
 				},
 			},
@@ -780,7 +780,7 @@ func KongTargetAttachedToUpstream(
 			GenerateName: "upstream-",
 		},
 		Spec: configurationv1alpha1.KongTargetSpec{
-			UpstreamRef: configurationv1alpha1.TargetRef{
+			UpstreamRef: commonv1alpha1.NameRef{
 				Name: upstream.Name,
 			},
 		},
@@ -1040,7 +1040,7 @@ func KongSNIAttachedToCertificate(
 			Name: name,
 		},
 		Spec: configurationv1alpha1.KongSNISpec{
-			CertificateRef: configurationv1alpha1.KongObjectRef{
+			CertificateRef: commonv1alpha1.NameRef{
 				Name: cert.Name,
 			},
 			KongSNIAPISpec: configurationv1alpha1.KongSNIAPISpec{


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump `kubernetes-configuration` repo and update the fields in the CRs.

**Which issue this PR fixes**

required for #1220 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
