### PR TITLE
chore(ci): prevent GitHub API throttling by using GITHUB_TOKEN env if available

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -167,9 +167,15 @@ jobs:
 
     - name: Verify generators consistency
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+      # Add GITHUB_TOKEN env so that scripts/generate-crd-kustomize.sh can
+      # access GitHub's API authenticated and thus not get rate-limited (which
+      # causes failures).
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         timeout_minutes: 3
-        max_attempts: 3
+        max_attempts: 6
+        retry_wait_seconds: 20
         command: make verify.generators
 
   samples:


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent failures like:

https://github.com/Kong/kong-operator/actions/runs/16805853345/job/47597984811?pr=2016#step:8:456

```
Diff output:
  diff --git a/config/crd/kustomization.yaml b/config/crd/kustomization.yaml
  index 5a4e6b8..b4be2f3 100644
  --- a/config/crd/kustomization.yaml
  +++ b/config/crd/kustomization.yaml
  @@ -2,7 +2,7 @@
   apiVersion: kustomize.config.k8s.io/v1beta1
   kind: Kustomization
   resources:
  -  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=813b35953281d6fcfa02118efc006f02e805da52 # Version is auto-updated by the generating script.
  +  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=null # Version is auto-updated by the generating script.
   
   patches:
     - path: patches/zz_generated_conversion_webhook.yaml
  make: *** [Makefile:289: verify.diff] Error 1
```

by making the calls to GitHub API using the `GITHUB_TOKEN` and thus not getting throttled.

Additionally add some diagnostic debugs on failures.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
