### PR TITLE
chore: use ctrl.GetConfig() to get REST config based on kubectl context

### DIFF
--- a/ingress-controller/internal/cmd/rootcmd/config/cli.go
+++ b/ingress-controller/internal/cmd/rootcmd/config/cli.go
@@ -95,7 +95,6 @@ func (c *CLIConfig) bindFlagSet() {
 		"Timeout of readiness checks on gateway admin clients.")
 
 	// Kong Proxy and Proxy Cache configurations
-	flagSet.StringVar(&c.APIServerHost, "apiserver-host", "", `The Kubernetes API server URL. If not set, the controller will use cluster config discovery.`)
 	flagSet.IntVar(&c.APIServerQPS, "apiserver-qps", 100, "The Kubernetes API RateLimiter maximum queries per second.")
 	flagSet.IntVar(&c.APIServerBurst, "apiserver-burst", 300, "The Kubernetes API RateLimiter maximum burst queries per second.")
 	flagSet.StringVar(&c.MetricsAddr, "metrics-bind-address", fmt.Sprintf(":%v", consts.MetricsPort), "The address the metric endpoint binds to.")


### PR DESCRIPTION
**What this PR does / why we need it**:

Use `ctrl.GetConfig()` to allow running operator with `kubectl` based context.

Without this change, locally run operator always returns:

```
W0731 13:04:58.319422   68126 client_config.go:667] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
W0731 13:04:58.319451   68126 client_config.go:672] error creating inClusterConfig, falling back to default config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
{"level":"error","ts":"2025-07-31T13:04:58.319+0200","msg":"failed to run manager","error":"invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable","errorCauses":[{"error":"no configuration has been provided, try setting KUBERNETES_MASTER environment variable"}],"stacktrace":"main.main\n\t/Users/patryk.malek@konghq.com/code_/gateway-operator/cmd/main.go:42\nruntime.main\n\t/Users/patryk.malek@konghq.com/.gvm/gos/go1.24.4/src/runtime/proc.go:283"}
```

Additionally this drops the `apiserver-host` CLI flag from ingress-controller which is unused ( as all the other flags from ingress-controller but that one was related to this change).

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
