### PR TITLE
(bakport 1.6.x):chore: update govulncheck excludes (#2046)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -268,12 +268,12 @@ replace (
 	k8s.io/component-base => k8s.io/component-base v0.33.0
 	k8s.io/component-helpers => k8s.io/component-helpers v0.33.0
 	k8s.io/controller-manager => k8s.io/controller-manager v0.33.0
-	k8s.io/cri-api => k8s.io/cri-api v0.33.2
+	k8s.io/cri-api => k8s.io/cri-api v0.33.3
 	k8s.io/cri-client => k8s.io/cri-client v0.33.0
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.33.0
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.33.0
 	k8s.io/endpointslice => k8s.io/endpointslice v0.33.0
-	k8s.io/externaljwt => k8s.io/externaljwt v0.33.2
+	k8s.io/externaljwt => k8s.io/externaljwt v0.33.3
 	k8s.io/kms => k8s.io/kms v0.33.0
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.33.0
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.33.0

--- a/hack/govulncheck-with-excludes.sh
+++ b/hack/govulncheck-with-excludes.sh
@@ -15,7 +15,12 @@ excludeVulns="$(jq -nc '[
   # Kubernetes GitRepo Volume Inadvertent Local Repository Access in k8s.io/kubernetes
   # We do not use the GitRepo volume type.
   # https://github.com/kubernetes/kubernetes/issues/130786
-  "GO-2025-3521"
+  "GO-2025-3521",
+
+  # Moby firewalld reload removes bridge network isolation in github.com/docker/docker
+  # https://pkg.go.dev/vuln/GO-2025-3829
+  # (aka CVE-2025-54410, GHSA-4vq8-7jfc-9cvp)
+  "GO-2025-3829"
 
 ]')"
 export excludeVulns

--- a/hack/govulncheck-with-excludes.sh
+++ b/hack/govulncheck-with-excludes.sh
@@ -20,7 +20,19 @@ excludeVulns="$(jq -nc '[
   # Moby firewalld reload removes bridge network isolation in github.com/docker/docker
   # https://pkg.go.dev/vuln/GO-2025-3829
   # (aka CVE-2025-54410, GHSA-4vq8-7jfc-9cvp)
-  "GO-2025-3829"
+  "GO-2025-3829",
+
+  # Kubernetes allows nodes to bypass dynamic resource allocation authorization checks in k8s.io/kubernetes
+  # Not applicable: this project is a controller and does not run or configure the affected DRA components.
+  # https://osv.dev/vulnerability/GO-2025-3774
+  # (aka CVE-2025-4563, GHSA-hj2p-8wj8-pfq4)
+  "GO-2025-3774",
+
+  # database/sql Rows Scan race on context cancellation
+  # Not applicable: this project does not use database/sql scanning; flagged only at package level transitively.
+  # https://osv.dev/vulnerability/GO-2025-3849
+  # (aka CVE-2025-47907)
+  "GO-2025-3849"
 
 ]')"
 export excludeVulns


### PR DESCRIPTION
(cherry picked from commit 5e6f897704b79828b16145fec5f3625ac92aa6cc)

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes~
