### PR TITLE
feat(gatewayconfiguration): add support for ControlPlane's watchnamespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,19 +51,20 @@
   [#1489](https://github.com/Kong/gateway-operator/pull/1489)
 - Added support for setting `PodDisruptionBudget` in `GatewayConfiguration`'s `DataPlane` options.
   [#1526](https://github.com/Kong/gateway-operator/pull/1526)
-
-### Changes
-
-- Added `spec.watchNamespace` field to `ControlPlane` CRD to allow watching resources
-  only in the specified namespace.
+- Added `spec.watchNamespace` field to `ControlPlane` and `GatewayConfiguration` CRDs
+  to allow watching resources only in the specified namespace.
   When `spec.watchNamespace.type=list` is used, each specified namespace requires
   a `WatchNamespaceGrant` that allows the `ControlPlane` to watch resources in the specified namespace.
   Aforementioned list is extended with `ControlPlane`'s own namespace which doesn't
   require said `WatchNamespaceGrant`.
   [#1388](https://github.com/Kong/gateway-operator/pull/1388)
   [#1410](https://github.com/Kong/gateway-operator/pull/1410)
+  [#1555](https://github.com/Kong/gateway-operator/pull/1555)
   <!-- TODO: https://github.com/Kong/gateway-operator/issues/1501 add link to guide from documentation. -->
   For more information on this please see: https://docs.konghq.com/gateway-operator/latest/
+
+### Changes
+
 - Deduce `KonnectCloudGatewayDataPlaneGroupConfiguration` region based on the attached
   `KonnectAPIAuthConfiguration` instead of using a hardcoded `eu` value.
   [#1409](https://github.com/Kong/gateway-operator/pull/1409)

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=d1989707dabb30394ee2f65a500cb21f90c27925 # Version is auto-updated by the generating script.
+  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=v1.4.0-rc.1 # Version is auto-updated by the generating script.

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=a4983cc581e8b60636b1f44a3f4c6af061173c9d # Version is auto-updated by the generating script.
+  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=d1989707dabb30394ee2f65a500cb21f90c27925 # Version is auto-updated by the generating script.

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -373,8 +373,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			k8sutils.NewConditionWithGeneration(
 				ConditionTypeWatchNamespaceGrantsValid,
 				metav1.ConditionFalse,
-				kcfgcontrolplane.ConditionReasonMissingReferenceGrant,
-				fmt.Sprintf("WatchNamespaceGrant(s) are missing for the ControlPlane: %v", err),
+				kcfgcontrolplane.ConditionReasonWatchNamespaceGrantInvalid,
+				fmt.Sprintf("WatchNamespaceGrant(s) are missing or invalid for the ControlPlane: %v", err),
 				cp.GetGeneration(),
 			),
 			cp,

--- a/controller/controlplane/controller_test.go
+++ b/controller/controlplane/controller_test.go
@@ -85,9 +85,6 @@ func TestReconciler_Reconcile(t *testing.T) {
 					},
 				},
 				Spec: operatorv1beta1.ControlPlaneSpec{
-					WatchNamespaces: &operatorv1beta1.WatchNamespaces{
-						Type: operatorv1beta1.WatchNamespacesTypeAll,
-					},
 					ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
 						Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{
 							PodTemplateSpec: &corev1.PodTemplateSpec{
@@ -102,6 +99,9 @@ func TestReconciler_Reconcile(t *testing.T) {
 							},
 						},
 						DataPlane: lo.ToPtr("test-dataplane"),
+						WatchNamespaces: &operatorv1beta1.WatchNamespaces{
+							Type: operatorv1beta1.WatchNamespacesTypeAll,
+						},
 					},
 				},
 				Status: operatorv1beta1.ControlPlaneStatus{

--- a/controller/controlplane/controller_utils_test.go
+++ b/controller/controlplane/controller_utils_test.go
@@ -917,6 +917,82 @@ func TestControlPlaneSpecDeepEqual(t *testing.T) {
 			},
 			equal: true,
 		},
+		{
+			name: "different watch namespaces yield unequal specs",
+			spec1: &operatorv1beta1.ControlPlaneOptions{
+				Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{
+					PodTemplateSpec: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "controller",
+								},
+							},
+						},
+					},
+				},
+				WatchNamespaces: &operatorv1beta1.WatchNamespaces{
+					Type: operatorv1beta1.WatchNamespacesTypeList,
+					List: []string{"ns1", "ns2"},
+				},
+			},
+			spec2: &operatorv1beta1.ControlPlaneOptions{
+				Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{
+					PodTemplateSpec: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "controller",
+								},
+							},
+						},
+					},
+				},
+				WatchNamespaces: &operatorv1beta1.WatchNamespaces{
+					Type: operatorv1beta1.WatchNamespacesTypeList,
+					List: []string{"ns1", "ns2", "ns3"},
+				},
+			},
+			equal: false,
+		},
+		{
+			name: "the same watch namespaces yield equal specs",
+			spec1: &operatorv1beta1.ControlPlaneOptions{
+				Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{
+					PodTemplateSpec: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "controller",
+								},
+							},
+						},
+					},
+				},
+				WatchNamespaces: &operatorv1beta1.WatchNamespaces{
+					Type: operatorv1beta1.WatchNamespacesTypeList,
+					List: []string{"ns1", "ns2"},
+				},
+			},
+			spec2: &operatorv1beta1.ControlPlaneOptions{
+				Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{
+					PodTemplateSpec: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "controller",
+								},
+							},
+						},
+					},
+				},
+				WatchNamespaces: &operatorv1beta1.WatchNamespaces{
+					Type: operatorv1beta1.WatchNamespacesTypeList,
+					List: []string{"ns1", "ns2"},
+				},
+			},
+			equal: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/controller/pkg/controlplane/controlplane.go
+++ b/controller/pkg/controlplane/controlplane.go
@@ -250,6 +250,10 @@ func SpecDeepEqual(spec1, spec2 *operatorv1beta1.ControlPlaneOptions, envVarsToI
 		return false
 	}
 
+	if !reflect.DeepEqual(spec1.WatchNamespaces, spec2.WatchNamespaces) {
+		return false
+	}
+
 	return true
 }
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/terratest v0.48.2
-	github.com/kong/kubernetes-configuration v1.3.2-0.20250423105439-a4983cc581e8
+	github.com/kong/kubernetes-configuration v1.4.0-rc.0.0.20250428151527-d1989707dabb
 	github.com/kong/kubernetes-telemetry v0.1.9
 	github.com/kong/kubernetes-testing-framework v0.47.2
 	github.com/kong/semver/v4 v4.0.1
@@ -34,7 +34,7 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/mod v0.24.0
 	k8s.io/api v0.33.0
-	k8s.io/apiextensions-apiserver v0.32.3
+	k8s.io/apiextensions-apiserver v0.33.0
 	k8s.io/apimachinery v0.33.0
 	k8s.io/client-go v0.33.0
 	k8s.io/kubernetes v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/terratest v0.48.2
-	github.com/kong/kubernetes-configuration v1.4.0-rc.0.0.20250428151527-d1989707dabb
+	github.com/kong/kubernetes-configuration v1.4.0-rc.1
 	github.com/kong/kubernetes-telemetry v0.1.9
 	github.com/kong/kubernetes-testing-framework v0.47.2
 	github.com/kong/semver/v4 v4.0.1

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kong/go-kong v0.65.1 h1:CM+8NlF+VbJckTxP2hGmSPKhA1GMliitXjQ7vJiPkaE=
 github.com/kong/go-kong v0.65.1/go.mod h1:sqdysTKrXIJ6mpxHwTwjgZhLW7jR1/puczTXHLUwJaE=
-github.com/kong/kubernetes-configuration v1.3.2-0.20250423105439-a4983cc581e8 h1:tyKIKCSvBiJqQJuAsOivuoYHZzCmxfKQiSPst8c4+FI=
-github.com/kong/kubernetes-configuration v1.3.2-0.20250423105439-a4983cc581e8/go.mod h1:3p31CROMO9LZmAB18Udn0luTPl/xu5XLls6DQj4IjB4=
+github.com/kong/kubernetes-configuration v1.4.0-rc.0.0.20250428151527-d1989707dabb h1:l37rLjvJe7zDvXMTddD+JL+U8rohvnIoUlZkFpiOiy4=
+github.com/kong/kubernetes-configuration v1.4.0-rc.0.0.20250428151527-d1989707dabb/go.mod h1:n7llpDlc+Se+4nHERfj6Kupb5q6nnTcBoL6noiv3Jz0=
 github.com/kong/kubernetes-telemetry v0.1.9 h1:XbDMZjZZclHO4oyJGW1mmZ6bzbTnANjcRAYsBg+jpno=
 github.com/kong/kubernetes-telemetry v0.1.9/go.mod h1:lBSbaQdJkoMMO0d+cJWopoJiJ+QHFBttbhCp5VRibJ8=
 github.com/kong/kubernetes-testing-framework v0.47.2 h1:+2Z9anTpbV/hwNeN+NFQz53BMU+g3QJydkweBp3tULo=

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kong/go-kong v0.65.1 h1:CM+8NlF+VbJckTxP2hGmSPKhA1GMliitXjQ7vJiPkaE=
 github.com/kong/go-kong v0.65.1/go.mod h1:sqdysTKrXIJ6mpxHwTwjgZhLW7jR1/puczTXHLUwJaE=
-github.com/kong/kubernetes-configuration v1.4.0-rc.0.0.20250428151527-d1989707dabb h1:l37rLjvJe7zDvXMTddD+JL+U8rohvnIoUlZkFpiOiy4=
-github.com/kong/kubernetes-configuration v1.4.0-rc.0.0.20250428151527-d1989707dabb/go.mod h1:n7llpDlc+Se+4nHERfj6Kupb5q6nnTcBoL6noiv3Jz0=
+github.com/kong/kubernetes-configuration v1.4.0-rc.1 h1:53FlnlymCVdinmYI+W4EaZWmCjaKRs4fzs6JBtOpAXo=
+github.com/kong/kubernetes-configuration v1.4.0-rc.1/go.mod h1:n7llpDlc+Se+4nHERfj6Kupb5q6nnTcBoL6noiv3Jz0=
 github.com/kong/kubernetes-telemetry v0.1.9 h1:XbDMZjZZclHO4oyJGW1mmZ6bzbTnANjcRAYsBg+jpno=
 github.com/kong/kubernetes-telemetry v0.1.9/go.mod h1:lBSbaQdJkoMMO0d+cJWopoJiJ+QHFBttbhCp5VRibJ8=
 github.com/kong/kubernetes-testing-framework v0.47.2 h1:+2Z9anTpbV/hwNeN+NFQz53BMU+g3QJydkweBp3tULo=

--- a/pkg/utils/kubernetes/resources/deployments_test.go
+++ b/pkg/utils/kubernetes/resources/deployments_test.go
@@ -311,7 +311,7 @@ func TestGenerateNewDeploymentForControlPlane(t *testing.T) {
 						"gateway-operator.konghq.com/managed-by": "controlplane",
 					},
 					Annotations: map[string]string{
-						"gateway-operator.konghq.com/spec-hash": "97702e5d8e850807",
+						"gateway-operator.konghq.com/spec-hash": "3b1c73e6ae6933f9",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -471,7 +471,7 @@ func TestGenerateNewDeploymentForControlPlane(t *testing.T) {
 						"gateway-operator.konghq.com/managed-by": "controlplane",
 					},
 					Annotations: map[string]string{
-						"gateway-operator.konghq.com/spec-hash": "97702e5d8e850807",
+						"gateway-operator.konghq.com/spec-hash": "3b1c73e6ae6933f9",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the possibility to specify the `watchNamespaces` field in `GatewayConfiguration`'s `ControlPlane` options.

Related API change: https://github.com/Kong/kubernetes-configuration/pull/416, please review first.

**Which issue this PR fixes**

Fixes #1548

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
