### PR TITLE
ci: add new conditions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,25 +14,9 @@ on:
   push:
     branches:
     - 'main'
-    paths-ignore:
-      - 'CHANGELOG.md'
-      - 'README.md'
-      - 'SECURITY.md'
-      - 'FEATURES.md'
-      - 'LICENSE'
-      - 'LICENSES'
-      - '.github/ISSUE_TEMPLATE/**'
   pull_request:
     branches:
       - '**'
-    paths-ignore:
-      - 'CHANGELOG.md'
-      - 'README.md'
-      - 'SECURITY.md'
-      - 'FEATURES.md'
-      - 'LICENSE'
-      - 'LICENSES'
-      - '.github/ISSUE_TEMPLATE/**'
   workflow_dispatch: {}
 
 permissions:
@@ -40,7 +24,36 @@ permissions:
   actions: read
 
 jobs:
+  check-docs-only:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.check-files.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - id: check-files
+        name: Check if only documentation files changed
+        run: |
+          # Get changed files compared to the base
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha || 'HEAD~1' }} ${{ github.sha }})
+
+          # Check if all changed files are documentation or license files
+          DOCS_ONLY=true
+          for file in $CHANGED_FILES; do
+            if [[ ! "$file" =~ ^(.*\.md|LICENSE|LICENSES|\.github/ISSUE_TEMPLATE/.*)$ ]]; then
+              DOCS_ONLY=false
+              break
+            fi
+          done
+
+          echo "docs_only=$DOCS_ONLY" >> $GITHUB_OUTPUT
+          echo "Changed files: $CHANGED_FILES"
+          echo "Docs only: $DOCS_ONLY"
+
   build:
+    needs: [check-docs-only]
+    if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     uses: ./.github/workflows/__build-workflow.yaml
     secrets:
       dockerhub-token: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
@@ -55,3 +68,24 @@ jobs:
       # Branch filter above will decide pushes to which branch will trigger this.
       push: ${{ github.event.action == 'push' }}
       slack-send: ${{ github.event.action == 'push' }}
+
+  # This job exists to satisfy the required check when only docs change
+  passed:
+    runs-on: ubuntu-latest
+    needs: [check-docs-only]
+    if: always()
+    steps:
+      - name: Check if docs-only changes
+        run: |
+          if [[ "${{ needs.check-docs-only.outputs.docs_only }}" == "true" ]]; then
+            echo "Only documentation files were changed, skipping build"
+            exit 0
+          fi
+
+      - name: Check build result
+        if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "Build job failed or was cancelled."
+            exit 1
+          fi

--- a/.github/workflows/charts-tests.yaml
+++ b/.github/workflows/charts-tests.yaml
@@ -15,28 +15,12 @@ on:
     branches:
       - '**'
       - 'release/*'
-    paths-ignore:
-      - 'CHANGELOG.md'
-      - 'README.md'
-      - 'SECURITY.md'
-      - 'FEATURES.md'
-      - 'LICENSE'
-      - 'LICENSES'
-      - '.github/ISSUE_TEMPLATE/**'
   push:
     branches:
       - 'main'
       - 'release/*'
     tags:
       - '*'
-    paths-ignore:
-      - 'CHANGELOG.md'
-      - 'README.md'
-      - 'SECURITY.md'
-      - 'FEATURES.md'
-      - 'LICENSE'
-      - 'LICENSES'
-      - '.github/ISSUE_TEMPLATE/**'
   workflow_dispatch: {}
 
 permissions:
@@ -50,9 +34,38 @@ env:
   KIND_VERSION: "0.28.0"
 
 jobs:
+  check-docs-only:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.check-files.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - id: check-files
+        name: Check if only documentation files changed
+        run: |
+          # Get changed files compared to the base
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha || 'HEAD~1' }} ${{ github.sha }})
+          
+          # Check if all changed files are documentation or license files
+          DOCS_ONLY=true
+          for file in $CHANGED_FILES; do
+            if [[ ! "$file" =~ ^(.*\.md|LICENSE|LICENSES|\.github/ISSUE_TEMPLATE/.*)$ ]]; then
+              DOCS_ONLY=false
+              break
+            fi
+          done
+          
+          echo "docs_only=$DOCS_ONLY" >> $GITHUB_OUTPUT
+          echo "Changed files: $CHANGED_FILES"
+          echo "Docs only: $DOCS_ONLY"
+
   generate:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    needs: [check-docs-only]
+    if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -74,6 +87,8 @@ jobs:
   lint:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    needs: [check-docs-only]
+    if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -101,7 +116,9 @@ jobs:
   lint-test:
     timeout-minutes: 30
     needs:
+      - check-docs-only
       - matrix_k8s_node_versions
+    if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -140,6 +157,8 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     name: golden-tests
+    needs: [check-docs-only]
+    if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -159,13 +178,22 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     needs:
+      - check-docs-only
       - generate
       - lint
       - lint-test
       - golden-tests
     if: always()
     steps:
-      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      - name: Check if docs-only changes
+        run: |
+          if [[ "${{ needs.check-docs-only.outputs.docs_only }}" == "true" ]]; then
+            echo "Only documentation files were changed, skipping charts tests"
+            exit 0
+          fi
+
+      - name: Check test results
+        if: ${{ needs.check-docs-only.outputs.docs_only != 'true' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
         run: |
           echo "Some jobs failed or were cancelled."
           exit 1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,34 +15,45 @@ on:
     branches:
       - '**'
       - 'release/*'
-    paths-ignore:
-      - 'CHANGELOG.md'
-      - 'README.md'
-      - 'SECURITY.md'
-      - 'FEATURES.md'
-      - 'LICENSE'
-      - 'LICENSES'
-      - '.github/ISSUE_TEMPLATE/**'
   push:
     branches:
       - 'main'
       - 'release/*'
     tags:
       - '*'
-    paths-ignore:
-      - 'CHANGELOG.md'
-      - 'README.md'
-      - 'SECURITY.md'
-      - 'FEATURES.md'
-      - 'LICENSE'
-      - 'LICENSES'
-      - '.github/ISSUE_TEMPLATE/**'
   workflow_dispatch: {}
 
 permissions:
   contents: read
 
 jobs:
+  check-docs-only:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.check-files.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - id: check-files
+        name: Check if only documentation files changed
+        run: |
+          # Get changed files compared to the base
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha || 'HEAD~1' }} ${{ github.sha }})
+          
+          # Check if all changed files are documentation or license files
+          DOCS_ONLY=true
+          for file in $CHANGED_FILES; do
+            if [[ ! "$file" =~ ^(.*\.md|LICENSE|LICENSES|\.github/ISSUE_TEMPLATE/.*)$ ]]; then
+              DOCS_ONLY=false
+              break
+            fi
+          done
+          
+          echo "docs_only=$DOCS_ONLY" >> $GITHUB_OUTPUT
+          echo "Changed files: $CHANGED_FILES"
+          echo "Docs only: $DOCS_ONLY"
+
   ensure-actions-sha-pin:
     runs-on: ubuntu-latest
     steps:
@@ -214,6 +225,8 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-latest
+    needs: [check-docs-only]
+    if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     steps:
     - name: checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -297,6 +310,8 @@ jobs:
 
   conformance-tests:
     runs-on: ubuntu-latest
+    needs: [check-docs-only]
+    if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -349,6 +364,8 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     name: integration-tests
+    needs: [check-docs-only]
+    if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     steps:
     - name: checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -396,6 +413,8 @@ jobs:
   integration-tests-bluegreen:
     runs-on: ubuntu-latest
     name: integration-tests-bluegreen
+    needs: [check-docs-only]
+    if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     steps:
     - name: checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -439,6 +458,8 @@ jobs:
   
   e2e-tests:
     runs-on: ubuntu-latest
+    needs: [check-docs-only]
+    if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     steps:
     - name: checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -518,26 +539,41 @@ jobs:
   # Ref: https://github.com/orgs/community/discussions/26822#discussioncomment-3305794
   passed:
     runs-on: ubuntu-latest
-    needs:
-      - ensure-actions-sha-pin
-      - ossf-scorecard
-      - lint
-      - govulncheck
-      - verify
-      - install-with-kustomize
-      - build
-      - unit-tests
-      - envtest-tests
-      - CRDs-validation
-      - samples
-      - conformance-tests
-      - integration-tests
-      - integration-tests-bluegreen
-      - e2e-tests
-      - buildpulse-report
+    needs: [check-docs-only]
     if: always()
     steps:
-      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      - name: Check if docs-only changes
+        run: |
+          if [[ "${{ needs.check-docs-only.outputs.docs_only }}" == "true" ]]; then
+            echo "Only documentation files were changed, skipping tests"
+            exit 0
+          fi
+
+      - name: Check test results
+        if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "Some jobs failed or were cancelled."
+            exit 1
+          fi
+
+  # This job exists to satisfy all required checks when only docs change
+  real-passed:
+    runs-on: ubuntu-latest
+    needs:
+      - check-docs-only
+      - passed
+    if: always()
+    steps:
+      - name: Check if docs-only changes
+        run: |
+          if [[ "${{ needs.check-docs-only.outputs.docs_only }}" == "true" ]]; then
+            echo "Only documentation files were changed, all checks pass"
+            exit 0
+          fi
+
+      - name: Check test results
+        if: ${{ needs.check-docs-only.outputs.docs_only != 'true' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
         run: |
           echo "Some jobs failed or were cancelled."
           exit 1


### PR DESCRIPTION
**What this PR does / why we need it**:

Quote from @pmalek 's [comment](https://github.com/Kong/gateway-operator/pull/1646#issuecomment-2894173448). 

>  I totally forgot about 1 important thing that would prevent this from working correctly: required checks.
> 
> Since these are unconditional it basically means that now each PR that changes e.g. README.md will not get its workflows run and thus it won't pass the required checks. I think that it might be possible to check the changed files (e.g. using https://github.com/tj-actions/changed-files but that action had its problems recently so I'm not sure we want to use it) and then conditionally pass jobs in workflows. That might end up being a nightmare to maintain though.


This pull request introduces a mechanism to optimize GitHub Actions workflows by detecting documentation-only changes and skipping unnecessary build and test jobs. The main changes involve adding a `check-docs-only` job to multiple workflows and modifying job dependencies and conditions to respect the output of this new job.


**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
