### PR TITLE
chore(ci): use team k8s email in chart sync workflow

### DIFF
--- a/.github/workflows/charts-sync.yaml
+++ b/.github/workflows/charts-sync.yaml
@@ -27,8 +27,8 @@ jobs:
       - uses: BetaHuhn/repo-file-sync-action@8b92be3375cf1d1b0cd579af488a9255572e4619 # v1.21.1
         with:
           GH_PAT: ${{ secrets.PAT_GITHUB }}
+          GIT_EMAIL: team-k8s+github-bot@konghq.com
           CONFIG_PATH: .github/charts-sync.yaml
-          TEAM_REVIEWERS: Kong/k8s-maintainers
           OVERWRITE_EXISTING_PR: true
           PR_BODY: |
             ### Sync charts from ${{ github.repository }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix:

<img width="693" alt="image" src="https://github.com/user-attachments/assets/0a89371c-4844-4fa2-9456-6c09febf6898" />

By setting the correct address.

Even though the instructions on https://github.com/BetaHuhn/repo-file-sync-action would indicate this input on the action is not needed, apparently it is.

Additionally unset the team reviewers to prevent:

> Error: Reviews may only be requested from collaborators. One or more of the teams you specified is not a collaborator of the Kong/charts repository.


