### PR TITLE
chore(ci): fix GHA build permissions

### DIFF
--- a/.github/workflows/__build-workflow.yaml
+++ b/.github/workflows/__build-workflow.yaml
@@ -85,6 +85,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   semver:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   build:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   build-push-images:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix failing build workflows:

For example: https://github.com/Kong/gateway-operator/actions/runs/14659725887

```
[Invalid workflow file: .github/workflows/build.yaml#L26](https://github.com/Kong/gateway-operator/actions/runs/14659725887/workflow)
The workflow is not valid. .github/workflows/build.yaml (Line: 26, Col: 3): Error calling workflow 'Kong/gateway-operator/.github/workflows/__build-workflow.yaml@a3f69b8a8961500a318441481ca64b75625ec537'. The nested job 'build' is requesting 'actions: read', but is only allowed 'actions: none'. .github/workflows/build.yaml (Line: 26, Col: 3): Error calling workflow 'Kong/gateway-operator/.github/workflows/__build-workflow.yaml@a3f69b8a8961500a318441481ca64b75625ec537'. The nested job 'build-multi-arch' is requesting 'actions: read', but is only allowed 'actions: none'.
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
