### PR TITLE
chore(ci): re-enable after release of 2.0.0-alpha.1

### DIFF
--- a/.github/workflows/charts-tests.yaml
+++ b/.github/workflows/charts-tests.yaml
@@ -98,60 +98,58 @@ jobs:
             echo 'EOF'
           ) >> "${GITHUB_OUTPUT}"
 
-  #TODO: https://github.com/Kong/gateway-operator/issues/1717 
-  # See the line 184 too!
-  # lint-test:
-  #   timeout-minutes: 30
-  #   needs:
-  #     - check-docs-only
-  #     - matrix_k8s_node_versions
-  #   if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       kubernetes-node-version: ${{ fromJson(needs.matrix_k8s_node_versions.outputs.matrix) }}
-  #       chart-name:
-  #         - kong-operator
-  #   steps:
-  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-  #       with:
-  #         fetch-depth: 0
+  lint-test:
+    timeout-minutes: 30
+    needs:
+      - check-docs-only
+      - matrix_k8s_node_versions
+    if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        kubernetes-node-version: ${{ fromJson(needs.matrix_k8s_node_versions.outputs.matrix) }}
+        chart-name:
+          - kong-operator
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
 
-  #     - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
-  #       with:
-  #         install: false
+      - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
+        with:
+          install: false
 
-  #     - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+      - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
 
-  #     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-  #       with:
-  #         python-version: "3.13"
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.13"
 
-  #     - uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
+      - uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
 
-  #     - name: Run chart-testing (lint)
-  #       run: ct lint --target-branch main --check-version-increment=false
+      - name: Run chart-testing (lint)
+        run: ct lint --target-branch main --check-version-increment=false
 
-  #     - name: setup testing environment (kind-cluster)
-  #       env:
-  #         KUBERNETES_VERSION: ${{ matrix.kubernetes-node-version }}
-  #         CHART_NAME: ${{ matrix.chart-name }}
-  #       run: ./scripts/charts-test-env.sh
+      - name: setup testing environment (kind-cluster)
+        env:
+          KUBERNETES_VERSION: ${{ matrix.kubernetes-node-version }}
+          CHART_NAME: ${{ matrix.chart-name }}
+        run: ./scripts/charts-test-env.sh
 
-  #     - name: Install kubernetes-configuration CRDs (ingress-controller)
-  #       run: make install.kubernetes-configuration-crds-ingress-controller
+      - name: Install kubernetes-configuration CRDs (ingress-controller)
+        run: make install.kubernetes-configuration-crds-ingress-controller
 
-  #     - name: Install kubernetes-configuration CRDs (operator)
-  #       run: make install.kubernetes-configuration-crds-operator
+      - name: Install kubernetes-configuration CRDs (operator)
+        run: make install.kubernetes-configuration-crds-operator
 
-  #     - name: Install Gateway API CRDs
-  #       run: make install.gateway-api-crds
+      - name: Install Gateway API CRDs
+        run: make install.gateway-api-crds
 
-  #     - name: Run chart-testing (install)
-  #       run: |
-  #         kubectl create ns kong-test
-  #         ct install --target-branch main --charts charts/${{ matrix.chart-name}} --namespace kong-test
-  #         # No need to delete the ns the cluster is scrapped after the job anyway.
+      - name: Run chart-testing (install)
+        run: |
+          kubectl create ns kong-test
+          ct install --target-branch main --charts charts/${{ matrix.chart-name}} --namespace kong-test
+          # No need to delete the ns the cluster is scrapped after the job anyway.
 
   golden-tests:
     timeout-minutes: 30
@@ -181,8 +179,7 @@ jobs:
       - check-docs-only
       - generate
       - lint
-      #TODO: https://github.com/Kong/gateway-operator/issues/1717
-      # - lint-test
+      - lint-test
       - golden-tests
     if: always()
     steps:

--- a/.github/workflows/release-bot.yaml
+++ b/.github/workflows/release-bot.yaml
@@ -1,4 +1,4 @@
-# This job is not inteneded to be run manually. Instead it assumes that proper
+# This job is not intended to be run manually. Instead it assumes that proper
 # release commit is pushed to the repository. It will then create a new release
 # on GitHub.
 name: release-bot

--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,7 @@ manifests.crds: controller-gen manifests.versions ## Generate CustomResourceDefi
 .PHONY: manifests.versions
 manifests.versions: kustomize yq
 	$(YQ) eval '.appVersion = "$(VERSION)"' -i charts/kong-operator/Chart.yaml
-	$(YQ) eval '.tag = "$(VERSION)"' -i charts/kong-operator/values.yaml
+	$(YQ) eval '.image.tag = "$(VERSION)"' -i charts/kong-operator/values.yaml
 	cd config/components/manager-image/ && $(KUSTOMIZE) edit set image $(KUSTOMIZE_IMG_NAME)=$(IMG):$(VERSION)
 
 .PHONY: manifests.charts

--- a/Makefile
+++ b/Makefile
@@ -356,6 +356,8 @@ manifests.crds: controller-gen manifests.versions ## Generate CustomResourceDefi
 # manifests.versions ensures that image versions are set in the manifests according to the current version.
 .PHONY: manifests.versions
 manifests.versions: kustomize yq
+	$(YQ) eval '.appVersion = "$(VERSION)"' -i charts/kong-operator/Chart.yaml
+	$(YQ) eval '.tag = "$(VERSION)"' -i charts/kong-operator/values.yaml
 	cd config/components/manager-image/ && $(KUSTOMIZE) edit set image $(KUSTOMIZE_IMG_NAME)=$(IMG):$(VERSION)
 
 .PHONY: manifests.charts

--- a/charts/kong-operator/Chart.yaml
+++ b/charts/kong-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: kong-operator
 sources:
   - https://github.com/Kong/kong-operator/charts/kong-operator/
 version: 0.0.1
-appVersion: "2.0.0-alpha.0"
+appVersion: "2.0.0-alpha.1"
 annotations:
   artifacthub.io/prerelease: "true"
 dependencies:

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -693,7 +693,7 @@ metadata:
     app.kubernetes.io/name: kong-operator
     helm.sh/chart: kong-operator-0.0.1
     app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0.0-alpha.0"
+    app.kubernetes.io/version: "2.0.0-alpha.1"
     app.kubernetes.io/component: ko
   name: chartsnap-kong-operator-controller-manager
   namespace: default
@@ -715,10 +715,10 @@ spec:
         app.kubernetes.io/name: kong-operator
         helm.sh/chart: kong-operator-0.0.1
         app.kubernetes.io/instance: "chartsnap"
-        app.kubernetes.io/version: "2.0.0-alpha.0"
+        app.kubernetes.io/version: "2.0.0-alpha.1"
         app.kubernetes.io/component: ko
         app: chartsnap-kong-operator
-        version: "2.0.0-alpha.0"
+        version: "2.0.0-alpha.1"
     spec:
       affinity:
         podAffinity:
@@ -743,7 +743,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: "docker.io/kong/kong-operator:2.0.0-alpha.0"
+        image: "docker.io/kong/kong-operator:2.0.0-alpha.1"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -693,7 +693,7 @@ metadata:
     app.kubernetes.io/name: kong-operator
     helm.sh/chart: kong-operator-0.0.1
     app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0.0-alpha.0"
+    app.kubernetes.io/version: "2.0.0-alpha.1"
     app.kubernetes.io/component: ko
   name: chartsnap-kong-operator-controller-manager
   namespace: default
@@ -715,10 +715,10 @@ spec:
         app.kubernetes.io/name: kong-operator
         helm.sh/chart: kong-operator-0.0.1
         app.kubernetes.io/instance: "chartsnap"
-        app.kubernetes.io/version: "2.0.0-alpha.0"
+        app.kubernetes.io/version: "2.0.0-alpha.1"
         app.kubernetes.io/component: ko
         app: chartsnap-kong-operator
-        version: "2.0.0-alpha.0"
+        version: "2.0.0-alpha.1"
     spec:
       containers:
       - name: manager
@@ -735,7 +735,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: "docker.io/kong/kong-operator:2.0.0-alpha.0"
+        image: "docker.io/kong/kong-operator:2.0.0-alpha.1"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/kong-operator/ci/__snapshots__/effective-version-1-6-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/effective-version-1-6-values.snap
@@ -693,7 +693,7 @@ metadata:
     app.kubernetes.io/name: kong-operator
     helm.sh/chart: kong-operator-0.0.1
     app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0.0-alpha.0"
+    app.kubernetes.io/version: "2.0.0-alpha.1"
     app.kubernetes.io/component: ko
   name: chartsnap-kong-operator-controller-manager
   namespace: default
@@ -715,10 +715,10 @@ spec:
         app.kubernetes.io/name: kong-operator
         helm.sh/chart: kong-operator-0.0.1
         app.kubernetes.io/instance: "chartsnap"
-        app.kubernetes.io/version: "2.0.0-alpha.0"
+        app.kubernetes.io/version: "2.0.0-alpha.1"
         app.kubernetes.io/component: ko
         app: chartsnap-kong-operator
-        version: "2.0.0-alpha.0"
+        version: "2.0.0-alpha.1"
     spec:
       containers:
       - name: manager
@@ -733,7 +733,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: "docker.io/kong/nightly-kong-operator:20250409"
+        image: "docker.io/kong/nightly-gateway-operator-oss:20250409"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -693,7 +693,7 @@ metadata:
     app.kubernetes.io/name: kong-operator
     helm.sh/chart: kong-operator-0.0.1
     app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0.0-alpha.0"
+    app.kubernetes.io/version: "2.0.0-alpha.1"
     app.kubernetes.io/component: ko
   name: chartsnap-kong-operator-controller-manager
   namespace: default
@@ -715,10 +715,10 @@ spec:
         app.kubernetes.io/name: kong-operator
         helm.sh/chart: kong-operator-0.0.1
         app.kubernetes.io/instance: "chartsnap"
-        app.kubernetes.io/version: "2.0.0-alpha.0"
+        app.kubernetes.io/version: "2.0.0-alpha.1"
         app.kubernetes.io/component: ko
         app: chartsnap-kong-operator
-        version: "2.0.0-alpha.0"
+        version: "2.0.0-alpha.1"
     spec:
       containers:
       - name: manager
@@ -735,7 +735,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: "docker.io/kong/kong-operator:2.0.0-alpha.0"
+        image: "docker.io/kong/kong-operator:2.0.0-alpha.1"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -693,7 +693,7 @@ metadata:
     app.kubernetes.io/name: kong-operator
     helm.sh/chart: kong-operator-0.0.1
     app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0.0-alpha.0"
+    app.kubernetes.io/version: "2.0.0-alpha.1"
     app.kubernetes.io/component: ko
   name: chartsnap-kong-operator-controller-manager
   namespace: default
@@ -715,10 +715,10 @@ spec:
         app.kubernetes.io/name: kong-operator
         helm.sh/chart: kong-operator-0.0.1
         app.kubernetes.io/instance: "chartsnap"
-        app.kubernetes.io/version: "2.0.0-alpha.0"
+        app.kubernetes.io/version: "2.0.0-alpha.1"
         app.kubernetes.io/component: ko
         app: chartsnap-kong-operator
-        version: "2.0.0-alpha.0"
+        version: "2.0.0-alpha.1"
     spec:
       containers:
       - name: manager
@@ -737,7 +737,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: "docker.io/kong/kong-operator:2.0.0-alpha.0"
+        image: "docker.io/kong/kong-operator:2.0.0-alpha.1"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -693,7 +693,7 @@ metadata:
     app.kubernetes.io/name: kong-operator
     helm.sh/chart: kong-operator-0.0.1
     app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0.0-alpha.0"
+    app.kubernetes.io/version: "2.0.0-alpha.1"
     a: "b"
     app.kubernetes.io/component: ko
   name: chartsnap-kong-operator-controller-manager
@@ -716,11 +716,11 @@ spec:
         app.kubernetes.io/name: kong-operator
         helm.sh/chart: kong-operator-0.0.1
         app.kubernetes.io/instance: "chartsnap"
-        app.kubernetes.io/version: "2.0.0-alpha.0"
+        app.kubernetes.io/version: "2.0.0-alpha.1"
         a: "b"
         app.kubernetes.io/component: ko
         app: chartsnap-kong-operator
-        version: "2.0.0-alpha.0"
+        version: "2.0.0-alpha.1"
     spec:
       containers:
       - name: manager
@@ -735,7 +735,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: "docker.io/kong/kong-operator:2.0.0-alpha.0"
+        image: "docker.io/kong/kong-operator:2.0.0-alpha.1"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrest-values.snap
@@ -693,7 +693,7 @@ metadata:
     app.kubernetes.io/name: kong-operator
     helm.sh/chart: kong-operator-0.0.1
     app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0.0-alpha.0"
+    app.kubernetes.io/version: "2.0.0-alpha.1"
     app.kubernetes.io/component: ko
   name: chartsnap-kong-operator-controller-manager
   namespace: default
@@ -715,10 +715,10 @@ spec:
         app.kubernetes.io/name: kong-operator
         helm.sh/chart: kong-operator-0.0.1
         app.kubernetes.io/instance: "chartsnap"
-        app.kubernetes.io/version: "2.0.0-alpha.0"
+        app.kubernetes.io/version: "2.0.0-alpha.1"
         app.kubernetes.io/component: ko
         app: chartsnap-kong-operator
-        version: "2.0.0-alpha.0"
+        version: "2.0.0-alpha.1"
     spec:
       imagePullSecrets:
       - name: myRegistryKeySecretName
@@ -735,7 +735,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: "docker.io/kong/kong-operator:2.0.0-alpha.0"
+        image: "docker.io/kong/kong-operator:2.0.0-alpha.1"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -693,7 +693,7 @@ metadata:
     app.kubernetes.io/name: kong-operator
     helm.sh/chart: kong-operator-0.0.1
     app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0.0-alpha.0"
+    app.kubernetes.io/version: "2.0.0-alpha.1"
     app.kubernetes.io/component: ko
   name: chartsnap-kong-operator-controller-manager
   namespace: default
@@ -715,10 +715,10 @@ spec:
         app.kubernetes.io/name: kong-operator
         helm.sh/chart: kong-operator-0.0.1
         app.kubernetes.io/instance: "chartsnap"
-        app.kubernetes.io/version: "2.0.0-alpha.0"
+        app.kubernetes.io/version: "2.0.0-alpha.1"
         app.kubernetes.io/component: ko
         app: chartsnap-kong-operator
-        version: "2.0.0-alpha.0"
+        version: "2.0.0-alpha.1"
     spec:
       containers:
       - name: manager

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -693,7 +693,7 @@ metadata:
     app.kubernetes.io/name: kong-operator
     helm.sh/chart: kong-operator-0.0.1
     app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0.0-alpha.0"
+    app.kubernetes.io/version: "2.0.0-alpha.1"
     app.kubernetes.io/component: ko
   name: chartsnap-kong-operator-controller-manager
   namespace: default
@@ -716,10 +716,10 @@ spec:
         app.kubernetes.io/name: kong-operator
         helm.sh/chart: kong-operator-0.0.1
         app.kubernetes.io/instance: "chartsnap"
-        app.kubernetes.io/version: "2.0.0-alpha.0"
+        app.kubernetes.io/version: "2.0.0-alpha.1"
         app.kubernetes.io/component: ko
         app: chartsnap-kong-operator
-        version: "2.0.0-alpha.0"
+        version: "2.0.0-alpha.1"
     spec:
       containers:
       - name: manager
@@ -734,7 +734,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: "docker.io/kong/kong-operator:2.0.0-alpha.0"
+        image: "docker.io/kong/kong-operator:2.0.0-alpha.1"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -693,7 +693,7 @@ metadata:
     app.kubernetes.io/name: kong-operator
     helm.sh/chart: kong-operator-0.0.1
     app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0.0-alpha.0"
+    app.kubernetes.io/version: "2.0.0-alpha.1"
     app.kubernetes.io/component: ko
   name: chartsnap-kong-operator-controller-manager
   namespace: default
@@ -715,10 +715,10 @@ spec:
         app.kubernetes.io/name: kong-operator
         helm.sh/chart: kong-operator-0.0.1
         app.kubernetes.io/instance: "chartsnap"
-        app.kubernetes.io/version: "2.0.0-alpha.0"
+        app.kubernetes.io/version: "2.0.0-alpha.1"
         app.kubernetes.io/component: ko
         app: chartsnap-kong-operator
-        version: "2.0.0-alpha.0"
+        version: "2.0.0-alpha.1"
     spec:
       containers:
       - name: manager
@@ -735,7 +735,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: "docker.io/kong/kong-operator:2.0.0-alpha.0"
+        image: "docker.io/kong/kong-operator:2.0.0-alpha.1"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -693,7 +693,7 @@ metadata:
     app.kubernetes.io/name: kong-operator
     helm.sh/chart: kong-operator-0.0.1
     app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0.0-alpha.0"
+    app.kubernetes.io/version: "2.0.0-alpha.1"
     app.kubernetes.io/component: ko
   name: chartsnap-kong-operator-controller-manager
   namespace: default
@@ -715,10 +715,10 @@ spec:
         app.kubernetes.io/name: kong-operator
         helm.sh/chart: kong-operator-0.0.1
         app.kubernetes.io/instance: "chartsnap"
-        app.kubernetes.io/version: "2.0.0-alpha.0"
+        app.kubernetes.io/version: "2.0.0-alpha.1"
         app.kubernetes.io/component: ko
         app: chartsnap-kong-operator
-        version: "2.0.0-alpha.0"
+        version: "2.0.0-alpha.1"
     spec:
       tolerations:
       - effect: NoSchedule
@@ -737,7 +737,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: "docker.io/kong/kong-operator:2.0.0-alpha.0"
+        image: "docker.io/kong/kong-operator:2.0.0-alpha.1"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/kong-operator/ci/effective-version-1-6-values.yaml
+++ b/charts/kong-operator/ci/effective-version-1-6-values.yaml
@@ -1,7 +1,7 @@
 image:
-  repository: docker.io/kong/nightly-kong-operator
+  repository: docker.io/kong/nightly-gateway-operator-oss
   tag: "20250409"
-  effectiveSemver: "2.0.0-alpha.0"
+  effectiveSemver: "1.6.0"
 
 livenessProbe:
   httpGet:

--- a/charts/kong-operator/values.yaml
+++ b/charts/kong-operator/values.yaml
@@ -13,47 +13,35 @@ image:
   ##
   # pullSecrets:
   #   - myRegistrKeySecretName
+# Override namespace for gateway-operator chart resources. By default, the chart creates resources in the release namespace.
 
- # Override namespace for gateway-operator chart resources. By default, the chart creates resources in the release namespace.
 # namespace: kong-system
-
 replicaCount: 1
-
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: controller-manager
-
 test:
   enabled: false
-
 # This section can be used to configure some extra labels that will be added to each Kubernetes object generated.
 extraLabels: {}
-
 # Labels to be added to KGO pods
 podLabels: {}
-
 # Annotations to be added to KGO pods
 podAnnotations: {}
-
 # Install KIC's CRDs
 kic-crds:
   enabled: true
-
 # Install Gateway API standard CRDs
 gwapi-standard-crds:
   enabled: true
-
 # Install Gateway API experimental CRDs
 gwapi-experimental-crds:
   enabled: false
-
 affinity: {}
-
 tolerations: []
-
 # Customize gateway-operator livenessProbe.
 livenessProbe:
   httpGet:
@@ -68,7 +56,6 @@ readinessProbe:
     port: 8081
   initialDelaySeconds: 5
   periodSeconds: 10
-
 # Use this section to customize the requests and limits of gateway-operator
 resources:
   limits:
@@ -77,25 +64,24 @@ resources:
   requests:
     cpu: 10m
     memory: 128Mi
-
 # Use this section to add environment variables to operator's container
 # NOTE: This is mutually exclusive with the args sections.
 # When both an env and a corresponding arg are provided, the arg will take precedence.
 env: {}
-  # # gateway controller
-  # enable_controller_gateway: true
-  # # controlPlane controller
-  # enable_controller_controlplane: true
-  # # dataplane controller. mutually exclusive with dataplane bluegreen controller
-  # enable_controller_dataplane: true
-  # # dataplane bluegreen controller. mutually exclusive with dataplane controller
-  # enable_controller_dataplane_bluegreen: true
-  # # aigateway controller. (experimental)
-  # enable_controller_aigateway: false
-  # # konglicense controller. (EE only)
-  # enable_controller_konglicense: true
-  # # controlplane extensions controller. (EE only)
-  # enable_controller_controlplaneextensions: true
+# # gateway controller
+# enable_controller_gateway: true
+# # controlPlane controller
+# enable_controller_controlplane: true
+# # dataplane controller. mutually exclusive with dataplane bluegreen controller
+# enable_controller_dataplane: true
+# # dataplane bluegreen controller. mutually exclusive with dataplane controller
+# enable_controller_dataplane_bluegreen: true
+# # aigateway controller. (experimental)
+# enable_controller_aigateway: false
+# # konglicense controller. (EE only)
+# enable_controller_konglicense: true
+# # controlplane extensions controller. (EE only)
+# enable_controller_controlplaneextensions: true
 
 # This section is any customer specific environments variables that doesn't require CONTROLLER_ prefix.
 # Example as below, uncomment if required and add additional attributes as required.
@@ -107,11 +93,10 @@ env: {}
 # NOTE: This is mutually exclusive with the env and customEnv sections.
 # When both an env and a corresponding arg are provided, the arg will take precedence.
 args: []
-
 # Use this section to change the certs-dir emptyDir size
 certsDir:
   sizeLimit: 256Mi
-
+tag: 2.0.0-alpha.1
 # Override the default deployment selector labels. This is useful if you don't want
 # to use the defaults or are migrating to this chart and want to use existing labels.
 # selectorLabels: []

--- a/charts/kong-operator/values.yaml
+++ b/charts/kong-operator/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.io/kong/kong-operator
-  tag: "2.0.0-alpha.0"
+  tag: "2.0.0-alpha.1"
   # Optionally set a semantic version for version-gated features. This can normally
   # be left unset. You only need to set this if your tag is not a semver string,
   # such as when you are using a "next" tag. Set this to the effective semantic

--- a/test/e2e/helm_install_upgrade_test.go
+++ b/test/e2e/helm_install_upgrade_test.go
@@ -65,8 +65,8 @@ func TestHelmUpgrade(t *testing.T) {
 		{
 			name:        "upgrade from one before latest to latest minor",
 			skip:        "Two versions are needed to upgrade from, but currently only one exists (https://github.com/Kong/gateway-operator/issues/1716)",
-			fromVersion: "2.0.0-alpha.0", // renovate: datasource=docker packageName=kong/kong-operator depName=kong/kong-operator@only-patch
-			toVersion:   "2.0.0-alpha.0", // renovate: datasource=docker packageName=kong/kong-operator depName=kong/kong-operator
+			fromVersion: "2.0.0-alpha.1", // renovate: datasource=docker packageName=kong/kong-operator depName=kong/kong-operator@only-patch
+			toVersion:   "2.0.0-alpha.1", // renovate: datasource=docker packageName=kong/kong-operator depName=kong/kong-operator
 			objectsToDeploy: []client.Object{
 				&operatorv1beta1.GatewayConfiguration{
 					ObjectMeta: metav1.ObjectMeta{
@@ -138,11 +138,11 @@ func TestHelmUpgrade(t *testing.T) {
 		{
 			name:             "upgrade from latest minor to current",
 			skip:             "ControlPlane assertions have to be adjusted to KIC as a library approach (https://github.com/Kong/gateway-operator/issues/1188)",
-			fromVersion:      "2.0.0-alpha.0", // renovate: datasource=docker packageName=kong/kong-operator depName=kong/kong-operator
+			fromVersion:      "2.0.0-alpha.1", // renovate: datasource=docker packageName=kong/kong-operator depName=kong/kong-operator
 			upgradeToCurrent: true,
 			// This is the effective semver of a next release.
 			// It's needed for the chart to properly render semver-conditional templates.
-			upgradeToEffectiveSemver: "2.0.0-alpha.0",
+			upgradeToEffectiveSemver: "2.0.0-alpha.1",
 			objectsToDeploy: []client.Object{
 				&operatorv1beta1.GatewayConfiguration{
 					ObjectMeta: metav1.ObjectMeta{
@@ -217,7 +217,7 @@ func TestHelmUpgrade(t *testing.T) {
 			upgradeToCurrent: true,
 			// This is the effective semver of a next release.
 			// It's needed for the chart to properly render semver-conditional templates.
-			upgradeToEffectiveSemver: "2.0.0-alpha.0",
+			upgradeToEffectiveSemver: "2.0.0-alpha.1",
 			objectsToDeploy: []client.Object{
 				&operatorv1beta1.GatewayConfiguration{
 					ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:

Continuation of https://github.com/Kong/gateway-operator/pull/1686 and https://github.com/Kong/gateway-operator/pull/1721

Furthermore, it fixes the release-bot to update the version in `charts/kong-operator/Chart.yaml` and `charts/kong-operator/values.yaml` too, which was omitted in 
- https://github.com/Kong/gateway-operator/pull/1722

**Which issue this PR fixes**

Fixes #1717

Part of #1490 & #1598


