### PR TITLE
tests: fix flaky TestKonnectEntities integration test

### DIFF
--- a/test/integration/test_konnect_entities.go
+++ b/test/integration/test_konnect_entities.go
@@ -114,16 +114,20 @@ func TestKonnectEntities(t *testing.T) {
 	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
 	t.Log("Making KongRoute service bound")
-	err := GetClients().MgrClient.Get(GetCtx(), types.NamespacedName{Name: kr.Name, Namespace: kr.Namespace}, kr)
-	require.NoError(t, err)
-	kr.Spec.ServiceRef = &configurationv1alpha1.ServiceRef{
-		Type: configurationv1alpha1.ServiceRefNamespacedRef,
-		NamespacedRef: &commonv1alpha1.NameRef{
-			Name: ks.Name,
-		},
-	}
-	err = GetClients().MgrClient.Update(GetCtx(), kr)
-	require.NoError(t, err)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		err := GetClients().MgrClient.Get(GetCtx(), types.NamespacedName{Name: kr.Name, Namespace: kr.Namespace}, kr)
+		if !assert.NoError(c, err) {
+			return
+		}
+		kr.Spec.ServiceRef = &configurationv1alpha1.ServiceRef{
+			Type: configurationv1alpha1.ServiceRefNamespacedRef,
+			NamespacedRef: &commonv1alpha1.NameRef{
+				Name: ks.Name,
+			},
+		}
+		assert.NoError(c, GetClients().MgrClient.Update(GetCtx(), kr))
+	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
+
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		err := GetClients().MgrClient.Get(GetCtx(), types.NamespacedName{Name: kr.Name, Namespace: kr.Namespace}, kr)
 		require.NoError(t, err)
@@ -134,11 +138,15 @@ func TestKonnectEntities(t *testing.T) {
 	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
 	t.Log("Making KongRoute serviceless again")
-	err = GetClients().MgrClient.Get(GetCtx(), types.NamespacedName{Name: kr.Name, Namespace: kr.Namespace}, kr)
-	require.NoError(t, err)
-	kr.Spec.ServiceRef = nil
-	err = GetClients().MgrClient.Update(GetCtx(), kr)
-	require.NoError(t, err)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		err := GetClients().MgrClient.Get(GetCtx(), types.NamespacedName{Name: kr.Name, Namespace: kr.Namespace}, kr)
+		if !assert.NoError(c, err) {
+			return
+		}
+		kr.Spec.ServiceRef = nil
+		assert.NoError(c, GetClients().MgrClient.Update(GetCtx(), kr))
+	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
+
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		err := GetClients().MgrClient.Get(GetCtx(), types.NamespacedName{Name: kr.Name, Namespace: kr.Namespace}, kr)
 		require.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix failures like:

```
2025-04-23T09:23:50Z	INFO	KongService	operation in Konnect API complete	{"konnect_id": "c444bacf-c56e-4c52-9aa4-d16e2701cd1a", "op": "update", "duration": "58.763599ms"}
    test_konnect_entities.go:141: 
        	Error Trace:	/home/runner/work/gateway-operator/gateway-operator/test/integration/test_konnect_entities.go:141
        	Error:      	Received unexpected error:
        	            	Operation cannot be fulfilled on kongroutes.configuration.konghq.com "kongroute-9a31bef1": the object has been modified; please apply your changes to the latest version and try again
        	Test:       	TestIntegration/TestKonnectEntities
```

https://github.com/Kong/gateway-operator/actions/runs/14614527412/job/40999650354?pr=1516#step:5:7009

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
