### PR TITLE
chore(ci): ensure yq for modernize target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ golangci-lint: mise yq ## Download golangci-lint locally if necessary.
 MODERNIZE_VERSION = $(shell $(YQ) -r '.modernize' < $(TOOLS_VERSIONS_FILE))
 MODERNIZE = $(PROJECT_DIR)/bin/modernize
 .PHONY: modernize
-modernize:
+modernize: yq
 	GOBIN=$(PROJECT_DIR)/bin go install -v \
 		golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@$(MODERNIZE_VERSION)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Missing `yq` may lead to 

```
bash: /Users/jakub.warczarek@konghq.com/Documents/work/kong-operator/bin/installs/yq/4.46.1/bin/yq: No such file or directory
GOBIN=/Users/jakub.warczarek@konghq.com/Documents/work/kong-operator/bin go install -v \
                golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@
go: golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@: version must not be empty
make: *** [modernize] Error 1
```

This PR prevents this.

**Which issue this PR fixes**

Improvement for 

- https://github.com/Kong/kong-operator/pull/1828
