### PR TITLE
chore: fix generate crd kustomize

### DIFF
--- a/scripts/generate-crd-kustomize.sh
+++ b/scripts/generate-crd-kustomize.sh
@@ -16,8 +16,8 @@ if [[ $(echo "${RAW_VERSION}" | tr -cd '-' | wc -c) -ge 2 ]]; then
     # If there are 2 or more hyphens, extract the part after the last hyphen as
     # that's a git commit hash (e.g. `v1.1.1-0.20250217181409-44e5ddce290d`).
     SHA_SHORT="$(echo "${RAW_VERSION}" | rev | cut -d'-' -f1 | rev)"
-    [[ "${GITHUB_TOKEN}" ]] && OPTS=(--header "authorization: Bearer ${GITHUB_TOKEN}")
-    COMMIT_JSON=$(curl -s "${OPTS[@]}" https://api.github.com/repos/Kong/kubernetes-configuration/commits/${SHA_SHORT})
+    [[ -n "${GITHUB_TOKEN-}" ]] && OPTS=(--header "authorization: Bearer ${GITHUB_TOKEN}")
+    COMMIT_JSON=$(curl -s ${OPTS[@]:-} https://api.github.com/repos/Kong/kubernetes-configuration/commits/${SHA_SHORT})
     [[ $(echo "${COMMIT_JSON}" | jq '. | has("sha")') == "false" ]] && {
         echo "ERROR: Could not find commit ${SHA_SHORT} in Kong/kubernetes-configuration repository."
         echo "Output from GitHub: ${COMMIT_JSON}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix

```
./scripts/generate-crd-kustomize.sh
./scripts/generate-crd-kustomize.sh: line 19: GITHUB_TOKEN: unbound variable
make: *** [Makefile:312: generate.crd-kustomize] Error 1
```

when running `make generate.crd-kustomize`.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
