### PR TITLE
tests: re-enable TestHTTPRouteWithTLS integration test

### DIFF
--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -118,8 +118,6 @@ func TestHTTPRoute(t *testing.T) {
 }
 
 func TestHTTPRouteWithTLS(t *testing.T) {
-	t.Skip("skipping as this test requires changed after changes to ControlPlane API in v2beta1")
-
 	t.Parallel()
 	namespace, cleaner := helpers.SetupTestEnv(t, GetCtx(), GetEnv())
 

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -17,6 +17,7 @@ import (
 
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1beta1"
 
+	"github.com/kong/kong-operator/modules/manager/config"
 	testutils "github.com/kong/kong-operator/pkg/utils/test"
 	"github.com/kong/kong-operator/test/helpers"
 	"github.com/kong/kong-operator/test/helpers/certificate"
@@ -150,6 +151,9 @@ func TestHTTPRouteWithTLS(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace.Name,
 			Name:      host,
+			Labels: map[string]string{
+				config.DefaultSecretLabelSelector: "true",
+			},
 		},
 		Type: corev1.SecretTypeTLS,
 		Data: map[string][]byte{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR re-enables `TestHTTPRouteWithTLS` and fixes it to account for the changes in default `Secret` label selector.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
