### PR TITLE
fix: handle Konnect CP re-creation in `KonnectExtension` logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
 
 - Fixed lack of `instance_name` and `protocols` reconciliation for `KongPluginBinding` when reconciling against Konnect.
   [#1681](https://github.com/Kong/gateway-operator/pull/1681)
+- The `KonnectExtension` status is kept updated when the `KonnectGatewayControlPlane` is rotated.
+  [#1684](https://github.com/Kong/gateway-operator/pull/1684)
 
 ## [v1.6.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,9 @@
 
 - Fixed lack of `instance_name` and `protocols` reconciliation for `KongPluginBinding` when reconciling against Konnect.
   [#1681](https://github.com/Kong/gateway-operator/pull/1681)
-- The `KonnectExtension` status is kept updated when the `KonnectGatewayControlPlane` is rotated.
+- The `KonnectExtension` status is kept updated when the `KonnectGatewayControlPlane` is deleted and 
+  re-created. When this happens, the `KonnectGatewayControlPlane` sees its Konnect ID changed, as well
+  as the endpoints. All this data is constantly enforced into the `KonnectExtension` status.
   [#1684](https://github.com/Kong/gateway-operator/pull/1684)
 
 ## [v1.6.1]

--- a/controller/konnect/konnectextension_controller_utils_test.go
+++ b/controller/konnect/konnectextension_controller_utils_test.go
@@ -5,6 +5,7 @@ import (
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -114,6 +115,8 @@ func TestEnforceKonnectExtensionStatus(t *testing.T) {
 		}
 		updated := enforceKonnectExtensionStatus(cp, certificateSecret, ext)
 		assert.True(t, updated)
+		require.NotNil(t, ext.Status.Konnect)
+		require.NotNil(t, ext.Status.DataPlaneClientAuth)
 		assert.Equal(t, "cp-id", ext.Status.Konnect.ControlPlaneID)
 		assert.Equal(t, konnectv1alpha1.ClusterTypeControlPlane, ext.Status.Konnect.ClusterType)
 		assert.Equal(t, "cp-endpoint", ext.Status.Konnect.Endpoints.ControlPlaneEndpoint)

--- a/controller/konnect/konnectextension_controller_utils_test.go
+++ b/controller/konnect/konnectextension_controller_utils_test.go
@@ -43,8 +43,8 @@ func TestEnforceKonnectExtensionStatus(t *testing.T) {
 		}
 		updated := enforceKonnectExtensionStatus(cp, certificateSecret, ext)
 		assert.True(t, updated)
-		assert.NotNil(t, ext.Status.Konnect)
-		assert.NotNil(t, ext.Status.DataPlaneClientAuth)
+		require.NotNil(t, ext.Status.Konnect)
+		require.NotNil(t, ext.Status.DataPlaneClientAuth)
 		assert.Equal(t, "cp-id", ext.Status.Konnect.ControlPlaneID)
 		assert.Equal(t, konnectv1alpha1.ClusterTypeControlPlane, ext.Status.Konnect.ClusterType)
 		assert.Equal(t, "cp-endpoint", ext.Status.Konnect.Endpoints.ControlPlaneEndpoint)
@@ -91,7 +91,7 @@ func TestEnforceKonnectExtensionStatus(t *testing.T) {
 		}
 		updated := enforceKonnectExtensionStatus(cp, certificateSecret, ext)
 		assert.True(t, updated)
-		assert.NotNil(t, ext.Status.DataPlaneClientAuth)
+		require.NotNil(t, ext.Status.DataPlaneClientAuth)
 		assert.Equal(t, "my-secret", ext.Status.DataPlaneClientAuth.CertificateSecretRef.Name)
 	})
 

--- a/controller/konnect/konnectextension_controller_utils_test.go
+++ b/controller/konnect/konnectextension_controller_utils_test.go
@@ -1,0 +1,123 @@
+package konnect
+
+import (
+	"testing"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+func TestEnforceKonnectExtensionStatus(t *testing.T) {
+	cp := konnectv1alpha1.KonnectGatewayControlPlane{
+		Status: konnectv1alpha1.KonnectGatewayControlPlaneStatus{
+			KonnectEntityStatus: konnectv1alpha1.KonnectEntityStatus{
+				ID: "cp-id",
+			},
+			Endpoints: &konnectv1alpha1.KonnectEndpoints{
+				ControlPlaneEndpoint: "cp-endpoint",
+				TelemetryEndpoint:    "telemetry-endpoint",
+			},
+		},
+		Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+			CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+				ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane.ToPointer(),
+			},
+		},
+	}
+	certificateSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-secret",
+		},
+	}
+
+	t.Run("updates both Konnect and DataPlaneClientAuth when both are different", func(t *testing.T) {
+		ext := &konnectv1alpha1.KonnectExtension{
+			Status: konnectv1alpha1.KonnectExtensionStatus{
+				Konnect:             nil,
+				DataPlaneClientAuth: nil,
+			},
+		}
+		updated := enforceKonnectExtensionStatus(cp, certificateSecret, ext)
+		assert.True(t, updated)
+		assert.NotNil(t, ext.Status.Konnect)
+		assert.NotNil(t, ext.Status.DataPlaneClientAuth)
+		assert.Equal(t, "cp-id", ext.Status.Konnect.ControlPlaneID)
+		assert.Equal(t, konnectv1alpha1.ClusterTypeControlPlane, ext.Status.Konnect.ClusterType)
+		assert.Equal(t, "cp-endpoint", ext.Status.Konnect.Endpoints.ControlPlaneEndpoint)
+		assert.Equal(t, "telemetry-endpoint", ext.Status.Konnect.Endpoints.TelemetryEndpoint)
+		assert.Equal(t, "my-secret", ext.Status.DataPlaneClientAuth.CertificateSecretRef.Name)
+	})
+
+	t.Run("does not update if already up-to-date", func(t *testing.T) {
+		konnectStatus := &konnectv1alpha1.KonnectExtensionControlPlaneStatus{
+			ControlPlaneID: "cp-id",
+			ClusterType:    konnectv1alpha1.ClusterTypeControlPlane,
+			Endpoints: konnectv1alpha1.KonnectEndpoints{
+				ControlPlaneEndpoint: "cp-endpoint",
+				TelemetryEndpoint:    "telemetry-endpoint",
+			},
+		}
+		dataPlaneClientAuth := &konnectv1alpha1.DataPlaneClientAuthStatus{
+			CertificateSecretRef: &konnectv1alpha1.SecretRef{Name: "my-secret"},
+		}
+		ext := &konnectv1alpha1.KonnectExtension{
+			Status: konnectv1alpha1.KonnectExtensionStatus{
+				Konnect:             konnectStatus,
+				DataPlaneClientAuth: dataPlaneClientAuth,
+			},
+		}
+		updated := enforceKonnectExtensionStatus(cp, certificateSecret, ext)
+		assert.False(t, updated)
+	})
+
+	t.Run("updates only DataPlaneClientAuth if only that is different", func(t *testing.T) {
+		konnectStatus := &konnectv1alpha1.KonnectExtensionControlPlaneStatus{
+			ControlPlaneID: "cp-id",
+			ClusterType:    konnectv1alpha1.ClusterTypeControlPlane,
+			Endpoints: konnectv1alpha1.KonnectEndpoints{
+				ControlPlaneEndpoint: "cp-endpoint",
+				TelemetryEndpoint:    "telemetry-endpoint",
+			},
+		}
+		ext := &konnectv1alpha1.KonnectExtension{
+			Status: konnectv1alpha1.KonnectExtensionStatus{
+				Konnect:             konnectStatus,
+				DataPlaneClientAuth: nil,
+			},
+		}
+		updated := enforceKonnectExtensionStatus(cp, certificateSecret, ext)
+		assert.True(t, updated)
+		assert.NotNil(t, ext.Status.DataPlaneClientAuth)
+		assert.Equal(t, "my-secret", ext.Status.DataPlaneClientAuth.CertificateSecretRef.Name)
+	})
+
+	t.Run("updates only Konnect if only that is different", func(t *testing.T) {
+		dataPlaneClientAuth := &konnectv1alpha1.DataPlaneClientAuthStatus{
+			CertificateSecretRef: &konnectv1alpha1.SecretRef{Name: "my-secret"},
+		}
+		ext := &konnectv1alpha1.KonnectExtension{
+			Status: konnectv1alpha1.KonnectExtensionStatus{
+				Konnect: &konnectv1alpha1.KonnectExtensionControlPlaneStatus{
+					ControlPlaneID: "other-id",
+					ClusterType:    konnectv1alpha1.ClusterTypeK8sIngressController,
+					Endpoints: konnectv1alpha1.KonnectEndpoints{
+						ControlPlaneEndpoint: "other-endpoint",
+						TelemetryEndpoint:    "other-telemetry",
+					},
+				},
+				DataPlaneClientAuth: dataPlaneClientAuth,
+			},
+		}
+		updated := enforceKonnectExtensionStatus(cp, certificateSecret, ext)
+		assert.True(t, updated)
+		assert.Equal(t, "cp-id", ext.Status.Konnect.ControlPlaneID)
+		assert.Equal(t, konnectv1alpha1.ClusterTypeControlPlane, ext.Status.Konnect.ClusterType)
+		assert.Equal(t, "cp-endpoint", ext.Status.Konnect.Endpoints.ControlPlaneEndpoint)
+		assert.Equal(t, "telemetry-endpoint", ext.Status.Konnect.Endpoints.TelemetryEndpoint)
+		assert.Equal(t, "my-secret", ext.Status.DataPlaneClientAuth.CertificateSecretRef.Name)
+	})
+}

--- a/test/helpers/deploy/deploy_resources.go
+++ b/test/helpers/deploy/deploy_resources.go
@@ -56,6 +56,13 @@ func WithLabel(key, value string) ObjOption {
 	}
 }
 
+// WithName returns an ObjOption that sets the name of the object.
+func WithName(name string) ObjOption {
+	return func(obj client.Object) {
+		obj.SetName(name)
+	}
+}
+
 // WithTestIDLabel returns an ObjOption that sets the test ID label on the object.
 func WithTestIDLabel(testID string) func(obj client.Object) {
 	return func(obj client.Object) {

--- a/test/integration/konnect_extension_test.go
+++ b/test/integration/konnect_extension_test.go
@@ -151,6 +151,8 @@ func TestKonnectExtensionControlPlaneRotation(t *testing.T) {
 		checkKonnectExtensionStatus(konnectExtension, cp.GetKonnectID(), ""),
 		testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
+	// delete the KonnectExtension first to avoid the ControlPlane gets deleted first and
+	// the KonnectExtension gets stuck in deletion.
 	deleteObjectAndWaitForDeletionFn(t, konnectExtension.DeepCopy())()
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #1620 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
