### PR TITLE
stale issue handling - dry-run

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -1,0 +1,38 @@
+name: Mark stale issues
+
+on:
+  schedule:
+    - cron: '30 1 * * *'  # Runs daily at 01:30 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark stale issues
+        id: stale
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+        with:
+          days-before-stale: 60
+          days-before-close: 700
+          stale-issue-label: 'stale'
+          stale-issue-message: 'This issue has been automatically marked as stale due to 60 days of inactivity. Please update or comment if this is still relevant.'
+          remove-issue-stale-when-updated: true
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          debug-only: 'true'
+
+      - name: List marked stale and closed issues
+        run: |
+          STALE_JSON='${{ steps.stale.outputs.staled-issues-prs }}'
+          CLOSED_JSON='${{ steps.stale.outputs.closed-issues-prs }}'
+          echo "🔎 Listing stale and closed issues..."
+          echo ""
+          echo "## 📌 Staled Issues: $(echo "$STALE_JSON" | jq -r '. | length')"
+          echo "$STALE_JSON" | jq -r '.[] | "#\(.number) - \(.title) - \(.html_url)"'
+          echo ""
+          echo "## ❌ Closed Issues: $(echo "$CLOSED_JSON" | jq -r '. | length')"
+          echo "$CLOSED_JSON" | jq -r '.[] | "#\(.number) - \(.title) - \(.html_url)"'

--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -32,7 +32,7 @@ jobs:
           echo "🔎 Listing stale and closed issues..."
           echo ""
           echo "## 📌 Staled Issues: $(echo "$STALE_JSON" | jq -r '. | length')"
-          echo "$STALE_JSON" | jq -r '.[] | "#\(.number) - \(.title) - \(.html_url)"'
+          echo "$STALE_JSON" | jq -r '.[] | "#\(.number) - \(.title) - https://github.com/${{ github.repository }}/issues/\(.number)"'
           echo ""
           echo "## ❌ Closed Issues: $(echo "$CLOSED_JSON" | jq -r '. | length')"
-          echo "$CLOSED_JSON" | jq -r '.[] | "#\(.number) - \(.title) - \(.html_url)"'
+          echo "$CLOSED_JSON" | jq -r '.[] | "#\(.number) - \(.title) - https://github.com/${{ github.repository }}/issues/\(.number)"'

--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -6,11 +6,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  issues: write
+  issues: read
 
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Mark stale issues
         id: stale


### PR DESCRIPTION
**What this PR does / why we need it**:

the repo has a huge number of stale issues. this PR will check the amount of stale issues (60 days of inactivity) and the amount of stale issues that can be closes (stale state for 700 days). currently in dry-run (flag `debug-only` enabled) to check how the action behaves.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`: