### PR TITLE
tests: re-enable TestOperatorLogs e2e test

### DIFF
--- a/test/e2e/environment.go
+++ b/test/e2e/environment.go
@@ -29,14 +29,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
-	operatorv1alpha1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1alpha1"
-	operatorv1beta1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1beta1"
 	configurationclient "github.com/kong/kubernetes-configuration/v2/pkg/clientset"
 
 	"github.com/kong/kong-operator/internal/versions"
+	"github.com/kong/kong-operator/modules/manager/scheme"
 	testutils "github.com/kong/kong-operator/pkg/utils/test"
 	"github.com/kong/kong-operator/test"
 	"github.com/kong/kong-operator/test/helpers"
@@ -213,12 +211,12 @@ func CreateEnvironment(t *testing.T, ctx context.Context, opts ...TestEnvOption)
 			o.DestWriter = io.Discard
 		}))
 	})
-	clients.MgrClient, err = client.New(env.Cluster().Config(), client.Options{})
+	clients.MgrClient, err = client.New(env.Cluster().Config(),
+		client.Options{
+			Scheme: scheme.Get(),
+		},
+	)
 	require.NoError(t, err)
-
-	require.NoError(t, gatewayv1.Install(clients.MgrClient.Scheme()))
-	require.NoError(t, operatorv1alpha1.AddToScheme(clients.MgrClient.Scheme()))
-	require.NoError(t, operatorv1beta1.AddToScheme(clients.MgrClient.Scheme()))
 
 	if opt.InstallViaKustomize {
 		t.Logf("deploying Gateway APIs CRDs from %s", testutils.GatewayExperimentalCRDsKustomizeURL)

--- a/test/e2e/operator_logs_test.go
+++ b/test/e2e/operator_logs_test.go
@@ -60,8 +60,6 @@ var (
 )
 
 func TestOperatorLogs(t *testing.T) {
-	t.Skip("skipping as this test requires changed in the GatewayConfiguration API: https://github.com/kong/kong-operator/issues/1608")
-
 	ctx := t.Context()
 	if imageLoad == "" && imageOverride == "" {
 		t.Skipf("No KONG_TEST_KONG_OPERATOR_IMAGE_OVERRIDE nor KONG_TEST_KONG_OPERATOR_IMAGE_LOAD" +


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR re-enables TestOperatorLogs e2e test and closes #1608 as there are no more mentions of #1608 in the codebase).

**Which issue this PR fixes**

Fixes #1608

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
