### PR TITLE
chore(ci): add charts-passed job to allow the CI to pass

### DIFF
--- a/.github/workflows/charts-tests.yaml
+++ b/.github/workflows/charts-tests.yaml
@@ -1,0 +1,34 @@
+name: charts tests
+run-name: charts tests, branch:${{ github.ref_name }}, triggered by @${{ github.actor }}
+
+concurrency:
+  # Run only for most recent commit in PRs but for all tags and commits on main
+  # Ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+on:
+  merge_group:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - '**'
+      - 'release/*'
+  push:
+    branches:
+      - 'main'
+      - 'release/*'
+    tags:
+      - '*'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  charts-passed:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "This is a stub job, allowing the CI to pass. GitHub Actions supports only 1 set of required checks and this is a workaround for that limitation."

--- a/go.mod
+++ b/go.mod
@@ -268,12 +268,12 @@ replace (
 	k8s.io/component-base => k8s.io/component-base v0.33.0
 	k8s.io/component-helpers => k8s.io/component-helpers v0.33.0
 	k8s.io/controller-manager => k8s.io/controller-manager v0.33.0
-	k8s.io/cri-api => k8s.io/cri-api v0.33.0
+	k8s.io/cri-api => k8s.io/cri-api v0.33.1
 	k8s.io/cri-client => k8s.io/cri-client v0.33.0
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.33.0
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.33.0
 	k8s.io/endpointslice => k8s.io/endpointslice v0.33.0
-	k8s.io/externaljwt => k8s.io/externaljwt v0.33.0
+	k8s.io/externaljwt => k8s.io/externaljwt v0.33.1
 	k8s.io/kms => k8s.io/kms v0.33.0
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.33.0
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.33.0


### PR DESCRIPTION
**What this PR does / why we need it**:

After we've added `chart-passed` as a required check on CI, we need the same job in 1.6 release branch to make the CI pass. 

This PR does just that.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
