### PR TITLE
chore: fix manifests

### DIFF
--- a/.github/workflows/charts-tests.yaml
+++ b/.github/workflows/charts-tests.yaml
@@ -120,7 +120,7 @@ jobs:
 
   # Workaround to allow checking the matrix tests as required tests without adding the individual cases
   # Ref: https://github.com/orgs/community/discussions/26822#discussioncomment-3305794
-  passed:
+  charts-passed:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     needs:

--- a/charts/kong-operator/Chart.yaml
+++ b/charts/kong-operator/Chart.yaml
@@ -3,7 +3,7 @@ description: Deploy Kong Operator
 home: https://konghq.com/
 icon: https://s3.amazonaws.com/downloads.kong/universe/assets/icon-kong-inc-large.png
 maintainers:
-  - name: team-k8s
+  - name: team-k8s-bot
     email: team-k8s@konghq.com
 name: kong-operator
 sources:

--- a/charts/kong-operator/charts/kic-crds/crds/kic-crds.yaml
+++ b/charts/kong-operator/charts/kic-crds/crds/kic-crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: ingressclassparameterses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -61,7 +61,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongclusterplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -369,7 +369,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongconsumergroups.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -621,7 +621,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -900,7 +900,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongcustomentities.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1092,7 +1092,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1484,7 +1484,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: konglicenses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1684,7 +1684,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1986,7 +1986,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   labels:
     gateway.networking.k8s.io/policy: direct
   name: kongupstreampolicies.configuration.konghq.com
@@ -2674,7 +2674,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongvaults.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2965,7 +2965,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: tcpingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -3176,7 +3176,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: udpingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/charts/kong-operator/crds/custom-resource-definitions.yaml
+++ b/charts/kong-operator/crds/custom-resource-definitions.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: aigateways.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com
@@ -534,7 +534,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: controlplanes.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com
@@ -8919,7 +8919,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com
@@ -9072,7 +9072,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: dataplanes.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com
@@ -18173,8 +18173,6 @@ spec:
                               Type determines how the Service is exposed.
                               Defaults to `LoadBalancer`.
 
-                              Valid options are `LoadBalancer` and `ClusterIP`.
-
                               `ClusterIP` allocates a cluster-internal IP address for load-balancing
                               to endpoints.
 
@@ -18623,7 +18621,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com
@@ -36068,8 +36066,6 @@ spec:
                                   Type determines how the Service is exposed.
                                   Defaults to `LoadBalancer`.
 
-                                  Valid options are `LoadBalancer` and `ClusterIP`.
-
                                   `ClusterIP` allocates a cluster-internal IP address for load-balancing
                                   to endpoints.
 
@@ -36324,7 +36320,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongcacertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -36575,7 +36571,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongcertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -36843,7 +36839,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongconsumergroups.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -37095,7 +37091,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -37374,7 +37370,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongcredentialacls.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -37564,7 +37560,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -37754,7 +37750,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -37948,7 +37944,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -38144,7 +38140,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongcredentialjwts.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -38364,7 +38360,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -38613,7 +38609,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongkeys.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -38939,7 +38935,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongkeysets.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -39189,7 +39185,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: konglicenses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -39389,7 +39385,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongpluginbindings.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -39799,7 +39795,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com
@@ -39982,7 +39978,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -40284,7 +40280,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongroutes.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -40686,7 +40682,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongservices.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -40998,7 +40994,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongsnis.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -41186,7 +41182,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongtargets.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -41380,7 +41376,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongupstreams.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -41823,7 +41819,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: kongvaults.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -42114,7 +42110,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
   group: konnect.konghq.com
@@ -42318,7 +42314,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:
   group: konnect.konghq.com
@@ -42778,7 +42774,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:
   group: konnect.konghq.com
@@ -43017,7 +43013,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: konnectcloudgatewaytransitgateways.konnect.konghq.com
 spec:
   group: konnect.konghq.com
@@ -43404,7 +43400,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: konnectextensions.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com
@@ -43612,7 +43608,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: konnectextensions.konnect.konghq.com
 spec:
   group: konnect.konghq.com
@@ -44037,7 +44033,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
   group: konnect.konghq.com
@@ -44378,7 +44374,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.4.0
+    kubernetes-configuration.konghq.com/version: v1.4.1
   name: watchnamespacegrants.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/Kong/gateway-operator/pull/1610#event-17667817086 incorrectly merged the commit which didn't pass the CI.

Most likely this was caused by the duplicate `passed` job which is the only required one to pass the CI: 

- https://github.com/Kong/gateway-operator/blob/c95fdd2b6c3df835ce44ae509a56ee7515646c58/.github/workflows/charts-tests.yaml#L123
- https://github.com/Kong/gateway-operator/blob/18af54c9a9bc4dc209f6bb5008bb24b6d602690f/.github/workflows/tests.yaml#L502-L503

This PR changes it so that the charts related required check is called `charts-passed`.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
