### PR TITLE
chore(tests): re-enable e2e `TestOperatorLogs`

### DIFF
--- a/test/e2e/operator_logs_test.go
+++ b/test/e2e/operator_logs_test.go
@@ -60,8 +60,6 @@ var (
 )
 
 func TestOperatorLogs(t *testing.T) {
-	t.Skip("https://github.com/Kong/gateway-operator/issues/1350")
-
 	ctx := t.Context()
 	if imageLoad == "" && imageOverride == "" {
 		t.Skipf("No KONG_TEST_GATEWAY_OPERATOR_IMAGE_OVERRIDE nor KONG_TEST_GATEWAY_OPERATOR_IMAGE_LOAD" +


### PR DESCRIPTION
**What this PR does / why we need it**:

Thanks to the work done in #1701 this test passes now and can be re-enabled

**Which issue this PR fixes**

Fixes #1350
