### PR TITLE
fix(test/helpers): handle telepresence traffic manager upgrade if aleady installed

### DIFF
--- a/test/helpers/telepresence.go
+++ b/test/helpers/telepresence.go
@@ -1,11 +1,11 @@
 package helpers
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/kong/kong-operator/test"
 )
@@ -29,7 +29,7 @@ func SetupTelepresence(ctx context.Context) (func(), error) {
 	}
 
 	out, err := exec.CommandContext(ctx, telepresenceExecutable, "helm", "install").CombinedOutput()
-	if err != nil && strings.Contains(string(out), "use 'telepresence helm upgrade' instead to replace it") {
+	if err != nil && bytes.Contains(out, []byte("use 'telepresence helm upgrade' instead to replace it")) {
 		if out, err := exec.CommandContext(ctx, telepresenceExecutable, "helm", "upgrade").CombinedOutput(); err != nil {
 			return nil, fmt.Errorf("failed to upgrade telepresence traffic manager: %w, %s", err, string(out))
 		}

--- a/test/helpers/telepresence.go
+++ b/test/helpers/telepresence.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/kong/kong-operator/test"
 )
@@ -28,7 +29,11 @@ func SetupTelepresence(ctx context.Context) (func(), error) {
 	}
 
 	out, err := exec.CommandContext(ctx, telepresenceExecutable, "helm", "install").CombinedOutput()
-	if err != nil {
+	if err != nil && strings.Contains(string(out), "use 'telepresence helm upgrade' instead to replace it") {
+		if out, err := exec.CommandContext(ctx, telepresenceExecutable, "helm", "upgrade").CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("failed to upgrade telepresence traffic manager: %w, %s", err, string(out))
+		}
+	} else if err != nil {
 		return nil, fmt.Errorf("failed to install telepresence traffic manager: %w, %s", err, string(out))
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Update SetupTelepresence to run `telepresence helm upgrade` if `telepresence helm install` fails with a message indicating the manager is already installed. This improves idempotency and error handling, making it handy when running tests multiple times and reusing the same environment.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
