### PR TITLE
chore: adapt to v2alpha1 GatewayConfiguration API

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=403ef6b96f0b190acc5d94c3b6d3f08dc3e405ed # Version is auto-updated by the generating script.
+  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=842ead2a5ced9667a6eabcc86c5b0f122923d12f # Version is auto-updated by the generating script.

--- a/config/samples/gateway-with-gatewayconfiguration_v2.yaml
+++ b/config/samples/gateway-with-gatewayconfiguration_v2.yaml
@@ -1,0 +1,41 @@
+kind: GatewayConfiguration
+apiVersion: gateway-operator.konghq.com/v2alpha1
+metadata:
+  name: kong-v2alpha1
+  namespace: default
+spec:
+  dataPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        spec:
+          containers:
+          - name: proxy
+            # renovate: datasource=docker versioning=docker
+            image: kong/kong-gateway:3.10
+            readinessProbe:
+              initialDelaySeconds: 1
+              periodSeconds: 1
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: kong-v2alpha1
+spec:
+  controllerName: konghq.com/gateway-operator
+  parametersRef:
+    group: gateway-operator.konghq.com
+    kind: GatewayConfiguration
+    name: kong-v2alpha1
+    namespace: default
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: kong-v2alpha1
+  namespace: default
+spec:
+  gatewayClassName: kong-v2alpha1
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80

--- a/controller/controlplane/controller_test.go
+++ b/controller/controlplane/controller_test.go
@@ -71,13 +71,13 @@ func TestReconciler_Reconcile(t *testing.T) {
 					},
 				},
 				Spec: operatorv2alpha1.ControlPlaneSpec{
-					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
-						DataPlane: operatorv2alpha1.ControlPlaneDataPlaneTarget{
-							Type: operatorv2alpha1.ControlPlaneDataPlaneTargetRefType,
-							Ref: &operatorv2alpha1.ControlPlaneDataPlaneTargetRef{
-								Name: "test-dataplane",
-							},
+					DataPlane: operatorv2alpha1.ControlPlaneDataPlaneTarget{
+						Type: operatorv2alpha1.ControlPlaneDataPlaneTargetRefType,
+						Ref: &operatorv2alpha1.ControlPlaneDataPlaneTargetRef{
+							Name: "test-dataplane",
 						},
+					},
+					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
 						WatchNamespaces: &operatorv1beta1.WatchNamespaces{
 							Type: operatorv1beta1.WatchNamespacesTypeAll,
 						},

--- a/controller/controlplane/controller_utils_test.go
+++ b/controller/controlplane/controller_utils_test.go
@@ -13,11 +13,10 @@ import (
 
 func TestControlPlaneSpecDeepEqual(t *testing.T) {
 	testCases := []struct {
-		name            string
-		spec1           *gwtypes.ControlPlaneOptions
-		spec2           *gwtypes.ControlPlaneOptions
-		envVarsToIgnore []string
-		equal           bool
+		name  string
+		spec1 *gwtypes.ControlPlaneOptions
+		spec2 *gwtypes.ControlPlaneOptions
+		equal bool
 	}{
 		{
 			name: "different watch namespaces yield unequal specs",
@@ -55,7 +54,7 @@ func TestControlPlaneSpecDeepEqual(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.equal, controlplane.SpecDeepEqual(tc.spec1, tc.spec2, tc.envVarsToIgnore...))
+			require.Equal(t, tc.equal, controlplane.SpecDeepEqual(tc.spec1, tc.spec2))
 		})
 	}
 }

--- a/controller/controlplane/controller_utils_test.go
+++ b/controller/controlplane/controller_utils_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/kong/gateway-operator/controller/pkg/controlplane"
 	gwtypes "github.com/kong/gateway-operator/internal/types"
 
-	commonv1alpha1 "github.com/kong/kubernetes-configuration/api/common/v1alpha1"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
 )
 
@@ -20,42 +19,6 @@ func TestControlPlaneSpecDeepEqual(t *testing.T) {
 		envVarsToIgnore []string
 		equal           bool
 	}{
-		{
-			name:  "not matching Extensions",
-			spec1: &gwtypes.ControlPlaneOptions{},
-			spec2: &gwtypes.ControlPlaneOptions{
-				Extensions: []commonv1alpha1.ExtensionRef{
-					{
-						NamespacedRef: commonv1alpha1.NamespacedRef{
-							Name: "test",
-						},
-					},
-				},
-			},
-			equal: false,
-		},
-		{
-			name: "matching Extensions",
-			spec1: &gwtypes.ControlPlaneOptions{
-				Extensions: []commonv1alpha1.ExtensionRef{
-					{
-						NamespacedRef: commonv1alpha1.NamespacedRef{
-							Name: "test",
-						},
-					},
-				},
-			},
-			spec2: &gwtypes.ControlPlaneOptions{
-				Extensions: []commonv1alpha1.ExtensionRef{
-					{
-						NamespacedRef: commonv1alpha1.NamespacedRef{
-							Name: "test",
-						},
-					},
-				},
-			},
-			equal: true,
-		},
 		{
 			name: "different watch namespaces yield unequal specs",
 			spec1: &gwtypes.ControlPlaneOptions{

--- a/controller/controlplane_extensions/metricsscraper/manager_test.go
+++ b/controller/controlplane_extensions/metricsscraper/manager_test.go
@@ -54,12 +54,10 @@ func TestMetricsScrapeManagerAdd(t *testing.T) {
 							Namespace: "ns1",
 						},
 						Spec: gwtypes.ControlPlaneSpec{
-							ControlPlaneOptions: gwtypes.ControlPlaneOptions{
-								DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
-									Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
-									Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
-										Name: "dp1",
-									},
+							DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
+								Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
+								Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
+									Name: "dp1",
 								},
 							},
 						},
@@ -101,12 +99,10 @@ func TestMetricsScrapeManagerAdd(t *testing.T) {
 							Namespace: "ns1",
 						},
 						Spec: gwtypes.ControlPlaneSpec{
-							ControlPlaneOptions: gwtypes.ControlPlaneOptions{
-								DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
-									Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
-									Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
-										Name: "dp1",
-									},
+							DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
+								Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
+								Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
+									Name: "dp1",
 								},
 							},
 						},
@@ -134,12 +130,10 @@ func TestMetricsScrapeManagerAdd(t *testing.T) {
 							Namespace: "ns1",
 						},
 						Spec: gwtypes.ControlPlaneSpec{
-							ControlPlaneOptions: gwtypes.ControlPlaneOptions{
-								DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
-									Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
-									Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
-										Name: "dp1",
-									},
+							DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
+								Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
+								Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
+									Name: "dp1",
 								},
 							},
 						},
@@ -181,12 +175,10 @@ func TestMetricsScrapeManagerAdd(t *testing.T) {
 							Namespace: "ns1",
 						},
 						Spec: gwtypes.ControlPlaneSpec{
-							ControlPlaneOptions: gwtypes.ControlPlaneOptions{
-								DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
-									Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
-									Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
-										Name: "dp1",
-									},
+							DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
+								Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
+								Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
+									Name: "dp1",
 								},
 							},
 						},
@@ -214,12 +206,10 @@ func TestMetricsScrapeManagerAdd(t *testing.T) {
 							Namespace: "ns1",
 						},
 						Spec: gwtypes.ControlPlaneSpec{
-							ControlPlaneOptions: gwtypes.ControlPlaneOptions{
-								DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
-									Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
-									Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
-										Name: "dp2",
-									},
+							DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
+								Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
+								Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
+									Name: "dp2",
 								},
 							},
 						},
@@ -300,12 +290,10 @@ func TestMetricsScrapeManager_RemoveForControlPlaneNN(t *testing.T) {
 							Namespace: "ns1",
 						},
 						Spec: gwtypes.ControlPlaneSpec{
-							ControlPlaneOptions: gwtypes.ControlPlaneOptions{
-								DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
-									Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
-									Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
-										Name: "dp1",
-									},
+							DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
+								Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
+								Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
+									Name: "dp1",
 								},
 							},
 						},
@@ -333,12 +321,10 @@ func TestMetricsScrapeManager_RemoveForControlPlaneNN(t *testing.T) {
 							Namespace: "ns1",
 						},
 						Spec: gwtypes.ControlPlaneSpec{
-							ControlPlaneOptions: gwtypes.ControlPlaneOptions{
-								DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
-									Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
-									Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
-										Name: "dp2",
-									},
+							DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
+								Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
+								Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
+									Name: "dp2",
 								},
 							},
 						},
@@ -484,12 +470,10 @@ func TestMetricsScrapeManager_Start(t *testing.T) {
 							Namespace: "ns1",
 						},
 						Spec: gwtypes.ControlPlaneSpec{
-							ControlPlaneOptions: gwtypes.ControlPlaneOptions{
-								DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
-									Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
-									Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
-										Name: "dp1",
-									},
+							DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
+								Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
+								Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
+									Name: "dp1",
 								},
 							},
 						},
@@ -509,12 +493,10 @@ func TestMetricsScrapeManager_Start(t *testing.T) {
 							Namespace: "ns1",
 						},
 						Spec: gwtypes.ControlPlaneSpec{
-							ControlPlaneOptions: gwtypes.ControlPlaneOptions{
-								DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
-									Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
-									Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
-										Name: "dp2",
-									},
+							DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
+								Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
+								Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
+									Name: "dp2",
 								},
 							},
 						},

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -428,7 +428,7 @@ func (r *Reconciler) provisionDataPlane(
 	ctx context.Context,
 	logger logr.Logger,
 	gateway *gwtypes.Gateway,
-	gatewayConfig *operatorv1beta1.GatewayConfiguration,
+	gatewayConfig *GatewayConfiguration,
 ) (*operatorv1beta1.DataPlane, error) {
 	logger = logger.WithName("dataplaneProvisioning")
 
@@ -540,7 +540,7 @@ func (r *Reconciler) provisionControlPlane(
 	ctx context.Context,
 	logger logr.Logger,
 	gateway *gwtypes.Gateway,
-	gatewayConfig *operatorv1beta1.GatewayConfiguration,
+	gatewayConfig *GatewayConfiguration,
 	dataplane *operatorv1beta1.DataPlane,
 	ingressService corev1.Service,
 	adminService corev1.Service,
@@ -601,7 +601,8 @@ func (r *Reconciler) provisionControlPlane(
 	//   expectedControlPlaneOptions = gatewayConfig.Spec.ControlPlaneOptions
 	// }
 
-	expectedControlPlaneOptions.Extensions = extensions.MergeExtensions(gatewayConfig.Spec.Extensions, expectedControlPlaneOptions.Extensions)
+	// TODO: https://github.com/Kong/gateway-operator/issues/1361
+	// expectedControlPlaneOptions.Extensions = extensions.MergeExtensions(gatewayConfig.Spec.Extensions, expectedControlPlaneOptions.Extensions)
 
 	if !controlplanecontroller.SpecDeepEqual(&controlPlane.Spec.ControlPlaneOptions, expectedControlPlaneOptions) {
 		log.Trace(logger, "controlplane config is out of date")

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -24,6 +24,7 @@ import (
 	kcfgconsts "github.com/kong/kubernetes-configuration/api/common/consts"
 	kcfggateway "github.com/kong/kubernetes-configuration/api/gateway-operator/gateway"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v1beta1"
+	operatorv2alpha1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v2alpha1"
 )
 
 func TestParseKongProxyListenEnv(t *testing.T) {
@@ -1163,19 +1164,19 @@ func TestGatewayConfigDataPlaneOptionsToDataPlaneOptions(t *testing.T) {
 	testCases := []struct {
 		name                  string
 		gatewayConfigNS       string
-		opts                  operatorv1beta1.GatewayConfigDataPlaneOptions
+		opts                  GatewayConfigDataPlaneOptions
 		expectedDataPlaneOpts *operatorv1beta1.DataPlaneOptions
 	}{
 		{
 			name:                  "empty options",
 			gatewayConfigNS:       "default",
-			opts:                  operatorv1beta1.GatewayConfigDataPlaneOptions{},
+			opts:                  GatewayConfigDataPlaneOptions{},
 			expectedDataPlaneOpts: &operatorv1beta1.DataPlaneOptions{},
 		},
 		{
 			name:            "deployment options",
 			gatewayConfigNS: "default",
-			opts: operatorv1beta1.GatewayConfigDataPlaneOptions{
+			opts: GatewayConfigDataPlaneOptions{
 				Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
 					DeploymentOptions: operatorv1beta1.DeploymentOptions{
 						PodTemplateSpec: &corev1.PodTemplateSpec{
@@ -1209,8 +1210,8 @@ func TestGatewayConfigDataPlaneOptionsToDataPlaneOptions(t *testing.T) {
 		{
 			name:            "plugins to install (same namespace)",
 			gatewayConfigNS: "default",
-			opts: operatorv1beta1.GatewayConfigDataPlaneOptions{
-				PluginsToInstall: []operatorv1beta1.NamespacedName{
+			opts: GatewayConfigDataPlaneOptions{
+				PluginsToInstall: []operatorv2alpha1.NamespacedName{
 					{
 						Name: "plugin1",
 					},
@@ -1236,8 +1237,8 @@ func TestGatewayConfigDataPlaneOptionsToDataPlaneOptions(t *testing.T) {
 		{
 			name:            "plugins to install (different namespace)",
 			gatewayConfigNS: "default",
-			opts: operatorv1beta1.GatewayConfigDataPlaneOptions{
-				PluginsToInstall: []operatorv1beta1.NamespacedName{
+			opts: GatewayConfigDataPlaneOptions{
+				PluginsToInstall: []operatorv2alpha1.NamespacedName{
 					{
 						Name: "plugin1",
 					},
@@ -1263,11 +1264,11 @@ func TestGatewayConfigDataPlaneOptionsToDataPlaneOptions(t *testing.T) {
 		{
 			name:            "network services options with ingress",
 			gatewayConfigNS: "default",
-			opts: operatorv1beta1.GatewayConfigDataPlaneOptions{
-				Network: operatorv1beta1.GatewayConfigDataPlaneNetworkOptions{
-					Services: &operatorv1beta1.GatewayConfigDataPlaneServices{
-						Ingress: &operatorv1beta1.GatewayConfigServiceOptions{
-							ServiceOptions: operatorv1beta1.ServiceOptions{
+			opts: GatewayConfigDataPlaneOptions{
+				Network: operatorv2alpha1.GatewayConfigDataPlaneNetworkOptions{
+					Services: &operatorv2alpha1.GatewayConfigDataPlaneServices{
+						Ingress: &operatorv2alpha1.GatewayConfigServiceOptions{
+							ServiceOptions: operatorv2alpha1.ServiceOptions{
 								Name: lo.ToPtr("custom-ingress"),
 								Annotations: map[string]string{
 									"service.beta.kubernetes.io/aws-load-balancer-type": "nlb",
@@ -1295,10 +1296,10 @@ func TestGatewayConfigDataPlaneOptionsToDataPlaneOptions(t *testing.T) {
 		{
 			name:            "PodDisruptionBudget",
 			gatewayConfigNS: "default",
-			opts: operatorv1beta1.GatewayConfigDataPlaneOptions{
-				Resources: &operatorv1beta1.GatewayConfigDataPlaneResources{
-					PodDisruptionBudget: &operatorv1beta1.PodDisruptionBudget{
-						Spec: operatorv1beta1.PodDisruptionBudgetSpec{
+			opts: GatewayConfigDataPlaneOptions{
+				Resources: &operatorv2alpha1.GatewayConfigDataPlaneResources{
+					PodDisruptionBudget: &operatorv2alpha1.PodDisruptionBudget{
+						Spec: operatorv2alpha1.PodDisruptionBudgetSpec{
 							MinAvailable: lo.ToPtr(intstr.FromInt(1)),
 						},
 					},

--- a/controller/gateway/controller_test.go
+++ b/controller/gateway/controller_test.go
@@ -185,12 +185,10 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 						UID:       types.UID(uuid.NewString()),
 					},
 					Spec: gwtypes.ControlPlaneSpec{
-						ControlPlaneOptions: gwtypes.ControlPlaneOptions{
-							DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
-								Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
-								Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
-									Name: "test-dataplane",
-								},
+						DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
+							Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
+							Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
+								Name: "test-dataplane",
 							},
 						},
 					},

--- a/controller/gateway/controller_watch.go
+++ b/controller/gateway/controller_watch.go
@@ -316,16 +316,15 @@ func (r *Reconciler) listGatewaysAttachedByHTTPRoute(ctx context.Context, obj cl
 // GatewayReconciler - Config Defaults
 // -----------------------------------------------------------------------------
 
-func (r *Reconciler) setDataPlaneGatewayConfigDefaults(gatewayConfig *operatorv1beta1.GatewayConfiguration) {
+func (r *Reconciler) setDataPlaneGatewayConfigDefaults(gatewayConfig *GatewayConfiguration) {
 	if gatewayConfig.Spec.DataPlaneOptions == nil {
-		gatewayConfig.Spec.DataPlaneOptions = new(operatorv1beta1.GatewayConfigDataPlaneOptions)
+		gatewayConfig.Spec.DataPlaneOptions = new(GatewayConfigDataPlaneOptions)
 	}
 }
 
-// TODO(pmalek): add support for GatewayConfiguration v2 https://github.com/Kong/gateway-operator/issues/1728
 func (r *Reconciler) setControlPlaneGatewayConfigDefaults(
 	gateway *gwtypes.Gateway,
-	gatewayConfig *operatorv1beta1.GatewayConfiguration,
+	gatewayConfig *GatewayConfiguration,
 	dataplaneName,
 	dataplaneIngressServiceName,
 	dataplaneAdminServiceName,

--- a/controller/gateway/types.go
+++ b/controller/gateway/types.go
@@ -1,0 +1,19 @@
+package gateway
+
+import (
+	gwtypes "github.com/kong/gateway-operator/internal/types"
+)
+
+// Aliases below allow to easily switch between different versions of the GatewayConfiguration API.
+// This is to make it easier to refactor code.
+// We can potentially get rid of this at some point when we change all
+// references to the GatewayConfiguration type to use the internal/types.GatewayConfiguration type.
+
+type (
+
+	// GatewayConfiguration is an alias for the internally used GatewayConfiguration version type.
+	GatewayConfiguration = gwtypes.GatewayConfiguration
+
+	// GatewayConfigDataPlaneOptions is an alias for the internally used GatewayConfigDataPlaneOptions version type.
+	GatewayConfigDataPlaneOptions = gwtypes.GatewayConfigDataPlaneOptions
+)

--- a/controller/pkg/controlplane/controlplane.go
+++ b/controller/pkg/controlplane/controlplane.go
@@ -21,17 +21,5 @@ type DefaultsArgs struct {
 
 // SpecDeepEqual returns true if the two ControlPlaneOptions are equal.
 func SpecDeepEqual(spec1, spec2 *gwtypes.ControlPlaneOptions, envVarsToIgnore ...string) bool {
-	if !reflect.DeepEqual(spec1.DataPlane, spec2.DataPlane) {
-		return false
-	}
-
-	if !reflect.DeepEqual(spec1.Extensions, spec2.Extensions) {
-		return false
-	}
-
-	if !reflect.DeepEqual(spec1.WatchNamespaces, spec2.WatchNamespaces) {
-		return false
-	}
-
-	return true
+	return reflect.DeepEqual(spec1, spec2)
 }

--- a/controller/pkg/controlplane/controlplane.go
+++ b/controller/pkg/controlplane/controlplane.go
@@ -20,6 +20,6 @@ type DefaultsArgs struct {
 // -----------------------------------------------------------------------------
 
 // SpecDeepEqual returns true if the two ControlPlaneOptions are equal.
-func SpecDeepEqual(spec1, spec2 *gwtypes.ControlPlaneOptions, envVarsToIgnore ...string) bool {
+func SpecDeepEqual(spec1, spec2 *gwtypes.ControlPlaneOptions) bool {
 	return reflect.DeepEqual(spec1, spec2)
 }

--- a/controller/pkg/controlplane/controlplane_test.go
+++ b/controller/pkg/controlplane/controlplane_test.go
@@ -1,0 +1,194 @@
+package controlplane
+
+import (
+	"testing"
+
+	gwtypes "github.com/kong/gateway-operator/internal/types"
+
+	operatorv2alpha1 "github.com/kong/kubernetes-configuration/api/gateway-operator/v2alpha1"
+)
+
+func TestSpecDeepEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec1    *gwtypes.ControlPlaneOptions
+		spec2    *gwtypes.ControlPlaneOptions
+		expected bool
+	}{
+		{
+			name:     "both nil",
+			spec1:    nil,
+			spec2:    nil,
+			expected: true,
+		},
+		{
+			name:     "first nil, second not nil",
+			spec1:    nil,
+			spec2:    &gwtypes.ControlPlaneOptions{},
+			expected: false,
+		},
+		{
+			name:     "first not nil, second nil",
+			spec1:    &gwtypes.ControlPlaneOptions{},
+			spec2:    nil,
+			expected: false,
+		},
+		{
+			name:     "both empty",
+			spec1:    &gwtypes.ControlPlaneOptions{},
+			spec2:    &gwtypes.ControlPlaneOptions{},
+			expected: true,
+		},
+		{
+			name: "same controllers",
+			spec1: &gwtypes.ControlPlaneOptions{
+				Controllers: []operatorv2alpha1.ControlPlaneController{
+					{
+						Name:  "controller1",
+						State: operatorv2alpha1.ControllerStateEnabled,
+					},
+				},
+			},
+			spec2: &gwtypes.ControlPlaneOptions{
+				Controllers: []operatorv2alpha1.ControlPlaneController{
+					{
+						Name:  "controller1",
+						State: operatorv2alpha1.ControllerStateEnabled,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "different controllers order",
+			spec1: &gwtypes.ControlPlaneOptions{
+				Controllers: []operatorv2alpha1.ControlPlaneController{
+					{
+						Name:  "controller1",
+						State: operatorv2alpha1.ControllerStateEnabled,
+					},
+					{
+						Name:  "controller2",
+						State: operatorv2alpha1.ControllerStateEnabled,
+					},
+				},
+			},
+			spec2: &gwtypes.ControlPlaneOptions{
+				Controllers: []operatorv2alpha1.ControlPlaneController{
+					{
+						Name:  "controller2",
+						State: operatorv2alpha1.ControllerStateEnabled,
+					},
+					{
+						Name:  "controller1",
+						State: operatorv2alpha1.ControllerStateEnabled,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "different controllers length",
+			spec1: &gwtypes.ControlPlaneOptions{
+				Controllers: []operatorv2alpha1.ControlPlaneController{
+					{
+						Name:  "controller1",
+						State: operatorv2alpha1.ControllerStateEnabled,
+					},
+				},
+			},
+			spec2: &gwtypes.ControlPlaneOptions{
+				Controllers: []operatorv2alpha1.ControlPlaneController{
+					{
+						Name:  "controller2",
+						State: operatorv2alpha1.ControllerStateEnabled,
+					},
+					{
+						Name:  "controller1",
+						State: operatorv2alpha1.ControllerStateEnabled,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "different controllers content",
+			spec1: &gwtypes.ControlPlaneOptions{
+				Controllers: []operatorv2alpha1.ControlPlaneController{
+					{
+						Name:  "controller1",
+						State: operatorv2alpha1.ControllerStateEnabled,
+					},
+				},
+			},
+			spec2: &gwtypes.ControlPlaneOptions{
+				Controllers: []operatorv2alpha1.ControlPlaneController{
+					{
+						Name:  "controller1",
+						State: operatorv2alpha1.ControllerStateEnabled,
+					},
+					{
+						Name:  "controller3",
+						State: operatorv2alpha1.ControllerStateEnabled,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "one has controllers, other doesn't",
+			spec1: &gwtypes.ControlPlaneOptions{
+				Controllers: []operatorv2alpha1.ControlPlaneController{
+					{
+						Name:  "controller1",
+						State: operatorv2alpha1.ControllerStateEnabled,
+					},
+				},
+			},
+			spec2:    &gwtypes.ControlPlaneOptions{},
+			expected: false,
+		},
+		{
+			name: "same feature gates",
+			spec1: &gwtypes.ControlPlaneOptions{
+				FeatureGates: []operatorv2alpha1.ControlPlaneFeatureGate{
+					{
+						Name:  "feature1",
+						State: operatorv2alpha1.FeatureGateStateEnabled,
+					},
+				},
+			},
+			spec2: &gwtypes.ControlPlaneOptions{
+				FeatureGates: []operatorv2alpha1.ControlPlaneFeatureGate{
+					{
+						Name:  "feature1",
+						State: operatorv2alpha1.FeatureGateStateEnabled,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "one has feature gates, other doesn't",
+			spec1: &gwtypes.ControlPlaneOptions{
+				FeatureGates: []operatorv2alpha1.ControlPlaneFeatureGate{
+					{
+						Name:  "feature1",
+						State: operatorv2alpha1.FeatureGateStateEnabled,
+					},
+				},
+			},
+			spec2:    &gwtypes.ControlPlaneOptions{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SpecDeepEqual(tt.spec1, tt.spec2)
+			if result != tt.expected {
+				t.Errorf("SpecDeepEqual() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/terratest v0.50.0
 	github.com/kong/go-kong v0.66.2-0.20250624172857-72863432614c
-	github.com/kong/kubernetes-configuration v1.4.1-0.20250623142530-403ef6b96f0b
+	github.com/kong/kubernetes-configuration v1.4.1-0.20250625110007-842ead2a5ced
 	github.com/kong/kubernetes-ingress-controller/v3 v3.4.7-0.20250625104300-5da6f0a43a2d
 	github.com/kong/kubernetes-telemetry v0.1.10
 	github.com/kong/kubernetes-testing-framework v0.47.2

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/kong/go-database-reconciler v1.24.1 h1:c0gHP8WEt9HF602IxwJq8ZsKKmQ13w
 github.com/kong/go-database-reconciler v1.24.1/go.mod h1:AXbC5CtSZv8ldtt8ho4Ol2K1gi8mZ948d1EHckECHC8=
 github.com/kong/go-kong v0.66.2-0.20250624172857-72863432614c h1:rdUQW4ZlDvNXb0GwMF2Y6HI+hVpPbGNmFKCwR7vXRtc=
 github.com/kong/go-kong v0.66.2-0.20250624172857-72863432614c/go.mod h1:P/LnAoHdlF+GGMjov3G/lb4vHNRZmLHE5wcQx5+Z1pE=
-github.com/kong/kubernetes-configuration v1.4.1-0.20250623142530-403ef6b96f0b h1:IbKRfbeP3bchAoPI9LsOwNRjkKLUF8qKGXykN2UqvR4=
-github.com/kong/kubernetes-configuration v1.4.1-0.20250623142530-403ef6b96f0b/go.mod h1:Pqm6hhgk4CvHpw+OIhlVqdpfrNo0B6Z4zkiI9O7V1jM=
+github.com/kong/kubernetes-configuration v1.4.1-0.20250625110007-842ead2a5ced h1:cYrrnzSbxq0dKb2ZbHQQIa4FngaE9tlfqPzCQ/t6Epo=
+github.com/kong/kubernetes-configuration v1.4.1-0.20250625110007-842ead2a5ced/go.mod h1:Pqm6hhgk4CvHpw+OIhlVqdpfrNo0B6Z4zkiI9O7V1jM=
 github.com/kong/kubernetes-ingress-controller/v3 v3.4.7-0.20250625104300-5da6f0a43a2d h1:mOp5hN/76p4TIpUdv9OrbkptBjL3OTv0ssEKdKYzaaI=
 github.com/kong/kubernetes-ingress-controller/v3 v3.4.7-0.20250625104300-5da6f0a43a2d/go.mod h1:Dm/b7PoaEDcGbvUcp7hmAkT3CvBA6hSzhpPV+EDoDVY=
 github.com/kong/kubernetes-telemetry v0.1.10 h1:V+/Lco8VFY/CzoELwOPcGTyg0zbj/HAvoFkH50UsKYs=

--- a/internal/types/operatortypes.go
+++ b/internal/types/operatortypes.go
@@ -41,6 +41,13 @@ type (
 	ControllerState = operatorv2alpha1.ControllerState
 )
 
+type (
+	// GatewayConfiguration is an alias for the v2alpha1 GatewayConfiguration type.
+	GatewayConfiguration = operatorv2alpha1.GatewayConfiguration
+	// GatewayConfigDataPlaneOptions is an alias for the v2alpha1 GatewayConfigDataPlaneOptions type.
+	GatewayConfigDataPlaneOptions = operatorv2alpha1.GatewayConfigDataPlaneOptions
+)
+
 const (
 	// ControlPlaneDataPlaneTargetRefType is an alias for the v2alpha1 ControlPlaneDataPlaneTargetRefType type.
 	ControlPlaneDataPlaneTargetRefType = operatorv2alpha1.ControlPlaneDataPlaneTargetRefType

--- a/test/integration/controlplane_test.go
+++ b/test/integration/controlplane_test.go
@@ -193,12 +193,10 @@ func TestControlPlaneEssentials(t *testing.T) {
 			Name:      controlplaneName.Name,
 		},
 		Spec: gwtypes.ControlPlaneSpec{
-			ControlPlaneOptions: gwtypes.ControlPlaneOptions{
-				DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
-					Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
-					Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
-						Name: dataplane.Name,
-					},
+			DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
+				Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
+				Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
+					Name: dataplane.Name,
 				},
 			},
 		},
@@ -403,13 +401,13 @@ func TestControlPlaneWatchNamespaces(t *testing.T) {
 			GenerateName: "cp-watchnamespaces-",
 		},
 		Spec: gwtypes.ControlPlaneSpec{
-			ControlPlaneOptions: gwtypes.ControlPlaneOptions{
-				DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
-					Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
-					Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
-						Name: dp.Name,
-					},
+			DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
+				Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
+				Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
+					Name: dp.Name,
 				},
+			},
+			ControlPlaneOptions: gwtypes.ControlPlaneOptions{
 				WatchNamespaces: &operatorv1beta1.WatchNamespaces{
 					Type: operatorv1beta1.WatchNamespacesTypeList,
 					List: []string{
@@ -663,12 +661,10 @@ func TestControlPlaneUpdate(t *testing.T) {
 			Name:      controlplaneName.Name,
 		},
 		Spec: gwtypes.ControlPlaneSpec{
-			ControlPlaneOptions: gwtypes.ControlPlaneOptions{
-				DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
-					Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
-					Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
-						Name: dataplane.Name,
-					},
+			DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
+				Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
+				Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
+					Name: dataplane.Name,
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a first PR that adapts the GatewayConfiguration API usage to v2alpha1.

**Which issue this PR fixes**

Part of #1728

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
