### PR TITLE
feat(konnect): filter name in listing transit gateways and reuse getMatchingEntryFromListResponseData to extract Konnect ID

### DIFF
--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -594,6 +594,17 @@ func sliceToEntityWithIDSlice[
 	return result
 }
 
+// extractedEntityID represents the ID of an entity.
+// The type is defined to satisfy the interface in the parameter of getMatchingEntryFromListResponseData.
+// Some types of responses does not provide a GetID in sdk-konnect-go
+// so we need to extract the ID and return this type for getMatchingEntryFromListResponseData.
+type extractedEntityID string
+
+// GetID returns the extracted ID. Implements the interface in the parameter of getMatchingEntryFromListResponseData.
+func (e extractedEntityID) GetID() string {
+	return string(e)
+}
+
 // getMatchingEntryFromListResponseData returns the ID of the first entry in the list response data.
 // It returns an error if no entry with a non-empty ID was found.
 // It is used in conjunction with the list operation to get the ID of the entity that matches the UID

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -596,7 +596,7 @@ func sliceToEntityWithIDSlice[
 
 // extractedEntityID represents the ID of an entity.
 // The type is defined to satisfy the interface in the parameter of getMatchingEntryFromListResponseData.
-// Some types of responses does not provide a GetID in sdk-konnect-go
+// Some types of responses do not provide a GetID in sdk-konnect-go
 // so we need to extract the ID and return this type for getMatchingEntryFromListResponseData.
 type extractedEntityID string
 

--- a/test/envtest/konnect_entities_konnecttransitgateway_test.go
+++ b/test/envtest/konnect_entities_konnecttransitgateway_test.go
@@ -184,7 +184,10 @@ func TestKonnectCloudGatewayTransitGateway(t *testing.T) {
 			&sdkkonnecterrs.ConflictError{},
 		)
 		sdk.CloudGatewaysSDK.EXPECT().ListTransitGateways(mock.Anything, mock.MatchedBy(func(req sdkkonnectops.ListTransitGatewaysRequest) bool {
-			return req.NetworkID == networkID
+			return req.NetworkID == networkID &&
+				req.Filter != nil && req.Filter.Name != nil &&
+				req.Filter.Name.CloudGatewaysStringFieldEqualsFilterOverride != nil &&
+				*req.Filter.Name.CloudGatewaysStringFieldEqualsFilterOverride.Str == transitGatewayName
 		})).Return(
 			&sdkkonnectops.ListTransitGatewaysResponse{
 				ListTransitGatewaysResponse: &sdkkonnectcomp.ListTransitGatewaysResponse{


### PR DESCRIPTION

**What this PR does / why we need it**:
filter name in listing transit gateways and extract ID of listing responses to reuse `getMatchingEntryFromListResponseData` to extract Konnect ID of transit gateways.
**Which issue this PR fixes**

Fixes #1527

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes~
No need to update CHANGELOG?