### PR TITLE
feat: add cache sync cli flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@
 - Added the following CLI flags to control operator's behavior:
   - `--cache-sync-timeout` to control controller-runtime's time limit set to wait for syncing caches.
     [#1818](https://github.com/kong/kong-operator/pull/1818)
+  - `--cache-sync-period` to control controller-runtime's cache sync period.
+    [#1846](https://github.com/kong/kong-operator/pull/1846)
 
 ### Fixed
 

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -48,6 +48,7 @@ const requeueAfterBoot = time.Second
 // Reconciler reconciles a ControlPlane object
 type Reconciler struct {
 	client.Client
+	CacheSyncPeriod          time.Duration
 	CacheSyncTimeout         time.Duration
 	ClusterCASecretName      string
 	ClusterCASecretNamespace string
@@ -364,6 +365,7 @@ func (r *Reconciler) constructControlPlaneManagerConfigOptions(
 
 	cfgOpts := []managercfg.Opt{
 		WithRestConfig(r.RestConfig, r.KubeConfigPath),
+		WithCacheSyncPeriod(r.CacheSyncPeriod),
 		WithKongAdminService(types.NamespacedName{
 			Name:      dataplaneAdminServiceName,
 			Namespace: cp.Namespace,

--- a/controller/controlplane/manager_options.go
+++ b/controller/controlplane/manager_options.go
@@ -460,3 +460,13 @@ func WithClusterDomain(clusterDomain string) managercfg.Opt {
 		c.ClusterDomain = clusterDomain
 	}
 }
+
+// WithCacheSyncPeriod sets the cache sync period for the manager.
+func WithCacheSyncPeriod(period time.Duration) managercfg.Opt {
+	return func(c *managercfg.Config) {
+		if period <= 0 {
+			return
+		}
+		c.SyncPeriod = period
+	}
+}

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -6,6 +6,7 @@
 | ---- | ---- | ----------- | ------- |
 | `--anonymous-reports` | `bool` | Send anonymized usage data to help improve Kong. | `true` |
 | `--apiserver-host` | `string` | The Kubernetes API server URL. If not set, the operator will use cluster config discovery. | `""` |
+| `--cache-sync-period` | `string` | Determine the minimum frequency at which watched resources are reconciled. By default falls back to controller-runtime's default. | `0s` |
 | `--cache-sync-timeout` | `string` | The time limit set to wait for syncing controllers' caches. Defaults to 0 to fall back to default from controller-runtime. | `0s` |
 | `--cluster-ca-key-size` | `string` | Size (in bits) of the key used for the cluster CA certificate. Only used for RSA keys. | `4096` |
 | `--cluster-ca-key-type` | `string` | Type of the key used for the cluster CA certificate (possible values: ecdsa, rsa). Default: ecdsa. | `ecdsa` |

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ------- |
 | `--anonymous-reports` | `bool` | Send anonymized usage data to help improve Kong. | `true` |
 | `--apiserver-host` | `string` | The Kubernetes API server URL. If not set, the operator will use cluster config discovery. | `""` |
-| `--cache-sync-period` | `string` | Determine the minimum frequency at which watched resources are reconciled. By default falls back to controller-runtime's default. | `0s` |
+| `--cache-sync-period` | `string` | Determine the minimum frequency at which watched resources are reconciled. By default or for 0s value, it falls back to controller-runtime's default. | `0s` |
 | `--cache-sync-timeout` | `string` | The time limit set to wait for syncing controllers' caches. Defaults to 0 to fall back to default from controller-runtime. | `0s` |
 | `--cluster-ca-key-size` | `string` | Size (in bits) of the key used for the cluster CA certificate. Only used for RSA keys. | `4096` |
 | `--cluster-ca-key-type` | `string` | Type of the key used for the cluster CA certificate (possible values: ecdsa, rsa). Default: ecdsa. | `ecdsa` |

--- a/modules/cli/cli.go
+++ b/modules/cli/cli.go
@@ -52,6 +52,7 @@ func New(m metadata.Info) *CLI {
 	flagSet.IntVar(&cfg.ClusterCAKeySize, "cluster-ca-key-size", mgrconfig.DefaultClusterCAKeySize, "Size (in bits) of the key used for the cluster CA certificate. Only used for RSA keys.")
 	flagSet.DurationVar(&cfg.CacheSyncTimeout, "cache-sync-timeout", 0, "The time limit set to wait for syncing controllers' caches. Defaults to 0 to fall back to default from controller-runtime.")
 	flagSet.StringVar(&cfg.ClusterDomain, "cluster-domain", ingressmgrconfig.DefaultClusterDomain, "The cluster domain. This is used e.g. in generating addresses for upstream services.")
+	flagSet.DurationVar(&cfg.CacheSyncPeriod, "cache-sync-period", 0, "Determine the minimum frequency at which watched resources are reconciled. By default falls back to controller-runtime's default.")
 
 	// controllers for standard APIs and features
 	flagSet.BoolVar(&cfg.GatewayControllerEnabled, "enable-controller-gateway", true, "Enable the Gateway controller.")

--- a/modules/cli/cli.go
+++ b/modules/cli/cli.go
@@ -52,7 +52,7 @@ func New(m metadata.Info) *CLI {
 	flagSet.IntVar(&cfg.ClusterCAKeySize, "cluster-ca-key-size", mgrconfig.DefaultClusterCAKeySize, "Size (in bits) of the key used for the cluster CA certificate. Only used for RSA keys.")
 	flagSet.DurationVar(&cfg.CacheSyncTimeout, "cache-sync-timeout", 0, "The time limit set to wait for syncing controllers' caches. Defaults to 0 to fall back to default from controller-runtime.")
 	flagSet.StringVar(&cfg.ClusterDomain, "cluster-domain", ingressmgrconfig.DefaultClusterDomain, "The cluster domain. This is used e.g. in generating addresses for upstream services.")
-	flagSet.DurationVar(&cfg.CacheSyncPeriod, "cache-sync-period", 0, "Determine the minimum frequency at which watched resources are reconciled. By default falls back to controller-runtime's default.")
+	flagSet.DurationVar(&cfg.CacheSyncPeriod, "cache-sync-period", 0, "Determine the minimum frequency at which watched resources are reconciled. By default or for 0s value, it falls back to controller-runtime's default.")
 
 	// controllers for standard APIs and features
 	flagSet.BoolVar(&cfg.GatewayControllerEnabled, "enable-controller-gateway", true, "Enable the Gateway controller.")

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -386,6 +386,7 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 		{
 			Enabled: c.GatewayControllerEnabled || c.ControlPlaneControllerEnabled,
 			Controller: &controlplane.Reconciler{
+				CacheSyncPeriod:          c.CacheSyncPeriod,
 				CacheSyncTimeout:         c.CacheSyncTimeout,
 				AnonymousReportsEnabled:  c.AnonymousReports,
 				LoggingMode:              c.LoggingMode,


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds the `--cache-sync-period` flag which controls the controller-runtime's cache sync period which determines the minimum frequency at which watched resources are reconciled.

**Which issue this PR fixes**

Fixes #1845

**Special notes for your reviewer**:

This setting could be a setting on a `ControlPlane` but this PR proposes a CLI flag instead to set this globally to the same value for operator manager and `ControlPlane`'s managers.

The demand for this option on the `ControlPlane` itself is rather unlikely to happen but if that happens we can still introduce this in the `ControlPlane` API.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
