### PR TITLE
fix(ci): update version of KO in chart and its tests during release

### DIFF
--- a/.github/workflows/__release-workflow.yaml
+++ b/.github/workflows/__release-workflow.yaml
@@ -310,6 +310,10 @@ jobs:
         if: ${{ inputs.regenerate-manifests }}
         run: make manifests
 
+      # Chart and golden tests for it includes information about current KO version.
+      - name: Update version in chart and its tests
+        run: make test.charts.golden.update
+
       # The generated bundle is part of the release PR.
       # This is done locally in this job, to avoid including unintended changes.
       # If anything needs to be fixed before the release, it should be done on the base branch


### PR DESCRIPTION
**What this PR does / why we need it**:

During the release

- https://github.com/Kong/kong-operator/issues/1630

discovered that in the release PR

- #1914

commit https://github.com/Kong/kong-operator/pull/1914/commits/23e1392afd77de0602900ca5316179a912902854 was omitted and had to be added manually. 

This PR ensures that those changes are introduced by automation for subsequent releases.

