### PR TITLE
chore: upgrade kubernetes-configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@
 - Bump default `DataPlane` image to 3.10
   Default image changes from `kong` to `kong/kong-gateway`.
   [#1405](https://github.com/Kong/gateway-operator/pull/1405)
+- Updated `kubernetes-configuration` dependency for adding `scale` subresource for `DataPlane` CRD.
+  [#1523](https://github.com/Kong/gateway-operator/pull/1523)
 
 ### Fixes
 

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=1c6842bc66da6bb32b30be6e1464bfcf04e9e46c # Version is auto-updated by the generating script.
+  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=9a4e025f1ccb904ba3f6bfd4e2d639460d0655ef # Version is auto-updated by the generating script.

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/terratest v0.48.2
-	github.com/kong/kubernetes-configuration v1.3.2-0.20250416141332-1c6842bc66da
+	github.com/kong/kubernetes-configuration v1.3.2-0.20250422040405-9a4e025f1ccb
 	github.com/kong/kubernetes-telemetry v0.1.9
 	github.com/kong/kubernetes-testing-framework v0.47.2
 	github.com/kong/semver/v4 v4.0.1

--- a/go.sum
+++ b/go.sum
@@ -309,8 +309,8 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kong/go-kong v0.65.1 h1:CM+8NlF+VbJckTxP2hGmSPKhA1GMliitXjQ7vJiPkaE=
 github.com/kong/go-kong v0.65.1/go.mod h1:sqdysTKrXIJ6mpxHwTwjgZhLW7jR1/puczTXHLUwJaE=
-github.com/kong/kubernetes-configuration v1.3.2-0.20250416141332-1c6842bc66da h1:LLP1I+lIdU+hbasONUxnjpK2TUAr0juMqw+bqygwYd8=
-github.com/kong/kubernetes-configuration v1.3.2-0.20250416141332-1c6842bc66da/go.mod h1:+HRrz0eeoy7d5YJYiCkk736xaSq3y9fbV5SvucYo/tY=
+github.com/kong/kubernetes-configuration v1.3.2-0.20250422040405-9a4e025f1ccb h1:jQCvZ7rKYcYLLSR7QXmwpGKIK8j3P7mBYARP8WHYVf8=
+github.com/kong/kubernetes-configuration v1.3.2-0.20250422040405-9a4e025f1ccb/go.mod h1:3p31CROMO9LZmAB18Udn0luTPl/xu5XLls6DQj4IjB4=
 github.com/kong/kubernetes-telemetry v0.1.9 h1:XbDMZjZZclHO4oyJGW1mmZ6bzbTnANjcRAYsBg+jpno=
 github.com/kong/kubernetes-telemetry v0.1.9/go.mod h1:lBSbaQdJkoMMO0d+cJWopoJiJ+QHFBttbhCp5VRibJ8=
 github.com/kong/kubernetes-testing-framework v0.47.2 h1:+2Z9anTpbV/hwNeN+NFQz53BMU+g3QJydkweBp3tULo=

--- a/test/integration/test_dataplane_scale_subresource.go
+++ b/test/integration/test_dataplane_scale_subresource.go
@@ -1,0 +1,108 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/gateway-operator/pkg/consts"
+	testutils "github.com/kong/gateway-operator/pkg/utils/test"
+	"github.com/kong/gateway-operator/test/helpers"
+
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+)
+
+// TestDataPlaneScaleSubresource tests the scale subresource of the DataPlane CRD.
+// It verifies that when a deployment is restarted using kubectl rollout restart,
+// the new ReplicaSet maintains the correct replica count.
+func TestDataPlaneScaleSubresource(t *testing.T) {
+	t.Parallel()
+
+	namespace, cleaner := helpers.SetupTestEnv(t, GetCtx(), GetEnv())
+	clients := GetClients()
+
+	t.Log("deploying dataplane resource with 2 replicas")
+	dataplane := &operatorv1beta1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    namespace.Name,
+			GenerateName: "dataplane-scale-test-",
+		},
+		Spec: operatorv1beta1.DataPlaneSpec{
+			DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+				Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+					DeploymentOptions: operatorv1beta1.DeploymentOptions{
+						Replicas: lo.ToPtr(int32(2)), // Set initial replica count to 2
+						PodTemplateSpec: &corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"label-a": "value-a",
+									"label-x": "value-x",
+								},
+							},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Env: []corev1.EnvVar{
+											{
+												Name:  "TEST_ENV",
+												Value: "test",
+											},
+										},
+										Name:  consts.DataPlaneProxyContainerName,
+										Image: helpers.GetDefaultDataPlaneImage(),
+									},
+								},
+							},
+						},
+					},
+				},
+				Network: operatorv1beta1.DataPlaneNetworkOptions{
+					Services: &operatorv1beta1.DataPlaneServices{
+						Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+							ServiceOptions: operatorv1beta1.ServiceOptions{
+								Annotations: map[string]string{
+									"purpose": "scale",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dataplaneClient := clients.OperatorClient.GatewayOperatorV1beta1().DataPlanes(namespace.Name)
+	dataplane, err := dataplaneClient.Create(GetCtx(), dataplane, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(dataplane)
+
+	dataplaneName := client.ObjectKeyFromObject(dataplane)
+
+	t.Log("verifying dataplane gets marked ready")
+	require.Eventually(t, testutils.DataPlaneIsReady(t, GetCtx(), dataplaneName, clients.OperatorClient), testutils.GatewayReadyTimeLimit, testutils.ObjectUpdateTick)
+
+	t.Log("verifying dataplane has 2 ready replicas")
+	require.Eventually(t, testutils.DataPlaneHasNReadyPods(t, GetCtx(), dataplaneName, clients, 2), testutils.GatewayReadyTimeLimit, testutils.ObjectUpdateTick)
+
+	// Get the deployment created by the dataplane controller
+	var deployment appsv1.Deployment
+	require.Eventually(t, testutils.DataPlaneHasActiveDeployment(t, GetCtx(), dataplaneName, &deployment, client.MatchingLabels{
+		consts.GatewayOperatorManagedByLabel: consts.DataPlaneManagedLabelValue,
+	}, clients), testutils.GatewayReadyTimeLimit, testutils.ObjectUpdateTick)
+
+	// Test scaling through the scale subresource
+	t.Log("testing scaling through scale subresource")
+	require.Eventually(t,
+		testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients, func(dp *operatorv1beta1.DataPlane) {
+			dp.Spec.Deployment.Replicas = lo.ToPtr(int32(3)) // Scale up to 3 replicas
+		}),
+		testutils.GatewayReadyTimeLimit, testutils.ObjectUpdateTick)
+
+	t.Log("verifying dataplane scales to 3 replicas")
+	require.Eventually(t, testutils.DataPlaneHasNReadyPods(t, GetCtx(), dataplaneName, clients, 3), testutils.GatewayReadyTimeLimit, testutils.ObjectUpdateTick)
+}

--- a/test/integration/zz_generated.registered_testcases.go
+++ b/test/integration/zz_generated.registered_testcases.go
@@ -13,6 +13,7 @@ func init() {
 		TestDataPlaneEssentials,
 		TestDataPlaneHorizontalScaling,
 		TestDataPlanePodDisruptionBudget,
+		TestDataPlaneScaleSubresource,
 		TestDataPlaneServiceExternalTrafficPolicy,
 		TestDataPlaneServiceTypes,
 		TestDataPlaneSpecifyingServiceName,


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request updates the `kubernetes-configuration` dependency to include support for the `scale` subresource in the `DataPlane` CRD.


**Which issue this PR fixes**

part of https://github.com/Kong/gateway-operator/issues/1498


**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
