### PR TITLE
ci: add modernize as one of the linter steps

### DIFF
--- a/.tools_versions.yaml
+++ b/.tools_versions.yaml
@@ -6,6 +6,8 @@ controller-tools: "0.18.0"
 kustomize: "5.7.0"
 # renovate: datasource=github-releases depName=golangci/golangci-lint
 golangci-lint: "2.2.1"
+# TODO: Renovate comment is missing. This needs to be added at some point.
+modernize: "v0.19.1"
 # renovate: datasource=github-releases depName=GoogleContainerTools/skaffold
 skaffold: "2.16.1"
 # renovate: datasource=github-releases depName=go-delve/delve
@@ -34,6 +36,7 @@ shellcheck: "0.10.0"
 #  WARN: Attempting to use non-git url for git operations (repository=local)
 #        "url": "vuln"
 #
+# TODO: Make this work.
 # renovate: datasource=git-tags depName=vuln registryUrl=https://go.googlesource.com
 govulncheck: "1.1.4"
 # renovate: datasource=github-releases depName=jlandowner/helm-chartsnap

--- a/controller/dataplane/controller_utils.go
+++ b/controller/dataplane/controller_utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 
 	"github.com/go-logr/logr"
@@ -67,9 +68,7 @@ func addAnnotationsForDataPlaneIngressService(obj client.Object, dataplane opera
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
-	for k, v := range specAnnotations {
-		annotations[k] = v
-	}
+	maps.Copy(annotations, specAnnotations)
 	encodedSpecAnnotations, err := json.Marshal(specAnnotations)
 	if err == nil {
 		annotations[consts.AnnotationLastAppliedAnnotations] = string(encodedSpecAnnotations)

--- a/controller/dataplane/owned_deployment.go
+++ b/controller/dataplane/owned_deployment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"time"
 
@@ -224,9 +225,7 @@ func listOrReduceDataPlaneDeployments(
 	additionalDeploymentLabels client.MatchingLabels,
 ) (reduced bool, deployment *appsv1.Deployment, err error) {
 	matchingLabels := k8sresources.GetManagedLabelForOwner(dataplane)
-	for k, v := range additionalDeploymentLabels {
-		matchingLabels[k] = v
-	}
+	maps.Copy(matchingLabels, additionalDeploymentLabels)
 
 	deployments, err := k8sutils.ListDeploymentsForOwner(
 		ctx,

--- a/controller/dataplane/owned_resources.go
+++ b/controller/dataplane/owned_resources.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
@@ -176,9 +177,7 @@ func matchingLabelsToServiceOpt(ml client.MatchingLabels) k8sresources.ServiceOp
 		if s.Labels == nil {
 			s.Labels = make(map[string]string)
 		}
-		for k, v := range ml {
-			s.Labels[k] = v
-		}
+		maps.Copy(s.Labels, ml)
 	}
 }
 
@@ -187,9 +186,7 @@ func matchingLabelsToDeploymentOpt(ml client.MatchingLabels) k8sresources.Deploy
 		if a.Labels == nil {
 			a.Labels = make(map[string]string)
 		}
-		for k, v := range ml {
-			a.Labels[k] = v
-		}
+		maps.Copy(a.Labels, ml)
 	}
 }
 
@@ -203,9 +200,7 @@ func ensureAdminServiceForDataPlane(
 	// Get the Services for the DataPlane by label.
 	matchingLabels := k8sresources.GetManagedLabelForOwner(dataPlane)
 	matchingLabels[consts.DataPlaneServiceTypeLabel] = string(consts.DataPlaneAdminServiceLabelValue)
-	for k, v := range additionalServiceLabels {
-		matchingLabels[k] = v
-	}
+	maps.Copy(matchingLabels, additionalServiceLabels)
 
 	services, err := k8sutils.ListServicesForOwner(
 		ctx,
@@ -282,9 +277,7 @@ func ensureIngressServiceForDataPlane(
 	// Get the Services for the DataPlane by label.
 	matchingLabels := k8sresources.GetManagedLabelForOwner(dataPlane)
 	matchingLabels[consts.DataPlaneServiceTypeLabel] = string(consts.DataPlaneIngressServiceLabelValue)
-	for k, v := range additionalServiceLabels {
-		matchingLabels[k] = v
-	}
+	maps.Copy(matchingLabels, additionalServiceLabels)
 
 	services, err := k8sutils.ListServicesForOwner(
 		ctx,

--- a/controller/dataplane/utils/certificates/cert-manager.go
+++ b/controller/dataplane/utils/certificates/cert-manager.go
@@ -119,7 +119,7 @@ func GenerateCMCertificateForOwner(
 	}
 
 	kind := strings.ToLower(owner.GetObjectKind().GroupVersionKind().Kind)
-	cn := sha256.Sum256([]byte(fmt.Sprintf("%s.%s", owner.GetName(), owner.GetNamespace())))
+	cn := sha256.Sum256(fmt.Appendf([]byte{}, "%s.%s", owner.GetName(), owner.GetNamespace()))
 	cert := &certmanagerv1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: k8sutils.TrimGenerateName(fmt.Sprintf("%s-%s-", kind, owner.GetName())),

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -1041,7 +1041,7 @@ type kongListenConfig struct {
 func parseKongListenEnv(str string) (kongListenConfig, error) {
 	kongListenConfig := kongListenConfig{}
 
-	for _, s := range strings.Split(str, ",") {
+	for s := range strings.SplitSeq(str, ",") {
 		s = strings.TrimPrefix(s, " ")
 		i := strings.IndexRune(s, ' ')
 		var hostPort string

--- a/controller/gateway/controller_test.go
+++ b/controller/gateway/controller_test.go
@@ -789,7 +789,7 @@ func BenchmarkGatewayReconciler_Reconcile(b *testing.B) {
 
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := reconciler.Reconcile(b.Context(), gatewayReq)
 		if err != nil {
 			b.Error(err)

--- a/controller/konnect/ops/objects_metadata.go
+++ b/controller/konnect/ops/objects_metadata.go
@@ -2,6 +2,7 @@ package ops
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 
@@ -116,9 +117,7 @@ func WithKubernetesMetadataLabels(obj ObjectWithMetadata, userSetLabels map[stri
 	if k8sNamespace := obj.GetNamespace(); k8sNamespace != "" {
 		labels[KubernetesNamespaceLabelKey] = k8sNamespace
 	}
-	for k, v := range userSetLabels {
-		labels[k] = v
-	}
+	maps.Copy(labels, userSetLabels)
 
 	// The maximum length of a label value in Konnect is 63 characters. We truncate the values to ensure they are
 	// within the limit.

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -526,7 +526,7 @@ func loggerForEntity[
 	T constraints.SupportedKonnectEntityType,
 	TEnt constraints.EntityType[T],
 ](ctx context.Context, e TEnt, op Op) logr.Logger {
-	keysAndValues := []interface{}{
+	keysAndValues := []any{
 		"op", op,
 	}
 

--- a/controller/pkg/log/log.go
+++ b/controller/pkg/log/log.go
@@ -11,29 +11,29 @@ import (
 )
 
 // Info logs a message at the info level.
-func Info(logger logr.Logger, msg string, keysAndValues ...interface{}) {
+func Info(logger logr.Logger, msg string, keysAndValues ...any) {
 	_log(logger, logging.InfoLevel, msg, keysAndValues...)
 }
 
 // Debug logs a message at the debug level.
-func Debug(logger logr.Logger, msg string, keysAndValues ...interface{}) {
+func Debug(logger logr.Logger, msg string, keysAndValues ...any) {
 	_log(logger, logging.DebugLevel, msg, keysAndValues...)
 }
 
 // Trace logs a message at the trace level.
-func Trace(logger logr.Logger, msg string, keysAndValues ...interface{}) {
+func Trace(logger logr.Logger, msg string, keysAndValues ...any) {
 	_log(logger, logging.TraceLevel, msg, keysAndValues...)
 }
 
 // Error logs a message at the error level.
-func Error(logger logr.Logger, err error, msg string, keysAndValues ...interface{}) {
+func Error(logger logr.Logger, err error, msg string, keysAndValues ...any) {
 	if !oddKeyValues(logger, msg, keysAndValues...) {
 		return
 	}
 	logger.Error(err, msg, keysAndValues...)
 }
 
-func _log(logger logr.Logger, level logging.Level, msg string, keysAndValues ...interface{}) {
+func _log(logger logr.Logger, level logging.Level, msg string, keysAndValues ...any) {
 	if !oddKeyValues(logger, msg, keysAndValues...) {
 		return
 	}
@@ -41,7 +41,7 @@ func _log(logger logr.Logger, level logging.Level, msg string, keysAndValues ...
 		Info(msg, keysAndValues...)
 }
 
-func oddKeyValues(logger logr.Logger, msg string, keysAndValues ...interface{}) bool {
+func oddKeyValues(logger logr.Logger, msg string, keysAndValues ...any) bool {
 	if len(keysAndValues)%2 != 0 {
 		err := fmt.Errorf("log message has odd number of arguments")
 		logger.Error(err, msg)

--- a/controller/pkg/secrets/cert.go
+++ b/controller/pkg/secrets/cert.go
@@ -9,6 +9,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"maps"
 	"net/url"
 	"strings"
 	"sync"
@@ -193,9 +194,7 @@ func EnsureCertificate[
 ) (op.Result, *corev1.Secret, error) {
 	// Get the Secrets for the DataPlane using new labels.
 	matchingLabels := k8sresources.GetManagedLabelForOwner(owner)
-	for k, v := range additionalMatchingLabels {
-		matchingLabels[k] = v
-	}
+	maps.Copy(matchingLabels, additionalMatchingLabels)
 
 	secrets, err := k8sutils.ListSecretsForOwner(ctx, cl, owner.GetUID(), matchingLabels)
 	if err != nil {
@@ -261,9 +260,7 @@ func matchingLabelsToSecretOpt(ml client.MatchingLabels) k8sresources.SecretOpt 
 		if a.Labels == nil {
 			a.Labels = make(map[string]string)
 		}
-		for k, v := range ml {
-			a.Labels[k] = v
-		}
+		maps.Copy(a.Labels, ml)
 	}
 }
 

--- a/controller/pkg/secrets/cert_test.go
+++ b/controller/pkg/secrets/cert_test.go
@@ -456,7 +456,7 @@ func Test_parsePrivateKey(t *testing.T) {
 		name             string
 		keyType          x509.PublicKeyAlgorithm
 		expectedAlg      x509.SignatureAlgorithm
-		expectedKeyType  interface{}
+		expectedKeyType  any
 		expectedErrorMsg string
 	}{
 		{

--- a/controller/pkg/utils/compare.go
+++ b/controller/pkg/utils/compare.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"slices"
+
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -46,10 +48,5 @@ func IgnoreAnnotationKeysComparer(keys ...string) cmp.Option {
 }
 
 func containsString(slice []string, s string) bool {
-	for _, item := range slice {
-		if item == s {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slice, s)
 }

--- a/controller/specialized/aigateway_controller_utils.go
+++ b/controller/specialized/aigateway_controller_utils.go
@@ -3,6 +3,7 @@ package specialized
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
 
@@ -55,12 +56,7 @@ func getAuthHeaderForInference(provider operatorv1alpha1.AICloudProvider) (map[s
 		return nil, fmt.Errorf("%s is not a valid provider (valid providers: %+v)", provider, aiCloudProviderAuthHeaders)
 	}
 
-	headerInfoCopy := make(map[string]string, len(headerInfo))
-	for k, v := range headerInfo {
-		headerInfoCopy[k] = v
-	}
-
-	return headerInfoCopy, nil
+	return maps.Clone(headerInfo), nil
 }
 
 // ----------------------------------------------------------------------------

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -539,10 +539,10 @@ func TestTelemetryUpdates(t *testing.T) {
 				_, err := dyn.Resource(operatorv1beta1.DataPlaneGVR()).
 					Namespace("kong").
 					Create(ctx, &unstructured.Unstructured{
-						Object: map[string]interface{}{
+						Object: map[string]any{
 							"apiVersion": "gateway-operator.konghq.com/v1beta1",
 							"kind":       "DataPlane",
-							"metadata": map[string]interface{}{
+							"metadata": map[string]any{
 								"name":      "cloud-gateway-0",
 								"namespace": "kong",
 							},
@@ -552,10 +552,10 @@ func TestTelemetryUpdates(t *testing.T) {
 				_, err = dyn.Resource(operatorv1beta1.DataPlaneGVR()).
 					Namespace("kong").
 					Create(ctx, &unstructured.Unstructured{
-						Object: map[string]interface{}{
+						Object: map[string]any{
 							"apiVersion": "gateway-operator.konghq.com/v1beta1",
 							"kind":       "DataPlane",
-							"metadata": map[string]interface{}{
+							"metadata": map[string]any{
 								"name":      "cloud-gateway-1",
 								"namespace": "kong",
 							},

--- a/pkg/utils/kubernetes/owners.go
+++ b/pkg/utils/kubernetes/owners.go
@@ -56,16 +56,6 @@ type managingObjectT interface {
 		*operatorv1beta1.DataPlane
 }
 
-// SetOwnerForObjectThroughLabels sets the owner of the provided object through a label.
-func SetOwnerForObjectThroughLabels[managingObject managingObjectT](obj client.Object, owner managingObject) {
-	labels := obj.GetLabels()
-	managedByLabelSet := GetManagedByLabelSet(owner)
-	for k, v := range managedByLabelSet {
-		labels[k] = v
-	}
-	obj.SetLabels(labels)
-}
-
 // GetManagedByLabelSet returns a map of labels with the provided object's metadata.
 // These can be applied to other objects that are owned by the object provided as an argument.
 func GetManagedByLabelSet[managingObject managingObjectT](object managingObject) map[string]string {

--- a/pkg/utils/kubernetes/resources/services.go
+++ b/pkg/utils/kubernetes/resources/services.go
@@ -230,8 +230,7 @@ func getSelectorOverrides(overrideAnnotation string) (map[string]string, error) 
 	}
 
 	selector := make(map[string]string)
-	overrides := strings.Split(overrideAnnotation, ",")
-	for _, o := range overrides {
+	for o := range strings.SplitSeq(overrideAnnotation, ",") {
 		annotationParts := strings.Split(o, "=")
 		if len(annotationParts) != 2 || annotationParts[0] == "" || annotationParts[1] == "" {
 			return nil, errors.New("selector override malformed - expected format: key1=value,key2=value2")

--- a/pkg/utils/kubernetes/status.go
+++ b/pkg/utils/kubernetes/status.go
@@ -42,7 +42,7 @@ func SetCondition(condition metav1.Condition, resource ConditionsAware) {
 	newConditions := make([]metav1.Condition, 0, len(conditions))
 
 	var conditionFound bool
-	for i := 0; i < len(conditions); i++ {
+	for i := range conditions {
 		if conditions[i].Type != condition.Type {
 			newConditions = append(newConditions, conditions[i])
 		} else {

--- a/test/integration/dataplane_bluegreen_test.go
+++ b/test/integration/dataplane_bluegreen_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"maps"
 	"testing"
 	"time"
 
@@ -508,9 +509,7 @@ func patchDataPlaneAnnotations(t *testing.T, dataplane *operatorv1beta1.DataPlan
 	if dataplane.Annotations == nil {
 		dataplane.Annotations = annotations
 	} else {
-		for k, v := range annotations {
-			dataplane.Annotations[k] = v
-		}
+		maps.Copy(dataplane.Annotations, annotations)
 	}
 	require.NoError(t, cl.Patch(GetCtx(), dataplane, client.MergeFrom(oldDataPlane)))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Add https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize as one of the linters steps (run via `lint.modernize` makefile target).

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

Thanks to @programmer04 for reminding me about this tool (which is being used by vs code) is being available as a standalone binary.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
