### PR TITLE
feat(controller): handle transient errors during ControlPlane scheduling

### DIFF
--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"reflect"
 	"strings"
 	"time"
@@ -32,6 +33,7 @@ import (
 	"github.com/kong/kong-operator/controller/pkg/log"
 	"github.com/kong/kong-operator/controller/pkg/op"
 	"github.com/kong/kong-operator/controller/pkg/secrets"
+	ingresserrors "github.com/kong/kong-operator/ingress-controller/pkg/errors"
 	"github.com/kong/kong-operator/ingress-controller/pkg/manager"
 	managercfg "github.com/kong/kong-operator/ingress-controller/pkg/manager/config"
 	"github.com/kong/kong-operator/ingress-controller/pkg/manager/multiinstance"
@@ -263,7 +265,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			}
 			mgrCfg.DisableRunningDiagnosticsServer = true
 			if err := r.scheduleInstance(ctx, logger, mgrID, mgrCfg); err != nil {
-				return ctrl.Result{}, err
+				return r.handleScheduleInstanceOutcome(ctx, logger, cp, err)
 			}
 			r.ensureControlPlaneStatus(cp, mgrCfg)
 		}
@@ -299,7 +301,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			}
 
 			if err := r.scheduleInstance(ctx, logger, mgrID, mgrCfg); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to schedule instance: %w", err)
+				return r.handleScheduleInstanceOutcome(ctx, logger, cp, err)
 			}
 			r.ensureControlPlaneStatus(cp, mgrCfg)
 
@@ -525,4 +527,40 @@ func (r *Reconciler) initStatusToWaitingToBecomeReady(
 		return res, nil
 	}
 	return ctrl.Result{RequeueAfter: requeueAfterBoot}, nil
+}
+
+// handleScheduleInstanceOutcome handles the outcome of r.scheduleInstance.
+// It checks for transient errors, logs them, and requeues the resource with a patched status.
+func (r *Reconciler) handleScheduleInstanceOutcome(
+	ctx context.Context,
+	logger logr.Logger,
+	cp *ControlPlane,
+	err error,
+) (ctrl.Result, error) {
+	// If the error is transient, we log it and requeue the resource. Such errors include:
+	// - NoAvailableEndpointsError: indicates that there are no available endpoints for the dataplane;
+	// - io.EOF: indicates that the connection to the dataplane service was closed unexpectedly.
+	// These errors are considered transient and will be retried after a delay.
+	if errors.As(err, &ingresserrors.NoAvailableEndpointsError{}) || errors.Is(err, io.EOF) {
+		logger.Info("Transient error encountered while creating kong api clients, retrying after delay", "error", err, "retryDelay", requeueAfterBoot)
+		k8sutils.SetCondition(
+			k8sutils.NewCondition(
+				kcfgdataplane.ReadyType,
+				metav1.ConditionFalse,
+				kcfgdataplane.WaitingToBecomeReadyReason,
+				kcfgdataplane.WaitingToBecomeReadyMessage,
+			),
+			cp,
+		)
+		res, patchErr := r.patchStatus(ctx, logger, cp)
+		if patchErr != nil {
+			logger.Error(patchErr, "Failed to patch ControlPlane status")
+			return ctrl.Result{}, patchErr
+		}
+		if !res.IsZero() {
+			return res, nil
+		}
+		return ctrl.Result{RequeueAfter: requeueAfterBoot}, nil
+	}
+	return ctrl.Result{}, err
 }

--- a/ingress-controller/internal/adminapi/kong_test.go
+++ b/ingress-controller/internal/adminapi/kong_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kong/kong-operator/ingress-controller/internal/adminapi"
 	"github.com/kong/kong-operator/ingress-controller/internal/versions"
+	ingresserrors "github.com/kong/kong-operator/ingress-controller/pkg/errors"
 	managercfg "github.com/kong/kong-operator/ingress-controller/pkg/manager/config"
 	"github.com/kong/kong-operator/ingress-controller/test/helpers/certificate"
 	"github.com/kong/kong-operator/ingress-controller/test/mocks"
@@ -138,14 +139,14 @@ func TestNewKongClientForWorkspace(t *testing.T) {
 			name:          "admin api is not ready",
 			adminAPIReady: false,
 			workspace:     "",
-			expectError:   adminapi.KongClientNotReadyError{},
+			expectError:   ingresserrors.KongClientNotReadyError{},
 		},
 		{
 			name:            "admin api is not ready for an existing workspace",
 			adminAPIReady:   false,
 			workspace:       workspace,
 			workspaceExists: true,
-			expectError:     adminapi.KongClientNotReadyError{},
+			expectError:     ingresserrors.KongClientNotReadyError{},
 		},
 		{
 			name:            "admin api is in too old version",

--- a/ingress-controller/internal/manager/setup.go
+++ b/ingress-controller/internal/manager/setup.go
@@ -372,8 +372,9 @@ func AdminAPIClientFromServiceDiscovery(
 			// log the error if the error is NOT caused by 0 available gateway endpoints.
 			if !errors.As(err, &ingresserrors.NoAvailableEndpointsError{}) {
 				logger.V(logging.DebugLevel).Info("Failed to create kong client(s)", "error", err)
+			} else {
+				logger.V(logging.DebugLevel).Info("Failed to create kong client(s), retrying...", "error", err, "delay", delay)
 			}
-			logger.V(logging.DebugLevel).Info("Failed to create kong client(s), retrying...", "error", err, "delay", delay)
 		}),
 	}, retryOpts...)
 

--- a/ingress-controller/internal/manager/setup.go
+++ b/ingress-controller/internal/manager/setup.go
@@ -37,11 +37,13 @@ import (
 	"github.com/kong/kong-operator/ingress-controller/internal/konnect"
 	konnectLicense "github.com/kong/kong-operator/ingress-controller/internal/konnect/license"
 	"github.com/kong/kong-operator/ingress-controller/internal/license"
+	"github.com/kong/kong-operator/ingress-controller/internal/logging"
 	"github.com/kong/kong-operator/ingress-controller/internal/metrics"
 	"github.com/kong/kong-operator/ingress-controller/internal/store"
 	"github.com/kong/kong-operator/ingress-controller/internal/util"
 	"github.com/kong/kong-operator/ingress-controller/internal/util/clock"
 	"github.com/kong/kong-operator/ingress-controller/internal/util/kubernetes/object/status"
+	ingresserrors "github.com/kong/kong-operator/ingress-controller/pkg/errors"
 	managercfg "github.com/kong/kong-operator/ingress-controller/pkg/manager/config"
 	"github.com/kong/kong-operator/ingress-controller/pkg/manager/scheme"
 )
@@ -332,14 +334,6 @@ func adminAPIClients(
 	return clients, nil
 }
 
-type NoAvailableEndpointsError struct {
-	serviceNN k8stypes.NamespacedName
-}
-
-func (e NoAvailableEndpointsError) Error() string {
-	return fmt.Sprintf("no endpoints for service: %q", e.serviceNN)
-}
-
 type AdminAPIsDiscoverer interface {
 	GetAdminAPIsForService(context.Context, client.Client, k8stypes.NamespacedName) (sets.Set[adminapi.DiscoveredAdminAPI], error)
 }
@@ -376,10 +370,10 @@ func AdminAPIClientFromServiceDiscovery(
 		retry.Delay(delay),
 		retry.OnRetry(func(_ uint, err error) {
 			// log the error if the error is NOT caused by 0 available gateway endpoints.
-			if !errors.As(err, &NoAvailableEndpointsError{}) {
-				logger.Error(err, "Failed to create kong client(s)")
+			if !errors.As(err, &ingresserrors.NoAvailableEndpointsError{}) {
+				logger.V(logging.DebugLevel).Info("Failed to create kong client(s)", "error", err)
 			}
-			logger.Error(err, "Failed to create kong client(s), retrying...", "delay", delay)
+			logger.V(logging.DebugLevel).Info("Failed to create kong client(s), retrying...", "error", err, "delay", delay)
 		}),
 	}, retryOpts...)
 
@@ -390,7 +384,7 @@ func AdminAPIClientFromServiceDiscovery(
 			return retry.Unrecoverable(err)
 		}
 		if s.Len() == 0 {
-			return NoAvailableEndpointsError{serviceNN: kongAdminSvcNN}
+			return ingresserrors.NewNoAvailableEndpointsError(kongAdminSvcNN)
 		}
 		adminAPIs = s.UnsortedList()
 		return nil

--- a/ingress-controller/pkg/errors/errors.go
+++ b/ingress-controller/pkg/errors/errors.go
@@ -1,0 +1,22 @@
+package errors
+
+import (
+	"fmt"
+
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+// NoAvailableEndpointsError is returned when there are no endpoints available for a service.
+type NoAvailableEndpointsError struct {
+	serviceNN k8stypes.NamespacedName
+}
+
+// NewNoAvailableEndpointsError creates a new NoAvailableEndpointsError.
+func NewNoAvailableEndpointsError(serviceNN k8stypes.NamespacedName) NoAvailableEndpointsError {
+	return NoAvailableEndpointsError{serviceNN: serviceNN}
+}
+
+// Error implements the error interface for NoAvailableEndpointsError.
+func (e NoAvailableEndpointsError) Error() string {
+	return fmt.Sprintf("no endpoints for service: %q", e.serviceNN)
+}

--- a/ingress-controller/pkg/errors/errors.go
+++ b/ingress-controller/pkg/errors/errors.go
@@ -20,3 +20,19 @@ func NewNoAvailableEndpointsError(serviceNN k8stypes.NamespacedName) NoAvailable
 func (e NoAvailableEndpointsError) Error() string {
 	return fmt.Sprintf("no endpoints for service: %q", e.serviceNN)
 }
+
+// KongClientNotReadyError is returned when the Kong client is not ready to be used yet.
+// This can happen if the Kong Admin API is not reachable, or if it's reachable but `GET /status` does not return 200.
+type KongClientNotReadyError struct {
+	Err error
+}
+
+// Error implements the error interface for KongClientNotReadyError.
+func (e KongClientNotReadyError) Error() string {
+	return fmt.Sprintf("client not ready: %s", e.Err)
+}
+
+// Unwrap allows access to the underlying error wrapped by KongClientNotReadyError.
+func (e KongClientNotReadyError) Unwrap() error {
+	return e.Err
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Added handling for `NoAvailableEndpointsError` and `io.EOF` as transient errors in `handleScheduleInstanceOutcome`.
- Updated the status of `ControlPlane` to reflect retry conditions when transient errors occur.
- Improved logging for better traceability during error handling and retries.

**Which issue this PR fixes**

Fixes #1375 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
