### PR TITLE
fix: fix manager config logging

### DIFF
--- a/ingress-controller/pkg/manager/config/config.go
+++ b/ingress-controller/pkg/manager/config/config.go
@@ -69,7 +69,7 @@ type Config struct {
 	// KubeRestConfig takes precedence over any fields related to what it configures,
 	// such as APIServerHost, APIServerQPS, etc. It's intended to be used when the controller
 	// is run as a part of Kong Operator. It bypass the mechanism of constructing this config.
-	KubeRestConfig *rest.Config
+	KubeRestConfig *rest.Config `json:"-"`
 
 	// Kubernetes configurations
 	KubeconfigPath           string
@@ -159,7 +159,7 @@ type Config struct {
 	Konnect KonnectConfig
 
 	// AnonymousReportsFixedPayloadCustomizer allows customization of anonymous telemetry reports sent by the controller.
-	AnonymousReportsFixedPayloadCustomizer types.PayloadCustomizer
+	AnonymousReportsFixedPayloadCustomizer types.PayloadCustomizer `json:"-"`
 	// Override default telemetry settings (e.g. for testing). They aren't exposed in the CLI.
 	SplunkEndpoint                   string
 	SplunkEndpointInsecureSkipVerify bool

--- a/ingress-controller/pkg/manager/config/config_test.go
+++ b/ingress-controller/pkg/manager/config/config_test.go
@@ -1,14 +1,23 @@
 package config_test
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
 
 	managercfg "github.com/kong/kong-operator/ingress-controller/pkg/manager/config"
 	"github.com/kong/kong-operator/ingress-controller/pkg/telemetry/types"
 )
+
+func TestConfigJSONMarshal(t *testing.T) {
+	_, err := json.Marshal(managercfg.Config{
+		KubeRestConfig: &rest.Config{},
+	})
+	require.NoError(t, err)
+}
 
 func TestConfigResolve(t *testing.T) {
 	t.Run("Admin Token Path", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Encountered the following log entries when running recently:

```
2025-08-21T12:30:34+02:00	DEBUG	controlplane	creating new instance	{"manager_id": "990e33bf-2904-48d8-8a79-cdac7c9b8851", "manager_configError": "json: unsupported type: func(types.ProviderReport) types.ProviderReport"}
```

It appears that this is an issue with marshalling the controlplane config to JSON because of the embedded func fields.

This PR fixes that by ignoring `AnonymousReportsFixedPayloadCustomizer` and `KubeRestConfig` fields from json marshalling. The latter contains the [`WrapperFunc` field](https://github.com/kubernetes/client-go/blob/v0.33.4/rest/config.go#L115) which is also a func and cannot get marshalled. Since we do not control that type we have to ignore the whole config.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
