### PR TITLE
fix(konnect): ignore sdkerrors.ForbiddenError in konnect entity reconciler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@
 ### Fixed
 
 - Ignore the `ForbiddenError` in `sdk-konnect-go` returned from running CRUD
-  operations against Konnect APIs.
+  operations against Konnect APIs. This prevents endless reconciliation when an
+  operation is not allowed (due to e.g. exhausted quota).
   [#1811](https://github.com/Kong/kong-operator/pull/1811)
 
 ## [v2.0.0-alpha.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
 
+## Unreleased
+
+### Fixed
+
+- Ignore the `ForbiddenError` in `sdk-konnect-go` returned from running CRUD
+  operations against Konnect APIs.
+  [#1811](https://github.com/Kong/kong-operator/pull/1811)
+
 ## [v2.0.0-alpha.1]
 
 > Release date: 2025-06-11

--- a/controller/konnect/ops/ops_errors.go
+++ b/controller/konnect/ops/ops_errors.go
@@ -129,7 +129,7 @@ func ParseSDKErrorBody(body string) (sdkErrorBody, error) {
 	return sdkErr, nil
 }
 
-// ErrorIsSDKError403 returns true if the provided error is a 403 Forbidden error.
+// ErrorIsForbiddenError returns true if the provided error is a 403 Forbidden error.
 // This can happen when the requested operation is not permitted.
 // Example SDKError body (SDKError message is a separate field from body message):
 //
@@ -145,7 +145,11 @@ func ParseSDKErrorBody(body string) (sdkErrorBody, error) {
 //			}
 //		]
 //	}
-func ErrorIsSDKError403(err error) bool {
+func ErrorIsForbiddenError(err error) bool {
+	var errForbidden *sdkkonnecterrs.ForbiddenError
+	if errors.As(err, &errForbidden) {
+		return true
+	}
 	var errSDK *sdkkonnecterrs.SDKError
 	if !errors.As(err, &errSDK) {
 		return false
@@ -340,7 +344,7 @@ func IgnoreUnrecoverableAPIErr(err error, logger logr.Logger) error {
 	// manifest. The entity's status is already updated with the error.
 	if ErrorIsSDKBadRequestError(err) ||
 		ErrorIsSDKError400(err) ||
-		ErrorIsSDKError403(err) ||
+		ErrorIsForbiddenError(err) ||
 		ErrorIsConflictError(err) {
 		log.Debug(logger, "ignoring unrecoverable API error, consult object's status for details", "err", err)
 		return nil

--- a/controller/konnect/ops/ops_errors_test.go
+++ b/controller/konnect/ops/ops_errors_test.go
@@ -9,12 +9,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestErrorIsSDKError403(t *testing.T) {
+func TestErrorIsForbiddenError(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
 		want bool
 	}{
+		{
+			name: "error is ForbiddenError",
+			err: &sdkkonnecterrs.ForbiddenError{
+				Status:   403,
+				Title:    "Quota Exceeded",
+				Instance: "kong:trace:0000000000000000000",
+				Detail:   "Maximum number of Active Networks exceeded. Max allowed: 0",
+			},
+			want: true,
+		},
 		{
 			name: "error is SDKError with 403 status code",
 			err: &sdkkonnecterrs.SDKError{
@@ -62,7 +72,7 @@ func TestErrorIsSDKError403(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ErrorIsSDKError403(tt.err)
+			got := ErrorIsForbiddenError(tt.err)
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/test/envtest/konnect_entities_konnectcloudgatewaynetwork_test.go
+++ b/test/envtest/konnect_entities_konnectcloudgatewaynetwork_test.go
@@ -1,0 +1,145 @@
+package envtest
+
+import (
+	"testing"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
+	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kong-operator/controller/konnect"
+	sdkmocks "github.com/kong/kong-operator/controller/konnect/ops/sdk/mocks"
+	"github.com/kong/kong-operator/modules/manager/logging"
+	"github.com/kong/kong-operator/modules/manager/scheme"
+	"github.com/kong/kong-operator/test/helpers/deploy"
+	"github.com/kong/kong-operator/test/helpers/eventually"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+func TestKonnectCloudGatewayNetwork(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := Context(t, t.Context())
+	defer cancel()
+	cfg, ns := Setup(t, ctx, scheme.Get())
+
+	t.Log("Setting up the manager with reconcilers")
+	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+	factory := sdkmocks.NewMockSDKFactory(t)
+	sdk := factory.SDK
+	StartReconcilers(ctx, t, mgr, logs,
+		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
+			konnect.WithKonnectEntitySyncPeriod[konnectv1alpha1.KonnectCloudGatewayNetwork](konnectInfiniteSyncTime),
+		),
+	)
+
+	t.Log("Setting up clients")
+	cl, err := client.NewWithWatch(mgr.GetConfig(), client.Options{
+		Scheme: scheme.Get(),
+	})
+	require.NoError(t, err)
+	clientNamespaced := client.NewNamespacedClient(mgr.GetClient(), ns.Name)
+
+	t.Run("Creating, updating and deleting Konnect cloud gateway network", func(t *testing.T) {
+		t.Log("Setting up a watch for KonnectCloudGatewayNetwork events")
+		w := setupWatch[konnectv1alpha1.KonnectCloudGatewayNetworkList](t, ctx, cl, client.InNamespace(ns.Name))
+		t.Log("Setting up SDK expectations on creation")
+
+		var (
+			networkID   = "kcgn-" + uuid.NewString()
+			networkName = "cloud-gateway-network-test-" + uuid.NewString()[:8]
+		)
+
+		t.Log("Setting up SDK expectations on creation")
+		sdk.CloudGatewaysSDK.EXPECT().CreateNetwork(
+			mock.Anything,
+			mock.MatchedBy(func(req sdkkonnectcomp.CreateNetworkRequest) bool {
+				return req.Name == networkName
+			}),
+		).Return(&sdkkonnectops.CreateNetworkResponse{
+			Network: &sdkkonnectcomp.Network{
+				ID:    networkID,
+				Name:  networkName,
+				State: sdkkonnectcomp.NetworkStateInitializing,
+			},
+		}, nil)
+
+		t.Log("Creating KonnectAPIAuthConfiguration")
+		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
+
+		t.Log("Creating a KonnectCloudGatewayNetwork")
+		network := deploy.KonnectCloudGatewayNetwork(t, ctx, clientNamespaced, apiAuth, func(o client.Object) {
+			n, ok := o.(*konnectv1alpha1.KonnectCloudGatewayNetwork)
+			if !ok {
+				return
+			}
+			n.Spec.Name = networkName
+		})
+
+		t.Log("Waiting for KonnectCloudGatewayNetwork to be Programmed and get a Konnect ID")
+		watchFor(t, ctx, w, apiwatch.Modified, func(n *konnectv1alpha1.KonnectCloudGatewayNetwork) bool {
+			return n.GetKonnectID() == networkID && conditionsContainProgrammed(n.GetConditions(), metav1.ConditionTrue)
+		}, "Did not see KonnectCloudGatewayNetwork get Programmed and Konnect ID set.")
+
+		t.Log("Setting up SDK expectations on deletion")
+		sdk.CloudGatewaysSDK.EXPECT().DeleteNetwork(mock.Anything, networkID, mock.Anything).Return(&sdkkonnectops.DeleteNetworkResponse{}, nil)
+
+		t.Log("Deleting the network")
+		require.NoError(t, clientNamespaced.Delete(ctx, network))
+		eventually.WaitForObjectToNotExist(t, ctx, cl, network, waitTime, tickTime)
+
+		t.Log("Waiting for object to be deleted in the SDK")
+		eventuallyAssertSDKExpectations(t, factory.SDK.CloudGatewaysSDK, waitTime, tickTime)
+	})
+
+	t.Run("Creating network when SDK returns ForbiddenError", func(t *testing.T) {
+		t.Log("Setting up a watch for KonnectCloudGatewayNetwork events")
+		w := setupWatch[konnectv1alpha1.KonnectCloudGatewayNetworkList](t, ctx, cl, client.InNamespace(ns.Name))
+		t.Log("Setting up SDK expectations on creation")
+
+		var (
+			networkName = "cloud-gateway-network-test-" + uuid.NewString()[:8]
+		)
+
+		t.Log("Setting up SDK expectations on creation")
+		sdk.CloudGatewaysSDK.EXPECT().CreateNetwork(
+			mock.Anything,
+			mock.MatchedBy(func(req sdkkonnectcomp.CreateNetworkRequest) bool {
+				return req.Name == networkName
+			}),
+		).Return(nil, &sdkkonnecterrs.ForbiddenError{
+			Status:   403,
+			Title:    "Quota Exceeded",
+			Instance: "kong:trace:0000000000000000000",
+			Detail:   "Maximum number of Active Networks exceeded. Max allowed: 0",
+		})
+
+		t.Log("Creating KonnectAPIAuthConfiguration")
+		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
+
+		t.Log("Creating a KonnectCloudGatewayNetwork")
+		deploy.KonnectCloudGatewayNetwork(t, ctx, clientNamespaced, apiAuth, func(o client.Object) {
+			n, ok := o.(*konnectv1alpha1.KonnectCloudGatewayNetwork)
+			if !ok {
+				return
+			}
+			n.Spec.Name = networkName
+		})
+
+		t.Log("Waiting for KonnectCloudGatewayNetwork to be Programmed and get a Konnect ID")
+		watchFor(t, ctx, w, apiwatch.Modified, func(n *konnectv1alpha1.KonnectCloudGatewayNetwork) bool {
+			return conditionsContainProgrammedFalse(n.GetConditions())
+		}, "Did not see KonnectCloudGatewayNetwork get Programmed condition set to false.")
+
+		t.Log("Waiting for the expected calls called in SDK")
+		eventuallyAssertSDKExpectations(t, factory.SDK.CloudGatewaysSDK, waitTime, tickTime)
+
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Ignore `sdkkonnecterrs.ForbiddenError` when running CRUD ops against Konnect APIs.

**Which issue this PR fixes**

Fixes #1787

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
