### PR TITLE
chore(deps): bump `kubernetes-configuration` and adjust code

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=7dde593f190e9516679ab8fdd7b5d9c56a1b3817 # Version is auto-updated by the generating script.
+  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=1c6842bc66da6bb32b30be6e1464bfcf04e9e46c # Version is auto-updated by the generating script.

--- a/controller/konnect/konnectextension_controller_utils.go
+++ b/controller/konnect/konnectextension_controller_utils.go
@@ -66,7 +66,7 @@ func (r *KonnectExtensionReconciler) getGatewayKonnectControlPlane(
 	case commonv1alpha1.ControlPlaneRefKonnectID:
 		kgcpList := &konnectv1alpha1.KonnectGatewayControlPlaneList{}
 		if err := r.List(ctx, kgcpList, client.InNamespace(ext.Namespace), client.MatchingFields{
-			index.IndexFieldKonnectGatewayControlPlaneOnKonnectID: *ext.Spec.Konnect.ControlPlane.Ref.KonnectID,
+			index.IndexFieldKonnectGatewayControlPlaneOnKonnectID: string(*ext.Spec.Konnect.ControlPlane.Ref.KonnectID),
 		}); err != nil {
 			return nil, ctrl.Result{}, err
 		}

--- a/controller/konnect/ops/ops_controlplane_test.go
+++ b/controller/konnect/ops/ops_controlplane_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
@@ -48,8 +47,8 @@ func TestCreateControlPlane(t *testing.T) {
 				sdkGroups := sdkmocks.NewMockControlPlaneGroupSDK(t)
 				cp := &konnectv1alpha1.KonnectGatewayControlPlane{
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-							Name: "cp-1",
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name: lo.ToPtr("cp-1"),
 						},
 					},
 				}
@@ -58,7 +57,7 @@ func TestCreateControlPlane(t *testing.T) {
 				expectedRequest.Labels = WithKubernetesMetadataLabels(cp, expectedRequest.Labels)
 				sdk.
 					EXPECT().
-					CreateControlPlane(ctx, expectedRequest).
+					CreateControlPlane(ctx, convertCreateControlPlaneRequestToSDK(expectedRequest)).
 					Return(
 						&sdkkonnectops.CreateControlPlaneResponse{
 							ControlPlane: &sdkkonnectcomp.ControlPlane{
@@ -83,8 +82,8 @@ func TestCreateControlPlane(t *testing.T) {
 						Namespace: "default",
 					},
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-							Name: "cp-1",
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name: lo.ToPtr("cp-1"),
 						},
 					},
 				}
@@ -93,7 +92,7 @@ func TestCreateControlPlane(t *testing.T) {
 				expectedRequest.Labels = WithKubernetesMetadataLabels(cp, expectedRequest.Labels)
 				sdk.
 					EXPECT().
-					CreateControlPlane(ctx, expectedRequest).
+					CreateControlPlane(ctx, convertCreateControlPlaneRequestToSDK(expectedRequest)).
 					Return(
 						nil,
 						&sdkkonnecterrs.BadRequestError{
@@ -136,9 +135,9 @@ func TestCreateControlPlane(t *testing.T) {
 						Namespace: "default",
 					},
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
 							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup),
-							Name:        "cpg-1",
+							Name:        lo.ToPtr("cpg-1"),
 						},
 						Members: []corev1.LocalObjectReference{
 							{
@@ -151,7 +150,7 @@ func TestCreateControlPlane(t *testing.T) {
 				expectedRequest.Labels = WithKubernetesMetadataLabels(cp, expectedRequest.Labels)
 				sdk.
 					EXPECT().
-					CreateControlPlane(ctx, expectedRequest).
+					CreateControlPlane(ctx, convertCreateControlPlaneRequestToSDK(expectedRequest)).
 					Return(
 						&sdkkonnectops.CreateControlPlaneResponse{
 							ControlPlane: &sdkkonnectcomp.ControlPlane{
@@ -205,9 +204,9 @@ func TestCreateControlPlane(t *testing.T) {
 						Namespace: "default",
 					},
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
 							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup),
-							Name:        "cpg-1",
+							Name:        lo.ToPtr("cpg-1"),
 						},
 						Members: []corev1.LocalObjectReference{
 							{
@@ -220,7 +219,7 @@ func TestCreateControlPlane(t *testing.T) {
 				expectedRequest.Labels = WithKubernetesMetadataLabels(cp, expectedRequest.Labels)
 				sdk.
 					EXPECT().
-					CreateControlPlane(ctx, expectedRequest).
+					CreateControlPlane(ctx, convertCreateControlPlaneRequestToSDK(expectedRequest)).
 					Return(
 						&sdkkonnectops.CreateControlPlaneResponse{
 							ControlPlane: &sdkkonnectcomp.ControlPlane{
@@ -287,8 +286,8 @@ func TestDeleteControlPlane(t *testing.T) {
 				sdk := sdkmocks.NewMockControlPlaneSDK(t)
 				cp := &konnectv1alpha1.KonnectGatewayControlPlane{
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-							Name: "cp-1",
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name: lo.ToPtr("cp-1"),
 						},
 					},
 					Status: konnectv1alpha1.KonnectGatewayControlPlaneStatus{
@@ -320,8 +319,8 @@ func TestDeleteControlPlane(t *testing.T) {
 						Namespace: "default",
 					},
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-							Name: "cp-1",
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name: lo.ToPtr("cp-1"),
 						},
 					},
 					Status: konnectv1alpha1.KonnectGatewayControlPlaneStatus{
@@ -355,8 +354,8 @@ func TestDeleteControlPlane(t *testing.T) {
 						Namespace: "default",
 					},
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-							Name: "cp-1",
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name: lo.ToPtr("cp-1"),
 						},
 					},
 					Status: konnectv1alpha1.KonnectGatewayControlPlaneStatus{
@@ -416,8 +415,8 @@ func TestUpdateControlPlane(t *testing.T) {
 				sdkGroups := sdkmocks.NewMockControlPlaneGroupSDK(t)
 				cp := &konnectv1alpha1.KonnectGatewayControlPlane{
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-							Name: "cp-1",
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name: lo.ToPtr("cp-1"),
 						},
 					},
 					Status: konnectv1alpha1.KonnectGatewayControlPlaneStatus{
@@ -430,7 +429,7 @@ func TestUpdateControlPlane(t *testing.T) {
 					EXPECT().
 					UpdateControlPlane(ctx, "12345",
 						sdkkonnectcomp.UpdateControlPlaneRequest{
-							Name:        sdkkonnectgo.String(cp.Spec.Name),
+							Name:        cp.Spec.Name,
 							Description: cp.Spec.Description,
 							AuthType:    (*sdkkonnectcomp.UpdateControlPlaneRequestAuthType)(cp.Spec.AuthType),
 							ProxyUrls:   cp.Spec.ProxyUrls,
@@ -461,8 +460,8 @@ func TestUpdateControlPlane(t *testing.T) {
 						Namespace: "default",
 					},
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-							Name: "cp-1",
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name: lo.ToPtr("cp-1"),
 						},
 					},
 					Status: konnectv1alpha1.KonnectGatewayControlPlaneStatus{
@@ -476,7 +475,7 @@ func TestUpdateControlPlane(t *testing.T) {
 					EXPECT().
 					UpdateControlPlane(ctx, "12345",
 						sdkkonnectcomp.UpdateControlPlaneRequest{
-							Name:        sdkkonnectgo.String(cp.Spec.Name),
+							Name:        cp.Spec.Name,
 							Description: cp.Spec.Description,
 							AuthType:    (*sdkkonnectcomp.UpdateControlPlaneRequestAuthType)(cp.Spec.AuthType),
 							ProxyUrls:   cp.Spec.ProxyUrls,
@@ -506,8 +505,8 @@ func TestUpdateControlPlane(t *testing.T) {
 						Namespace: "default",
 					},
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-							Name: "cp-1",
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name: lo.ToPtr("cp-1"),
 						},
 					},
 					Status: konnectv1alpha1.KonnectGatewayControlPlaneStatus{
@@ -521,7 +520,7 @@ func TestUpdateControlPlane(t *testing.T) {
 					EXPECT().
 					UpdateControlPlane(ctx, "12345",
 						sdkkonnectcomp.UpdateControlPlaneRequest{
-							Name:        sdkkonnectgo.String(cp.Spec.Name),
+							Name:        cp.Spec.Name,
 							Description: cp.Spec.Description,
 							AuthType:    (*sdkkonnectcomp.UpdateControlPlaneRequestAuthType)(cp.Spec.AuthType),
 							ProxyUrls:   cp.Spec.ProxyUrls,
@@ -536,8 +535,10 @@ func TestUpdateControlPlane(t *testing.T) {
 						},
 					)
 
-				expectedRequest := cp.Spec.CreateControlPlaneRequest
-				expectedRequest.Labels = WithKubernetesMetadataLabels(cp, expectedRequest.Labels)
+				expectedRequest := sdkkonnectcomp.CreateControlPlaneRequest{ // Use the correct struct type
+					Name:   lo.FromPtr(cp.Spec.Name),
+					Labels: WithKubernetesMetadataLabels(cp, cp.Spec.Labels),
+				}
 				sdk.
 					EXPECT().
 					CreateControlPlane(ctx, expectedRequest).
@@ -589,8 +590,8 @@ func TestCreateAndUpdateControlPlane_KubernetesMetadataConsistency(t *testing.T)
 				Generation: 2,
 			},
 			Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-				CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-					Name: "cp-1",
+				CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+					Name: lo.ToPtr("cp-1"),
 				},
 			},
 		}
@@ -655,8 +656,8 @@ func TestSetGroupMembers(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-						Name:        "cp-group",
+					CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+						Name:        lo.ToPtr("cp-group"),
 						ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup),
 					},
 				},
@@ -685,8 +686,8 @@ func TestSetGroupMembers(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-						Name:        "cp-group",
+					CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+						Name:        lo.ToPtr("cp-group"),
 						ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup),
 					},
 					Members: []corev1.LocalObjectReference{
@@ -740,8 +741,8 @@ func TestSetGroupMembers(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-						Name:        "cp-group",
+					CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+						Name:        lo.ToPtr("cp-group"),
 						ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup),
 					},
 					Members: []corev1.LocalObjectReference{
@@ -776,8 +777,8 @@ func TestSetGroupMembers(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-						Name:        "cp-group",
+					CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+						Name:        lo.ToPtr("cp-group"),
 						ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup),
 					},
 					Members: []corev1.LocalObjectReference{
@@ -848,8 +849,8 @@ func TestSetGroupMembers(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-						Name:        "cp-group",
+					CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+						Name:        lo.ToPtr("cp-group"),
 						ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup),
 					},
 					Members: []corev1.LocalObjectReference{

--- a/controller/konnect/ops/ops_test.go
+++ b/controller/konnect/ops/ops_test.go
@@ -8,6 +8,7 @@ import (
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -47,8 +48,8 @@ func TestCreate(t *testing.T) {
 					Namespace: "test-ns",
 				},
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-						Name: "test-cp",
+					CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+						Name: lo.ToPtr("test-cp"),
 						Labels: map[string]string{
 							"label": "very-long-label-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 						},
@@ -110,8 +111,8 @@ func TestCreate(t *testing.T) {
 					Namespace: "test-ns",
 				},
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-						Name: "test-cp",
+					CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+						Name: lo.ToPtr("test-cp"),
 					},
 				},
 			},
@@ -176,8 +177,8 @@ func TestCreate(t *testing.T) {
 					Namespace: "test-ns",
 				},
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-						Name: "test-cp",
+					CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+						Name: lo.ToPtr("test-cp"),
 					},
 				},
 			},

--- a/controller/konnect/reconciler_controlplaneref_test.go
+++ b/controller/konnect/reconciler_controlplaneref_test.go
@@ -59,7 +59,7 @@ func TestHandleControlPlaneRef(t *testing.T) {
 				Name:      "cp-group",
 			},
 			Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-				CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+				CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
 					ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup),
 				},
 			},

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/terratest v0.48.2
-	github.com/kong/kubernetes-configuration v1.3.2-0.20250411121302-7dde593f190e
+	github.com/kong/kubernetes-configuration v1.3.2-0.20250416141332-1c6842bc66da
 	github.com/kong/kubernetes-telemetry v0.1.9
 	github.com/kong/kubernetes-testing-framework v0.47.2
 	github.com/kong/semver/v4 v4.0.1

--- a/go.sum
+++ b/go.sum
@@ -309,8 +309,8 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kong/go-kong v0.65.1 h1:CM+8NlF+VbJckTxP2hGmSPKhA1GMliitXjQ7vJiPkaE=
 github.com/kong/go-kong v0.65.1/go.mod h1:sqdysTKrXIJ6mpxHwTwjgZhLW7jR1/puczTXHLUwJaE=
-github.com/kong/kubernetes-configuration v1.3.2-0.20250411121302-7dde593f190e h1:7UJfOI5LFtAtIjQWm9DSZaoGV7O68u1fkHsG6F2wHUE=
-github.com/kong/kubernetes-configuration v1.3.2-0.20250411121302-7dde593f190e/go.mod h1:+HRrz0eeoy7d5YJYiCkk736xaSq3y9fbV5SvucYo/tY=
+github.com/kong/kubernetes-configuration v1.3.2-0.20250416141332-1c6842bc66da h1:LLP1I+lIdU+hbasONUxnjpK2TUAr0juMqw+bqygwYd8=
+github.com/kong/kubernetes-configuration v1.3.2-0.20250416141332-1c6842bc66da/go.mod h1:+HRrz0eeoy7d5YJYiCkk736xaSq3y9fbV5SvucYo/tY=
 github.com/kong/kubernetes-telemetry v0.1.9 h1:XbDMZjZZclHO4oyJGW1mmZ6bzbTnANjcRAYsBg+jpno=
 github.com/kong/kubernetes-telemetry v0.1.9/go.mod h1:lBSbaQdJkoMMO0d+cJWopoJiJ+QHFBttbhCp5VRibJ8=
 github.com/kong/kubernetes-testing-framework v0.47.2 h1:+2Z9anTpbV/hwNeN+NFQz53BMU+g3QJydkweBp3tULo=

--- a/test/envtest/dataplane_konnectextensions_test.go
+++ b/test/envtest/dataplane_konnectextensions_test.go
@@ -54,7 +54,7 @@ func TestDataPlaneKonnectExtension(t *testing.T) {
 
 	const (
 		clusterCASecretName   = "cluster-ca"
-		konnectControlPlaneID = "konnect-cp-id"
+		konnectControlPlaneID = "aee0667a-90c6-45a6-a2d8-575e1e487b86"
 	)
 
 	clusterCAKeyConfig := secrets.KeyConfig{
@@ -131,7 +131,7 @@ func TestDataPlaneKonnectExtension(t *testing.T) {
 				ControlPlane: konnectv1alpha1.KonnectExtensionControlPlane{
 					Ref: commonv1alpha1.ControlPlaneRef{
 						Type:      commonv1alpha1.ControlPlaneRefKonnectID,
-						KonnectID: lo.ToPtr(konnectControlPlaneID),
+						KonnectID: lo.ToPtr(commonv1alpha1.KonnectIDType(konnectControlPlaneID)),
 					},
 				},
 				Configuration: &konnectv1alpha1.KonnectConfiguration{

--- a/test/envtest/konnect_entities_gatewaycontrolplane_test.go
+++ b/test/envtest/konnect_entities_gatewaycontrolplane_test.go
@@ -35,7 +35,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 				func(obj client.Object) {
 					cp := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
 					cp.Name = "cp-1"
-					cp.Spec.Name = "cp-1"
+					cp.Spec.Name = lo.ToPtr("cp-1")
 					cp.Spec.Description = lo.ToPtr("test control plane 1")
 				},
 			)
@@ -114,14 +114,14 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 				func(obj client.Object) {
 					cp := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
 					cp.Name = "cp-groupmember-1"
-					cp.Spec.Name = "cp-groupmember-1"
+					cp.Spec.Name = lo.ToPtr("cp-groupmember-1")
 				},
 			)
 			deploy.KonnectGatewayControlPlane(t, ctx, cl, auth,
 				func(obj client.Object) {
 					cp := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
 					cp.Name = "cp-2"
-					cp.Spec.Name = "cp-2"
+					cp.Spec.Name = lo.ToPtr("cp-2")
 					cp.Spec.ClusterType = lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup)
 					cp.Spec.Members = []corev1.LocalObjectReference{
 						{
@@ -280,14 +280,14 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 				func(obj client.Object) {
 					cp := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
 					cp.Name = "cp-groupmember-2"
-					cp.Spec.Name = "cp-groupmember-2"
+					cp.Spec.Name = lo.ToPtr("cp-groupmember-2")
 				},
 			)
 			deploy.KonnectGatewayControlPlane(t, ctx, cl, auth,
 				func(obj client.Object) {
 					cp := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
 					cp.Name = "cp-3"
-					cp.Spec.Name = "cp-3"
+					cp.Spec.Name = lo.ToPtr("cp-3")
 					cp.Spec.ClusterType = lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup)
 					cp.Spec.Members = []corev1.LocalObjectReference{
 						{
@@ -443,7 +443,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 				func(obj client.Object) {
 					cp := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
 					cp.Name = "cp-4"
-					cp.Spec.Name = "cp-4"
+					cp.Spec.Name = lo.ToPtr("cp-4")
 				},
 			)
 		},
@@ -543,7 +543,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 				func(obj client.Object) {
 					cp := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
 					cp.Name = "cp-5"
-					cp.Spec.Name = "cp-5"
+					cp.Spec.Name = lo.ToPtr("cp-5")
 				},
 			)
 
@@ -551,7 +551,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 				func(obj client.Object) {
 					cp := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
 					cp.Name = "cp-group-1"
-					cp.Spec.Name = "cp-group-1"
+					cp.Spec.Name = lo.ToPtr("cp-group-1")
 					cp.Spec.ClusterType = lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup)
 					cp.Spec.Members = []corev1.LocalObjectReference{
 						{Name: "cp-5"},
@@ -730,7 +730,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 				func(obj client.Object) {
 					cp := obj.(*konnectv1alpha1.KonnectGatewayControlPlane)
 					cp.Name = "cp-group-no-members"
-					cp.Spec.Name = "cp-group-no-members"
+					cp.Spec.Name = lo.ToPtr("cp-group-no-members")
 					cp.Spec.ClusterType = lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup)
 				},
 			)

--- a/test/helpers/deploy/deploy_resources.go
+++ b/test/helpers/deploy/deploy_resources.go
@@ -111,7 +111,7 @@ func WithKonnectIDControlPlaneRef(cp *konnectv1alpha1.KonnectGatewayControlPlane
 		o.SetControlPlaneRef(
 			&commonv1alpha1.ControlPlaneRef{
 				Type:      commonv1alpha1.ControlPlaneRefKonnectID,
-				KonnectID: lo.ToPtr(cp.GetKonnectStatus().GetKonnectID()),
+				KonnectID: lo.ToPtr(commonv1alpha1.KonnectIDType(cp.GetKonnectStatus().GetKonnectID())),
 			},
 		)
 	}
@@ -208,8 +208,8 @@ func KonnectGatewayControlPlane(
 					Name: apiAuth.Name,
 				},
 			},
-			CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-				Name: name,
+			CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+				Name: lo.ToPtr(name),
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump `kubernetes-configuration` to its newest `main` that includes https://github.com/Kong/kubernetes-configuration/pull/386 which is required by 

- https://github.com/Kong/gateway-operator/pull/1492

