### PR TITLE
fix(gateway/dataplane): support configuring nodeport of ingress service for listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@
   `GatewayClass.status.supportedFeatures` when the default was assumed to be
   `expressions`.
   [#2043](https://github.com/Kong/kong-operator/pull/2043)
+- Support setting exposed nodeport of the dataplane service for `Gateway`s by
+  `nodePort` field in `spec.listenersOptions`.
+  [#2058](https://github.com/Kong/kong-operator/pull/2058)
 
 ## [v2.0.0-alpha.3]
 

--- a/config/samples/gateway-with-listener-nodeport-in-gatewayconfiguration_v2.yaml
+++ b/config/samples/gateway-with-listener-nodeport-in-gatewayconfiguration_v2.yaml
@@ -1,0 +1,49 @@
+kind: GatewayConfiguration
+apiVersion: gateway-operator.konghq.com/v2beta1
+metadata:
+  name: kong-v2beta1
+  namespace: default
+spec:
+  dataPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        spec:
+          containers:
+          - name: proxy
+            # renovate: datasource=docker versioning=docker
+            image: kong/kong-gateway:3.11
+            readinessProbe:
+              initialDelaySeconds: 1
+              periodSeconds: 1
+    network:
+      services:
+        ingress:
+          type: NodePort
+  listenersOptions:
+  # Configure the ingress service to expose nodeport 30080 for the `http` listener.
+  - name: http
+    nodePort: 30080
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: kong-v2beta1
+spec:
+  controllerName: konghq.com/gateway-operator
+  parametersRef:
+    group: gateway-operator.konghq.com
+    kind: GatewayConfiguration
+    name: kong-v2beta1
+    namespace: default
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: kong-v2beta1
+  namespace: default
+spec:
+  gatewayClassName: kong-v2beta1
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -501,7 +501,7 @@ func (r *Reconciler) provisionDataPlane(
 	}
 	// Don't require setting defaults for DataPlane when using Gateway CRD.
 	setDataPlaneOptionsDefaults(expectedDataPlaneOptions, r.DefaultDataPlaneImage)
-	err = setDataPlaneIngressServicePorts(expectedDataPlaneOptions, gateway.Spec.Listeners)
+	err = setDataPlaneIngressServicePorts(expectedDataPlaneOptions, gateway.Spec.Listeners, gatewayConfig.Spec.ListenersOptions)
 	if err != nil {
 		errWrap := fmt.Errorf("dataplane creation failed - error: %w", err)
 		k8sutils.SetCondition(

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -59,7 +59,7 @@ func (r *Reconciler) createDataPlane(ctx context.Context,
 		dataplane.Spec.DataPlaneOptions = *gatewayConfigDataPlaneOptionsToDataPlaneOptions(gatewayConfig.Namespace, *gatewayConfig.Spec.DataPlaneOptions)
 	}
 	setDataPlaneOptionsDefaults(&dataplane.Spec.DataPlaneOptions, r.DefaultDataPlaneImage)
-	if err := setDataPlaneIngressServicePorts(&dataplane.Spec.DataPlaneOptions, gateway.Spec.Listeners); err != nil {
+	if err := setDataPlaneIngressServicePorts(&dataplane.Spec.DataPlaneOptions, gateway.Spec.Listeners, gatewayConfig.Spec.ListenersOptions); err != nil {
 		return nil, err
 	}
 
@@ -888,7 +888,21 @@ func (g *gatewayConditionsAndListenersAwareT) setProgrammed() {
 	}
 }
 
-func setDataPlaneIngressServicePorts(opts *operatorv1beta1.DataPlaneOptions, listeners []gatewayv1.Listener) error {
+func setDataPlaneIngressServicePorts(
+	opts *operatorv1beta1.DataPlaneOptions,
+	listeners []gatewayv1.Listener,
+	listenersOpts []operatorv2beta1.GatewayConfigurationListenerOptions,
+) error {
+
+	// Check if all the names in GatewayConfiguration's spec.listenersOptions matches a listener in Gateway.
+	for i, listenerOpts := range listenersOpts {
+		if !lo.ContainsBy(listeners, func(l gatewayv1.Listener) bool {
+			return l.Name == listenerOpts.Name
+		}) {
+			return fmt.Errorf("GatewayConfiguration.spec.listenersOptions[%d]: name '%s' not in gateway's listeners", i, listenerOpts.Name)
+		}
+	}
+
 	if len(listeners) == 0 {
 		return nil
 	}
@@ -925,6 +939,14 @@ func setDataPlaneIngressServicePorts(opts *operatorv1beta1.DataPlaneOptions, lis
 			errs = errors.Join(errs, fmt.Errorf("listener %d uses unsupported protocol %s", i, l.Protocol))
 			continue
 		}
+
+		// Update the service port by GatewayConfiguration's spec.listenersOptions if there is a matching item by listener name.
+		if listenerOpt, found := lo.Find(listenersOpts, func(listenerOpts operatorv2beta1.GatewayConfigurationListenerOptions) bool {
+			return listenerOpts.Name == l.Name
+		}); found {
+			port.NodePort = listenerOpt.NodePort
+		}
+
 		opts.Network.Services.Ingress.Ports = append(opts.Network.Services.Ingress.Ports, port)
 	}
 	return errs

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -513,10 +513,11 @@ func TestSetAcceptedOnGateway(t *testing.T) {
 
 func TestSetDataPlaneIngressServicePorts(t *testing.T) {
 	testCases := []struct {
-		name          string
-		listeners     []gwtypes.Listener
-		expectedPorts []operatorv1beta1.DataPlaneServicePort
-		expectedError error
+		name             string
+		listeners        []gwtypes.Listener
+		listenersOptions []operatorv2beta1.GatewayConfigurationListenerOptions
+		expectedPorts    []operatorv1beta1.DataPlaneServicePort
+		expectedError    error
 	}{
 		{
 			name: "no listeners",
@@ -571,11 +572,68 @@ func TestSetDataPlaneIngressServicePorts(t *testing.T) {
 			},
 			expectedError: errors.New("listener 1 uses unsupported protocol UDP"),
 		},
+		{
+			name: "listener options sets nodeport",
+			listeners: []gwtypes.Listener{
+				{
+					Name:     "http",
+					Protocol: gwtypes.HTTPProtocolType,
+					Port:     gatewayv1.PortNumber(80),
+				},
+				{
+					Name:     "https",
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Port:     gatewayv1.PortNumber(443),
+				},
+			},
+			listenersOptions: []operatorv2beta1.GatewayConfigurationListenerOptions{
+				{
+					Name:     "http",
+					NodePort: int32(30080),
+				},
+			},
+			expectedPorts: []operatorv1beta1.DataPlaneServicePort{
+				{
+					Name:       "http",
+					Port:       80,
+					TargetPort: intstr.FromInt(consts.DataPlaneProxyPort),
+					NodePort:   int32(30080),
+				},
+				{
+					Name:       "https",
+					Port:       443,
+					TargetPort: intstr.FromInt(consts.DataPlaneProxySSLPort),
+				},
+			},
+		},
+		{
+			name: "listener options' name does not match listener",
+			listeners: []gwtypes.Listener{
+				{
+					Name:     "http",
+					Protocol: gwtypes.HTTPProtocolType,
+					Port:     gatewayv1.PortNumber(80),
+				},
+				{
+					Name:     "https",
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Port:     gatewayv1.PortNumber(443),
+				},
+			},
+			listenersOptions: []operatorv2beta1.GatewayConfigurationListenerOptions{
+				{
+					Name:     "http-1",
+					NodePort: int32(30080),
+				},
+			},
+			expectedPorts: nil,
+			expectedError: errors.New("GatewayConfiguration.spec.listenersOptions[0]: name 'http-1' not in gateway's listeners"),
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := setDataPlaneIngressServicePorts(&operatorv1beta1.DataPlaneOptions{}, tc.listeners)
+			err := setDataPlaneIngressServicePorts(&operatorv1beta1.DataPlaneOptions{}, tc.listeners, tc.listenersOptions)
 			if tc.expectedError == nil {
 				require.NoError(t, err)
 			} else {


### PR DESCRIPTION
**What this PR does / why we need it**:

Support configure `NodePort` of ingress service ports for `Gateway`'s listeners by `GatewayConfiguration`'s `spec.listenerOptions`.

**Which issue this PR fixes**

Fixes #1997 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
