### PR TITLE
ci: group Dependabot's Go updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,9 @@
 version: 2
 updates:
 - package-ecosystem: gomod
-  directory: /
-  schedule:
-    interval: daily
-  labels:
-  - dependencies
-  # Create a group of dependencies to be updated together in one pull request
-  groups:
-     # Specify a name for the group, which will be used in pull request titles and branch names
-     k8s.io:
-        # Define patterns to include dependencies in the group (based on dependency name)
-        applies-to: version-updates # Applies the group rule to version updates
-        patterns:
-          - "k8s.io/*"
-        exclude-patterns:
-        - k8s.io/klog/*
-        - k8s.io/utils
-        - k8s.io/kube-openapi
-- package-ecosystem: gomod
-  directory: /hack/generators/
+  directories:
+  - /
+  - /hack/generators/
   schedule:
     interval: daily
   labels:


### PR DESCRIPTION
**What this PR does / why we need it**:

Use https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#defining-multiple-locations-for-manifest-files to merge updates in `/go.mod` and and in `/hack/generators/go.mod`

Docs ref: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
