### PR TITLE
Revert "chore(refactor): in `KonnectExtension` controller do not fetch `KonnectGatewayControlPlane` from Konnect (#1436)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -268,12 +268,12 @@ replace (
 	k8s.io/component-base => k8s.io/component-base v0.33.0
 	k8s.io/component-helpers => k8s.io/component-helpers v0.33.0
 	k8s.io/controller-manager => k8s.io/controller-manager v0.33.0
-	k8s.io/cri-api => k8s.io/cri-api v0.33.3
+	k8s.io/cri-api => k8s.io/cri-api v0.33.4
 	k8s.io/cri-client => k8s.io/cri-client v0.33.0
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.33.0
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.33.0
 	k8s.io/endpointslice => k8s.io/endpointslice v0.33.0
-	k8s.io/externaljwt => k8s.io/externaljwt v0.33.3
+	k8s.io/externaljwt => k8s.io/externaljwt v0.33.4
 	k8s.io/kms => k8s.io/kms v0.33.0
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.33.0
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.33.0

--- a/test/helpers/deploy/deploy_resources.go
+++ b/test/helpers/deploy/deploy_resources.go
@@ -311,13 +311,6 @@ func KonnectGatewayControlPlaneWithID(
 		},
 	}
 	cp.Status.ID = uuid.NewString()[:8]
-	cp.Status.Endpoints = &konnectv1alpha1.KonnectEndpoints{
-		ControlPlaneEndpoint: "cp.endpoint",
-		TelemetryEndpoint:    "tp.endpoint",
-	}
-	for _, opt := range opts {
-		opt(cp)
-	}
 	require.NoError(t, cl.Status().Update(ctx, cp))
 	return cp
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This reverts commit f8d4f259bbc881ce3981dd9a36105ce480268891.

**Which issue this PR fixes**

Fixes #https://github.com/Kong/kong-operator/issues/2152

**Special notes for your reviewer**:

This PR reverts changes that introduced a regression in KGO starting from version 1.6.0. It allows users to migrated from the `konnectID` field in `KonnectExtension` to `KonnectGatewayControlPlane`. See: #2152 and https://github.com/Kong/developer.konghq.com/pull/2724

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
