### PR TITLE
chore: remove ControlPlane metrics TODO

### DIFF
--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -406,8 +406,9 @@ func (r *Reconciler) constructControlPlaneManagerConfigOptions(
 		WithFeatureGates(logger, cp.Spec.FeatureGates),
 		WithControllers(logger, cp.Spec.Controllers),
 		WithIngressClass(cp.Spec.IngressClass),
-
-		// TODO: https://github.com/kong/kong-operator/issues/1749 metrics.
+		// We disable the metrics server by default, as all the ControlPlane metrics
+		// are exposed via the operator's metrics server (through a shared, global
+		// metrics registry handle).
 		WithMetricsServerOff(),
 		WithAnonymousReports(r.AnonymousReportsEnabled),
 		WithAnonymousReportsFixedPayloadCustomizer(payloadCustomizer),

--- a/ingress-controller/internal/cmd/rootcmd/config/cli.go
+++ b/ingress-controller/internal/cmd/rootcmd/config/cli.go
@@ -98,7 +98,6 @@ func (c *CLIConfig) bindFlagSet() {
 	flagSet.StringVar(&c.APIServerHost, "apiserver-host", "", `The Kubernetes API server URL. If not set, the controller will use cluster config discovery.`)
 	flagSet.IntVar(&c.APIServerQPS, "apiserver-qps", 100, "The Kubernetes API RateLimiter maximum queries per second.")
 	flagSet.IntVar(&c.APIServerBurst, "apiserver-burst", 300, "The Kubernetes API RateLimiter maximum burst queries per second.")
-	flagSet.StringVar(&c.MetricsAddr, "metrics-bind-address", fmt.Sprintf(":%v", consts.MetricsPort), "The address the metric endpoint binds to.")
 	flagSet.Var(flags.NewValidatedValue(&c.MetricsAccessFilter, metricsAccessFilterFromFlagValue, flags.WithDefault(managercfg.MetricsAccessFilterOff)), "metrics-access-filter", "Specifies the filter access function to be used for accessing the metrics endpoint (possible values: off, rbac).")
 	flagSet.StringVar(&c.ProbeAddr, "health-probe-bind-address", fmt.Sprintf(":%v", consts.HealthzPort), "The address the probe endpoint binds to.")
 	flagSet.DurationVar(&c.ProxySyncInterval, "proxy-sync-interval", dataplane.DefaultSyncInterval, "Define the rate in which configuration updates will be applied to the Kong Admin API.")

--- a/ingress-controller/pkg/manager/config_test.go
+++ b/ingress-controller/pkg/manager/config_test.go
@@ -44,7 +44,7 @@ func TestNewConfig(t *testing.T) {
 			APIServerCAData:                        nil,
 			APIServerCertData:                      nil,
 			APIServerKeyData:                       nil,
-			MetricsAddr:                            ":10255",
+			MetricsAddr:                            "",
 			MetricsAccessFilter:                    "off",
 			ProbeAddr:                              ":10254",
 			KongAdminURLs:                          []string{"http://localhost:8001"},


### PR DESCRIPTION
**What this PR does / why we need it**:

Metrics are already served through a shared instance of prometheus registry and are served through operator's metrics server.

**Which issue this PR fixes**

Fixes #1749

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
