### PR TITLE
backport(1.6.x): fix default router_flavor to traditional_compatible (#2043)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
 
+## Unreleased
+
+### Fixed
+
+- Correctly assume default Kong router flavor is `traditional_compatible` when
+  `KONG_ROUTER_FLAVOR` is not set. This fixes incorrectly populated
+  `GatewayClass.status.supportedFeatures` when the default was assumed to be
+  `expressions`.
+  [#2043](https://github.com/Kong/kong-operator/pull/2043)
+
 ## [v1.6.2]
 
 > Release date: 2025-07-11
@@ -47,7 +57,7 @@
 ## Changed
 
 - Allowed the `kubectl rollout restart` operation for Deployment resources created via DataPlane CRD.
-  [#1660](hhttps://github.com/Kong/gateway-operator/pull/1660)
+  [#1660](https://github.com/Kong/gateway-operator/pull/1660)
 
 ## [v1.6.0]
 

--- a/controller/gatewayclass/controller_reconciler_utils_test.go
+++ b/controller/gatewayclass/controller_reconciler_utils_test.go
@@ -146,7 +146,7 @@ func TestGetRouterFlavor(t *testing.T) {
 		{
 			name:           "GatewayConfiguration is nil",
 			gatewayConfig:  nil,
-			expectedFlavor: consts.RouterFlavorExpressions,
+			expectedFlavor: consts.RouterFlavorTraditionalCompatible,
 		},
 		{
 			name: "DataPlaneOptions is nil",
@@ -155,7 +155,7 @@ func TestGetRouterFlavor(t *testing.T) {
 					DataPlaneOptions: nil,
 				},
 			},
-			expectedFlavor: consts.RouterFlavorExpressions,
+			expectedFlavor: consts.RouterFlavorTraditionalCompatible,
 		},
 		{
 			name: "PodTemplateSpec is nil",
@@ -170,7 +170,7 @@ func TestGetRouterFlavor(t *testing.T) {
 					},
 				},
 			},
-			expectedFlavor: consts.RouterFlavorExpressions,
+			expectedFlavor: consts.RouterFlavorTraditionalCompatible,
 		},
 		{
 			name: "Container not found",
@@ -189,7 +189,7 @@ func TestGetRouterFlavor(t *testing.T) {
 					},
 				},
 			},
-			expectedFlavor: consts.RouterFlavorExpressions,
+			expectedFlavor: consts.RouterFlavorTraditionalCompatible,
 		},
 		{
 			name: "KONG_ROUTER_FLAVOR not found",
@@ -215,7 +215,7 @@ func TestGetRouterFlavor(t *testing.T) {
 					},
 				},
 			},
-			expectedFlavor: consts.RouterFlavorExpressions,
+			expectedFlavor: consts.RouterFlavorTraditionalCompatible,
 		},
 		{
 			name: "KONG_ROUTER_FLAVOR found",

--- a/pkg/consts/dataplane.go
+++ b/pkg/consts/dataplane.go
@@ -77,7 +77,8 @@ const (
 	// RouterFlavorExpressions is the expressions router flavor.
 	RouterFlavorExpressions RouterFlavor = "expressions"
 	// DefaultRouterFlavor is the default router flavor.
-	DefaultRouterFlavor = RouterFlavorExpressions
+	// https://developer.konghq.com/gateway/configuration/#router-flavor
+	DefaultRouterFlavor = RouterFlavorTraditionalCompatible
 )
 
 // -----------------------------------------------------------------------------

--- a/test/integration/test_gateway.go
+++ b/test/integration/test_gateway.go
@@ -84,7 +84,7 @@ func TestGatewayEssentials(t *testing.T) {
 	require.Eventually(t, Expect404WithNoRouteFunc(t, GetCtx(), "http://"+gatewayIPAddress), testutils.SubresourceReadinessWait, time.Second)
 
 	t.Log("verifying GatewayClass has supportedFeatures set")
-	requiredFeatures, err := gatewayapi.GetSupportedFeatures(consts.RouterFlavorExpressions)
+	requiredFeatures, err := gatewayapi.GetSupportedFeatures(consts.DefaultRouterFlavor)
 	require.NoError(t, err)
 	require.Eventually(t, testutils.GatewayClassHasSupportedFeatures(t, GetCtx(), string(gateway.Spec.GatewayClassName), clients, requiredFeatures.UnsortedList()...), testutils.SubresourceReadinessWait, time.Second)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

backport https://github.com/Kong/kong-operator/pull/2043 to KGO v1.6.x

**Which issue this PR fixes**

Fixes https://github.com/Kong/kong-operator/issues/1952

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
