### PR TITLE
Revert "chore: adjust cert generation for KO communication with `Data Plane` and introduce validation (#1950)

### DIFF
--- a/controller/dataplane/owned_resources.go
+++ b/controller/dataplane/owned_resources.go
@@ -50,7 +50,7 @@ func ensureDataPlaneCertificate(
 	}
 	return secrets.EnsureCertificate(ctx,
 		dataplane,
-		fmt.Sprintf("%s.%s.svc", adminServiceNN.Name, adminServiceNN.Namespace),
+		fmt.Sprintf("*.%s.%s.svc", adminServiceNN.Name, adminServiceNN.Namespace),
 		clusterCASecretNN,
 		usages,
 		keyConfig,

--- a/ingress-controller/internal/adminapi/endpoints_test.go
+++ b/ingress-controller/internal/adminapi/endpoints_test.go
@@ -70,7 +70,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 			want: sets.New(
 				DiscoveredAdminAPI{
 					Address:       "https://[fe80::cae2:65ff:fe7b:2852]:8444",
-					TLSServerName: "kong-admin.ns.svc",
+					TLSServerName: "pod.kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Name: "pod-1", Namespace: namespaceName,
 					},
@@ -98,7 +98,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 			want: sets.New(
 				DiscoveredAdminAPI{
 					Address:       "https://10.0.0.1:8444",
-					TLSServerName: "kong-admin.ns.svc",
+					TLSServerName: "pod.kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Name: "pod-1", Namespace: namespaceName,
 					},
@@ -127,7 +127,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 			want: sets.New(
 				DiscoveredAdminAPI{
 					Address:       "https://10.0.0.1:8444",
-					TLSServerName: "kong-admin.ns.svc",
+					TLSServerName: "pod.kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Name: "pod-1", Namespace: namespaceName,
 					},
@@ -155,7 +155,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 			want: sets.New(
 				DiscoveredAdminAPI{
 					Address:       "https://10.0.0.1:8444",
-					TLSServerName: "kong-admin.ns.svc",
+					TLSServerName: "pod.kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Name: "pod-1", Namespace: namespaceName,
 					},
@@ -257,7 +257,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 			want: sets.New(
 				DiscoveredAdminAPI{
 					Address:       "https://10.0.0.1:8444",
-					TLSServerName: "kong-admin.ns.svc",
+					TLSServerName: "pod.kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Namespace: namespaceName,
 						Name:      "pod-1",
@@ -265,7 +265,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 				},
 				DiscoveredAdminAPI{
 					Address:       "https://10.0.1.1:8444",
-					TLSServerName: "kong-admin.ns.svc",
+					TLSServerName: "pod.kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Namespace: namespaceName,
 						Name:      "pod-2",
@@ -353,7 +353,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 			want: sets.New(
 				DiscoveredAdminAPI{
 					Address:       "https://10.0.0.1:8443",
-					TLSServerName: "kong-admin.ns.svc",
+					TLSServerName: "pod.kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Namespace: namespaceName,
 						Name:      "pod-1",
@@ -361,7 +361,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 				},
 				DiscoveredAdminAPI{
 					Address:       "https://10.0.0.1:8444",
-					TLSServerName: "kong-admin.ns.svc",
+					TLSServerName: "pod.kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Namespace: namespaceName,
 						Name:      "pod-1",
@@ -524,7 +524,7 @@ func TestDiscoverer_GetAdminAPIsForService(t *testing.T) {
 			want: sets.New(
 				DiscoveredAdminAPI{
 					Address:       "https://10.0.0.1:8444",
-					TLSServerName: "kong-admin.ns.svc",
+					TLSServerName: "pod.kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Namespace: namespaceName,
 						Name:      "pod-1",
@@ -532,7 +532,7 @@ func TestDiscoverer_GetAdminAPIsForService(t *testing.T) {
 				},
 				DiscoveredAdminAPI{
 					Address:       "https://9.0.0.1:8444",
-					TLSServerName: "kong-admin.ns.svc",
+					TLSServerName: "pod.kong-admin.ns.svc",
 					PodRef: k8stypes.NamespacedName{
 						Namespace: namespaceName,
 						Name:      "pod-2",

--- a/ingress-controller/internal/adminapi/kong.go
+++ b/ingress-controller/internal/adminapi/kong.go
@@ -122,9 +122,6 @@ func makeHTTPClient(opts managercfg.AdminAPIClientConfig, kongAdminToken string)
 
 	if opts.TLSSkipVerify {
 		tlsConfig.InsecureSkipVerify = true //nolint:gosec
-		if opts.TLSServerName != "" || opts.CACertPath != "" || opts.CACert != "" || !opts.TLSClient.IsZero() {
-			return nil, errors.New("when TLSSkipVerify is set, no other TLS options can be set")
-		}
 	}
 
 	tlsConfig.ServerName = opts.TLSServerName

--- a/ingress-controller/internal/adminapi/kong_test.go
+++ b/ingress-controller/internal/adminapi/kong_test.go
@@ -37,13 +37,6 @@ func TestAdminAPIClientWithTLSOpts(t *testing.T) {
 		},
 	}
 
-	t.Run("with mutually exclusive options set, it should fail", func(t *testing.T) {
-		optsConflict := opts
-		optsConflict.TLSSkipVerify = true
-		_, err := adminapi.NewKongAPIClient("https://localhost", optsConflict, "")
-		require.ErrorContains(t, err, "when TLSSkipVerify is set, no other TLS options can be set")
-	})
-
 	t.Run("without kong admin token", func(t *testing.T) {
 		validate(t, opts, caCert, cert, key, "")
 	})
@@ -89,13 +82,6 @@ func TestAdminAPIClientWithTLSOptsAndFilePaths(t *testing.T) {
 			KeyFile:  certPrivateKeyFile.Name(),
 		},
 	}
-
-	t.Run("with mutually exclusive options set, it should fail", func(t *testing.T) {
-		optsConflict := opts
-		optsConflict.TLSSkipVerify = true
-		_, err := adminapi.NewKongAPIClient("https://localhost", optsConflict, "")
-		require.ErrorContains(t, err, "when TLSSkipVerify is set, no other TLS options can be set")
-	})
 
 	t.Run("without kong admin token", func(t *testing.T) {
 		validate(t, opts, caCert, cert, key, "")

--- a/ingress-controller/test/envtest/kongadminapi_controller_envtest_test.go
+++ b/ingress-controller/test/envtest/kongadminapi_controller_envtest_test.go
@@ -127,7 +127,7 @@ func TestKongAdminAPIController(t *testing.T) {
 	client, err := ctrlclient.New(cfg, ctrlclient.Options{})
 	require.NoError(t, err)
 	getTLSServerName := func(adminSvc corev1.Service) string {
-		return fmt.Sprintf("%s.%s.svc", adminSvc.Name, adminSvc.Namespace)
+		return fmt.Sprintf("pod.%s.%s.svc", adminSvc.Name, adminSvc.Namespace)
 	}
 
 	t.Run("Endpoints are matched properly", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR reverts the TLS server name changes introduced in PR #1950 to restore backward compatibility during upgrades from KGO 1.6.x to KO 2.0.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
