### PR TITLE
tests: do not get throttled in tests, add rate limiter with high quota

### DIFF
--- a/test/envtest/setup.go
+++ b/test/envtest/setup.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/flowcontrol"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
@@ -77,6 +78,7 @@ func Setup(t *testing.T, ctx context.Context, scheme *k8sruntime.Scheme) (*rest.
 	config.CertData = cfg.CertData
 	config.CAData = cfg.CAData
 	config.KeyData = cfg.KeyData
+	config.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(1_000, 10_000)
 
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
 	require.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent errors like:

```
    controller.go:98: 2025-06-27T14:41:55Z	error	Reconciler error	{"controller": "KongConsumer", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongConsumer", "KongConsumer": {"name":"consumer-9b2qq","namespace":"test-5prgb"}, "namespace": "test-5prgb", "name": "consumer-9b2qq", "reconcileID": "c8d0dc4b-f8a3-4867-b8e2-5161a146394f", "error": "failed to update in cluster resource after Konnect update: client rate limiter Wait returned an error: context canceled %!w(<nil>)"}
    controller.go:98: 2025-06-27T14:41:55Z	error	Reconciler error	{"controller": "KongConsumer", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongConsumer", "KongConsumer": {"name":"consumer-9b2qq","namespace":"test-5prgb"}, "namespace": "test-5prgb", "name": "consumer-9b2qq", "
```

https://github.com/Kong/kong-operator/actions/runs/15928906749/job/44932944407?pr=1770#step:5:1946

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
