### PR TITLE
tests: re-enable TestKongPluginInstallationEssentials integration test

### DIFF
--- a/controller/dataplane/controller.go
+++ b/controller/dataplane/controller.go
@@ -42,11 +42,14 @@ type Reconciler struct {
 	ClusterCASecretNamespace string
 	ClusterCAKeyConfig       secrets.KeyConfig
 	SecretLabelSelector      string
-	DefaultImage             string
-	KonnectEnabled           bool
-	EnforceConfig            bool
-	LoggingMode              logging.Mode
-	ValidateDataPlaneImage   bool
+	// ConfigMapLabelSelector is the label selector configured at the oprator level.
+	// When not empty, it is used as the config map label selector of all reconcilers.
+	ConfigMapLabelSelector string
+	DefaultImage           string
+	KonnectEnabled         bool
+	EnforceConfig          bool
+	LoggingMode            logging.Mode
+	ValidateDataPlaneImage bool
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -195,7 +198,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	log.Trace(logger, "ensuring generation of deployment configuration for KongPluginInstallations configured for DataPlane")
-	kpisForDeployment, requeue, err := ensureMappedConfigMapToKongPluginInstallationForDataPlane(ctx, logger, r.Client, dataplane)
+	kpisForDeployment, requeue, err := ensureMappedConfigMapToKongPluginInstallationForDataPlane(ctx, logger, r.Client, dataplane, r.ConfigMapLabelSelector)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("cannot ensure KongPluginInstallation for DataPlane: %w", err)
 	}

--- a/controller/kongplugininstallation/controller.go
+++ b/controller/kongplugininstallation/controller.go
@@ -43,6 +43,9 @@ type Reconciler struct {
 	CacheSyncTimeout time.Duration
 	Scheme           *runtime.Scheme
 	LoggingMode      logging.Mode
+	// ConfigMapLabelSelector is the label selector configured at the oprator level.
+	// When not empty, it is used as the config map label selector of all reconcilers.
+	ConfigMapLabelSelector string
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -174,6 +177,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		} else {
 			cm.GenerateName = kpi.Name + "-"
 		}
+		k8sresources.SetLabel(&cm, r.ConfigMapLabelSelector, "true")
 		k8sresources.LabelObjectAsKongPluginInstallationManaged(&cm)
 		k8sresources.AnnotateConfigMapWithKongPluginInstallation(&cm, kpi)
 		cm.Namespace = kpi.Namespace

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -427,6 +427,7 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 				ClusterCASecretNamespace: c.ClusterCASecretNamespace,
 				ClusterCAKeyConfig:       clusterCAKeyConfig,
 				SecretLabelSelector:      c.SecretLabelSelector,
+				ConfigMapLabelSelector:   c.ConfigMapLabelSelector,
 				DefaultImage:             consts.DefaultDataPlaneImage,
 				KonnectEnabled:           c.KonnectControllersEnabled,
 				EnforceConfig:            c.EnforceConfig,
@@ -451,6 +452,7 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 					ClusterCASecretNamespace: c.ClusterCASecretNamespace,
 					ClusterCAKeyConfig:       clusterCAKeyConfig,
 					SecretLabelSelector:      c.SecretLabelSelector,
+					ConfigMapLabelSelector:   c.ConfigMapLabelSelector,
 					DefaultImage:             consts.DefaultDataPlaneImage,
 					KonnectEnabled:           c.KonnectControllersEnabled,
 					EnforceConfig:            c.EnforceConfig,
@@ -504,10 +506,11 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 		{
 			Enabled: c.KongPluginInstallationControllerEnabled,
 			Controller: &kongplugininstallation.Reconciler{
-				CacheSyncTimeout: c.CacheSyncTimeout,
-				Client:           mgr.GetClient(),
-				Scheme:           mgr.GetScheme(),
-				LoggingMode:      c.LoggingMode,
+				CacheSyncTimeout:       c.CacheSyncTimeout,
+				Client:                 mgr.GetClient(),
+				Scheme:                 mgr.GetScheme(),
+				LoggingMode:            c.LoggingMode,
+				ConfigMapLabelSelector: c.ConfigMapLabelSelector,
 			},
 		},
 		// ControlPlaneExtensions controller

--- a/pkg/utils/kubernetes/resources/labels.go
+++ b/pkg/utils/kubernetes/resources/labels.go
@@ -15,31 +15,35 @@ import (
 // provided object to signal that it's owned by a DataPlane resource
 // and that its lifecycle is managed by this operator.
 func LabelObjectAsDataPlaneManaged(obj metav1.Object) {
-	setLabel(obj, consts.GatewayOperatorManagedByLabel, consts.DataPlaneManagedLabelValue)
+	SetLabel(obj, consts.GatewayOperatorManagedByLabel, consts.DataPlaneManagedLabelValue)
 }
 
 // LabelObjectAsKongPluginInstallationManaged ensures that labels are set on the
 // provided object to signal that it's owned by a KongPluginInstallation
 // resource and that its lifecycle is managed by this operator.
 func LabelObjectAsKongPluginInstallationManaged(obj metav1.Object) {
-	setLabel(obj, consts.GatewayOperatorManagedByLabel, consts.KongPluginInstallationManagedLabelValue)
+	SetLabel(obj, consts.GatewayOperatorManagedByLabel, consts.KongPluginInstallationManagedLabelValue)
 }
 
 // LabelObjectAsKonnectExtensionManaged ensures that labels are set on the
 // provided object to signal that it's owned by a KonnectExtension resource
 // and that its lifecycle is managed by this operator.
 func LabelObjectAsKonnectExtensionManaged(obj metav1.Object) {
-	setLabel(obj, consts.GatewayOperatorManagedByLabel, consts.KonnectExtensionManagedByLabelValue)
+	SetLabel(obj, consts.GatewayOperatorManagedByLabel, consts.KonnectExtensionManagedByLabelValue)
 }
 
 // LabelObjectAsControlPlaneManaged ensures that labels are set on the
 // provided object to signal that it's owned by a ControlPlane resource and that its
 // lifecycle is managed by this operator.
 func LabelObjectAsControlPlaneManaged(obj metav1.Object) {
-	setLabel(obj, consts.GatewayOperatorManagedByLabel, consts.ControlPlaneManagedLabelValue)
+	SetLabel(obj, consts.GatewayOperatorManagedByLabel, consts.ControlPlaneManagedLabelValue)
 }
 
-func setLabel(obj metav1.Object, key string, value string) { //nolint:unparam
+// SetLabel sets a label on the provided object.
+func SetLabel(obj metav1.Object, key string, value string) {
+	if key == "" || value == "" {
+		return
+	}
 	labels := obj.GetLabels()
 	if labels == nil {
 		labels = make(map[string]string)

--- a/test/integration/kongplugininstallation_test.go
+++ b/test/integration/kongplugininstallation_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestKongPluginInstallationEssentials(t *testing.T) {
-	t.Skip("skipping as this test requires changed in the GatewayConfiguration API: https://github.com/kong/kong-operator/issues/1367")
+	t.Parallel()
 
 	namespace, cleaner := helpers.SetupTestEnv(t, GetCtx(), GetEnv())
 	t.Log("this test accesses container registries on public internet")

--- a/test/integration/kongplugininstallation_test.go
+++ b/test/integration/kongplugininstallation_test.go
@@ -28,6 +28,7 @@ import (
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1beta1"
 	"github.com/kong/kubernetes-configuration/v2/pkg/metadata"
 
+	"github.com/kong/kong-operator/modules/manager/config"
 	testutils "github.com/kong/kong-operator/pkg/utils/test"
 	"github.com/kong/kong-operator/test/helpers"
 )
@@ -128,9 +129,8 @@ func TestKongPluginInstallationEssentials(t *testing.T) {
 		namespaceForSecret := createRandomNamespace(t)
 		kpiPrivate, err = GetClients().OperatorClient.GatewayOperatorV1alpha1().KongPluginInstallations(kpiPrivateNN.Namespace).Get(GetCtx(), kpiPrivateNN.Name, metav1.GetOptions{})
 		require.NoError(t, err)
-		const kindSecret = gatewayv1.Kind("Secret")
 		secretRef := gatewayv1.SecretObjectReference{
-			Kind:      lo.ToPtr(kindSecret),
+			Kind:      lo.ToPtr(gatewayv1.Kind("Secret")),
 			Namespace: lo.ToPtr(gatewayv1.Namespace(namespaceForSecret)),
 			Name:      "kong-plugin-image-registry-credentials",
 		}
@@ -156,7 +156,7 @@ func TestKongPluginInstallationEssentials(t *testing.T) {
 			Spec: gatewayv1beta1.ReferenceGrantSpec{
 				To: []gatewayv1beta1.ReferenceGrantTo{
 					{
-						Kind: kindSecret,
+						Kind: gatewayv1.Kind("Secret"),
 						Name: lo.ToPtr(secretRef.Name),
 					},
 				},
@@ -186,6 +186,9 @@ func TestKongPluginInstallationEssentials(t *testing.T) {
 		secret := corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: string(secretRef.Name),
+				Labels: map[string]string{
+					config.DefaultSecretLabelSelector: "true",
+				},
 			},
 			Type: corev1.SecretTypeDockerConfigJson,
 			StringData: map[string]string{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR re-enabled the TestKongPluginInstallationEssentials integration tests.

In order for it to pass:

- config map label selector has been added in `DataPlane` controller to make it create the DP's ConfigMap for KongPluginInstallation with that label
- config map label selector has been added in `KongPluginInstallation` controller for the same
- the test has been updated so that the created Secret has the label from the default Secret label selector

**Which issue this PR fixes**

Part of https://github.com/Kong/kong-operator/issues/1608

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
