### PR TITLE
feat(gateway): Set network policy on DP pods

### DIFF
--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -780,7 +780,7 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
-        - name: chartsnap-kong-operator-pod-info
+        - name: chartsnap-kong-operator-pod-labels
           mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
@@ -790,7 +790,7 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
-      - name: chartsnap-kong-operator-pod-info
+      - name: chartsnap-kong-operator-pod-labels
         downwardAPI:
           items:
           - path: labels

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -780,6 +780,8 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
+        - name: chartsnap-kong-operator-pod-info
+          mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
       serviceAccountName: controller-manager
@@ -788,6 +790,12 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
+      - name: chartsnap-kong-operator-pod-info
+        downwardAPI:
+          items:
+          - path: labels
+            fieldRef:
+              fieldPath: metadata.labels
 ---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -772,6 +772,8 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
+        - name: chartsnap-kong-operator-pod-info
+          mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
       serviceAccountName: controller-manager
@@ -780,6 +782,12 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
+      - name: chartsnap-kong-operator-pod-info
+        downwardAPI:
+          items:
+          - path: labels
+            fieldRef:
+              fieldPath: metadata.labels
 ---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -772,7 +772,7 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
-        - name: chartsnap-kong-operator-pod-info
+        - name: chartsnap-kong-operator-pod-labels
           mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
@@ -782,7 +782,7 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
-      - name: chartsnap-kong-operator-pod-info
+      - name: chartsnap-kong-operator-pod-labels
         downwardAPI:
           items:
           - path: labels

--- a/charts/kong-operator/ci/__snapshots__/effective-version-1-6-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/effective-version-1-6-values.snap
@@ -770,7 +770,7 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
-        - name: chartsnap-kong-operator-pod-info
+        - name: chartsnap-kong-operator-pod-labels
           mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
@@ -780,7 +780,7 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
-      - name: chartsnap-kong-operator-pod-info
+      - name: chartsnap-kong-operator-pod-labels
         downwardAPI:
           items:
           - path: labels

--- a/charts/kong-operator/ci/__snapshots__/effective-version-1-6-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/effective-version-1-6-values.snap
@@ -770,6 +770,8 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
+        - name: chartsnap-kong-operator-pod-info
+          mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
       serviceAccountName: controller-manager
@@ -778,6 +780,12 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
+      - name: chartsnap-kong-operator-pod-info
+        downwardAPI:
+          items:
+          - path: labels
+            fieldRef:
+              fieldPath: metadata.labels
 ---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -772,6 +772,8 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
+        - name: chartsnap-kong-operator-pod-info
+          mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
       serviceAccountName: controller-manager
@@ -780,6 +782,12 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
+      - name: chartsnap-kong-operator-pod-info
+        downwardAPI:
+          items:
+          - path: labels
+            fieldRef:
+              fieldPath: metadata.labels
 ---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -772,7 +772,7 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
-        - name: chartsnap-kong-operator-pod-info
+        - name: chartsnap-kong-operator-pod-labels
           mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
@@ -782,7 +782,7 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
-      - name: chartsnap-kong-operator-pod-info
+      - name: chartsnap-kong-operator-pod-labels
         downwardAPI:
           items:
           - path: labels

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -774,6 +774,8 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
+        - name: chartsnap-kong-operator-pod-info
+          mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
       serviceAccountName: controller-manager
@@ -782,6 +784,12 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
+      - name: chartsnap-kong-operator-pod-info
+        downwardAPI:
+          items:
+          - path: labels
+            fieldRef:
+              fieldPath: metadata.labels
 ---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -774,7 +774,7 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
-        - name: chartsnap-kong-operator-pod-info
+        - name: chartsnap-kong-operator-pod-labels
           mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
@@ -784,7 +784,7 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
-      - name: chartsnap-kong-operator-pod-info
+      - name: chartsnap-kong-operator-pod-labels
         downwardAPI:
           items:
           - path: labels

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -772,6 +772,8 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
+        - name: chartsnap-kong-operator-pod-info
+          mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
       serviceAccountName: controller-manager
@@ -780,6 +782,12 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
+      - name: chartsnap-kong-operator-pod-info
+        downwardAPI:
+          items:
+          - path: labels
+            fieldRef:
+              fieldPath: metadata.labels
 ---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -772,7 +772,7 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
-        - name: chartsnap-kong-operator-pod-info
+        - name: chartsnap-kong-operator-pod-labels
           mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
@@ -782,7 +782,7 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
-      - name: chartsnap-kong-operator-pod-info
+      - name: chartsnap-kong-operator-pod-labels
         downwardAPI:
           items:
           - path: labels

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrest-values.snap
@@ -772,6 +772,8 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
+        - name: chartsnap-kong-operator-pod-info
+          mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
       serviceAccountName: controller-manager
@@ -780,6 +782,12 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
+      - name: chartsnap-kong-operator-pod-info
+        downwardAPI:
+          items:
+          - path: labels
+            fieldRef:
+              fieldPath: metadata.labels
 ---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrest-values.snap
@@ -772,7 +772,7 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
-        - name: chartsnap-kong-operator-pod-info
+        - name: chartsnap-kong-operator-pod-labels
           mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
@@ -782,7 +782,7 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
-      - name: chartsnap-kong-operator-pod-info
+      - name: chartsnap-kong-operator-pod-labels
         downwardAPI:
           items:
           - path: labels

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -770,6 +770,8 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
+        - name: chartsnap-kong-operator-pod-info
+          mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
       serviceAccountName: controller-manager
@@ -778,3 +780,9 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
+      - name: chartsnap-kong-operator-pod-info
+        downwardAPI:
+          items:
+          - path: labels
+            fieldRef:
+              fieldPath: metadata.labels

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -770,7 +770,7 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
-        - name: chartsnap-kong-operator-pod-info
+        - name: chartsnap-kong-operator-pod-labels
           mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
@@ -780,7 +780,7 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
-      - name: chartsnap-kong-operator-pod-info
+      - name: chartsnap-kong-operator-pod-labels
         downwardAPI:
           items:
           - path: labels

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -771,6 +771,8 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
+        - name: chartsnap-kong-operator-pod-info
+          mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
       serviceAccountName: controller-manager
@@ -779,6 +781,12 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
+      - name: chartsnap-kong-operator-pod-info
+        downwardAPI:
+          items:
+          - path: labels
+            fieldRef:
+              fieldPath: metadata.labels
 ---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -771,7 +771,7 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
-        - name: chartsnap-kong-operator-pod-info
+        - name: chartsnap-kong-operator-pod-labels
           mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
@@ -781,7 +781,7 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
-      - name: chartsnap-kong-operator-pod-info
+      - name: chartsnap-kong-operator-pod-labels
         downwardAPI:
           items:
           - path: labels

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -772,6 +772,8 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
+        - name: chartsnap-kong-operator-pod-info
+          mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
       serviceAccountName: controller-manager
@@ -780,6 +782,12 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
+      - name: chartsnap-kong-operator-pod-info
+        downwardAPI:
+          items:
+          - path: labels
+            fieldRef:
+              fieldPath: metadata.labels
 ---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -772,7 +772,7 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
-        - name: chartsnap-kong-operator-pod-info
+        - name: chartsnap-kong-operator-pod-labels
           mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
@@ -782,7 +782,7 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
-      - name: chartsnap-kong-operator-pod-info
+      - name: chartsnap-kong-operator-pod-labels
         downwardAPI:
           items:
           - path: labels

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -774,6 +774,8 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
+        - name: chartsnap-kong-operator-pod-info
+          mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
       serviceAccountName: controller-manager
@@ -782,6 +784,12 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
+      - name: chartsnap-kong-operator-pod-info
+        downwardAPI:
+          items:
+          - path: labels
+            fieldRef:
+              fieldPath: metadata.labels
 ---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -774,7 +774,7 @@ spec:
         volumeMounts:
         - name: chartsnap-kong-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
-        - name: chartsnap-kong-operator-pod-info
+        - name: chartsnap-kong-operator-pod-labels
           mountPath: /etc/podinfo
       securityContext:
         runAsNonRoot: true
@@ -784,7 +784,7 @@ spec:
       - name: chartsnap-kong-operator-certs-dir
         emptyDir:
           sizeLimit: 256Mi
-      - name: chartsnap-kong-operator-pod-info
+      - name: chartsnap-kong-operator-pod-labels
         downwardAPI:
           items:
           - path: labels

--- a/charts/kong-operator/templates/_helpers.tpl
+++ b/charts/kong-operator/templates/_helpers.tpl
@@ -94,7 +94,7 @@ Create a list of env vars based on the values of the `env` and `customEnv` maps.
 - name: {{ template "kong.fullname" . }}-certs-dir
   emptyDir:
     sizeLimit: {{ .Values.certsDir.sizeLimit }}
-- name: {{ template "kong.fullname" . }}-pod-info
+- name: {{ template "kong.fullname" . }}-pod-labels
   downwardAPI:
     items:
     - path: labels
@@ -105,7 +105,7 @@ Create a list of env vars based on the values of the `env` and `customEnv` maps.
 {{- define "kong.volumeMounts" -}}
 - name: {{ template "kong.fullname" . }}-certs-dir
   mountPath: /tmp/k8s-webhook-server/serving-certs
-- name: {{ template "kong.fullname" . }}-pod-info
+- name: {{ template "kong.fullname" . }}-pod-labels
   mountPath: /etc/podinfo
 {{- end }}
 

--- a/charts/kong-operator/templates/_helpers.tpl
+++ b/charts/kong-operator/templates/_helpers.tpl
@@ -94,11 +94,19 @@ Create a list of env vars based on the values of the `env` and `customEnv` maps.
 - name: {{ template "kong.fullname" . }}-certs-dir
   emptyDir:
     sizeLimit: {{ .Values.certsDir.sizeLimit }}
+- name: {{ template "kong.fullname" . }}-pod-info
+  downwardAPI:
+    items:
+    - path: labels
+      fieldRef:
+        fieldPath: metadata.labels
 {{- end }}
 
 {{- define "kong.volumeMounts" -}}
 - name: {{ template "kong.fullname" . }}-certs-dir
   mountPath: /tmp/k8s-webhook-server/serving-certs
+- name: {{ template "kong.fullname" . }}-pod-info
+  mountPath: /etc/podinfo
 {{- end }}
 
 {{/* effectiveVersion takes the image dict from values.yaml. */}}

--- a/charts/kong-operator/templates/deployment.yaml
+++ b/charts/kong-operator/templates/deployment.yaml
@@ -62,6 +62,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_LABELS
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         livenessProbe:
           {{- toYaml .Values.livenessProbe | nindent 10 }}

--- a/charts/kong-operator/templates/deployment.yaml
+++ b/charts/kong-operator/templates/deployment.yaml
@@ -62,10 +62,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: POD_LABELS
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.labels
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         livenessProbe:
           {{- toYaml .Values.livenessProbe | nindent 10 }}

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -62,5 +62,15 @@ spec:
           requests:
             cpu: 10m
             memory: 128Mi
+        volumeMounts:
+        - name: controller-manager-pod-labels
+          mountPath: /etc/podinfo
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
+      volumes:
+      - name: controller-manager-pod-labels
+        downwardAPI:
+          items:
+          - path: labels
+            fieldRef:
+              fieldPath: metadata.labels

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,6 +59,9 @@ import (
 type Reconciler struct {
 	client.Client
 	CacheSyncTimeout        time.Duration
+	Scheme                  *runtime.Scheme
+	Namespace               string
+	PodLabels               map[string]string
 	DefaultDataPlaneImage   string
 	KonnectEnabled          bool
 	AnonymousReportsEnabled bool
@@ -391,7 +395,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	// DataPlane NetworkPolicies
 	log.Trace(logger, "ensuring DataPlane's NetworkPolicy exists")
-	createdOrUpdated, err := r.ensureDataPlaneHasNetworkPolicy(ctx, &gateway, dataplane, controlplane)
+	createdOrUpdated, err := r.ensureDataPlaneHasNetworkPolicy(ctx, &gateway, dataplane)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -415,7 +415,7 @@ func generateDataPlaneNetworkPolicy(
 
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:    namespace,
+			Namespace:    dataplane.Namespace,
 			GenerateName: k8sutils.TrimGenerateName(fmt.Sprintf("%s-limit-admin-api-", dataplane.Name)),
 		},
 		Spec: networkingv1.NetworkPolicySpec{

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -354,6 +354,10 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 	if err := mgr.Add(scrapersMgr); err != nil {
 		return nil, fmt.Errorf("failed to add scrapers manager to controller-runtime manager: %w", err)
 	}
+	podLabels, err := k8sutils.GetSelfPodLabels()
+	if err != nil {
+		return nil, err
+	}
 
 	ctrlOpts := controller.Options{
 		CacheSyncTimeout: c.CacheSyncTimeout,
@@ -376,6 +380,9 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 			Controller: &gateway.Reconciler{
 				CacheSyncTimeout:        c.CacheSyncTimeout,
 				Client:                  mgr.GetClient(),
+				Scheme:                  mgr.GetScheme(),
+				Namespace:               c.ControllerNamespace,
+				PodLabels:               podLabels,
 				DefaultDataPlaneImage:   consts.DefaultDataPlaneImage,
 				KonnectEnabled:          c.KonnectControllersEnabled,
 				AnonymousReportsEnabled: c.AnonymousReports,

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -356,7 +356,8 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 	}
 	podLabels, err := k8sutils.GetSelfPodLabels()
 	if err != nil {
-		return nil, err
+		// TODO: output some log here?
+		podLabels = map[string]string{}
 	}
 
 	ctrlOpts := controller.Options{

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -356,7 +356,9 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 	}
 	podLabels, err := k8sutils.GetSelfPodLabels()
 	if err != nil {
-		// TODO: output some log here?
+		if k8sutils.RunningOnKubernetes() {
+			return nil, fmt.Errorf("failed to get pod labels: %w", err)
+		}
 		podLabels = map[string]string{}
 	}
 

--- a/pkg/utils/kubernetes/self_metadata.go
+++ b/pkg/utils/kubernetes/self_metadata.go
@@ -36,9 +36,9 @@ func GetSelfPodLabels() (map[string]string, error) {
 		return nil, fmt.Errorf("cannot find pod labels from file %s: %w", podLabelsFile, err)
 	}
 
-	labelList := strings.Split(string(buf), "\n")
-	ret := make(map[string]string, len(labelList))
-	for _, label := range labelList {
+	labels := strings.SplitSeq(string(buf), "\n")
+	ret := make(map[string]string)
+	for label := range labels {
 		labelKV := strings.SplitN(label, "=", 2)
 		if len(labelKV) != 2 {
 			return nil, fmt.Errorf("invalid label format, should be key=value")
@@ -55,7 +55,7 @@ func GetSelfPodLabels() (map[string]string, error) {
 }
 
 // RunningOnKubernetes returns true if it is running in the kubernetes environment.
-// If the env KUBERNETES_SERVICE_HOST is configured to access the kubernetes API server, it is considered to running on k8s.
+// If the env KUBERNETES_SERVICE_HOST is configured to access the kubernetes API server, // it is considered to be running on k8s.
 func RunningOnKubernetes() bool {
 	return os.Getenv("KUBERNETES_SERVICE_HOST") != ""
 }

--- a/pkg/utils/kubernetes/self_metadata.go
+++ b/pkg/utils/kubernetes/self_metadata.go
@@ -32,7 +32,7 @@ func GetSelfNamespace() (string, error) {
 func GetSelfPodLabels() (map[string]string, error) {
 	buf, err := os.ReadFile(podLabelsFile)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot find pod labels from file %s: %v", podLabelsFile, err)
+		return nil, fmt.Errorf("Cannot find pod labels from file %s: %w", podLabelsFile, err)
 	}
 
 	labelList := strings.Split(string(buf), "\n")

--- a/pkg/utils/kubernetes/self_metadata.go
+++ b/pkg/utils/kubernetes/self_metadata.go
@@ -1,0 +1,50 @@
+package kubernetes
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// This file includes utility functions for operating the metadata of
+// the running KO instance itself.
+
+const (
+	podNamespaceEnvName         = "POD_NAMESPACE"
+	podLabelsEnvName            = "POD_LABELS"
+	serviceAccountNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+)
+
+// GetSelfNamespace gets the namespace in which KO runs.
+func GetSelfNamespace() (string, error) {
+	if ns := os.Getenv(podNamespaceEnvName); ns != "" {
+		return ns, nil
+	}
+	// This actually gets the namespace of the service account to run the pod.
+	buf, err := os.ReadFile(serviceAccountNamespaceFile)
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+// GetSelfPodLabels gets all the labels of the KO pod.
+func GetSelfPodLabels() (map[string]string, error) {
+	labels := os.Getenv(podLabelsEnvName)
+	if labels == "" {
+		return nil, fmt.Errorf("Cannot find pod labels from env %s", podLabelsEnvName)
+	}
+
+	labelList := strings.Split(labels, "\n")
+	ret := make(map[string]string, len(labelList))
+	for _, label := range labelList {
+		labelKV := strings.SplitN(label, "=", 2)
+		if len(labelKV) != 2 {
+			// TODO: return error here?
+			continue
+		}
+		key, value := labelKV[0], labelKV[1]
+		ret[key] = value
+	}
+	return ret, nil
+}

--- a/pkg/utils/kubernetes/self_metadata.go
+++ b/pkg/utils/kubernetes/self_metadata.go
@@ -55,7 +55,8 @@ func GetSelfPodLabels() (map[string]string, error) {
 }
 
 // RunningOnKubernetes returns true if it is running in the kubernetes environment.
-// If the env KUBERNETES_SERVICE_HOST is configured to access the kubernetes API server, // it is considered to be running on k8s.
+// If the env KUBERNETES_SERVICE_HOST is configured to access the kubernetes API server,
+// it is considered to be running on k8s.
 func RunningOnKubernetes() bool {
 	return os.Getenv("KUBERNETES_SERVICE_HOST") != ""
 }

--- a/pkg/utils/kubernetes/self_metadata.go
+++ b/pkg/utils/kubernetes/self_metadata.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	podNamespaceEnvName         = "POD_NAMESPACE"
-	podLabelsEnvName            = "POD_LABELS"
+	podLabelsFile               = "/etc/podinfo/labels"
 	serviceAccountNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 )
 
@@ -30,12 +30,12 @@ func GetSelfNamespace() (string, error) {
 
 // GetSelfPodLabels gets all the labels of the KO pod.
 func GetSelfPodLabels() (map[string]string, error) {
-	labels := os.Getenv(podLabelsEnvName)
-	if labels == "" {
-		return nil, fmt.Errorf("Cannot find pod labels from env %s", podLabelsEnvName)
+	buf, err := os.ReadFile(podLabelsFile)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot find pod labels from file %s: %v", podLabelsFile, err)
 	}
 
-	labelList := strings.Split(labels, "\n")
+	labelList := strings.Split(string(buf), "\n")
 	ret := make(map[string]string, len(labelList))
 	for _, label := range labelList {
 		labelKV := strings.SplitN(label, "=", 2)

--- a/pkg/utils/kubernetes/self_metadata.go
+++ b/pkg/utils/kubernetes/self_metadata.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -43,7 +44,12 @@ func GetSelfPodLabels() (map[string]string, error) {
 			// TODO: return error here?
 			continue
 		}
-		key, value := labelKV[0], labelKV[1]
+		key := labelKV[0]
+		// The value in labels are escaped, e.g: "ko" => "\"ko\"". So we need to unquote it.
+		value, err := strconv.Unquote(labelKV[1])
+		if err != nil {
+			continue
+		}
 		ret[key] = value
 	}
 	return ret, nil

--- a/pkg/utils/kubernetes/self_metadata.go
+++ b/pkg/utils/kubernetes/self_metadata.go
@@ -33,7 +33,7 @@ func GetSelfNamespace() (string, error) {
 func GetSelfPodLabels() (map[string]string, error) {
 	buf, err := os.ReadFile(podLabelsFile)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot find pod labels from file %s: %w", podLabelsFile, err)
+		return nil, fmt.Errorf("cannot find pod labels from file %s: %w", podLabelsFile, err)
 	}
 
 	labelList := strings.Split(string(buf), "\n")
@@ -41,8 +41,7 @@ func GetSelfPodLabels() (map[string]string, error) {
 	for _, label := range labelList {
 		labelKV := strings.SplitN(label, "=", 2)
 		if len(labelKV) != 2 {
-			// TODO: return error here?
-			continue
+			return nil, fmt.Errorf("invalid label format, should be key=value")
 		}
 		key := labelKV[0]
 		// The value in labels are escaped, e.g: "ko" => "\"ko\"". So we need to unquote it.
@@ -53,4 +52,10 @@ func GetSelfPodLabels() (map[string]string, error) {
 		ret[key] = value
 	}
 	return ret, nil
+}
+
+// RunningOnKubernetes returns true if it is running in the kubernetes environment.
+// If the env KUBERNETES_SERVICE_HOST is configured to access the kubernetes API server, it is considered to running on k8s.
+func RunningOnKubernetes() bool {
+	return os.Getenv("KUBERNETES_SERVICE_HOST") != ""
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Set `NetworkPolicy` to limit only KO pod can access admin API of Kong gateway

**Which issue this PR fixes**

Fixes #1700

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
