### PR TITLE
feat!: add --cluster-domain flag and set default to 'cluster.local'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@
     updating dataplanes by `spec.cache.initSyncDuration`
     [#1858](https://github.com/Kong/kong-operator/pull/1858)
 
+### Breaking Changes
+
+> Add --cluster-domain flag and set default to 'cluster.local'
+  This commit introduces a new --cluster-domain flag to the KO binary, which is now propagated to the ingress-controller.
+  The default value for the cluster domain is set to 'cluster.local', whereas previously it was an empty string ("").
+  This is a breaking change, as any code or configuration relying on the previous default will now use 'cluster.local'
+  unless explicitly overridden.
+  [#1870](https://github.com/Kong/kong-operator/pull/1870)
+
 ## [v2.0.0-alpha.1]
 
 > Release date: 2025-06-11

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -60,6 +60,7 @@ type Reconciler struct {
 	EnforceConfig           bool
 	LoggingMode             logging.Mode
 	AnonymousReportsEnabled bool
+	ClusterDomain           string
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -393,6 +394,7 @@ func (r *Reconciler) constructControlPlaneManagerConfigOptions(
 		WithMetricsServerOff(),
 		WithAnonymousReports(r.AnonymousReportsEnabled),
 		WithAnonymousReportsFixedPayloadCustomizer(payloadCustomizer),
+		WithClusterDomain(r.ClusterDomain),
 	}
 
 	if cp.Spec.GatewayDiscovery != nil {

--- a/controller/controlplane/manager_options.go
+++ b/controller/controlplane/manager_options.go
@@ -453,3 +453,10 @@ func WithInitCacheSyncDuration(delay time.Duration) managercfg.Opt {
 		c.InitCacheSyncDuration = delay
 	}
 }
+
+// WithClusterDomain sets the cluster domain for the manager.
+func WithClusterDomain(clusterDomain string) managercfg.Opt {
+	return func(c *managercfg.Config) {
+		c.ClusterDomain = clusterDomain
+	}
+}

--- a/controller/controlplane/manager_options_test.go
+++ b/controller/controlplane/manager_options_test.go
@@ -927,3 +927,10 @@ func TestWithGatewayDiscoveryReadinessCheckTimeout(t *testing.T) {
 		})
 	}
 }
+
+func TestWithClusterDomain(t *testing.T) {
+	cfg := &managercfg.Config{}
+	opt := WithClusterDomain("foo.bar")
+	opt(cfg)
+	assert.Equal(t, cfg.ClusterDomain, "foo.bar")
+}

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -11,6 +11,7 @@
 | `--cluster-ca-key-type` | `string` | Type of the key used for the cluster CA certificate (possible values: ecdsa, rsa). Default: ecdsa. | `ecdsa` |
 | `--cluster-ca-secret` | `string` | Name of the Secret containing the cluster CA certificate. | `kong-operator-ca` |
 | `--cluster-ca-secret-namespace` | `string` | Name of the namespace for Secret containing the cluster CA certificate. | `""` |
+| `--cluster-domain` | `string` | The cluster domain. This is used e.g. in generating addresses for upstream services. | `cluster.local` |
 | `--controller-name` | `string` | Controller name to use if other than the default, only needed for multi-tenancy. | `""` |
 | `--enable-controller-aigateway` | `bool` | Enable the AIGateway controller. (Experimental). | `false` |
 | `--enable-controller-controlplane` | `bool` | Enable the ControlPlane controller. | `true` |

--- a/ingress-controller/internal/cmd/rootcmd/config/cli.go
+++ b/ingress-controller/internal/cmd/rootcmd/config/cli.go
@@ -122,7 +122,7 @@ func (c *CLIConfig) bindFlagSet() {
 	flagSet.StringSliceVar(&c.WatchNamespaces, "watch-namespace", nil,
 		`Namespace(s) in comma-separated format (or specify this flag multiple times) to watch for Kubernetes resources. Defaults to all namespaces.`)
 	flagSet.BoolVar(&c.EmitKubernetesEvents, "emit-kubernetes-events", true, `Emit Kubernetes events for successful configuration applies, translation failures and configuration apply failures on managed objects.`)
-	flagSet.StringVar(&c.ClusterDomain, "cluster-domain", consts.DefaultClusterDomain, `The cluster domain. This is used e.g. in generating addresses for upstream services.`)
+	flagSet.StringVar(&c.ClusterDomain, "cluster-domain", managercfg.DefaultClusterDomain, `The cluster domain. This is used e.g. in generating addresses for upstream services.`)
 
 	// Ingress status
 	flagSet.Var(flags.NewValidatedValue(&c.PublishService, namespacedNameFromFlagValue, nnTypeNameOverride), "publish-service",

--- a/ingress-controller/internal/dataplane/kong_client_golden_test.go
+++ b/ingress-controller/internal/dataplane/kong_client_golden_test.go
@@ -262,7 +262,7 @@ func runKongClientGoldenTest(t *testing.T, tc kongClientGoldenTestCase) {
 	s := store.New(cacheStores, "kong", logger)
 	p, err := translator.NewTranslator(logger, s, "", semver.MustParse("3.9.1"), tc.featureFlags, fakeSchemaServiceProvier{},
 		translator.Config{
-			ClusterDomain:      consts.DefaultClusterDomain,
+			ClusterDomain:      managercfg.DefaultClusterDomain,
 			EnableDrainSupport: consts.DefaultEnableDrainSupport,
 		},
 	)

--- a/ingress-controller/internal/dataplane/translator/translator_test.go
+++ b/ingress-controller/internal/dataplane/translator/translator_test.go
@@ -3859,7 +3859,7 @@ func TestGetEndpoints(t *testing.T) {
 			},
 			result: []util.Endpoint{
 				{
-					Address: "foo.bar.svc",
+					Address: "foo.bar.svc.cluster.local",
 					Port:    "2080",
 				},
 			},
@@ -3893,7 +3893,7 @@ func TestGetEndpoints(t *testing.T) {
 			},
 			result: []util.Endpoint{
 				{
-					Address: "foo.bar.svc",
+					Address: "foo.bar.svc.cluster.local",
 					Port:    "2080",
 				},
 			},
@@ -4163,7 +4163,7 @@ func TestGetEndpoints(t *testing.T) {
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			clusterDomain := consts.DefaultClusterDomain
+			clusterDomain := managercfg.DefaultClusterDomain
 			if testCase.clusterDomain != "" {
 				clusterDomain = testCase.clusterDomain
 			}
@@ -4490,7 +4490,7 @@ func TestGetEndpoints(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			cfg := getEndpointsConfig{
 				IsSvcUpstream:      false,
-				ClusterDomain:      consts.DefaultClusterDomain,
+				ClusterDomain:      managercfg.DefaultClusterDomain,
 				EnableDrainSupport: testCase.enableDrainSupport,
 			}
 			result := getEndpoints(zapr.NewLogger(zap.NewNop()), testCase.svc, testCase.port, testCase.proto, testCase.fn, cfg)
@@ -5451,7 +5451,7 @@ func mustNewTranslator(t *testing.T, storer store.Storer) *Translator {
 		fakeSchemaServiceProvier{},
 		Config{
 			EnableDrainSupport: consts.DefaultEnableDrainSupport,
-			ClusterDomain:      consts.DefaultClusterDomain,
+			ClusterDomain:      managercfg.DefaultClusterDomain,
 		},
 	)
 	require.NoError(t, err)

--- a/ingress-controller/internal/manager/consts/consts.go
+++ b/ingress-controller/internal/manager/consts/consts.go
@@ -26,10 +26,6 @@ const (
 	// KongClientEventRecorderComponentName is a KongClient component name used to identify the events recording component.
 	KongClientEventRecorderComponentName = "kong-client"
 
-	// DefaultClusterDomain is the default cluster domain used by the controller.
-	// TODO: change this in next major release: https://github.com/Kong/kubernetes-ingress-controller/issues/6756
-	DefaultClusterDomain = ""
-
 	// DefaultEnableDrainSupport is the default value for enabling drain support feature.
 	// When enabled, terminating endpoints are kept in Kong upstreams with weight=0 for graceful connection draining.
 	DefaultEnableDrainSupport = false

--- a/ingress-controller/pkg/manager/config/consts.go
+++ b/ingress-controller/pkg/manager/config/consts.go
@@ -26,3 +26,8 @@ const (
 	// DefaultKonnectConfigUploadPeriod is the default period between operations to upload Kong configuration to Konnect.
 	DefaultKonnectConfigUploadPeriod = 30 * time.Second
 )
+
+const (
+	// DefaultClusterDomain is the default cluster domain used by the controller.
+	DefaultClusterDomain = "cluster.local"
+)

--- a/ingress-controller/pkg/manager/config_test.go
+++ b/ingress-controller/pkg/manager/config_test.go
@@ -66,7 +66,7 @@ func TestNewConfig(t *testing.T) {
 			GatewayAPIControllerName:               string(gateway.GetControllerName()),
 			Impersonate:                            "",
 			EmitKubernetesEvents:                   true,
-			ClusterDomain:                          consts.DefaultClusterDomain,
+			ClusterDomain:                          managercfg.DefaultClusterDomain,
 			PublishServiceUDP:                      managercfg.OptionalNamespacedName{},
 			PublishService:                         managercfg.OptionalNamespacedName{},
 			PublishStatusAddress:                   []string{},

--- a/modules/cli/cli.go
+++ b/modules/cli/cli.go
@@ -10,6 +10,7 @@ import (
 	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	ingressmgrconfig "github.com/kong/kong-operator/ingress-controller/pkg/manager/config"
 	"github.com/kong/kong-operator/modules/manager"
 	mgrconfig "github.com/kong/kong-operator/modules/manager/config"
 	"github.com/kong/kong-operator/modules/manager/logging"
@@ -50,6 +51,7 @@ func New(m metadata.Info) *CLI {
 	flagSet.Var(&cfg.ClusterCAKeyType, "cluster-ca-key-type", "Type of the key used for the cluster CA certificate (possible values: ecdsa, rsa). Default: ecdsa.")
 	flagSet.IntVar(&cfg.ClusterCAKeySize, "cluster-ca-key-size", mgrconfig.DefaultClusterCAKeySize, "Size (in bits) of the key used for the cluster CA certificate. Only used for RSA keys.")
 	flagSet.DurationVar(&cfg.CacheSyncTimeout, "cache-sync-timeout", 0, "The time limit set to wait for syncing controllers' caches. Defaults to 0 to fall back to default from controller-runtime.")
+	flagSet.StringVar(&cfg.ClusterDomain, "cluster-domain", ingressmgrconfig.DefaultClusterDomain, "The cluster domain. This is used e.g. in generating addresses for upstream services.")
 
 	// controllers for standard APIs and features
 	flagSet.BoolVar(&cfg.GatewayControllerEnabled, "enable-controller-gateway", true, "Enable the Gateway controller.")

--- a/modules/cli/cli_test.go
+++ b/modules/cli/cli_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	ingressmgrconfig "github.com/kong/kong-operator/ingress-controller/pkg/manager/config"
 	"github.com/kong/kong-operator/modules/manager"
 	mgrconfig "github.com/kong/kong-operator/modules/manager/config"
 	"github.com/kong/kong-operator/modules/manager/logging"
@@ -112,6 +113,17 @@ func TestParse(t *testing.T) {
 				return cfg
 			},
 		},
+		{
+			name: "cluster domain argument is set",
+			args: []string{
+				"--cluster-domain=foo.bar",
+			},
+			expectedCfg: func() manager.Config {
+				cfg := expectedDefaultCfg()
+				cfg.ClusterDomain = "foo.bar"
+				return cfg
+			},
+		},
 	}
 
 	for _, tC := range testCases {
@@ -160,5 +172,6 @@ func expectedDefaultCfg() manager.Config {
 		KongPluginInstallationControllerEnabled: false,
 		LoggerOpts:                              &zap.Options{},
 		KonnectMaxConcurrentReconciles:          consts.DefaultKonnectMaxConcurrentReconciles,
+		ClusterDomain:                           ingressmgrconfig.DefaultClusterDomain,
 	}
 }

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -398,6 +398,7 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 				KubeConfigPath:           c.KubeconfigPath,
 				RestConfig:               mgr.GetConfig(),
 				InstancesManager:         cpsMgr,
+				ClusterDomain:            c.ClusterDomain,
 			},
 		},
 		// DataPlane controller

--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -72,6 +72,7 @@ type Config struct {
 	ClusterCAKeySize         int
 	LoggerOpts               *zap.Options
 	EnforceConfig            bool
+	ClusterDomain            string
 
 	// ServiceAccountToImpersonate is the name of the service account to impersonate,
 	// by the controller manager, when making requests to the API server.


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit introduces a new --cluster-domain flag to the ko binary, which is now propagated to the ingress-controller. The default value for the cluster domain is set to 'cluster.local', whereas previously it was an empty string (""). This is a breaking change, as any code or configuration relying on the previous default will now use 'cluster.local' unless explicitly overridden.

**Which issue this PR fixes**

Fixes #1797 Kong/kubernetes-ingress-controller#6756

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
