### PR TITLE
Backport(1.6.x):chore(deps): update kong/kubernetes-ingress-controller docker tag to v3.4.8 (#1839)

### DIFF
--- a/config/samples/controlplane-dataplane-watchnamespaces.yaml
+++ b/config/samples/controlplane-dataplane-watchnamespaces.yaml
@@ -83,7 +83,7 @@ spec:
         containers:
         - name: controller
           # renovate: datasource=docker versioning=docker
-          image: kong/kubernetes-ingress-controller:3.4.4
+          image: kong/kubernetes-ingress-controller:3.4.8
           readinessProbe:
             initialDelaySeconds: 1
             periodSeconds: 3

--- a/config/samples/controlplane-konnect-extension.yaml
+++ b/config/samples/controlplane-konnect-extension.yaml
@@ -71,7 +71,7 @@ spec:
         containers:
         - name: controller
           # renovate: datasource=docker versioning=docker
-          image: kong/kubernetes-ingress-controller:3.4.4
+          image: kong/kubernetes-ingress-controller:3.4.8
           readinessProbe:
             initialDelaySeconds: 1
             periodSeconds: 3

--- a/config/samples/controlplane.yaml
+++ b/config/samples/controlplane.yaml
@@ -14,7 +14,7 @@ spec:
         containers:
         - name: controller
           # renovate: datasource=docker versioning=docker
-          image: kong/kubernetes-ingress-controller:3.4.4
+          image: kong/kubernetes-ingress-controller:3.4.8
           readinessProbe:
             initialDelaySeconds: 1
             periodSeconds: 3

--- a/config/samples/gateway-httproute-allowedroutes.yaml
+++ b/config/samples/gateway-httproute-allowedroutes.yaml
@@ -82,7 +82,7 @@ spec:
           containers:
           - name: controller
             # renovate: datasource=docker versioning=docker
-            image: kong/kubernetes-ingress-controller:3.4.4
+            image: kong/kubernetes-ingress-controller:3.4.8
             readinessProbe:
               initialDelaySeconds: 1
               periodSeconds: 1

--- a/config/samples/gateway-httproute.yaml
+++ b/config/samples/gateway-httproute.yaml
@@ -144,7 +144,7 @@ spec:
           containers:
           - name: controller
             # renovate: datasource=docker versioning=docker
-            image: kong/kubernetes-ingress-controller:3.4.4
+            image: kong/kubernetes-ingress-controller:3.4.8
             readinessProbe:
               initialDelaySeconds: 1
               periodSeconds: 1

--- a/config/samples/gateway-kongplugininstallation-httproute.yaml
+++ b/config/samples/gateway-kongplugininstallation-httproute.yaml
@@ -74,7 +74,7 @@ spec:
           containers:
             - name: controller
               # renovate: datasource=docker versioning=docker
-              image: kong/kubernetes-ingress-controller:3.4.4
+              image: kong/kubernetes-ingress-controller:3.4.8
               readinessProbe:
                 initialDelaySeconds: 1
                 periodSeconds: 1

--- a/config/samples/gateway-with-disabled-controlplane-admission-webhook.yaml
+++ b/config/samples/gateway-with-disabled-controlplane-admission-webhook.yaml
@@ -78,7 +78,7 @@ spec:
           containers:
           - name: controller
             # renovate: datasource=docker versioning=docker
-            image: kong/kubernetes-ingress-controller:3.4.4
+            image: kong/kubernetes-ingress-controller:3.4.8
             readinessProbe:
               initialDelaySeconds: 1
               periodSeconds: 1

--- a/internal/versions/controlplane.go
+++ b/internal/versions/controlplane.go
@@ -13,7 +13,7 @@ const (
 	// and those tests create KIC's URLs for things like roles or CRDs.
 	// Since KIC only defines the full tags in its repo (as expected) we cannot use
 	// a partial version here, as it would not match KIC's tag.
-	DefaultControlPlaneVersion = "3.4.4" // renovate: datasource=docker depName=kong/kubernetes-ingress-controller
+	DefaultControlPlaneVersion = "3.4.8" // renovate: datasource=docker depName=kong/kubernetes-ingress-controller
 )
 
 // minimumControlPlaneVersion indicates the bare minimum version of the


### PR DESCRIPTION

**What this PR does / why we need it**:
Backport #1839 to `release/1.6.x` to bump default KIC version to  3.4.8.
**Which issue this PR fixes**

Part of #1830 
**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
