### PR TITLE
chore(tests): make helper for `KongRoute` more generic and reduce flakiness

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=9a4e025f1ccb904ba3f6bfd4e2d639460d0655ef # Version is auto-updated by the generating script.
+  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=a8792c961a8771ebe75765aa0315d84aef433359 # Version is auto-updated by the generating script.

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/terratest v0.48.2
-	github.com/kong/kubernetes-configuration v1.3.2-0.20250422040405-9a4e025f1ccb
+	github.com/kong/kubernetes-configuration v1.3.2-0.20250423091447-a8792c961a87
 	github.com/kong/kubernetes-telemetry v0.1.9
 	github.com/kong/kubernetes-testing-framework v0.47.2
 	github.com/kong/semver/v4 v4.0.1

--- a/go.sum
+++ b/go.sum
@@ -309,8 +309,8 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kong/go-kong v0.65.1 h1:CM+8NlF+VbJckTxP2hGmSPKhA1GMliitXjQ7vJiPkaE=
 github.com/kong/go-kong v0.65.1/go.mod h1:sqdysTKrXIJ6mpxHwTwjgZhLW7jR1/puczTXHLUwJaE=
-github.com/kong/kubernetes-configuration v1.3.2-0.20250422040405-9a4e025f1ccb h1:jQCvZ7rKYcYLLSR7QXmwpGKIK8j3P7mBYARP8WHYVf8=
-github.com/kong/kubernetes-configuration v1.3.2-0.20250422040405-9a4e025f1ccb/go.mod h1:3p31CROMO9LZmAB18Udn0luTPl/xu5XLls6DQj4IjB4=
+github.com/kong/kubernetes-configuration v1.3.2-0.20250423091447-a8792c961a87 h1:czdn9EKOj+dW4QNbrDUeeibIl+ygxbgvt/xPvNCRFOc=
+github.com/kong/kubernetes-configuration v1.3.2-0.20250423091447-a8792c961a87/go.mod h1:3p31CROMO9LZmAB18Udn0luTPl/xu5XLls6DQj4IjB4=
 github.com/kong/kubernetes-telemetry v0.1.9 h1:XbDMZjZZclHO4oyJGW1mmZ6bzbTnANjcRAYsBg+jpno=
 github.com/kong/kubernetes-telemetry v0.1.9/go.mod h1:lBSbaQdJkoMMO0d+cJWopoJiJ+QHFBttbhCp5VRibJ8=
 github.com/kong/kubernetes-testing-framework v0.47.2 h1:+2Z9anTpbV/hwNeN+NFQz53BMU+g3QJydkweBp3tULo=

--- a/test/envtest/kongpluginbinding_managed_test.go
+++ b/test/envtest/kongpluginbinding_managed_test.go
@@ -215,8 +215,10 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			require.NoError(t, clientNamespaced.Delete(ctx, kongService))
 		})
 		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
-		kongRoute := deploy.KongRouteAttachedToService(t, ctx, clientNamespaced, kongService,
+		kongRoute := deploy.KongRoute(
+			t, ctx, clientNamespaced,
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
+			deploy.WithNamespacedKongServiceRef(kongService),
 		)
 		t.Cleanup(func() {
 			require.NoError(t, clientNamespaced.Delete(ctx, kongRoute))
@@ -320,7 +322,8 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			require.NoError(t, clientNamespaced.Delete(ctx, kongService))
 		})
 		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
-		kongRoute := deploy.KongRouteAttachedToService(t, ctx, clientNamespaced, kongService,
+		kongRoute := deploy.KongRoute(t, ctx, clientNamespaced,
+			deploy.WithNamespacedKongServiceRef(kongService),
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
 		)
 		t.Cleanup(func() {
@@ -447,7 +450,9 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			require.NoError(t, clientNamespaced.Delete(ctx, kongService))
 		})
 		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
-		kongRoute := deploy.KongRouteAttachedToService(t, ctx, clientNamespaced, kongService,
+		kongRoute := deploy.KongRoute(
+			t, ctx, clientNamespaced,
+			deploy.WithNamespacedKongServiceRef(kongService),
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
 		)
 		t.Cleanup(func() {
@@ -646,7 +651,9 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			require.NoError(t, clientNamespaced.Delete(ctx, kongService))
 		})
 		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
-		kongRoute := deploy.KongRouteAttachedToService(t, ctx, clientNamespaced, kongService,
+		kongRoute := deploy.KongRoute(
+			t, ctx, clientNamespaced,
+			deploy.WithNamespacedKongServiceRef(kongService),
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
 		)
 		t.Cleanup(func() {

--- a/test/envtest/kongpluginbinding_unmanaged_test.go
+++ b/test/envtest/kongpluginbinding_unmanaged_test.go
@@ -144,7 +144,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 
 		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
-		kongRoute := deploy.KongRouteAttachedToService(t, ctx, clientNamespaced, kongService)
+		kongRoute := deploy.KongRoute(t, ctx, clientNamespaced, deploy.WithNamespacedKongServiceRef(kongService))
 		updateKongRouteStatusWithProgrammed(t, ctx, clientNamespaced, kongRoute, routeID, cp.GetKonnectStatus().GetKonnectID(), serviceID)
 
 		kpb := deploy.KongPluginBinding(t, ctx, clientNamespaced,
@@ -209,7 +209,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 
 		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
-		kongRoute := deploy.KongRouteAttachedToService(t, ctx, clientNamespaced, kongService)
+		kongRoute := deploy.KongRoute(t, ctx, clientNamespaced, deploy.WithNamespacedKongServiceRef(kongService))
 		updateKongRouteStatusWithProgrammed(t, ctx, clientNamespaced, kongRoute, routeID, cp.GetKonnectStatus().GetKonnectID(), serviceID)
 
 		sdk.PluginSDK.EXPECT().

--- a/test/envtest/kongplugincleanupfinalizer_test.go
+++ b/test/envtest/kongplugincleanupfinalizer_test.go
@@ -91,7 +91,9 @@ func TestKongPluginFinalizer(t *testing.T) {
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 		)
 		wKongRoute := setupWatch[configurationv1alpha1.KongRouteList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
-		kongRoute := deploy.KongRouteAttachedToService(t, ctx, clientNamespaced, kongService,
+		kongRoute := deploy.KongRoute(
+			t, ctx, clientNamespaced,
+			deploy.WithNamespacedKongServiceRef(kongService),
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
 		)
 

--- a/test/envtest/konnect_entities_kongroute_test.go
+++ b/test/envtest/konnect_entities_kongroute_test.go
@@ -79,7 +79,9 @@ func TestKongRoute(t *testing.T) {
 			)
 
 		t.Log("Creating a KongRoute")
-		createdRoute := deploy.KongRouteAttachedToService(t, ctx, clientNamespaced, svc,
+		createdRoute := deploy.KongRoute(
+			t, ctx, clientNamespaced,
+			deploy.WithNamespacedKongServiceRef(svc),
 			func(obj client.Object) {
 				s := obj.(*configurationv1alpha1.KongRoute)
 				s.Spec.Paths = []string{"/path"}

--- a/test/integration/test_konnect_extension.go
+++ b/test/integration/test_konnect_extension.go
@@ -133,7 +133,9 @@ func TestKonnectExtension(t *testing.T) {
 		}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 		t.Cleanup(deleteObjectAndWaitForDeletionFn(t, ks))
 
-		kr := deploy.KongRouteAttachedToService(t, ctx, clientNamespaced, ks,
+		kr := deploy.KongRoute(
+			t, ctx, clientNamespaced,
+			deploy.WithNamespacedKongServiceRef(ks),
 			func(obj client.Object) {
 				s := obj.(*configurationv1alpha1.KongRoute)
 				s.Spec.Paths = []string{"/test"}


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of having `KongRouteAttachedToControlPlane` and `KongRouteAttachedToService`, introduce only one that takes the respective options.

Also, wrap updates in eventually to ensure they will be retried gracefully in case of conflict to reduce flakiness (spotted locally).

**Which issue this PR fixes**

closes #1522