### PR TITLE
fix: data race for setting `cfssl` logger

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/kong/gateway-operator/controller/pkg/secrets"
 	"github.com/kong/gateway-operator/modules/cli"
 	"github.com/kong/gateway-operator/modules/manager"
 	"github.com/kong/gateway-operator/modules/manager/metadata"
@@ -35,6 +36,7 @@ func main() {
 	cfg := cli.Parse(os.Args[1:])
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(cfg.LoggerOpts)))
+	secrets.SetCALogger(ctrl.Log)
 
 	if err := manager.Run(cfg, scheme.Get(), manager.SetupControllers, nil, m); err != nil {
 		ctrl.Log.Error(err, "failed to run manager")

--- a/controller/pkg/secrets/cert.go
+++ b/controller/pkg/secrets/cert.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cloudflare/cfssl/config"
@@ -36,10 +37,15 @@ import (
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
 )
 
+var caLoggerInit sync.Once
+
 // SetCALogger sets the logger for the CFSSL signer. Call it once at the start
 // of the program to ensure that CFSSL logs are captured by the operator's logger.
+// Subsequent calls to this function will have no effect.
 func SetCALogger(logger logr.Logger) {
-	cflog.SetLogger(loggerShim{logger: logger})
+	caLoggerInit.Do(func() {
+		cflog.SetLogger(loggerShim{logger: logger})
+	})
 }
 
 // -----------------------------------------------------------------------------

--- a/controller/pkg/secrets/cert.go
+++ b/controller/pkg/secrets/cert.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/cloudflare/cfssl/config"
@@ -25,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kong/gateway-operator/controller/pkg/dataplane"
 	"github.com/kong/gateway-operator/controller/pkg/op"
@@ -37,6 +35,12 @@ import (
 
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
 )
+
+// SetCALogger sets the logger for the CFSSL signer. Call it once at the start
+// of the program to ensure that CFSSL logs are captured by the operator's logger.
+func SetCALogger(logger logr.Logger) {
+	cflog.SetLogger(loggerShim{logger: logger})
+}
 
 // -----------------------------------------------------------------------------
 // Private Functions - Certificate management
@@ -64,14 +68,6 @@ func (l loggerShim) Crit(msg string) { l.logger.V(logging.InfoLevel.Value()).Inf
 
 // Emerg logs on emergency level.
 func (l loggerShim) Emerg(msg string) { l.logger.V(logging.InfoLevel.Value()).Info(msg) }
-
-var caLoggerInit sync.Once
-
-func setCALogger(logger logr.Logger) {
-	caLoggerInit.Do(func() {
-		cflog.SetLogger(loggerShim{logger: logger})
-	})
-}
 
 /*
 Adapted from the Kubernetes CFSSL signer:
@@ -189,8 +185,6 @@ func EnsureCertificate[
 	cl client.Client,
 	additionalMatchingLabels client.MatchingLabels,
 ) (op.Result, *corev1.Secret, error) {
-	setCALogger(ctrllog.Log)
-
 	// Get the Secrets for the DataPlane using new labels.
 	matchingLabels := k8sresources.GetManagedLabelForOwner(owner)
 	for k, v := range additionalMatchingLabels {


### PR DESCRIPTION
**What this PR does / why we need it**:

Since the logger for the whole controller is explicitly configured in `main` let's do the same for a logger used by `cfssl`, it will avoid datarace and make all loggers set in a single place

**Which issue this PR fixes**

Fixes #1683
