### PR TITLE
chore(ci): run all kongintegration tests

### DIFF
--- a/.github/workflows/_kongintegration_tests.yaml
+++ b/.github/workflows/_kongintegration_tests.yaml
@@ -56,7 +56,7 @@ jobs:
           MISE_VERBOSE: 1
           MISE_DEBUG: 1
           GOTESTSUM_JUNITFILE: ${{ env.GOTESTSUM_JUNITFILE }}
-          TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.K8S_TEAM_KONNECT_ACCESS_TOKEN }}
+          TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.konnect-pat }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
           TEST_KONG_ENTERPRISE: ${{ matrix.enterprise }}
 

--- a/.github/workflows/_kongintegration_tests.yaml
+++ b/.github/workflows/_kongintegration_tests.yaml
@@ -56,7 +56,7 @@ jobs:
           MISE_VERBOSE: 1
           MISE_DEBUG: 1
           GOTESTSUM_JUNITFILE: ${{ env.GOTESTSUM_JUNITFILE }}
-          TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.konnect-pat }}
+          TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
           TEST_KONG_ENTERPRISE: ${{ matrix.enterprise }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -379,6 +379,10 @@ jobs:
       with:
         name: tests-report-envtest-tests
         path: envtest-tests.xml
+  
+  kongintegration-tests:
+    uses: ./.github/workflows/_kongintegration_tests.yaml
+    secrets: inherit
 
   conformance-tests:
     runs-on: ubuntu-latest
@@ -646,6 +650,7 @@ jobs:
       - build
       - CRDs-validation
       - envtest-tests
+      - kongintegration-tests
       - conformance-tests
       - integration-tests
       - integration-tests-bluegreen

--- a/Makefile
+++ b/Makefile
@@ -660,7 +660,6 @@ _test.kongintegration: gotestsum
 		-coverprofile=coverage.kongintegration.out \
 		./ingress-controller/test/kongintegration
 
-
 .PHONY: test.samples
 test.samples:
 	@cd config/samples/ && find . -not -name "kustomization.*" -type f | sort | xargs -I{} bash -c "echo;echo {}; kubectl apply -f {} && kubectl delete -f {}" \;

--- a/Makefile
+++ b/Makefile
@@ -638,6 +638,29 @@ test.conformance:
 		TEST_SUITE_PATH='./ingress-controller/test/conformance/...'
 
 
+.PHONY: test.kongintegration
+test.kongintegration:
+	@$(MAKE) _test.kongintegration GOTESTSUM_FORMAT=standard-verbose
+
+.PHONY: test.kongintegration.pretty
+test.kongintegration.pretty:
+	@$(MAKE) _test.kongintegration GOTESTSUM_FORMAT=testname
+
+.PHONY: _test.kongintegration
+_test.kongintegration: gotestsum
+	# Disable testcontainer's reaper (Ryuk). It's needed because Ryuk requires
+	# privileged mode to run, which is not desired and could cause issues in CI.
+	TESTCONTAINERS_RYUK_DISABLED="true" \
+	GOTESTSUM_FORMAT=$(GOTESTSUM_FORMAT) \
+	$(GOTESTSUM) -- $(GOTESTFLAGS) \
+		-race \
+		-ldflags="$(LDFLAGS_COMMON)" \
+		-parallel $(NCPU) \
+		-coverpkg=$(PKG_LIST) \
+		-coverprofile=coverage.kongintegration.out \
+		./ingress-controller/test/kongintegration
+
+
 .PHONY: test.samples
 test.samples:
 	@cd config/samples/ && find . -not -name "kustomization.*" -type f | sort | xargs -I{} bash -c "echo;echo {}; kubectl apply -f {} && kubectl delete -f {}" \;

--- a/ingress-controller/test/kongintegration/inmemory_update_strategy_test.go
+++ b/ingress-controller/test/kongintegration/inmemory_update_strategy_test.go
@@ -91,9 +91,8 @@ func TestUpdateStrategyInMemory_PropagatesResourcesErrors(t *testing.T) {
 		},
 	}
 	expectedMessage := "invalid path: value must be null"
-	expectedRawErrBody := []byte(`{"code":14,"name":"invalid declarative configuration","fields":{},"message":"declarative config is invalid: {}","flattened_errors":[{"entity_type":"service","entity_name":"test-service","entity_tags":["k8s-name:test-service","k8s-namespace:default","k8s-kind:Service","k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3","k8s-group:","k8s-version:v1"],"errors":[{"type":"field","message":"value must be null","field":"path"},{"type":"entity","message":"failed conditional validation given value of field 'protocol'"}],"entity":{"path":"/test","name":"test-service","protocol":"grpc","tags":["k8s-name:test-service","k8s-namespace:default","k8s-kind:Service","k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3","k8s-group:","k8s-version:v1"],"host":"konghq.com","port":80}}]}`)
-	expectedBody := map[string]any{}
-	require.NoError(t, json.Unmarshal(expectedRawErrBody, &expectedBody))
+	// We don't hardcode the expected response body as it can vary between Kong versions
+	// Instead, we verify the essential structure and fields are present
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		configSize, err := sut.Update(ctx, faultyConfig)
@@ -125,18 +124,50 @@ func TestUpdateStrategyInMemory_PropagatesResourcesErrors(t *testing.T) {
 		if !assert.Truef(t, found, "expected resource error for test-service, got: %+v", updateError.ResourceFailures()) {
 			return
 		}
-		if !assert.Equal(t, expectedMessage, resourceErr.Message()) {
+		if !assert.Equal(t, resourceErr.Message(), expectedMessage) {
 			return
 		}
 		if diff := cmp.Diff(expectedCausingObjects, resourceErr.CausingObjects()); !assert.Empty(t, diff) {
 			return
 		}
+		// Verify essential structure of the response body
 		actualBody := map[string]any{}
 		err = json.Unmarshal(updateError.RawResponseBody(), &actualBody)
 		if !assert.NoError(t, err) {
 			return
 		}
-		if diff := cmp.Diff(expectedBody, actualBody); !assert.Empty(t, diff) {
+
+		// Check for required fields in the error response
+		if !assert.Contains(t, actualBody, "code") {
+			return
+		}
+		if !assert.Contains(t, actualBody, "name") {
+			return
+		}
+		if !assert.Contains(t, actualBody, "flattened_errors") {
+			return
+		}
+
+		// Verify the flattened_errors contains our test service
+		flattenedErrors, ok := actualBody["flattened_errors"].([]any)
+		if !assert.True(t, ok) {
+			return
+		}
+		if !assert.NotEmpty(t, flattenedErrors) {
+			return
+		}
+
+		// Check that at least one error relates to our test service
+		foundServiceError := false
+		for _, errorItem := range flattenedErrors {
+			if errorMap, ok := errorItem.(map[string]any); ok {
+				if entityName, ok := errorMap["entity_name"].(string); ok && entityName == "test-service" {
+					foundServiceError = true
+					break
+				}
+			}
+		}
+		if !assert.True(t, foundServiceError, "Expected to find flattened error for test-service") {
 			return
 		}
 	}, timeout, period)

--- a/ingress-controller/test/kongintegration/kongupstreampolicy_test.go
+++ b/ingress-controller/test/kongintegration/kongupstreampolicy_test.go
@@ -327,6 +327,9 @@ func dropKongDefaults(upstream *kong.Upstream) *kong.Upstream {
 	if upstream.HashOnCookiePath != nil && *upstream.HashOnCookiePath == "/" {
 		upstream.HashOnCookiePath = nil
 	}
+	if upstream.StickySessionsCookiePath != nil && *upstream.StickySessionsCookiePath == "/" {
+		upstream.StickySessionsCookiePath = nil
+	}
 	if upstream.UseSrvName != nil && *upstream.UseSrvName == false {
 		upstream.UseSrvName = nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

KIC contains a test suite - `kongintegration`. Introduce it to KO `Makefile` adjust paths in a target and add CI configuration to run it as a part of the pipeline.

It contains the fix from

- https://github.com/Kong/kubernetes-ingress-controller/pull/7620

basically it's a kinda cherry-pick

**Which issue this PR fixes**

Part of

- https://github.com/Kong/kong-operator/issues/1567

A new issue will be created when all test runs are complete to cover further improvements for them 