### PR TITLE
fix: apply Ingress service name for DP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@
   timeouts and/or delays are specified. Now the HTTPGet field is set to `/status/ready`
   as expected with the `Gateway` scenario.
   [#1395](https://github.com/Kong/gateway-operator/pull/1395)
-- Fix ingress service name is not applied when using GatewayConfiguration.
+- Fix ingress service name not being applied when using `GatewayConfiguration`.
   [#1515](https://github.com/Kong/gateway-operator/pull/1515)
 
 ## [v1.5.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@
   timeouts and/or delays are specified. Now the HTTPGet field is set to `/status/ready`
   as expected with the `Gateway` scenario.
   [#1395](https://github.com/Kong/gateway-operator/pull/1395)
+- Fix ingress service name is not applied when using GatewayConfiguration.
+  [#1515](https://github.com/Kong/gateway-operator/pull/1515)
 
 ## [v1.5.1]
 

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -160,6 +160,7 @@ func gatewayConfigDataPlaneOptionsToDataPlaneOptions(
 						Type:                  opts.Network.Services.Ingress.Type,
 						Annotations:           opts.Network.Services.Ingress.Annotations,
 						ExternalTrafficPolicy: opts.Network.Services.Ingress.ExternalTrafficPolicy,
+						Name:                  opts.Network.Services.Ingress.Name,
 					},
 				},
 			},

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -1159,6 +1159,30 @@ func TestGetSupportedKindsWithResolvedRefsCondition(t *testing.T) {
 	}
 }
 
+func TestServiceNameIsApplied(t *testing.T) {
+	// Create a GatewayConfigDataPlaneOptions with a service name
+	gatewayConfigOpts := operatorv1beta1.GatewayConfigDataPlaneOptions{
+		Network: operatorv1beta1.GatewayConfigDataPlaneNetworkOptions{
+			Services: &operatorv1beta1.GatewayConfigDataPlaneServices{
+				Ingress: &operatorv1beta1.GatewayConfigServiceOptions{
+					ServiceOptions: operatorv1beta1.ServiceOptions{
+						Name: lo.ToPtr("custom-service-name"),
+					},
+				},
+			},
+		},
+	}
+
+	// Convert to DataPlaneOptions
+	dataPlaneOpts := gatewayConfigDataPlaneOptionsToDataPlaneOptions("default", gatewayConfigOpts)
+
+	// Verify that the service name was copied
+	require.NotNil(t, dataPlaneOpts.Network.Services)
+	require.NotNil(t, dataPlaneOpts.Network.Services.Ingress)
+	require.NotNil(t, dataPlaneOpts.Network.Services.Ingress.Name)
+	require.Equal(t, "custom-service-name", *dataPlaneOpts.Network.Services.Ingress.Name)
+}
+
 func TestCountAttachedRoutesForGatewayListener(t *testing.T) {
 	testCases := []struct {
 		Name           string

--- a/test/integration/test_gatewayconfiguration_service_name.go
+++ b/test/integration/test_gatewayconfiguration_service_name.go
@@ -103,7 +103,7 @@ func TestGatewayConfigurationServiceName(t *testing.T) {
 			return false
 		}
 		return *dp.Spec.Network.Services.Ingress.Name == customServiceName
-	}, testutils.GatewayReadyTimeLimit, time.Second)
+	}, testutils.GatewayReadyTimeLimit, testutils.ObjectUpdateTick)
 
 	t.Log("verifying that the service has the custom name")
 	require.Eventually(t, func() bool {
@@ -118,5 +118,5 @@ func TestGatewayConfigurationServiceName(t *testing.T) {
 			}
 		}
 		return false
-	}, testutils.GatewayReadyTimeLimit, time.Second)
+	}, testutils.GatewayReadyTimeLimit, testutils.ObjectUpdateTick)
 }

--- a/test/integration/test_gatewayconfiguration_service_name.go
+++ b/test/integration/test_gatewayconfiguration_service_name.go
@@ -1,0 +1,122 @@
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	gwtypes "github.com/kong/gateway-operator/internal/types"
+	gatewayutils "github.com/kong/gateway-operator/pkg/utils/gateway"
+	testutils "github.com/kong/gateway-operator/pkg/utils/test"
+	"github.com/kong/gateway-operator/pkg/vars"
+	"github.com/kong/gateway-operator/test/helpers"
+
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+)
+
+func TestGatewayConfigurationServiceName(t *testing.T) {
+	t.Parallel()
+	namespace, cleaner := helpers.SetupTestEnv(t, GetCtx(), GetEnv())
+
+	// Create a custom service name
+	customServiceName := "custom-service-name-" + uuid.NewString()
+
+	t.Log("deploying a GatewayConfiguration resource with a custom service name")
+	gatewayConfig := &operatorv1beta1.GatewayConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace.Name,
+			Name:      uuid.NewString(),
+		},
+		Spec: operatorv1beta1.GatewayConfigurationSpec{
+			DataPlaneOptions: &operatorv1beta1.GatewayConfigDataPlaneOptions{
+				Network: operatorv1beta1.GatewayConfigDataPlaneNetworkOptions{
+					Services: &operatorv1beta1.GatewayConfigDataPlaneServices{
+						Ingress: &operatorv1beta1.GatewayConfigServiceOptions{
+							ServiceOptions: operatorv1beta1.ServiceOptions{
+								Name: &customServiceName,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	gatewayConfig, err := GetClients().OperatorClient.GatewayOperatorV1beta1().GatewayConfigurations(namespace.Name).Create(GetCtx(), gatewayConfig, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(gatewayConfig)
+
+	t.Log("deploying a GatewayClass resource with the GatewayConfiguration attached via ParametersReference")
+	gatewayClass := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: uuid.NewString(),
+		},
+		Spec: gatewayv1.GatewayClassSpec{
+			ParametersRef: &gatewayv1.ParametersReference{
+				Group:     gatewayv1.Group(operatorv1beta1.SchemeGroupVersion.Group),
+				Kind:      gatewayv1.Kind("GatewayConfiguration"),
+				Namespace: (*gatewayv1.Namespace)(&gatewayConfig.Namespace),
+				Name:      gatewayConfig.Name,
+			},
+			ControllerName: gatewayv1.GatewayController(vars.ControllerName()),
+		},
+	}
+	gatewayClass, err = GetClients().GatewayClient.GatewayV1().GatewayClasses().Create(GetCtx(), gatewayClass, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(gatewayClass)
+
+	t.Log("deploying Gateway resource")
+	gateway := &gwtypes.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace.Name,
+			Name:      uuid.NewString(),
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(gatewayClass.Name),
+			Listeners: []gatewayv1.Listener{{
+				Name:     "http",
+				Protocol: gatewayv1.HTTPProtocolType,
+				Port:     gatewayv1.PortNumber(80),
+			}},
+		},
+	}
+	gateway, err = GetClients().GatewayClient.GatewayV1().Gateways(namespace.Name).Create(GetCtx(), gateway, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(gateway)
+
+	t.Log("verifying that the DataPlane has the custom service name")
+	require.Eventually(t, func() bool {
+		dataplanes, err := gatewayutils.ListDataPlanesForGateway(GetCtx(), GetClients().MgrClient, gateway)
+		if err != nil {
+			return false
+		}
+		if len(dataplanes) != 1 {
+			return false
+		}
+		dp := dataplanes[0]
+		if dp.Spec.Network.Services == nil || dp.Spec.Network.Services.Ingress == nil || dp.Spec.Network.Services.Ingress.Name == nil {
+			return false
+		}
+		return *dp.Spec.Network.Services.Ingress.Name == customServiceName
+	}, testutils.GatewayReadyTimeLimit, time.Second)
+
+	t.Log("verifying that the service has the custom name")
+	require.Eventually(t, func() bool {
+		var serviceList corev1.ServiceList
+		err := GetClients().MgrClient.List(GetCtx(), &serviceList, client.InNamespace(namespace.Name))
+		if err != nil {
+			return false
+		}
+		for _, svc := range serviceList.Items {
+			if svc.Name == customServiceName {
+				return true
+			}
+		}
+		return false
+	}, testutils.GatewayReadyTimeLimit, time.Second)
+}

--- a/test/integration/zz_generated.registered_testcases.go
+++ b/test/integration/zz_generated.registered_testcases.go
@@ -22,6 +22,7 @@ func init() {
 		TestGatewayClassCreation,
 		TestGatewayClassUpdates,
 		TestGatewayConfigurationEssentials,
+		TestGatewayConfigurationServiceName,
 		TestGatewayDataPlaneNetworkPolicy,
 		TestGatewayEssentials,
 		TestGatewayMultiple,


### PR DESCRIPTION
**What this PR does / why we need it**:

When a Gateway is created with a GatewayConfiguration that specifies a service name for the ingress service, that name is not being applied to the DataPlane that gets created. This is because the `gatewayConfigDataPlaneOptionsToDataPlaneOptions` function in `controller/gateway/controller_reconciler_utils.go` is not copying the `Name` field from the GatewayConfiguration to the DataPlane.

**Which issue this PR fixes**

Fixes https://github.com/Kong/gateway-operator/issues/1411

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
