### PR TITLE
fix(samples): remove CombinedServicesFromDifferentHTTPRoutes feature flag

### DIFF
--- a/config/samples/controlplane_v2.yaml
+++ b/config/samples/controlplane_v2.yaml
@@ -10,8 +10,6 @@ spec:
   featureGates:
   - name: GatewayAlpha
     state: enabled
-  - name: CombinedServicesFromDifferentHTTPRoutes
-    state: enabled
   controllers:
   - name: KONG_UDPINGRESS
     state: disabled

--- a/config/samples/gateway-with-gatewayconfiguration_with_httproute_v2.yaml
+++ b/config/samples/gateway-with-gatewayconfiguration_with_httproute_v2.yaml
@@ -19,8 +19,6 @@ spec:
     featureGates:
     - name: GatewayAlpha
       state: enabled
-    - name: CombinedServicesFromDifferentHTTPRoutes
-      state: enabled
     controllers:
     - name: KONG_UDPINGRESS
       state: disabled


### PR DESCRIPTION
**What this PR does / why we need it**:

- Removed the `CombinedServicesFromDifferentHTTPRoutes` feature flag from `controlplane_v2.yaml` and `gateway-with-gatewayconfiguration_with_httproute_v2.yaml`.
- See: https://github.com/Kong/kubernetes-ingress-controller/pull/7569

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
