### PR TITLE
feat: add support for -enforce-config for ControlPlane's ValidatingWebhookConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@
   - `--validate-images` (or `GATEWAY_OPERATOR_VALIDATE_IMAGES` env var) to enable ControlPlane and DataPlane image 
     validation (it's set by default to `true`).
   [#1435](https://github.com/Kong/gateway-operator/pull/1435)
+- Add support for `-enforce-config` for `ControlPlane`'s `ValidatingWebhookConfiguration`.
+  This allows to use operator's `ControlPlane` resources in AKS clusters.
+  [#1512](https://github.com/Kong/gateway-operator/pull/1512)
 
 ### Changes
 

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -407,7 +407,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		WatchNamespaces:         validatedWatchNamespaces,
 	}
 
-	admissionWebhookCertificateSecretName, res, err := r.ensureWebhookResources(ctx, logger, cp)
+	admissionWebhookCertificateSecretName, res, err := r.ensureWebhookResources(ctx, logger, cp, r.EnforceConfig)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to ensure webhook resources: %w", err)
 	} else if res != op.Noop {
@@ -510,7 +510,10 @@ func (r *Reconciler) patchStatus(ctx context.Context, logger logr.Logger, update
 }
 
 func (r *Reconciler) ensureWebhookResources(
-	ctx context.Context, logger logr.Logger, cp *operatorv1beta1.ControlPlane,
+	ctx context.Context,
+	logger logr.Logger,
+	cp *operatorv1beta1.ControlPlane,
+	enforceConfig bool,
 ) (string, op.Result, error) {
 	webhookEnabled := isAdmissionWebhookEnabled(ctx, r.Client, logger, cp)
 	if !webhookEnabled {
@@ -548,7 +551,7 @@ func (r *Reconciler) ensureWebhookResources(
 	}
 
 	log.Trace(logger, "ensuring admission webhook configuration")
-	res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, admissionWebhookCertificateSecret, admissionWebhookService)
+	res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, admissionWebhookCertificateSecret, admissionWebhookService, enforceConfig)
 	if err != nil {
 		return "", res, err
 	}

--- a/controller/controlplane/controller_reconciler_utils_test.go
+++ b/controller/controlplane/controller_reconciler_utils_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
+	const enforceConfig = true
+
 	webhookSvc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "webhook-svc",
@@ -88,14 +90,14 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 					},
 				}
 
-				res, err := r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
+				res, err := r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc, enforceConfig)
 				require.NoError(t, err)
 				require.Equal(t, op.Created, res)
 
 				require.NoError(t, r.List(ctx, &webhooks))
 				require.Len(t, webhooks.Items, 1)
 
-				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
+				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc, enforceConfig)
 				require.NoError(t, err)
 				require.Equal(t, op.Noop, res)
 			},
@@ -154,14 +156,14 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 					},
 				}
 
-				res, err := r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
+				res, err := r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc, enforceConfig)
 				require.NoError(t, err)
 				require.Equal(t, op.Created, res)
 
 				require.NoError(t, r.List(ctx, &webhooks))
 				require.Len(t, webhooks.Items, 1, "webhook configuration should be created")
 
-				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
+				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc, enforceConfig)
 				require.NoError(t, err)
 				require.Equal(t, op.Noop, res)
 
@@ -173,7 +175,7 @@ func Test_ensureValidatingWebhookConfiguration(t *testing.T) {
 				}
 
 				t.Log("running ensureValidatingWebhookConfiguration to enforce ObjectMeta")
-				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc)
+				res, err = r.ensureValidatingWebhookConfiguration(ctx, cp, certSecret, webhookSvc, enforceConfig)
 				require.NoError(t, err)
 				require.Equal(t, op.Updated, res)
 

--- a/controller/dataplane/owned_deployment.go
+++ b/controller/dataplane/owned_deployment.go
@@ -289,12 +289,12 @@ func reconcileDataPlaneDeployment(
 		// existing Deployment with the spec hash of the desired Deployment. If
 		// the hashes match, we skip the update.
 		if !enforceConfig {
-			hash, err := k8sresources.CalculateHash(dataplane.Spec)
+			match, err := k8sresources.SpecHashMatchesAnnotation(dataplane.Spec, existing)
 			if err != nil {
-				return op.Noop, nil, fmt.Errorf("failed to calculate hash spec from DataPlane: %w", err)
+				return op.Noop, nil, err
 			}
-			if h, ok := existing.GetAnnotations()[consts.AnnotationPodTemplateSpecHash]; ok && h == hash {
-				log.Debug(logger, "DataPlane Deployment spec hash matches existing Deployment, skipping update", "hash", hash)
+			if match {
+				log.Debug(logger, "DataPlane Deployment spec hash matches existing Deployment, skipping update")
 				return op.Noop, existing, nil
 			}
 			// If the spec hash does not match, we need to enforce the configuration

--- a/pkg/consts/annotations.go
+++ b/pkg/consts/annotations.go
@@ -1,8 +1,11 @@
 package consts
 
 const (
-	// AnnotationPodTemplateSpecHash is the annotation used to store the hash of the
-	// spec of the DataPlane. This is used to detect changes in the spec of the
-	// DataPlane and trigger a rolling update.
-	AnnotationPodTemplateSpecHash = "gateway-operator.konghq.com/spec-hash"
+	// AnnotationSpecHash is the annotation used to store the hash of the spec
+	// in the owner object.
+	// This is used to detect changes in the spec of the owner object and to prevent
+	// unnecessary updates to the child objects when enforce-config is set to false.
+	// One exemplar use case for this is AKS where Admission Enforcer mutates
+	// ControlPlane's ValidatingWebhookConfiguration.
+	AnnotationSpecHash = "gateway-operator.konghq.com/spec-hash"
 )

--- a/pkg/utils/kubernetes/resources/annotations.go
+++ b/pkg/utils/kubernetes/resources/annotations.go
@@ -31,13 +31,13 @@ func AnnotateObjWithHash[T any](
 ) error {
 	hash, err := CalculateHash(toHash)
 	if err != nil {
-		return fmt.Errorf("failed to calculate hash spec from DataPlane: %w", err)
+		return fmt.Errorf("failed to calculate hash spec from %T: %w", toHash, err)
 	}
 	anns := obj.GetAnnotations()
 	if anns == nil {
 		anns = make(map[string]string)
 	}
-	anns[consts.AnnotationPodTemplateSpecHash] = hash
+	anns[consts.AnnotationSpecHash] = hash
 	obj.SetAnnotations(anns)
 
 	return nil

--- a/pkg/utils/kubernetes/resources/annotations_test.go
+++ b/pkg/utils/kubernetes/resources/annotations_test.go
@@ -60,7 +60,7 @@ func TestSpecHash(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, deployment.Annotations[consts.AnnotationPodTemplateSpecHash])
+			assert.Equal(t, tt.want, deployment.Annotations[consts.AnnotationSpecHash])
 
 			// Running twice yields the same result
 			err = AnnotateObjWithHash(&deployment, tt.opts)
@@ -69,7 +69,7 @@ func TestSpecHash(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, deployment.Annotations[consts.AnnotationPodTemplateSpecHash])
+			assert.Equal(t, tt.want, deployment.Annotations[consts.AnnotationSpecHash])
 		})
 	}
 }

--- a/pkg/utils/kubernetes/resources/hash.go
+++ b/pkg/utils/kubernetes/resources/hash.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 
 	"github.com/gohugoio/hashstructure"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/gateway-operator/pkg/consts"
 )
 
 // CalculateHash calculates the hash of the given object.
@@ -17,4 +20,21 @@ func CalculateHash[T any](
 	}
 
 	return fmt.Sprintf("%0x", hash), nil
+}
+
+// SpecHashMatchesAnnotation calculates the hash of the given spec and returns boolean
+// indicating whether the hash matches the one in the annotations of the given
+// object.
+func SpecHashMatchesAnnotation[T any](
+	spec T,
+	obj client.Object,
+) (bool, error) {
+	hash, err := CalculateHash(spec)
+	if err != nil {
+		return false, fmt.Errorf("failed to calculate hash spec from %T: %w", spec, err)
+	}
+	if h, ok := obj.GetAnnotations()[consts.AnnotationSpecHash]; !ok || h != hash {
+		return false, nil
+	}
+	return true, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support for `-enforce-config` for `ControlPlane`'s `ValidatingWebhookConfiguration`.

This allows to use operator's `ControlPlane` resources in AKS clusters when `-enforce-config` is set to `false` (default `true` will keep giving results as described in #239).

**Which issue this PR fixes**

Fixes #239

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
