### PR TITLE
feat(controlplane): check watch namespaces set on ControlPlane with operator flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,11 @@
 - Introduce the flag `--watch-namespaces` to specify which namespaces the operator
   should watch for configuration resources.
   The default value is `""` which makes the operator watch all namespaces.
+  This flag is checked against the `ControlPlane`'s `spec.watchNamespaces`
+  field during `ControlPlane` reconciliation and if incompatible, `ControlPlane`
+  reconciliation returns with an error.
   [#1958](https://github.com/Kong/kong-operator/pull/1958)
+  [#1974](https://github.com/Kong/kong-operator/pull/1974)
 
 ### Fixed
 

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -245,7 +245,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	log.Trace(logger, "validating WatchNamespaceGrants exist for the ControlPlane")
 	validatedWatchNamespaces, err := r.validateWatchNamespaceGrants(ctx, cp)
-	if err != nil { //nolint:gocritic
+	if err != nil {
 		// If there was an error validating the WatchNamespaceGrants, we set the condition
 		// to false indicating that the WatchNamespaceGrants are invalid or missing.
 

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -23,7 +23,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	kcfgcontrolplane "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/controlplane"
 	kcfgdataplane "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/dataplane"
+	operatorv1alpha1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1alpha1"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1beta1"
 	operatorv2alpha1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v2alpha1"
 	konnectv1alpha2 "github.com/kong/kubernetes-configuration/v2/api/konnect/v1alpha2"
@@ -72,6 +74,9 @@ type Reconciler struct {
 	// ConfigMapLabelSelector is the label selector configured at the oprator level.
 	// When not empty, it is used as the config map label selector of all ingress cotrollers' managers.
 	ConfigMapLabelSelector string
+
+	// WatchNamespaces is a list of namespaces to watch. If empty (default), all namespaces are watched.
+	WatchNamespaces []string
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -82,7 +87,10 @@ func (r *Reconciler) SetupWithManager(_ context.Context, mgr ctrl.Manager) error
 		}).
 		For(&ControlPlane{}).
 		// Watch for changes in Secret objects that are owned by ControlPlane objects.
-		Owns(&corev1.Secret{})
+		Owns(&corev1.Secret{}).
+		Watches(
+			&operatorv1alpha1.WatchNamespaceGrant{},
+			handler.EnqueueRequestsFromMapFunc(r.listControlPlanesForWatchNamespaceGrants))
 
 	if r.KonnectEnabled {
 		// Watch for changes in KonnectExtension objects that are referenced by ControlPlane objects.
@@ -227,6 +235,55 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		log.Debug(logger, "DataPlane not set, deployment for ControlPlane will remain dormant")
 	}
 
+	log.Trace(logger, "validating watch namespaces for the ControlPlane")
+	if err := validateWatchNamespaces(cp, r.WatchNamespaces); err != nil {
+		// TODO: Set status condition on the ControlPlane.
+		// https://github.com/Kong/kong-operator/issues/1975
+		log.Debug(logger, "watch namespaces validation failed", "error", err)
+		return ctrl.Result{}, err
+	}
+
+	log.Trace(logger, "validating WatchNamespaceGrants exist for the ControlPlane")
+	validatedWatchNamespaces, err := r.validateWatchNamespaceGrants(ctx, cp)
+	if err != nil { //nolint:gocritic
+		k8sutils.SetCondition(
+			k8sutils.NewConditionWithGeneration(
+				kcfgcontrolplane.ConditionTypeWatchNamespaceGrantValid,
+				metav1.ConditionFalse,
+				kcfgcontrolplane.ConditionReasonWatchNamespaceGrantInvalid,
+				fmt.Sprintf("WatchNamespaceGrant(s) are missing or invalid for the ControlPlane: %v", err),
+				cp.GetGeneration(),
+			),
+			cp,
+		)
+		// We do not return here as we want to proceed with reconciling the Deployment.
+		// This will prevent users using the ControlPlane with previous
+		// WatchNamespaces spec.
+		// We do not patch the status here either because that's done below.
+	} else if cp.Spec.WatchNamespaces != nil {
+		k8sutils.SetCondition(
+			k8sutils.NewConditionWithGeneration(
+				kcfgcontrolplane.ConditionTypeWatchNamespaceGrantValid,
+				metav1.ConditionTrue,
+				kcfgcontrolplane.ConditionReasonWatchNamespaceGrantValid,
+				"WatchNamespaceGrant(s) are present and valid",
+				cp.GetGeneration(),
+			),
+			cp,
+		)
+	} else {
+		k8sutils.SetCondition(
+			k8sutils.NewConditionWithGeneration(
+				kcfgcontrolplane.ConditionTypeWatchNamespaceGrantValid,
+				metav1.ConditionTrue,
+				kcfgcontrolplane.ConditionReasonWatchNamespaceGrantValid,
+				"WatchNamespaceGrant(s) not required",
+				cp.GetGeneration(),
+			),
+			cp,
+		)
+	}
+
 	var caSecret corev1.Secret
 	if err := r.Get(ctx, types.NamespacedName{
 		Namespace: r.ClusterCASecretNamespace,
@@ -249,7 +306,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 			log.Debug(logger, "control plane instance not found, creating new instance")
 			cfgOpts, err := r.constructControlPlaneManagerConfigOptions(
-				logger, cp, &caSecret, mtlsSecret, dataplaneAdminServiceName, dataplaneIngressServiceName, r.RestConfig.Burst, r.RestConfig.QPS,
+				logger, cp, &caSecret, mtlsSecret, dataplaneAdminServiceName, dataplaneIngressServiceName,
+				r.RestConfig.Burst, r.RestConfig.QPS, validatedWatchNamespaces,
 			)
 			if err != nil {
 				return ctrl.Result{}, err
@@ -274,7 +332,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	} else {
 		// Calculate the hash of config from the ControlPlane spec.
 		cfgOpts, err := r.constructControlPlaneManagerConfigOptions(
-			logger, cp, &caSecret, mtlsSecret, dataplaneAdminServiceName, dataplaneIngressServiceName, r.RestConfig.Burst, r.RestConfig.QPS,
+			logger, cp, &caSecret, mtlsSecret, dataplaneAdminServiceName, dataplaneIngressServiceName,
+			r.RestConfig.Burst, r.RestConfig.QPS, validatedWatchNamespaces,
 		)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -357,6 +416,7 @@ func (r *Reconciler) constructControlPlaneManagerConfigOptions(
 	dataplaneIngressServiceName string,
 	apiServerBurst int,
 	apiServerQPS float32,
+	validatedWatchNamespaces []string,
 ) ([]managercfg.Opt, error) {
 	// TODO: https://github.com/kong/kong-operator/issues/1361
 	// Configure the manager with Konnect options if KonnectExtension is attached to the ControlPlane.
@@ -413,6 +473,7 @@ func (r *Reconciler) constructControlPlaneManagerConfigOptions(
 		WithQPSAndBurst(apiServerQPS, apiServerBurst),
 		WithEmitKubernetesEvents(r.EmitKubernetesEvents),
 		WithTranslationOptions(cp.Spec.Translation),
+		WithWatchNamespaces(validatedWatchNamespaces),
 	}
 
 	if r.SecretLabelSelector != "" {

--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -234,13 +234,11 @@ func validateWatchNamespaces(
 			return nil
 		}
 
-		for _, ns := range cp.Spec.WatchNamespaces.List {
-			if !lo.Contains(watchNamespaces, ns) {
-				return fmt.Errorf(
-					"ControlPlane's watchNamespaces requests %v, but operator is only allowed on: %v",
-					ns, watchNamespaces,
-				)
-			}
+		if !lo.Every(watchNamespaces, cp.Spec.WatchNamespaces.List) {
+			return fmt.Errorf(
+				"ControlPlane's watchNamespaces requests %v, but operator is only allowed on: %v",
+				cp.Spec.WatchNamespaces.List, watchNamespaces,
+			)
 		}
 	}
 

--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -176,7 +176,10 @@ func ensureWatchNamespaceGrantsForNamespace(
 		return fmt.Errorf("failed listing WatchNamespaceGrants in namespace %s: %w", ns, err)
 	}
 	for _, grant := range grants.Items {
-		if !watchNamespaceGrantContainsControlPlaneFrom(grant, cp) {
+		if watchNamespaceGrantContainsControlPlaneFrom(grant, cp) {
+		// return nil if there is one grant allows the CP to watch the namespace.
+		    return nil
+		}
 			continue
 		}
 

--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -177,13 +177,9 @@ func ensureWatchNamespaceGrantsForNamespace(
 	}
 	for _, grant := range grants.Items {
 		if watchNamespaceGrantContainsControlPlaneFrom(grant, cp) {
-		// return nil if there is one grant allows the CP to watch the namespace.
-		    return nil
+			// return nil if there is one grant allows the CP to watch the namespace.
+			return nil
 		}
-			continue
-		}
-
-		return nil
 	}
 	return fmt.Errorf("WatchNamespaceGrant in Namespace %s to ControlPlane in Namespace %s not found", ns, cp.Namespace)
 }

--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -222,10 +222,13 @@ func validateWatchNamespaces(
 		}
 
 	case operatorv2alpha1.WatchNamespacesTypeOwn:
+		// NOTE: In case the operator Pod does not have watch namespaces flag/environment variable set
+		// to include the ControlPlane's namespace, it will not be able to watch
+		// the ControlPlane's own namespace, which is required for the operator to function properly.
 		if len(watchNamespaces) > 0 && !lo.Contains(watchNamespaces, cp.Namespace) {
 			return fmt.Errorf(
-				"ControlPlane's watchNamespaces is set to 'Own', but operator is only allowed on: %v",
-				watchNamespaces,
+				"ControlPlane's watchNamespaces is set to 'Own' (current ControlPlane namespace: %v), but operator is only allowed on: %v",
+				cp.Namespace, watchNamespaces,
 			)
 		}
 

--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -2,8 +2,10 @@ package controlplane
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/samber/lo"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kcfgcontrolplane "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/controlplane"
+	operatorv1alpha1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1alpha1"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1beta1"
 	operatorv2alpha1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v2alpha1"
 
@@ -44,7 +47,7 @@ func (r *Reconciler) ensureIsMarkedScheduled(
 }
 
 // ensureDataPlaneStatus ensures that the dataplane is in the correct state
-// to carry on with the controlplane deployments reconciliation.
+// to carry on with the controlplane reconciliation.
 // Information about the missing dataplane is stored in the controlplane status.
 func (r *Reconciler) ensureDataPlaneStatus(
 	cp *ControlPlane,
@@ -119,4 +122,127 @@ func (r *Reconciler) ensureAdminMTLSCertificateSecret(
 		r.Client,
 		matchingLabels,
 	)
+}
+
+func (r *Reconciler) validateWatchNamespaceGrants(
+	ctx context.Context,
+	cp *ControlPlane,
+) ([]string, error) {
+	if cp.Spec.WatchNamespaces == nil {
+		return nil, errors.New("spec.watchNamespaces cannot be empty")
+	}
+
+	switch cp.Spec.WatchNamespaces.Type {
+	// NOTE: We currentlty do not require any ReferenceGrants or other permission
+	// granting resources for the "All" case.
+	case operatorv2alpha1.WatchNamespacesTypeAll:
+		return nil, nil
+	// No special permissions are required to watch the controlplane's own namespace.
+	case operatorv2alpha1.WatchNamespacesTypeOwn:
+		return []string{cp.Namespace}, nil
+	case operatorv2alpha1.WatchNamespacesTypeList:
+		var nsList []string
+		for _, ns := range cp.Spec.WatchNamespaces.List {
+			if err := ensureWatchNamespaceGrantsForNamespace(ctx, r.Client, cp, ns); err != nil {
+				return nsList, err
+			}
+			nsList = append(nsList, ns)
+		}
+		// Add ControlPlane's own namespace as it will add it anyway because
+		// that's where the default "publish service" exists.
+		// We add it here as we do not require a ReferenceGrant for own namespace
+		// so there's no validation whether a grant exists.
+		nsList = append(nsList, cp.Namespace)
+
+		return nsList, nil
+	default:
+		return nil, fmt.Errorf("unexpected watchNamespaces.type: %q", cp.Spec.WatchNamespaces.Type)
+	}
+}
+
+// +kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=watchnamespacegrants,verbs=list
+
+// ensureWatchNamespaceGrantsForNamespace ensures that a WatchNamespaceGrant exists for the
+// given namespace and ControlPlane.
+// It returns an error if a WatchNamespaceGrant is missing.
+func ensureWatchNamespaceGrantsForNamespace(
+	ctx context.Context,
+	cl client.Client,
+	cp *ControlPlane,
+	ns string,
+) error {
+	var grants operatorv1alpha1.WatchNamespaceGrantList
+	if err := cl.List(ctx, &grants, client.InNamespace(ns)); err != nil {
+		return fmt.Errorf("failed listing WatchNamespaceGrants in namespace %s: %w", ns, err)
+	}
+	for _, grant := range grants.Items {
+		if !watchNamespaceGrantContainsControlPlaneFrom(grant, cp) {
+			continue
+		}
+
+		return nil
+	}
+	return fmt.Errorf("WatchNamespaceGrant in Namespace %s to ControlPlane in Namespace %s not found", ns, cp.Namespace)
+}
+
+func watchNamespaceGrantContainsControlPlaneFrom(
+	grant operatorv1alpha1.WatchNamespaceGrant,
+	cp *ControlPlane,
+) bool {
+	for _, from := range grant.Spec.From {
+		if from.Group == operatorv2alpha1.SchemeGroupVersion.Group &&
+			from.Kind == "ControlPlane" &&
+			from.Namespace == cp.Namespace {
+			return true
+		}
+	}
+	return false
+}
+
+// validateWatchNamespaces validates that the operator's watch namespaces are compatible
+// with the ControlPlane's watch namespaces configuration.
+func validateWatchNamespaces(
+	cp *ControlPlane,
+	watchNamespaces []string,
+) error {
+	if cp.Spec.WatchNamespaces == nil {
+		return nil
+	}
+
+	// If ControlPlane is configured to watch all namespaces, operator should
+	// not be configured to watch any specific namespaces: it should have the watchNamespaces
+	// list empty, indicating that it will watch all namespaces.
+	switch cp.Spec.WatchNamespaces.Type {
+	case operatorv2alpha1.WatchNamespacesTypeAll:
+		if len(watchNamespaces) > 0 {
+			return fmt.Errorf(
+				"ControlPlane's watchNamespaces is set to 'All', but operator is only allowed on: %v",
+				watchNamespaces,
+			)
+		}
+
+	case operatorv2alpha1.WatchNamespacesTypeOwn:
+		if len(watchNamespaces) > 0 && !lo.Contains(watchNamespaces, cp.Namespace) {
+			return fmt.Errorf(
+				"ControlPlane's watchNamespaces is set to 'Own', but operator is only allowed on: %v",
+				watchNamespaces,
+			)
+		}
+
+	case operatorv2alpha1.WatchNamespacesTypeList:
+		if len(watchNamespaces) == 0 {
+			return nil
+		}
+
+		for _, ns := range cp.Spec.WatchNamespaces.List {
+			if !lo.Contains(watchNamespaces, ns) {
+				return fmt.Errorf(
+					"ControlPlane's watchNamespaces requests %v, but operator is only allowed on: %v",
+					ns, watchNamespaces,
+				)
+			}
+		}
+	}
+
+	return nil
 }

--- a/controller/controlplane/controller_reconciler_utils_test.go
+++ b/controller/controlplane/controller_reconciler_utils_test.go
@@ -1,0 +1,485 @@
+package controlplane
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	operatorv1alpha1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1alpha1"
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1beta1"
+	operatorv2alpha1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v2alpha1"
+
+	"github.com/kong/kong-operator/modules/manager/scheme"
+)
+
+func TestEnsureWatchNamespaceGrantsForNamespace(t *testing.T) {
+	tests := []struct {
+		name                string
+		namespace           string
+		controlPlane        *ControlPlane
+		existingGrants      []client.Object
+		expectedError       bool
+		expectedErrorString string
+	}{
+		{
+			name:      "grant exists for controlplane",
+			namespace: "target-ns",
+			controlPlane: &ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "cp-ns",
+				},
+			},
+			existingGrants: []client.Object{
+				&operatorv1alpha1.WatchNamespaceGrant{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "grant-1",
+						Namespace: "target-ns",
+					},
+					Spec: operatorv1alpha1.WatchNamespaceGrantSpec{
+						From: []operatorv1alpha1.WatchNamespaceGrantFrom{
+							{
+								Group:     operatorv1beta1.SchemeGroupVersion.Group,
+								Kind:      "ControlPlane",
+								Namespace: "cp-ns",
+							},
+						},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name:      "no grants exist in namespace",
+			namespace: "target-ns",
+			controlPlane: &ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "cp-ns",
+				},
+			},
+			existingGrants:      []client.Object{},
+			expectedError:       true,
+			expectedErrorString: "WatchNamespaceGrant in Namespace target-ns to ControlPlane in Namespace cp-ns not found",
+		},
+		{
+			name:      "grant exists but for different namespace",
+			namespace: "target-ns",
+			controlPlane: &ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "cp-ns",
+				},
+			},
+			existingGrants: []client.Object{
+				&operatorv1alpha1.WatchNamespaceGrant{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "grant-1",
+						Namespace: "target-ns",
+					},
+					Spec: operatorv1alpha1.WatchNamespaceGrantSpec{
+						From: []operatorv1alpha1.WatchNamespaceGrantFrom{
+							{
+								Group:     operatorv1beta1.SchemeGroupVersion.Group,
+								Kind:      "ControlPlane",
+								Namespace: "different-ns",
+							},
+						},
+					},
+				},
+			},
+			expectedError:       true,
+			expectedErrorString: "WatchNamespaceGrant in Namespace target-ns to ControlPlane in Namespace cp-ns not found",
+		},
+		{
+			name:      "grant exists but for different kind",
+			namespace: "target-ns",
+			controlPlane: &ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "cp-ns",
+				},
+			},
+			existingGrants: []client.Object{
+				&operatorv1alpha1.WatchNamespaceGrant{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "grant-1",
+						Namespace: "target-ns",
+					},
+					Spec: operatorv1alpha1.WatchNamespaceGrantSpec{
+						From: []operatorv1alpha1.WatchNamespaceGrantFrom{
+							{
+								Group:     operatorv1beta1.SchemeGroupVersion.Group,
+								Kind:      "DataPlane",
+								Namespace: "cp-ns",
+							},
+						},
+					},
+				},
+			},
+			expectedError:       true,
+			expectedErrorString: "WatchNamespaceGrant in Namespace target-ns to ControlPlane in Namespace cp-ns not found",
+		},
+		{
+			name:      "grant exists but for different group",
+			namespace: "target-ns",
+			controlPlane: &ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "cp-ns",
+				},
+			},
+			existingGrants: []client.Object{
+				&operatorv1alpha1.WatchNamespaceGrant{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "grant-1",
+						Namespace: "target-ns",
+					},
+					Spec: operatorv1alpha1.WatchNamespaceGrantSpec{
+						From: []operatorv1alpha1.WatchNamespaceGrantFrom{
+							{
+								Group:     "different.group",
+								Kind:      "ControlPlane",
+								Namespace: "cp-ns",
+							},
+						},
+					},
+				},
+			},
+			expectedError:       true,
+			expectedErrorString: "WatchNamespaceGrant in Namespace target-ns to ControlPlane in Namespace cp-ns not found",
+		},
+		{
+			name:      "multiple grants exist, one matches",
+			namespace: "target-ns",
+			controlPlane: &ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "cp-ns",
+				},
+			},
+			existingGrants: []client.Object{
+				&operatorv1alpha1.WatchNamespaceGrant{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "grant-1",
+						Namespace: "target-ns",
+					},
+					Spec: operatorv1alpha1.WatchNamespaceGrantSpec{
+						From: []operatorv1alpha1.WatchNamespaceGrantFrom{
+							{
+								Group:     "different.group",
+								Kind:      "ControlPlane",
+								Namespace: "cp-ns",
+							},
+						},
+					},
+				},
+				&operatorv1alpha1.WatchNamespaceGrant{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "grant-2",
+						Namespace: "target-ns",
+					},
+					Spec: operatorv1alpha1.WatchNamespaceGrantSpec{
+						From: []operatorv1alpha1.WatchNamespaceGrantFrom{
+							{
+								Group:     operatorv1beta1.SchemeGroupVersion.Group,
+								Kind:      "ControlPlane",
+								Namespace: "cp-ns",
+							},
+						},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name:      "grant with multiple from entries, one matches",
+			namespace: "target-ns",
+			controlPlane: &ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "cp-ns",
+				},
+			},
+			existingGrants: []client.Object{
+				&operatorv1alpha1.WatchNamespaceGrant{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "grant-1",
+						Namespace: "target-ns",
+					},
+					Spec: operatorv1alpha1.WatchNamespaceGrantSpec{
+						From: []operatorv1alpha1.WatchNamespaceGrantFrom{
+							{
+								Group:     "different.group",
+								Kind:      "ControlPlane",
+								Namespace: "cp-ns",
+							},
+							{
+								Group:     operatorv1beta1.SchemeGroupVersion.Group,
+								Kind:      "ControlPlane",
+								Namespace: "cp-ns",
+							},
+						},
+					},
+				},
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme.Get()).
+				WithObjects(tt.existingGrants...).
+				Build()
+
+			err := ensureWatchNamespaceGrantsForNamespace(t.Context(), cl, tt.controlPlane, tt.namespace)
+
+			if tt.expectedError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrorString)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateWatchNamespaces(t *testing.T) {
+	tests := []struct {
+		name            string
+		controlPlane    *ControlPlane
+		watchNamespaces []string
+		expectedError   bool
+		errorContains   string
+	}{
+		{
+			name: "nil watchNamespaces spec - should pass",
+			controlPlane: &ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "cp-ns",
+				},
+				Spec: operatorv2alpha1.ControlPlaneSpec{
+					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+						WatchNamespaces: nil,
+					},
+				},
+			},
+			watchNamespaces: []string{"ns1", "ns2"},
+			expectedError:   false,
+		},
+		{
+			name: "WatchNamespacesTypeAll - empty operator watchNamespaces - should pass",
+			controlPlane: &ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "cp-ns",
+				},
+				Spec: operatorv2alpha1.ControlPlaneSpec{
+					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
+							Type: operatorv2alpha1.WatchNamespacesTypeAll,
+						},
+					},
+				},
+			},
+			watchNamespaces: []string{},
+			expectedError:   false,
+		},
+		{
+			name: "WatchNamespacesTypeAll - non-empty operator watchNamespaces - should fail",
+			controlPlane: &ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "cp-ns",
+				},
+				Spec: operatorv2alpha1.ControlPlaneSpec{
+					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
+							Type: operatorv2alpha1.WatchNamespacesTypeAll,
+						},
+					},
+				},
+			},
+			watchNamespaces: []string{"ns1", "ns2"},
+			expectedError:   true,
+			errorContains:   "ControlPlane's watchNamespaces is set to 'All', but operator is only allowed on: [ns1 ns2]",
+		},
+		{
+			name: "WatchNamespacesTypeOwn - operator allows own namespace - should pass",
+			controlPlane: &ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "cp-ns",
+				},
+				Spec: operatorv2alpha1.ControlPlaneSpec{
+					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
+							Type: operatorv2alpha1.WatchNamespacesTypeOwn,
+						},
+					},
+				},
+			},
+			watchNamespaces: []string{"cp-ns", "other-ns"},
+			expectedError:   false,
+		},
+		{
+			name: "WatchNamespacesTypeOwn - empty operator watchNamespaces - should pass",
+			controlPlane: &ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "cp-ns",
+				},
+				Spec: operatorv2alpha1.ControlPlaneSpec{
+					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
+							Type: operatorv2alpha1.WatchNamespacesTypeOwn,
+						},
+					},
+				},
+			},
+			watchNamespaces: []string{},
+			expectedError:   false,
+		},
+		{
+			name: "WatchNamespacesTypeOwn - operator doesn't allow own namespace - should fail",
+			controlPlane: &ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "cp-ns",
+				},
+				Spec: operatorv2alpha1.ControlPlaneSpec{
+					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
+							Type: operatorv2alpha1.WatchNamespacesTypeOwn,
+						},
+					},
+				},
+			},
+			watchNamespaces: []string{"ns1", "ns2"},
+			expectedError:   true,
+			errorContains:   "ControlPlane's watchNamespaces is set to 'Own', but operator is only allowed on: [ns1 ns2]",
+		},
+		{
+			name: "WatchNamespacesTypeList - empty operator watchNamespaces - should pass",
+			controlPlane: &ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "cp-ns",
+				},
+				Spec: operatorv2alpha1.ControlPlaneSpec{
+					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
+							Type: operatorv2alpha1.WatchNamespacesTypeList,
+							List: []string{"ns1", "ns2"},
+						},
+					},
+				},
+			},
+			watchNamespaces: []string{},
+			expectedError:   false,
+		},
+		{
+			name: "WatchNamespacesTypeList - all requested namespaces allowed - should pass",
+			controlPlane: &ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "cp-ns",
+				},
+				Spec: operatorv2alpha1.ControlPlaneSpec{
+					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
+							Type: operatorv2alpha1.WatchNamespacesTypeList,
+							List: []string{"ns1", "ns2"},
+						},
+					},
+				},
+			},
+			watchNamespaces: []string{"ns1", "ns2", "ns3"},
+			expectedError:   false,
+		},
+		{
+			name: "WatchNamespacesTypeList - partial match - should fail",
+			controlPlane: &ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "cp-ns",
+				},
+				Spec: operatorv2alpha1.ControlPlaneSpec{
+					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
+							Type: operatorv2alpha1.WatchNamespacesTypeList,
+							List: []string{"ns1", "ns2", "ns3"},
+						},
+					},
+				},
+			},
+			watchNamespaces: []string{"ns1", "ns2"},
+			expectedError:   true,
+			errorContains:   "ControlPlane's watchNamespaces requests ns3, but operator is only allowed on: [ns1 ns2]",
+		},
+		{
+			name: "WatchNamespacesTypeList - no match - should fail",
+			controlPlane: &ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "cp-ns",
+				},
+				Spec: operatorv2alpha1.ControlPlaneSpec{
+					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
+							Type: operatorv2alpha1.WatchNamespacesTypeList,
+							List: []string{"ns1", "ns2"},
+						},
+					},
+				},
+			},
+			watchNamespaces: []string{"ns3", "ns4"},
+			expectedError:   true,
+			errorContains:   "ControlPlane's watchNamespaces requests ns1, but operator is only allowed on: [ns3 ns4]",
+		},
+		{
+			name: "WatchNamespacesTypeList - single namespace not allowed - should fail",
+			controlPlane: &ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "cp-ns",
+				},
+				Spec: operatorv2alpha1.ControlPlaneSpec{
+					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
+							Type: operatorv2alpha1.WatchNamespacesTypeList,
+							List: []string{"forbidden-ns"},
+						},
+					},
+				},
+			},
+			watchNamespaces: []string{"ns1", "ns2"},
+			expectedError:   true,
+			errorContains:   "ControlPlane's watchNamespaces requests forbidden-ns, but operator is only allowed on: [ns1 ns2]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateWatchNamespaces(tt.controlPlane, tt.watchNamespaces)
+
+			if tt.expectedError {
+				require.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/controller/controlplane/controller_reconciler_utils_test.go
+++ b/controller/controlplane/controller_reconciler_utils_test.go
@@ -365,7 +365,7 @@ func TestValidateWatchNamespaces(t *testing.T) {
 			},
 			watchNamespaces: []string{"ns1", "ns2"},
 			expectedError:   true,
-			errorContains:   "ControlPlane's watchNamespaces is set to 'Own', but operator is only allowed on: [ns1 ns2]",
+			errorContains:   "ControlPlane's watchNamespaces is set to 'Own' (current ControlPlane namespace: cp-ns), but operator is only allowed on: [ns1 ns2]",
 		},
 		{
 			name: "WatchNamespacesTypeList - empty operator watchNamespaces - should pass",

--- a/controller/controlplane/controller_reconciler_utils_test.go
+++ b/controller/controlplane/controller_reconciler_utils_test.go
@@ -423,7 +423,7 @@ func TestValidateWatchNamespaces(t *testing.T) {
 			},
 			watchNamespaces: []string{"ns1", "ns2"},
 			expectedError:   true,
-			errorContains:   "ControlPlane's watchNamespaces requests ns3, but operator is only allowed on: [ns1 ns2]",
+			errorContains:   "ControlPlane's watchNamespaces requests [ns1 ns2 ns3], but operator is only allowed on: [ns1 ns2]",
 		},
 		{
 			name: "WatchNamespacesTypeList - no match - should fail",
@@ -443,7 +443,7 @@ func TestValidateWatchNamespaces(t *testing.T) {
 			},
 			watchNamespaces: []string{"ns3", "ns4"},
 			expectedError:   true,
-			errorContains:   "ControlPlane's watchNamespaces requests ns1, but operator is only allowed on: [ns3 ns4]",
+			errorContains:   "ControlPlane's watchNamespaces requests [ns1 ns2], but operator is only allowed on: [ns3 ns4]",
 		},
 		{
 			name: "WatchNamespacesTypeList - single namespace not allowed - should fail",
@@ -463,7 +463,7 @@ func TestValidateWatchNamespaces(t *testing.T) {
 			},
 			watchNamespaces: []string{"ns1", "ns2"},
 			expectedError:   true,
-			errorContains:   "ControlPlane's watchNamespaces requests forbidden-ns, but operator is only allowed on: [ns1 ns2]",
+			errorContains:   "ControlPlane's watchNamespaces requests [forbidden-ns], but operator is only allowed on: [ns1 ns2]",
 		},
 	}
 

--- a/controller/controlplane/controller_watch.go
+++ b/controller/controlplane/controller_watch.go
@@ -1,0 +1,60 @@
+package controlplane
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	operatorv1alpha1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1alpha1"
+	operatorv2alpha1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v2alpha1"
+
+	operatorerrors "github.com/kong/kong-operator/internal/errors"
+)
+
+func (r *Reconciler) listControlPlanesForWatchNamespaceGrants(
+	ctx context.Context,
+	obj client.Object,
+) []reconcile.Request {
+	rg, ok := obj.(*operatorv1alpha1.WatchNamespaceGrant)
+	if !ok {
+		ctrllog.FromContext(ctx).Error(
+			operatorerrors.ErrUnexpectedObject,
+			"failed to map WatchNamespaceGrant on ControlPlane",
+			"expected", "WatchNamespaceGrant", "found", reflect.TypeOf(obj),
+		)
+		return nil
+	}
+
+	fromsForControlPlane := lo.Filter(rg.Spec.From,
+		func(from operatorv1alpha1.WatchNamespaceGrantFrom, _ int) bool {
+			return from.Group == operatorv2alpha1.ControlPlaneGVR().Group &&
+				from.Kind == "ControlPlane"
+		},
+	)
+
+	var recs []reconcile.Request
+	for _, from := range fromsForControlPlane {
+		var controlPlaneList operatorv2alpha1.ControlPlaneList
+		if err := r.List(ctx, &controlPlaneList,
+			client.InNamespace(from.Namespace),
+		); err != nil {
+			ctrllog.FromContext(ctx).Error(err, "failed to map WatchNamespaceGrant to ControlPlane")
+			return nil
+		}
+		for _, cp := range controlPlaneList.Items {
+			recs = append(recs, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: cp.Namespace,
+					Name:      cp.Name,
+				},
+			})
+		}
+	}
+
+	return recs
+}

--- a/controller/controlplane/manager_options.go
+++ b/controller/controlplane/manager_options.go
@@ -509,7 +509,6 @@ func WithDataPlaneSyncOptions(syncOptions operatorv2alpha1.ControlPlaneDataPlane
 func WithEmitKubernetesEvents(emit bool) managercfg.Opt {
 	return func(c *managercfg.Config) {
 		c.EmitKubernetesEvents = emit
-
 	}
 }
 
@@ -566,5 +565,12 @@ func WithConfigDumpEnabled(enabled bool) managercfg.Opt {
 func WithSensitiveConfigDumpEnabled(enabled bool) managercfg.Opt {
 	return func(c *managercfg.Config) {
 		c.DumpSensitiveConfig = enabled
+	}
+}
+
+// WithWatchNamespaces enables/disables watching namespaces for the manager.
+func WithWatchNamespaces(watchNamespaces []string) managercfg.Opt {
+	return func(c *managercfg.Config) {
+		c.WatchNamespaces = watchNamespaces
 	}
 }

--- a/modules/cli/cli.go
+++ b/modules/cli/cli.go
@@ -59,7 +59,7 @@ func New(m metadata.Info) *CLI {
 	flagSet.StringVar(&cfg.ClusterDomain, "cluster-domain", ingressmgrconfig.DefaultClusterDomain, "The cluster domain. This is used e.g. in generating addresses for upstream services.")
 	flagSet.DurationVar(&cfg.CacheSyncPeriod, "cache-sync-period", 0, "Determine the minimum frequency at which watched resources are reconciled. By default or for 0s value, it falls back to controller-runtime's default.")
 	flagSet.BoolVar(&cfg.EmitKubernetesEvents, "emit-kubernetes-events", ingressmgrconfig.DefaultEmitKubernetesEvents, "Emit Kubernetes events for successful configuration applies, translation failures and configuration apply failures on managed objects.")
-	flagSet.StringVar(&cfg.WatchNamespaces, "watch-namespaces", "", "Comma-separated list of namespaces to watch. If empty (default), all namespaces are watched.")
+	flagSet.Var(newValidatedValue(&cfg.WatchNamespaces, manager.NewWatchNamespaces), "watch-namespaces", "Comma-separated list of namespaces to watch. If empty (default), all namespaces are watched.")
 
 	// controllers for standard APIs and features
 	flagSet.BoolVar(&cfg.GatewayControllerEnabled, "enable-controller-gateway", true, "Enable the Gateway controller.")

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -413,6 +413,7 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 				InstancesManager:         cpsMgr,
 				ClusterDomain:            c.ClusterDomain,
 				EmitKubernetesEvents:     c.EmitKubernetesEvents,
+				WatchNamespaces:          c.WatchNamespaces,
 			},
 		},
 		// DataPlane controller

--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -86,8 +86,8 @@ type Config struct {
 	SecretLabelSelector string
 	// ConfigMapLabelSelector specifies the label which will be used to limit the ingestion of configmaps. Only those that have this label set to "true" will be ingested.
 	ConfigMapLabelSelector string
-	// WatchNamespaces is a comma-separated list of namespaces to watch. If empty (default), all namespaces are watched.
-	WatchNamespaces string
+	// WatchNamespaces is a list of namespaces to watch. If empty (default), all namespaces are watched.
+	WatchNamespaces []string
 
 	// ServiceAccountToImpersonate is the name of the service account to impersonate,
 	// by the controller manager, when making requests to the API server.
@@ -208,11 +208,9 @@ func Run(
 	// This is the default behavior of the controller-runtime manager.
 	// If there are configured watch namespaces, then we're watching only those namespaces.
 	if len(cfg.WatchNamespaces) > 0 {
-		watchNamespaces := strings.Split(cfg.WatchNamespaces, ",")
-		setupLog.Info("Manager set up with multiple namespaces", "namespaces", watchNamespaces)
+		setupLog.Info("Manager set up with multiple namespaces", "namespaces", cfg.WatchNamespaces)
 		watched := make(map[string]cache.Config)
-		for _, ns := range watchNamespaces {
-			ns = strings.TrimSpace(ns)
+		for _, ns := range cfg.WatchNamespaces {
 			watched[ns] = cache.Config{}
 		}
 		cacheOptions.DefaultNamespaces = watched

--- a/modules/manager/watchnamespaces.go
+++ b/modules/manager/watchnamespaces.go
@@ -1,0 +1,25 @@
+package manager
+
+import (
+	"errors"
+	"strings"
+)
+
+// NewWatchNamespaces parses the watchNamespaces string and returns a slice
+// of trimmed namespace names.
+func NewWatchNamespaces(watchNamespaces string) ([]string, error) {
+	if watchNamespaces == "" {
+		return nil, nil
+	}
+
+	// Split the namespaces by comma and trim whitespace
+	namespaces := make([]string, 0)
+	for ns := range strings.SplitSeq(watchNamespaces, ",") {
+		ns = strings.TrimSpace(ns)
+		if ns == "" {
+			return nil, errors.New("watchNamespaces cannot contain empty namespace names")
+		}
+		namespaces = append(namespaces, ns)
+	}
+	return namespaces, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

During the development of KO we've removed the watch namespaces related code from `ControlPlane` controller.

This PR brings it back and adds checks which ensure that watch namespace set on `ControlPlane` spec are compatible with what's set through operator's flags/envs.

Most notably:

- When `-watch-namespaces` flag is unset, `ControlPlane`'s `spec.watchNamespaces` can be set to anything. Operator watches all namespaces.
- When `-watch-namespaces` flag is set to a list:
  - `ControlPlane`'s `spec.watchNamespaces` can be set to a list which is a subset of that list or
  - `ControlPlane`'s `spec.watchNamespaces` can be set to `own` option and in that case operator has to include CP's namespace in its `-watch-namespaces`

**Which issue this PR fixes**

Part of #1693

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
