### PR TITLE
chore(ci): run all conformance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -622,12 +622,18 @@ _test.conformance: gotestsum download.telepresence
 		-ldflags "$(LDFLAGS_COMMON) $(LDFLAGS) $(LDFLAGS_METADATA)" \
 		-race \
 		-parallel $(PARALLEL) \
-		./test/conformance/...
+		$(TEST_SUITE_PATH)
 
 .PHONY: test.conformance
 test.conformance:
 	@$(MAKE) _test.conformance \
-		GOTESTFLAGS="$(GOTESTFLAGS)"
+		GOTESTFLAGS="$(GOTESTFLAGS)" \
+		TEST_SUITE_PATH='./test/conformance/...'
+	@echo 'Conformance tests from the ingress-controller subdirectory'
+	@$(MAKE) _test.conformance \
+		GOTESTFLAGS="$(GOTESTFLAGS)-tags=conformance_tests" \
+		TEST_SUITE_PATH='./ingress-controller/test/conformance/...'
+
 
 .PHONY: test.samples
 test.samples:

--- a/ingress-controller/test/util/kustomize_consts.go
+++ b/ingress-controller/test/util/kustomize_consts.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	kubernetesConfigurationModulePath = "github.com/kong/kubernetes-configuration"
+	ingressControllerLocalPath        = "./ingress-controller/"
 )
 
 var (
@@ -29,19 +30,19 @@ func initKongIncubatorCRDsKustomizePath() string {
 }
 
 func initKongRBACsKustomizePath() string {
-	dir := filepath.Join(lo.Must(getRepoRoot()), "config/rbac/")
+	dir := filepath.Join(lo.Must(getRepoRoot()), ingressControllerLocalPath+"config/rbac/")
 	ensureDirExists(dir)
 	return dir
 }
 
 func initKongGatewayRBACsKustomizePath() string {
-	dir := filepath.Join(lo.Must(getRepoRoot()), "config/rbac/gateway")
+	dir := filepath.Join(lo.Must(getRepoRoot()), ingressControllerLocalPath+"config/rbac/gateway")
 	ensureDirExists(dir)
 	return dir
 }
 
 func initKongCRDsRBACsKustomizePath() string {
-	dir := filepath.Join(lo.Must(getRepoRoot()), "config/rbac/crds")
+	dir := filepath.Join(lo.Must(getRepoRoot()), ingressControllerLocalPath+"config/rbac/crds")
 	ensureDirExists(dir)
 	return dir
 }
@@ -65,6 +66,6 @@ func getRepoRoot() (string, error) {
 	if !ok {
 		return "", fmt.Errorf("failed to get repo root: runtime.Caller(0) failed")
 	}
-	d := filepath.Dir(path.Join(path.Dir(b), "../")) // Number of ../ depends on the path of this file.
+	d := filepath.Dir(path.Join(path.Dir(b), "../..")) // Number of ../ depends on the path of this file.
 	return filepath.Abs(d)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Run conformance tests from ingress-controller subdir too

**Which issue this PR fixes**

Part of 

- https://github.com/Kong/kong-operator/issues/1567

to be improved in the future - https://github.com/Kong/kong-operator/issues/1872


