### PR TITLE
chore(ci): pin mise version

### DIFF
--- a/.github/workflows/__release-workflow.yaml
+++ b/.github/workflows/__release-workflow.yaml
@@ -154,6 +154,7 @@ jobs:
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
           install: false
+          version: 2025.9.0
 
       # This step is required to check if the OP Service Account Token is available and export a boolean output
       # to be used in the next step. It's because we cannot use a secret in a step's condition.
@@ -215,6 +216,7 @@ jobs:
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
           install: false
+          version: 2025.9.0
 
       # This step is required to check if the OP Service Account Token is available and export a boolean output
       # to be used in the next step. It's because we cannot use a secret in a step's condition.
@@ -304,6 +306,7 @@ jobs:
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
           install: false
+          version: 2025.9.0
 
       # Generated manifests are part of the release PR.
       - name: Generate manifests

--- a/.github/workflows/_kongintegration_tests.yaml
+++ b/.github/workflows/_kongintegration_tests.yaml
@@ -47,6 +47,7 @@ jobs:
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
           install: false
+          version: 2025.9.0
 
       - run: echo "GOTESTSUM_JUNITFILE=kongintegration-${{ matrix.name }}-tests.xml" >> $GITHUB_ENV
 

--- a/.github/workflows/charts-tests.yaml
+++ b/.github/workflows/charts-tests.yaml
@@ -70,6 +70,7 @@ jobs:
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
           install: false
+          version: 2025.9.0
 
       - name: Run manifests.charts
         run: make manifests.charts
@@ -92,6 +93,7 @@ jobs:
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
           install: false
+          version: 2025.9.0
 
       - name: Run linters
         run: make lint.charts
@@ -138,6 +140,7 @@ jobs:
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
           install: false
+          version: 2025.9.0
 
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
 
@@ -192,6 +195,7 @@ jobs:
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
           install: false
+          version: 2025.9.0
 
       - name: run golden tests
         run: make test.charts.golden

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -91,6 +91,7 @@ jobs:
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
         install: false
+        version: 2025.9.0
 
     - name: run lint
       env:
@@ -121,6 +122,7 @@ jobs:
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
         install: false
+        version: 2025.9.0
 
     - name: run lint.markdownlint
       run: make lint.markdownlint
@@ -143,6 +145,7 @@ jobs:
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
         install: false
+        version: 2025.9.0
     - run: make govulncheck
 
   verify:
@@ -165,6 +168,7 @@ jobs:
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
         install: false
+        version: 2025.9.0
 
     - name: Verify manifests consistency
       run: make verify.manifests
@@ -205,6 +209,7 @@ jobs:
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
         install: false
+        version: 2025.9.0
 
     # We use install.all to install all CRDs and resources also the ones that are not bundled
     # in base kustomization (e.g. currently AIGateway) but which have samples defined.
@@ -249,6 +254,7 @@ jobs:
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
         install: false
+        version: 2025.9.0
 
     - name: Verify installing CRDs via kustomize works
       run: make install
@@ -309,6 +315,7 @@ jobs:
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
         install: false
+        version: 2025.9.0
 
     - name: run unit tests
       run: make test.unit
@@ -347,6 +354,7 @@ jobs:
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
         install: false
+        version: 2025.9.0
 
     - name: Run the crds validation tests
       run: make test.crds-validation
@@ -376,6 +384,7 @@ jobs:
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
         install: false
+        version: 2025.9.0
 
     - uses: Kong/kong-license@c4decf08584f84ff8fe8e7cd3c463e0192f6111b # master @ 20250107
       id: license
@@ -438,6 +447,7 @@ jobs:
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
         install: false
+        version: 2025.9.0
 
     - name: run conformance tests
       run: make test.conformance
@@ -496,6 +506,7 @@ jobs:
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
         install: false
+        version: 2025.9.0
 
     - name: run integration tests
       working-directory: ${{ matrix.directory }}
@@ -554,6 +565,7 @@ jobs:
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
         install: false
+        version: 2025.9.0
 
     - name: run integration tests
       run: make test.integration_bluegreen
@@ -611,6 +623,7 @@ jobs:
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
         install: false
+        version: 2025.9.0
 
     - name: run e2e tests
       run: make test.e2e


### PR DESCRIPTION
**What this PR does / why we need it**:

Pin mise version to 2025.9.0 due to missing release (and its assets) for 2025.9.1.

Relates discussion: https://github.com/jdx/mise/discussions/6188.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
