### PR TITLE
chart: use namespaced names for Cluster wide resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -416,7 +416,7 @@ ensure.go.pkg.downloaded.gateway-api:
 .PHONY: manifests.charts.kong-operator.role
 manifests.charts.kong-operator.role: manifests.role
 	cp $(CONFIG_RBAC_ROLE_DIR)/role.yaml $(KONG_OPERATOR_CHART_DIR)/templates/cluster-role.yaml
-	$(YQ) eval '.metadata.name = "{{ template \"kong.fullname\" . }}-manager-role"' -i $(KONG_OPERATOR_CHART_DIR)/templates/cluster-role.yaml
+	$(YQ) eval '.metadata.name = "{{ template \"kong.fullnamespacedname\" . }}-manager-role"' -i $(KONG_OPERATOR_CHART_DIR)/templates/cluster-role.yaml
 
 .PHONY: manifests.charts.kong-operator.crds.operator
 manifests.charts.kong-operator.crds.operator: kustomize ensure.go.pkg.downloaded.kubernetes-configuration

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -52541,7 +52541,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: 'chartsnap-kong-operator-manager-role'
+  name: 'default-chartsnap-kong-operator-manager-role'
 rules:
 - apiGroups:
   - ""
@@ -53034,7 +53034,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 rules:
 - apiGroups:
   - ""
@@ -53051,7 +53051,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-metrics-reader
+  name: default-chartsnap-kong-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -53062,7 +53062,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -53081,11 +53081,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-kong-mtls-secret-rolebinding
+  name: default-chartsnap-kong-operator-kong-mtls-secret-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53095,11 +53095,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-manager-rolebinding
+  name: default-chartsnap-kong-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-manager-role
+  name: default-chartsnap-kong-operator-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53109,11 +53109,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-proxy-rolebinding
+  name: default-chartsnap-kong-operator-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -52541,7 +52541,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: 'chartsnap-kong-operator-manager-role'
+  name: 'default-chartsnap-kong-operator-manager-role'
 rules:
 - apiGroups:
   - ""
@@ -53034,7 +53034,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 rules:
 - apiGroups:
   - ""
@@ -53051,7 +53051,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-metrics-reader
+  name: default-chartsnap-kong-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -53062,7 +53062,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -53081,11 +53081,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-kong-mtls-secret-rolebinding
+  name: default-chartsnap-kong-operator-kong-mtls-secret-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53095,11 +53095,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-manager-rolebinding
+  name: default-chartsnap-kong-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-manager-role
+  name: default-chartsnap-kong-operator-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53109,11 +53109,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-proxy-rolebinding
+  name: default-chartsnap-kong-operator-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/charts/kong-operator/ci/__snapshots__/conversion-webhook-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/conversion-webhook-enabled-cert-manager.snap
@@ -52516,7 +52516,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: 'chartsnap-kong-operator-manager-role'
+  name: 'default-chartsnap-kong-operator-manager-role'
 rules:
 - apiGroups:
   - ""
@@ -53009,7 +53009,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 rules:
 - apiGroups:
   - ""
@@ -53026,7 +53026,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-metrics-reader
+  name: default-chartsnap-kong-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -53037,7 +53037,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -53056,11 +53056,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-kong-mtls-secret-rolebinding
+  name: default-chartsnap-kong-operator-kong-mtls-secret-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53070,11 +53070,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-manager-rolebinding
+  name: default-chartsnap-kong-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-manager-role
+  name: default-chartsnap-kong-operator-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53084,11 +53084,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-proxy-rolebinding
+  name: default-chartsnap-kong-operator-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -52541,7 +52541,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: 'chartsnap-kong-operator-manager-role'
+  name: 'default-chartsnap-kong-operator-manager-role'
 rules:
 - apiGroups:
   - ""
@@ -53034,7 +53034,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 rules:
 - apiGroups:
   - ""
@@ -53051,7 +53051,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-metrics-reader
+  name: default-chartsnap-kong-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -53062,7 +53062,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -53081,11 +53081,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-kong-mtls-secret-rolebinding
+  name: default-chartsnap-kong-operator-kong-mtls-secret-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53095,11 +53095,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-manager-rolebinding
+  name: default-chartsnap-kong-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-manager-role
+  name: default-chartsnap-kong-operator-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53109,11 +53109,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-proxy-rolebinding
+  name: default-chartsnap-kong-operator-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -52541,7 +52541,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: 'chartsnap-kong-operator-manager-role'
+  name: 'default-chartsnap-kong-operator-manager-role'
 rules:
 - apiGroups:
   - ""
@@ -53034,7 +53034,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 rules:
 - apiGroups:
   - ""
@@ -53051,7 +53051,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-metrics-reader
+  name: default-chartsnap-kong-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -53062,7 +53062,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -53081,11 +53081,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-kong-mtls-secret-rolebinding
+  name: default-chartsnap-kong-operator-kong-mtls-secret-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53095,11 +53095,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-manager-rolebinding
+  name: default-chartsnap-kong-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-manager-role
+  name: default-chartsnap-kong-operator-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53109,11 +53109,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-proxy-rolebinding
+  name: default-chartsnap-kong-operator-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -52541,7 +52541,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: 'chartsnap-kong-operator-manager-role'
+  name: 'default-chartsnap-kong-operator-manager-role'
 rules:
 - apiGroups:
   - ""
@@ -53034,7 +53034,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 rules:
 - apiGroups:
   - ""
@@ -53051,7 +53051,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-metrics-reader
+  name: default-chartsnap-kong-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -53062,7 +53062,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -53081,11 +53081,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-kong-mtls-secret-rolebinding
+  name: default-chartsnap-kong-operator-kong-mtls-secret-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53095,11 +53095,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-manager-rolebinding
+  name: default-chartsnap-kong-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-manager-role
+  name: default-chartsnap-kong-operator-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53109,11 +53109,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-proxy-rolebinding
+  name: default-chartsnap-kong-operator-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -52541,7 +52541,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: 'chartsnap-kong-operator-manager-role'
+  name: 'default-chartsnap-kong-operator-manager-role'
 rules:
 - apiGroups:
   - ""
@@ -53034,7 +53034,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 rules:
 - apiGroups:
   - ""
@@ -53051,7 +53051,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-metrics-reader
+  name: default-chartsnap-kong-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -53062,7 +53062,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -53081,11 +53081,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-kong-mtls-secret-rolebinding
+  name: default-chartsnap-kong-operator-kong-mtls-secret-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53095,11 +53095,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-manager-rolebinding
+  name: default-chartsnap-kong-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-manager-role
+  name: default-chartsnap-kong-operator-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53109,11 +53109,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-proxy-rolebinding
+  name: default-chartsnap-kong-operator-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrest-values.snap
@@ -52541,7 +52541,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: 'chartsnap-kong-operator-manager-role'
+  name: 'default-chartsnap-kong-operator-manager-role'
 rules:
 - apiGroups:
   - ""
@@ -53034,7 +53034,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 rules:
 - apiGroups:
   - ""
@@ -53051,7 +53051,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-metrics-reader
+  name: default-chartsnap-kong-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -53062,7 +53062,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -53081,11 +53081,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-kong-mtls-secret-rolebinding
+  name: default-chartsnap-kong-operator-kong-mtls-secret-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53095,11 +53095,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-manager-rolebinding
+  name: default-chartsnap-kong-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-manager-role
+  name: default-chartsnap-kong-operator-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53109,11 +53109,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-proxy-rolebinding
+  name: default-chartsnap-kong-operator-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -52541,7 +52541,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: 'chartsnap-kong-operator-manager-role'
+  name: 'default-chartsnap-kong-operator-manager-role'
 rules:
 - apiGroups:
   - ""
@@ -53034,7 +53034,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 rules:
 - apiGroups:
   - ""
@@ -53051,7 +53051,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-metrics-reader
+  name: default-chartsnap-kong-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -53062,7 +53062,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -53081,11 +53081,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-kong-mtls-secret-rolebinding
+  name: default-chartsnap-kong-operator-kong-mtls-secret-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53095,11 +53095,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-manager-rolebinding
+  name: default-chartsnap-kong-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-manager-role
+  name: default-chartsnap-kong-operator-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53109,11 +53109,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-proxy-rolebinding
+  name: default-chartsnap-kong-operator-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -52541,7 +52541,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: 'chartsnap-kong-operator-manager-role'
+  name: 'default-chartsnap-kong-operator-manager-role'
 rules:
 - apiGroups:
   - ""
@@ -53034,7 +53034,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 rules:
 - apiGroups:
   - ""
@@ -53051,7 +53051,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-metrics-reader
+  name: default-chartsnap-kong-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -53062,7 +53062,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -53081,11 +53081,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-kong-mtls-secret-rolebinding
+  name: default-chartsnap-kong-operator-kong-mtls-secret-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53095,11 +53095,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-manager-rolebinding
+  name: default-chartsnap-kong-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-manager-role
+  name: default-chartsnap-kong-operator-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53109,11 +53109,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-proxy-rolebinding
+  name: default-chartsnap-kong-operator-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -52541,7 +52541,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: 'chartsnap-kong-operator-manager-role'
+  name: 'default-chartsnap-kong-operator-manager-role'
 rules:
 - apiGroups:
   - ""
@@ -53034,7 +53034,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 rules:
 - apiGroups:
   - ""
@@ -53051,7 +53051,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-metrics-reader
+  name: default-chartsnap-kong-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -53062,7 +53062,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -53081,11 +53081,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-kong-mtls-secret-rolebinding
+  name: default-chartsnap-kong-operator-kong-mtls-secret-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53095,11 +53095,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-manager-rolebinding
+  name: default-chartsnap-kong-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-manager-role
+  name: default-chartsnap-kong-operator-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53109,11 +53109,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-proxy-rolebinding
+  name: default-chartsnap-kong-operator-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -52541,7 +52541,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: 'chartsnap-kong-operator-manager-role'
+  name: 'default-chartsnap-kong-operator-manager-role'
 rules:
 - apiGroups:
   - ""
@@ -53034,7 +53034,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 rules:
 - apiGroups:
   - ""
@@ -53051,7 +53051,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-metrics-reader
+  name: default-chartsnap-kong-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -53062,7 +53062,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -53081,11 +53081,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-kong-mtls-secret-rolebinding
+  name: default-chartsnap-kong-operator-kong-mtls-secret-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53095,11 +53095,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-manager-rolebinding
+  name: default-chartsnap-kong-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-manager-role
+  name: default-chartsnap-kong-operator-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53109,11 +53109,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-proxy-rolebinding
+  name: default-chartsnap-kong-operator-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -52541,7 +52541,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: 'chartsnap-kong-operator-manager-role'
+  name: 'default-chartsnap-kong-operator-manager-role'
 rules:
 - apiGroups:
   - ""
@@ -53034,7 +53034,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 rules:
 - apiGroups:
   - ""
@@ -53051,7 +53051,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-metrics-reader
+  name: default-chartsnap-kong-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -53062,7 +53062,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -53081,11 +53081,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-kong-mtls-secret-rolebinding
+  name: default-chartsnap-kong-operator-kong-mtls-secret-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53095,11 +53095,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-manager-rolebinding
+  name: default-chartsnap-kong-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-manager-role
+  name: default-chartsnap-kong-operator-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -53109,11 +53109,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-proxy-rolebinding
+  name: default-chartsnap-kong-operator-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/charts/kong-operator/ci/__snapshots__/webhook-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-disabled-values.snap
@@ -27364,7 +27364,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: 'chartsnap-kong-operator-manager-role'
+  name: 'default-chartsnap-kong-operator-manager-role'
 rules:
 - apiGroups:
   - ""
@@ -27857,7 +27857,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 rules:
 - apiGroups:
   - ""
@@ -27874,7 +27874,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-metrics-reader
+  name: default-chartsnap-kong-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -27885,7 +27885,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -27904,11 +27904,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-kong-mtls-secret-rolebinding
+  name: default-chartsnap-kong-operator-kong-mtls-secret-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-kong-mtls-secret-role
+  name: default-chartsnap-kong-operator-kong-mtls-secret-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -27918,11 +27918,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-manager-rolebinding
+  name: default-chartsnap-kong-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-manager-role
+  name: default-chartsnap-kong-operator-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
@@ -27932,11 +27932,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: chartsnap-kong-operator-proxy-rolebinding
+  name: default-chartsnap-kong-operator-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong-operator-proxy-role
+  name: default-chartsnap-kong-operator-proxy-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/charts/kong-operator/templates/_helpers.tpl
+++ b/charts/kong-operator/templates/_helpers.tpl
@@ -17,6 +17,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- default (printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-") .Values.fullnameOverride -}}
 {{- end -}}
 
+{{- define "kong.fullnamespacedname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- default (printf "%s-%s-%s" .Release.Namespace .Release.Name $name | trunc 63 | trimSuffix "-") .Values.fullnameOverride -}}
+{{- end -}}
+
 # kong.webhookServiceName is used in different subcharts and name has to match
 # hence only variadic part of this name is .Release.Name.
 {{- define "kong.webhookServiceName" -}}

--- a/charts/kong-operator/templates/cluster-role.yaml
+++ b/charts/kong-operator/templates/cluster-role.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ template "kong.fullname" . }}-manager-role'
+  name: '{{ template "kong.fullnamespacedname" . }}-manager-role'
 rules:
   - apiGroups:
       - ""

--- a/charts/kong-operator/templates/rbac-resources.yaml
+++ b/charts/kong-operator/templates/rbac-resources.yaml
@@ -40,7 +40,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: {{ template "kong.fullname" . }}-kong-mtls-secret-role
+  name: {{ template "kong.fullnamespacedname" . }}-kong-mtls-secret-role
 rules:
   - apiGroups:
       - ""
@@ -56,7 +56,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "kong.fullname" . }}-metrics-reader
+  name: {{ template "kong.fullnamespacedname" . }}-metrics-reader
 rules:
   - nonResourceURLs:
       - /metrics
@@ -66,7 +66,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "kong.fullname" . }}-proxy-role
+  name: {{ template "kong.fullnamespacedname" . }}-proxy-role
 rules:
   - apiGroups:
       - authentication.k8s.io
@@ -98,11 +98,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "kong.fullname" . }}-kong-mtls-secret-rolebinding
+  name: {{ template "kong.fullnamespacedname" . }}-kong-mtls-secret-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "kong.fullname" . }}-kong-mtls-secret-role
+  name: {{ template "kong.fullnamespacedname" . }}-kong-mtls-secret-role
 subjects:
   - kind: ServiceAccount
     name: {{ template "kong.serviceAccountName" . }}
@@ -111,11 +111,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "kong.fullname" . }}-manager-rolebinding
+  name: {{ template "kong.fullnamespacedname" . }}-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "kong.fullname" . }}-manager-role
+  name: {{ template "kong.fullnamespacedname" . }}-manager-role
 subjects:
   - kind: ServiceAccount
     name: {{ template "kong.serviceAccountName" . }}
@@ -124,11 +124,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "kong.fullname" . }}-proxy-rolebinding
+  name: {{ template "kong.fullnamespacedname" . }}-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "kong.fullname" . }}-proxy-role
+  name: {{ template "kong.fullnamespacedname" . }}-proxy-role
 subjects:
   - kind: ServiceAccount
     name: {{ template "kong.serviceAccountName" . }}


### PR DESCRIPTION
This allows to enable multi-tenancy when using the same release name in different namespaces.

----
```
$> helm install -n kong --create-namespace ko kong/kong-operator
...
$> helm install -n kong2 --create-namespace ko kong/kong-operator --set ko-crds.enabled=false
Error: INSTALLATION FAILED: Unable to continue with install: ClusterRole "ko-kong-operator-manager-role"
in namespace "" exists and cannot be imported into the current release: invalid ownership metadata;
annotation validation error: key "meta.helm.sh/release-namespace" must equal "kong2": current value is "kong"
```

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
