### PR TITLE
chore(ci): add osv-scanner.toml with vulnerabilities excludes

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,13 @@
+[[IgnoredVulns]]
+# https://osv.dev/vulnerability/GO-2025-3521
+# Kubernetes GitRepo Volume Inadvertent Local Repository Access in k8s.io/kubernetes
+id = "GO-2025-3521"
+# ignoreUntil = 2022-11-09 # Optional exception expiry date
+reason = "GitRepo volume is not used by this project"
+
+[[IgnoredVulns]]
+# https://osv.dev/vulnerability/GO-2025-3547
+# Kubernetes kube-apiserver Vulnerable to Race Condition in k8s.io/kubernetes
+id = "GO-2025-3547"
+# ignoreUntil = 2022-11-09 # Optional exception expiry date
+reason = "Low severity, no known fix yet"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix: https://github.com/Kong/gateway-operator/actions/runs/14654834304/job/41127975424?pr=1542

Reference: https://google.github.io/osv-scanner/configuration/

Excluded vulnerabilities:
- https://osv.dev/vulnerability/GO-2025-3547
  Kubernetes kube-apiserver Vulnerable to Race Condition in k8s.io/kubernetes
- https://osv.dev/vulnerability/GO-2025-3521
  Kubernetes GitRepo Volume Inadvertent Local Repository Access in k8s.io/kubernetes

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
