### PR TITLE
fix(controlplane): prevent nil dereference

### DIFF
--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -190,6 +190,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{}, err
 		}
 		log.Debug(logger, "no existing dataplane for controlplane", "error", err)
+		return ctrl.Result{}, err
 	} else {
 		dataplaneIngressServiceName, err = gatewayutils.GetDataPlaneServiceName(ctx, r.Client, dataplane, consts.DataPlaneIngressServiceLabelValue)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Halt the reconciliation when dataplane for controlplane is not found.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
