### PR TITLE
chore: add sample for GatewayConfiguration with DataPlane HPA

### DIFF
--- a/config/samples/gateway-with-gatewayconfiguration-dataplane-hpa.yaml
+++ b/config/samples/gateway-with-gatewayconfiguration-dataplane-hpa.yaml
@@ -1,0 +1,78 @@
+kind: GatewayConfiguration
+apiVersion: gateway-operator.konghq.com/v1beta1
+metadata:
+  name: kong
+  namespace: default
+spec:
+  dataPlaneOptions:
+    deployment:
+      scaling:
+        horizontal:
+          minReplicas: 2
+          maxReplicas: 10
+          metrics:
+          - type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 50
+          behavior:
+            scaleDown:
+              stabilizationWindowSeconds: 1
+              policies:
+              - type: Percent
+                value: 100
+                periodSeconds: 2
+            scaleUp:
+              stabilizationWindowSeconds: 1
+              policies:
+              - type: Percent
+                value: 100
+                periodSeconds: 2
+              - type: Pods
+                value: 5
+                periodSeconds: 2
+              selectPolicy: Max
+      podTemplateSpec:
+        spec:
+          containers:
+          - name: proxy
+            # renovate: datasource=docker versioning=docker
+            image: kong/kong-gateway:3.10
+            readinessProbe:
+              initialDelaySeconds: 1
+              periodSeconds: 1
+  controlPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        spec:
+          containers:
+          - name: controller
+            env:
+            - name: CONTROLLER_LOG_LEVEL
+              value: debug
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: kong
+spec:
+  controllerName: konghq.com/gateway-operator
+  parametersRef:
+    group: gateway-operator.konghq.com
+    kind: GatewayConfiguration
+    name: kong
+    namespace: default
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: kong
+  namespace: default
+spec:
+  gatewayClassName: kong
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a sample for `GatewayConfiguration` with `DataPlane` HPA.

This is currently possible and a sample already exists for `DataPlane` at https://github.com/Kong/gateway-operator/blob/3b7cdb6015e8a2da8a948756fbdf2f04209c1d9a/config/samples/dataplane-horizontal-autoscaling.yaml.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
