### PR TITLE
chore: remove redundant EE mentions and field `.tag` in chart `values.yaml`

### DIFF
--- a/.github/ISSUE_TEMPLATE/---release.md
+++ b/.github/ISSUE_TEMPLATE/---release.md
@@ -39,11 +39,6 @@ If the troubleshooting section does not contain the answer to the problem you en
     ${KUBERNETES_CONFIGURATION_REPO}/scripts/apidocs-gen/post-process-for-konghq.sh ${KUBERNETES_CONFIGURATION_REPO}/docs/gateway-operator-api-reference.md ${KONGHQ_DOCS_REPO}/app/_src/gateway-operator/reference/custom-resources/1.2.x.md
     ```
 
-  - NOTE: [CLI configuration options docs][cli_ref_docs] should be updated when releasing KGO EE as that's the source of truth for those.
-    The reason for this is that KGO EE configuration flags are a superset of OSS flags.
-
-- [ ] Proceed to release KGO EE as it relies on OSS releases.
-
 **Only for major and minor releases**:
 
 - [ ] After the release tag is created, bump the `fromVersion` in the `upgrade from one before latest to latest minor` [upgrade E2E test][helm_upgrade_test] to the one before the latest minor release.

--- a/charts/kong-operator/values.yaml
+++ b/charts/kong-operator/values.yaml
@@ -78,9 +78,9 @@ env: {}
 # enable_controller_dataplane_bluegreen: true
 # # aigateway controller. (experimental)
 # enable_controller_aigateway: false
-# # konglicense controller. (EE only)
+# # konglicense controller.
 # enable_controller_konglicense: true
-# # controlplane extensions controller. (EE only)
+# # controlplane extensions controller.
 # enable_controller_controlplaneextensions: true
 
 # This section is any customer specific environments variables that doesn't require CONTROLLER_ prefix.
@@ -96,7 +96,6 @@ args: []
 # Use this section to change the certs-dir emptyDir size
 certsDir:
   sizeLimit: 256Mi
-tag: 2.0.0-alpha.1
 # Override the default deployment selector labels. This is useful if you don't want
 # to use the defaults or are migrating to this chart and want to use existing labels.
 # selectorLabels: []


### PR DESCRIPTION
**What this PR does / why we need it**:

PR #1724 introduced by mistake redundant field `.tag` in chart `values.yaml`, this PR removes it.

Furthermore, remove mentions about EE that are not valid anymore, since everything is OSS.
