### PR TITLE
fix(controlplane): Fix the invalid label causing ingress controller fails to store license to secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,12 @@
   The default value is `""` which makes the operator watch all namespaces.
   [#1958](https://github.com/Kong/kong-operator/pull/1958)
 
+### Fixed
+
+- Fix the issue that invalid label value causing ingress controller fails to
+  store the license from Konnect into `Secret`.
+  [#1976](https://github.com/Kong/kong-operator/pull/1976)
+
 ## [v2.0.0-alpha.2]
 
 > Release date: 2025-07-23

--- a/ingress-controller/internal/konnect/license/client.go
+++ b/ingress-controller/internal/konnect/license/client.go
@@ -93,8 +93,9 @@ func (c *Client) Get(ctx context.Context) (mo.Option[license.KonnectLicense], er
 	}
 
 	if c.enableLicenseStorage && l.IsPresent() {
-		err = c.licenseStore.Store(ctx, l.MustGet())
-		c.logger.Error(err, "failed to store retrieved license to local storage")
+		if err := c.licenseStore.Store(ctx, l.MustGet()); err != nil {
+			c.logger.Error(err, "failed to store retrieved license to local storage")
+		}
 	}
 
 	return l, nil

--- a/ingress-controller/internal/labels/labels.go
+++ b/ingress-controller/internal/labels/labels.go
@@ -25,7 +25,7 @@ const (
 	// ManagedByLabel is the label key to mark that the object is managed by a specific controller.
 	ManagedByLabel = LabelPrefix + ManagedByKey
 	// ManagedByLabelValueIngressController is the label value that marks the object is managed byu KIC.
-	ManagedByLabelValueIngressController = LabelPrefix + "/ingress-controller"
+	ManagedByLabelValueIngressController = "kong-ingress-controller"
 )
 
 // ValidateType indicates the type of validation applied to a Secret.


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the issue where control plane (ingress-controller package) fails to store license to local `Secret`. Migrated from https://github.com/Kong/kubernetes-ingress-controller/pull/7648.
**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:
How to write changelog here? I think we should put it in the KO changelog but not the embedded `CHANGELOG.md` file in the `ingress-controller` package. That one should be only for archive.
**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
