### PR TITLE
chore: bump min Go version to 1.24.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Builder
 # ------------------------------------------------------------------------------
 
-FROM --platform=$BUILDPLATFORM golang:1.24.3@sha256:39d9e7d9c5d9c9e4baf0d8fff579f06d5032c0f4425cdec9e86732e8e4e374dc AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.4@sha256:20a022e5112a144aa7b7aeb3f22ebf2cdaefcc4aac0d64e8deeee8cdc18b9c0f AS builder
 
 WORKDIR /workspace
 ARG GOPATH

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -2,7 +2,7 @@
 # Debug image
 # ------------------------------------------------------------------------------
 
-FROM --platform=$BUILDPLATFORM golang:1.24.3@sha256:39d9e7d9c5d9c9e4baf0d8fff579f06d5032c0f4425cdec9e86732e8e4e374dc AS debug
+FROM --platform=$BUILDPLATFORM golang:1.24.4@sha256:20a022e5112a144aa7b7aeb3f22ebf2cdaefcc4aac0d64e8deeee8cdc18b9c0f AS debug
 
 ARG GOPATH
 ARG GOCACHE

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/gateway-operator
 
-go 1.24.2
+go 1.24.4
 
 // 1.2.2 was released on main branch with a breaking change that was not
 // intended to be released in 1.2.x:
@@ -268,12 +268,12 @@ replace (
 	k8s.io/component-base => k8s.io/component-base v0.33.0
 	k8s.io/component-helpers => k8s.io/component-helpers v0.33.0
 	k8s.io/controller-manager => k8s.io/controller-manager v0.33.0
-	k8s.io/cri-api => k8s.io/cri-api v0.33.1
+	k8s.io/cri-api => k8s.io/cri-api v0.33.2
 	k8s.io/cri-client => k8s.io/cri-client v0.33.0
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.33.0
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.33.0
 	k8s.io/endpointslice => k8s.io/endpointslice v0.33.0
-	k8s.io/externaljwt => k8s.io/externaljwt v0.33.1
+	k8s.io/externaljwt => k8s.io/externaljwt v0.33.2
 	k8s.io/kms => k8s.io/kms v0.33.0
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.33.0
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,6 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kong/go-kong v0.65.1 h1:CM+8NlF+VbJckTxP2hGmSPKhA1GMliitXjQ7vJiPkaE=
 github.com/kong/go-kong v0.65.1/go.mod h1:sqdysTKrXIJ6mpxHwTwjgZhLW7jR1/puczTXHLUwJaE=
-github.com/kong/kubernetes-configuration v1.4.0-rc.1 h1:53FlnlymCVdinmYI+W4EaZWmCjaKRs4fzs6JBtOpAXo=
-github.com/kong/kubernetes-configuration v1.4.0-rc.1/go.mod h1:n7llpDlc+Se+4nHERfj6Kupb5q6nnTcBoL6noiv3Jz0=
 github.com/kong/kubernetes-configuration v1.4.0 h1:4uzZ23mXt4zg+PyQLwNBLY/xj5HaqzlEwwf8EfvK36M=
 github.com/kong/kubernetes-configuration v1.4.0/go.mod h1:mk3PTaKhpDgIRpjo0f+pOfDZ93vSYlgXORUjM7nTYSU=
 github.com/kong/kubernetes-telemetry v0.1.9 h1:XbDMZjZZclHO4oyJGW1mmZ6bzbTnANjcRAYsBg+jpno=

--- a/hack/generators/go.mod
+++ b/hack/generators/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/gateway-operator/hack/generators
 
-go 1.24.2
+go 1.24.4
 
 replace github.com/kong/gateway-operator => ../../
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes problems like the one encountered in https://github.com/Kong/kong-operator/pull/1815

https://github.com/Kong/kong-operator/actions/runs/16109504099/job/45450299396?pr=1815#step:14:313

```
 > [builder  3/12] RUN --mount=type=cache,target=/home/runner/go/pkg/mod     --mount=type=cache,target=/home/runner/.cache/go-build     --mount=type=bind,source=go.sum,target=go.sum     --mount=type=bind,source=go.mod,target=go.mod     go mod download -x:
0.074 go: go.mod requires go >= 1.24.4 (running go 1.24.3; GOTOOLCHAIN=local)
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
