### PR TITLE
chore(ci): run all unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -516,7 +516,7 @@ E2E_TEST_TIMEOUT ?= "20m"
 .PHONY: test
 test: test.unit
 
-UNIT_TEST_PATHS := ./controller/... ./internal/... ./pkg/... ./modules/...
+UNIT_TEST_PATHS := ./controller/... ./internal/... ./pkg/... ./modules/... ./ingress-controller/internal/... ./ingress-controller/pkg/...
 
 .PHONY: _test.unit
 _test.unit: gotestsum


### PR DESCRIPTION
**What this PR does / why we need it**:

   
   Running `make test.unit` in KO root results in

   ```log
   DONE 927 tests, 1 skipped in 38.791s
   ```

   and in ingress-controller dir 

   ```log
   DONE 2331 tests in 36.590s
   ```

   After the adjustment of `Makefile`, all tests are run from the root

   ```log
   DONE 3258 tests, 1 skipped in 51.268s
   ```
   


**Which issue this PR fixes**

Part of 

- https://github.com/Kong/kong-operator/issues/1567

**Special notes for your reviewer**:

Other test suites will be handled in next PRs

