### PR TITLE
feat: controlplane extensions and DataPlaneMetricsExtension from EE

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -37,6 +37,9 @@ linters:
         # Incorrectly formatted error string.
         # https://staticcheck.dev/docs/checks/#ST1005
         - -ST1005
+        # Underscore in the name of a package.
+        # https://staticcheck.dev/docs/checks/#ST1003
+        - -ST1003
     exhaustive:
       default-signifies-exhaustive: true
     forbidigo:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
 
+## Unreleased for Kong Operator
+
+### Added
+
+- Move implementation of ControlPlane Extensions mechanism and DataPlaneMetricsExtension from EE.
+  [#1583](https://github.com/Kong/gateway-operator/pull/1583)
+
 ## [v1.6.0]
 
 > Release date: 2025-05-07

--- a/Makefile
+++ b/Makefile
@@ -558,6 +558,7 @@ _run:
 		-enable-controller-kongplugininstallation \
 		-enable-controller-aigateway \
 		-enable-controller-konnect \
+		-enable-controller-controlplaneextensions \
 		-zap-time-encoding iso8601 \
 		-zap-log-level 2 \
 		-zap-devel true

--- a/config/dev/manager_dev.yaml
+++ b/config/dev/manager_dev.yaml
@@ -25,6 +25,7 @@ spec:
             - -enable-controller-kongplugininstallation
             - -enable-validating-webhook
             - -enable-controller-konnect
+            - -enable-controller-controlplaneextensions
           name: manager
           env:
             - name: GATEWAY_OPERATOR_ANONYMOUS_REPORTS

--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -290,6 +290,7 @@ rules:
   - gateway-operator.konghq.com
   resources:
   - controlplane
+  - dataplanemetricsextensions
   - gatewayconfigurations
   verbs:
   - get

--- a/config/samples/gateway-with-dataplane-metrics.yaml
+++ b/config/samples/gateway-with-dataplane-metrics.yaml
@@ -17,7 +17,7 @@ spec:
           containers:
           - name: proxy
             # renovate: datasource=docker versioning=docker
-            image: kong/kong-gateway:3.10
+            image: kong:3.9
             env:
             - name: KONG_LOG_LEVEL
               value: debug

--- a/config/samples/gateway-with-dataplane-metrics.yaml
+++ b/config/samples/gateway-with-dataplane-metrics.yaml
@@ -1,0 +1,164 @@
+kind: GatewayConfiguration
+apiVersion: gateway-operator.konghq.com/v1beta1
+metadata:
+  name: kong
+  namespace: default
+spec:
+  dataPlaneOptions:
+    deployment:
+      replicas: 1
+      podTemplateSpec:
+        metadata:
+          labels:
+            dataplane-pod-label: example
+          annotations:
+            dataplane-pod-annotation: example
+        spec:
+          containers:
+          - name: proxy
+            # renovate: datasource=docker versioning=docker
+            image: kong/kong-gateway:3.10
+            env:
+            - name: KONG_LOG_LEVEL
+              value: debug
+            readinessProbe:
+              initialDelaySeconds: 1
+              periodSeconds: 1
+    network:
+      services:
+        ingress:
+          annotations:
+            foo: bar
+  controlPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        metadata:
+          labels:
+            controlplane-pod-label: example
+        spec:
+          containers:
+          - name: controller
+            env:
+            - name: CONTROLLER_LOG_LEVEL
+              value: debug
+            readinessProbe:
+              initialDelaySeconds: 1
+              periodSeconds: 1
+    extensions:
+    - kind: DataPlaneMetricsExtension
+      group: gateway-operator.konghq.com
+      name: kong
+---
+kind: DataPlaneMetricsExtension
+apiVersion: gateway-operator.konghq.com/v1alpha1
+metadata:
+  name: kong
+  namespace: default
+spec:
+  serviceSelector:
+    matchNames:
+    - name: echo
+  config:
+    latency: true
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: kong
+spec:
+  controllerName: konghq.com/gateway-operator
+  parametersRef:
+    group: gateway-operator.konghq.com
+    kind: GatewayConfiguration
+    name: kong
+    namespace: default
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: kong
+  namespace: default
+spec:
+  gatewayClassName: kong
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: default
+spec:
+  ports:
+    - protocol: TCP
+      name: http
+      port: 80
+      targetPort: http
+  selector:
+    app: echo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: echo
+  name: echo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo
+  template:
+    metadata:
+      labels:
+        app: echo
+    spec:
+      containers:
+        - name: echo
+          image: registry.k8s.io/e2e-test-images/agnhost:2.40
+          command:
+            - /agnhost
+            - netexec
+            - --http-port=8080
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-echo
+  namespace: default
+  annotations:
+    konghq.com/strip-path: "true"
+spec:
+  parentRefs:
+  - name: kong
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /echo
+    backendRefs:
+    - name: echo
+      kind: Service
+      port: 80

--- a/controller/controlplane_extensions/controller.go
+++ b/controller/controlplane_extensions/controller.go
@@ -1,0 +1,434 @@
+package controlplane_extensions
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	ossctxinjector "github.com/kong/gateway-operator/controller/pkg/ctxinjector"
+	"github.com/kong/gateway-operator/controller/pkg/extensions"
+	"github.com/kong/gateway-operator/controller/pkg/log"
+	osslogging "github.com/kong/gateway-operator/modules/manager/logging"
+	"github.com/kong/gateway-operator/pkg/consts"
+
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
+	operatorv1alpha1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1alpha1"
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+)
+
+const (
+
+	// GatewayOperatorControlPlaneNameManagingPluginsLabel is the label set on
+	// Services to indicate that the ControlPlane is managing plugins for the
+	// Service.
+	GatewayOperatorControlPlaneNameManagingPluginsLabel = consts.OperatorLabelPrefix + "control-plane-managing-plugins-name"
+
+	// GatewayOperatorControlPlaneNamespaceManagingPluginsLabel is the label set on
+	// Services to indicate that the ControlPlane's namespace that is managing plugins
+	// for the Service.
+	GatewayOperatorControlPlaneNamespaceManagingPluginsLabel = consts.OperatorLabelPrefix + "control-plane-managing-plugins-namespace"
+
+	// GatewayOperatorControlPlaneManagedPluginsAnnotation is the annotationset on
+	// Services to indicate which plugins attached to this Service are managed
+	// by the ControlPlane.
+	// The annotation value is set to a comma separated list of KongPlugin names
+	// that are managed by the ControlPlane.
+	GatewayOperatorControlPlaneManagedPluginsAnnotation = consts.OperatorAnnotationPrefix + "control-plane-managed-plugins"
+)
+
+// ScrapeUpdateNotifier is an interface for notifying the scrapers manager
+// about the need to add or remove a scraper for a DataPlane associated with
+// the provided ControlPlane.
+type ScrapeUpdateNotifier interface {
+	NotifyAdd(ctx context.Context, cp *operatorv1beta1.ControlPlane)
+	NotifyRemove(ctx context.Context, cp types.NamespacedName)
+}
+
+// Reconciler reconciles ControlPlane plugins as specified in
+// ControlPlane's spec.controlPlaneOptions.dataplanePlugins field.
+// It ensures that the KongPlugin instances are created and their configuration
+// is up to date.
+// It also ensures that the Services that have their plugins managed by the
+// ControlPlane have the correct annotation set.
+type Reconciler struct {
+	client.Client
+	LoggingMode                     osslogging.Mode
+	DataPlaneScraperManagerNotifier ScrapeUpdateNotifier
+	CtxInjector                     ossctxinjector.CtxInjector
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(_ context.Context, mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		// Watch for changes to owned ControlPlane that had DataPlane.
+		For(&operatorv1beta1.ControlPlane{},
+			builder.WithPredicates(
+				ControlPlaneDataPlanePluginsSpecChangedPredicate{},
+			),
+		).
+		// Enqueue requests for KongPlugins that are owned by ControlPlanes.
+		Watches(&configurationv1.KongPlugin{},
+			handler.EnqueueRequestsFromMapFunc(
+				enqueueControlPlaneOwningKongPluginFunc(r.Client),
+			),
+		).
+		// Enqueue requests when Services that have their plugins managed
+		// by the ControlPlane change.
+		Watches(&corev1.Service{},
+			handler.EnqueueRequestsFromMapFunc(
+				enqueueControlPlaneForServicesThatHavePluginsManaged(),
+			),
+		).
+		// Enqueue requests when Services that should have their plugins managed
+		// by the ControlPlane are created in the cluster and at that point do not
+		// have the backreference through the means of
+		// "gateway-operator.konghq.com/control-plane-managing-plugins-name" label
+		Watches(&corev1.Service{},
+			handler.EnqueueRequestsFromMapFunc(
+				enqueueControlPlaneForServicesThatHavePluginsConfigured(r.Client),
+			),
+			builder.WithPredicates(
+				predicate.Funcs{
+					CreateFunc: func(event.CreateEvent) bool {
+						return true
+					},
+				},
+			),
+		).
+		// Enqueue requests when DataPlaneMetricsExtensions have association from
+		// a ControlPlane. At that point, the ControlPlane should be enqueued.
+		Watches(&operatorv1alpha1.DataPlaneMetricsExtension{},
+			handler.EnqueueRequestsFromMapFunc(
+				enqueueControlPlaneForDataPlaneMetricsExtension(r.Client),
+			),
+		).
+		// Enqueue requests when DataPlanes change. This is important to ensure that
+		// the scrapers are up to date and are scraping the correct targets.
+		Watches(&operatorv1beta1.DataPlane{},
+			handler.EnqueueRequestsFromMapFunc(
+				enqueueControlPlaneForDataPlane(r.Client),
+			),
+		).
+		Complete(r)
+}
+
+// Reconcile moves the current state of an object to the intended state.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx = r.CtxInjector.InjectKeyValues(ctx)
+
+	logger := log.GetLogger(ctx, "controlplane_extensions", r.LoggingMode)
+
+	log.Trace(logger, "reconciling ControlPlane extensions", "req", req)
+	controlplane := new(operatorv1beta1.ControlPlane)
+
+	if err := r.Get(ctx, req.NamespacedName, controlplane); err != nil {
+		if k8serrors.IsNotFound(err) {
+			r.DataPlaneScraperManagerNotifier.NotifyRemove(ctx, types.NamespacedName{
+				Name:      req.Name,
+				Namespace: req.Namespace,
+			})
+
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if !controlplane.DeletionTimestamp.IsZero() {
+		if controlplane.DeletionTimestamp.After(time.Now()) {
+			return ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: time.Until(controlplane.DeletionTimestamp.Time),
+			}, nil
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// DataPlaneMetricsExtension
+	if err := r.ensureDataPlaneMetricsExtensions(ctx, controlplane); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// ensureDataPlaneMetricsExtensions ensures that the metrics plugin is enabled for the services
+// specified in the DataPlanePluginOptions.Metrics.ServiceSelector.MatchNames
+// and that the plugin config is up to date.
+// It also ensures that the plugin is disabled for services that are not in the
+// ServiceSelector.MatchNames.
+func (r *Reconciler) ensureDataPlaneMetricsExtensions(ctx context.Context, controlplane *operatorv1beta1.ControlPlane) error {
+	logger := log.GetLogger(ctx, "controlplane_dataplanemetrics_extension", r.LoggingMode)
+	extensions, err := extensions.GetAllDataPlaneMetricExtensionsForControlPlane(ctx, r.Client, controlplane)
+	// In case there is an error, we don't want to return early because we still want to perform the cleanup.
+	if err != nil {
+		log.Error(logger, err, "failed to get DataPlaneMetricsExtensions for ControlPlane", "controlplane")
+	}
+
+	if len(extensions) > 0 {
+		r.DataPlaneScraperManagerNotifier.NotifyAdd(ctx, controlplane)
+	} else {
+		r.DataPlaneScraperManagerNotifier.NotifyRemove(ctx, client.ObjectKeyFromObject(controlplane))
+	}
+
+	svcToExt := make(map[types.NamespacedName]*operatorv1alpha1.DataPlaneMetricsExtension)
+	for _, ext := range extensions {
+		for _, svcSS := range ext.Spec.ServiceSelector.MatchNames {
+			svcNN := types.NamespacedName{
+				Name:      svcSS.Name,
+				Namespace: controlplane.Namespace,
+			}
+			if v, ok := svcToExt[svcNN]; ok {
+				err := fmt.Errorf(
+					"DataPlaneMetricsExtension %v contains service ref %v that is already managed by DataPlaneMetricsExtension %v",
+					client.ObjectKeyFromObject(&ext), svcNN, client.ObjectKeyFromObject(v),
+				)
+				logger.Error(err, "failed to ensure metrics extension", "extension", client.ObjectKeyFromObject(&ext))
+				return err
+			}
+			svcToExt[svcNN] = &ext
+		}
+	}
+
+	svcListWithManagedLabel, err := listServicesThatHavePluginsManagedByControlPlane(ctx, controlplane, r.Client)
+	if err != nil {
+		return err
+	}
+
+	// Find all services with GatewayOperatorControlPlaneManagingPluginsLabel
+	// label set to the name of currently reconciled ControlPlane and if they
+	// are not in DataPlanePluginOptions.Metrics.ServiceSelector.MatchNames,
+	// remove the label, annotation and delete the plugin if it still exits.
+	for _, svc := range svcListWithManagedLabel {
+		if _, ok := svcToExt[client.ObjectKeyFromObject(&svc)]; ok {
+			// If the Service name is in one of the extensions ServiceSelector.MatchNames we don't do anything.
+			// We'll enforce the plugin config below where we iterate over matchNames.
+			continue
+		}
+
+		prometheusPluginName := prometheusPluginNameForSvc(&svc)
+		old := svc.DeepCopy()
+		if svc.Labels != nil {
+			delete(svc.Labels, GatewayOperatorControlPlaneNameManagingPluginsLabel)
+			delete(svc.Labels, GatewayOperatorControlPlaneNamespaceManagingPluginsLabel)
+		}
+		ensureKongPluginsAnnotationIsUnsetForPrometheusPlugin(&svc, prometheusPluginName)
+		if err := r.Patch(ctx, &svc, client.MergeFrom(old)); err != nil {
+			return fmt.Errorf("failed to Service %s: %w", client.ObjectKeyFromObject(&svc), err)
+		}
+
+		prometheusPlugin := configurationv1.KongPlugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      prometheusPluginName,
+				Namespace: svc.Namespace,
+			},
+		}
+		if err := r.Delete(ctx, &prometheusPlugin); err != nil {
+			return fmt.Errorf("failed to delete Prometheus KongPlugin for Service %s: %w", client.ObjectKeyFromObject(&svc), err)
+		}
+	}
+
+	// For each service in DataPlaneMetricsExtensions' ServiceSelector.MatchNames,
+	// ensure the Kong Plugin exists and its config is up to date.
+	for svcNN, ext := range svcToExt {
+		svc := corev1.Service{}
+		if err := r.Get(ctx, svcNN, &svc); err != nil {
+			logger.Error(err, "failed to get Service to enable metrics plugin on", "service", svcNN)
+			continue
+		}
+
+		prometheusPlugin, err := r.ensurePrometheusPlugin(ctx, &svc, controlplane, ext)
+		if err != nil {
+			logger.Error(err, "failed to ensure Prometheus Plugin for Service", "service", svcNN)
+			continue
+		}
+
+		old := svc.DeepCopy()
+
+		if svc.Labels == nil {
+			svc.Labels = make(map[string]string)
+		}
+		svc.Labels[GatewayOperatorControlPlaneNameManagingPluginsLabel] = controlplane.Name
+		svc.Labels[GatewayOperatorControlPlaneNamespaceManagingPluginsLabel] = controlplane.Namespace
+		ensureKongPluginsAnnotationIsSetForPrometheusPlugin(&svc, prometheusPlugin)
+		if err := r.Patch(ctx, &svc, client.MergeFrom(old)); err != nil {
+			logger.Error(err, "failed to patch Service to enable metrics plugin on", "service", svcNN)
+			continue
+		}
+	}
+	return err
+}
+
+func listServicesThatHavePluginsManagedByControlPlane(
+	ctx context.Context,
+	controlplane *operatorv1beta1.ControlPlane,
+	cl client.Client,
+) ([]corev1.Service, error) {
+	cpNameLabelReq, err := labels.NewRequirement(
+		GatewayOperatorControlPlaneNameManagingPluginsLabel, selection.Equals, []string{controlplane.Name},
+	)
+	if err != nil {
+		return nil, err
+	}
+	cpNamespaceLabelReq, err := labels.NewRequirement(
+		GatewayOperatorControlPlaneNamespaceManagingPluginsLabel, selection.Equals, []string{controlplane.Namespace},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	svcListWithManagedLabel := &corev1.ServiceList{}
+	err = cl.List(ctx, svcListWithManagedLabel, &client.ListOptions{
+		LabelSelector: labels.NewSelector().Add(*cpNameLabelReq).Add(*cpNamespaceLabelReq),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return svcListWithManagedLabel.Items, nil
+}
+
+func ensureStringInCommaSeparatedString(v, commaSeparated string) string {
+	split := strings.Split(commaSeparated, ",")
+	if lo.Contains(split, v) {
+		return commaSeparated
+	}
+	return commaSeparated + "," + v
+}
+
+func ensureStringNotInCommaSeparatedString(v, commaSeparated string) string {
+	split := strings.Split(commaSeparated, ",")
+	if lo.Contains(split, v) {
+		return strings.Join(
+			lo.Filter(split, func(s string, _ int) bool {
+				return s != v
+			}),
+			",",
+		)
+	}
+	return commaSeparated
+}
+
+// ensurePrometheusPlugin ensures that the Prometheus plugin exists for the given
+// Service and that it's up to date.
+func (r *Reconciler) ensurePrometheusPlugin(
+	ctx context.Context, svc *corev1.Service, controlplane *operatorv1beta1.ControlPlane, ext *operatorv1alpha1.DataPlaneMetricsExtension,
+) (*configurationv1.KongPlugin, error) {
+	generatedPlugin, err := prometheusPluginForSvc(svc, controlplane, ext)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate Prometheus KongPlugin: %w", err)
+	}
+
+	if err := controllerutil.SetControllerReference(controlplane, generatedPlugin, r.Scheme()); err != nil {
+		return nil, fmt.Errorf("failed to set owner reference for Prometheus KongPlugin for Service %s: %w", client.ObjectKeyFromObject(svc), err)
+	}
+
+	prometheusPluginActual := configurationv1.KongPlugin{}
+	pluginNN := client.ObjectKeyFromObject(generatedPlugin)
+	svcNN := client.ObjectKeyFromObject(svc)
+	if err = r.Get(ctx, pluginNN, &prometheusPluginActual); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to get Prometheus KongPlugin %s for Service %s: %w", pluginNN, svcNN, err)
+		}
+
+		// Create the plugin if it doesn't exist.
+		if err := r.Create(ctx, generatedPlugin); err != nil {
+			return nil, fmt.Errorf("failed to create Prometheus KongPlugin for Service %s: %w", svcNN, err)
+		}
+		return generatedPlugin, nil
+	}
+
+	// If it exists, ensure it's up to date.
+	if !cmp.Equal(generatedPlugin.Config, &prometheusPluginActual.Config) ||
+		!cmp.Equal(generatedPlugin.Annotations, &prometheusPluginActual.Annotations) ||
+		!cmp.Equal(generatedPlugin.OwnerReferences, &prometheusPluginActual.OwnerReferences) ||
+		!cmp.Equal(generatedPlugin.Labels, &prometheusPluginActual.Labels) ||
+		!cmp.Equal(generatedPlugin.Finalizers, &prometheusPluginActual.Finalizers) ||
+		!cmp.Equal(generatedPlugin.InstanceName, &prometheusPluginActual.InstanceName) ||
+		!cmp.Equal(generatedPlugin.PluginName, &prometheusPluginActual.PluginName) ||
+		!cmp.Equal(generatedPlugin.Disabled, &prometheusPluginActual.Disabled) {
+		prometheusPluginActual.Config = generatedPlugin.Config
+		prometheusPluginActual.Disabled = generatedPlugin.Disabled
+		prometheusPluginActual.Annotations = generatedPlugin.Annotations
+		prometheusPluginActual.Labels = generatedPlugin.Labels
+		prometheusPluginActual.Finalizers = generatedPlugin.Finalizers
+		prometheusPluginActual.InstanceName = generatedPlugin.InstanceName
+		prometheusPluginActual.PluginName = generatedPlugin.PluginName
+		prometheusPluginActual.OwnerReferences = generatedPlugin.OwnerReferences
+		if err := r.Update(ctx, &prometheusPluginActual); err != nil {
+			return nil, fmt.Errorf("failed to updated Prometheus KongPlugin %s for Service %s: %w", pluginNN, svcNN, err)
+		}
+	}
+
+	return &prometheusPluginActual, nil
+}
+
+func ensureKongPluginsAnnotationIsSetForPrometheusPlugin(svc *corev1.Service, prometheusPlugin *configurationv1.KongPlugin) {
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+
+	if ann, ok := svc.Annotations[consts.KongIngressControllerPluginsAnnotation]; !ok {
+		svc.Annotations[consts.KongIngressControllerPluginsAnnotation] = prometheusPlugin.Name
+	} else if ann != prometheusPlugin.Name {
+		pluginNames := strings.Split(ann, ",")
+		ok = lo.Contains(pluginNames, prometheusPlugin.Name)
+		if !ok {
+			svc.Annotations[consts.KongIngressControllerPluginsAnnotation] = ann + "," + prometheusPlugin.Name
+		}
+	}
+
+	if ann, ok := svc.Annotations[GatewayOperatorControlPlaneManagedPluginsAnnotation]; ok {
+		ann = ensureStringInCommaSeparatedString(prometheusPlugin.Name, ann)
+		svc.Annotations[GatewayOperatorControlPlaneManagedPluginsAnnotation] = ann
+	} else {
+		svc.Annotations[GatewayOperatorControlPlaneManagedPluginsAnnotation] = prometheusPlugin.Name
+	}
+}
+
+func ensureKongPluginsAnnotationIsUnsetForPrometheusPlugin(svc *corev1.Service, prometheusPluginName string) {
+	if svc.Annotations == nil {
+		return
+	}
+
+	if ann, ok := svc.Annotations[consts.KongIngressControllerPluginsAnnotation]; ok {
+		if ann == prometheusPluginName {
+			// Short circuit if the annotation only contains the managed plugin.
+			delete(svc.Annotations, consts.KongIngressControllerPluginsAnnotation)
+		} else {
+			// If there are other plugins, remove the managed plugin from
+			// the comma separated list.
+			pluginNames := strings.Split(ann, ",")
+			filteredPluginNames := lo.Filter(pluginNames,
+				func(pluginName string, _ int) bool {
+					return pluginName != prometheusPluginName
+				},
+			)
+			svc.Annotations[consts.KongIngressControllerPluginsAnnotation] = strings.Join(filteredPluginNames, ",")
+		}
+	}
+
+	if ann, ok := svc.Annotations[GatewayOperatorControlPlaneManagedPluginsAnnotation]; ok {
+		ann = ensureStringNotInCommaSeparatedString(prometheusPluginName, ann)
+		if ann == "" {
+			delete(svc.Annotations, GatewayOperatorControlPlaneManagedPluginsAnnotation)
+		} else {
+			svc.Annotations[GatewayOperatorControlPlaneManagedPluginsAnnotation] = ann
+		}
+	}
+}

--- a/controller/controlplane_extensions/controller_enqueue_funcs.go
+++ b/controller/controlplane_extensions/controller_enqueue_funcs.go
@@ -1,0 +1,301 @@
+package controlplane_extensions
+
+import (
+	"context"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kong/gateway-operator/pkg/consts"
+
+	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
+	operatorv1alpha1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1alpha1"
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+)
+
+// enqueueControlPlaneOwningKongPluginFunc returns a function that enqueues
+// ControlPlane reconciliation for events that impact KongPlugins, that are managed
+// by that ControlPlane.
+func enqueueControlPlaneOwningKongPluginFunc(
+	cl client.Client,
+) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []ctrl.Request {
+		if obj == nil {
+			return nil
+		}
+
+		p, ok := obj.(*configurationv1.KongPlugin)
+		if !ok {
+			return nil
+		}
+
+		managedBy, ok := p.Labels[consts.GatewayOperatorManagedByLabel]
+		if !ok {
+			return nil
+		}
+		if managedBy != "controlplane" {
+			return nil
+		}
+
+		name, ok := p.Labels[consts.GatewayOperatorManagedByNameLabel]
+		if !ok {
+			return nil
+		}
+
+		namespace, ok := p.Labels[consts.GatewayOperatorManagedByNamespaceLabel]
+		if !ok {
+			return nil
+		}
+
+		nn := types.NamespacedName{
+			Namespace: namespace,
+			Name:      name,
+		}
+
+		cp := operatorv1beta1.ControlPlane{}
+		if err := cl.Get(ctx, nn, &cp); err != nil {
+			return nil
+		}
+
+		return []ctrl.Request{
+			{
+				NamespacedName: types.NamespacedName{
+					Name:      cp.Name,
+					Namespace: cp.Namespace,
+				},
+			},
+		}
+	}
+}
+
+// enqueueControlPlaneForServicesThatHavePluginsManaged returns a function that
+// enqueues ControlPlane reconciliation for events impacting Services which have
+// its plugins managed by a ControlPlane. The relationship is established by
+// the presence of the label `gateway-operator.konghq.com/control-plane-managing-plugins`.
+func enqueueControlPlaneForServicesThatHavePluginsManaged() handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []ctrl.Request {
+		if obj == nil {
+			return nil
+		}
+
+		svc, ok := obj.(*corev1.Service)
+		if !ok {
+			return nil
+		}
+		if svc.Annotations == nil {
+			return nil
+		}
+		name, ok := svc.Labels[GatewayOperatorControlPlaneNameManagingPluginsLabel]
+		if !ok {
+			return nil
+		}
+
+		namespace, ok := svc.Labels[GatewayOperatorControlPlaneNamespaceManagingPluginsLabel]
+		if !ok {
+			return nil
+		}
+
+		return []ctrl.Request{
+			{
+				NamespacedName: types.NamespacedName{
+					Name:      name,
+					Namespace: namespace,
+				},
+			},
+		}
+	}
+}
+
+// enqueueControlPlaneForServicesThatHavePluginsConfigured enqueue ControlPlane
+// reconciliation for events impacting Services which have its plugins configured
+// through ControlPlane's DataPlanePluginOptions.
+//
+// This is only triggered when the Services are created which at that point
+// do not contain the backreference through the means of
+// `gateway-operator.konghq.com/control-plane-managing-plugins-name` and
+// `gateway-operator.konghq.com/control-plane-managing-plugins-namespace` labels.
+func enqueueControlPlaneForServicesThatHavePluginsConfigured(
+	cl client.Client,
+) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []ctrl.Request {
+		if obj == nil {
+			return nil
+		}
+
+		svc, ok := obj.(*corev1.Service)
+		if !ok {
+			return nil
+		}
+
+		var controlplanes operatorv1beta1.ControlPlaneList
+		if err := cl.List(ctx, &controlplanes); err != nil {
+			return nil
+		}
+
+		for _, controlplane := range controlplanes.Items {
+			filteredRefs := lo.Filter(controlplane.Spec.Extensions, func(e commonv1alpha1.ExtensionRef, _ int) bool {
+				return e.Kind == operatorv1alpha1.DataPlaneMetricsExtensionKind && e.Group == operatorv1alpha1.SchemeGroupVersion.Group
+			})
+
+			// NOTE: code below assumes 1:1 mapping between a Service and ControlPlane
+			// extension. The reason for this stems from the fact that there should be only 1
+			// plugin configuration per Service.
+			var exts []*operatorv1alpha1.DataPlaneMetricsExtension
+			for _, e := range filteredRefs {
+				nn := types.NamespacedName{
+					Name:      e.Name,
+					Namespace: controlplane.Namespace,
+				}
+				if e.Namespace != nil {
+					nn.Namespace = *e.Namespace
+				}
+
+				dpMetricExt := operatorv1alpha1.DataPlaneMetricsExtension{}
+				if err := cl.Get(ctx, nn, &dpMetricExt); err != nil {
+					continue
+				}
+				exts = append(exts, &dpMetricExt)
+			}
+			for _, ext := range exts {
+				for _, svcMatchName := range ext.Spec.ServiceSelector.MatchNames {
+					if svcMatchName.Name == svc.Name && ext.Namespace == svc.Namespace {
+						return []ctrl.Request{
+							{
+								NamespacedName: types.NamespacedName{
+									Name:      controlplane.Name,
+									Namespace: controlplane.Namespace,
+								},
+							},
+						}
+					}
+				}
+			}
+
+		}
+
+		return nil
+	}
+}
+
+func enqueueControlPlaneForDataPlaneMetricsExtension(
+	cl client.Client,
+) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []ctrl.Request {
+		if obj == nil {
+			return nil
+		}
+
+		ext, ok := obj.(*operatorv1alpha1.DataPlaneMetricsExtension)
+		if !ok {
+			return nil
+		}
+
+		var controlplanes operatorv1beta1.ControlPlaneList
+		if err := cl.List(ctx, &controlplanes); err != nil {
+			return nil
+		}
+
+		// NOTE: code below assumes 1:1 mapping between a DataPlaneMetricsExtension and ControlPlane
+		// and that there can only be one ControlPlane associated with a given DataPlaneMetricsExtension.
+		var recs []ctrl.Request
+		for _, controlplane := range controlplanes.Items {
+			for _, e := range controlplane.Spec.Extensions {
+				if e.Kind != operatorv1alpha1.DataPlaneMetricsExtensionKind &&
+					e.Group != operatorv1alpha1.SchemeGroupVersion.Group {
+					continue
+				}
+
+				if e.Name != ext.Name {
+					continue
+				}
+
+				if e.Namespace != nil && *e.Namespace != ext.Namespace {
+					continue
+				}
+
+				if controlplane.Namespace != ext.Namespace {
+					continue
+				}
+				return []ctrl.Request{
+					{
+						NamespacedName: types.NamespacedName{
+							Name:      controlplane.Name,
+							Namespace: controlplane.Namespace,
+						},
+					},
+				}
+			}
+		}
+
+		return recs
+	}
+}
+
+func enqueueControlPlaneForDataPlane(
+	cl client.Client,
+) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []ctrl.Request {
+		if obj == nil {
+			return nil
+		}
+
+		dp, ok := obj.(*operatorv1beta1.DataPlane)
+		if !ok {
+			return nil
+		}
+
+		// If the DataPlane is owned by a Gateway, we want to enqueue the ControlPlane
+		// is also part of the same Gateway.
+		var owner *metav1.OwnerReference
+		for _, ref := range dp.OwnerReferences {
+			if ref.APIVersion != gatewayv1.GroupVersion.String() ||
+				ref.Kind != "Gateway" {
+				owner = ref.DeepCopy()
+				break
+			}
+		}
+
+		var controlplanes operatorv1beta1.ControlPlaneList
+		if err := cl.List(ctx, &controlplanes, &client.ListOptions{
+			Namespace: dp.Namespace,
+		}); err != nil {
+			return nil
+		}
+
+		for _, controlplane := range controlplanes.Items {
+			if owner != nil {
+				for _, ref := range controlplane.OwnerReferences {
+					if ref.Name != owner.Name {
+						continue
+					}
+					if ref.APIVersion != gatewayv1.GroupVersion.String() ||
+						ref.Kind != "Gateway" {
+						continue
+					}
+				}
+			}
+
+			if controlplane.Spec.DataPlane == nil || *controlplane.Spec.DataPlane != dp.Name {
+				continue
+			}
+
+			return []ctrl.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						Name:      controlplane.Name,
+						Namespace: controlplane.Namespace,
+					},
+				},
+			}
+		}
+
+		return nil
+	}
+}

--- a/controller/controlplane_extensions/controller_predicates.go
+++ b/controller/controlplane_extensions/controller_predicates.go
@@ -1,0 +1,86 @@
+package controlplane_extensions
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
+	operatorv1alpha1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1alpha1"
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+)
+
+// ControlPlaneDataPlanePluginsSpecChangedPredicate is a predicate that checks if the
+// ControlPlane's DataPlane metrics extensions have changed.
+type ControlPlaneDataPlanePluginsSpecChangedPredicate struct {
+	predicate.Funcs
+}
+
+// Create returns true if at least one DataPlane metrics extensions is set on
+// the ControlPlane.
+func (ControlPlaneDataPlanePluginsSpecChangedPredicate) Create(e event.CreateEvent) bool {
+	if e.Object == nil {
+		return false
+	}
+	return dataplaneMetricsExtensionIsAttachedToControlPlane(e.Object)
+}
+
+// Update returns true if the ControlPlane's DataPlane metrics extensions have changed.
+func (ControlPlaneDataPlanePluginsSpecChangedPredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectOld == nil {
+		return false
+	}
+	cpOld, ok := e.ObjectOld.(*operatorv1beta1.ControlPlane)
+	if !ok {
+		return false
+	}
+
+	if e.ObjectNew == nil {
+		return false
+	}
+	cpNew, ok := e.ObjectNew.(*operatorv1beta1.ControlPlane)
+	if !ok {
+		return false
+	}
+
+	newExts := make([]commonv1alpha1.ExtensionRef, 0, len(cpNew.Spec.Extensions))
+	for _, ext := range cpNew.Spec.Extensions {
+		if ext.Kind == operatorv1alpha1.DataPlaneMetricsExtensionKind &&
+			ext.Group == operatorv1alpha1.SchemeGroupVersion.Group {
+			newExts = append(newExts, ext)
+		}
+	}
+
+	oldExts := make([]commonv1alpha1.ExtensionRef, 0, len(cpNew.Spec.Extensions))
+	for _, ext := range cpOld.Spec.Extensions {
+		if ext.Kind == operatorv1alpha1.DataPlaneMetricsExtensionKind &&
+			ext.Group == operatorv1alpha1.SchemeGroupVersion.Group {
+			oldExts = append(oldExts, ext)
+		}
+	}
+
+	return !cmp.Equal(newExts, oldExts)
+}
+
+// Delete returns true if the ControlPlane's DataPlanePluginOptions is set.
+func (ControlPlaneDataPlanePluginsSpecChangedPredicate) Delete(e event.DeleteEvent) bool {
+	if e.Object == nil {
+		return false
+	}
+	return dataplaneMetricsExtensionIsAttachedToControlPlane(e.Object)
+}
+
+func dataplaneMetricsExtensionIsAttachedToControlPlane(obj client.Object) bool {
+	controlplane, ok := obj.(*operatorv1beta1.ControlPlane)
+	if !ok {
+		return false
+	}
+	for _, ext := range controlplane.Spec.Extensions {
+		if ext.Kind == operatorv1alpha1.DataPlaneMetricsExtensionKind ||
+			ext.Group == operatorv1alpha1.SchemeGroupVersion.Group {
+			return true
+		}
+	}
+	return false
+}

--- a/controller/controlplane_extensions/controller_rbac.go
+++ b/controller/controlplane_extensions/controller_rbac.go
@@ -1,0 +1,5 @@
+package controlplane_extensions
+
+//+kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=dataplanemetricsextensions,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;patch;watch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongplugins,verbs=get;create;list;watch;delete;patch;update

--- a/controller/controlplane_extensions/metricsscraper/admin_api_address_provider.go
+++ b/controller/controlplane_extensions/metricsscraper/admin_api_address_provider.go
@@ -1,0 +1,182 @@
+package metricsscraper
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/gateway-operator/pkg/consts"
+
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+)
+
+// AdminAPIAddressProvider is an interface for providing the admin API addresses for a DataPlane.
+type AdminAPIAddressProvider interface {
+	AdminAddressesForDP(ctx context.Context, dataplane *operatorv1beta1.DataPlane) ([]string, error)
+}
+
+type adminAPIAddressProvider struct {
+	client client.Client
+}
+
+// NewAdminAPIAddressProvider creates a new AdminAPIAddressProvider.
+func NewAdminAPIAddressProvider(cl client.Client) *adminAPIAddressProvider {
+	return &adminAPIAddressProvider{
+		client: cl,
+	}
+}
+
+// AdminAddressesForDP returns the admin API addresses for the given DataPlane.
+func (a *adminAPIAddressProvider) AdminAddressesForDP(ctx context.Context, dataplane *operatorv1beta1.DataPlane) ([]string, error) {
+	labelReqs := []struct {
+		labelName string
+		selector  selection.Operator
+		values    []string
+	}{
+		{
+			labelName: consts.DataPlaneServiceStateLabel,
+			selector:  selection.Equals,
+			values:    []string{consts.DataPlaneStateLabelValueLive},
+		},
+		{
+			labelName: consts.DataPlaneServiceTypeLabel,
+			selector:  selection.Equals,
+			values:    []string{string(consts.DataPlaneAdminServiceLabelValue)},
+		},
+		{
+			labelName: consts.GatewayOperatorManagedByLabel,
+			selector:  selection.Equals,
+			values:    []string{consts.DataPlaneManagedLabelValue},
+		},
+		{
+			labelName: "app",
+			selector:  selection.Equals,
+			values:    []string{dataplane.Name},
+		},
+	}
+
+	labelselector := labels.NewSelector()
+	for _, req := range labelReqs {
+		labelReq, err := labels.NewRequirement(req.labelName, req.selector, req.values)
+		if err != nil {
+			return nil, err
+		}
+		labelselector = labelselector.Add(*labelReq)
+	}
+
+	var (
+		endpointsList discoveryv1.EndpointSliceList
+		urls          []string
+	)
+	if err := a.client.List(ctx, &endpointsList, &client.ListOptions{
+		LabelSelector: labelselector,
+		Namespace:     dataplane.Namespace,
+	}); err != nil {
+		return nil, err
+	}
+
+	for _, es := range endpointsList.Items {
+		var serviceName string
+		for _, or := range es.OwnerReferences {
+			if or.Kind == "Service" && or.APIVersion == "v1" {
+				serviceName = or.Name
+				break
+			}
+		}
+		if serviceName == "" {
+			continue
+		}
+
+		for _, port := range es.Ports {
+			if port.Port == nil {
+				continue
+			}
+
+			for _, endpoint := range es.Endpoints {
+				if len(endpoint.Addresses) == 0 {
+					continue
+				}
+				if endpoint.Conditions.Terminating != nil && *endpoint.Conditions.Terminating {
+					continue
+				}
+				if endpoint.Conditions.Ready != nil && !*endpoint.Conditions.Ready {
+					continue
+				}
+				if endpoint.Conditions.Serving != nil && !*endpoint.Conditions.Serving {
+					continue
+				}
+
+				svc := k8stypes.NamespacedName{
+					Name:      serviceName,
+					Namespace: es.Namespace,
+				}
+
+				// TODO: support IPv6
+				if es.AddressType != discoveryv1.AddressTypeIPv4 {
+					continue
+				}
+
+				url, err := adminAPIFromEndpoint(endpoint, port, svc)
+				if err != nil {
+					return nil, err
+				}
+
+				urls = append(urls, url.Address)
+			}
+		}
+	}
+
+	return urls, nil
+}
+
+// DiscoveredAdminAPI represents an Admin API discovered from a Kubernetes Service.
+type DiscoveredAdminAPI struct {
+	// Address is the Admin API's URL reachable from within the cluster.
+	Address string
+}
+
+func adminAPIFromEndpoint(
+	endpoint discoveryv1.Endpoint,
+	port discoveryv1.EndpointPort,
+	service k8stypes.NamespacedName,
+) (DiscoveredAdminAPI, error) {
+	// NOTE: Endpoint's addresses are assumed to be fungible, therefore we pick
+	// only the first one.
+	// For the context please see the `Endpoint.Addresses` godoc.
+	eAddress := endpoint.Addresses[0]
+
+	// NOTE: We assume https below because the referenced Admin API
+	// server will live in another Pod/elsewhere so allowing http would
+	// not be considered best practice.
+
+	if service.Name == "" {
+		return DiscoveredAdminAPI{}, fmt.Errorf(
+			"service name is empty for an endpoint with TargetRef %s/%s",
+			endpoint.TargetRef.Namespace, endpoint.TargetRef.Name,
+		)
+	}
+
+	// NOTE: This uses the service scoped Pod DNS strategy similar to the one
+	// used by KIC but in here that's the only one available because when the
+	// operator generates the DataPlane certifcates it uses only the DNS names
+	// and not IPs (primarily because the IPs are not known at the time of creation
+	// and it would be infeasible to reissue the certificates every time the IPs
+	// change).
+	// Alternatively this could use the namespace scope Pod DNS strategy but that
+	// would be less secure (only namespace scoped, not bound to DataPlane Service)
+	// and it would require change in the DataPlane certificate generation logic.
+	// Hence for now we only allow service scoped DNS names.
+
+	ipAddr := strings.ReplaceAll(eAddress, ".", "-")
+	address := fmt.Sprintf("%s.%s.%s.svc", ipAddr, service.Name, service.Namespace)
+
+	return DiscoveredAdminAPI{
+		Address: fmt.Sprintf("https://%s:%d", address, *port.Port),
+	}, nil
+}

--- a/controller/controlplane_extensions/metricsscraper/admin_api_address_provider_test.go
+++ b/controller/controlplane_extensions/metricsscraper/admin_api_address_provider_test.go
@@ -1,0 +1,348 @@
+package metricsscraper
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kong/gateway-operator/pkg/consts"
+
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+)
+
+func TestAdminAPIAddressProvider_AdminAddressesFromDP(t *testing.T) {
+	testCases := []struct {
+		name           string
+		dataplane      *operatorv1beta1.DataPlane
+		endpointSlices *discoveryv1.EndpointSliceList
+		expectedResult []string
+		expectedError  error
+	}{
+		{
+			name: "Single EndpointSlice",
+			dataplane: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dataplane-1",
+					Namespace: "default",
+				},
+			},
+			endpointSlices: &discoveryv1.EndpointSliceList{
+				Items: []discoveryv1.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "endpoint-slice-1",
+							Namespace: "default",
+							Labels: map[string]string{
+								"gateway-operator.konghq.com/dataplane-service-state": "live",
+								"gateway-operator.konghq.com/dataplane-service-type":  "admin",
+								"gateway-operator.konghq.com/managed-by":              "dataplane",
+								"app":                                                 "dataplane-1",
+							},
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: "v1",
+									Kind:       "Service",
+									Name:       "servicename",
+								},
+							},
+						},
+						AddressType: discoveryv1.AddressTypeIPv4,
+						Ports: []discoveryv1.EndpointPort{
+							{
+								Name:     lo.ToPtr("http"),
+								Protocol: lo.ToPtr(corev1.ProtocolTCP),
+								Port:     lo.ToPtr(int32(8001)),
+							},
+						},
+						Endpoints: []discoveryv1.Endpoint{
+							{
+								Addresses: []string{"192.168.0.1"},
+							},
+							{
+								Addresses: []string{"192.168.0.2"},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: []string{
+				"https://192-168-0-1.servicename.default.svc:8001",
+				"https://192-168-0-2.servicename.default.svc:8001",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Single EndpointSlice, IPv6 not supported",
+			dataplane: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dataplane-1",
+					Namespace: "default",
+				},
+			},
+			endpointSlices: &discoveryv1.EndpointSliceList{
+				Items: []discoveryv1.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "endpoint-slice-1",
+							Namespace: "default",
+							Labels: map[string]string{
+								"gateway-operator.konghq.com/dataplane-service-state": "live",
+								"gateway-operator.konghq.com/dataplane-service-type":  "admin",
+								"gateway-operator.konghq.com/managed-by":              "dataplane",
+								"app":                                                 "dataplane-1",
+							},
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: "v1",
+									Kind:       "Service",
+									Name:       "servicename",
+								},
+							},
+						},
+						AddressType: discoveryv1.AddressTypeIPv6,
+						Ports: []discoveryv1.EndpointPort{
+							{
+								Name:     lo.ToPtr("http"),
+								Protocol: lo.ToPtr(corev1.ProtocolTCP),
+								Port:     lo.ToPtr(int32(8001)),
+							},
+						},
+						Endpoints: []discoveryv1.Endpoint{
+							{
+								Addresses: []string{"fd69:2f34:87f7:8411:48e:92f4:f3ec:dd01"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Single EndpointSlice, IPv4 and IPv6, only the former is returned",
+			dataplane: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dataplane-1",
+					Namespace: "default",
+				},
+			},
+			endpointSlices: &discoveryv1.EndpointSliceList{
+				Items: []discoveryv1.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "endpoint-slice-1",
+							Namespace: "default",
+							Labels: map[string]string{
+								"gateway-operator.konghq.com/dataplane-service-state": "live",
+								"gateway-operator.konghq.com/dataplane-service-type":  "admin",
+								"gateway-operator.konghq.com/managed-by":              "dataplane",
+								"app":                                                 "dataplane-1",
+							},
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: "v1",
+									Kind:       "Service",
+									Name:       "servicename",
+								},
+							},
+						},
+						AddressType: discoveryv1.AddressTypeIPv6,
+						Ports: []discoveryv1.EndpointPort{
+							{
+								Name:     lo.ToPtr("http"),
+								Protocol: lo.ToPtr(corev1.ProtocolTCP),
+								Port:     lo.ToPtr(int32(8001)),
+							},
+						},
+						Endpoints: []discoveryv1.Endpoint{
+							{
+								Addresses: []string{"fd69:2f34:87f7:8411:48e:92f4:f3ec:dd01"},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "endpoint-slice-2",
+							Namespace: "default",
+							Labels: map[string]string{
+								"gateway-operator.konghq.com/dataplane-service-state": "live",
+								"gateway-operator.konghq.com/dataplane-service-type":  "admin",
+								"gateway-operator.konghq.com/managed-by":              "dataplane",
+								"app":                                                 "dataplane-1",
+							},
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: "v1",
+									Kind:       "Service",
+									Name:       "servicename",
+								},
+							},
+						},
+						AddressType: discoveryv1.AddressTypeIPv4,
+						Ports: []discoveryv1.EndpointPort{
+							{
+								Name:     lo.ToPtr("http"),
+								Protocol: lo.ToPtr(corev1.ProtocolTCP),
+								Port:     lo.ToPtr(int32(8001)),
+							},
+						},
+						Endpoints: []discoveryv1.Endpoint{
+							{
+								Addresses: []string{"192.168.0.2"},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: []string{
+				"https://192-168-0-2.servicename.default.svc:8001",
+			},
+		},
+		{
+			name: "2 EndpointSlices, 1 belongs to another DataPlane",
+			dataplane: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dataplane-1",
+					Namespace: "default",
+				},
+			},
+			endpointSlices: &discoveryv1.EndpointSliceList{
+				Items: []discoveryv1.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "endpoint-slice-1",
+							Namespace: "default",
+							Labels: map[string]string{
+								consts.DataPlaneServiceStateLabel:    consts.DataPlaneStateLabelValueLive,
+								consts.DataPlaneServiceTypeLabel:     string(consts.DataPlaneAdminServiceLabelValue),
+								consts.GatewayOperatorManagedByLabel: consts.DataPlaneManagedLabelValue,
+								"app":                                "dataplane-1",
+							},
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: "v1",
+									Kind:       "Service",
+									Name:       "servicename",
+								},
+							},
+						},
+						AddressType: discoveryv1.AddressTypeIPv4,
+						Ports: []discoveryv1.EndpointPort{
+							{
+								Name:     lo.ToPtr("http"),
+								Protocol: lo.ToPtr(corev1.ProtocolTCP),
+								Port:     lo.ToPtr(int32(8001)),
+							},
+						},
+						Endpoints: []discoveryv1.Endpoint{
+							{
+								Addresses: []string{"192.168.0.1"},
+							},
+							{
+								Addresses: []string{"192.168.0.2"},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "endpoint-slice-2",
+							Namespace: "default",
+							Labels: map[string]string{
+								consts.DataPlaneServiceStateLabel:    consts.DataPlaneStateLabelValueLive,
+								consts.DataPlaneServiceTypeLabel:     string(consts.DataPlaneAdminServiceLabelValue),
+								consts.GatewayOperatorManagedByLabel: consts.DataPlaneManagedLabelValue,
+								"app":                                "dataplane-2",
+							},
+						},
+						AddressType: discoveryv1.AddressTypeIPv4,
+						Ports: []discoveryv1.EndpointPort{
+							{
+								Name:     lo.ToPtr("http"),
+								Protocol: lo.ToPtr(corev1.ProtocolTCP),
+								Port:     lo.ToPtr(int32(8001)),
+							},
+						},
+						Endpoints: []discoveryv1.Endpoint{
+							{
+								Addresses: []string{"192.168.100.1"},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: []string{
+				"https://192-168-0-1.servicename.default.svc:8001",
+				"https://192-168-0-2.servicename.default.svc:8001",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "multiple addresses in a single endpoint result in only the first address being used",
+			dataplane: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dataplane-3",
+					Namespace: "default",
+				},
+			},
+			endpointSlices: &discoveryv1.EndpointSliceList{
+				Items: []discoveryv1.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "endpoint-slice-3",
+							Namespace: "default",
+							Labels: map[string]string{
+								consts.DataPlaneServiceStateLabel:    consts.DataPlaneStateLabelValueLive,
+								consts.DataPlaneServiceTypeLabel:     string(consts.DataPlaneAdminServiceLabelValue),
+								consts.GatewayOperatorManagedByLabel: consts.DataPlaneManagedLabelValue,
+								"app":                                "dataplane-3",
+							},
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: "v1",
+									Kind:       "Service",
+									Name:       "servicename",
+								},
+							},
+						},
+						AddressType: discoveryv1.AddressTypeIPv4,
+						Ports: []discoveryv1.EndpointPort{
+							{
+								Name:     lo.ToPtr("http"),
+								Protocol: lo.ToPtr(corev1.ProtocolTCP),
+								Port:     lo.ToPtr(int32(8001)),
+							},
+						},
+						Endpoints: []discoveryv1.Endpoint{
+							{
+								Addresses: []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"},
+							},
+							{
+								Addresses: []string{"192.168.100.1"},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: []string{
+				"https://192-168-0-1.servicename.default.svc:8001",
+				"https://192-168-100-1.servicename.default.svc:8001",
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithLists(tc.endpointSlices).Build()
+			provider := NewAdminAPIAddressProvider(fakeClient)
+
+			addresses, err := provider.AdminAddressesForDP(t.Context(), tc.dataplane)
+
+			assert.Equal(t, tc.expectedError, err)
+			assert.ElementsMatch(t, tc.expectedResult, addresses)
+		})
+	}
+}

--- a/controller/controlplane_extensions/metricsscraper/enricher.go
+++ b/controller/controlplane_extensions/metricsscraper/enricher.go
@@ -1,0 +1,197 @@
+package metricsscraper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/kong/go-kong/kong"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/samber/lo"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+)
+
+func init() {
+	collectors := []prometheus.Collector{
+		KongUpstreamLatencyMsHistogram,
+	}
+
+	for _, c := range collectors {
+		if err := metrics.Registry.Register(c); err != nil {
+			if !errors.As(err, &prometheus.AlreadyRegisteredError{}) {
+				panic(err)
+			}
+		}
+	}
+}
+
+// MetricsEnricher consumes Metrics and enriches them with Kubernetes metadata.
+type MetricsEnricher interface {
+	Consume(context.Context, Metrics) error
+}
+
+// metricsEnricher enriches the metrics with additional metadata.
+type metricsEnricher struct {
+	dataplane               *operatorv1beta1.DataPlane
+	adminAPIAddressProvider AdminAPIAddressProvider
+	httpClient              *http.Client
+	cl                      client.Client
+	logger                  logr.Logger
+}
+
+// NewEnricher creates a new MetricsEnricher.
+func NewEnricher(
+	logger logr.Logger,
+	dataplane *operatorv1beta1.DataPlane,
+	cl client.Client,
+	certs certs,
+	adminAPIAddressProvider AdminAPIAddressProvider,
+) (metricsEnricher, error) {
+	return metricsEnricher{
+		dataplane:               dataplane,
+		adminAPIAddressProvider: adminAPIAddressProvider,
+		httpClient:              httpClientWithCerts(certs),
+		cl:                      cl,
+		logger:                  logger,
+	}, nil
+}
+
+const (
+	// KongMetricTagK8sName is the tag set on Kong Services in the Admin API
+	// configuration to indicate the name of the Kubernetes Service associated
+	// with the Kong Service.
+	KongMetricTagK8sName = "k8s-name"
+	// KongMetricTagK8sNamespace is the tag set on Kong Services in the Admin API
+	// configuration to indicate the namespace of the Kubernetes Service associated
+	// with the Kong Service.
+	KongMetricTagK8sNamespace = "k8s-namespace"
+)
+
+// Consume consumes the metrics and enriches them with kubernetes metadata.
+func (me metricsEnricher) Consume(ctx context.Context, m Metrics) error {
+	// TODO: Potentially, create a watch which will get notifications on new
+	// endpoints for a DataPlane.
+	addrs, err := me.adminAPIAddressProvider.AdminAddressesForDP(ctx, me.dataplane)
+	if err != nil {
+		return fmt.Errorf("failed fetching Admin API addresses for DataPlane %s error: %w",
+			client.ObjectKeyFromObject(me.dataplane), err,
+		)
+	}
+	if len(addrs) == 0 {
+		return nil
+	}
+
+	// A DataPlane has homogenous configuration so we just take the first
+	// address available and use it to get the Kong services from the configuration.
+	kongClient, err := kong.NewClient(&addrs[0], me.httpClient)
+	if err != nil {
+		return fmt.Errorf("failed creating kong.Client for DataPlane %s error: %w", client.ObjectKeyFromObject(me.dataplane), err)
+	}
+
+	services, err := kongClient.Services.ListAll(ctx)
+	if err != nil {
+		return fmt.Errorf("failed listing Services for DataPlane %s error: %w", client.ObjectKeyFromObject(me.dataplane), err)
+	}
+
+	for dataplaneURL, metricFamily := range m.metrics {
+		for name, metric := range metricFamily {
+			if name != KongMetricNameKongUpstreamLatencyMs {
+				continue
+			}
+
+			for _, m := range metric.GetMetric() {
+				// Extract the name of the service from the metric labels.
+				// This has the name of the service in the Kong configuration.
+				serviceLabel, ok := lo.Find(m.GetLabel(),
+					func(p *dto.LabelPair) bool {
+						return *p.Name == "service"
+					},
+				)
+				if !ok || serviceLabel.Value == nil {
+					me.logger.Info("'service' label not found", "metric", name)
+					continue
+				}
+
+				svc, ok := lo.Find(services, func(s *kong.Service) bool {
+					return s.Name != nil && serviceLabel.GetValue() == *s.Name
+				})
+				if !ok {
+					me.logger.Info("service not found in config", "service", *serviceLabel.Value)
+					continue
+				}
+
+				tagK8sName, ok := extractAndTrimPrefix(svc.Tags, KongMetricTagK8sName)
+				if !ok {
+					me.logger.Info(KongMetricTagK8sName + " tag not found for service " + *svc.Name)
+					continue
+				}
+
+				tagK8sNamespace, ok := extractAndTrimPrefix(svc.Tags, KongMetricTagK8sNamespace)
+				if !ok {
+					me.logger.Info(KongMetricTagK8sNamespace + " tag not found for service " + *svc.Name)
+					continue
+				}
+
+				// Below labels have to match the ones in HistogramPassthroughMetric.Desc.
+				m.Label = []*dto.LabelPair{
+					{
+						Name:  lo.ToPtr("namespace"),
+						Value: lo.ToPtr(tagK8sNamespace),
+					},
+					{
+						Name:  lo.ToPtr("service"),
+						Value: lo.ToPtr(tagK8sName),
+					},
+					{
+						Name:  lo.ToPtr("kubernetes_apiversion"),
+						Value: lo.ToPtr("v1"),
+					},
+					{
+						Name:  lo.ToPtr("kubernetes_kind"),
+						Value: lo.ToPtr("service"),
+					},
+					{
+						Name:  lo.ToPtr("kubernetes_name"),
+						Value: lo.ToPtr(tagK8sName),
+					},
+					{
+						Name:  lo.ToPtr("kubernetes_namespace"),
+						Value: lo.ToPtr(tagK8sNamespace),
+					},
+					{
+						Name:  lo.ToPtr("dataplane_url"),
+						Value: lo.ToPtr(string(dataplaneURL)),
+					},
+				}
+
+				KongUpstreamLatencyMsHistogram.Observe(m, dataplaneURL)
+			}
+		}
+	}
+
+	// NOTE: to consider
+	// Now that we've observed the metrics, we can remove the time series about
+	// dataplanes instances that do not exist anymore.
+	// KongUpstreamLatencyHistogram.Prune(addrs)
+
+	return nil
+}
+
+// extractAndTrimPrefix looks for a tag with the given prefix and returns the
+// value with the prefix + ":" trimmed.
+func extractAndTrimPrefix(tags []*string, prefix string) (string, bool) {
+	raw, ok := lo.Find(tags, func(tag *string) bool {
+		return tag != nil && strings.HasPrefix(*tag, prefix+":")
+	})
+	if !ok {
+		return "", false
+	}
+	return strings.TrimPrefix(*raw, prefix+":"), true
+}

--- a/controller/controlplane_extensions/metricsscraper/histogram.go
+++ b/controller/controlplane_extensions/metricsscraper/histogram.go
@@ -1,0 +1,100 @@
+package metricsscraper
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+const (
+	// KongMetricNameKongUpstreamLatencyMs is the name of the kong_upstream_latency_ms metric.
+	KongMetricNameKongUpstreamLatencyMs = "kong_upstream_latency_ms"
+)
+
+// HistogramCollector is a prometheus.Collector that collects histograms.
+type HistogramCollector struct {
+	Name    string
+	Help    string
+	lock    sync.RWMutex
+	Metrics map[adminAPIEndpointURL]prometheus.Metric
+}
+
+var _ prometheus.Collector = &HistogramCollector{}
+
+// KongUpstreamLatencyMsHistogram is a prometheus.Collector that collects
+// kong_upstream_latency_ms histograms.
+var KongUpstreamLatencyMsHistogram = &HistogramCollector{
+	Name:    KongMetricNameKongUpstreamLatencyMs,
+	Help:    "Provides kong_upstream_latency_ms histogram enriched with dataplane metadata",
+	Metrics: make(map[adminAPIEndpointURL]prometheus.Metric),
+}
+
+// Collect implements prometheus.Collector.
+func (m *HistogramCollector) Collect(ch chan<- prometheus.Metric) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	for _, metric := range m.Metrics {
+		ch <- metric
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (m *HistogramCollector) Describe(ch chan<- *prometheus.Desc) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	for _, metric := range m.Metrics {
+		ch <- metric.Desc()
+	}
+}
+
+// Observe observes a metric for a given dataplaneURL.
+func (m *HistogramCollector) Observe(metric *dto.Metric, dataplaneURL adminAPIEndpointURL) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.Metrics[dataplaneURL] = &HistogramPassthroughMetric{
+		Name:   m.Name,
+		Help:   m.Help,
+		Metric: metric,
+	}
+}
+
+// HistogramPassthroughMetric is a prometheus.Metric that passes through a dto.Metric.
+// It allows observing whole histograms and not observing individual data points
+// like it's done with prometheus.HistogramVec.
+type HistogramPassthroughMetric struct {
+	Name   string
+	Help   string
+	Metric *dto.Metric
+}
+
+var _ prometheus.Metric = &HistogramPassthroughMetric{}
+
+// Desc implements prometheus.Metric.
+func (m *HistogramPassthroughMetric) Desc() *prometheus.Desc {
+	return prometheus.NewDesc(
+		m.Name,
+		m.Help,
+		[]string{
+			"namespace",
+			"service",
+			"kubernetes_apiversion",
+			"kubernetes_kind",
+			"kubernetes_name",
+			"kubernetes_namespace",
+			"dataplane_url",
+		},
+		nil,
+	)
+}
+
+// Write implements prometheus.Write.
+// Passed parameter dm is an output for metrics (target of write).
+func (m *HistogramPassthroughMetric) Write(dm *dto.Metric) error {
+	dm.Histogram = m.Metric.Histogram
+	dm.Label = m.Metric.Label
+	dm.TimestampMs = m.Metric.TimestampMs
+	dm.Untyped = m.Metric.Untyped
+
+	return nil
+}

--- a/controller/controlplane_extensions/metricsscraper/httpclient.go
+++ b/controller/controlplane_extensions/metricsscraper/httpclient.go
@@ -1,0 +1,33 @@
+package metricsscraper
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"time"
+)
+
+func httpClientWithCerts(certs certs) *http.Client {
+	rootCAs := x509.NewCertPool()
+	rootCAs.AddCert(certs.CA)
+
+	httpClient := *http.DefaultClient
+	httpClient.Timeout = 10 * time.Second
+	httpClient.Transport = &http.Transport{
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig: &tls.Config{
+			Certificates: []tls.Certificate{
+				{
+					Certificate: [][]byte{
+						certs.Cert.Raw,
+					},
+					Leaf:       certs.Cert,
+					PrivateKey: certs.Key,
+				},
+			},
+			RootCAs:    rootCAs,
+			MinVersion: tls.VersionTLS12,
+		},
+	}
+	return &httpClient
+}

--- a/controller/controlplane_extensions/metricsscraper/manager.go
+++ b/controller/controlplane_extensions/metricsscraper/manager.go
@@ -1,0 +1,413 @@
+package metricsscraper
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/cloudflare/cfssl/config"
+	"github.com/cloudflare/cfssl/signer"
+	"github.com/cloudflare/cfssl/signer/local"
+	"github.com/go-logr/logr"
+	"github.com/samber/lo"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/gateway-operator/controller/pkg/log"
+	"github.com/kong/gateway-operator/controller/pkg/secrets"
+	"github.com/kong/gateway-operator/pkg/consts"
+
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+)
+
+type certs struct {
+	Key  crypto.Signer
+	CA   *x509.Certificate
+	Cert *x509.Certificate
+}
+
+// MetricsScrapePipeline is a pipeline for scraping and enriching metrics.
+type MetricsScrapePipeline interface {
+	MetricsScraper
+	MetricsEnricher
+}
+
+type metricsPipeline struct {
+	MetricsScraper
+	MetricsEnricher
+}
+
+// Manager is a manager for metrics scrapers.
+type Manager struct {
+	logger                   logr.Logger
+	scrapeInterval           time.Duration
+	client                   client.Client
+	caSecretNN               types.NamespacedName
+	certs                    certs
+	pipelinesNotificationsCh chan scrapeUpdateNotification
+	pipelinesLock            sync.RWMutex
+	pipelines                map[types.UID]MetricsScrapePipeline
+	cpNNToDpUID              map[types.NamespacedName]types.UID
+	clusterCAKeyConfig       secrets.KeyConfig
+}
+
+// NewManager creates new MetricsScrapeManager.
+func NewManager(
+	logger logr.Logger,
+	interval time.Duration,
+	cl client.Client,
+	caSecretNN types.NamespacedName,
+	clusterCAKeyConfig secrets.KeyConfig,
+) *Manager {
+	return &Manager{
+		logger:                   logger,
+		scrapeInterval:           interval,
+		caSecretNN:               caSecretNN,
+		client:                   cl,
+		pipelinesNotificationsCh: make(chan scrapeUpdateNotification),
+		pipelines:                make(map[types.UID]MetricsScrapePipeline),
+		cpNNToDpUID:              make(map[types.NamespacedName]types.UID),
+		clusterCAKeyConfig:       clusterCAKeyConfig,
+	}
+}
+
+// initMTLSCerts creates mTLS certs for the manager so that it can use them for
+// secure communication with DataPlane's AdminAPI endpoints.
+// When successful, it sets the certs on the manager.
+func (msm *Manager) initMTLSCerts(ctx context.Context) error {
+	msm.logger.Info("getting CA cluster secret to generate certs for MTLs communication with Kong Gateway", "secret", msm.caSecretNN)
+	var (
+		caCert *x509.Certificate
+		caKey  crypto.Signer
+	)
+	if err := retry.Do(
+		func() error {
+			var err error
+			caCert, caKey, err = msm.getCASecretAndKey(ctx)
+			return err
+		},
+		retry.Context(ctx),
+		retry.Attempts(0),
+		retry.MaxDelay(time.Second),
+		retry.MaxJitter(500*time.Millisecond),
+		retry.DelayType(retry.BackOffDelay),
+		retry.LastErrorOnly(true),
+		retry.OnRetry(func(n uint, err error) {
+			msm.logger.Info(
+				"failed to get CA cluster secret to generate certs for MTLs communication with Kong Gateway, retrying...",
+				"error", err,
+			)
+		}),
+	); err != nil {
+		return err
+	}
+
+	signingAlgorithm := secrets.SignatureAlgorithmForKeyType(msm.clusterCAKeyConfig.Type)
+	template := x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName:   "localhost",
+			Organization: []string{"Kong, Inc."},
+			Country:      []string{"US"},
+		},
+		SignatureAlgorithm: signingAlgorithm,
+		DNSNames:           []string{"localhost"},
+	}
+
+	csrKey, _, signingAlgorithm, err := secrets.CreatePrivateKey(msm.clusterCAKeyConfig)
+	if err != nil {
+		return err
+	}
+
+	der, err := x509.CreateCertificateRequest(rand.Reader, &template, csrKey)
+	if err != nil {
+		return err
+	}
+	// Let's make this valid for 10 years.
+	expiration := int32(315400000)
+	csr := certificatesv1.CertificateSigningRequestSpec{
+		Request: pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE REQUEST",
+			Bytes: der,
+		}),
+		SignerName:        "gateway-operator.konghq.com/mtls",
+		ExpirationSeconds: &expiration,
+		Usages: []certificatesv1.KeyUsage{
+			certificatesv1.UsageDigitalSignature,
+		},
+	}
+
+	signedCertPem, err := signCertificate(csr, caKey, caCert, signingAlgorithm)
+	if err != nil {
+		return err
+	}
+	pb, _ := pem.Decode(signedCertPem)
+	if pb == nil {
+		return fmt.Errorf("failed to decode signed certificate")
+	}
+	cert, err := x509.ParseCertificate(pb.Bytes)
+	if err != nil {
+		return err
+	}
+
+	msm.certs = certs{
+		CA:   caCert,
+		Cert: cert,
+		Key:  csrKey,
+	}
+	return nil
+}
+
+func (msm *Manager) getCASecretAndKey(ctx context.Context) (*x509.Certificate, crypto.Signer, error) {
+	var caSecret corev1.Secret
+	err := msm.client.Get(ctx, msm.caSecretNN, &caSecret)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ca, ok := caSecret.Data[consts.TLSCRT]
+	if !ok {
+		return nil, nil, fmt.Errorf(consts.TLSCRT + " field not found")
+	}
+	caCertBlock, _ := pem.Decode(ca)
+	if caCertBlock == nil {
+		return nil, nil, fmt.Errorf("failed decoding %q data from secret %s", consts.TLSCRT, caSecret.Name)
+	}
+	caCert, err := x509.ParseCertificate(caCertBlock.Bytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	key, ok := caSecret.Data[consts.TLSKey]
+	if !ok {
+		return nil, nil, fmt.Errorf(consts.TLSKey + " field not found")
+	}
+	caKeyBlock, _ := pem.Decode(key)
+	if caKeyBlock == nil {
+		return nil, nil, fmt.Errorf("failed decoding %q data from secret %s", consts.TLSKey, caSecret.Name)
+	}
+
+	caKey, err := secrets.ParseKey(msm.clusterCAKeyConfig.Type, caKeyBlock)
+	return caCert, caKey, err
+}
+
+// Start starts the metrics scraping loop.
+// It spawns a goroutine that periodically scrapes metrics from the enabled scrapers.
+// This satisfies the Manager interface and can be used with controller-runtime Manager.
+func (msm *Manager) Start(ctx context.Context) error {
+	if err := msm.initMTLSCerts(ctx); err != nil {
+		return fmt.Errorf("failed to create mTLS certs: %w", err)
+	}
+
+	go func(ctx context.Context) {
+		ticker := time.NewTicker(msm.scrapeInterval)
+		defer ticker.Stop()
+		defer close(msm.pipelinesNotificationsCh)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+
+			case sun := <-msm.pipelinesNotificationsCh:
+				switch sun.Action {
+				case add:
+					if err := msm.enableMetricsScraperForControlPlanesDataPlane(ctx, sun.ControlPlane); err != nil {
+						log.Error(msm.logger, err, "failed to enable metrics scraper for ControlPlane", sun.ControlPlane)
+					}
+				case remove:
+					msm.RemoveForControlPlaneNN(sun.ControlPlaneNN)
+				}
+
+			case <-ticker.C:
+				msm.pipelinesLock.RLock()
+				pipeline := lo.Values(msm.pipelines)
+				msm.pipelinesLock.RUnlock()
+
+				for _, p := range pipeline {
+					go func(p MetricsScrapePipeline) {
+						metrics, err := p.Scrape(ctx)
+						if err != nil {
+							msm.logger.Error(err, "failed to scrape metrics")
+							return
+						}
+						if err := p.Consume(ctx, metrics); err != nil {
+							msm.logger.Error(err, "failed to consume metrics")
+							return
+						}
+					}(p)
+				}
+
+			}
+		}
+	}(ctx)
+
+	return nil
+}
+
+type scrapeUpdateAction uint8
+
+const (
+	add scrapeUpdateAction = iota
+	remove
+)
+
+type scrapeUpdateNotification struct {
+	ControlPlane   *operatorv1beta1.ControlPlane
+	ControlPlaneNN types.NamespacedName
+	Action         scrapeUpdateAction
+}
+
+// NotifyAdd notifies the manager that a new ControlPlane has been added.
+func (msm *Manager) NotifyAdd(ctx context.Context, cp *operatorv1beta1.ControlPlane) {
+	select {
+	case <-ctx.Done():
+	case msm.pipelinesNotificationsCh <- scrapeUpdateNotification{ControlPlane: cp, Action: add}:
+	}
+}
+
+// NotifyRemove notifies the manager that a ControlPlane has been removed.
+// It uses the ControlPlane's NamespacedName to identify the ControlPlane because
+// the ControlPlane object is already deleted when this method is called.
+func (msm *Manager) NotifyRemove(ctx context.Context, cp types.NamespacedName) {
+	select {
+	case <-ctx.Done():
+	case msm.pipelinesNotificationsCh <- scrapeUpdateNotification{ControlPlaneNN: cp, Action: remove}:
+	}
+}
+
+// Add adds a scraper to the manager for the given ControlPlane.
+// If a scraper already exists for the given DataPlane UID, it is replaced.
+// User is responsible for ensuring that the scraper is configured for DataPlane
+// that is associated with the given ControlPlane.
+// It returns true if the scraper was added.
+func (msm *Manager) Add(cp *operatorv1beta1.ControlPlane, pipeline MetricsScrapePipeline) bool {
+	if cp == nil || cp.Spec.DataPlane == nil {
+		return false
+	}
+
+	dpUID := pipeline.DataPlaneUID()
+	cpNN := client.ObjectKeyFromObject(cp)
+
+	msm.pipelinesLock.Lock()
+	defer msm.pipelinesLock.Unlock()
+	if _, ok := msm.pipelines[dpUID]; ok {
+		// If we already have a scraper for this DataPlane, we don't need to add
+		// it again. We just need to update the mapping of the ControlPlane NN
+		// to the DataPlane UID.
+		msm.cpNNToDpUID[cpNN] = dpUID
+		return false
+	}
+
+	msm.pipelines[dpUID] = pipeline
+	if oldDpDUID, ok := msm.cpNNToDpUID[cpNN]; ok {
+		// If we already have a scraper for this ControlPlane, we need to check
+		// if it's the same DataPlane. If it's not, we need to remove the old
+		// scraper.
+		if oldDpDUID != dpUID {
+			delete(msm.pipelines, oldDpDUID)
+		}
+	}
+	msm.cpNNToDpUID[cpNN] = dpUID
+	return true
+}
+
+// RemoveForControlPlaneNN removes a scraper from the manager for the given ControlPlane.
+func (msm *Manager) RemoveForControlPlaneNN(cpNN types.NamespacedName) {
+	msm.pipelinesLock.Lock()
+	defer msm.pipelinesLock.Unlock()
+
+	dpUID, ok := msm.cpNNToDpUID[cpNN]
+	if !ok {
+		return
+	}
+
+	delete(msm.pipelines, dpUID)
+	delete(msm.cpNNToDpUID, cpNN)
+	log.Debug(msm.logger, "removed metrics scraper for ControlPlane", cpNN, "dataplane_uid", dpUID)
+}
+
+func (msm *Manager) enableMetricsScraperForControlPlanesDataPlane(
+	ctx context.Context,
+	controlplane *operatorv1beta1.ControlPlane,
+) error {
+	if controlplane.Spec.DataPlane == nil {
+		return fmt.Errorf("DataPlane is not set in ControlPlane %s", controlplane.Name)
+	}
+
+	var (
+		dpNN = types.NamespacedName{
+			Name:      *controlplane.Spec.DataPlane,
+			Namespace: controlplane.Namespace,
+		}
+		dp operatorv1beta1.DataPlane
+	)
+	if err := msm.client.Get(ctx, dpNN, &dp); err != nil {
+		return fmt.Errorf("failed to get DataPlane %s: %w", dpNN, err)
+	}
+
+	adminAPIAddressProvider := NewAdminAPIAddressProvider(msm.client)
+	httpClient := httpClientWithCerts(msm.certs)
+
+	enricher, err := NewEnricher(msm.logger, &dp, msm.client, msm.certs, adminAPIAddressProvider)
+	if err != nil {
+		return fmt.Errorf("failed to create metrics enricher: %w", err)
+	}
+
+	pipeline := &metricsPipeline{
+		MetricsScraper:  NewPrometheusMetricsScraper(msm.logger, &dp, httpClient, adminAPIAddressProvider),
+		MetricsEnricher: enricher,
+	}
+
+	if msm.Add(controlplane, pipeline) {
+		log.Debug(msm.logger, "enabled metrics scraper for ControlPlane", controlplane, "DataPlane", controlplane.Spec.DataPlane)
+	}
+	return nil
+}
+
+func signCertificate(
+	csr certificatesv1.CertificateSigningRequestSpec,
+	key crypto.Signer,
+	caCert *x509.Certificate,
+	signingAlgorithm x509.SignatureAlgorithm,
+) ([]byte, error) {
+	usages := make([]string, 0, len(csr.Usages))
+	for _, usage := range csr.Usages {
+		usages = append(usages, string(usage))
+	}
+
+	certExpiryDuration := time.Second * time.Duration(*csr.ExpirationSeconds)
+	durationUntilExpiry := time.Until(caCert.NotAfter)
+	if durationUntilExpiry <= 0 {
+		return nil, fmt.Errorf("the signer has expired: %v", caCert.NotAfter)
+	}
+	if durationUntilExpiry < certExpiryDuration {
+		certExpiryDuration = durationUntilExpiry
+	}
+
+	policy := &config.Signing{
+		Default: &config.SigningProfile{
+			Usage:        usages,
+			Expiry:       certExpiryDuration,
+			ExpiryString: certExpiryDuration.String(),
+		},
+	}
+	cfs, err := local.NewSigner(key, caCert, signingAlgorithm, policy)
+	if err != nil {
+		return nil, err
+	}
+
+	certBytes, err := cfs.Sign(signer.SignRequest{Request: string(csr.Request)})
+	if err != nil {
+		return nil, err
+	}
+	return certBytes, nil
+}

--- a/controller/controlplane_extensions/metricsscraper/manager_test.go
+++ b/controller/controlplane_extensions/metricsscraper/manager_test.go
@@ -1,0 +1,531 @@
+package metricsscraper
+
+import (
+	"context"
+	"crypto/x509"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kong/gateway-operator/controller/pkg/secrets"
+
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+)
+
+type pair struct {
+	controlplane *operatorv1beta1.ControlPlane
+	pipeline     MetricsScrapePipeline
+}
+
+func TestMetricsScrapeManagerAdd(t *testing.T) {
+	const (
+		interval = time.Second
+	)
+	clusterCAKeyType := secrets.KeyConfig{
+		Type: x509.ECDSA,
+		Size: 1024,
+	}
+
+	tests := []struct {
+		name                 string
+		pairs                []pair
+		expectedCpNNToDPUID  map[types.NamespacedName]types.UID
+		expectedScrapersUIDs []types.UID
+	}{
+		{
+			name: "one ControlPlane with one scraper",
+			pairs: []pair{
+				{
+					controlplane: &operatorv1beta1.ControlPlane{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "cp1",
+							Namespace: "ns1",
+						},
+						Spec: operatorv1beta1.ControlPlaneSpec{
+							ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+								DataPlane: lo.ToPtr("dp1"),
+							},
+						},
+					},
+					pipeline: metricsPipeline{
+						MetricsScraper: NewPrometheusMetricsScraper(
+							logr.Discard(),
+							&operatorv1beta1.DataPlane{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "dp1",
+									Namespace: "ns1",
+									UID:       types.UID("dp-uid1"),
+								},
+							},
+							http.DefaultClient,
+							&mockAdminAPIAddressProvider{},
+						),
+						MetricsEnricher: &metricsEnricher{},
+					},
+				},
+			},
+			expectedCpNNToDPUID: map[types.NamespacedName]types.UID{
+				{
+					Name:      "cp1",
+					Namespace: "ns1",
+				}: "dp-uid1",
+			},
+			expectedScrapersUIDs: []types.UID{
+				"dp-uid1",
+			},
+		},
+		{
+			name: "one ControlPlane with one scraper which then gets overridden by another scraper for a different DataPlane",
+			pairs: []pair{
+				{
+					controlplane: &operatorv1beta1.ControlPlane{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "cp1",
+							Namespace: "ns1",
+						},
+						Spec: operatorv1beta1.ControlPlaneSpec{
+							ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+								DataPlane: lo.ToPtr("dp1"),
+							},
+						},
+					},
+					pipeline: metricsPipeline{
+						MetricsScraper: NewPrometheusMetricsScraper(
+							logr.Discard(),
+							&operatorv1beta1.DataPlane{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "dp1",
+									Namespace: "ns1",
+									UID:       types.UID("dp-uid1"),
+								},
+							},
+							http.DefaultClient,
+							&mockAdminAPIAddressProvider{},
+						),
+						MetricsEnricher: &metricsEnricher{},
+					},
+				},
+				{
+					controlplane: &operatorv1beta1.ControlPlane{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "cp1",
+							Namespace: "ns1",
+						},
+						Spec: operatorv1beta1.ControlPlaneSpec{
+							ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+								DataPlane: lo.ToPtr("dp1"),
+							},
+						},
+					},
+					pipeline: metricsPipeline{
+						MetricsScraper: NewPrometheusMetricsScraper(
+							logr.Discard(),
+							&operatorv1beta1.DataPlane{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "dp2",
+									Namespace: "ns1",
+									UID:       types.UID("dp-uid2"),
+								},
+							},
+							http.DefaultClient,
+							&mockAdminAPIAddressProvider{},
+						),
+						MetricsEnricher: &metricsEnricher{},
+					},
+				},
+			},
+			expectedCpNNToDPUID: map[types.NamespacedName]types.UID{
+				{
+					Name:      "cp1",
+					Namespace: "ns1",
+				}: "dp-uid2",
+			},
+			expectedScrapersUIDs: []types.UID{
+				"dp-uid2",
+			},
+		},
+		{
+			name: "2 ControlPlanes with 2 scrapers",
+			pairs: []pair{
+				{
+					controlplane: &operatorv1beta1.ControlPlane{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "cp1",
+							Namespace: "ns1",
+						},
+						Spec: operatorv1beta1.ControlPlaneSpec{
+							ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+								DataPlane: lo.ToPtr("dp1"),
+							},
+						},
+					},
+					pipeline: metricsPipeline{
+						MetricsScraper: NewPrometheusMetricsScraper(
+							logr.Discard(),
+							&operatorv1beta1.DataPlane{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "dp1",
+									Namespace: "ns1",
+									UID:       types.UID("dp-uid1"),
+								},
+							},
+							http.DefaultClient,
+							&mockAdminAPIAddressProvider{},
+						),
+						MetricsEnricher: &metricsEnricher{},
+					},
+				},
+				{
+					controlplane: &operatorv1beta1.ControlPlane{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "cp2",
+							Namespace: "ns1",
+						},
+						Spec: operatorv1beta1.ControlPlaneSpec{
+							ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+								DataPlane: lo.ToPtr("dp2"),
+							},
+						},
+					},
+					pipeline: metricsPipeline{
+						MetricsScraper: NewPrometheusMetricsScraper(
+							logr.Discard(),
+							&operatorv1beta1.DataPlane{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "dp2",
+									Namespace: "ns1",
+									UID:       types.UID("dp-uid2"),
+								},
+							},
+							http.DefaultClient,
+							&mockAdminAPIAddressProvider{},
+						),
+						MetricsEnricher: &metricsEnricher{},
+					},
+				},
+			},
+			expectedCpNNToDPUID: map[types.NamespacedName]types.UID{
+				{
+					Name:      "cp1",
+					Namespace: "ns1",
+				}: "dp-uid1",
+				{
+					Name:      "cp2",
+					Namespace: "ns1",
+				}: "dp-uid2",
+			},
+			expectedScrapersUIDs: []types.UID{
+				"dp-uid1",
+				"dp-uid2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().Build()
+			msm := NewManager(logr.Discard(), interval, fakeClient, types.NamespacedName{}, clusterCAKeyType)
+			for _, pipeline := range tt.pairs {
+				msm.Add(pipeline.controlplane, pipeline.pipeline)
+			}
+
+			assert.Equal(t, tt.expectedCpNNToDPUID, msm.cpNNToDpUID)
+			assert.ElementsMatch(t, tt.expectedScrapersUIDs, lo.Keys(msm.pipelines))
+			for uid, scraper := range msm.pipelines {
+				assert.Equal(t, uid, scraper.DataPlaneUID())
+			}
+		})
+	}
+}
+
+func TestMetricsScrapeManager_RemoveForControlPlaneNN(t *testing.T) {
+	const interval = time.Second
+
+	clusterCAKeyType := secrets.KeyConfig{
+		Type: x509.ECDSA,
+		Size: 1024,
+	}
+
+	tests := []struct {
+		name                 string
+		addPairs             []pair
+		removeCpNN           *types.NamespacedName
+		expectedCpNNToDPUID  map[types.NamespacedName]types.UID
+		expectedScrapersUIDs []types.UID
+	}{
+		{
+			name: "add 2 ControlPlanes and then remove 1",
+			addPairs: []pair{
+				{
+					controlplane: &operatorv1beta1.ControlPlane{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "cp1",
+							Namespace: "ns1",
+						},
+						Spec: operatorv1beta1.ControlPlaneSpec{
+							ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+								DataPlane: lo.ToPtr("dp1"),
+							},
+						},
+					},
+					pipeline: metricsPipeline{
+						MetricsScraper: NewPrometheusMetricsScraper(
+							logr.Discard(),
+							&operatorv1beta1.DataPlane{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "dp1",
+									Namespace: "ns1",
+									UID:       types.UID("dp-uid1"),
+								},
+							},
+							http.DefaultClient,
+							&mockAdminAPIAddressProvider{},
+						),
+						MetricsEnricher: &metricsEnricher{},
+					},
+				},
+				{
+					controlplane: &operatorv1beta1.ControlPlane{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "cp2",
+							Namespace: "ns1",
+						},
+						Spec: operatorv1beta1.ControlPlaneSpec{
+							ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+								DataPlane: lo.ToPtr("dp2"),
+							},
+						},
+					},
+					pipeline: metricsPipeline{
+						MetricsScraper: NewPrometheusMetricsScraper(
+							logr.Discard(),
+							&operatorv1beta1.DataPlane{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "dp2",
+									Namespace: "ns1",
+									UID:       types.UID("dp-uid2"),
+								},
+							},
+							http.DefaultClient,
+							&mockAdminAPIAddressProvider{},
+						),
+						MetricsEnricher: &metricsEnricher{},
+					},
+				},
+			},
+			removeCpNN: &types.NamespacedName{
+				Name:      "cp2",
+				Namespace: "ns1",
+			},
+			expectedCpNNToDPUID: map[types.NamespacedName]types.UID{
+				{
+					Name:      "cp1",
+					Namespace: "ns1",
+				}: "dp-uid1",
+			},
+			expectedScrapersUIDs: []types.UID{
+				"dp-uid1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().Build()
+			msm := NewManager(logr.Discard(), interval, fakeClient, types.NamespacedName{}, clusterCAKeyType)
+			for _, pair := range tt.addPairs {
+				msm.Add(pair.controlplane, pair.pipeline)
+			}
+
+			if tt.removeCpNN != nil {
+				msm.RemoveForControlPlaneNN(*tt.removeCpNN)
+			}
+
+			assert.Equal(t, tt.expectedCpNNToDPUID, msm.cpNNToDpUID)
+			assert.Equal(t, tt.expectedScrapersUIDs, lo.Keys(msm.pipelines))
+			for uid, scraper := range msm.pipelines {
+				assert.Equal(t, uid, scraper.DataPlaneUID())
+			}
+		})
+	}
+}
+
+type mockScraper struct {
+	uid       types.UID
+	err       error
+	callCount atomic.Int32
+}
+
+func (m *mockScraper) DataPlaneUID() types.UID {
+	return m.uid
+}
+
+func (m *mockScraper) Scrape(_ context.Context) (Metrics, error) {
+	m.callCount.Add(1)
+	return Metrics{}, m.err
+}
+
+func (m *mockScraper) CallCount() int {
+	return int(m.callCount.Load())
+}
+
+func (m *mockScraper) AddSubscriber(_ MetricsConsumer) {
+}
+
+type mockConsumer struct{}
+
+func (mc *mockConsumer) Consume(_ context.Context, _ Metrics) error { return nil }
+
+func TestMetricsScrapeManager_Start(t *testing.T) {
+	caSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ca-secret",
+			Namespace: "kong-system",
+		},
+		Data: map[string][]byte{
+			"ca.crt": []byte(`` +
+				`-----BEGIN CERTIFICATE-----` + "\n" +
+				`MIIBwTCCAWigAwIBAgIIKs87j5BiGj4wCgYIKoZIzj0EAwIwRTELMAkGA1UEBhMC` +
+				`VVMxEzARBgNVBAoTCktvbmcsIEluYy4xITAfBgNVBAMTGEtvbmcgR2F0ZXdheSBP` +
+				`cGVyYXRvciBDQTAeFw0yNDAyMTIxMDM3NDRaFw0zNDAyMDkyMTQ0MjRaMEUxCzAJ` +
+				`BgNVBAYTAlVTMRMwEQYDVQQKEwpLb25nLCBJbmMuMSEwHwYDVQQDExhLb25nIEdh` +
+				`dGV3YXkgT3BlcmF0b3IgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQLj/6b` +
+				`NM6qJFqnFcv+MZeamXilwpI0y7SbKfaSu1IrbMSL/anHaqRTDTHuuft9AuMj00W2` +
+				`T3iQyVLT5cf7dqzxo0IwQDAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUwAwEB` +
+				`/zAdBgNVHQ4EFgQUXcm63z6XvW7V2QurDH2gesszVpAwCgYIKoZIzj0EAwIDRwAw` +
+				`RAIgUXfDI3Touxkhv1TQtU9piBDoaVMg2iVlvkXdJOdoBnICIBvwJLbX3u6Yr+ap` +
+				`WHQ15pbL+bpfn7O3LfGp7YpUWDv3` + "\n" +
+				`-----END CERTIFICATE-----`,
+			),
+			"tls.crt": []byte(`` +
+				`-----BEGIN CERTIFICATE-----` + "\n" +
+				`MIIBwTCCAWigAwIBAgIIKs87j5BiGj4wCgYIKoZIzj0EAwIwRTELMAkGA1UEBhMC` +
+				`VVMxEzARBgNVBAoTCktvbmcsIEluYy4xITAfBgNVBAMTGEtvbmcgR2F0ZXdheSBP` +
+				`cGVyYXRvciBDQTAeFw0yNDAyMTIxMDM3NDRaFw0zNDAyMDkyMTQ0MjRaMEUxCzAJ` +
+				`BgNVBAYTAlVTMRMwEQYDVQQKEwpLb25nLCBJbmMuMSEwHwYDVQQDExhLb25nIEdh` +
+				`dGV3YXkgT3BlcmF0b3IgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQLj/6b` +
+				`NM6qJFqnFcv+MZeamXilwpI0y7SbKfaSu1IrbMSL/anHaqRTDTHuuft9AuMj00W2` +
+				`T3iQyVLT5cf7dqzxo0IwQDAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUwAwEB` +
+				`/zAdBgNVHQ4EFgQUXcm63z6XvW7V2QurDH2gesszVpAwCgYIKoZIzj0EAwIDRwAw` +
+				`RAIgUXfDI3Touxkhv1TQtU9piBDoaVMg2iVlvkXdJOdoBnICIBvwJLbX3u6Yr+ap` +
+				`WHQ15pbL+bpfn7O3LfGp7YpUWDv3` + "\n" +
+				`-----END CERTIFICATE-----`,
+			),
+			"tls.key": []byte(`` +
+				`-----BEGIN EC PRIVATE KEY-----` + "\n" +
+				`MHcCAQEEIHj7JB7holIu7giiCIhKlQcRX6Xvst+EklaFANbAy6L2oAoGCCqGSM49` +
+				`AwEHoUQDQgAEC4/+mzTOqiRapxXL/jGXmpl4pcKSNMu0myn2krtSK2zEi/2px2qk` +
+				`Uw0x7rn7fQLjI9NFtk94kMlS0+XH+3as8Q==` + "\n" +
+				`-----END EC PRIVATE KEY-----`,
+			),
+		},
+	}
+
+	tests := []struct {
+		name                 string
+		addPairs             []pair
+		expectedCpNNToDPUID  map[types.NamespacedName]types.UID
+		expectedScrapersUIDs []types.UID
+	}{
+		{
+			name: "add 2 ControlPlanes",
+			addPairs: []pair{
+				{
+					controlplane: &operatorv1beta1.ControlPlane{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "cp1",
+							Namespace: "ns1",
+						},
+						Spec: operatorv1beta1.ControlPlaneSpec{
+							ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+								DataPlane: lo.ToPtr("dp1"),
+							},
+						},
+					},
+
+					pipeline: metricsPipeline{
+						MetricsScraper: &mockScraper{
+							uid: "dp-uid1",
+						},
+						MetricsEnricher: &mockConsumer{},
+					},
+				},
+				{
+					controlplane: &operatorv1beta1.ControlPlane{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "cp2",
+							Namespace: "ns1",
+						},
+						Spec: operatorv1beta1.ControlPlaneSpec{
+							ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+								DataPlane: lo.ToPtr("dp2"),
+							},
+						},
+					},
+					pipeline: metricsPipeline{
+						MetricsScraper: &mockScraper{
+							uid: "dp-uid2",
+						},
+						MetricsEnricher: &mockConsumer{},
+					},
+				},
+			},
+		},
+	}
+
+	const (
+		waitTime     = time.Second
+		intervalTime = 100 * time.Microsecond
+	)
+	clusterCAKeyType := secrets.KeyConfig{
+		Type: x509.ECDSA,
+		Size: 1024,
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithObjects(caSecret).Build()
+
+			msm := NewManager(logr.Discard(), intervalTime, fakeClient, client.ObjectKeyFromObject(caSecret), clusterCAKeyType)
+			for _, pair := range tt.addPairs {
+				msm.Add(pair.controlplane, pair.pipeline)
+			}
+
+			for idx, pipeline := range msm.pipelines {
+				mp, ok := pipeline.(metricsPipeline)
+				require.True(t, ok)
+				assert.Zero(t, mp.MetricsScraper.(*mockScraper).CallCount(),
+					"scraper %d should not have been called yet", idx,
+				)
+			}
+			require.NoError(t, msm.Start(t.Context()))
+
+			require.Eventually(t,
+				func() bool {
+					for _, pipeline := range msm.pipelines {
+						mp, ok := pipeline.(metricsPipeline)
+						require.True(t, ok)
+
+						if mp.MetricsScraper.(*mockScraper).CallCount() == 0 {
+							return false
+						}
+					}
+					return true
+				},
+				waitTime, intervalTime,
+				"all scrapers should have been called at least once",
+			)
+		})
+	}
+}

--- a/controller/controlplane_extensions/metricsscraper/scraper.go
+++ b/controller/controlplane_extensions/metricsscraper/scraper.go
@@ -1,0 +1,146 @@
+package metricsscraper
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+
+	"github.com/go-logr/logr"
+	prometheus "github.com/prometheus/client_model/go"
+	prometheusexpfmt "github.com/prometheus/common/expfmt"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/gateway-operator/controller/pkg/log"
+
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+)
+
+// MetricsConsumer is an interface for consumers of metrics scraped by a MetricsScraper.
+type MetricsConsumer interface {
+	Consume(context.Context, Metrics) error
+}
+
+// MetricsScraper is an interface for a scraper that scrapes metrics from a DataPlane.
+type MetricsScraper interface {
+	Scrape(ctx context.Context) (Metrics, error)
+	DataPlaneUID() types.UID
+}
+
+// adminAPIEndpointURL is a strong type for the URL of an Admin API endpoint for metrics map indexing.
+type adminAPIEndpointURL string
+
+// metricName is a strong type for the name of a metric for metrics map indexing.
+type metricName string
+
+// metricsMap groups metrics by the Admin API endpoint URL they were scraped from,
+// and then by the metric name.
+type metricsMap map[adminAPIEndpointURL]map[metricName]*prometheus.MetricFamily
+
+// Metrics represents a collection of metrics scraped from a DataPlane.
+type Metrics struct {
+	metrics metricsMap
+}
+
+// PrometheusMetricsScraper is a MetricsScraper that scrapes Prometheus metrics
+// from the Admin API endpoint of provided DataPlane.
+type PrometheusMetricsScraper struct {
+	logger                  logr.Logger
+	httpClient              *http.Client
+	dp                      *operatorv1beta1.DataPlane
+	adminAPIAddressProvider AdminAPIAddressProvider
+
+	subscribersLock    sync.RWMutex
+	metricsSubscribers []MetricsConsumer
+}
+
+// NewPrometheusMetricsScraper creates a new PrometheusMetricsScraper that scrapes
+// metrics from the Admin API endpoints of the provided DataPlane.
+func NewPrometheusMetricsScraper(
+	logger logr.Logger, dp *operatorv1beta1.DataPlane, httpClient *http.Client, adminAPIAddrProvider AdminAPIAddressProvider,
+) MetricsScraper {
+	return &PrometheusMetricsScraper{
+		logger:                  logger,
+		httpClient:              httpClient,
+		dp:                      dp,
+		metricsSubscribers:      make([]MetricsConsumer, 0),
+		adminAPIAddressProvider: adminAPIAddrProvider,
+	}
+}
+
+// Scrape scrapes metrics from the Admin API endpoints of the configured DataPlane.
+func (p *PrometheusMetricsScraper) Scrape(ctx context.Context) (Metrics, error) {
+	// TODO: watch for changes in admin API addresses, do not query every scrape.
+	urls, err := p.adminAPIAddressProvider.AdminAddressesForDP(ctx, p.dp)
+	if err != nil {
+		return Metrics{}, err
+	}
+	if len(urls) == 0 {
+		return Metrics{}, nil
+	}
+
+	log.Debug(p.logger, "scraping DataPlane metrics", "DataPlane", p.dp, "urls", urls)
+
+	metrics := Metrics{
+		metrics: make(metricsMap),
+	}
+
+	for _, u := range urls {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u+"/metrics", nil)
+		if err != nil {
+			return Metrics{}, err
+		}
+
+		resp, err := p.httpClient.Do(req)
+		if err != nil {
+			return Metrics{}, fmt.Errorf("failed to scrape metrics from %s: %w", u, err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			return Metrics{}, fmt.Errorf("failed to scrape metrics from %s: %s: %s", u, resp.Status, string(b))
+		}
+
+		var parser prometheusexpfmt.TextParser
+		metricFamilies, err := parser.TextToMetricFamilies(resp.Body)
+		if err != nil {
+			b, errBody := io.ReadAll(resp.Body)
+			if errBody != nil {
+				return Metrics{}, fmt.Errorf("failed to parse metrics (failed reading response body: %w) from %s: %s: %s", errBody, u, resp.Status, string(b))
+			}
+			return Metrics{}, fmt.Errorf("failed to parse metrics from %s: %s: %s", u, resp.Status, string(b))
+		}
+
+		adminAPIURL := adminAPIEndpointURL(u)
+		m := metrics.metrics[adminAPIURL]
+		for name, metricFamily := range metricFamilies {
+			if m == nil {
+				m = make(map[metricName]*prometheus.MetricFamily)
+			}
+			m[metricName(name)] = metricFamily
+		}
+		metrics.metrics[adminAPIURL] = m
+	}
+
+	p.subscribersLock.RLock()
+	for _, subscriber := range p.metricsSubscribers {
+		if err := subscriber.Consume(ctx, metrics); err != nil {
+			p.logger.Error(err, "failed to consume metrics", "dataplane", client.ObjectKeyFromObject(p.dp))
+		}
+	}
+	p.subscribersLock.RUnlock()
+
+	return metrics, nil
+}
+
+// DataPlaneUID returns the UID of the DataPlane this scraper is scraping metrics for.
+func (p *PrometheusMetricsScraper) DataPlaneUID() types.UID {
+	if p == nil || p.dp == nil {
+		return ""
+	}
+
+	return p.dp.UID
+}

--- a/controller/controlplane_extensions/metricsscraper/scraper_test.go
+++ b/controller/controlplane_extensions/metricsscraper/scraper_test.go
@@ -1,0 +1,139 @@
+package metricsscraper
+
+import (
+	"context"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-logr/logr"
+	prometheus "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+)
+
+type mockAdminAPIAddressProvider struct {
+	addresses []string
+}
+
+func (m *mockAdminAPIAddressProvider) AdminAddressesForDP(ctx context.Context, dataplane *operatorv1beta1.DataPlane) ([]string, error) {
+	return m.addresses, nil
+}
+
+func kongMetricsServer(t *testing.T) *httptest.Server {
+	const metricsBody = `` +
+		`# HELP kong_upstream_latency_ms Latency added by upstream response for each service/route in Kong` + "\n" +
+		`# TYPE kong_upstream_latency_ms histogram` + "\n" +
+		`kong_upstream_latency_ms_bucket{service="httproute.default.httproute-echo.0",route="httproute.default.httproute-echo.0.0",le="25"} 550` + "\n" +
+		`kong_upstream_latency_ms_bucket{service="httproute.default.httproute-echo.0",route="httproute.default.httproute-echo.0.0",le="50"} 550` + "\n" +
+		`kong_upstream_latency_ms_bucket{service="httproute.default.httproute-echo.0",route="httproute.default.httproute-echo.0.0",le="80"} 550` + "\n" +
+		`kong_upstream_latency_ms_bucket{service="httproute.default.httproute-echo.0",route="httproute.default.httproute-echo.0.0",le="60000"} 610` + "\n" +
+		`kong_upstream_latency_ms_bucket{service="httproute.default.httproute-echo.0",route="httproute.default.httproute-echo.0.0",le="+Inf"} 610` + "\n" +
+		`kong_upstream_latency_ms_count{service="httproute.default.httproute-echo.0",route="httproute.default.httproute-echo.0.0"} 610` + "\n" +
+		`kong_upstream_latency_ms_sum{service="httproute.default.httproute-echo.0",route="httproute.default.httproute-echo.0.0"} 12232` + "\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte(metricsBody)); err != nil {
+			t.Logf("failed to write response: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(func() { srv.Close() })
+	return srv
+}
+
+func TestPrometheusMetricsScraper_Scrape(t *testing.T) {
+	tests := []struct {
+		name        string
+		dataplane   *operatorv1beta1.DataPlane
+		expected    func(adminAPIMetricsServerAddress string) Metrics
+		expectedErr error
+	}{
+		{
+			name: "scraping from a valid Admin API endpoint works",
+			dataplane: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dataplane-1",
+					Namespace: "default",
+				},
+			},
+			expected: func(serverAddr string) Metrics {
+				return Metrics{
+					metrics: metricsMap{
+						adminAPIEndpointURL(serverAddr): {
+							"kong_upstream_latency_ms": {
+								Name: proto.String("kong_upstream_latency_ms"),
+								Help: proto.String("Latency added by upstream response for each service/route in Kong"),
+								Type: prometheus.MetricType_HISTOGRAM.Enum(),
+								Metric: []*prometheus.Metric{
+									{
+										Histogram: &prometheus.Histogram{
+											SampleCount: proto.Uint64(610),
+											SampleSum:   proto.Float64(12232),
+											Bucket: []*prometheus.Bucket{
+												{
+													CumulativeCount: proto.Uint64(550),
+													UpperBound:      proto.Float64(25),
+												},
+												{
+													CumulativeCount: proto.Uint64(550),
+													UpperBound:      proto.Float64(50),
+												},
+												{
+													CumulativeCount: proto.Uint64(550),
+													UpperBound:      proto.Float64(80),
+												},
+												{
+													CumulativeCount: proto.Uint64(610),
+													UpperBound:      proto.Float64(60000),
+												},
+												{
+													CumulativeCount: proto.Uint64(610),
+													UpperBound:      proto.Float64(math.Inf(1)),
+												},
+											},
+										},
+										Label: []*prometheus.LabelPair{
+											{
+												Name:  proto.String("service"),
+												Value: proto.String("httproute.default.httproute-echo.0"),
+											},
+											{
+												Name:  proto.String("route"),
+												Value: proto.String("httproute.default.httproute-echo.0.0"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adminAPIMetricsServer := kongMetricsServer(t)
+			addressProvider := &mockAdminAPIAddressProvider{
+				addresses: []string{adminAPIMetricsServer.URL},
+			}
+
+			httpClient := http.DefaultClient
+
+			scraper := NewPrometheusMetricsScraper(logr.Discard(), tt.dataplane, httpClient, addressProvider)
+
+			metrics, err := scraper.Scrape(t.Context())
+			require.NoError(t, err)
+
+			expected := tt.expected(adminAPIMetricsServer.URL)
+			require.Equal(t, expected, metrics)
+		})
+	}
+}

--- a/controller/controlplane_extensions/prometheus_plugin.go
+++ b/controller/controlplane_extensions/prometheus_plugin.go
@@ -1,0 +1,75 @@
+package controlplane_extensions
+
+import (
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/gateway-operator/pkg/consts"
+
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
+	operatorv1alpha1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1alpha1"
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+)
+
+func prometheusPluginForSvc(svc *corev1.Service, cp *operatorv1beta1.ControlPlane, ext *operatorv1alpha1.DataPlaneMetricsExtension) (*configurationv1.KongPlugin, error) {
+	var b []byte
+	if ext != nil {
+		var err error
+		pluginConfig := convertDataPlanePluginMetricsExtensionConfigToPrometheusPluginConfig(ext)
+		b, err = json.Marshal(pluginConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal Prometheus plugin config for Service %s: %w",
+				client.ObjectKeyFromObject(svc), err,
+			)
+		}
+	}
+
+	plugin := &configurationv1.KongPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      prometheusPluginNameForSvc(svc),
+			Namespace: svc.Namespace,
+			Labels: map[string]string{
+				consts.GatewayOperatorManagedByLabel:          "controlplane",
+				consts.GatewayOperatorManagedByNameLabel:      cp.GetName(),
+				consts.GatewayOperatorManagedByNamespaceLabel: cp.GetNamespace(),
+				consts.GatewayOperatorKongPluginTypeLabel:     consts.KongPluginNamePrometheus,
+			},
+		},
+		PluginName: consts.KongPluginNamePrometheus,
+		Config: apiextensionsv1.JSON{
+			Raw: b,
+		},
+	}
+
+	return plugin, nil
+}
+
+func prometheusPluginNameForSvc(svc *corev1.Service) string {
+	return svc.GetName() + "-metrics-prometheus"
+}
+
+func convertDataPlanePluginMetricsExtensionConfigToPrometheusPluginConfig(
+	ext *operatorv1alpha1.DataPlaneMetricsExtension,
+) PrometheusPluginConfig {
+	return PrometheusPluginConfig{
+		Latency:        ext.Spec.Config.Latency,
+		Bandwidth:      ext.Spec.Config.Bandwidth,
+		UpstreamHealth: ext.Spec.Config.UpstreamHealth,
+		StatusCode:     ext.Spec.Config.StatusCode,
+	}
+}
+
+// PrometheusPluginConfig holds the configuration for the Prometheus plugin.
+//
+// Ref: https://docs.konghq.com/hub/kong-inc/prometheus/configuration/.
+type PrometheusPluginConfig struct {
+	Latency        bool `json:"latency_metrics"`
+	Bandwidth      bool `json:"bandwidth_metrics"`
+	UpstreamHealth bool `json:"upstream_health_metrics"`
+	StatusCode     bool `json:"status_code_metrics"`
+}

--- a/controller/pkg/extensions/dataplanemetrics.go
+++ b/controller/pkg/extensions/dataplanemetrics.go
@@ -1,0 +1,55 @@
+package extensions
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samber/lo"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
+	operatorv1alpha1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1alpha1"
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+)
+
+// GetAllDataPlaneMetricsExtensionRefsForControlPlane gets all DataPlaneMetricsExtension
+// refs set in the ControlPlane's spec.
+func GetAllDataPlaneMetricsExtensionRefsForControlPlane(controlplane *operatorv1beta1.ControlPlane) []commonv1alpha1.ExtensionRef {
+	return lo.Filter(controlplane.Spec.Extensions,
+		func(ef commonv1alpha1.ExtensionRef, _ int) bool {
+			return ef.Kind == operatorv1alpha1.DataPlaneMetricsExtensionKind &&
+				ef.Group == operatorv1alpha1.SchemeGroupVersion.Group
+		},
+	)
+}
+
+// GetAllDataPlaneMetricExtensionsForControlPlane returns all DataPlaneMetricsExtensions
+// that are referenced in the ControlPlane's spec.extensions.
+func GetAllDataPlaneMetricExtensionsForControlPlane(
+	ctx context.Context, cl client.Client, controlplane *operatorv1beta1.ControlPlane,
+) ([]operatorv1alpha1.DataPlaneMetricsExtension, error) {
+	extensionsRefs := GetAllDataPlaneMetricsExtensionRefsForControlPlane(controlplane)
+
+	// For all the refs, get the DataPlaneMetricsExtensions using the client.
+	extensions := make([]operatorv1alpha1.DataPlaneMetricsExtension, 0, len(extensionsRefs))
+	for _, ext := range extensionsRefs {
+		metricsExt := operatorv1alpha1.DataPlaneMetricsExtension{}
+		nn := types.NamespacedName{
+			Name:      ext.Name,
+			Namespace: controlplane.Namespace,
+		}
+		if ext.Namespace != nil {
+			nn.Namespace = *ext.Namespace
+		}
+		if err := cl.Get(ctx, nn, &metricsExt); err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil, fmt.Errorf("failed to get %s %s", operatorv1alpha1.DataPlaneMetricsExtensionKind, nn)
+			}
+			return nil, err
+		}
+		extensions = append(extensions, metricsExt)
+	}
+	return extensions, nil
+}

--- a/modules/cli/cli.go
+++ b/modules/cli/cli.go
@@ -55,6 +55,7 @@ func New(m metadata.Info) *CLI {
 	flagSet.BoolVar(&cfg.ControlPlaneControllerEnabled, "enable-controller-controlplane", true, "Enable the ControlPlane controller.")
 	flagSet.BoolVar(&cfg.DataPlaneControllerEnabled, "enable-controller-dataplane", true, "Enable the DataPlane controller.")
 	flagSet.BoolVar(&cfg.DataPlaneBlueGreenControllerEnabled, "enable-controller-dataplane-bluegreen", true, "Enable the DataPlane BlueGreen controller. Mutually exclusive with DataPlane controller.")
+	flagSet.BoolVar(&cfg.ControlPlaneExtensionsControllerEnabled, "enable-controller-controlplaneextensions", true, "Enable the ControlPlane extensions controller.")
 
 	// controllers for specialized APIs and features
 	flagSet.BoolVar(&cfg.AIGatewayControllerEnabled, "enable-controller-aigateway", false, "Enable the AIGateway controller. (Experimental).")

--- a/modules/cli/cli_test.go
+++ b/modules/cli/cli_test.go
@@ -186,6 +186,7 @@ func expectedDefaultCfg() manager.Config {
 		ControlPlaneControllerEnabled:           true,
 		DataPlaneControllerEnabled:              true,
 		DataPlaneBlueGreenControllerEnabled:     true,
+		ControlPlaneExtensionsControllerEnabled: true,
 		KonnectControllersEnabled:               false,
 		KonnectSyncPeriod:                       consts.DefaultKonnectSyncPeriod,
 		KongPluginInstallationControllerEnabled: false,

--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -88,6 +88,7 @@ type Config struct {
 	KonnectSyncPeriod                       time.Duration
 	KonnectMaxConcurrentReconciles          uint
 	GatewayAPIExperimentalEnabled           bool
+	ControlPlaneExtensionsControllerEnabled bool
 
 	// Controllers for Konnect APIs.
 	KonnectControllersEnabled bool

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -40,6 +40,11 @@ const (
 	// Kubernetes API.
 	GatewayOperatorManagedByNamespaceLabel = OperatorLabelPrefix + "managed-by-namespace"
 
+	// GatewayOperatorKongPluginTypeLabel is the label set on KongPlugin instances
+	// to indicate the type of the plugin.
+	// It is used to filter KongPlugin instances that are managed by the ControlPlane.
+	GatewayOperatorKongPluginTypeLabel = OperatorLabelPrefix + "kong-plugin-type"
+
 	// GatewayOperatorOwnerUIDControlPlane is the label that is used for objects
 	// to indicate a ControlPlane resource is the owner of the object.
 	// The value set for this label is the UID of the ControlPlane resource that
@@ -171,4 +176,16 @@ const (
 
 	// DefaultKonnectMaxConcurrentReconciles is the default max concurrent reconciles for Konnect entities.
 	DefaultKonnectMaxConcurrentReconciles = uint(8)
+)
+
+const (
+	// KongIngressControllerPluginsAnnotation is the name of the annotation set on Services
+	// which indicates to ControlPlane which KongPlugin instances to enable
+	// for the Service.
+	//
+	// Ref: https://docs.konghq.com/kubernetes-ingress-controller/latest/reference/custom-resources/#kongplugin
+	KongIngressControllerPluginsAnnotation = "konghq.com/plugins"
+
+	// KongPluginNamePrometheus is the name of the KongPlugin for the Prometheus plugin.
+	KongPluginNamePrometheus = "prometheus"
 )

--- a/test/integration/suite.go
+++ b/test/integration/suite.go
@@ -200,6 +200,7 @@ func DefaultControllerConfigForTests() manager.Config {
 	cfg.ControllerName = "konghq.com/gateway-operator-integration-tests"
 	cfg.GatewayControllerEnabled = true
 	cfg.ControlPlaneControllerEnabled = true
+	cfg.ControlPlaneExtensionsControllerEnabled = true
 	cfg.DataPlaneControllerEnabled = true
 	cfg.DataPlaneBlueGreenControllerEnabled = bluegreenController
 	cfg.KongPluginInstallationControllerEnabled = true

--- a/test/integration/test_controlplane_extensions_dataplanemetrics.go
+++ b/test/integration/test_controlplane_extensions_dataplanemetrics.go
@@ -1,0 +1,318 @@
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kong/gateway-operator/pkg/consts"
+	osstestutils "github.com/kong/gateway-operator/pkg/utils/test"
+	"github.com/kong/gateway-operator/pkg/vars"
+	osshelpers "github.com/kong/gateway-operator/test/helpers"
+
+	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
+	operatorv1alpha1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1alpha1"
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+)
+
+func TestControlPlaneExtensionsDataPlaneMetrics(t *testing.T) {
+	createExtensionRefWithoutNamespace := func(extRefName string) commonv1alpha1.ExtensionRef {
+		return commonv1alpha1.ExtensionRef{
+			Group: operatorv1alpha1.SchemeGroupVersion.Group,
+			Kind:  operatorv1alpha1.DataPlaneMetricsExtensionKind,
+			NamespacedRef: commonv1alpha1.NamespacedRef{
+				Name: extRefName,
+			},
+		}
+	}
+
+	const (
+		waitTimeout = 3 * time.Minute
+		interval    = time.Second
+	)
+
+	ctx := GetCtx()
+	env := GetEnv()
+	namespace, cleaner := osshelpers.SetupTestEnv(t, ctx, env)
+
+	clients := GetClients()
+	operatorClient := clients.OperatorClient
+	gwClient := clients.GatewayClient
+	mgrClient := clients.MgrClient
+	k8sClient := clients.K8sClient
+
+	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
+	container := generators.NewContainer("httpbin", osstestutils.HTTPBinImage, 80)
+	deployment := generators.NewDeploymentForContainer(container)
+	deployment, err := k8sClient.AppsV1().Deployments(namespace.Name).Create(ctx, deployment, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(deployment)
+
+	t.Logf("exposing deployment %s via service", deployment.Name)
+	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
+	service, err = k8sClient.CoreV1().Services(namespace.Name).Create(ctx, service, metav1.CreateOptions{})
+	require.NoError(t, err)
+	t.Logf("service %s created", service.Name)
+	cleaner.Add(service)
+
+	dpMetricExt1 := &operatorv1alpha1.DataPlaneMetricsExtension{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "dataplane-metrics-ext-",
+		},
+		Spec: operatorv1alpha1.DataPlaneMetricsExtensionSpec{
+			ServiceSelector: operatorv1alpha1.ServiceSelector{
+				MatchNames: []operatorv1alpha1.ServiceSelectorEntry{
+					{
+						Name: service.Name,
+					},
+				},
+			},
+			Config: operatorv1alpha1.MetricsConfig{
+				Latency: true,
+			},
+		},
+	}
+	dbMetricExt1, err := operatorClient.GatewayOperatorV1alpha1().DataPlaneMetricsExtensions(namespace.Name).Create(ctx, dpMetricExt1, metav1.CreateOptions{})
+	require.NoError(t, err)
+	t.Logf("DataPlaneMetricsExtension %s created", dbMetricExt1.Name)
+	cleaner.Add(dbMetricExt1)
+
+	t.Log("deploying a GatewayConfiguration resource")
+	gatewayConfig := &operatorv1beta1.GatewayConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "gwconfig-",
+		},
+		Spec: operatorv1beta1.GatewayConfigurationSpec{
+			DataPlaneOptions: &operatorv1beta1.GatewayConfigDataPlaneOptions{
+				Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+					DeploymentOptions: operatorv1beta1.DeploymentOptions{
+						PodTemplateSpec: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  consts.DataPlaneProxyContainerName,
+										Image: consts.DefaultDataPlaneImage,
+										// Speed up the test.
+										ReadinessProbe: &corev1.Probe{
+											InitialDelaySeconds: 1,
+											PeriodSeconds:       1,
+											SuccessThreshold:    1,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ControlPlaneOptions: &operatorv1beta1.ControlPlaneOptions{
+				Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{
+					PodTemplateSpec: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  consts.ControlPlaneControllerContainerName,
+									Image: consts.DefaultControlPlaneImage,
+									// Speed up the test.
+									ReadinessProbe: &corev1.Probe{
+										InitialDelaySeconds: 1,
+										PeriodSeconds:       1,
+										SuccessThreshold:    1,
+									},
+								},
+							},
+						},
+					},
+				},
+				Extensions: []commonv1alpha1.ExtensionRef{
+					createExtensionRefWithoutNamespace(dbMetricExt1.Name),
+				},
+			},
+		},
+	}
+	gatewayConfig, err = operatorClient.GatewayOperatorV1beta1().GatewayConfigurations(namespace.Name).Create(ctx, gatewayConfig, metav1.CreateOptions{})
+	require.NoError(t, err)
+	t.Logf("deployed GatewayConfiguration %s", gatewayConfig.Name)
+	cleaner.Add(gatewayConfig)
+
+	t.Log("deploying a GatewayClass resource with the GatewayConfiguration attached via ParametersReference")
+	gatewayClass := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "gwclass-",
+		},
+		Spec: gatewayv1.GatewayClassSpec{
+			ParametersRef: &gatewayv1.ParametersReference{
+				Group:     gatewayv1.Group(operatorv1alpha1.SchemeGroupVersion.Group),
+				Kind:      gatewayv1.Kind("GatewayConfiguration"),
+				Namespace: (*gatewayv1.Namespace)(&gatewayConfig.Namespace),
+				Name:      gatewayConfig.Name,
+			},
+			ControllerName: gatewayv1.GatewayController(vars.ControllerName()),
+		},
+	}
+	gatewayClass, err = gwClient.GatewayV1().GatewayClasses().Create(ctx, gatewayClass, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(gatewayClass)
+	t.Logf("deployed GatewayClass %s", gatewayClass.Name)
+
+	t.Log("deploying Gateway resource")
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "gw-",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(gatewayClass.Name),
+			Listeners: []gatewayv1.Listener{{
+				Name:     "http",
+				Protocol: gatewayv1.HTTPProtocolType,
+				Port:     gatewayv1.PortNumber(80),
+			}},
+		},
+	}
+	gateway, err = gwClient.GatewayV1().Gateways(namespace.Name).Create(ctx, gateway, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(gateway)
+	t.Logf("deployed Gateway %s", gateway.Name)
+
+	t.Log("verifying that the ControlPlane becomes provisioned")
+	require.Eventually(t, osstestutils.GatewayControlPlaneIsProvisioned(t, ctx, gateway, clients), waitTimeout, interval)
+	controlplanes := osstestutils.MustListControlPlanesForGateway(t, ctx, gateway, clients)
+	require.Len(t, controlplanes, 1)
+	cp := controlplanes[0]
+
+	pluginMatchingLabels := client.MatchingLabels{
+		consts.GatewayOperatorKongPluginTypeLabel:     consts.KongPluginNamePrometheus,
+		consts.GatewayOperatorManagedByNameLabel:      cp.GetName(),
+		consts.GatewayOperatorManagedByNamespaceLabel: cp.GetNamespace(),
+		consts.GatewayOperatorManagedByLabel:          "controlplane",
+	}
+
+	t.Run("verify Prometheus plugin is created and Service gets konghq.com/plugins annotation equal to its name", func(t *testing.T) {
+		var kongPlugin configurationv1.KongPlugin
+		require.Eventually(t, func() bool {
+			var kongPlugins configurationv1.KongPluginList
+			err := mgrClient.List(ctx, &kongPlugins,
+				client.InNamespace(namespace.Name),
+				pluginMatchingLabels,
+			)
+			if err != nil {
+				t.Logf("error listing KongPlugins: %v", err)
+				return false
+			}
+			if len(kongPlugins.Items) == 0 {
+				return false
+			}
+			kongPlugin = kongPlugins.Items[0]
+			return true
+		}, waitTimeout, interval)
+
+		require.Eventually(t, func() bool {
+			if err := mgrClient.Get(ctx, client.ObjectKeyFromObject(service), service); err != nil {
+				t.Logf("error getting Service %s: %v", service, err)
+				return false
+			}
+
+			if service.Annotations == nil {
+				return false
+			}
+
+			a, ok := service.Annotations[consts.KongIngressControllerPluginsAnnotation]
+			if !ok {
+				return false
+			}
+			return a == kongPlugin.Name
+		}, waitTimeout, interval)
+	})
+
+	t.Run("verify Prometheus plugin is deleted when ControlPlane extension ref is removed and Service gets konghq.com/plugins annotation cleared", func(t *testing.T) {
+		t.Logf("updating GatewayConfiguration %s to remove the DataPlaneMetricsExtension ref", gatewayConfig.Name)
+		gatewayConfig.Spec.ControlPlaneOptions.Extensions = nil
+		gatewayConfig, err = operatorClient.GatewayOperatorV1beta1().GatewayConfigurations(namespace.Name).Update(ctx, gatewayConfig, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		t.Logf("checking if KongPlugin is deleted")
+		require.Eventually(t, func() bool {
+			var kongPlugins configurationv1.KongPluginList
+			err := mgrClient.List(ctx, &kongPlugins,
+				client.InNamespace(namespace.Name),
+				pluginMatchingLabels,
+			)
+			if err != nil {
+				t.Logf("error listing KongPlugins: %v", err)
+				return false
+			}
+
+			if len(kongPlugins.Items) > 0 {
+				t.Log("kongPlugin is still in place")
+				return false
+			}
+			return true
+		}, waitTimeout, interval)
+
+		t.Logf("check that the Service %s has no %s annotation", service.Name, consts.KongIngressControllerPluginsAnnotation)
+		require.Eventually(t, func() bool {
+			if err := mgrClient.Get(ctx, client.ObjectKeyFromObject(service), service); err != nil {
+				t.Logf("error getting Service %s: %v", service, err)
+				return false
+			}
+
+			if service.Annotations == nil {
+				return true
+			}
+
+			_, ok := service.Annotations[consts.KongIngressControllerPluginsAnnotation]
+			return !ok
+		}, waitTimeout, interval)
+	})
+
+	t.Run("verify Prometheus plugin is re-created and Service gets konghq.com/plugins annotation set again equal to created Plugins's name", func(t *testing.T) {
+		t.Logf("updating GatewayConfiguration %s to re-add the DataPlaneMetricsExtension ref", gatewayConfig.Name)
+		gatewayConfig.Spec.ControlPlaneOptions.Extensions = []commonv1alpha1.ExtensionRef{
+			createExtensionRefWithoutNamespace(dbMetricExt1.Name),
+		}
+		gatewayConfig, err = operatorClient.GatewayOperatorV1beta1().GatewayConfigurations(namespace.Name).Update(ctx, gatewayConfig, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		var kongPlugin configurationv1.KongPlugin
+		require.Eventually(t, func() bool {
+			var kongPlugins configurationv1.KongPluginList
+			err := mgrClient.List(ctx, &kongPlugins,
+				client.InNamespace(namespace.Name),
+				pluginMatchingLabels,
+			)
+			if err != nil {
+				t.Logf("error listing KongPlugins: %v", err)
+				return false
+			}
+			if len(kongPlugins.Items) == 0 {
+				return false
+			}
+			kongPlugin = kongPlugins.Items[0]
+			return true
+		}, waitTimeout, interval)
+
+		require.Eventually(t, func() bool {
+			if err := mgrClient.Get(ctx, client.ObjectKeyFromObject(service), service); err != nil {
+				t.Logf("error getting Service %s: %v", service, err)
+				return false
+			}
+
+			if service.Annotations == nil {
+				return false
+			}
+
+			a, ok := service.Annotations[consts.KongIngressControllerPluginsAnnotation]
+			if !ok {
+				return false
+			}
+			return a == kongPlugin.Name
+		}, waitTimeout, interval)
+	})
+}

--- a/test/integration/zz_generated.registered_testcases.go
+++ b/test/integration/zz_generated.registered_testcases.go
@@ -5,6 +5,7 @@ func init() {
 	addTestsToTestSuite(
 		TestAIGatewayCreation,
 		TestControlPlaneEssentials,
+		TestControlPlaneExtensionsDataPlaneMetrics,
 		TestControlPlaneUpdate,
 		TestControlPlaneWatchNamespaces,
 		TestControlPlaneWhenNoDataPlane,


### PR DESCRIPTION
**What this PR does / why we need it**:

Features that were used in EE only will be OSS in KO.

This PR migrates `controlplane` extensions and `DataPlaneMetricsExtension` based on the prerequisite work done in

- https://github.com/Kong/gateway-operator-enterprise/pull/461

original issues are

- https://github.com/Kong/gateway-operator-archive/issues/1355
- https://github.com/Kong/gateway-operator-archive/issues/1359

and PRs

- https://github.com/Kong/gateway-operator-enterprise/pull/31
- https://github.com/Kong/gateway-operator-enterprise/pull/41
- https://github.com/Kong/gateway-operator-enterprise/pull/50

authored by @pmalek 

**Which issue this PR fixes**

Part of
- #1493

**Special notes for your reviewer**:

It's copy-paste only with required adjustments, such as registering the controller and cli flag, adjusting import paths, etc. Tests are also migrated to ensure that everything works as expected. 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
