### PR TITLE
Backport: fix:fix the rollout restart op (#1540) to release/1.6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
 
+## Unreleased
+
+## Changed
+
+- Allowed the `kubectl rollout restart` operation for Deployment resources created via DataPlane CRD.
+  [#1540](https://github.com/Kong/gateway-operator/pull/1540)
+
 ## [v1.6.0]
 
 > Release date: 2025-05-07

--- a/controller/pkg/utils/compare.go
+++ b/controller/pkg/utils/compare.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"github.com/google/go-cmp/cmp"
+)
+
+// IgnoreAnnotationKeysComparer returns a cmp.Option that ignores specified annotation keys when comparing.
+func IgnoreAnnotationKeysComparer(keys ...string) cmp.Option {
+	return cmp.FilterPath(
+		func(p cmp.Path) bool {
+			return p.String() == "ObjectMeta.Annotations"
+		},
+		cmp.Comparer(
+			func(a, b map[string]string) bool {
+				if a == nil && b == nil {
+					return true
+				}
+				if a == nil || b == nil {
+					return false
+				}
+
+				for k, v := range a {
+					// Skip ignored keys
+					if containsString(keys, k) {
+						continue
+					}
+					if b[k] != v {
+						return false
+					}
+				}
+
+				for k, v := range b {
+					// Skip ignored keys
+					if containsString(keys, k) {
+						continue
+					}
+					if a[k] != v {
+						return false
+					}
+				}
+
+				return true
+			},
+		),
+	)
+}
+
+func containsString(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}

--- a/go.mod
+++ b/go.mod
@@ -268,12 +268,12 @@ replace (
 	k8s.io/component-base => k8s.io/component-base v0.33.0
 	k8s.io/component-helpers => k8s.io/component-helpers v0.33.0
 	k8s.io/controller-manager => k8s.io/controller-manager v0.33.0
-	k8s.io/cri-api => k8s.io/cri-api v0.33.0
+	k8s.io/cri-api => k8s.io/cri-api v0.33.1
 	k8s.io/cri-client => k8s.io/cri-client v0.33.0
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.33.0
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.33.0
 	k8s.io/endpointslice => k8s.io/endpointslice v0.33.0
-	k8s.io/externaljwt => k8s.io/externaljwt v0.33.0
+	k8s.io/externaljwt => k8s.io/externaljwt v0.33.1
 	k8s.io/kms => k8s.io/kms v0.33.0
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.33.0
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.33.0

--- a/test/integration/replicaset_helpers.go
+++ b/test/integration/replicaset_helpers.go
@@ -1,0 +1,69 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	testutils "github.com/kong/gateway-operator/pkg/utils/test"
+
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+)
+
+// FindDataPlaneReplicaSetNewerThan finds a ReplicaSet created after or at the specified time.
+// This helper logs detailed information about ReplicaSets found to help
+// with debugging timestamp issues.
+//
+// It will return nil if no ReplicaSet is found or if there's an error listing ReplicaSets.
+// If multiple ReplicaSets are found that were created after or at the specified time,
+// it will fail the test immediately with t.FailNow().
+// It succeed when exactly 1 matching ReplicaSet is found.
+func FindDataPlaneReplicaSetNewerThan(
+	t *testing.T,
+	ctx context.Context,
+	cli client.Client,
+	creationTime time.Time,
+	namespace string,
+	dp *operatorv1beta1.DataPlane,
+) *appsv1.ReplicaSet {
+	t.Helper()
+
+	rsList, err := testutils.GetDataPlaneReplicaSets(ctx, cli, dp)
+	if err != nil {
+		t.Logf("Error listing ReplicaSets: %v", err)
+		return nil
+	}
+
+	// Find ReplicaSets newer than or exactly at the specified time
+	var newReplicaSets []*appsv1.ReplicaSet
+	t.Logf("Looking for ReplicaSets created at or after %v", creationTime)
+	for _, rs := range rsList {
+		t.Logf("Found ReplicaSet %s with creation time %v", rs.Name, rs.CreationTimestamp.Time)
+		// Truncate times to seconds for comparison since k8s doesn't use same precision
+		rsTime := rs.CreationTimestamp.Truncate(time.Second)
+		refTime := creationTime.Truncate(time.Second)
+		if rsTime.Equal(refTime) || rsTime.After(refTime) {
+			t.Logf("ReplicaSet %s is at or after %v", rs.Name, creationTime)
+			newReplicaSets = append(newReplicaSets, rs)
+		}
+	}
+
+	// No new ReplicaSets found
+	if len(newReplicaSets) == 0 {
+		t.Logf("No ReplicaSets found at or after %v", creationTime)
+		return nil
+	}
+
+	// Multiple new ReplicaSets found - fail the test
+	if len(newReplicaSets) > 1 {
+		t.Errorf("Found %d ReplicaSets created at or after %v, expected exactly 1",
+			len(newReplicaSets), creationTime)
+		t.FailNow()
+	}
+
+	// Success: exactly one new ReplicaSet found
+	return newReplicaSets[0]
+}

--- a/test/integration/test_dataplane_scale_subresource.go
+++ b/test/integration/test_dataplane_scale_subresource.go
@@ -1,13 +1,17 @@
 package integration
 
 import (
+	"fmt"
+	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/gateway-operator/pkg/consts"
@@ -16,6 +20,18 @@ import (
 
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
 )
+
+// runKubectlScaleDataPlane runs the kubectl scale command to test the scale subresource for the DataPlane CRD.
+// It scales the DataPlane resource to the specified number of replicas and returns the output and error.
+func runKubectlScaleDataPlane(t *testing.T, namespacedName types.NamespacedName, replicas int) (string, error) {
+	t.Helper()
+
+	// Execute kubectl scale command
+	cmd := "kubectl scale --namespace=" + namespacedName.Namespace + " dataplane/" + namespacedName.Name + " --replicas=" + fmt.Sprint(replicas)
+
+	out, err := exec.CommandContext(t.Context(), "sh", "-c", cmd).CombinedOutput()
+	return string(out), err
+}
 
 // TestDataPlaneScaleSubresource tests the scale subresource of the DataPlane CRD.
 // It verifies that when a deployment is restarted using kubectl rollout restart,
@@ -38,35 +54,12 @@ func TestDataPlaneScaleSubresource(t *testing.T) {
 					DeploymentOptions: operatorv1beta1.DeploymentOptions{
 						Replicas: lo.ToPtr(int32(2)), // Set initial replica count to 2
 						PodTemplateSpec: &corev1.PodTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels: map[string]string{
-									"label-a": "value-a",
-									"label-x": "value-x",
-								},
-							},
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
 									{
-										Env: []corev1.EnvVar{
-											{
-												Name:  "TEST_ENV",
-												Value: "test",
-											},
-										},
 										Name:  consts.DataPlaneProxyContainerName,
 										Image: helpers.GetDefaultDataPlaneImage(),
 									},
-								},
-							},
-						},
-					},
-				},
-				Network: operatorv1beta1.DataPlaneNetworkOptions{
-					Services: &operatorv1beta1.DataPlaneServices{
-						Ingress: &operatorv1beta1.DataPlaneServiceOptions{
-							ServiceOptions: operatorv1beta1.ServiceOptions{
-								Annotations: map[string]string{
-									"purpose": "scale",
 								},
 							},
 						},
@@ -95,14 +88,96 @@ func TestDataPlaneScaleSubresource(t *testing.T) {
 		consts.GatewayOperatorManagedByLabel: consts.DataPlaneManagedLabelValue,
 	}, clients), testutils.GatewayReadyTimeLimit, testutils.ObjectUpdateTick)
 
-	// Test scaling through the scale subresource
-	t.Log("testing scaling through scale subresource")
-	require.Eventually(t,
-		testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients, func(dp *operatorv1beta1.DataPlane) {
-			dp.Spec.Deployment.Replicas = lo.ToPtr(int32(3)) // Scale up to 3 replicas
-		}),
-		testutils.GatewayReadyTimeLimit, testutils.ObjectUpdateTick)
+	// Test scaling through the scale subresource - use kubectl scale
+	t.Log("testing scaling through scale subresource with kubectl scale")
+
+	// Using kubectl scale command to test the scale subresource
+	output, scaleErr := runKubectlScaleDataPlane(t, types.NamespacedName{
+		Namespace: namespace.Name,
+		Name:      dataplane.Name,
+	}, 3)
+	t.Logf("Scale command output: %s", output)
+	require.NoError(t, scaleErr)
 
 	t.Log("verifying dataplane scales to 3 replicas")
 	require.Eventually(t, testutils.DataPlaneHasNReadyPods(t, GetCtx(), dataplaneName, clients, 3), testutils.GatewayReadyTimeLimit, testutils.ObjectUpdateTick)
+
+	t.Log("simulating kubectl rollout restart by adding restart annotation")
+	deploymentCopy := deployment.DeepCopy()
+	if deploymentCopy.Spec.Template.Annotations == nil {
+		deploymentCopy.Spec.Template.Annotations = make(map[string]string)
+	}
+
+	restartTime := time.Now()
+	deploymentCopy.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = restartTime.Format(time.RFC3339)
+
+	err = clients.MgrClient.Patch(GetCtx(), deploymentCopy, client.MergeFrom(&deployment))
+	require.NoError(t, err)
+
+	t.Log("waiting for new ReplicaSet to be created")
+
+	var newReplicaSet *appsv1.ReplicaSet
+	require.Eventually(t, func() bool {
+		rs := FindDataPlaneReplicaSetNewerThan(
+			t,
+			GetCtx(),
+			clients.MgrClient,
+			restartTime,
+			namespace.Name,
+			dataplane,
+		)
+		if rs != nil {
+			t.Logf("Found new ReplicaSet %s created at %v", rs.Name, rs.CreationTimestamp)
+			newReplicaSet = rs
+			return true
+		}
+		return false
+	}, testutils.GatewayReadyTimeLimit, testutils.ObjectUpdateTick, "Failed to find new ReplicaSet after rollout restart")
+
+	t.Log("verifying new ReplicaSet has correct replica count")
+	require.NotNil(t, newReplicaSet, "New ReplicaSet should be created")
+
+	// Wait for the ReplicaSet to have the correct replica count
+	require.Eventually(t, func() bool {
+		if err := clients.MgrClient.Get(GetCtx(), types.NamespacedName{
+			Namespace: newReplicaSet.Namespace,
+			Name:      newReplicaSet.Name,
+		}, newReplicaSet); err != nil {
+			t.Logf("Error getting ReplicaSet: %v", err)
+			return false
+		}
+		t.Logf("Current ReplicaSet replicas: %d", *newReplicaSet.Spec.Replicas)
+		return *newReplicaSet.Spec.Replicas == 3
+	}, testutils.GatewayReadyTimeLimit, testutils.ObjectUpdateTick, "New ReplicaSet should have 3 replicas")
+
+	t.Log("waiting for rollout to complete")
+	require.Eventually(t, func() bool {
+		if err := clients.MgrClient.Get(GetCtx(), types.NamespacedName{
+			Namespace: newReplicaSet.Namespace,
+			Name:      newReplicaSet.Name,
+		}, newReplicaSet); err != nil {
+			return false
+		}
+		return newReplicaSet.Status.ReadyReplicas == *newReplicaSet.Spec.Replicas
+	}, testutils.GatewayReadyTimeLimit, testutils.ObjectUpdateTick, "New ReplicaSet should have all replicas ready")
+
+	t.Log("verifying dataplane still has 3 ready replicas after rollout")
+	require.Eventually(t, testutils.DataPlaneHasNReadyPods(t, GetCtx(), dataplaneName, clients, 3), testutils.GatewayReadyTimeLimit, testutils.ObjectUpdateTick)
+
+	// Test the specific issue where scaling after restart didn't work properly
+	t.Log("scaling DataPlane to 4 replicas after restart")
+	// Test scaling through the scale subresource - use kubectl scale
+	t.Log("testing scaling through scale subresource with kubectl scale")
+
+	// Using kubectl scale command to test the scale subresource
+	output, scaleErr = runKubectlScaleDataPlane(t, types.NamespacedName{
+		Namespace: namespace.Name,
+		Name:      dataplane.Name,
+	}, 4)
+	t.Logf("Scale command output: %s", output)
+	require.NoError(t, scaleErr)
+
+	t.Log("verifying dataplane scales to 4 replicas")
+	require.Eventually(t, testutils.DataPlaneHasNReadyPods(t, GetCtx(), dataplaneName, clients, 4), testutils.GatewayReadyTimeLimit, testutils.ObjectUpdateTick)
+
 }


### PR DESCRIPTION
(cherry picked from commit 3c61e5c487834ee433a452e5506f80be77812a59)

**What this PR does / why we need it**:
Backport of #1540 to `release/1.6.x`.
**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
