### PR TITLE
fix(controlplane): Remove the check of listener programmed condition in extracting certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,15 @@
   to `true`.
   [#1982](https://github.com/Kong/kong-operator/pull/1982)
 
+### Fixed
+
+- Do not check "Programmed" condition in status of `Gateway` listeners in
+  extracting certificates in controlplane's translation of Kong configuration.
+  This fixes the disappearance of certificates when deployment status of
+  `DataPlane` owned by the gateway (including deletion of pods, rolling update
+  of dataplane deployment, scaling of dataplane and so on).
+  [#2038](https://github.com/Kong/kong-operator/pull/2038)
+
 ## [v2.0.0-alpha.3]
 
 > Release date: 2025-08-08

--- a/ingress-controller/internal/dataplane/translator/translate_certs.go
+++ b/ingress-controller/internal/dataplane/translator/translate_certs.go
@@ -61,7 +61,7 @@ func (t *Translator) getGatewayCerts() []certWrapper {
 		}
 
 		for _, listener := range gateway.Spec.Listeners {
-			status, ok := statuses[listener.Name]
+			_, ok := statuses[listener.Name]
 			if !ok {
 				logger.V(logging.DebugLevel).Info("Listener missing status information",
 					"gateway", gateway.Name,
@@ -72,16 +72,9 @@ func (t *Translator) getGatewayCerts() []certWrapper {
 				continue
 			}
 
-			// Check if listener is marked as programmed
-			if !util.CheckCondition(
-				status.Conditions,
-				util.ConditionType(gatewayapi.ListenerConditionProgrammed),
-				util.ConditionReason(gatewayapi.ListenerReasonProgrammed),
-				metav1.ConditionTrue,
-				gateway.Generation,
-			) {
-				continue
-			}
+			// We were checking if listener is marked as programmed when KIC reconciles "Unmanaged" gateways.
+			// But here we do not need to do the check because the gateways are always managed by Kong operator.
+			// Ref: https://github.com/Kong/kong-operator/issues/1769
 
 			if listener.TLS != nil {
 				if len(listener.TLS.CertificateRefs) > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove the check of `Programmed` condition in listeners when extracting certificates from them to fix the disappearance of certificates when dataplane pods changed.

Since in this repo `ingress-controller` does not run as a standalone KIC and will not reconcile the "Unmanaged" gateways, we do not need to check the gateway or gateway class to decide whether it should run the check.

**Which issue this PR fixes**

Part of #1769 

**Special notes for your reviewer**:

Same as https://github.com/Kong/kubernetes-ingress-controller/pull/7666 but we do not need to check the `GatewayClass` as standalone KIC still need to reconcile "Unmanged" gateways, but the embedded controllers in KO does not need to.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
