### PR TITLE
test(conformance): re-enable conformance tests

### DIFF
--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -43,8 +43,6 @@ type ConformanceConfig struct {
 }
 
 func TestGatewayConformance(t *testing.T) {
-	t.Skip("skipping Gateway API conformance tests: TODO https://github.com/kong/kong-operator/issues/1726")
-
 	t.Parallel()
 
 	const looserTimeout = 180 * time.Second

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -169,6 +169,13 @@ func exitOnErr(err error) {
 func startControllerManager(metadata metadata.Info) <-chan struct{} {
 	cfg := testutils.DefaultControllerConfigForTests()
 
+	// Disable label selectors for secrets and configMaps to make the secrets and configMaps in the tests reconciled.
+	// The secrets (used as listener certificates) does not support adding labels to them,
+	// so we need to disable the label selector to get them reconciled:
+	// https://github.com/kubernetes-sigs/gateway-api/issues/4056
+	cfg.SecretLabelSelector = ""
+	cfg.ConfigMapLabelSelector = ""
+
 	startedChan := make(chan struct{})
 	go func() {
 		exitOnErr(manager.Run(cfg, scheme.Get(), manager.SetupControllers, startedChan, metadata))


### PR DESCRIPTION
**What this PR does / why we need it**:

Re-enable the gateway API conformance tests as we migrated `ControlPlane` and `GatewayConfiguration` to v2beta1.

**Which issue this PR fixes**

Fixes #1726

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
