### PR TITLE
chore: delete old controlplane managed resources

### DIFF
--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -52573,7 +52573,6 @@ rules:
   resources:
   - configmaps
   - serviceaccounts
-  - services
   verbs:
   - create
   - delete
@@ -52626,6 +52625,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services/status
   verbs:
   - get
@@ -52638,6 +52650,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -52657,6 +52670,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53023,6 +53037,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53040,6 +53055,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - deletecollection
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -52573,7 +52573,6 @@ rules:
   resources:
   - configmaps
   - serviceaccounts
-  - services
   verbs:
   - create
   - delete
@@ -52626,6 +52625,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services/status
   verbs:
   - get
@@ -52638,6 +52650,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -52657,6 +52670,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53023,6 +53037,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53040,6 +53055,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - deletecollection
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -52573,7 +52573,6 @@ rules:
   resources:
   - configmaps
   - serviceaccounts
-  - services
   verbs:
   - create
   - delete
@@ -52626,6 +52625,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services/status
   verbs:
   - get
@@ -52638,6 +52650,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -52657,6 +52670,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53023,6 +53037,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53040,6 +53055,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - deletecollection
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -52573,7 +52573,6 @@ rules:
   resources:
   - configmaps
   - serviceaccounts
-  - services
   verbs:
   - create
   - delete
@@ -52626,6 +52625,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services/status
   verbs:
   - get
@@ -52638,6 +52650,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -52657,6 +52670,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53023,6 +53037,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53040,6 +53055,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - deletecollection
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -52573,7 +52573,6 @@ rules:
   resources:
   - configmaps
   - serviceaccounts
-  - services
   verbs:
   - create
   - delete
@@ -52626,6 +52625,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services/status
   verbs:
   - get
@@ -52638,6 +52650,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -52657,6 +52670,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53023,6 +53037,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53040,6 +53055,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - deletecollection
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -52574,7 +52574,6 @@ rules:
   resources:
   - configmaps
   - serviceaccounts
-  - services
   verbs:
   - create
   - delete
@@ -52627,6 +52626,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services/status
   verbs:
   - get
@@ -52639,6 +52651,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -52658,6 +52671,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53024,6 +53038,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53041,6 +53056,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - deletecollection
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrest-values.snap
@@ -52573,7 +52573,6 @@ rules:
   resources:
   - configmaps
   - serviceaccounts
-  - services
   verbs:
   - create
   - delete
@@ -52626,6 +52625,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services/status
   verbs:
   - get
@@ -52638,6 +52650,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -52657,6 +52670,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53023,6 +53037,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53040,6 +53055,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - deletecollection
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -52573,7 +52573,6 @@ rules:
   resources:
   - configmaps
   - serviceaccounts
-  - services
   verbs:
   - create
   - delete
@@ -52626,6 +52625,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services/status
   verbs:
   - get
@@ -52638,6 +52650,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -52657,6 +52670,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53023,6 +53037,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53040,6 +53055,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - deletecollection
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -52573,7 +52573,6 @@ rules:
   resources:
   - configmaps
   - serviceaccounts
-  - services
   verbs:
   - create
   - delete
@@ -52626,6 +52625,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services/status
   verbs:
   - get
@@ -52638,6 +52650,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -52657,6 +52670,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53023,6 +53037,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53040,6 +53055,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - deletecollection
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -52573,7 +52573,6 @@ rules:
   resources:
   - configmaps
   - serviceaccounts
-  - services
   verbs:
   - create
   - delete
@@ -52626,6 +52625,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services/status
   verbs:
   - get
@@ -52638,6 +52650,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -52657,6 +52670,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53023,6 +53037,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53040,6 +53055,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - deletecollection
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -52573,7 +52573,6 @@ rules:
   resources:
   - configmaps
   - serviceaccounts
-  - services
   verbs:
   - create
   - delete
@@ -52626,6 +52625,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services/status
   verbs:
   - get
@@ -52638,6 +52650,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -52657,6 +52670,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53023,6 +53037,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53040,6 +53055,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - deletecollection
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -52573,7 +52573,6 @@ rules:
   resources:
   - configmaps
   - serviceaccounts
-  - services
   verbs:
   - create
   - delete
@@ -52626,6 +52625,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services/status
   verbs:
   - get
@@ -52638,6 +52650,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -52657,6 +52670,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53023,6 +53037,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -53040,6 +53055,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - deletecollection
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -27396,7 +27396,6 @@ rules:
   resources:
   - configmaps
   - serviceaccounts
-  - services
   verbs:
   - create
   - delete
@@ -27449,6 +27448,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services/status
   verbs:
   - get
@@ -27461,6 +27473,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -27480,6 +27493,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -27846,6 +27860,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -27863,6 +27878,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - deletecollection
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -52523,7 +52523,6 @@ rules:
   resources:
   - configmaps
   - serviceaccounts
-  - services
   verbs:
   - create
   - delete
@@ -52576,6 +52575,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services/status
   verbs:
   - get
@@ -52588,6 +52600,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -52607,6 +52620,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -52973,6 +52987,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -52990,6 +53005,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - deletecollection
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -27371,7 +27371,6 @@ rules:
   resources:
   - configmaps
   - serviceaccounts
-  - services
   verbs:
   - create
   - delete
@@ -27424,6 +27423,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services/status
   verbs:
   - get
@@ -27436,6 +27448,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -27455,6 +27468,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -27821,6 +27835,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -27838,6 +27853,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - deletecollection
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/charts/kong-operator/templates/cluster-role.yaml
+++ b/charts/kong-operator/templates/cluster-role.yaml
@@ -11,7 +11,6 @@ rules:
     resources:
       - configmaps
       - serviceaccounts
-      - services
     verbs:
       - create
       - delete
@@ -64,6 +63,19 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - services
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
       - services/status
     verbs:
       - get
@@ -76,6 +88,7 @@ rules:
     verbs:
       - create
       - delete
+      - deletecollection
       - get
       - list
       - patch
@@ -95,6 +108,7 @@ rules:
     verbs:
       - create
       - delete
+      - deletecollection
       - get
       - list
       - patch
@@ -461,6 +475,7 @@ rules:
     verbs:
       - create
       - delete
+      - deletecollection
       - get
       - list
       - patch
@@ -478,6 +493,13 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - deletecollection
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:

--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -11,7 +11,6 @@ rules:
   resources:
   - configmaps
   - serviceaccounts
-  - services
   verbs:
   - create
   - delete
@@ -64,6 +63,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services/status
   verbs:
   - get
@@ -76,6 +88,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -95,6 +108,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -461,6 +475,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -478,6 +493,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - deletecollection
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -827,6 +827,13 @@ func controlPlaneStatusEqual(
 		reflect.DeepEqual(b.Status.DataPlane, a.Status.DataPlane)
 }
 
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=deletecollection
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=deletecollection
+// +kubebuilder:rbac:groups=core,resources=services,verbs=deletecollection
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=deletecollection
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=deletecollection
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=deletecollection
+
 // cleanupOldManagedResources cleans up resources that were managed by
 // older versions of the Kong Gateway Operator. This includes Deployments,
 // Services, NetworkPolicies, ValidatingWebhookConfigurations, ClusterRoles,

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -80,6 +80,12 @@ const (
 
 	// CertPurposeLabel indicates the purpose of a certificate.
 	CertPurposeLabel = OperatorLabelPrefix + "cert-purpose"
+
+	// ControlPlaneKGOCleanupAnnotation indicates that the clean up KGO related resources
+	// has been performed for this ControlPlane.
+	// NOTE: This will be removed together with the logic that performs the cleanup
+	// as part of https://github.com/Kong/kong-operator/issues/2228.
+	ControlPlaneKGOCleanupAnnotation = OperatorAnnotationPrefix + "kgo-cleanup"
 )
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a clean up step in `ControlPlane` reconciliation where old managed resources are deleted (managed by KGO 1.6 and older).

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

This will be removed as part of https://github.com/Kong/kong-operator/issues/2228.

Tentatively added to KO 2.2 milestone.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
