### PR TITLE
chore(ci): do not send Slack notifications for PR build failures

### DIFF
--- a/.github/workflows/__release-workflow.yaml
+++ b/.github/workflows/__release-workflow.yaml
@@ -118,6 +118,7 @@ jobs:
       image-name: ${{ inputs.image-name }}
       additional-build-contexts: ${{ inputs.additional-build-contexts }}
       push: true
+      slack-send: true
       latest: ${{ inputs.latest }}
       tag: ${{ inputs.tag }}
       verify-image-script: ${{ inputs.verify-image-script }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,4 +38,4 @@ jobs:
       # If we pushed then it means we want to build and push the image.
       # Branch filter above will decide pushes to which branch will trigger this.
       push: ${{ github.event.action == 'push' }}
-      slack-send: true
+      slack-send: ${{ github.event.action == 'push' }}


### PR DESCRIPTION
**What this PR does / why we need it**:

#1531 missed the fact that builds for PRs shouldn't cause Slack notifications. This fixes it by disabling notifications on PR build failures.

Additionally this enables the notifications for release builds.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
