### PR TITLE
chore: update govulncheck excludes

### DIFF
--- a/hack/govulncheck-with-excludes.sh
+++ b/hack/govulncheck-with-excludes.sh
@@ -15,7 +15,12 @@ excludeVulns="$(jq -nc '[
   # Kubernetes GitRepo Volume Inadvertent Local Repository Access in k8s.io/kubernetes
   # We do not use the GitRepo volume type.
   # https://github.com/kubernetes/kubernetes/issues/130786
-  "GO-2025-3521"
+  "GO-2025-3521",
+
+  # Moby firewalld reload removes bridge network isolation in github.com/docker/docker
+  # https://pkg.go.dev/vuln/GO-2025-3829
+  # (aka CVE-2025-54410, GHSA-4vq8-7jfc-9cvp)
+  "GO-2025-3829"
 
 ]')"
 export excludeVulns


### PR DESCRIPTION
**What this PR does / why we need it**:

Exclude https://pkg.go.dev/vuln/GO-2025-3829.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
