### PR TITLE
fix: fix lack of instance_name and protocols reconciliation for `KongPluginBinding`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@
 - Move implementation of certificate management for Konnect DPs from EE.
   [#1590](https://github.com/Kong/gateway-operator/pull/1590)
 
+### Fixed
+
+- Fixed lack of `instance_name` and `protocols` reconciliation for `KongPluginBinding` when reconciling against Konnect.
+  [#1681](https://github.com/Kong/gateway-operator/pull/1681)
+
 ## [v1.6.1]
 
 > Release date: 2025-05-22

--- a/controller/konnect/ops/ops_kongpluginbinding.go
+++ b/controller/konnect/ops/ops_kongpluginbinding.go
@@ -264,6 +264,18 @@ func kongPluginWithTargetsToKongPluginInput(binding *configurationv1alpha1.KongP
 		Enabled: lo.ToPtr(!plugin.Disabled),
 		Tags:    tags,
 	}
+	if plugin.InstanceName != "" {
+		pluginInput.InstanceName = lo.ToPtr(plugin.InstanceName)
+	}
+	if len(plugin.Protocols) > 0 {
+		pluginInput.Protocols = lo.Map(
+			plugin.Protocols,
+			func(p configurationv1.KongProtocol, _ int) sdkkonnectcomp.Protocols {
+				return sdkkonnectcomp.Protocols(p)
+			},
+		)
+	}
+	// TODO: add support for ordering https://github.com/Kong/gateway-operator/issues/1682
 
 	// TODO(mlavacca): check all the entities reference the same KonnectGatewayControlPlane
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `instance_name` and `protocols` ordering for plugins reconciled against Konnect using `KongPluginBinding`.

**Which issue this PR fixes**

Fixes #1626

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
