### PR TITLE
chore: bump kubernetes-configuration to v2.0.0-alpha.6

### DIFF
--- a/charts/kong-operator/charts/kic-crds/crds/kic-crds.yaml
+++ b/charts/kong-operator/charts/kic-crds/crds/kic-crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.5
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.6
   name: ingressclassparameterses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -61,7 +61,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.5
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.6
   name: kongclusterplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -369,7 +369,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.5
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.6
   name: kongcustomentities.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/jpillora/backoff v1.0.0
 	github.com/kong/go-database-reconciler v1.26.0
 	github.com/kong/go-kong v0.67.0
-	github.com/kong/kubernetes-configuration/v2 v2.0.0-alpha.5
+	github.com/kong/kubernetes-configuration/v2 v2.0.0-alpha.6
 	github.com/kong/kubernetes-telemetry v0.1.10
 	github.com/kong/kubernetes-testing-framework v0.47.3
 	github.com/kong/semver/v4 v4.0.1

--- a/go.sum
+++ b/go.sum
@@ -349,8 +349,8 @@ github.com/kong/go-database-reconciler v1.26.0 h1:x074dbSwYbTaUVmrCbDy1z9dy2oWu/
 github.com/kong/go-database-reconciler v1.26.0/go.mod h1:wq48xbXrcs1NCm7MlPhOIuYFjw66NR0zu+du+Br9q0I=
 github.com/kong/go-kong v0.67.0 h1:54zXKc58IZpZdlJCv8p95SJjejTxT+cwbWXw97icCak=
 github.com/kong/go-kong v0.67.0/go.mod h1:J0vGB3wsZ2i99zly1zTRe3v7rOKpkhQZRwbcTFP76qM=
-github.com/kong/kubernetes-configuration/v2 v2.0.0-alpha.5 h1:T1we+c8yo4pra6TNwUyJq2W6SCaJjAI9Hj8VP0+Re5w=
-github.com/kong/kubernetes-configuration/v2 v2.0.0-alpha.5/go.mod h1:ydQ/dHFNrsc2QojF5ECvJ10zU4jmtR1KQT11aV9QNA4=
+github.com/kong/kubernetes-configuration/v2 v2.0.0-alpha.6 h1:oCb2ufurArN6eAH08Bs59shpJzImgHpTcw1i9eda2EI=
+github.com/kong/kubernetes-configuration/v2 v2.0.0-alpha.6/go.mod h1:QhVQpOoydI+m50eMgEFv48VLYYbOxn5YYb8wg6M6J9I=
 github.com/kong/kubernetes-telemetry v0.1.10 h1:V+/Lco8VFY/CzoELwOPcGTyg0zbj/HAvoFkH50UsKYs=
 github.com/kong/kubernetes-telemetry v0.1.10/go.mod h1:/r/FevTOGegCqaxXCJyGkbE1E3IcYUGJd7xX7D73s2Y=
 github.com/kong/kubernetes-testing-framework v0.47.3 h1:2qqWxIQXAd/r1f+b+d/kuHZfN22IjgKouktyIA0B5so=


### PR DESCRIPTION
**What this PR does / why we need it**:

Include the fix: https://github.com/Kong/kubernetes-configuration/pull/599

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
