### PR TITLE
fix: error handling for CA secret creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@
 
 ## Unreleased
 
+## Fixes
+
+- Fix incorrect error handling during cluster CA secret creation
+  [#2250](https://github.com/Kong/kong-operator/pull/2250)
+
 ## [v2.0.0]
 
 > Release date: 2025-09-09

--- a/controller/pkg/secrets/clusterca.go
+++ b/controller/pkg/secrets/clusterca.go
@@ -71,11 +71,15 @@ func CreateClusterCACertificate(ctx context.Context, logger logr.Logger, cl clie
 	if err := retry.Do(
 		func() error {
 			err := cl.Create(ctx, signedSecret)
-			if errS := (&k8serrors.StatusError{}); errors.As(err, &errS) {
-				if errS.ErrStatus.Code == 409 && errS.ErrStatus.Reason == metav1.StatusReasonAlreadyExists {
-					// If it's a 409 status code then the Secret already exists.
-					return nil
+			if err != nil {
+				if errS := (&k8serrors.StatusError{}); errors.As(err, &errS) {
+					if errS.ErrStatus.Code == 409 &&
+						errS.ErrStatus.Reason == metav1.StatusReasonAlreadyExists {
+						// If it's a 409 status code then the Secret already exists.
+						return nil
+					}
 				}
+				return err
 			}
 			return nil
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix an error discovered by @alacuku where the CA secret doesn't get created due to incorrect error handling causing perpetual

```
{"level":"info","ts":"2025-09-09T14:53:17Z","msg":"failed to get CA cluster secret to generate certs for MTLs communication with Kong Gateway, retrying...","error":"Secret \"kong-operator-ca\" not found"}
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
