### PR TITLE
chore(ci): run integration and envtest tests for `ingress-controller` too

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -367,11 +367,18 @@ jobs:
       with:
         install: false
 
+    - uses: Kong/kong-license@c4decf08584f84ff8fe8e7cd3c463e0192f6111b # master @ 20250107
+      id: license
+      with:
+        op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        
+
     - name: run envtest tests
       working-directory: ${{ matrix.directory }}
       run: make test.envtest
       env:
-        GOTESTSUM_JUNITFILE: "envtest-tests.xml"
+        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
+        GOTESTSUM_JUNITFILE: "${{ matrix.directory }}/envtest-tests.xml"
 
     - name: collect test coverage
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -482,7 +489,7 @@ jobs:
       env:
         KONG_PLUGIN_IMAGE_REGISTRY_CREDENTIALS: ${{ secrets.KONG_PLUGIN_IMAGE_REGISTRY_CREDENTIALS }}
         KONG_CONTROLLER_OUT: stdout
-        GOTESTSUM_JUNITFILE: integration-tests.xml
+        GOTESTSUM_JUNITFILE: "${{ matrix.directory }}/integration-tests.xml"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
         KONG_TEST_KONNECT_SERVER_URL: us.api.konghq.tech

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -345,6 +345,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check-docs-only]
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
+    strategy:
+      matrix:
+        directory:
+          - ingress-controller
+          - .
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -363,6 +368,7 @@ jobs:
         install: false
 
     - name: run envtest tests
+      working-directory: ${{ matrix.directory }}
       run: make test.envtest
       env:
         GOTESTSUM_JUNITFILE: "envtest-tests.xml"
@@ -370,15 +376,15 @@ jobs:
     - name: collect test coverage
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: coverage-envtest
-        path: coverage.envtest.out
+        name: ${{ matrix.directory == '.' && 'ko' || matrix.directory }}-coverage-envtest-tests
+        path: ${{ matrix.directory }}/coverage.envtest.out
 
     - name: collect test report
       if: ${{ always() }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: tests-report-envtest-tests
-        path: envtest-tests.xml
+        name: ${{ matrix.directory == '.' && 'ko' || matrix.directory }}-tests-report-envtest-tests
+        path: ${{ matrix.directory }}/envtest-tests.xml
   
   kongintegration-tests:
     needs: [check-docs-only]
@@ -448,6 +454,11 @@ jobs:
     name: integration-tests
     needs: [check-docs-only]
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
+    strategy:
+      matrix:
+        directory:
+          - ingress-controller
+          - .
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -466,6 +477,7 @@ jobs:
         install: false
 
     - name: run integration tests
+      working-directory: ${{ matrix.directory }}
       run: make test.integration
       env:
         KONG_PLUGIN_IMAGE_REGISTRY_CREDENTIALS: ${{ secrets.KONG_PLUGIN_IMAGE_REGISTRY_CREDENTIALS }}
@@ -486,15 +498,15 @@ jobs:
     - name: collect test coverage
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: coverage-integration
-        path: coverage.integration.out
+        name: ${{ matrix.directory == '.' && 'ko' || matrix.directory }}-coverage-integration
+        path: ${{ matrix.directory }}/coverage.integration.out
 
     - name: collect test report
       if: ${{ always() }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: tests-report-integration
-        path: integration-tests.xml
+        name: ${{ matrix.directory == '.' && 'ko' || matrix.directory }}-tests-report-integration
+        path: ${{ matrix.directory }}/integration-tests.xml
 
   integration-tests-bluegreen:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What this PR does / why we need it**:

PR https://github.com/Kong/kong-operator/pull/1931 adjusted wrong workflow for `envtest` tests, here it's fixed. 

The same method ensures that all integration tests are run too.

**Which issue this PR fixes**

Closes #1567

will create a spin-off issues that describe the next steps for test suites 

