### PR TITLE
refactor(dataplane): relax deployment readiness check during rolling updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
 
 - Vendor gateway-operator CRDs locally and switch Kustomize to use the vendored source.
   [#2195](https://github.com/Kong/kong-operator/pull/2195)
+- Relax deployment readiness check during rolling updates.
+  [#2223](https://github.com/Kong/kong-operator/pull/2223)
 
 ## [v2.0.0-alpha.5]
 


### PR DESCRIPTION
**What this PR does / why we need it**:

During Kong Operator upgrades, the current strict readiness check can cause service disruption when DataPlane deployments undergo rolling updates. The previous logic marked DataPlanes as not ready when not all replicas were available, which created a problematic cycle:

1. Kong Operator starts with empty route cache after upgrade
2. DataPlane marked as not ready during rolling update
3. Gateway becomes unprogrammed, preventing KIC from pushing routes
4. Existing routes get wiped from DataPlane, causing traffic loss

This change relaxes the readiness check to consider the DataPlane ready as long as at least one replica is available (AvailableReplicas > 0), ensuring service continuity during rolling updates while new replicas are being deployed.

We should add a degraded status condition to indicate when the DataPlane is functional but not operating at full capacity

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
