### PR TITLE
chore: use alias types for ControlPlane related types in v2alpha1

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,6 +7,7 @@ run:
     - conformance_tests
     - istio_tests
     - envtest
+    - performance_tests
 linters:
   enable:
     - asciicheck
@@ -54,13 +55,16 @@ linters:
       default-signifies-exhaustive: true
     forbidigo:
       forbid:
-      # Uncomment or remove - TODO: https://github.com/Kong/kong-operator/issues/1847
+        # Uncomment or remove - TODO: https://github.com/Kong/kong-operator/issues/1847
         # - pattern: ^.*Dataplane[^G].*$
         #   msg: Please use camel case 'DataPlane' instead of 'Dataplane'
         - pattern: ^.*Controlplane.*$
           msg: Please use camel case 'ControlPlane' instead of 'Controlplane'
         - pattern: ^.*operatorv1beta1.ControlPlane.*$
           msg: Please use v2alpha1 ControlPlane (through github.com/kong/kong-operator/internal/types)
+        # NOTE: When all references use the types package, this rule can use .* instead of listing types.
+        - pattern: ^.*operatorv2alpha1.(ControlPlane|ControlPlaneStatus|ControlPlaneList|ControlPlaneSpec|ControlPlaneOptions|ControlPlaneDataPlaneTarget\w*)\b.*$
+          msg: Please use the types package to refer to the type (through github.com/kong/kong-operator/internal/types)
     gomodguard:
       blocked:
         modules:
@@ -195,7 +199,10 @@ linters:
       - linters:
           - gosec
         text: integer overflow conversion
-      # end of section.
+      - linters:
+          - forbidigo
+        path: internal/types/operatortypes.go
+        text: use of `operatorv2alpha1.(ControlPlane\w*)` forbidden
     paths:
       - pkg/clientset
       - config/

--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,10 @@ govulncheck: download.govulncheck
 
 GOLANGCI_LINT_CONFIG ?= $(PROJECT_DIR)/.golangci.yaml
 .PHONY: lint
-lint: golangci-lint lint.modernize
+lint: lint.golangci-lint lint.modernize
+
+.PHONY: lint.golangci-lint
+lint.golangci-lint: golangci-lint
 	$(GOLANGCI_LINT) run -v --config $(GOLANGCI_LINT_CONFIG) $(GOLANGCI_LINT_FLAGS)
 
 .PHONY: lint.modernize

--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/kong/kong-operator/controller/pkg/op"
 	"github.com/kong/kong-operator/controller/pkg/secrets"
+	gwtypes "github.com/kong/kong-operator/internal/types"
 	"github.com/kong/kong-operator/pkg/consts"
 	k8sutils "github.com/kong/kong-operator/pkg/utils/kubernetes"
 )
@@ -54,7 +55,7 @@ func (r *Reconciler) ensureDataPlaneStatus(
 	dataplane *operatorv1beta1.DataPlane,
 ) (dataplaneIsSet bool, err error) {
 	switch cp.Spec.DataPlane.Type {
-	case operatorv2alpha1.ControlPlaneDataPlaneTargetRefType:
+	case gwtypes.ControlPlaneDataPlaneTargetRefType:
 		dataplaneIsSet = cp.Spec.DataPlane.Ref != nil && cp.Spec.DataPlane.Ref.Name == dataplane.Name
 
 		var newCondition metav1.Condition
@@ -91,7 +92,7 @@ func (r *Reconciler) ensureDataPlaneStatus(
 // communication between the ControlPlane and the DataPlane.
 func (r *Reconciler) ensureAdminMTLSCertificateSecret(
 	ctx context.Context,
-	cp *operatorv2alpha1.ControlPlane,
+	cp *gwtypes.ControlPlane,
 ) (
 	op.Result,
 	*corev1.Secret,

--- a/controller/controlplane/controller_reconciler_utils_test.go
+++ b/controller/controlplane/controller_reconciler_utils_test.go
@@ -13,6 +13,7 @@ import (
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1beta1"
 	operatorv2alpha1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v2alpha1"
 
+	gwtypes "github.com/kong/kong-operator/internal/types"
 	"github.com/kong/kong-operator/modules/manager/scheme"
 )
 
@@ -266,8 +267,8 @@ func TestValidateWatchNamespaces(t *testing.T) {
 					Name:      "test-cp",
 					Namespace: "cp-ns",
 				},
-				Spec: operatorv2alpha1.ControlPlaneSpec{
-					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+				Spec: gwtypes.ControlPlaneSpec{
+					ControlPlaneOptions: gwtypes.ControlPlaneOptions{
 						WatchNamespaces: nil,
 					},
 				},
@@ -282,8 +283,8 @@ func TestValidateWatchNamespaces(t *testing.T) {
 					Name:      "test-cp",
 					Namespace: "cp-ns",
 				},
-				Spec: operatorv2alpha1.ControlPlaneSpec{
-					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+				Spec: gwtypes.ControlPlaneSpec{
+					ControlPlaneOptions: gwtypes.ControlPlaneOptions{
 						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
 							Type: operatorv2alpha1.WatchNamespacesTypeAll,
 						},
@@ -300,8 +301,8 @@ func TestValidateWatchNamespaces(t *testing.T) {
 					Name:      "test-cp",
 					Namespace: "cp-ns",
 				},
-				Spec: operatorv2alpha1.ControlPlaneSpec{
-					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+				Spec: gwtypes.ControlPlaneSpec{
+					ControlPlaneOptions: gwtypes.ControlPlaneOptions{
 						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
 							Type: operatorv2alpha1.WatchNamespacesTypeAll,
 						},
@@ -319,8 +320,8 @@ func TestValidateWatchNamespaces(t *testing.T) {
 					Name:      "test-cp",
 					Namespace: "cp-ns",
 				},
-				Spec: operatorv2alpha1.ControlPlaneSpec{
-					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+				Spec: gwtypes.ControlPlaneSpec{
+					ControlPlaneOptions: gwtypes.ControlPlaneOptions{
 						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
 							Type: operatorv2alpha1.WatchNamespacesTypeOwn,
 						},
@@ -337,8 +338,8 @@ func TestValidateWatchNamespaces(t *testing.T) {
 					Name:      "test-cp",
 					Namespace: "cp-ns",
 				},
-				Spec: operatorv2alpha1.ControlPlaneSpec{
-					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+				Spec: gwtypes.ControlPlaneSpec{
+					ControlPlaneOptions: gwtypes.ControlPlaneOptions{
 						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
 							Type: operatorv2alpha1.WatchNamespacesTypeOwn,
 						},
@@ -355,8 +356,8 @@ func TestValidateWatchNamespaces(t *testing.T) {
 					Name:      "test-cp",
 					Namespace: "cp-ns",
 				},
-				Spec: operatorv2alpha1.ControlPlaneSpec{
-					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+				Spec: gwtypes.ControlPlaneSpec{
+					ControlPlaneOptions: gwtypes.ControlPlaneOptions{
 						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
 							Type: operatorv2alpha1.WatchNamespacesTypeOwn,
 						},
@@ -374,8 +375,8 @@ func TestValidateWatchNamespaces(t *testing.T) {
 					Name:      "test-cp",
 					Namespace: "cp-ns",
 				},
-				Spec: operatorv2alpha1.ControlPlaneSpec{
-					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+				Spec: gwtypes.ControlPlaneSpec{
+					ControlPlaneOptions: gwtypes.ControlPlaneOptions{
 						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
 							Type: operatorv2alpha1.WatchNamespacesTypeList,
 							List: []string{"ns1", "ns2"},
@@ -393,8 +394,8 @@ func TestValidateWatchNamespaces(t *testing.T) {
 					Name:      "test-cp",
 					Namespace: "cp-ns",
 				},
-				Spec: operatorv2alpha1.ControlPlaneSpec{
-					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+				Spec: gwtypes.ControlPlaneSpec{
+					ControlPlaneOptions: gwtypes.ControlPlaneOptions{
 						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
 							Type: operatorv2alpha1.WatchNamespacesTypeList,
 							List: []string{"ns1", "ns2"},
@@ -412,8 +413,8 @@ func TestValidateWatchNamespaces(t *testing.T) {
 					Name:      "test-cp",
 					Namespace: "cp-ns",
 				},
-				Spec: operatorv2alpha1.ControlPlaneSpec{
-					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+				Spec: gwtypes.ControlPlaneSpec{
+					ControlPlaneOptions: gwtypes.ControlPlaneOptions{
 						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
 							Type: operatorv2alpha1.WatchNamespacesTypeList,
 							List: []string{"ns1", "ns2", "ns3"},
@@ -432,8 +433,8 @@ func TestValidateWatchNamespaces(t *testing.T) {
 					Name:      "test-cp",
 					Namespace: "cp-ns",
 				},
-				Spec: operatorv2alpha1.ControlPlaneSpec{
-					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+				Spec: gwtypes.ControlPlaneSpec{
+					ControlPlaneOptions: gwtypes.ControlPlaneOptions{
 						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
 							Type: operatorv2alpha1.WatchNamespacesTypeList,
 							List: []string{"ns1", "ns2"},
@@ -452,8 +453,8 @@ func TestValidateWatchNamespaces(t *testing.T) {
 					Name:      "test-cp",
 					Namespace: "cp-ns",
 				},
-				Spec: operatorv2alpha1.ControlPlaneSpec{
-					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+				Spec: gwtypes.ControlPlaneSpec{
+					ControlPlaneOptions: gwtypes.ControlPlaneOptions{
 						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
 							Type: operatorv2alpha1.WatchNamespacesTypeList,
 							List: []string{"forbidden-ns"},

--- a/controller/controlplane/controller_test.go
+++ b/controller/controlplane/controller_test.go
@@ -20,6 +20,7 @@ import (
 	operatorv2alpha1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v2alpha1"
 
 	"github.com/kong/kong-operator/ingress-controller/pkg/manager/multiinstance"
+	gwtypes "github.com/kong/kong-operator/internal/types"
 	"github.com/kong/kong-operator/modules/manager/scheme"
 	"github.com/kong/kong-operator/pkg/consts"
 	k8sutils "github.com/kong/kong-operator/pkg/utils/kubernetes"
@@ -70,20 +71,20 @@ func TestReconciler_Reconcile(t *testing.T) {
 						string(ControlPlaneFinalizerCleanupValidatingWebhookConfiguration),
 					},
 				},
-				Spec: operatorv2alpha1.ControlPlaneSpec{
-					DataPlane: operatorv2alpha1.ControlPlaneDataPlaneTarget{
-						Type: operatorv2alpha1.ControlPlaneDataPlaneTargetRefType,
-						Ref: &operatorv2alpha1.ControlPlaneDataPlaneTargetRef{
+				Spec: gwtypes.ControlPlaneSpec{
+					DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
+						Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
+						Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
 							Name: "test-dataplane",
 						},
 					},
-					ControlPlaneOptions: operatorv2alpha1.ControlPlaneOptions{
+					ControlPlaneOptions: gwtypes.ControlPlaneOptions{
 						WatchNamespaces: &operatorv2alpha1.WatchNamespaces{
 							Type: operatorv2alpha1.WatchNamespacesTypeAll,
 						},
 					},
 				},
-				Status: operatorv2alpha1.ControlPlaneStatus{
+				Status: gwtypes.ControlPlaneStatus{
 					Conditions: []metav1.Condition{
 						{
 							Type:   string(kcfgcontrolplane.ConditionTypeProvisioned),

--- a/controller/controlplane/controller_utils.go
+++ b/controller/controlplane/controller_utils.go
@@ -8,9 +8,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1beta1"
-	operatorv2alpha1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v2alpha1"
 
 	operatorerrors "github.com/kong/kong-operator/internal/errors"
+	gwtypes "github.com/kong/kong-operator/internal/types"
 )
 
 // GetDataPlaneForControlPlane retrieves the DataPlane object referenced by a ControlPlane.
@@ -20,7 +20,7 @@ func GetDataPlaneForControlPlane(
 	cp *ControlPlane,
 ) (*operatorv1beta1.DataPlane, error) {
 	switch cp.Spec.DataPlane.Type {
-	case operatorv2alpha1.ControlPlaneDataPlaneTargetRefType:
+	case gwtypes.ControlPlaneDataPlaneTargetRefType:
 		if cp.Spec.DataPlane.Ref == nil || cp.Spec.DataPlane.Ref.Name == "" {
 			return nil, fmt.Errorf("%w, controlplane = %s/%s", operatorerrors.ErrDataPlaneNotSet, cp.Namespace, cp.Name)
 		}

--- a/controller/controlplane/controller_watch.go
+++ b/controller/controlplane/controller_watch.go
@@ -14,6 +14,7 @@ import (
 	operatorv2alpha1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v2alpha1"
 
 	operatorerrors "github.com/kong/kong-operator/internal/errors"
+	gwtypes "github.com/kong/kong-operator/internal/types"
 )
 
 func (r *Reconciler) listControlPlanesForWatchNamespaceGrants(
@@ -39,7 +40,7 @@ func (r *Reconciler) listControlPlanesForWatchNamespaceGrants(
 
 	var recs []reconcile.Request
 	for _, from := range fromsForControlPlane {
-		var controlPlaneList operatorv2alpha1.ControlPlaneList
+		var controlPlaneList gwtypes.ControlPlaneList
 		if err := r.List(ctx, &controlPlaneList,
 			client.InNamespace(from.Namespace),
 		); err != nil {

--- a/controller/controlplane_extensions/controller.go
+++ b/controller/controlplane_extensions/controller.go
@@ -26,7 +26,6 @@ import (
 	configurationv1 "github.com/kong/kubernetes-configuration/v2/api/configuration/v1"
 	operatorv1alpha1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1alpha1"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1beta1"
-	operatorv2alpha1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v2alpha1"
 
 	"github.com/kong/kong-operator/controller/pkg/extensions"
 	"github.com/kong/kong-operator/controller/pkg/log"
@@ -83,7 +82,7 @@ func (r *Reconciler) SetupWithManager(_ context.Context, mgr ctrl.Manager) error
 			CacheSyncTimeout: r.CacheSyncTimeout,
 		}).
 		// Watch for changes to owned ControlPlane that had DataPlane.
-		For(&operatorv2alpha1.ControlPlane{},
+		For(&gwtypes.ControlPlane{},
 			builder.WithPredicates(
 				ControlPlaneDataPlanePluginsSpecChangedPredicate{},
 			),

--- a/internal/utils/index/controlplane.go
+++ b/internal/utils/index/controlplane.go
@@ -3,8 +3,6 @@ package index
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	operatorv2alpha1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v2alpha1"
-
 	gwtypes "github.com/kong/kong-operator/internal/types"
 )
 
@@ -43,7 +41,7 @@ func dataPlaneNameOnControlPlane(o client.Object) []string {
 	}
 	dp := controlPlane.Spec.DataPlane
 	switch dp.Type {
-	case operatorv2alpha1.ControlPlaneDataPlaneTargetRefType:
+	case gwtypes.ControlPlaneDataPlaneTargetRefType:
 		// Note: .Name is a pointer, enforced to be non nil at the CRD level.
 		return []string{controlPlane.Spec.DataPlane.Ref.Name}
 	// TODO(pmalek): implement DataPlane external URL type


### PR DESCRIPTION
**What this PR does / why we need it**:

Use alias types for `ControlPlane` related types. This is a starter. The list of supported type aliases that are enforced via golangci-lint is not complete.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
