### PR TITLE
tests: add support for KONG_TEST_DISABLE_CRD_INSTALL which disables installing CRDs in integration and conformance tests

### DIFF
--- a/pkg/utils/test/setup_helpers.go
+++ b/pkg/utils/test/setup_helpers.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/kong/gateway-operator/modules/manager"
+	"github.com/kong/gateway-operator/test"
 
 	operatorclient "github.com/kong/kubernetes-configuration/pkg/clientset"
 )
@@ -213,6 +214,10 @@ func ExtractModuleVersion(moduleName string) (string, error) {
 
 // DeployCRDs deploys the CRDs commonly used in tests.
 func DeployCRDs(ctx context.Context, crdPath string, operatorClient *operatorclient.Clientset, cluster clusters.Cluster) error {
+	if test.IsInstallingCRDsDisabled() {
+		return nil
+	}
+
 	// CRDs for stable features.
 	kubectlFlags := []string{"--server-side", "-v5"}
 	fmt.Printf("INFO: deploying KGO CRDs: %s\n", crdPath)

--- a/pkg/utils/test/setup_helpers.go
+++ b/pkg/utils/test/setup_helpers.go
@@ -26,7 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/kong/gateway-operator/modules/manager"
-	"github.com/kong/gateway-operator/test"
 
 	operatorclient "github.com/kong/kubernetes-configuration/pkg/clientset"
 )
@@ -214,10 +213,6 @@ func ExtractModuleVersion(moduleName string) (string, error) {
 
 // DeployCRDs deploys the CRDs commonly used in tests.
 func DeployCRDs(ctx context.Context, crdPath string, operatorClient *operatorclient.Clientset, cluster clusters.Cluster) error {
-	if test.IsInstallingCRDsDisabled() {
-		return nil
-	}
-
 	// CRDs for stable features.
 	kubectlFlags := []string{"--server-side", "-v5"}
 	fmt.Printf("INFO: deploying KGO CRDs: %s\n", crdPath)

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -107,8 +107,10 @@ func TestMain(m *testing.M) {
 	err = os.Setenv("POD_NAMESPACE", "kong-system")
 	exitOnErr(err)
 
-	fmt.Println("INFO: deploying CRDs to test cluster")
-	exitOnErr(testutils.DeployCRDs(ctx, path.Join(configPath, "/crd"), clients.OperatorClient, env.Cluster()))
+	if !test.IsInstallingCRDsDisabled() {
+		fmt.Println("INFO: deploying CRDs to test cluster")
+		exitOnErr(testutils.DeployCRDs(ctx, path.Join(configPath, "/crd"), clients.OperatorClient, env.Cluster()))
+	}
 
 	fmt.Println("INFO: starting the operator's controller manager")
 	// startControllerManager will spawn the controller manager in a separate

--- a/test/envvars.go
+++ b/test/envvars.go
@@ -39,6 +39,17 @@ func IsMetalLBDisabled() bool {
 	return ret
 }
 
+// IsInstallingCRDsDisabled returns true if installing CRDs is disabled in the test environment.
+func IsInstallingCRDsDisabled() bool {
+	ret := strings.ToLower(os.Getenv("KONG_TEST_DISABLE_CRD_INSTALL")) == "true"
+	if ret {
+		fmt.Println("INFO: Installing CRDs is disabled")
+	} else {
+		fmt.Println("INFO: Installing CRDs is enabled")
+	}
+	return ret
+}
+
 // KonnectAccessToken returns the Konnect access token for the test environment.
 func KonnectAccessToken() string {
 	return os.Getenv("KONG_TEST_KONNECT_ACCESS_TOKEN")

--- a/test/integration/suite.go
+++ b/test/integration/suite.go
@@ -149,8 +149,10 @@ func TestMain(
 	err = os.Setenv("POD_NAMESPACE", "kong-system")
 	exitOnErr(err)
 
-	fmt.Println("INFO: deploying CRDs to test cluster")
-	exitOnErr(testutils.DeployCRDs(GetCtx(), path.Join(configPath, "/crd"), GetClients().OperatorClient, GetEnv().Cluster()))
+	if !test.IsInstallingCRDsDisabled() {
+		fmt.Println("INFO: deploying CRDs to test cluster")
+		exitOnErr(testutils.DeployCRDs(GetCtx(), path.Join(configPath, "/crd"), GetClients().OperatorClient, GetEnv().Cluster()))
+	}
 
 	fmt.Println("INFO: starting the operator's controller manager")
 	// Spawn the controller manager based on passed config in


### PR DESCRIPTION
**What this PR does / why we need it**:

Useful in local development when we don't need to keep re-installing the CRDs over and over again.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
