### PR TITLE
fix release workflow permissions

### DIFF
--- a/.github/workflows/__release-workflow.yaml
+++ b/.github/workflows/__release-workflow.yaml
@@ -108,6 +108,9 @@ jobs:
           version_extractor_regex: 'v(.*)$'
 
   build-push-images:
+    permissions:
+      actions: read
+      contents: read
     uses: ./.github/workflows/__build-workflow.yaml
     secrets:
       dockerhub-token: ${{ secrets.dockerhub-push-token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,7 @@ jobs:
   release:
     permissions:
       contents: write
+      actions: read
     uses: ./.github/workflows/__release-workflow.yaml
     secrets:
       dockerhub-push-token: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:

ref: https://github.com/Kong/gateway-operator/actions/runs/14884323318

> [Invalid workflow file: .github/workflows/release.yaml#L110](https://github.com/Kong/gateway-operator/actions/runs/14884323318/workflow)
The workflow is not valid. Kong/gateway-operator/.github/workflows/__release-workflow.yaml@b4c84a19d07198f0fdca2e235604eec716d1027e (Line: 110, Col: 3): Error calling workflow 'Kong/gateway-operator/.github/workflows/__build-workflow.yaml@b4c84a19d07198f0fdca2e235604eec716d1027e'. The workflow is requesting 'actions: read', but is only allowed 'actions: none'. Kong/gateway-operator/.github/workflows/__release-workflow.yaml@b4c84a19d07198f0fdca2e235604eec716d1027e (Line: 110, Col: 3): Error calling workflow 'Kong/gateway-operator/.github/workflows/__build-workflow.yaml@b4c84a19d07198f0fdca2e235604eec716d1027e'. The nested job 'build' is requesting 'actions: read', but is only allowed 'actions: none'.


According to the documentation https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions

> For each of the available permissions, shown in the table below, you can assign one of the access levels: read (if applicable), write, or none. write includes read. If you specify the access for any of these permissions, all of those that are not specified are set to none.


**Which issue this PR fixes**

part of https://github.com/Kong/gateway-operator/issues/1559

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:


~- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes~
