### PR TITLE
chore: adjustment needed for `ControlPlane` conversion

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=5fb4363e82b8d7330c078e2aee616e7e7af0e764 # Version is auto-updated by the generating script.
+  - https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=d381cd7afca6a300150a14e6261fc756ec776e70 # Version is auto-updated by the generating script.
 
 patches:
   - path: patches/zz_generated_conversion_webhook.yaml

--- a/config/dev/manager_dev.yaml
+++ b/config/dev/manager_dev.yaml
@@ -29,6 +29,14 @@ spec:
           env:
             - name: KONG_OPERATOR_ANONYMOUS_REPORTS
               value: "false"
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           resources:
             limits:
               cpu: 1000m

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/jpillora/backoff v1.0.0
 	github.com/kong/go-database-reconciler v1.24.3
 	github.com/kong/go-kong v0.67.0
-	github.com/kong/kubernetes-configuration/v2 v2.0.0-alpha.3.0.20250814120656-5fb4363e82b8
+	github.com/kong/kubernetes-configuration/v2 v2.0.0-alpha.3.0.20250815061942-d381cd7afca6
 	github.com/kong/kubernetes-telemetry v0.1.10
 	github.com/kong/kubernetes-testing-framework v0.47.3
 	github.com/kong/semver/v4 v4.0.1

--- a/go.sum
+++ b/go.sum
@@ -349,8 +349,8 @@ github.com/kong/go-database-reconciler v1.24.3 h1:UjactCAY+sJmOrUghuhuS2hg6jdE0w
 github.com/kong/go-database-reconciler v1.24.3/go.mod h1:4ILdknHkhkqscS2DsPUKWPP9GTZO5xksFI2u5jP645U=
 github.com/kong/go-kong v0.67.0 h1:54zXKc58IZpZdlJCv8p95SJjejTxT+cwbWXw97icCak=
 github.com/kong/go-kong v0.67.0/go.mod h1:J0vGB3wsZ2i99zly1zTRe3v7rOKpkhQZRwbcTFP76qM=
-github.com/kong/kubernetes-configuration/v2 v2.0.0-alpha.3.0.20250814120656-5fb4363e82b8 h1:HlXbTwzesRqoDQ2id4lmsFWfcmQsY12FeMZ9ToZ2YG4=
-github.com/kong/kubernetes-configuration/v2 v2.0.0-alpha.3.0.20250814120656-5fb4363e82b8/go.mod h1:2TcQhF9wnlAf6JYJIDoFKpKO12Hirn/PFr1uoBgGhGA=
+github.com/kong/kubernetes-configuration/v2 v2.0.0-alpha.3.0.20250815061942-d381cd7afca6 h1:kfe1rTu3dp3mmKjm0xb+Z2E9+17Vs76teNbSSh0Sp4M=
+github.com/kong/kubernetes-configuration/v2 v2.0.0-alpha.3.0.20250815061942-d381cd7afca6/go.mod h1:2TcQhF9wnlAf6JYJIDoFKpKO12Hirn/PFr1uoBgGhGA=
 github.com/kong/kubernetes-telemetry v0.1.10 h1:V+/Lco8VFY/CzoELwOPcGTyg0zbj/HAvoFkH50UsKYs=
 github.com/kong/kubernetes-telemetry v0.1.10/go.mod h1:/r/FevTOGegCqaxXCJyGkbE1E3IcYUGJd7xX7D73s2Y=
 github.com/kong/kubernetes-testing-framework v0.47.3 h1:2qqWxIQXAd/r1f+b+d/kuHZfN22IjgKouktyIA0B5so=

--- a/hack/generators/go.mod
+++ b/hack/generators/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kong/kubernetes-configuration/v2 v2.0.0-alpha.3.0.20250814120656-5fb4363e82b8 // indirect
+	github.com/kong/kubernetes-configuration/v2 v2.0.0-alpha.3.0.20250815061942-d381cd7afca6 // indirect
 	github.com/kong/semver/v4 v4.0.1 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/hack/generators/go.sum
+++ b/hack/generators/go.sum
@@ -58,8 +58,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
-github.com/kong/kubernetes-configuration/v2 v2.0.0-alpha.3.0.20250814120656-5fb4363e82b8 h1:HlXbTwzesRqoDQ2id4lmsFWfcmQsY12FeMZ9ToZ2YG4=
-github.com/kong/kubernetes-configuration/v2 v2.0.0-alpha.3.0.20250814120656-5fb4363e82b8/go.mod h1:2TcQhF9wnlAf6JYJIDoFKpKO12Hirn/PFr1uoBgGhGA=
+github.com/kong/kubernetes-configuration/v2 v2.0.0-alpha.3.0.20250815061942-d381cd7afca6 h1:kfe1rTu3dp3mmKjm0xb+Z2E9+17Vs76teNbSSh0Sp4M=
+github.com/kong/kubernetes-configuration/v2 v2.0.0-alpha.3.0.20250815061942-d381cd7afca6/go.mod h1:2TcQhF9wnlAf6JYJIDoFKpKO12Hirn/PFr1uoBgGhGA=
 github.com/kong/semver/v4 v4.0.1 h1:DIcNR8W3gfx0KabFBADPalxxsp+q/5COwIFkkhrFQ2Y=
 github.com/kong/semver/v4 v4.0.1/go.mod h1:LImQ0oT15pJvSns/hs2laLca2zcYoHu5EsSNY0J6/QA=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/pkg/utils/kubernetes/status.go
+++ b/pkg/utils/kubernetes/status.go
@@ -36,13 +36,21 @@ type ListenersConditionsAware interface {
 	SetListenersConditions([]gatewayv1.ListenerStatus)
 }
 
-// SetCondition sets a new condition to the provided resource
+// SetCondition sets a new condition to the provided resource.
 func SetCondition(condition metav1.Condition, resource ConditionsAware) {
 	conditions := resource.GetConditions()
 	newConditions := make([]metav1.Condition, 0, len(conditions))
 
 	var conditionFound bool
 	for i := range conditions {
+		// NOTICE:
+		// Skip "Scheduled" condition, it is condition type that was valid,
+		// when ControlPlane was a separate deployment. It's taken into
+		// account for compatibility reasons with v1beta1 (which sets it
+		// by default). Only ControlPlane uses it, so it can be here.
+		if conditions[i].Type == "Scheduled" {
+			continue
+		}
 		if conditions[i].Type != condition.Type {
 			newConditions = append(newConditions, conditions[i])
 		} else {

--- a/test/integration/controlplane_test.go
+++ b/test/integration/controlplane_test.go
@@ -97,8 +97,8 @@ func TestControlPlaneEssentials(t *testing.T) {
 			Namespace:    namespace.Name,
 		},
 		Spec: gwtypes.ControlPlaneSpec{
-			ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
-				IngressClass: lo.ToPtr("kong"),
+			ControlPlaneOptions: gwtypes.ControlPlaneOptions{
+				IngressClass: lo.ToPtr(ingressClass),
 			},
 			DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
 				Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
@@ -189,7 +189,7 @@ func TestControlPlaneWatchNamespaces(t *testing.T) {
 				},
 			},
 			ControlPlaneOptions: gwtypes.ControlPlaneOptions{
-				IngressClass: lo.ToPtr("kong"),
+				IngressClass: lo.ToPtr(ingressClass),
 				WatchNamespaces: &operatorv2beta1.WatchNamespaces{
 					Type: operatorv2beta1.WatchNamespacesTypeList,
 					List: []string{
@@ -391,8 +391,8 @@ func TestControlPlaneUpdate(t *testing.T) {
 			Name:      controlplaneName.Name,
 		},
 		Spec: gwtypes.ControlPlaneSpec{
-			ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
-				IngressClass: lo.ToPtr("kong"),
+			ControlPlaneOptions: gwtypes.ControlPlaneOptions{
+				IngressClass: lo.ToPtr(ingressClass),
 			},
 			DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
 				Type: gwtypes.ControlPlaneDataPlaneTargetRefType,


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump kcfg to the version that includes the implementation of conversion or ControlPlane from `v1beta1` to `v2beta1` from https://github.com/Kong/kubernetes-configuration/pull/558.

Furthermore, add a workaround for status setting for the converted object, and improve the dev config of Skaffold

**Which issue this PR fixes**

Closes https://github.com/Kong/kong-operator/issues/1368

**Special notes for your reviewer**:

Conversion logic lives here https://github.com/Kong/kubernetes-configuration/pull/558