### PR TITLE
feat(controlplane): add setting controllers and feature gates based on ControlPlane spec

### DIFF
--- a/controller/controlplane/manager_options.go
+++ b/controller/controlplane/manager_options.go
@@ -146,7 +146,7 @@ func WithControllers(logger logr.Logger, controllers []gwtypes.ControlPlaneContr
 		if b == nil {
 			return
 		}
-		*b = state == gwtypes.ControlPlaneControllerStateEnabled
+		*b = (state == gwtypes.ControlPlaneControllerStateEnabled)
 	}
 	return func(c *managercfg.Config) {
 		for _, controller := range controllers {

--- a/controller/controlplane/manager_options.go
+++ b/controller/controlplane/manager_options.go
@@ -147,12 +147,16 @@ func WithControllers(logger logr.Logger, controllers []gwtypes.ControlPlaneContr
 	return func(c *managercfg.Config) {
 		for _, controller := range controllers {
 			switch controller.Name {
+			// Ingress related controllers.
+
 			case "INGRESS_NETWORKINGV1":
 				setOpt(&c.IngressNetV1Enabled, controller.State)
 			case "INGRESS_CLASS_NETWORKINGV1":
 				setOpt(&c.IngressClassNetV1Enabled, controller.State)
 			case "INGRESS_CLASS_PARAMETERS":
 				setOpt(&c.IngressClassParametersEnabled, controller.State)
+
+			// Kong related controllers.
 
 			case "KONG_UDPINGRESS":
 				setOpt(&c.UDPIngressEnabled, controller.State)
@@ -181,6 +185,8 @@ func WithControllers(logger logr.Logger, controllers []gwtypes.ControlPlaneContr
 				setOpt(&c.KongCustomEntityEnabled, controller.State)
 			case "SERVICE":
 				setOpt(&c.ServiceEnabled, controller.State)
+
+			// Gateway API related controllers.
 
 			case "GWAPI_GATEWAY":
 				setOpt(&c.GatewayAPIGatewayController, controller.State)

--- a/controller/controlplane/manager_options.go
+++ b/controller/controlplane/manager_options.go
@@ -110,10 +110,6 @@ func WithFeatureGates(logger logr.Logger, featureGates []gwtypes.ControlPlaneFea
 				continue
 			}
 
-			v := false
-			if feature.State == gwtypes.FeatureGateStateEnabled {
-				v = true
-			}
 			// This should never happen as it should be enforced at the CRD level
 			// but we handle it gracefully here and log an error.
 			if _, ok := fgs[feature.Name]; ok {
@@ -122,7 +118,7 @@ func WithFeatureGates(logger logr.Logger, featureGates []gwtypes.ControlPlaneFea
 				)
 				continue
 			}
-			fgs[feature.Name] = v
+			fgs[feature.Name] = (feature.State == gwtypes.FeatureGateStateEnabled)
 		}
 
 		for k, v := range defaults {

--- a/controller/controlplane/manager_options.go
+++ b/controller/controlplane/manager_options.go
@@ -1,13 +1,17 @@
 package controlplane
 
 import (
+	"errors"
 	"time"
 
+	"github.com/go-logr/logr"
 	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/samber/mo"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 
+	"github.com/kong/gateway-operator/controller/pkg/log"
+	gwtypes "github.com/kong/gateway-operator/internal/types"
 	"github.com/kong/gateway-operator/pkg/vars"
 )
 
@@ -20,7 +24,6 @@ func WithRestConfig(restCfg *rest.Config, kubeConfigPath string) managercfg.Opt 
 		} else {
 			c.KubeRestConfig = restCfg
 		}
-
 	}
 }
 
@@ -91,5 +94,111 @@ func WithPublishService(service types.NamespacedName) managercfg.Opt {
 func WithMetricsServerOff() managercfg.Opt {
 	return func(c *managercfg.Config) {
 		c.MetricsAddr = "0" // 0 disables metrics server
+	}
+}
+
+// WithFeatureGates sets the feature gates for the manager.
+func WithFeatureGates(logger logr.Logger, featureGates []gwtypes.ControlPlaneFeatureGate) managercfg.Opt {
+	return func(c *managercfg.Config) {
+		fgs := managercfg.FeatureGates{}
+		defaults := managercfg.GetFeatureGatesDefaults()
+		for _, feature := range featureGates {
+			if _, ok := defaults[feature.Name]; !ok {
+				log.Error(logger, errors.New("unknown feature gate"), "unknown feature gate",
+					"feature", feature.Name, "state", feature.State,
+				)
+				continue
+			}
+
+			v := false
+			if feature.State == gwtypes.FeatureGateStateEnabled {
+				v = true
+			}
+			// This should never happen as it should be enforced at the CRD level
+			// but we handle it gracefully here and log an error.
+			if _, ok := fgs[feature.Name]; ok {
+				log.Error(logger, errors.New("feature gate already set"), "feature gate already set",
+					"feature", feature.Name, "state", feature.State,
+				)
+				continue
+			}
+			fgs[feature.Name] = v
+		}
+
+		for k, v := range defaults {
+			// Ensure that we don't override the defaults with empty values
+			if _, ok := fgs[k]; !ok {
+				fgs[k] = v
+			}
+		}
+		c.FeatureGates = fgs
+	}
+}
+
+// WithControllers sets the controllers for the manager.
+func WithControllers(logger logr.Logger, controllers []gwtypes.ControlPlaneController) managercfg.Opt {
+	logDeprecated := func(logger logr.Logger, enabled bool, controllerName string) {
+		if enabled {
+			log.Info(logger, "chosen controller is deprecated", "controller", controllerName)
+		}
+	}
+	setOpt := func(b *bool, state gwtypes.ControllerState) {
+		if b == nil {
+			return
+		}
+		*b = state == gwtypes.ControlPlaneControllerStateEnabled
+	}
+	return func(c *managercfg.Config) {
+		for _, controller := range controllers {
+			switch controller.Name {
+			case "INGRESS_NETWORKINGV1":
+				setOpt(&c.IngressNetV1Enabled, controller.State)
+			case "INGRESS_CLASS_NETWORKINGV1":
+				setOpt(&c.IngressClassNetV1Enabled, controller.State)
+			case "INGRESS_CLASS_PARAMETERS":
+				setOpt(&c.IngressClassParametersEnabled, controller.State)
+
+			case "KONG_UDPINGRESS":
+				setOpt(&c.UDPIngressEnabled, controller.State)
+				logDeprecated(logger, c.UDPIngressEnabled, controller.Name)
+			case "KONG_TCPINGRESS":
+				setOpt(&c.TCPIngressEnabled, controller.State)
+				logDeprecated(logger, c.TCPIngressEnabled, controller.Name)
+			case "KONG_INGRESS":
+				setOpt(&c.KongIngressEnabled, controller.State)
+				logDeprecated(logger, c.KongIngressEnabled, controller.Name)
+			case "KONG_CLUSTERPLUGIN":
+				setOpt(&c.KongClusterPluginEnabled, controller.State)
+			case "KONG_PLUGIN":
+				setOpt(&c.KongPluginEnabled, controller.State)
+			case "KONG_CONSUMER":
+				setOpt(&c.KongConsumerEnabled, controller.State)
+			case "KONG_UPSTREAM_POLICY":
+				setOpt(&c.KongUpstreamPolicyEnabled, controller.State)
+			case "KONG_SERVICE_FACADE":
+				setOpt(&c.KongServiceFacadeEnabled, controller.State)
+			case "KONG_VAULT":
+				setOpt(&c.KongVaultEnabled, controller.State)
+			case "KONG_LICENSE":
+				setOpt(&c.KongLicenseEnabled, controller.State)
+			case "KONG_CUSTOM_ENTITY":
+				setOpt(&c.KongCustomEntityEnabled, controller.State)
+			case "SERVICE":
+				setOpt(&c.ServiceEnabled, controller.State)
+
+			case "GWAPI_GATEWAY":
+				setOpt(&c.GatewayAPIGatewayController, controller.State)
+			case "GWAPI_HTTPROUTE":
+				setOpt(&c.GatewayAPIHTTPRouteController, controller.State)
+			case "GWAPI_GRPCROUTE":
+				setOpt(&c.GatewayAPIGRPCRouteController, controller.State)
+			case "GWAPI_REFERENCE_GRANT":
+				setOpt(&c.GatewayAPIReferenceGrantController, controller.State)
+
+			default:
+				// If the controller is not recognized, we can log it or handle it as needed.
+				log.Info(logger, "unknown controller", "controller", controller.Name, "state", controller.State)
+			}
+		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/sourcegraph/conc v0.3.0
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/pretty v1.2.1
+	github.com/tonglil/buflogr v1.1.1
 	go.uber.org/zap v1.27.0
 	golang.org/x/mod v0.25.0
 	google.golang.org/protobuf v1.36.6

--- a/internal/types/operatortypes.go
+++ b/internal/types/operatortypes.go
@@ -30,11 +30,30 @@ type (
 
 	// ControlPlaneStatus is an alias for the v2alpha1 ControlPlaneStatus type.
 	ControlPlaneStatus = operatorv2alpha1.ControlPlaneStatus
+
+	// ControlPlaneFeatureGate is an alias for the v2alpha1 ControlPlaneFeatureGate type.
+	ControlPlaneFeatureGate = operatorv2alpha1.ControlPlaneFeatureGate
+
+	// ControlPlaneController is an alias for the v2alpha1 ControlPlaneController type.
+	ControlPlaneController = operatorv2alpha1.ControlPlaneController
+
+	// ControllerState is an alias for the v2alpha1 ControllerState type.
+	ControllerState = operatorv2alpha1.ControllerState
 )
 
 const (
 	// ControlPlaneDataPlaneTargetRefType is an alias for the v2alpha1 ControlPlaneDataPlaneTargetRefType type.
 	ControlPlaneDataPlaneTargetRefType = operatorv2alpha1.ControlPlaneDataPlaneTargetRefType
+
+	// FeatureGateStateEnabled is an alias for the v2alpha1 FeatureGateStateEnabled type.
+	FeatureGateStateEnabled = operatorv2alpha1.FeatureGateStateEnabled
+	// FeatureGateStateDisabled is an alias for the v2alpha1 FeatureGateStateDisabled type.
+	FeatureGateStateDisabled = operatorv2alpha1.FeatureGateStateDisabled
+
+	// ControlPlaneControllerStateEnabled is an alias for the v2alpha1 ControlPlaneControllerStateEnabled type.
+	ControlPlaneControllerStateEnabled = operatorv2alpha1.ControllerStateEnabled
+	// ControlPlaneControllerStateDisabled is an alias for the v2alpha1 ControlPlaneControllerStateDisabled type.
+	ControlPlaneControllerStateDisabled = operatorv2alpha1.ControllerStateDisabled
 )
 
 func ControlPlaneGVR() schema.GroupVersionResource {


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the new `v2alpha1` `ControlPlane` API and set the controllers and feature gates based on the object spec.

**Which issue this PR fixes**

Part of #1739

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
