### PR TITLE
fix(konnect): Use correct label value of secret to store license

### DIFF
--- a/ingress-controller/internal/labels/labels.go
+++ b/ingress-controller/internal/labels/labels.go
@@ -24,7 +24,7 @@ const (
 
 	// ManagedByLabel is the label key to mark that the object is managed by a specific controller.
 	ManagedByLabel = LabelPrefix + ManagedByKey
-	// ManagedByLabelValueIngressController is the label value that marks the object is managed byu KIC.
+	// ManagedByLabelValueIngressController is the label value that marks the object is managed by KIC.
 	ManagedByLabelValueIngressController = "kong-ingress-controller"
 )
 

--- a/ingress-controller/test/e2e/konnect_test.go
+++ b/ingress-controller/test/e2e/konnect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver/v4"
 	environment "github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -122,6 +123,16 @@ func TestKonnectLicenseActivation(t *testing.T) {
 		}
 		return license.License.Expiration != ""
 	}, adminAPIWait, time.Second)
+
+	// Secret storage of license was added in 3.5.1. Skip this check on older versions.
+	skipTestIfControllerVersionBelow(t, semver.MustParse("3.5.1"))
+	t.Log("checking if the license is stored in the local secret")
+	secret, err := env.Cluster().Client().CoreV1().Secrets(namespace).Get(
+		ctx, "konnect-license-"+rgID, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, secret.Data, "secret to store Konnect license should not be empty")
+	require.NotEmpty(t, secret.Data["id"], "stored license should have a non-empty ID")
+
 	t.Log("done")
 }
 

--- a/ingress-controller/test/e2e/utils_test.go
+++ b/ingress-controller/test/e2e/utils_test.go
@@ -189,8 +189,7 @@ func extractVersionFromImage(imageName string) (semver.Version, error) {
 // below the minVersion.
 // if the override KIC image is not set, it assumes that the latest image is used, so it never skips
 // the test if override image is not given.
-//
-//lint:ignore U1000 retained for future use
+
 func skipTestIfControllerVersionBelow(t *testing.T, minVersion semver.Version) {
 	if testenv.ControllerImageTag() == "" {
 		return


### PR DESCRIPTION
**What this PR does / why we need it**:

backport https://github.com/Kong/kubernetes-ingress-controller/pull/7648 to KO

**Which issue this PR fixes**

related comment here https://github.com/Kong/kong-operator/issues/1804#issuecomment-3135515669

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
