### PR TITLE
chore(controlplane): Set OptionsValid condition and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@
   control over Konnect integration settings including consumer synchronization, licensing
   configuration, node refresh periods, and config upload periods.
   [#2009](https://github.com/Kong/kong-operator/pull/2009)
+- Added `OptionsValid` condition to `ControlPlane`s' status. The status is set to
+  `True` if the `ControlPlane`'s options in its `spec` is valid and set to `False`
+  if the options are invalid against the operator's configuration.
+  [#2070](https://github.com/Kong/kong-operator/pull/2070)
 
 ### Fixed
 

--- a/pkg/utils/test/predicates.go
+++ b/pkg/utils/test/predicates.go
@@ -145,6 +145,21 @@ func ControlPlaneIsProvisioned(t *testing.T, ctx context.Context, controlPlane t
 	}, clients.OperatorClient)
 }
 
+// ControlPlaneIsOptionsValid is a helper function for tests that returns a function
+// that can be used to check if a ControlPlane's options are valid.
+// Should be used in conjunction with require.Eventually or assert.Eventually.
+func ControlPlaneIsOptionsValid(t *testing.T, ctx context.Context, controlPlane types.NamespacedName, clients K8sClients) func() bool {
+	return controlPlanePredicate(t, ctx, controlPlane, func(c *gwtypes.ControlPlane) bool {
+		for _, condition := range c.Status.Conditions {
+			if condition.Type == string(kcfgcontrolplane.ConditionTypeOptionsValid) &&
+				condition.Status == metav1.ConditionTrue {
+				return true
+			}
+		}
+		return false
+	}, clients.OperatorClient)
+}
+
 // ControlPlaneIsNotReady is a helper function for tests. It returns a function
 // that can be used to check if a ControlPlane is marked as not Ready.
 // Should be used in conjunction with require.Eventually or assert.Eventually.

--- a/test/integration/controlplane_test.go
+++ b/test/integration/controlplane_test.go
@@ -120,6 +120,9 @@ func TestControlPlaneEssentials(t *testing.T) {
 	t.Log("verifying that the controlplane gets marked as provisioned")
 	require.Eventually(t, testutils.ControlPlaneIsProvisioned(t, GetCtx(), controlplaneName, clients), testutils.ControlPlaneCondDeadline, testutils.ControlPlaneCondTick)
 
+	t.Log("verifying that the controlplane gets marked as optionsValid")
+	require.Eventually(t, testutils.ControlPlaneIsOptionsValid(t, GetCtx(), controlplaneName, clients), testutils.ControlPlaneCondDeadline, testutils.ControlPlaneCondTick)
+
 	t.Run("webhook", func(t *testing.T) {
 		t.Skip("Skipping webhook tests for now, as they are not implemented yet for ControlPlane v2beta1, TODO: https://github.com/Kong/kong-operator/issues/1367")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Set `OptionsValid` condition in `ControlPlane`s' status. The reconcilier sets the status to `True` when options are valid and to `False` with messages when it is invalid. Also added unit test case for it.

**Which issue this PR fixes**

Fixes #1999 and also fixes #2024 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
