### PR TITLE
chore(ci): ensure Go packages downloaded for chart manifests generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,14 +370,12 @@ ensure.go.pkg.downloaded.gateway-api:
 	@go mod download $(GATEWAY_API_PACKAGE)@$(GATEWAY_API_VERSION)
 
 .PHONY: manifests.charts.kong-operator.crds.operator
-manifests.charts.kong-operator.crds.operator: kustomize
-	@$(MAKE) ensure.go.pkg.downloaded.kubernetes-configuration
+manifests.charts.kong-operator.crds.operator: kustomize ensure.go.pkg.downloaded.kubernetes-configuration
 	$(KUSTOMIZE) build $(KUBERNETES_CONFIGURATION_PACKAGE_PATH)/config/crd/gateway-operator > \
 		$(KONG_OPERATOR_CHART_DIR)/crds/custom-resource-definitions.yaml
 
 .PHONY: manifests.charts.kong-operator.crds.kic
-manifests.charts.kong-operator.crds.kic: kustomize
-	@$(MAKE) ensure.go.pkg.downloaded.kubernetes-configuration
+manifests.charts.kong-operator.crds.kic: kustomize ensure.go.pkg.downloaded.kubernetes-configuration
 	$(KUSTOMIZE) build $(KUBERNETES_CONFIGURATION_PACKAGE_PATH)/config/crd/ingress-controller > \
 		$(KONG_OPERATOR_CHART_DIR)/charts/kic-crds/crds/kic-crds.yaml
 
@@ -385,26 +383,24 @@ GATEWAY_API_STANDARD_CRDS_SUBCHART_CHART_YAML_PATH = $(KONG_OPERATOR_CHART_DIR)/
 GATEWAY_API_STANDARD_CRDS_SUBCHART_MANIFEST_PATH = $(KONG_OPERATOR_CHART_DIR)/charts/gwapi-standard-crds/crds/gwapi-crds.yaml
 
 .PHONY: manifests.charts.kong-operator.crds.gwapi-standard
-manifests.charts.kong-operator.crds.gwapi-standard: kustomize
+manifests.charts.kong-operator.crds.gwapi-standard: kustomize ensure.go.pkg.downloaded.gateway-api
 	@$(MAKE) manifests.charts.print.chart.yaml \
 		NAME=gwapi-standard-crds \
 		DESCRIPTION="A Helm chart for Kubernetes Gateway API standard channel CRDs" \
 		VERSION=$(GATEWAY_API_VERSION:v%=%) \
 		CHART_YAML_PATH=$(GATEWAY_API_STANDARD_CRDS_SUBCHART_CHART_YAML_PATH)
-	@$(MAKE) ensure.go.pkg.downloaded.gateway-api
 	$(KUSTOMIZE) build $(GATEWAY_API_CRDS_KUSTOMIZE_STANDARD_LOCAL_PATH) > $(GATEWAY_API_STANDARD_CRDS_SUBCHART_MANIFEST_PATH)
 
 GATEWAY_API_EXPERIMENTAL_CRDS_SUBCHART_CHART_YAML_PATH = $(KONG_OPERATOR_CHART_DIR)/charts/gwapi-experimental-crds/Chart.yaml
 GATEWAY_API_EXPERIMENTAL_CRDS_SUBCHART_MANIFEST_PATH = $(KONG_OPERATOR_CHART_DIR)/charts/gwapi-experimental-crds/crds/gwapi-crds.yaml
 
 .PHONY: manifests.charts.kong-operator.crds.gwapi-experimental
-manifests.charts.kong-operator.crds.gwapi-experimental: kustomize
+manifests.charts.kong-operator.crds.gwapi-experimental: kustomize ensure.go.pkg.downloaded.gateway-api
 	@$(MAKE) manifests.charts.print.chart.yaml \
 		NAME=gwapi-experimental-crds \
 		DESCRIPTION="A Helm chart for Kubernetes Gateway API experimental channel CRDs" \
 		VERSION=$(GATEWAY_API_VERSION:v%=%) \
 		CHART_YAML_PATH=$(GATEWAY_API_EXPERIMENTAL_CRDS_SUBCHART_CHART_YAML_PATH)
-	@$(MAKE) ensure.go.pkg.downloaded.gateway-api
 	$(KUSTOMIZE) build $(GATEWAY_API_CRDS_KUSTOMIZE_EXPERIMENTAL_LOCAL_PATH) > $(GATEWAY_API_EXPERIMENTAL_CRDS_SUBCHART_MANIFEST_PATH)
 
 .PHONY: manifests.charts.print.chart.yaml

--- a/Makefile
+++ b/Makefile
@@ -361,13 +361,23 @@ manifests.charts:
 
 KONG_OPERATOR_CHART_DIR = $(PROJECT_DIR)/charts/kong-operator
 
+.PHONY: ensure.go.pkg.downloaded.kubernetes-configuration
+ensure.go.pkg.downloaded.kubernetes-configuration:
+	@go mod download $(KUBERNETES_CONFIGURATION_PACKAGE)@$(KUBERNETES_CONFIGURATION_VERSION)
+
+.PHONY: ensure.go.pkg.downloaded.gateway-api
+ensure.go.pkg.downloaded.gateway-api:
+	@go mod download $(GATEWAY_API_PACKAGE)@$(GATEWAY_API_VERSION)
+
 .PHONY: manifests.charts.kong-operator.crds.operator
 manifests.charts.kong-operator.crds.operator: kustomize
+	@$(MAKE) ensure.go.pkg.downloaded.kubernetes-configuration
 	$(KUSTOMIZE) build $(KUBERNETES_CONFIGURATION_PACKAGE_PATH)/config/crd/gateway-operator > \
 		$(KONG_OPERATOR_CHART_DIR)/crds/custom-resource-definitions.yaml
 
 .PHONY: manifests.charts.kong-operator.crds.kic
 manifests.charts.kong-operator.crds.kic: kustomize
+	@$(MAKE) ensure.go.pkg.downloaded.kubernetes-configuration
 	$(KUSTOMIZE) build $(KUBERNETES_CONFIGURATION_PACKAGE_PATH)/config/crd/ingress-controller > \
 		$(KONG_OPERATOR_CHART_DIR)/charts/kic-crds/crds/kic-crds.yaml
 
@@ -381,6 +391,7 @@ manifests.charts.kong-operator.crds.gwapi-standard: kustomize
 		DESCRIPTION="A Helm chart for Kubernetes Gateway API standard channel CRDs" \
 		VERSION=$(GATEWAY_API_VERSION:v%=%) \
 		CHART_YAML_PATH=$(GATEWAY_API_STANDARD_CRDS_SUBCHART_CHART_YAML_PATH)
+	@$(MAKE) ensure.go.pkg.downloaded.gateway-api
 	$(KUSTOMIZE) build $(GATEWAY_API_CRDS_KUSTOMIZE_STANDARD_LOCAL_PATH) > $(GATEWAY_API_STANDARD_CRDS_SUBCHART_MANIFEST_PATH)
 
 GATEWAY_API_EXPERIMENTAL_CRDS_SUBCHART_CHART_YAML_PATH = $(KONG_OPERATOR_CHART_DIR)/charts/gwapi-experimental-crds/Chart.yaml
@@ -388,11 +399,12 @@ GATEWAY_API_EXPERIMENTAL_CRDS_SUBCHART_MANIFEST_PATH = $(KONG_OPERATOR_CHART_DIR
 
 .PHONY: manifests.charts.kong-operator.crds.gwapi-experimental
 manifests.charts.kong-operator.crds.gwapi-experimental: kustomize
-	$(MAKE) manifests.charts.print.chart.yaml \
+	@$(MAKE) manifests.charts.print.chart.yaml \
 		NAME=gwapi-experimental-crds \
 		DESCRIPTION="A Helm chart for Kubernetes Gateway API experimental channel CRDs" \
 		VERSION=$(GATEWAY_API_VERSION:v%=%) \
 		CHART_YAML_PATH=$(GATEWAY_API_EXPERIMENTAL_CRDS_SUBCHART_CHART_YAML_PATH)
+	@$(MAKE) ensure.go.pkg.downloaded.gateway-api
 	$(KUSTOMIZE) build $(GATEWAY_API_CRDS_KUSTOMIZE_EXPERIMENTAL_LOCAL_PATH) > $(GATEWAY_API_EXPERIMENTAL_CRDS_SUBCHART_MANIFEST_PATH)
 
 .PHONY: manifests.charts.print.chart.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensure that errors like: https://github.com/Kong/gateway-operator/actions/runs/15165111949/job/42640764460

```
/home/runner/work/gateway-operator/gateway-operator/bin/installs/kustomize/5.6.0/bin/kustomize build /home/runner/go/pkg/mod/github.com/kong/kubernetes-configuration@v1.4.1/config/crd/gateway-operator > \
	/home/runner/work/gateway-operator/gateway-operator/charts/kong-operator/crds/custom-resource-definitions.yaml
Error: must build at directory: not a valid directory: evalsymlink failure on '/home/runner/go/pkg/mod/github.com/kong/kubernetes-configuration@v1.4.1/config/crd/gateway-operator' : lstat /home/runner/go/pkg/mod/github.com: no such file or directory
make[1]: *** [Makefile:366: manifests.charts.kong-operator.crds.operator] Error 1
make[1]: Leaving directory '/home/runner/work/gateway-operator/gateway-operator'
```

do not happen.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
