### PR TITLE
feat: allow migration from serviceless to service bound for `KongRoute`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,12 +38,14 @@
 - Introduced new CLI flags:
   - `--logging-mode` (or `GATEWAY_OPERATOR_LOGGING_MODE` env var) to set the logging mode (`development` can be set
     for simplified logging).
-  - `--validate-images` (or `GATEWAY_OPERATOR_VALIDATE_IMAGES` env var) to enable ControlPlane and DataPlane image 
+  - `--validate-images` (or `GATEWAY_OPERATOR_VALIDATE_IMAGES` env var) to enable ControlPlane and DataPlane image
     validation (it's set by default to `true`).
   [#1435](https://github.com/Kong/gateway-operator/pull/1435)
 - Add support for `-enforce-config` for `ControlPlane`'s `ValidatingWebhookConfiguration`.
   This allows to use operator's `ControlPlane` resources in AKS clusters.
   [#1512](https://github.com/Kong/gateway-operator/pull/1512)
+- `KongRoute` can be migrated from serviceless to service bound and vice versa.
+  [#1492](https://github.com/Kong/gateway-operator/pull/1492)
 
 ### Changes
 

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -451,7 +451,6 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// Org ID, Server URL and status conditions.
 		// Konnect ID will be needed for the finalizer to work.
 		if res, err := patch.ApplyStatusPatchIfNotEmpty(ctx, r.Client, logger, any(ent).(client.Object), obj); err != nil {
-			// if err := r.Client.Status().Patch(ctx, ent, client.MergeFrom(obj)); err != nil {
 			if k8serrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
 			}

--- a/controller/konnect/reconciler_serviceref.go
+++ b/controller/konnect/reconciler_serviceref.go
@@ -21,6 +21,208 @@ import (
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
+// handleKongServiceRef handles the ServiceRef for the given entity.
+// It sets the owner reference to the referenced KongService and updates the
+// status of the entity based on the referenced KongService status.
+func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constraints.EntityType[T]](
+	ctx context.Context,
+	cl client.Client,
+	ent TEnt,
+) (ctrl.Result, error) {
+	kongServiceRef, ok := getServiceRef(ent).Get()
+	if !ok {
+		if kongRoute, ok := any(ent).(*configurationv1alpha1.KongRoute); ok {
+			// If the entity has a resolved reference, but the spec has changed, we need to adjust the status
+			// and transfer the ownership back from the KongService to the ControlPlane.
+			if kongRoute.Status.Konnect != nil && kongRoute.Status.Konnect.ServiceID != "" {
+				old := kongRoute.DeepCopyObject().(TEnt)
+				// Reset the KeySetID in the status and set the condition to True.
+				kongRoute.Status.Konnect.ServiceID = ""
+				_ = patch.SetStatusWithConditionIfDifferent(ent,
+					konnectv1alpha1.KongServiceRefValidConditionType,
+					metav1.ConditionTrue,
+					konnectv1alpha1.KeySetRefReasonValid,
+					"ServiceRef is unset",
+				)
+
+				// Patch the status
+				if _, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old); err != nil {
+					if k8serrors.IsConflict(err) {
+						return ctrl.Result{Requeue: true}, nil
+					}
+					return ctrl.Result{}, fmt.Errorf("failed to patch status: %w", err)
+				}
+
+				// Check if the entity has a ControlPlaneRef as not having it as well as not having
+				// a ServiceRef is an error.
+				_, hasCPRef := controlplane.GetControlPlaneRef(ent).Get()
+				if !hasCPRef {
+					return ctrl.Result{}, fmt.Errorf("key doesn't have neither a KongService ref not a ControlPlane ref")
+				}
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if kongServiceRef.Type != configurationv1alpha1.ServiceRefNamespacedRef {
+		ctrllog.FromContext(ctx).Error(fmt.Errorf("unsupported KongService ref type %q", kongServiceRef.Type), "unsupported KongService ref type", "entity", ent)
+		return ctrl.Result{}, nil
+	}
+
+	kongSvc := configurationv1alpha1.KongService{}
+	nn := types.NamespacedName{
+		Name: kongServiceRef.NamespacedRef.Name,
+		// TODO: handle cross namespace refs
+		Namespace: ent.GetNamespace(),
+	}
+	if err := cl.Get(ctx, nn, &kongSvc); err != nil {
+		if res, errStatus := patch.StatusWithCondition(
+			ctx, cl, ent,
+			konnectv1alpha1.KongServiceRefValidConditionType,
+			metav1.ConditionFalse,
+			konnectv1alpha1.KongServiceRefReasonInvalid,
+			err.Error(),
+		); errStatus != nil || !res.IsZero() {
+			return res, errStatus
+		}
+
+		// If the KongService is not found, we don't want to requeue.
+		if k8serrors.IsNotFound(err) {
+			return ctrl.Result{}, ReferencedObjectDoesNotExist{
+				Reference: nn,
+				Err:       err,
+			}
+		}
+
+		return ctrl.Result{}, fmt.Errorf("can't get the referenced KongService %s: %w", nn, err)
+	}
+
+	old := ent.DeepCopyObject().(TEnt)
+
+	// If referenced KongService is being deleted, return an error so that we
+	// can remove the entity from Konnect first.
+	if delTimestamp := kongSvc.GetDeletionTimestamp(); !delTimestamp.IsZero() {
+		_ = patch.SetStatusWithConditionIfDifferent(ent,
+			konnectv1alpha1.KongServiceRefValidConditionType,
+			metav1.ConditionFalse,
+			konnectv1alpha1.KongServiceRefReasonInvalid,
+			fmt.Sprintf("Referenced KongService %s is being deleted", nn),
+		)
+		_, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
+		if err != nil {
+			if k8serrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, ReferencedKongServiceIsBeingDeleted{
+			Reference: nn,
+		}
+	}
+
+	cond, ok := k8sutils.GetCondition(konnectv1alpha1.KonnectEntityProgrammedConditionType, &kongSvc)
+	if !ok || cond.Status != metav1.ConditionTrue {
+		ent.SetKonnectID("")
+		_ = patch.SetStatusWithConditionIfDifferent(ent,
+			konnectv1alpha1.KongServiceRefValidConditionType,
+			metav1.ConditionFalse,
+			konnectv1alpha1.KongServiceRefReasonInvalid,
+			fmt.Sprintf("Referenced KongService %s is not programmed yet", nn),
+		)
+
+		_, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
+		if err != nil {
+			if k8serrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// TODO(pmalek): make this generic.
+	// Service ID is not stored in KonnectEntityStatus because not all entities
+	// have a ServiceRef, hence the type constraints in the reconciler can't be used.
+	if route, ok := any(ent).(*configurationv1alpha1.KongRoute); ok {
+		if route.Status.Konnect == nil {
+			route.Status.Konnect = &konnectv1alpha1.KonnectEntityStatusWithControlPlaneAndServiceRefs{}
+		}
+		route.Status.Konnect.ServiceID = kongSvc.Status.Konnect.GetKonnectID()
+	}
+
+	_ = patch.SetStatusWithConditionIfDifferent(ent,
+		konnectv1alpha1.KongServiceRefValidConditionType,
+		metav1.ConditionTrue,
+		konnectv1alpha1.KongServiceRefReasonValid,
+		fmt.Sprintf("Referenced KongService %s programmed", nn),
+	)
+
+	_, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
+	if err != nil {
+		if k8serrors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	kongSvcCPRef, ok := controlplane.GetControlPlaneRef(&kongSvc).Get()
+	if !ok {
+		return ctrl.Result{}, fmt.Errorf(
+			"KongRoute references a KongService %s which does not have a ControlPlane ref",
+			client.ObjectKeyFromObject(&kongSvc),
+		)
+	}
+	cp, err := controlplane.GetCPForRef(ctx, cl, kongSvcCPRef, ent.GetNamespace())
+	if err != nil {
+		if res, errStatus := patch.StatusWithCondition(
+			ctx, cl, ent,
+			konnectv1alpha1.ControlPlaneRefValidConditionType,
+			metav1.ConditionFalse,
+			konnectv1alpha1.ControlPlaneRefReasonInvalid,
+			err.Error(),
+		); errStatus != nil || !res.IsZero() {
+			return res, errStatus
+		}
+		if k8serrors.IsNotFound(err) {
+			return ctrl.Result{}, controlplane.ReferencedControlPlaneDoesNotExistError{
+				Reference: kongSvcCPRef,
+				Err:       err,
+			}
+		}
+		return ctrl.Result{}, err
+	}
+
+	cond, ok = k8sutils.GetCondition(konnectv1alpha1.KonnectEntityProgrammedConditionType, cp)
+	if !ok || cond.Status != metav1.ConditionTrue || cond.ObservedGeneration != cp.GetGeneration() {
+		if res, errStatus := patch.StatusWithCondition(
+			ctx, cl, ent,
+			konnectv1alpha1.ControlPlaneRefValidConditionType,
+			metav1.ConditionFalse,
+			konnectv1alpha1.ControlPlaneRefReasonInvalid,
+			fmt.Sprintf("Referenced ControlPlane %s is not programmed yet", nn),
+		); errStatus != nil || !res.IsZero() {
+			return res, errStatus
+		}
+
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// TODO(pmalek): make this generic.
+	// CP ID is not stored in KonnectEntityStatus because not all entities
+	// have a ControlPlaneRef, hence the type constraints in the reconciler can't be used.
+	if resource, ok := any(ent).(EntityWithControlPlaneRef); ok {
+		resource.SetControlPlaneID(cp.Status.ID)
+	}
+
+	res, err := RemoveOwnerRefIfSet(ctx, cl, ent, &kongSvc)
+	if err != nil || !res.IsZero() {
+		return res, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
 func getServiceRef[T constraints.SupportedKonnectEntityType, TEnt constraints.EntityType[T]](
 	e TEnt,
 ) mo.Option[configurationv1alpha1.ServiceRef] {
@@ -33,179 +235,4 @@ func getServiceRef[T constraints.SupportedKonnectEntityType, TEnt constraints.En
 	default:
 		return mo.None[configurationv1alpha1.ServiceRef]()
 	}
-}
-
-// handleKongServiceRef handles the ServiceRef for the given entity.
-// It sets the owner reference to the referenced KongService and updates the
-// status of the entity based on the referenced KongService status.
-func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constraints.EntityType[T]](
-	ctx context.Context,
-	cl client.Client,
-	ent TEnt,
-) (ctrl.Result, error) {
-	kongServiceRef, ok := getServiceRef(ent).Get()
-	if !ok {
-		return ctrl.Result{}, nil
-	}
-	switch kongServiceRef.Type {
-	case configurationv1alpha1.ServiceRefNamespacedRef:
-		svc := configurationv1alpha1.KongService{}
-		nn := types.NamespacedName{
-			Name: kongServiceRef.NamespacedRef.Name,
-			// TODO: handle cross namespace refs
-			Namespace: ent.GetNamespace(),
-		}
-
-		if err := cl.Get(ctx, nn, &svc); err != nil {
-			if res, errStatus := patch.StatusWithCondition(
-				ctx, cl, ent,
-				konnectv1alpha1.KongServiceRefValidConditionType,
-				metav1.ConditionFalse,
-				konnectv1alpha1.KongServiceRefReasonInvalid,
-				err.Error(),
-			); errStatus != nil || !res.IsZero() {
-				return res, errStatus
-			}
-
-			return ctrl.Result{}, fmt.Errorf("can't get the referenced KongService %s: %w", nn, err)
-		}
-
-		old := ent.DeepCopyObject().(TEnt)
-
-		// If referenced KongService is being deleted, return an error so that we
-		// can remove the entity from Konnect first.
-		if delTimestamp := svc.GetDeletionTimestamp(); !delTimestamp.IsZero() {
-			_ = patch.SetStatusWithConditionIfDifferent(ent,
-				konnectv1alpha1.KongServiceRefValidConditionType,
-				metav1.ConditionFalse,
-				konnectv1alpha1.KongServiceRefReasonInvalid,
-				fmt.Sprintf("Referenced KongService %s is being deleted", nn),
-			)
-			_, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
-			if err != nil {
-				if k8serrors.IsConflict(err) {
-					return ctrl.Result{Requeue: true}, nil
-				}
-				return ctrl.Result{}, err
-			}
-			return ctrl.Result{}, ReferencedKongServiceIsBeingDeleted{
-				Reference: nn,
-			}
-		}
-
-		cond, ok := k8sutils.GetCondition(konnectv1alpha1.KonnectEntityProgrammedConditionType, &svc)
-		if !ok || cond.Status != metav1.ConditionTrue {
-			ent.SetKonnectID("")
-			_ = patch.SetStatusWithConditionIfDifferent(ent,
-				konnectv1alpha1.KongServiceRefValidConditionType,
-				metav1.ConditionFalse,
-				konnectv1alpha1.KongServiceRefReasonInvalid,
-				fmt.Sprintf("Referenced KongService %s is not programmed yet", nn),
-			)
-
-			_, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
-			if err != nil {
-				if k8serrors.IsConflict(err) {
-					return ctrl.Result{Requeue: true}, nil
-				}
-				return ctrl.Result{}, err
-			}
-
-			return ctrl.Result{Requeue: true}, nil
-		}
-
-		// TODO(pmalek): make this generic.
-		// Service ID is not stored in KonnectEntityStatus because not all entities
-		// have a ServiceRef, hence the type constraints in the reconciler can't be used.
-		if route, ok := any(ent).(*configurationv1alpha1.KongRoute); ok {
-			if route.Status.Konnect == nil {
-				route.Status.Konnect = &konnectv1alpha1.KonnectEntityStatusWithControlPlaneAndServiceRefs{}
-			}
-			route.Status.Konnect.ServiceID = svc.Status.Konnect.GetKonnectID()
-		}
-
-		_ = patch.SetStatusWithConditionIfDifferent(ent,
-			konnectv1alpha1.KongServiceRefValidConditionType,
-			metav1.ConditionTrue,
-			konnectv1alpha1.KongServiceRefReasonValid,
-			fmt.Sprintf("Referenced KongService %s programmed", nn),
-		)
-
-		_, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
-		if err != nil {
-			if k8serrors.IsConflict(err) {
-				return ctrl.Result{Requeue: true}, nil
-			}
-			return ctrl.Result{}, err
-		}
-
-		cpRef, ok := controlplane.GetControlPlaneRef(&svc).Get()
-		if !ok {
-			return ctrl.Result{}, fmt.Errorf(
-				"KongRoute references a KongService %s which does not have a ControlPlane ref",
-				client.ObjectKeyFromObject(&svc),
-			)
-		}
-		cp, err := controlplane.GetCPForRef(ctx, cl, cpRef, ent.GetNamespace())
-		if err != nil {
-			if res, errStatus := patch.StatusWithCondition(
-				ctx, cl, ent,
-				konnectv1alpha1.ControlPlaneRefValidConditionType,
-				metav1.ConditionFalse,
-				konnectv1alpha1.ControlPlaneRefReasonInvalid,
-				err.Error(),
-			); errStatus != nil || !res.IsZero() {
-				return res, errStatus
-			}
-			if k8serrors.IsNotFound(err) {
-				return ctrl.Result{}, controlplane.ReferencedControlPlaneDoesNotExistError{
-					Reference: cpRef,
-					Err:       err,
-				}
-			}
-			return ctrl.Result{}, err
-		}
-
-		cond, ok = k8sutils.GetCondition(konnectv1alpha1.KonnectEntityProgrammedConditionType, cp)
-		if !ok || cond.Status != metav1.ConditionTrue || cond.ObservedGeneration != cp.GetGeneration() {
-			if res, errStatus := patch.StatusWithCondition(
-				ctx, cl, ent,
-				konnectv1alpha1.ControlPlaneRefValidConditionType,
-				metav1.ConditionFalse,
-				konnectv1alpha1.ControlPlaneRefReasonInvalid,
-				fmt.Sprintf("Referenced ControlPlane %s is not programmed yet", nn),
-			); errStatus != nil || !res.IsZero() {
-				return res, errStatus
-			}
-
-			return ctrl.Result{Requeue: true}, nil
-		}
-
-		// TODO(pmalek): make this generic.
-		// CP ID is not stored in KonnectEntityStatus because not all entities
-		// have a ControlPlaneRef, hence the type constraints in the reconciler can't be used.
-		if resource, ok := any(ent).(EntityWithControlPlaneRef); ok {
-			resource.SetControlPlaneID(cp.Status.ID)
-		}
-
-		_ = patch.SetStatusWithConditionIfDifferent(ent,
-			konnectv1alpha1.ControlPlaneRefValidConditionType,
-			metav1.ConditionTrue,
-			konnectv1alpha1.ControlPlaneRefReasonValid,
-			fmt.Sprintf("Referenced ControlPlane %s is programmed", client.ObjectKeyFromObject(cp)),
-		)
-
-		_, err = patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
-		if err != nil {
-			if k8serrors.IsConflict(err) {
-				return ctrl.Result{Requeue: true}, nil
-			}
-			return ctrl.Result{}, err
-		}
-
-	default:
-		return ctrl.Result{}, fmt.Errorf("unimplemented KongService ref type %q", kongServiceRef.Type)
-	}
-
-	return ctrl.Result{}, nil
 }

--- a/controller/konnect/reconciler_serviceref_test.go
+++ b/controller/konnect/reconciler_serviceref_test.go
@@ -143,11 +143,6 @@ func TestHandleServiceRef(t *testing.T) {
 			updatedEntAssertions: []func(*configurationv1alpha1.KongRoute) (bool, string){
 				func(ks *configurationv1alpha1.KongRoute) (bool, string) {
 					return lo.ContainsBy(ks.Status.Conditions, func(c metav1.Condition) bool {
-						return c.Type == konnectv1alpha1.ControlPlaneRefValidConditionType && c.Status == metav1.ConditionTrue
-					}), "KongRoute does not have ControlPlaneRefValid condition set to True"
-				},
-				func(ks *configurationv1alpha1.KongRoute) (bool, string) {
-					return lo.ContainsBy(ks.Status.Conditions, func(c metav1.Condition) bool {
 						return c.Type == konnectv1alpha1.KongServiceRefValidConditionType && c.Status == metav1.ConditionTrue
 					}), "KongRoute does not have KongServiceRefValid condition set to True"
 				},
@@ -158,10 +153,6 @@ func TestHandleServiceRef(t *testing.T) {
 				func(ks *configurationv1alpha1.KongRoute) (bool, string) {
 					return ks.Status.Konnect.ServiceID == "12345",
 						"KongRoute does not have Konnect Service ID set"
-				},
-				func(ks *configurationv1alpha1.KongRoute) (bool, string) {
-					return ks.Status.Konnect.ControlPlaneID == "123456789",
-						"KongRoute does not have Konnect ControlPlane ID set (should be inherited from ControlPlane)"
 				},
 			},
 		},

--- a/controller/konnect/watch_kongroute.go
+++ b/controller/konnect/watch_kongroute.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kong/gateway-operator/internal/utils/index"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
 // TODO(pmalek): this can be extracted and used in reconciler.go
@@ -48,6 +49,16 @@ func KongRouteReconciliationWatchOptions(
 				),
 				builder.WithPredicates(
 					predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1alpha1.KongService]),
+				),
+			)
+		},
+		func(b *ctrl.Builder) *ctrl.Builder {
+			return b.Watches(
+				&konnectv1alpha1.KonnectGatewayControlPlane{},
+				handler.EnqueueRequestsFromMapFunc(
+					enqueueObjectForKonnectGatewayControlPlane[configurationv1alpha1.KongRouteList](
+						cl, index.IndexFieldKongRouteOnKonnectGatewayControlPlane,
+					),
 				),
 			)
 		},

--- a/internal/utils/index/kongroute.go
+++ b/internal/utils/index/kongroute.go
@@ -12,10 +12,12 @@ const (
 	IndexFieldKongRouteOnReferencedPluginNames = "kongRouteKongPluginRef"
 	// IndexFieldKongRouteOnReferencedKongService is the index field for KongRoute -> KongService.
 	IndexFieldKongRouteOnReferencedKongService = "kongRouteKongServiceRef"
+	// IndexFieldKongRouteOnKonnectGatewayControlPlane is the index field for KongRoute -> KonnectGatewayControlPlane.
+	IndexFieldKongRouteOnKonnectGatewayControlPlane = "kongRouteKonnectGatewayControlPlaneRef"
 )
 
 // OptionsForKongRoute returns required Index options for KongRoute reconciler.
-func OptionsForKongRoute() []Option {
+func OptionsForKongRoute(cl client.Client) []Option {
 	return []Option{
 		{
 			Object:         &configurationv1alpha1.KongRoute{},
@@ -26,6 +28,11 @@ func OptionsForKongRoute() []Option {
 			Object:         &configurationv1alpha1.KongRoute{},
 			Field:          IndexFieldKongRouteOnReferencedKongService,
 			ExtractValueFn: kongRouteRefersToKongService,
+		},
+		{
+			Object:         &configurationv1alpha1.KongRoute{},
+			Field:          IndexFieldKongRouteOnKonnectGatewayControlPlane,
+			ExtractValueFn: indexKonnectGatewayControlPlaneRef[configurationv1alpha1.KongRoute](cl),
 		},
 	}
 }

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -193,7 +193,7 @@ func SetupCacheIndexes(ctx context.Context, mgr manager.Manager, cfg Config) err
 			index.OptionsForKongConsumer(cl),
 			index.OptionsForKongConsumerGroup(cl),
 			index.OptionsForKongService(cl),
-			index.OptionsForKongRoute(),
+			index.OptionsForKongRoute(cl),
 			index.OptionsForKongUpstream(cl),
 			index.OptionsForKongTarget(),
 			index.OptionsForKongSNI(),

--- a/test/helpers/deploy/deploy_resources.go
+++ b/test/helpers/deploy/deploy_resources.go
@@ -473,6 +473,42 @@ func KongRouteAttachedToService(
 	return &kongRoute
 }
 
+// KongRouteAttachedToControlPlane deploys a KongRoute resource and returns the resource.
+func KongRouteAttachedToControlPlane(
+	t *testing.T,
+	ctx context.Context,
+	cl client.Client,
+	cp *konnectv1alpha1.KonnectGatewayControlPlane,
+	opts ...ObjOption,
+) *configurationv1alpha1.KongRoute {
+	t.Helper()
+
+	name := "kongroute-" + uuid.NewString()[:8]
+	kongRoute := configurationv1alpha1.KongRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: configurationv1alpha1.KongRouteSpec{
+			KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+				Name: lo.ToPtr(name),
+			},
+			ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+				Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+				KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+					Name: cp.Name,
+				},
+			},
+		},
+	}
+	for _, opt := range opts {
+		opt(&kongRoute)
+	}
+	require.NoError(t, cl.Create(ctx, &kongRoute))
+	logObjectCreate(t, &kongRoute)
+
+	return &kongRoute
+}
+
 // KongConsumerWithProgrammed deploys a KongConsumer resource and returns the resource.
 func KongConsumerWithProgrammed(
 	t *testing.T,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR implements it similarly as it has been done for `KongKey` and `KongKeySet` ([as suggested in the comment](https://github.com/Kong/gateway-operator/issues/668#issuecomment-2388681464)).


**Which issue this PR fixes**

Closes #668 


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
