### PR TITLE
fix: fix GatewayClass reconciler watch for GatewayConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
 
+## Unreleased
+
+### Fixed
+
+- Fixed a missing watch in `GatewayClass` reconciler for related `GatewayConfiguration` resources.
+  [#2161](https://github.com/Kong/kong-operator/pull/2161)
+
 ## [v2.0.0-alpha.5]
 
 > Release date: 2025-09-01

--- a/internal/utils/index/gatewayclass.go
+++ b/internal/utils/index/gatewayclass.go
@@ -13,11 +13,6 @@ const (
 	GatewayClassOnGatewayConfigurationIndex = "GatewayClassOnGatewayConfiguration"
 )
 
-// GatewayClassFlags contains flags that control which indexes are created for the GatewayClass object.
-type GatewayClassFlags struct {
-	GatewayAPIGatewayControllerEnabled bool
-}
-
 func OptionsForGatewayClass() []Option {
 	return []Option{
 		{

--- a/internal/utils/index/gatewayclass.go
+++ b/internal/utils/index/gatewayclass.go
@@ -1,0 +1,52 @@
+package index
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	operatorv2beta1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v2beta1"
+)
+
+const (
+	// GatewayClassOnGatewayConfigurationIndex is the key to index the GatewayClass
+	// based on the referenced GatewayConfiguration.
+	GatewayClassOnGatewayConfigurationIndex = "GatewayClassOnGatewayConfiguration"
+)
+
+// GatewayClassFlags contains flags that control which indexes are created for the GatewayClass object.
+type GatewayClassFlags struct {
+	GatewayAPIGatewayControllerEnabled bool
+}
+
+func OptionsForGatewayClass() []Option {
+	return []Option{
+		{
+			Object:         &gatewayv1.GatewayClass{},
+			Field:          GatewayClassOnGatewayConfigurationIndex,
+			ExtractValueFn: GatewayConfigurationOnGatewayClass,
+		},
+	}
+}
+
+func GatewayConfigurationOnGatewayClass(o client.Object) []string {
+	gwc, ok := o.(*gatewayv1.GatewayClass)
+	if !ok {
+		return nil
+	}
+
+	params := gwc.Spec.ParametersRef
+	if params == nil {
+		return nil
+	}
+
+	if string(params.Group) != operatorv2beta1.SchemeGroupVersion.Group ||
+		params.Kind != "GatewayConfiguration" {
+		return nil
+	}
+
+	if params.Namespace == nil {
+		return nil
+	}
+
+	return []string{string(*params.Namespace) + "/" + params.Name}
+}

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -94,6 +94,11 @@ func SetupCacheIndexes(ctx context.Context, mgr manager.Manager, cfg Config) err
 			}),
 		)
 	}
+
+	if cfg.GatewayControllerEnabled {
+		indexOptions = append(indexOptions, index.OptionsForGatewayClass()...)
+	}
+
 	if cfg.KonnectControllersEnabled {
 		cl := mgr.GetClient()
 		indexOptions = slices.Concat(indexOptions,

--- a/pkg/utils/test/setup_helpers.go
+++ b/pkg/utils/test/setup_helpers.go
@@ -34,6 +34,8 @@ import (
 const (
 	// KubernetesConfigurationModuleName is the name of the module where we import and install Kong configuration CRDs from.
 	KubernetesConfigurationModuleName = "github.com/kong/kubernetes-configuration/v2"
+	// GatewayAPIModuleName is the name of the module where we import and install Gateway API CRDs from.
+	GatewayAPIModuleName = "sigs.k8s.io/gateway-api"
 )
 
 func noOpClose() error {


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes an issue where a `GatewayClass` references a non existent `GatewayConfiguration`, and that `GatewayConfiguration` gets created.

Currently the operator doesn't react to that due to the missing watch.

This PR fixes that.

**Which issue this PR fixes**

Fixes https://github.com/Kong/kong-operator/issues/2160

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
