### PR TITLE
chart: fix config dump template

### DIFF
--- a/charts/kong-operator/CHANGELOG.md
+++ b/charts/kong-operator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix config dump service and template issue.
+
 ## 0.0.4
 
 ### Changes

--- a/charts/kong-operator/CHANGELOG.md
+++ b/charts/kong-operator/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix config dump service and template issue.
+  [#2129](https://github.com/Kong/kong-operator/pull/2129)
 
 ## 0.0.4
 

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -675,7 +675,9 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    app.kubernetes.io/component: ko---
+    app.kubernetes.io/component: ko
+---
+# Source: kong-operator/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -675,13 +675,15 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    app.kubernetes.io/component: ko---
+    app.kubernetes.io/component: ko
+---
+# Source: kong-operator/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: ko
-  name: chartsnap-kong-operator
+  name: chartsnap-kong-operator-config-dump
   namespace: default
 spec:
   ports:
@@ -690,7 +692,9 @@ spec:
     protocol: TCP
     targetPort: 10256
   selector:
-    app.kubernetes.io/component: ko---
+    app.kubernetes.io/component: ko
+---
+# Source: kong-operator/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -675,7 +675,9 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    app.kubernetes.io/component: ko---
+    app.kubernetes.io/component: ko
+---
+# Source: kong-operator/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kong-operator/ci/__snapshots__/effective-version-1-6-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/effective-version-1-6-values.snap
@@ -675,7 +675,9 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    app.kubernetes.io/component: ko---
+    app.kubernetes.io/component: ko
+---
+# Source: kong-operator/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -675,7 +675,9 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    app.kubernetes.io/component: ko---
+    app.kubernetes.io/component: ko
+---
+# Source: kong-operator/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -675,7 +675,9 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    app.kubernetes.io/component: ko---
+    app.kubernetes.io/component: ko
+---
+# Source: kong-operator/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -675,7 +675,9 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    app.kubernetes.io/component: ko---
+    app.kubernetes.io/component: ko
+---
+# Source: kong-operator/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrest-values.snap
@@ -675,7 +675,9 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    app.kubernetes.io/component: ko---
+    app.kubernetes.io/component: ko
+---
+# Source: kong-operator/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -675,7 +675,9 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    app.kubernetes.io/component: ko---
+    app.kubernetes.io/component: ko
+---
+# Source: kong-operator/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -675,7 +675,9 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    app.kubernetes.io/component: ko---
+    app.kubernetes.io/component: ko
+---
+# Source: kong-operator/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -675,7 +675,9 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    app.kubernetes.io/component: ko---
+    app.kubernetes.io/component: ko
+---
+# Source: kong-operator/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -675,7 +675,9 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    app.kubernetes.io/component: ko---
+    app.kubernetes.io/component: ko
+---
+# Source: kong-operator/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kong-operator/templates/services.yaml
+++ b/charts/kong-operator/templates/services.yaml
@@ -13,25 +13,25 @@ spec:
     targetPort: https
   selector:
     app.kubernetes.io/component: ko
-{{- if .Values.enableControlplaneConfigDump -}}
+{{- if .Values.enableControlplaneConfigDump }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: ko
-  name: {{ template "kong.fullname" . }}
+  name: {{ template "kong.fullname" . }}-config-dump
   namespace:  {{ template "kong.namespace" . }}
 spec:
   ports:
   - name: config-dump
-    port: {{.Values.controlplaneConfigDumpPort}}
+    port: {{ .Values.controlplaneConfigDumpPort }}
     protocol: TCP
-    targetPort: {{.Values.controlplaneConfigDumpPort}}
+    targetPort: {{ .Values.controlplaneConfigDumpPort }}
   selector:
     app.kubernetes.io/component: ko
-{{- end -}}
-{{- if .Values.conversionWebhook.enabled -}}
+{{- end }}
+{{- if .Values.conversionWebhook.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -47,4 +47,4 @@ spec:
     targetPort: 9443
   selector:
     app.kubernetes.io/component: ko
-{{- end -}}
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

- The config-dump svc should have its own independent name, otherwise it will be overwritten.
- The template has been fixed, otherwise --- it will be rendered incorrectly.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
