### PR TITLE
tests: add chart tests

### DIFF
--- a/.github/supported_k8s_node_versions.yaml
+++ b/.github/supported_k8s_node_versions.yaml
@@ -1,0 +1,8 @@
+# renovate: datasource=docker packageName=kindest/node depName=kindest/node@only-patch
+- v1.33.0
+# renovate: datasource=docker packageName=kindest/node depName=kindest/node@only-patch
+- v1.32.3
+# renovate: datasource=docker packageName=kindest/node depName=kindest/node@only-patch
+- v1.31.6
+# renovate: datasource=docker packageName=kindest/node depName=kindest/node@only-patch
+- v1.30.10

--- a/.github/workflows/charts-tests.yaml
+++ b/.github/workflows/charts-tests.yaml
@@ -29,6 +29,9 @@ permissions:
 env:
   MISE_VERBOSE: 1
   MISE_DEBUG: 1
+  # Specify this here because these tests rely on ktf to run kind for cluster creation.
+  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
+  KIND_VERSION: "0.27.0"
 
 jobs:
   lint:
@@ -44,6 +47,58 @@ jobs:
 
       - name: Run linters
         run: make lint.charts
+
+  matrix_k8s_node_versions:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - id: set-matrix
+        run: |
+          (
+            echo 'matrix<<EOF'
+            yq eval -o=json '.' .github/supported_k8s_node_versions.yaml
+            echo 'EOF'
+          ) >> "${GITHUB_OUTPUT}"
+
+  lint-test:
+    timeout-minutes: 30
+    needs:
+      - matrix_k8s_node_versions
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        kubernetes-node-version: ${{ fromJson(needs.matrix_k8s_node_versions.outputs.matrix) }}
+        chart-name:
+          - kong-operator
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.13"
+
+      - uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
+
+      - name: Run chart-testing (lint)
+        run: ct lint --target-branch main --check-version-increment=false
+
+      - name: setup testing environment (kind-cluster)
+        env:
+          KUBERNETES_VERSION: ${{ matrix.kubernetes-node-version }}
+          CHART_NAME: ${{ matrix.chart-name }}
+        run: ./scripts/charts-test-env.sh
+
+      - name: Run chart-testing (install)
+        run: |
+          kubectl create ns kong-test
+          ct install --target-branch main --charts charts/${{ matrix.chart-name}} --namespace kong-test
+          # No need to delete the ns the cluster is scrapped after the job anyway.
 
   golden-tests:
     timeout-minutes: 30
@@ -70,6 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - lint
+      - lint-test
       - golden-tests
     if: always()
     steps:

--- a/renovate.json
+++ b/renovate.json
@@ -57,6 +57,26 @@
       "matchStrings": [
         ".+\\s?[=:]\\s+\"(?<currentValue>.+?)\",?\\s+//\\s+renovate:\\s+datasource=(?<datasource>.*?)\\s+(packageName=(?<packageName>.*)\\s+)?depName=(?<depName>.*)"
       ]
+    },
+    {
+      "description": "Match dependencies in .github/workflows/* that are properly annotated with `# renovate: datasource={} depName={}.`",
+      "customType": "regex",
+      "fileMatch": [
+        "\\.github/workflows/.*\\.yaml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.+:\\s*\"?(?<currentValue>[0-9]+\\.[0-9.]+)\"?\\n"
+      ]
+    },
+    {
+      "description": "Match dependencies in .github/supported_k8s_node_versions.yaml that are properly annotated with `# renovate: datasource={} depName={}.`",
+      "customType": "regex",
+      "fileMatch": [
+        "\\.github/supported_k8s_node_versions.yaml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?)\\s+(packageName=(?<packageName>.*))\\s+depName=(?<depName>.*?)\\n.+v?(?<currentValue>[0-9]+\\.[0-9.]+\\.[0-9]+)\\n"
+      ]
     }
   ],
   "packageRules": [

--- a/scripts/charts-test-env.sh
+++ b/scripts/charts-test-env.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+# ------------------------------------------------------------------------------
+#
+# This script is used predominantly by CI in order to deploy a testing environment
+# for running the chart tests in this repository. The testing environment includes
+# a fully functional Kubernetes cluster, usually based on a local Kubernetes
+# distribution like Kubernetes in Docker (KIND).
+#
+# Note: Callers are responsible for cleaning up after themselves, the testing env
+#       created here can be torn down with `ktf environments delete --name <NAME>`.
+# ------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+TEST_ENV_NAME="${TEST_ENV_NAME:-kong-charts-tests}"
+if [[ -n $1 ]]
+then
+    if [[ "$1" == "cleanup" ]]
+    then
+        ktf environments delete --name "${TEST_ENV_NAME}"
+        exit $?
+    fi
+fi
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "${SCRIPT_DIR}/.."
+GATEWAY_API_VERSION="${GATEWAY_API_VERSION:-v1.3.0}"
+CHART_NAME="${CHART_NAME:-ingress}"
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"
+KTF_URL=https://github.com/Kong/kubernetes-testing-framework/releases/latest/download/ktf.${OS}.${ARCH}
+
+[[ -z ${KUBERNETES_VERSION} ]] && echo "ERROR: KUBERNETES_VERSION is not set" && exit 1
+
+# ------------------------------------------------------------------------------
+# Setup Tools - Docker
+# ------------------------------------------------------------------------------
+
+# ensure docker command is accessible
+if ! command -v docker &> /dev/null
+then
+    echo "ERROR: docker command not found"
+    exit 10
+fi
+
+# ensure docker is functional
+docker info 1>/dev/null
+
+# ------------------------------------------------------------------------------
+# Setup Tools - Kind
+# ------------------------------------------------------------------------------
+
+# ensure kind command is accessible
+if ! command -v kind &> /dev/null
+then
+    [[ -z ${KIND_VERSION} ]] && echo "ERROR: KIND_VERSION is not set" && exit 1
+    echo "Installing sigs.k8s.io/kind, version ${KIND_VERSION}"
+    go install sigs.k8s.io/kind@v"${KIND_VERSION}"
+fi
+
+# ensure kind is functional
+kind version 1>/dev/null
+
+# ------------------------------------------------------------------------------
+# Setup Tools - KTF
+# ------------------------------------------------------------------------------
+
+# ensure ktf command is accessible
+if ! command -v ktf 1>/dev/null
+then
+    mkdir -p "${HOME}"/.local/bin
+    echo "Downloading KTF from ${KTF_URL}"
+    # grep location header to show the actual URL
+    curl -vL -o "${HOME}"/.local/bin/ktf "${KTF_URL}" 2>&1 | grep "location: https://github.com/Kong/kubernetes-testing-framework/releases/download/"
+    chmod +x "${HOME}"/.local/bin/ktf
+    export PATH="${HOME}/.local/bin:$PATH"
+fi
+
+# ensure kind is functional
+ktf 1>/dev/null
+
+# ------------------------------------------------------------------------------
+# Create Testing Environment
+# ------------------------------------------------------------------------------
+if [[ "${CHART_NAME}" == "gateway-operator" ]]
+then
+  ktf environments create --name "${TEST_ENV_NAME}" --addon metallb --kubernetes-version "${KUBERNETES_VERSION}"
+  # Install Kong specific CRDs
+  kubectl apply -k https://github.com/Kong/kubernetes-ingress-controller/config/crd
+else
+  ktf environments create --name "${TEST_ENV_NAME}" --addon metallb --addon kuma --kubernetes-version "${KUBERNETES_VERSION}"
+fi
+
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=${GATEWAY_API_VERSION}" | kubectl apply -f -


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `ct install` tests migrated from `charts` repo.

Additionally, renovate config is being set up for supported k8s versions that are defined in `.github/supported_k8s_node_versions.yaml`.

**Which issue this PR fixes**

Part of #1360 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
