### PR TITLE
feat(gatewayconfiguration): add support for PodDisruptionBudget in GatewayConfiguration's DataPlane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
 - Add `KonnectCloudGatewayTransitGateway` controller to support managing Konnect
   transit gateways.
   [#1489](https://github.com/Kong/gateway-operator/pull/1489)
+- Added support for setting `PodDisruptionBudget` in `GatewayConfiguration`'s `DataPlane` options.
+  [#1526](https://github.com/Kong/gateway-operator/pull/1526)
 
 ### Changes
 

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=a8792c961a8771ebe75765aa0315d84aef433359 # Version is auto-updated by the generating script.
+  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=a4983cc581e8b60636b1f44a3f4c6af061173c9d # Version is auto-updated by the generating script.

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -726,12 +726,10 @@ func (r *Reconciler) patchStatus(ctx context.Context, gateway, oldGateway *gwtyp
 
 func dataplaneSpecDeepEqual(spec1, spec2 *operatorv1beta1.DataPlaneOptions) bool {
 	// TODO: Doesn't take .Rollout field into account.
-	if !deploymentOptionsDeepEqual(&spec1.Deployment.DeploymentOptions, &spec2.Deployment.DeploymentOptions) ||
-		!compare.NetworkOptionsDeepEqual(&spec1.Network, &spec2.Network) {
-		return false
-	}
-
-	return reflect.DeepEqual(spec1.Extensions, spec2.Extensions)
+	return deploymentOptionsDeepEqual(&spec1.Deployment.DeploymentOptions, &spec2.Deployment.DeploymentOptions) &&
+		compare.NetworkOptionsDeepEqual(&spec1.Network, &spec2.Network) &&
+		compare.DataPlaneResourceOptionsDeepEqual(&spec1.Resources, &spec2.Resources) &&
+		reflect.DeepEqual(spec1.Extensions, spec2.Extensions)
 }
 
 func deploymentOptionsDeepEqual(o1, o2 *operatorv1beta1.DeploymentOptions, envVarsToIgnore ...string) bool {

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/terratest v0.48.2
-	github.com/kong/kubernetes-configuration v1.3.2-0.20250423091447-a8792c961a87
+	github.com/kong/kubernetes-configuration v1.3.2-0.20250423105439-a4983cc581e8
 	github.com/kong/kubernetes-telemetry v0.1.9
 	github.com/kong/kubernetes-testing-framework v0.47.2
 	github.com/kong/semver/v4 v4.0.1

--- a/go.sum
+++ b/go.sum
@@ -309,8 +309,8 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kong/go-kong v0.65.1 h1:CM+8NlF+VbJckTxP2hGmSPKhA1GMliitXjQ7vJiPkaE=
 github.com/kong/go-kong v0.65.1/go.mod h1:sqdysTKrXIJ6mpxHwTwjgZhLW7jR1/puczTXHLUwJaE=
-github.com/kong/kubernetes-configuration v1.3.2-0.20250423091447-a8792c961a87 h1:czdn9EKOj+dW4QNbrDUeeibIl+ygxbgvt/xPvNCRFOc=
-github.com/kong/kubernetes-configuration v1.3.2-0.20250423091447-a8792c961a87/go.mod h1:3p31CROMO9LZmAB18Udn0luTPl/xu5XLls6DQj4IjB4=
+github.com/kong/kubernetes-configuration v1.3.2-0.20250423105439-a4983cc581e8 h1:tyKIKCSvBiJqQJuAsOivuoYHZzCmxfKQiSPst8c4+FI=
+github.com/kong/kubernetes-configuration v1.3.2-0.20250423105439-a4983cc581e8/go.mod h1:3p31CROMO9LZmAB18Udn0luTPl/xu5XLls6DQj4IjB4=
 github.com/kong/kubernetes-telemetry v0.1.9 h1:XbDMZjZZclHO4oyJGW1mmZ6bzbTnANjcRAYsBg+jpno=
 github.com/kong/kubernetes-telemetry v0.1.9/go.mod h1:lBSbaQdJkoMMO0d+cJWopoJiJ+QHFBttbhCp5VRibJ8=
 github.com/kong/kubernetes-testing-framework v0.47.2 h1:+2Z9anTpbV/hwNeN+NFQz53BMU+g3QJydkweBp3tULo=

--- a/pkg/utils/kubernetes/compare/comparators.go
+++ b/pkg/utils/kubernetes/compare/comparators.go
@@ -48,3 +48,8 @@ func ControlPlaneDeploymentOptionsDeepEqual(o1, o2 *operatorv1beta1.ControlPlane
 func NetworkOptionsDeepEqual(opts1, opts2 *operatorv1beta1.DataPlaneNetworkOptions) bool {
 	return reflect.DeepEqual(opts1.Services, opts2.Services)
 }
+
+// DataPlaneResourceOptionsDeepEqual checks if DataPlane resource options are equal.
+func DataPlaneResourceOptionsDeepEqual(opts1, opts2 *operatorv1beta1.DataPlaneResources) bool {
+	return reflect.DeepEqual(opts1, opts2)
+}

--- a/pkg/utils/kubernetes/compare/comparators_test.go
+++ b/pkg/utils/kubernetes/compare/comparators_test.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
 )
@@ -478,6 +479,111 @@ func TestDeploymentOptionsV1AlphaDeepEqual(t *testing.T) {
 			} else {
 				require.False(t, ret)
 			}
+		})
+	}
+}
+
+func TestDataPlaneResourceOptionsDeepEqual(t *testing.T) {
+	testCases := []struct {
+		name   string
+		opts1  *operatorv1beta1.DataPlaneResources
+		opts2  *operatorv1beta1.DataPlaneResources
+		expect bool
+	}{
+		{
+			name:   "nil values are equal",
+			opts1:  nil,
+			opts2:  nil,
+			expect: true,
+		},
+		{
+			name:   "empty values are equal",
+			opts1:  &operatorv1beta1.DataPlaneResources{},
+			opts2:  &operatorv1beta1.DataPlaneResources{},
+			expect: true,
+		},
+		{
+			name: "different minAvailable implies different resources",
+			opts1: &operatorv1beta1.DataPlaneResources{
+				PodDisruptionBudget: &operatorv1beta1.PodDisruptionBudget{
+					Spec: operatorv1beta1.PodDisruptionBudgetSpec{
+						MinAvailable: lo.ToPtr(intstr.FromInt32(1)),
+					},
+				},
+			},
+			opts2: &operatorv1beta1.DataPlaneResources{
+				PodDisruptionBudget: &operatorv1beta1.PodDisruptionBudget{
+					Spec: operatorv1beta1.PodDisruptionBudgetSpec{
+						MinAvailable: lo.ToPtr(intstr.FromInt32(2)),
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "different maxUnavailable implies different resources",
+			opts1: &operatorv1beta1.DataPlaneResources{
+				PodDisruptionBudget: &operatorv1beta1.PodDisruptionBudget{
+					Spec: operatorv1beta1.PodDisruptionBudgetSpec{
+						MaxUnavailable: lo.ToPtr(intstr.FromInt32(1)),
+					},
+				},
+			},
+			opts2: &operatorv1beta1.DataPlaneResources{
+				PodDisruptionBudget: &operatorv1beta1.PodDisruptionBudget{
+					Spec: operatorv1beta1.PodDisruptionBudgetSpec{
+						MaxUnavailable: lo.ToPtr(intstr.FromInt32(2)),
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "same PDB specs are equal",
+			opts1: &operatorv1beta1.DataPlaneResources{
+				PodDisruptionBudget: &operatorv1beta1.PodDisruptionBudget{
+					Spec: operatorv1beta1.PodDisruptionBudgetSpec{
+						MinAvailable: lo.ToPtr(intstr.FromInt32(1)),
+					},
+				},
+			},
+			opts2: &operatorv1beta1.DataPlaneResources{
+				PodDisruptionBudget: &operatorv1beta1.PodDisruptionBudget{
+					Spec: operatorv1beta1.PodDisruptionBudgetSpec{
+						MinAvailable: lo.ToPtr(intstr.FromInt32(1)),
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			name:  "one nil and one non-nil are not equal",
+			opts1: nil,
+			opts2: &operatorv1beta1.DataPlaneResources{
+				PodDisruptionBudget: &operatorv1beta1.PodDisruptionBudget{
+					Spec: operatorv1beta1.PodDisruptionBudgetSpec{
+						MinAvailable: lo.ToPtr(intstr.FromInt32(1)),
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "nil PDB and empty PDB are not equal",
+			opts1: &operatorv1beta1.DataPlaneResources{
+				PodDisruptionBudget: nil,
+			},
+			opts2: &operatorv1beta1.DataPlaneResources{
+				PodDisruptionBudget: &operatorv1beta1.PodDisruptionBudget{},
+			},
+			expect: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := DataPlaneResourceOptionsDeepEqual(tc.opts1, tc.opts2)
+			require.Equal(t, tc.expect, result)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #469

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
