### PR TITLE
chore(ci): run all e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -605,7 +605,9 @@ _test.e2e: gotestsum
 		-timeout $(E2E_TEST_TIMEOUT) \
 		-ldflags "$(LDFLAGS_COMMON) $(LDFLAGS) $(LDFLAGS_METADATA)" \
 		-race \
-		./test/e2e/...
+		-tags e2e_tests \
+		./test/e2e/... \
+		./ingress-controller/test/e2e/...
 
 .PHONY: test.e2e
 test.e2e:


### PR DESCRIPTION
## What this PR does / why we need it:

Run e2e tests from `ingress-controller` subdir too

## Which issue this PR fixes

Part of

- https://github.com/Kong/kong-operator/issues/1567