### PR TITLE
chore: adjust cert generation for KO communication with `DataPlane` and introduce validation

### DIFF
--- a/controller/dataplane/owned_resources.go
+++ b/controller/dataplane/owned_resources.go
@@ -45,7 +45,7 @@ func ensureDataPlaneCertificate(
 	}
 	return secrets.EnsureCertificate(ctx,
 		dataplane,
-		fmt.Sprintf("*.%s.%s.svc", adminServiceNN.Name, adminServiceNN.Namespace),
+		fmt.Sprintf("%s.%s.svc", adminServiceNN.Name, adminServiceNN.Namespace),
 		clusterCASecretNN,
 		usages,
 		keyConfig,

--- a/ingress-controller/internal/adminapi/endpoints.go
+++ b/ingress-controller/internal/adminapi/endpoints.go
@@ -14,11 +14,11 @@ import (
 
 // DiscoveredAdminAPI represents an Admin API discovered from a Kubernetes Service.
 // For field Address use format https://<podIP>:<port>, and for field TLSServerName
-// use format pod.<serviceName>.<namespace>.svc.
+// use format <serviceName>.<namespace>.svc.
 type DiscoveredAdminAPI struct {
 	// Address format is https://10.68.0.5:8444.
 	Address string
-	// TLSServerName format is pod.dataplane-admin-kong-rqwr9-sc49t.default.svc.
+	// TLSServerName format is dataplane-admin-kong-rqwr9-sc49t.default.svc.
 	TLSServerName string
 	// PodRef is the reference to the Pod with the above IP address.
 	PodRef k8stypes.NamespacedName
@@ -178,18 +178,11 @@ func adminAPIFromEndpoint(
 		//   - ipv4 - https://10.244.0.16:8444
 		//   - ipv6 - https://[fd00:10:244::d]:8444
 		Address: fmt.Sprintf("https://%s:%d", podIPAddr, *port.Port),
-		// TLSServerName format doesn't need to include the IP address part, it's the same for
-		// ipv4 and ipv6: pod.dataplane-admin-kong-rqwr9-sc49t.default.svc.
-		// Currently for KGO certificates are generated like that:
-		// *.<service-name>.<namespace>.svc e.g.: *.dataplane-admin-kong-rqwr9-sc49t.default.svc, see
-		// https://github.com/Kong/gateway-operator/blob/8f009b49b622197ac083abae1c3606bc2c35114f/controller/dataplane/owned_resources.go#L30-L53
-		// In case of Ingress Chart TLS never worked out of the box (by default it's disabled), due to hardcoded service name in the
-		// https://github.com/Kong/charts/blob/1903dd5370e2d028ec31f6b3cec1414a55462ebd/charts/kong/templates/service-kong-admin.yaml#L35-L37
-		// Let's follow the same 4-parts pattern here, to satisfy wildcard. The first part
-		// can be arbitral so let's use "pod". Ditching the first part (wildcard certificate) is
-		// problematic, because this requires changes in the certificate generation logic and may
-		// break existing users' setups, but it can be done one day.
-		TLSServerName: fmt.Sprintf("pod.%s.%s.svc", service.Name, service.Namespace),
+		// TLSServerName format doesn't need to include the IP address part,
+		// it's the same for ipv4 and ipv6: dataplane-admin-kong-rqwr9-sc49t.default.svc.
+		// Certificates are generated like that <service-name>.<namespace>.svc e.g.:
+		// dataplane-admin-kong-rqwr9-sc49t.default.svc, see controller/dataplane/owned_resources.go
+		TLSServerName: fmt.Sprintf("%s.%s.svc", service.Name, service.Namespace),
 		PodRef:        podNN,
 	}, nil
 }

--- a/ingress-controller/internal/adminapi/endpoints_test.go
+++ b/ingress-controller/internal/adminapi/endpoints_test.go
@@ -70,7 +70,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 			want: sets.New(
 				DiscoveredAdminAPI{
 					Address:       "https://[fe80::cae2:65ff:fe7b:2852]:8444",
-					TLSServerName: "pod.kong-admin.ns.svc",
+					TLSServerName: "kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Name: "pod-1", Namespace: namespaceName,
 					},
@@ -98,7 +98,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 			want: sets.New(
 				DiscoveredAdminAPI{
 					Address:       "https://10.0.0.1:8444",
-					TLSServerName: "pod.kong-admin.ns.svc",
+					TLSServerName: "kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Name: "pod-1", Namespace: namespaceName,
 					},
@@ -127,7 +127,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 			want: sets.New(
 				DiscoveredAdminAPI{
 					Address:       "https://10.0.0.1:8444",
-					TLSServerName: "pod.kong-admin.ns.svc",
+					TLSServerName: "kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Name: "pod-1", Namespace: namespaceName,
 					},
@@ -155,7 +155,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 			want: sets.New(
 				DiscoveredAdminAPI{
 					Address:       "https://10.0.0.1:8444",
-					TLSServerName: "pod.kong-admin.ns.svc",
+					TLSServerName: "kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Name: "pod-1", Namespace: namespaceName,
 					},
@@ -257,7 +257,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 			want: sets.New(
 				DiscoveredAdminAPI{
 					Address:       "https://10.0.0.1:8444",
-					TLSServerName: "pod.kong-admin.ns.svc",
+					TLSServerName: "kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Namespace: namespaceName,
 						Name:      "pod-1",
@@ -265,7 +265,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 				},
 				DiscoveredAdminAPI{
 					Address:       "https://10.0.1.1:8444",
-					TLSServerName: "pod.kong-admin.ns.svc",
+					TLSServerName: "kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Namespace: namespaceName,
 						Name:      "pod-2",
@@ -353,7 +353,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 			want: sets.New(
 				DiscoveredAdminAPI{
 					Address:       "https://10.0.0.1:8443",
-					TLSServerName: "pod.kong-admin.ns.svc",
+					TLSServerName: "kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Namespace: namespaceName,
 						Name:      "pod-1",
@@ -361,7 +361,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 				},
 				DiscoveredAdminAPI{
 					Address:       "https://10.0.0.1:8444",
-					TLSServerName: "pod.kong-admin.ns.svc",
+					TLSServerName: "kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Namespace: namespaceName,
 						Name:      "pod-1",
@@ -524,7 +524,7 @@ func TestDiscoverer_GetAdminAPIsForService(t *testing.T) {
 			want: sets.New(
 				DiscoveredAdminAPI{
 					Address:       "https://10.0.0.1:8444",
-					TLSServerName: "pod.kong-admin.ns.svc",
+					TLSServerName: "kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Namespace: namespaceName,
 						Name:      "pod-1",
@@ -532,7 +532,7 @@ func TestDiscoverer_GetAdminAPIsForService(t *testing.T) {
 				},
 				DiscoveredAdminAPI{
 					Address:       "https://9.0.0.1:8444",
-					TLSServerName: "pod.kong-admin.ns.svc",
+					TLSServerName: "kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Namespace: namespaceName,
 						Name:      "pod-2",

--- a/ingress-controller/internal/adminapi/kong.go
+++ b/ingress-controller/internal/adminapi/kong.go
@@ -135,6 +135,9 @@ func makeHTTPClient(opts managercfg.AdminAPIClientConfig, kongAdminToken string)
 
 	if opts.TLSSkipVerify {
 		tlsConfig.InsecureSkipVerify = true //nolint:gosec
+		if opts.TLSServerName != "" || opts.CACertPath != "" || opts.CACert != "" || !opts.TLSClient.IsZero() {
+			return nil, errors.New("when TLSSkipVerify is set, no other TLS options can be set")
+		}
 	}
 
 	tlsConfig.ServerName = opts.TLSServerName

--- a/ingress-controller/internal/adminapi/kong_test.go
+++ b/ingress-controller/internal/adminapi/kong_test.go
@@ -36,6 +36,13 @@ func TestAdminAPIClientWithTLSOpts(t *testing.T) {
 		},
 	}
 
+	t.Run("with mutually exclusive options set, it should fail", func(t *testing.T) {
+		optsConflict := opts
+		optsConflict.TLSSkipVerify = true
+		_, err := adminapi.NewKongAPIClient("https://localhost", optsConflict, "")
+		require.ErrorContains(t, err, "when TLSSkipVerify is set, no other TLS options can be set")
+	})
+
 	t.Run("without kong admin token", func(t *testing.T) {
 		validate(t, opts, caCert, cert, key, "")
 	})
@@ -81,6 +88,13 @@ func TestAdminAPIClientWithTLSOptsAndFilePaths(t *testing.T) {
 			KeyFile:  certPrivateKeyFile.Name(),
 		},
 	}
+
+	t.Run("with mutually exclusive options set, it should fail", func(t *testing.T) {
+		optsConflict := opts
+		optsConflict.TLSSkipVerify = true
+		_, err := adminapi.NewKongAPIClient("https://localhost", optsConflict, "")
+		require.ErrorContains(t, err, "when TLSSkipVerify is set, no other TLS options can be set")
+	})
 
 	t.Run("without kong admin token", func(t *testing.T) {
 		validate(t, opts, caCert, cert, key, "")

--- a/ingress-controller/test/envtest/kongadminapi_controller_envtest_test.go
+++ b/ingress-controller/test/envtest/kongadminapi_controller_envtest_test.go
@@ -127,7 +127,7 @@ func TestKongAdminAPIController(t *testing.T) {
 	client, err := ctrlclient.New(cfg, ctrlclient.Options{})
 	require.NoError(t, err)
 	getTLSServerName := func(adminSvc corev1.Service) string {
-		return fmt.Sprintf("pod.%s.%s.svc", adminSvc.Name, adminSvc.Namespace)
+		return fmt.Sprintf("%s.%s.svc", adminSvc.Name, adminSvc.Namespace)
 	}
 
 	t.Run("Endpoints are matched properly", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Since KIC and KGO have become KO, and a new independent chart has been introduced, it's no longer a breaking change to simplify the service name for the TLS certificate (to not include `pod` prefix to satisfy wildcard). Furthermore, implement secure by design and by default principles for configuring skipping TLS cert verification - that option can be set mutually exclusive with other TLS-related options.

From the users' perspective, those who use KO, this change is transparent 

**Which issue this PR fixes**

Closes #1109
Closes #1381

**Special notes for your reviewer**:

There is usage of that option in `ingress-controller` e2e test YAMLs, but since

- https://github.com/Kong/kong-operator/issues/1903

must be handled, and those tests are not run, it doesn't make sense to touch them in this PR.
