### PR TITLE
fix default router_flavor to traditional_compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@
   `DataPlane` owned by the gateway (including deletion of pods, rolling update
   of dataplane deployment, scaling of dataplane and so on).
   [#2038](https://github.com/Kong/kong-operator/pull/2038)
+- Correctly assume default Kong router flavor is `traditional_compatible` when
+  `KONG_ROUTER_FLAVOR` is not set. This fixes incorrectly populated
+  `GatewayClass.status.supportedFeatures` when the default was assumed to be
+  `expressions`.
+  [#2043](https://github.com/Kong/kong-operator/pull/2043)
 
 ## [v2.0.0-alpha.3]
 

--- a/controller/gatewayclass/controller_reconciler_utils_test.go
+++ b/controller/gatewayclass/controller_reconciler_utils_test.go
@@ -147,7 +147,7 @@ func TestGetRouterFlavor(t *testing.T) {
 		{
 			name:           "GatewayConfiguration is nil",
 			gatewayConfig:  nil,
-			expectedFlavor: consts.RouterFlavorExpressions,
+			expectedFlavor: consts.RouterFlavorTraditionalCompatible,
 		},
 		{
 			name: "DataPlaneOptions is nil",
@@ -156,7 +156,7 @@ func TestGetRouterFlavor(t *testing.T) {
 					DataPlaneOptions: nil,
 				},
 			},
-			expectedFlavor: consts.RouterFlavorExpressions,
+			expectedFlavor: consts.RouterFlavorTraditionalCompatible,
 		},
 		{
 			name: "PodTemplateSpec is nil",
@@ -171,7 +171,7 @@ func TestGetRouterFlavor(t *testing.T) {
 					},
 				},
 			},
-			expectedFlavor: consts.RouterFlavorExpressions,
+			expectedFlavor: consts.RouterFlavorTraditionalCompatible,
 		},
 		{
 			name: "Container not found",
@@ -190,7 +190,7 @@ func TestGetRouterFlavor(t *testing.T) {
 					},
 				},
 			},
-			expectedFlavor: consts.RouterFlavorExpressions,
+			expectedFlavor: consts.RouterFlavorTraditionalCompatible,
 		},
 		{
 			name: "KONG_ROUTER_FLAVOR not found",
@@ -216,7 +216,7 @@ func TestGetRouterFlavor(t *testing.T) {
 					},
 				},
 			},
-			expectedFlavor: consts.RouterFlavorExpressions,
+			expectedFlavor: consts.RouterFlavorTraditionalCompatible,
 		},
 		{
 			name: "KONG_ROUTER_FLAVOR found",

--- a/pkg/consts/dataplane.go
+++ b/pkg/consts/dataplane.go
@@ -77,7 +77,8 @@ const (
 	// RouterFlavorExpressions is the expressions router flavor.
 	RouterFlavorExpressions RouterFlavor = "expressions"
 	// DefaultRouterFlavor is the default router flavor.
-	DefaultRouterFlavor = RouterFlavorExpressions
+	// https://developer.konghq.com/gateway/configuration/#router-flavor
+	DefaultRouterFlavor = RouterFlavorTraditionalCompatible
 )
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

part of  https://github.com/Kong/kong-operator/issues/1952

**Special notes for your reviewer**:


~~In addition to fixing the issue, I happened to encounter [CVE-2025-54410](https://nvd.nist.gov/vuln/detail/CVE-2025-54410) in CI. I have skipped it because it will not affect us.~~

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
