### PR TITLE
Chore(ci): Add cleanup job for removing leftover Konnect control planes

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -2,7 +2,7 @@ name: cleanup
 
 on:
   schedule:
-    - cron: '*/30 * * * *'
+    - cron: '8 */1 * * *' # Run once per hour
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,0 +1,26 @@
+name: cleanup
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  konnect:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: setup golang
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+      - name: cleanup orphaned test clusters
+        run: go run ./hack/cleanup konnect
+        env:
+          KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
+          KONG_TEST_KONNECT_SERVER_URL: us.api.konghq.tech

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -24,3 +24,5 @@ jobs:
         env:
           KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
           KONG_TEST_KONNECT_SERVER_URL: us.api.konghq.tech
+          # Ref: https://github.com/Kong/sdk-konnect-go/issues/20
+          KONG_CUSTOM_DOMAIN: konghq.tech

--- a/hack/cleanup/konnect_control_planes.go
+++ b/hack/cleanup/konnect_control_planes.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/go-logr/logr"
+	"github.com/samber/lo"
+
+	"github.com/kong/kong-operator/controller/konnect/ops"
+	"github.com/kong/kong-operator/test"
+)
+
+const (
+	konnectControlPlanesLimit     = int64(100)
+	timeUntilControlPlaneOrphaned = time.Hour
+
+	kindKonnectGatewayControlPlane = "KonnectGatewayControlPlane"
+)
+
+// cleanupKonnectControlPlanes deletes orphaned control planes created by the tests and their roles.
+func cleanupKonnectControlPlanes(ctx context.Context, log logr.Logger) error {
+	// NOTE: The domain for global endpoints is overridden in cleanup.yaml workflow.
+	// See https://github.com/Kong/sdk-konnect-go/issues/20 for details
+	sdk := sdkkonnectgo.New(
+		sdkkonnectgo.WithSecurity(
+			sdkkonnectcomp.Security{
+				PersonalAccessToken: sdkkonnectgo.String(test.KonnectAccessToken()),
+			},
+		),
+		sdkkonnectgo.WithServerURL(test.KonnectServerURL()),
+	)
+	me, err := sdk.Me.GetUsersMe(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get user info: %w", err)
+	}
+	if me.User == nil || me.User.ID == nil {
+		return errors.New("failed to get user info, user is nil")
+	}
+
+	orphanedCPs, err := findOrphanedControlPlanes(ctx, log, sdk.ControlPlanes)
+	if err != nil {
+		return fmt.Errorf("failed to find orphaned control planes: %w", err)
+	}
+	if err := deleteControlPlanes(ctx, log, sdk.ControlPlanes, orphanedCPs); err != nil {
+		return fmt.Errorf("failed to delete control planes: %w", err)
+	}
+
+	userID := *me.User.ID
+
+	// We have to manually delete roles created for the control plane because Konnect doesn't do it automatically.
+	// If we don't do it, we will eventually hit a problem with Konnect APIs answering our requests with 504s
+	// because of a performance issue when there's too many roles for the account
+	// (see https://konghq.atlassian.net/browse/TPS-1319).
+	//
+	// We can drop this once the automated cleanup is implemented on Konnect side:
+	// https://konghq.atlassian.net/browse/TPS-1453.
+	rolesToDelete, err := findOrphanedRolesToDelete(ctx, log, sdk.Roles, orphanedCPs, userID)
+	if err != nil {
+		return fmt.Errorf("failed to list control plane roles to delete: %w", err)
+	}
+	if err := deleteRoles(ctx, log, sdk.Roles, *me.User.ID, rolesToDelete); err != nil {
+		return fmt.Errorf("failed to delete control plane roles: %w", err)
+	}
+
+	return nil
+}
+
+// findOrphanedControlPlanes finds control planes that were created by the tests and are older than timeUntilControlPlaneOrphaned.
+func findOrphanedControlPlanes(
+	ctx context.Context,
+	log logr.Logger,
+	c *sdkkonnectgo.ControlPlanes,
+) ([]string, error) {
+	response, err := c.ListControlPlanes(ctx, sdkkonnectops.ListControlPlanesRequest{
+		PageSize: lo.ToPtr(konnectControlPlanesLimit),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list control planes: %w", err)
+	}
+	if response.ListControlPlanesResponse == nil {
+		body, err := io.ReadAll(response.RawResponse.Body)
+		if err != nil {
+			body = []byte(err.Error())
+		}
+		return nil, fmt.Errorf("failed to list control planes, status: %d, body: %s", response.GetStatusCode(), body)
+	}
+
+	var orphanedControlPlanes []string
+	for _, ControlPlane := range response.ListControlPlanesResponse.Data {
+		if ControlPlane.Labels[ops.KubernetesKindLabelKey] != kindKonnectGatewayControlPlane {
+			log.Info("Control plane was not created by KonnectGatewayControlPlane resource, skipping", "name", ControlPlane.Name)
+			continue
+		}
+		if ControlPlane.CreatedAt.IsZero() {
+			log.Info("Control plane has no creation timestamp, skipping", "name", ControlPlane.Name)
+			continue
+		}
+		orphanedAfter := ControlPlane.CreatedAt.Add(timeUntilControlPlaneOrphaned)
+		if !time.Now().After(orphanedAfter) {
+			log.Info("Control plane is not old enough to be considered orphaned, skipping",
+				"name", ControlPlane.Name, "created_at", ControlPlane.CreatedAt,
+			)
+			continue
+		}
+		orphanedControlPlanes = append(orphanedControlPlanes, ControlPlane.ID)
+	}
+	return orphanedControlPlanes, nil
+}
+
+// deleteControlPlanes deletes control planes by their IDs.
+func deleteControlPlanes(
+	ctx context.Context,
+	log logr.Logger,
+	sdk *sdkkonnectgo.ControlPlanes,
+	cpsIDs []string,
+) error {
+	if len(cpsIDs) < 1 {
+		log.Info("No control planes to clean up")
+		return nil
+	}
+
+	var errs []error
+	for _, cpID := range cpsIDs {
+		log.Info("Deleting control plane", "name", cpID)
+		if _, err := sdk.DeleteControlPlane(ctx, cpID); err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete control plane %s: %w", cpID, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// findOrphanedRolesToDelete gets a list of roles that belong to the orphaned control planes.
+func findOrphanedRolesToDelete(
+	ctx context.Context,
+	log logr.Logger,
+	sdk *sdkkonnectgo.Roles,
+	orphanedCPsIDs []string,
+	userID string,
+) ([]string, error) {
+	if len(orphanedCPsIDs) < 1 {
+		log.Info("No control planes to clean up, skipping listing roles")
+		return nil, nil
+	}
+
+	resp, err := sdk.ListUserRoles(ctx, userID,
+		// NOTE: Sadly we can't do filtering here (yet?) because ListUserRolesQueryParamFilter
+		// can only match by exact name and we match against a list of orphaned control plane IDs.
+		&sdkkonnectops.ListUserRolesQueryParamFilter{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list user roles: %w", err)
+	}
+
+	if resp == nil || resp.AssignedRoleCollection == nil {
+		return nil, errors.New("failed to list user roles, response is nil")
+	}
+
+	var rolesIDsToDelete []string
+	for _, role := range resp.AssignedRoleCollection.GetData() {
+		log.Info("User role", "id", role.ID, "entity_id", role.EntityID)
+		belongsToOrphanedControlPlane := lo.ContainsBy(orphanedCPsIDs, func(cpID string) bool {
+			if role.EntityID == nil {
+				return false
+			}
+			return cpID == *role.EntityID
+		})
+		if !belongsToOrphanedControlPlane {
+			continue
+		}
+		rolesIDsToDelete = append(rolesIDsToDelete, *role.ID)
+	}
+
+	return rolesIDsToDelete, nil
+}
+
+// deleteRoles deletes roles by their IDs.
+func deleteRoles(
+	ctx context.Context,
+	log logr.Logger,
+	sdk *sdkkonnectgo.Roles,
+	userID string,
+	rolesIDsToDelete []string,
+) error {
+	if len(rolesIDsToDelete) == 0 {
+		log.Info("No roles to delete")
+		return nil
+	}
+
+	var errs []error
+	for _, roleID := range rolesIDsToDelete {
+		log.Info("Deleting role", "id", roleID)
+		_, err := sdk.UsersRemoveRole(ctx, userID, roleID)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete role %s: %w", roleID, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/hack/cleanup/konnect_control_planes.go
+++ b/hack/cleanup/konnect_control_planes.go
@@ -22,7 +22,7 @@ const (
 	konnectControlPlanesLimit     = int64(100)
 	timeUntilControlPlaneOrphaned = time.Hour
 
-	testIDLabel = "konghq.com/test-id"
+	testIDLabel = "operator-test-id"
 )
 
 // cleanupKonnectControlPlanes deletes orphaned control planes created by the tests and their roles.

--- a/hack/cleanup/konnect_control_planes.go
+++ b/hack/cleanup/konnect_control_planes.go
@@ -43,6 +43,14 @@ func cleanupKonnectControlPlanes(ctx context.Context, log logr.Logger) error {
 		sdkkonnectgo.WithServerURL(serverURL),
 	)
 
+	me, err := sdk.Me.GetUsersMe(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get user info: %w", err)
+	}
+	if me.User == nil || me.User.ID == nil {
+		return errors.New("failed to get user info, user is nil")
+	}
+
 	orphanedCPs, err := findOrphanedControlPlanes(ctx, log, sdk.ControlPlanes)
 	if err != nil {
 		return fmt.Errorf("failed to find orphaned control planes: %w", err)
@@ -51,7 +59,37 @@ func cleanupKonnectControlPlanes(ctx context.Context, log logr.Logger) error {
 		return fmt.Errorf("failed to delete control planes: %w", err)
 	}
 
+	userID := *me.User.ID
+
+	// We have to manually delete roles created for the control plane because Konnect doesn't do it automatically.
+	// If we don't do it, we will eventually hit a problem with Konnect APIs answering our requests with 504s
+	// because of a performance issue when there's too many roles for the account
+	// (see https://konghq.atlassian.net/browse/TPS-1319).
+	//
+	// We can drop this once the automated cleanup is implemented on Konnect side:
+	// https://konghq.atlassian.net/browse/TPS-1453.
+	rolesToDelete, err := findOrphanedRolesToDelete(ctx, log, sdk.Roles, orphanedCPs, userID)
+	if err != nil {
+		return fmt.Errorf("failed to list control plane roles to delete: %w", err)
+	}
+	if err := deleteRoles(ctx, log, sdk.Roles, *me.User.ID, rolesToDelete); err != nil {
+		return fmt.Errorf("failed to delete control plane roles: %w", err)
+	}
+
 	return nil
+}
+
+// canonicalizedServerURL returns the canonicalized Konnect API server URL (starting with https://) from environment variable.
+func canonicalizedServerURL() (string, error) {
+	serverURL := test.KonnectServerURL()
+	serverURL = strings.TrimPrefix(serverURL, "http://")
+	serverURL = strings.TrimPrefix(serverURL, "https://")
+	serverURL = "https://" + serverURL
+
+	if _, err := url.Parse(serverURL); err != nil {
+		return "", err
+	}
+	return serverURL, nil
 }
 
 // findOrphanedControlPlanes finds control planes that were created by the tests and are older than timeUntilControlPlaneOrphaned.
@@ -116,15 +154,71 @@ func deleteControlPlanes(
 	return errors.Join(errs...)
 }
 
-// canonicalizedServerURL returns the canonicalized Konnect API server URL (starting with https://) from environment variable.
-func canonicalizedServerURL() (string, error) {
-	serverURL := test.KonnectServerURL()
-	serverURL = strings.TrimPrefix(serverURL, "http://")
-	serverURL = strings.TrimPrefix(serverURL, "https://")
-	serverURL = "https://" + serverURL
-
-	if _, err := url.Parse(serverURL); err != nil {
-		return "", err
+// findOrphanedRolesToDelete gets a list of roles that belong to the orphaned control planes.
+func findOrphanedRolesToDelete(
+	ctx context.Context,
+	log logr.Logger,
+	sdk *sdkkonnectgo.Roles,
+	orphanedCPsIDs []string,
+	userID string,
+) ([]string, error) {
+	if len(orphanedCPsIDs) < 1 {
+		log.Info("No control planes to clean up, skipping listing roles")
+		return nil, nil
 	}
-	return serverURL, nil
+
+	resp, err := sdk.ListUserRoles(ctx, userID,
+		// NOTE: Sadly we can't do filtering here (yet?) because ListUserRolesQueryParamFilter
+		// can only match by exact name and we match against a list of orphaned control plane IDs.
+		&sdkkonnectops.ListUserRolesQueryParamFilter{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list user roles: %w", err)
+	}
+
+	if resp == nil || resp.AssignedRoleCollection == nil {
+		return nil, errors.New("failed to list user roles, response is nil")
+	}
+
+	var rolesIDsToDelete []string
+	for _, role := range resp.AssignedRoleCollection.GetData() {
+		log.Info("User role", "id", role.ID, "entity_id", role.EntityID)
+		belongsToOrphanedControlPlane := lo.ContainsBy(orphanedCPsIDs, func(cpID string) bool {
+			if role.EntityID == nil {
+				return false
+			}
+			return cpID == *role.EntityID
+		})
+		if !belongsToOrphanedControlPlane {
+			continue
+		}
+		rolesIDsToDelete = append(rolesIDsToDelete, *role.ID)
+	}
+
+	return rolesIDsToDelete, nil
+}
+
+// deleteRoles deletes roles by their IDs.
+func deleteRoles(
+	ctx context.Context,
+	log logr.Logger,
+	sdk *sdkkonnectgo.Roles,
+	userID string,
+	rolesIDsToDelete []string,
+) error {
+	if len(rolesIDsToDelete) == 0 {
+		log.Info("No roles to delete")
+		return nil
+	}
+
+	var errs []error
+	for _, roleID := range rolesIDsToDelete {
+		log.Info("Deleting role", "id", roleID)
+		_, err := sdk.UsersRemoveRole(ctx, userID, roleID)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete role %s: %w", roleID, err))
+		}
+	}
+
+	return errors.Join(errs...)
 }

--- a/hack/cleanup/main.go
+++ b/hack/cleanup/main.go
@@ -1,0 +1,122 @@
+// This script cleans up orphaned GKE clusters and Konnect runtime
+// groups that were created by the e2e tests (caued by e.g. unexpected
+// crash that didn't allow a test's teardown to be completed correctly).
+// It's meant to be installed as a cronjob and run repeatedly throughout
+// the day to catch any orphaned resources: however tests should be trying to
+// delete the resources they create themselves.
+//
+// A cluster is considered orphaned when all conditions are satisfied:
+// 1. Its name begins with a predefined prefix (`gke-e2e-`).
+// 2. It was created more than 1h ago.
+//
+// A control plane is considered orphaned when all conditions are satisfied:
+// 1. It has a label `created_in_tests` with value `true`.
+// 2. It was created more than 1h ago.
+//
+// Usage: `go run ./hack/cleanup [mode]`
+// Where `mode` is one of:
+// - `all` (default): clean up both GKE clusters and Konnect control planes
+// - `gke`: clean up only GKE clusters
+// - `konnect`: clean up only Konnect control planes
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+
+	"github.com/kong/kong-operator/test"
+)
+
+const (
+	cleanupModeKonnect = "konnect"
+
+	konnectAccessTokenVar = "KONG_TEST_KONNECT_ACCESS_TOKEN"
+	konnectServerURLVar   = "KONG_TEST_KONNECT_SERVER_URL"
+)
+
+func main() {
+	zaplog, err := zap.NewDevelopment()
+	if err != nil {
+		os.Exit(1)
+	}
+	log := zapr.NewLogger(zaplog)
+
+	mode, err := getCleanupMode()
+	if err != nil {
+		log.Error(err, "error getting cleanup mode")
+		os.Exit(1)
+	}
+
+	if err := validateVars(mode); err != nil {
+		log.Error(err, "error validating vars")
+		os.Exit(1)
+	}
+
+	cleanupFuncs := resolveCleanupFuncs(mode)
+	ctx := context.Background()
+	for _, f := range cleanupFuncs {
+		if err := f(ctx, log); err != nil {
+			log.Error(err, "error running cleanup function")
+			os.Exit(1)
+		}
+	}
+}
+
+func getCleanupMode() (string, error) {
+	if len(os.Args) < 2 {
+		return cleanupModeKonnect, nil
+	}
+
+	switch os.Args[1] {
+	case cleanupModeKonnect:
+	default:
+		return "", fmt.Errorf("invalid cleanup mode: %s", os.Args[1])
+	}
+
+	return os.Args[1], nil
+}
+
+func resolveCleanupFuncs(mode string) []func(context.Context, logr.Logger) error {
+	switch mode {
+	case cleanupModeKonnect:
+		return []func(context.Context, logr.Logger) error{
+			cleanupKonnectControlPlanes,
+		}
+	default:
+		return []func(context.Context, logr.Logger) error{
+			cleanupKonnectControlPlanes,
+		}
+	}
+}
+
+func validateVars(mode string) error {
+	switch mode {
+	case cleanupModeKonnect:
+		return validateKonnectVars()
+	default:
+		if err := validateKonnectVars(); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func validateKonnectVars() error {
+	return errors.Join(
+		notEmpty(konnectAccessTokenVar, test.KonnectAccessToken()),
+		notEmpty(konnectServerURLVar, test.KonnectServerURL()),
+	)
+}
+
+func notEmpty(name, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s was empty", name)
+	}
+	return nil
+}

--- a/hack/cleanup/main.go
+++ b/hack/cleanup/main.go
@@ -36,7 +36,7 @@ import (
 const (
 	cleanupModeKonnect = "konnect"
 
-	konnectAccessTokenVar = "KONG_TEST_KONNECT_ACCESS_TOKEN"
+	konnectAccessTokenVar = "KONG_TEST_KONNECT_ACCESS_TOKEN" //nolint:gosec
 	konnectServerURLVar   = "KONG_TEST_KONNECT_SERVER_URL"
 )
 

--- a/test/helpers/deploy/deploy_resources.go
+++ b/test/helpers/deploy/deploy_resources.go
@@ -28,6 +28,9 @@ import (
 const (
 	// TestIDLabel is the label key used to identify resources created by the test suite.
 	TestIDLabel = "konghq.com/test-id"
+	// KonnectTestIDLabel is the label key used to identify the entitiy in Konnect created by the test suite.
+	// Since the label cannot start with `kong`, we need another key.
+	KonnectTestIDLabel = "operator-test-id"
 )
 
 // ObjOption is a function that modifies a  client.Object.
@@ -313,6 +316,24 @@ func KonnectGatewayControlPlaneTypeWithCloudGatewaysEnabled() ObjOption {
 			panic(fmt.Errorf("%T does not implement KonnectGatewayControlPlane", obj))
 		}
 		cp.SetKonnectCloudGateway(lo.ToPtr(true))
+	}
+}
+
+// KonnectGatewayControlPlaneLabel sets the label `key:value` in the KonnectGatewayControlPlane
+// to set the corresponding label in the created Konnect control plane.
+func KonnectGatewayControlPlaneLabel(key, value string) ObjOption {
+	return func(obj client.Object) {
+		cp, ok := obj.(*konnectv1alpha2.KonnectGatewayControlPlane)
+		if !ok {
+			panic(fmt.Errorf("%T does not implement KonnectGatewayControlPlane", obj))
+		}
+		if cp.Spec.CreateControlPlaneRequest == nil {
+			cp.Spec.CreateControlPlaneRequest = &sdkkonnectcomp.CreateControlPlaneRequest{}
+		}
+		if cp.Spec.CreateControlPlaneRequest.Labels == nil {
+			cp.Spec.CreateControlPlaneRequest.Labels = map[string]string{}
+		}
+		cp.Spec.CreateControlPlaneRequest.Labels[key] = value
 	}
 }
 

--- a/test/helpers/deploy/deploy_resources.go
+++ b/test/helpers/deploy/deploy_resources.go
@@ -28,8 +28,8 @@ import (
 const (
 	// TestIDLabel is the label key used to identify resources created by the test suite.
 	TestIDLabel = "konghq.com/test-id"
-	// KonnectTestIDLabel is the label key used to identify the entitiy in Konnect created by the test suite.
-	// Since the label cannot start with `kong`, we need another key.
+	// KonnectTestIDLabel is the label key added in the Konnect entity used to identify them created by the test suite.
+	// Since the label cannot start with `kong`, we use another key.
 	KonnectTestIDLabel = "operator-test-id"
 )
 
@@ -319,8 +319,9 @@ func KonnectGatewayControlPlaneTypeWithCloudGatewaysEnabled() ObjOption {
 	}
 }
 
-// KonnectGatewayControlPlaneLabel sets the label `key:value` in the KonnectGatewayControlPlane
-// to set the corresponding label in the created Konnect control plane.
+// KonnectGatewayControlPlaneLabel returns an ObjOption that adds the given label to the `spec.createControlPlaneRequest.labels`
+// of the KonnectGatewayControlPlane.
+// This adds the given label on the created control plane in Konnect (instead of the label in the k8s metadata).
 func KonnectGatewayControlPlaneLabel(key, value string) ObjOption {
 	return func(obj client.Object) {
 		cp, ok := obj.(*konnectv1alpha2.KonnectGatewayControlPlane)

--- a/test/integration/konnect_entities_test.go
+++ b/test/integration/konnect_entities_test.go
@@ -57,6 +57,7 @@ func TestKonnectEntities(t *testing.T) {
 
 	cp := deploy.KonnectGatewayControlPlane(t, GetCtx(), clientNamespaced, authCfg,
 		deploy.WithTestIDLabel(testID),
+		deploy.KonnectGatewayControlPlaneLabel(deploy.KonnectTestIDLabel, testID),
 	)
 
 	t.Cleanup(deleteObjectAndWaitForDeletionFn(t, cp.DeepCopy()))

--- a/test/integration/konnect_extension_test.go
+++ b/test/integration/konnect_extension_test.go
@@ -89,6 +89,7 @@ func TestKonnectExtensionControlPlaneRotation(t *testing.T) {
 	// Create a Konnect control plane for the KonnectExtension to attach to.
 	cp := deploy.KonnectGatewayControlPlane(t, GetCtx(), clientNamespaced, authCfg,
 		deploy.WithTestIDLabel(testID),
+		deploy.KonnectGatewayControlPlaneLabel(deploy.KonnectTestIDLabel, testID),
 	)
 
 	t.Logf("Waiting for Konnect ID to be assigned to ControlPlane %s/%s", cp.Namespace, cp.Name)
@@ -126,6 +127,7 @@ func TestKonnectExtensionControlPlaneRotation(t *testing.T) {
 	cp = deploy.KonnectGatewayControlPlane(t, GetCtx(), clientNamespaced, authCfg,
 		deploy.WithTestIDLabel(testID),
 		deploy.WithName(cp.Name), // Reuse the same name to ensure the KonnectExtension is recreated with the same name.
+		deploy.KonnectGatewayControlPlaneLabel(deploy.KonnectTestIDLabel, testID),
 	)
 	t.Cleanup(deleteObjectAndWaitForDeletionFn(t, cp.DeepCopy()))
 
@@ -192,6 +194,7 @@ func TestKonnectExtension(t *testing.T) {
 		// Create a Konnect control plane for the KonnectExtension to attach to.
 		cp := deploy.KonnectGatewayControlPlane(t, GetCtx(), clientNamespaced, authCfg,
 			deploy.WithTestIDLabel(testID),
+			deploy.KonnectGatewayControlPlaneLabel(deploy.KonnectTestIDLabel, testID),
 		)
 		t.Cleanup(deleteObjectAndWaitForDeletionFn(t, cp.DeepCopy()))
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a cleanup workflow to remove the leftover control planes. 
Standard of cleanup:

- Created in KO's integration tests (has the label `operator-test-id`) 
- Created more than 1 hour before

Also deletes the roles related to the deleted CPs.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

Basically copied from the cleanup code and workflow file in KIC. Removed the cleanup of the `Role`s in Konnect.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
