### PR TITLE
fix(patches): prevent clobbering operator-set volumes with user-set v…

### DIFF
--- a/pkg/utils/kubernetes/resources/deployments.go
+++ b/pkg/utils/kubernetes/resources/deployments.go
@@ -347,8 +347,8 @@ func DefaultControlPlaneResources() *corev1.ResourceRequirements {
 func ClusterCertificateVolume(certSecretName string) corev1.Volume {
 	clusterCertificateVolume := corev1.Volume{}
 	clusterCertificateVolume.Secret = &corev1.SecretVolumeSource{}
-	SetDefaultsVolume(&clusterCertificateVolume)
 	clusterCertificateVolume.Name = consts.ClusterCertificateVolume
+	SetDefaultsVolume(&clusterCertificateVolume)
 	clusterCertificateVolume.Secret = &corev1.SecretVolumeSource{
 		SecretName: certSecretName,
 		Items: []corev1.KeyToPath{


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevents `may not specify more than 1 volume type` error when a user has specified some Pod volumes that they want to add to the deployment.

The StrategicPatch operation from Kube Sigs is broken - it smashes both 'base' and 'patch' instances of `Volume[0]` `Volume[1]` `etc`, together, resulting in a Volume that has multiple providers/types to it.

**Which issue this PR fixes**

Fixes **some of** long-running issue #128

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
