### PR TITLE
chore(makefile): add lint.all target to run all linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,9 @@ lint.markdownlint: download.markdownlint-cli2
 		charts/kong-operator/README.md \
 		charts/kong-operator/CHANGELOG.md
 
+.PHONY: lint.all
+lint.all: lint lint.charts lint.actions lint.markdownlint
+
 .PHONY: verify
 verify: verify.manifests verify.generators
 


### PR DESCRIPTION


**What this PR does / why we need it**:

Add a new lint.all target to the Makefile that runs all linter targets (lint, lint.charts, lint.actions, and lint.markdownlint) for easier code quality checks.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
