### PR TITLE
fix: fix DataPlaneMetricsExtension reconciliation and re-enable TestControlPlaneExtensionsDataPlaneMetrics

### DIFF
--- a/config/samples/gateway-with-dataplane-metrics-extension_v2.yaml
+++ b/config/samples/gateway-with-dataplane-metrics-extension_v2.yaml
@@ -1,0 +1,149 @@
+kind: GatewayConfiguration
+apiVersion: gateway-operator.konghq.com/v2beta1
+metadata:
+  name: kong
+  namespace: default
+spec:
+  dataPlaneOptions:
+    deployment:
+      replicas: 1
+      podTemplateSpec:
+        metadata:
+          labels:
+            dataplane-pod-label: example
+          annotations:
+            dataplane-pod-annotation: example
+        spec:
+          containers:
+          - name: proxy
+            # renovate: datasource=docker versioning=docker
+            image: kong:3.9
+            env:
+            - name: KONG_LOG_LEVEL
+              value: debug
+            readinessProbe:
+              initialDelaySeconds: 1
+              periodSeconds: 1
+    network:
+      services:
+        ingress:
+          annotations:
+            foo: bar
+  extensions:
+  - kind: DataPlaneMetricsExtension
+    group: gateway-operator.konghq.com
+    name: kong
+---
+kind: DataPlaneMetricsExtension
+apiVersion: gateway-operator.konghq.com/v1alpha1
+metadata:
+  name: kong
+  namespace: default
+spec:
+  serviceSelector:
+    matchNames:
+    - name: echo
+  config:
+    latency: true
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: kong
+spec:
+  controllerName: konghq.com/gateway-operator
+  parametersRef:
+    group: gateway-operator.konghq.com
+    kind: GatewayConfiguration
+    name: kong
+    namespace: default
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: kong
+  namespace: default
+spec:
+  gatewayClassName: kong
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: default
+spec:
+  ports:
+    - protocol: TCP
+      name: http
+      port: 80
+      targetPort: http
+  selector:
+    app: echo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: echo
+  name: echo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo
+  template:
+    metadata:
+      labels:
+        app: echo
+    spec:
+      containers:
+        - name: echo
+          image: registry.k8s.io/e2e-test-images/agnhost:2.40
+          command:
+            - /agnhost
+            - netexec
+            - --http-port=8080
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-echo
+  namespace: default
+  annotations:
+    konghq.com/strip-path: "true"
+spec:
+  parentRefs:
+  - name: kong
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /echo
+    backendRefs:
+    - name: echo
+      kind: Service
+      port: 80

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -511,7 +511,7 @@ func (r *Reconciler) provisionDataPlane(
 		return nil, errWrap
 	}
 
-	expectedDataPlaneOptions.Extensions = extensions.MergeExtensionsForType(gatewayConfig.Spec.Extensions, expectedDataPlaneOptions.Extensions)
+	expectedDataPlaneOptions.Extensions = extensions.MergeExtensionsForDataPlane(gatewayConfig.Spec.Extensions, expectedDataPlaneOptions.Extensions)
 
 	if !dataPlaneSpecDeepEqual(&dataplane.Spec.DataPlaneOptions, expectedDataPlaneOptions) {
 		log.Trace(logger, "dataplane config is out of date")

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -510,7 +510,7 @@ func (r *Reconciler) provisionDataPlane(
 		return nil, errWrap
 	}
 
-	expectedDataPlaneOptions.Extensions = extensions.MergeExtensions(gatewayConfig.Spec.Extensions, expectedDataPlaneOptions.Extensions)
+	expectedDataPlaneOptions.Extensions = extensions.MergeExtensionsForType(gatewayConfig.Spec.Extensions, expectedDataPlaneOptions.Extensions)
 
 	if !dataPlaneSpecDeepEqual(&dataplane.Spec.DataPlaneOptions, expectedDataPlaneOptions) {
 		log.Trace(logger, "dataplane config is out of date")

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -26,6 +26,7 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	kcfgconsts "github.com/kong/kubernetes-configuration/v2/api/common/consts"
+	commonv1alpha1 "github.com/kong/kubernetes-configuration/v2/api/common/v1alpha1"
 	kcfgdataplane "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/dataplane"
 	kcfggateway "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/gateway"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1beta1"
@@ -358,7 +359,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	// Provision controlplane creates a controlplane and adds the ControlPlaneReady condition to the Gateway status
 	// if the controlplane is ready, the ControlPlaneReady status is set to true, otherwise false.
-	controlplane := r.provisionControlPlane(ctx, logger, &gateway, gatewayConfig, dataplane, ingressServices[0], adminServices[0])
+	controlplane := r.provisionControlPlane(ctx, logger, &gateway, gatewayConfig)
 	// Set the ControlPlaneReady Condition to False. This happens only if:
 	// * the new status is false and there was no ControlPlaneReady condition in the gateway
 	// * the new status is false and the previous status was true
@@ -552,9 +553,6 @@ func (r *Reconciler) provisionControlPlane(
 	logger logr.Logger,
 	gateway *gwtypes.Gateway,
 	gatewayConfig *GatewayConfiguration,
-	dataplane *operatorv1beta1.DataPlane,
-	ingressService corev1.Service,
-	adminService corev1.Service,
 ) *gwtypes.ControlPlane {
 	logger = logger.WithName("controlplaneProvisioning")
 
@@ -574,7 +572,6 @@ func (r *Reconciler) provisionControlPlane(
 	count := len(controlplanes)
 	switch {
 	case count == 0:
-		r.setControlPlaneGatewayConfigDefaults(gateway, gatewayConfig, dataplane.Name, ingressService.Name, adminService.Name, "")
 		err := r.createControlPlane(ctx, gateway, gatewayConfig)
 		if err != nil {
 			log.Debug(logger, fmt.Sprintf("controlplane creation failed - error: %v", err))
@@ -601,7 +598,6 @@ func (r *Reconciler) provisionControlPlane(
 
 	// If we continue, there is only one controlplane.
 	controlPlane = controlplanes[0].DeepCopy()
-	r.setControlPlaneGatewayConfigDefaults(gateway, gatewayConfig, dataplane.Name, ingressService.Name, adminService.Name, controlPlane.Name)
 
 	log.Trace(logger, "ensuring controlplane config is up to date")
 	// compare options of controlplane with controlplane options of gatewayconfiguration.
@@ -610,11 +606,17 @@ func (r *Reconciler) provisionControlPlane(
 	if gatewayConfig.Spec.ControlPlaneOptions != nil {
 		expectedControlPlaneOptions = gatewayConfig.Spec.ControlPlaneOptions.ControlPlaneOptions
 	}
+	expectedExtensions := []commonv1alpha1.ExtensionRef{}
+	if gatewayConfig.Spec.Extensions != nil {
+		expectedExtensions = gatewayConfig.Spec.Extensions
+	}
 
-	if !controlPlaneSpecDeepEqual(&controlPlane.Spec.ControlPlaneOptions, &expectedControlPlaneOptions) {
+	if !controlPlaneSpecDeepEqual(&controlPlane.Spec.ControlPlaneOptions, &expectedControlPlaneOptions) ||
+		reflect.DeepEqual(controlPlane.Spec.Extensions, expectedExtensions) {
 		log.Trace(logger, "controlplane config is out of date")
 		controlplaneOld := controlPlane.DeepCopy()
 		controlPlane.Spec.ControlPlaneOptions = expectedControlPlaneOptions
+		controlPlane.Spec.Extensions = expectedExtensions
 		if err := r.Patch(ctx, controlPlane, client.MergeFrom(controlplaneOld)); err != nil {
 			k8sutils.SetCondition(
 				createControlPlaneCondition(metav1.ConditionFalse, kcfgdataplane.UnableToProvisionReason, err.Error(), gateway.Generation),

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -63,7 +63,7 @@ func (r *Reconciler) createDataPlane(ctx context.Context,
 		return nil, err
 	}
 
-	dataplane.Spec.Extensions = extensions.MergeExtensions(gatewayConfig.Spec.Extensions, dataplane.Spec.Extensions)
+	dataplane.Spec.Extensions = extensions.MergeExtensions(gatewayConfig.Spec.Extensions, dataplane)
 
 	k8sutils.SetOwnerForObject(dataplane, gateway)
 	gatewayutils.LabelObjectAsGatewayManaged(dataplane)
@@ -94,7 +94,7 @@ func (r *Reconciler) createControlPlane(
 		controlplane.Spec.ControlPlaneOptions = gatewayConfig.Spec.ControlPlaneOptions.ControlPlaneOptions
 	}
 
-	controlplane.Spec.Extensions = extensions.MergeExtensions(gatewayConfig.Spec.Extensions, controlplane.Spec.Extensions)
+	controlplane.Spec.Extensions = extensions.MergeExtensions(gatewayConfig.Spec.Extensions, controlplane)
 
 	k8sutils.SetOwnerForObject(controlplane, gateway)
 	gatewayutils.LabelObjectAsGatewayManaged(controlplane)

--- a/controller/gateway/controller_watch.go
+++ b/controller/gateway/controller_watch.go
@@ -322,17 +322,3 @@ func (r *Reconciler) setDataPlaneGatewayConfigDefaults(gatewayConfig *GatewayCon
 		gatewayConfig.Spec.DataPlaneOptions = new(GatewayConfigDataPlaneOptions)
 	}
 }
-
-func (r *Reconciler) setControlPlaneGatewayConfigDefaults(
-	gateway *gwtypes.Gateway,
-	gatewayConfig *GatewayConfiguration,
-	dataplaneName,
-	dataplaneIngressServiceName,
-	dataplaneAdminServiceName,
-	controlPlaneName string,
-) {
-	// TODO(pmalek): add support for GatewayConfiguration v2 https://github.com/kong/kong-operator/issues/1728
-	// if gatewayConfig.Spec.ControlPlaneOptions == nil {
-	// Set defaults
-	// }
-}

--- a/controller/pkg/extensions/merge.go
+++ b/controller/pkg/extensions/merge.go
@@ -1,8 +1,6 @@
 package extensions
 
 import (
-	"fmt"
-
 	"github.com/samber/lo"
 
 	commonv1alpha1 "github.com/kong/kubernetes-configuration/v2/api/common/v1alpha1"
@@ -59,29 +57,17 @@ forLoop:
 	return append(newExtensions, extensions...)
 }
 
-// MergeExtensionsForType is a wrapper around MergeExtensions for places where
+// MergeExtensionsForDataPlane is a wrapper around MergeExtensions for places where
 // we do not have an actual object to work on.
-func MergeExtensionsForType[
-	extendable *operatorv1beta1.DataPlane,
-](
+func MergeExtensionsForDataPlane(
 	defaultExtensions, extensions []commonv1alpha1.ExtensionRef,
 ) []commonv1alpha1.ExtensionRef {
-	var obj extendable
-	switch any(obj).(type) {
-	case *operatorv1beta1.DataPlane:
-		dataplane := operatorv1beta1.DataPlane{
-			Spec: operatorv1beta1.DataPlaneSpec{
-				DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
-					Extensions: extensions,
-				},
+	dataplane := operatorv1beta1.DataPlane{
+		Spec: operatorv1beta1.DataPlaneSpec{
+			DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+				Extensions: extensions,
 			},
-		}
-		return MergeExtensions(defaultExtensions, &dataplane)
-	default:
-		panic(
-			fmt.Sprintf(
-				"MergeExtensionsForType: unsupported type %T, expected *operatorv1beta1.DataPlane or *gwtypes.ControlPlane", obj,
-			),
-		)
+		},
 	}
+	return MergeExtensions(defaultExtensions, &dataplane)
 }

--- a/controller/pkg/extensions/merge.go
+++ b/controller/pkg/extensions/merge.go
@@ -1,23 +1,87 @@
 package extensions
 
 import (
+	"fmt"
+
 	"github.com/samber/lo"
 
 	commonv1alpha1 "github.com/kong/kubernetes-configuration/v2/api/common/v1alpha1"
+	operatorv1alpha1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1alpha1"
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1beta1"
 )
 
-// MergeExtensions merges the default extensions with the extensions provided by the user.
+// MergeExtensions merges the default extensions with the extensions from the
+// provided extendable object.
 // The provided extensions take precedence over the default extensions: in case
 // the user provides an extension that is also present in the default extensions,
 // the user's extension will be used.
-func MergeExtensions(defaultExtensions, extensions []commonv1alpha1.ExtensionRef) []commonv1alpha1.ExtensionRef {
-	newExtensions := make([]commonv1alpha1.ExtensionRef, 0)
-	for _, dext := range defaultExtensions {
-		if _, found := lo.Find(extensions, func(ext commonv1alpha1.ExtensionRef) bool {
+func MergeExtensions[
+	extendable interface {
+		GetExtensions() []commonv1alpha1.ExtensionRef
+	},
+](
+	defaultExtensions []commonv1alpha1.ExtensionRef,
+	extended extendable,
+) []commonv1alpha1.ExtensionRef {
+	var (
+		newExtensions = make([]commonv1alpha1.ExtensionRef, 0)
+		extensions    = extended.GetExtensions()
+	)
+	extensionMatcher := func(dext commonv1alpha1.ExtensionRef) func(commonv1alpha1.ExtensionRef) bool {
+		return func(ext commonv1alpha1.ExtensionRef) bool {
 			return ext.Group == dext.Group && ext.Kind == dext.Kind
-		}); !found {
+		}
+	}
+forLoop:
+	for _, dext := range defaultExtensions {
+		// Perform type specific checks for extensions.
+		// This is necessary to allow users to define extensions at the shared
+		// GatewayConfiguration level in the API and delegate the logic of merging
+		// them to the operator.
+
+		switch {
+		case dext.Group == operatorv1alpha1.SchemeGroupVersion.Group &&
+			dext.Kind == operatorv1alpha1.DataPlaneMetricsExtensionKind:
+
+			if _, ok := any(extended).(*operatorv1beta1.DataPlane); ok {
+				// Do not add the DataPlaneMetricsExtension to the DataPlane.
+				// That's a ControlPlane extension.
+				continue forLoop
+			}
+
+		default:
+		}
+
+		if !lo.ContainsBy(extensions, extensionMatcher(dext)) {
 			newExtensions = append(newExtensions, dext)
 		}
 	}
 	return append(newExtensions, extensions...)
+}
+
+// MergeExtensionsForType is a wrapper around MergeExtensions for places where
+// we do not have an actual object to work on.
+func MergeExtensionsForType[
+	extendable *operatorv1beta1.DataPlane,
+](
+	defaultExtensions, extensions []commonv1alpha1.ExtensionRef,
+) []commonv1alpha1.ExtensionRef {
+	var obj extendable
+	switch any(obj).(type) {
+	case *operatorv1beta1.DataPlane:
+		dataplane := operatorv1beta1.DataPlane{
+			Spec: operatorv1beta1.DataPlaneSpec{
+				DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+					Extensions: extensions,
+				},
+			},
+		}
+		return MergeExtensions(defaultExtensions, &dataplane)
+	default:
+		panic(
+			fmt.Sprintf(
+				"MergeExtensionsForType: unsupported type %T, expected *operatorv1beta1.DataPlane or *gwtypes.ControlPlane", obj,
+			),
+		)
+	}
 }

--- a/controller/pkg/extensions/merge_test.go
+++ b/controller/pkg/extensions/merge_test.go
@@ -205,7 +205,7 @@ func TestMergeExtensionsForType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := MergeExtensionsForType(tt.defaultExtensions, tt.extensions)
+			result := MergeExtensionsForDataPlane(tt.defaultExtensions, tt.extensions)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/controller/pkg/extensions/merge_test.go
+++ b/controller/pkg/extensions/merge_test.go
@@ -3,12 +3,17 @@ package extensions
 import (
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 
 	commonv1alpha1 "github.com/kong/kubernetes-configuration/v2/api/common/v1alpha1"
+	operatorv1alpha1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1alpha1"
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1beta1"
+
+	gwtypes "github.com/kong/kong-operator/internal/types"
 )
 
-func TestMergeExtensions(t *testing.T) {
+func TestMergeExtensionsForType(t *testing.T) {
 	tests := []struct {
 		name              string
 		defaultExtensions []commonv1alpha1.ExtensionRef
@@ -200,7 +205,222 @@ func TestMergeExtensions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := MergeExtensions(tt.defaultExtensions, tt.extensions)
+			result := MergeExtensionsForType(tt.defaultExtensions, tt.extensions)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// mockExtendable is a mock implementation of the extendable interface for testing
+type mockExtendable struct {
+	extensions []commonv1alpha1.ExtensionRef
+}
+
+func (m *mockExtendable) GetExtensions() []commonv1alpha1.ExtensionRef {
+	return m.extensions
+}
+
+func TestMergeExtensions(t *testing.T) {
+	tests := []struct {
+		name              string
+		defaultExtensions []commonv1alpha1.ExtensionRef
+		extendable        interface {
+			GetExtensions() []commonv1alpha1.ExtensionRef
+		}
+		expected []commonv1alpha1.ExtensionRef
+	}{
+		{
+			name:              "both empty",
+			defaultExtensions: []commonv1alpha1.ExtensionRef{},
+			extendable:        &mockExtendable{extensions: []commonv1alpha1.ExtensionRef{}},
+			expected:          []commonv1alpha1.ExtensionRef{},
+		},
+		{
+			name: "nil user extensions",
+			defaultExtensions: []commonv1alpha1.ExtensionRef{
+				{
+					Group: "group1",
+					Kind:  "kind1",
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "name1",
+					},
+				},
+			},
+			extendable: &mockExtendable{extensions: nil},
+			expected: []commonv1alpha1.ExtensionRef{
+				{
+					Group: "group1",
+					Kind:  "kind1",
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "name1",
+					},
+				},
+			},
+		},
+		{
+			name: "partial overlap with different names",
+			defaultExtensions: []commonv1alpha1.ExtensionRef{
+				{
+					Group: "group1",
+					Kind:  "kind1",
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name:      "default-name",
+						Namespace: lo.ToPtr("default-ns"),
+					},
+				},
+				{
+					Group: "group2",
+					Kind:  "kind2",
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "unique-default",
+					},
+				},
+			},
+			extendable: &mockExtendable{
+				extensions: []commonv1alpha1.ExtensionRef{
+					{
+						Group: "group1",
+						Kind:  "kind1",
+						NamespacedRef: commonv1alpha1.NamespacedRef{
+							Name:      "user-name",
+							Namespace: lo.ToPtr("user-ns"),
+						},
+					},
+					{
+						Group: "group3",
+						Kind:  "kind3",
+						NamespacedRef: commonv1alpha1.NamespacedRef{
+							Name: "unique-user",
+						},
+					},
+				},
+			},
+			expected: []commonv1alpha1.ExtensionRef{
+				{
+					Group: "group2",
+					Kind:  "kind2",
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "unique-default",
+					},
+				},
+				{
+					Group: "group1",
+					Kind:  "kind1",
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name:      "user-name",
+						Namespace: lo.ToPtr("user-ns"),
+					},
+				},
+				{
+					Group: "group3",
+					Kind:  "kind3",
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "unique-user",
+					},
+				},
+			},
+		},
+		{
+			name: "same group different kind",
+			defaultExtensions: []commonv1alpha1.ExtensionRef{
+				{
+					Group: "common-group",
+					Kind:  "kind1",
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "default1",
+					},
+				},
+				{
+					Group: "common-group",
+					Kind:  "kind2",
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "default2",
+					},
+				},
+			},
+			extendable: &mockExtendable{
+				extensions: []commonv1alpha1.ExtensionRef{
+					{
+						Group: "common-group",
+						Kind:  "kind1",
+						NamespacedRef: commonv1alpha1.NamespacedRef{
+							Name: "user1",
+						},
+					},
+					{
+						Group: "common-group",
+						Kind:  "kind3",
+						NamespacedRef: commonv1alpha1.NamespacedRef{
+							Name: "user3",
+						},
+					},
+				},
+			},
+			expected: []commonv1alpha1.ExtensionRef{
+				{
+					Group: "common-group",
+					Kind:  "kind2",
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "default2",
+					},
+				},
+				{
+					Group: "common-group",
+					Kind:  "kind1",
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "user1",
+					},
+				},
+				{
+					Group: "common-group",
+					Kind:  "kind3",
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "user3",
+					},
+				},
+			},
+		},
+		{
+			name: "DataPlaneMetricsExtension is not added to DataPlane",
+			defaultExtensions: []commonv1alpha1.ExtensionRef{
+				{
+					Group: operatorv1alpha1.SchemeGroupVersion.Group,
+					Kind:  operatorv1alpha1.DataPlaneMetricsExtensionKind,
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "default1",
+					},
+				},
+			},
+			extendable: &operatorv1beta1.DataPlane{},
+			expected:   []commonv1alpha1.ExtensionRef{},
+		},
+		{
+			name: "DataPlaneMetricsExtension is added to ControlPlane",
+			defaultExtensions: []commonv1alpha1.ExtensionRef{
+				{
+					Group: operatorv1alpha1.SchemeGroupVersion.Group,
+					Kind:  operatorv1alpha1.DataPlaneMetricsExtensionKind,
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "default1",
+					},
+				},
+			},
+			extendable: &gwtypes.ControlPlane{},
+			expected: []commonv1alpha1.ExtensionRef{
+				{
+					Group: operatorv1alpha1.SchemeGroupVersion.Group,
+					Kind:  operatorv1alpha1.DataPlaneMetricsExtensionKind,
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "default1",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MergeExtensions(tt.defaultExtensions, tt.extendable)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/test/integration/controlplane_extensions_dataplanemetrics_test.go
+++ b/test/integration/controlplane_extensions_dataplanemetrics_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestControlPlaneExtensionsDataPlaneMetrics(t *testing.T) {
-	t.Skip("skipping as this test requires changed in the GatewayConfiguration API: https://github.com/kong/kong-operator/issues/1608")
-
 	createExtensionRefWithoutNamespace := func(extRefName string) commonv1alpha1.ExtensionRef {
 		return commonv1alpha1.ExtensionRef{
 			Group: operatorv1alpha1.SchemeGroupVersion.Group,

--- a/test/integration/controlplane_extensions_dataplanemetrics_test.go
+++ b/test/integration/controlplane_extensions_dataplanemetrics_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestControlPlaneExtensionsDataPlaneMetrics(t *testing.T) {
+	t.Parallel()
+
 	createExtensionRefWithoutNamespace := func(extRefName string) commonv1alpha1.ExtensionRef {
 		return commonv1alpha1.ExtensionRef{
 			Group: operatorv1alpha1.SchemeGroupVersion.Group,
@@ -39,8 +41,7 @@ func TestControlPlaneExtensionsDataPlaneMetrics(t *testing.T) {
 	)
 
 	ctx := GetCtx()
-	env := GetEnv()
-	namespace, cleaner := osshelpers.SetupTestEnv(t, ctx, env)
+	namespace, cleaner := osshelpers.SetupTestEnv(t, ctx, GetEnv())
 
 	clients := GetClients()
 	operatorClient := clients.OperatorClient
@@ -88,6 +89,7 @@ func TestControlPlaneExtensionsDataPlaneMetrics(t *testing.T) {
 	gatewayConfig := &operatorv2beta1.GatewayConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "gwconfig-",
+			Namespace:    namespace.Name,
 		},
 		Spec: operatorv2beta1.GatewayConfigurationSpec{
 			DataPlaneOptions: &operatorv2beta1.GatewayConfigDataPlaneOptions{
@@ -112,9 +114,15 @@ func TestControlPlaneExtensionsDataPlaneMetrics(t *testing.T) {
 					},
 				},
 			},
-
-			// TODO(pmalek): add support for ControlPlane optionns using GatewayConfiguration v2
-			// https://github.com/kong/kong-operator/issues/1728
+			Extensions: []commonv1alpha1.ExtensionRef{
+				{
+					Kind:  "DataPlaneMetricsExtension",
+					Group: operatorv1alpha1.SchemeGroupVersion.Group,
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: dbMetricExt1.Name,
+					},
+				},
+			},
 		},
 	}
 	gatewayConfig, err = operatorClient.GatewayOperatorV2beta1().GatewayConfigurations(namespace.Name).Create(ctx, gatewayConfig, metav1.CreateOptions{})


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the enforcement of `Gateway`'s `ControlPlane` extensions and enables the integration test for `DataPlaneMetricsExtension`.

**Which issue this PR fixes**

Part of https://github.com/Kong/kong-operator/issues/1608

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
