### PR TITLE
chore(tests): single ctrl config and unit test for setup

### DIFF
--- a/modules/manager/controller_setup_test.go
+++ b/modules/manager/controller_setup_test.go
@@ -1,0 +1,40 @@
+package manager_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/kong/gateway-operator/modules/manager"
+	testutils "github.com/kong/gateway-operator/pkg/utils/test"
+)
+
+func TestSetupControllers(t *testing.T) {
+	t.Parallel()
+
+	// Actual values of parameters are not important for this test.
+	mgr, err := ctrl.NewManager(&rest.Config{}, ctrlmgr.Options{})
+	require.NoError(t, err)
+	cfg := testutils.DefaultControllerConfigForTests()
+	controllerDefs, err := manager.SetupControllers(mgr, &cfg)
+	require.NoError(t, err)
+
+	const expectedControllerCount = 42
+	require.Len(t, controllerDefs, expectedControllerCount)
+
+	seenControllerTypes := make(map[string]int, expectedControllerCount)
+	for _, def := range controllerDefs {
+		seenControllerTypes[reflect.TypeOf(def.Controller).String()]++
+	}
+	duplicates := make(map[string]int)
+	for typeName, count := range seenControllerTypes {
+		if count > 1 {
+			duplicates[typeName] = count
+		}
+	}
+	require.Empty(t, duplicates, "found duplicate controller types: %v", duplicates)
+}

--- a/pkg/utils/test/config.go
+++ b/pkg/utils/test/config.go
@@ -1,0 +1,47 @@
+package test
+
+import (
+	"github.com/kong/gateway-operator/modules/manager"
+	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
+	"github.com/kong/gateway-operator/modules/manager/logging"
+)
+
+// ControllerConfigOption is a function type that modifies a manager.Config.
+type ControllerConfigOption func(*manager.Config)
+
+// WithBlueGreenController enables or disables the blue-green controller.
+// By default it's disabled.
+func WithBlueGreenController(enabled bool) ControllerConfigOption {
+	return func(cfg *manager.Config) {
+		cfg.DataPlaneBlueGreenControllerEnabled = enabled
+	}
+}
+
+// DefaultControllerConfigForTests returns a default configuration for the controller manager used in tests.
+// It can be adjusted by overriding arbitrary fields in the returned config or by providing config options.
+func DefaultControllerConfigForTests(opts ...ControllerConfigOption) manager.Config {
+	cfg := manager.DefaultConfig()
+	cfg.LeaderElection = false
+	cfg.LoggingMode = logging.DevelopmentMode
+	cfg.ControllerName = "konghq.com/gateway-operator-integration-tests"
+	cfg.GatewayControllerEnabled = true
+	cfg.ControlPlaneControllerEnabled = true
+	cfg.ControlPlaneExtensionsControllerEnabled = true
+	cfg.DataPlaneControllerEnabled = true
+	cfg.DataPlaneBlueGreenControllerEnabled = false
+	cfg.KongPluginInstallationControllerEnabled = true
+	cfg.AIGatewayControllerEnabled = true
+	cfg.AnonymousReports = false
+	cfg.KonnectControllersEnabled = true
+	cfg.ClusterCAKeyType = mgrconfig.ECDSA
+	cfg.GatewayAPIExperimentalEnabled = true
+	cfg.EnforceConfig = true
+	cfg.ServiceAccountToImpersonate = ServiceAccountToImpersonate
+
+	// Apply all the provided options
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	return cfg
+}

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -19,8 +19,6 @@ import (
 
 	"github.com/kong/gateway-operator/config"
 	"github.com/kong/gateway-operator/modules/manager"
-	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
-	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/metadata"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	testutils "github.com/kong/gateway-operator/pkg/utils/test"
@@ -164,17 +162,7 @@ func exitOnErr(err error) {
 // startControllerManager will configure the manager and start it in a separate goroutine.
 // It returns a channel which will get closed when manager.Start() gets called.
 func startControllerManager(metadata metadata.Info) <-chan struct{} {
-	cfg := manager.DefaultConfig()
-	cfg.LeaderElection = false
-	cfg.LoggingMode = logging.DevelopmentMode
-	cfg.ControllerName = "konghq.com/gateway-operator-integration-tests"
-	cfg.GatewayControllerEnabled = true
-	cfg.ControlPlaneControllerEnabled = true
-	cfg.DataPlaneControllerEnabled = true
-	cfg.AnonymousReports = false
-	cfg.ClusterCAKeyType = mgrconfig.ECDSA
-	cfg.GatewayAPIExperimentalEnabled = true
-	cfg.ServiceAccountToImpersonate = testutils.ServiceAccountToImpersonate
+	cfg := testutils.DefaultControllerConfigForTests()
 
 	startedChan := make(chan struct{})
 	go func() {

--- a/test/envtest/controller.go
+++ b/test/envtest/controller.go
@@ -16,6 +16,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	kgomanager "github.com/kong/gateway-operator/modules/manager"
+	testutils "github.com/kong/gateway-operator/pkg/utils/test"
 )
 
 // Reconciler represents a reconciler.
@@ -76,8 +77,7 @@ func StartReconcilers(
 	t.Helper()
 
 	// Setup cache indices for all types.
-	cfg := kgomanager.DefaultConfig()
-	cfg.KonnectControllersEnabled = true
+	cfg := testutils.DefaultControllerConfigForTests()
 	require.NoError(t, kgomanager.SetupCacheIndexes(ctx, mgr, cfg))
 
 	for _, r := range reconcilers {

--- a/test/integration/dataplane_bluegreen_test.go
+++ b/test/integration/dataplane_bluegreen_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestDataPlaneBlueGreenRollout(t *testing.T) {
-	if !bluegreenController {
+	if !blueGreenController {
 		t.Skipf("GATEWAY_OPERATOR_BLUEGREEN_CONTROLLER not set, skipping")
 	}
 	const (
@@ -240,7 +240,7 @@ func TestDataPlaneBlueGreenRollout(t *testing.T) {
 }
 
 func TestDataPlaneBlueGreenHorizontalScaling(t *testing.T) {
-	if !bluegreenController {
+	if !blueGreenController {
 		t.Skipf("GATEWAY_OPERATOR_BLUEGREEN_CONTROLLER not set, skipping")
 	}
 	const (
@@ -339,7 +339,7 @@ func TestDataPlaneBlueGreenHorizontalScaling(t *testing.T) {
 }
 
 func TestDataPlaneBlueGreenResourcesNotDeletedUntilOwnerIsRemoved(t *testing.T) {
-	if !bluegreenController {
+	if !blueGreenController {
 		t.Skipf("GATEWAY_OPERATOR_BLUEGREEN_CONTROLLER not set, skipping")
 	}
 	const (

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -17,8 +17,6 @@ import (
 
 	"github.com/kong/gateway-operator/config"
 	"github.com/kong/gateway-operator/modules/manager"
-	mgrconfig "github.com/kong/gateway-operator/modules/manager/config"
-	"github.com/kong/gateway-operator/modules/manager/logging"
 	"github.com/kong/gateway-operator/modules/manager/metadata"
 	"github.com/kong/gateway-operator/modules/manager/scheme"
 	"github.com/kong/gateway-operator/pkg/consts"
@@ -35,7 +33,7 @@ var (
 	existingCluster      = os.Getenv("KONG_TEST_CLUSTER")
 	controllerManagerOut = os.Getenv("KONG_CONTROLLER_OUT")
 	skipClusterCleanup   = strings.ToLower(os.Getenv("KONG_TEST_CLUSTER_PERSIST")) == "true"
-	bluegreenController  = strings.ToLower(os.Getenv("GATEWAY_OPERATOR_BLUEGREEN_CONTROLLER")) == "true"
+	blueGreenController  = strings.ToLower(os.Getenv("GATEWAY_OPERATOR_BLUEGREEN_CONTROLLER")) == "true"
 )
 
 var (
@@ -69,7 +67,7 @@ func TestMain(m *testing.M) {
 	helpers.SetDefaultDataPlaneImage(consts.DefaultDataPlaneImage)
 	helpers.SetDefaultDataPlaneBaseImage(consts.DefaultDataPlaneBaseImage)
 
-	cfg := defaultControllerConfigForTests()
+	cfg := testutils.DefaultControllerConfigForTests(testutils.WithBlueGreenController(blueGreenController))
 
 	var code int
 	defer func() {
@@ -168,28 +166,4 @@ func exitOnErr(err error) {
 		}
 		panic(fmt.Sprintf("ERROR: %s\n", err.Error()))
 	}
-}
-
-// defaultControllerConfigForTests returns a default configuration for the controller manager used in tests.
-// It can be adjusted by overriding arbitrary fields in the returned config.
-func defaultControllerConfigForTests() manager.Config {
-	cfg := manager.DefaultConfig()
-	cfg.LeaderElection = false
-	cfg.LoggingMode = logging.DevelopmentMode
-	cfg.ControllerName = "konghq.com/gateway-operator-integration-tests"
-	cfg.GatewayControllerEnabled = true
-	cfg.ControlPlaneControllerEnabled = true
-	cfg.ControlPlaneExtensionsControllerEnabled = true
-	cfg.DataPlaneControllerEnabled = true
-	cfg.DataPlaneBlueGreenControllerEnabled = bluegreenController
-	cfg.KongPluginInstallationControllerEnabled = true
-	cfg.AIGatewayControllerEnabled = true
-	cfg.AnonymousReports = false
-	cfg.KonnectControllersEnabled = true
-	cfg.ClusterCAKeyType = mgrconfig.ECDSA
-	cfg.GatewayAPIExperimentalEnabled = true
-	cfg.EnforceConfig = true
-	cfg.ServiceAccountToImpersonate = testutils.ServiceAccountToImpersonate
-
-	return cfg
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Deduplicate bootstrapping default configuration for tests, single source of truth for all test types - less error prone, easier to maintain.

Introduce `TestSetupControllers` that checks the number of registered controllers and detects duplication, [see the comment](https://github.com/Kong/gateway-operator/pull/1636#discussion_r2095837864).

**Which issue this PR fixes**

Part of #1493

