### PR TITLE
fix(docs): proper URL to crds in KIC subchart README.md

### DIFF
--- a/charts/kong-operator/charts/kic-crds/README.md
+++ b/charts/kong-operator/charts/kic-crds/README.md
@@ -8,11 +8,11 @@ This sub-chart contains Kong Ingress Controller (KIC)'s CRDs, allowing users to 
 [kconf]: https://github.com/Kong/kubernetes-configuration
 
 ```bash
-kustomize build https://github.com/kong/kubernetes-configuration/v2/config/crd/ingress-controller\?ref\=${VERSION} > crds/kic-crds.yaml
+kustomize build https://github.com/kong/kubernetes-configuration/config/crd/ingress-controller\?ref\=${VERSION} > crds/kic-crds.yaml
 ```
 
 For example:
 
 ```bash
-kustomize build https://github.com/kong/kubernetes-configuration/v2/config/crd/ingress-controller\?ref\=v2.0.0-alpha.1 > crds/kic-crds.yaml
+kustomize build https://github.com/kong/kubernetes-configuration/config/crd/ingress-controller\?ref\=v2.0.0-alpha.1 > crds/kic-crds.yaml
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:

During review of https://github.com/Kong/charts/pull/1348/#discussion_r2201500624, it was discovered that the URL contains `/v2/` part, which makes sense only for go modules, so in this case, it breaks setup.

A spin-off issue to handle it properly with automation has been created 

- https://github.com/Kong/kong-operator/issues/1898



