### PR TITLE
fix(controlplane): add missing POD_NAME env variable for controller pod reference

### DIFF
--- a/charts/kong-operator/CHANGELOG.md
+++ b/charts/kong-operator/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unrealeased
+
+### Fixes
+
+- fix(controlplane): add missing POD_NAME env variable for controller pod reference
+  Previously, only POD_NAMESPACE was set, causing errors when resolving the controller's pod:
+  "unable to get POD information (missing POD_NAME or POD_NAMESPACE environment variable)"
+  This commit adds POD_NAME to ensure proper event attachment
+  [#2252](https://github.com/Kong/kong-operator/pull/2252)
+
 ## 0.0.7
 
 ### ⚠️ **IMPORTANT NOTICE ABOUT CONVERSION WEBHOOKS:**

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -53354,6 +53354,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: "docker.io/kong/kong-operator:2.0.0"
         livenessProbe:
           httpGet:

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -53367,6 +53367,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: "docker.io/kong/kong-operator:2.0.0"
         livenessProbe:
           httpGet:

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -53346,6 +53346,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: "docker.io/kong/kong-operator:2.0.0"
         livenessProbe:
           httpGet:

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -53348,6 +53348,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: "docker.io/kong/kong-operator:2.0.0"
         livenessProbe:
           httpGet:

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -53348,6 +53348,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: "docker.io/kong/kong-operator:2.0.0"
         livenessProbe:
           httpGet:

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -53347,6 +53347,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: "docker.io/kong/kong-operator:2.0.0"
         livenessProbe:
           httpGet:

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrest-values.snap
@@ -53346,6 +53346,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: "docker.io/kong/kong-operator:2.0.0"
         livenessProbe:
           httpGet:

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -53344,6 +53344,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: "docker.io/kong/nightly-kong-operator:nightly"
         livenessProbe:
           httpGet:

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -53345,6 +53345,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: "docker.io/kong/kong-operator:2.0.0"
         livenessProbe:
           httpGet:

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -53346,6 +53346,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: "docker.io/kong/kong-operator:2.0.0"
         livenessProbe:
           httpGet:

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -53348,6 +53348,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: "docker.io/kong/kong-operator:2.0.0"
         livenessProbe:
           httpGet:

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -53344,6 +53344,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: "docker.io/kong/kong-operator:2.0.0"
         livenessProbe:
           httpGet:

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -28165,6 +28165,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: "docker.io/kong/kong-operator:2.0.0"
         livenessProbe:
           httpGet:

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -53294,6 +53294,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: "docker.io/kong/kong-operator:2.0.0"
         livenessProbe:
           httpGet:

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -28125,6 +28125,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: "docker.io/kong/kong-operator:2.0.0"
         livenessProbe:
           httpGet:

--- a/charts/kong-operator/templates/deployment.yaml
+++ b/charts/kong-operator/templates/deployment.yaml
@@ -62,6 +62,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         livenessProbe:
           {{- toYaml .Values.livenessProbe | nindent 10 }}


### PR DESCRIPTION




**What this PR does / why we need it**:

Previously, only POD_NAMESPACE was set, causing errors when resolving the controller's pod: "unable to get POD information (missing POD_NAME or POD_NAMESPACE environment variable)" This commit adds POD_NAME to ensure proper event attachment.
Error in the controller:

```
{
  "level": "error",
  "ts": "2025-09-09T15:43:14Z",
  "logger": "controlplane",
  "msg": "Failed to resolve controller's pod to attach the apply configuration events to",
  "controller": "controlplane",
  "controllerGroup": "gateway-operator.konghq.com",
  "controllerKind": "ControlPlane",
  "ControlPlane": {
    "name": "kong-9fzqj",
    "namespace": "kong"
  },
  "namespace": "kong",
  "name": "kong-9fzqj",
  "reconcileID": "3a5b9e45-cece-46ca-a28f-9823da85df9c",
  "error": "unable to get POD information (missing POD_NAME or POD_NAMESPACE environment variable",
  "stacktrace": "github.com/kong/kong-operator/ingress-controller/internal/dataplane.(*KongClient).initializeControllerPodReference\n\t/workspace/ingress-controller/internal/dataplane/kong_client.go:256\ngithub.com/kong/kong-operator/ingress-controller/internal/dataplane.NewKongClient\n\t/workspace/ingress-controller/internal/dataplane/kong_client.go:244\ngithub.com/kong/kong-operator/ingress-controller/internal/manager.New\n\t/workspace/ingress-controller/internal/manager/run.go:245\ngithub.com/kong/kong-operator/ingress-controller/pkg/manager.NewManager\n\t/workspace/ingress-controller/pkg/manager/manager.go:28\ngithub.com/kong/kong-operator/controller/controlplane.(*Reconciler).scheduleInstance\n\t/workspace/controller/controlplane/controller.go:644\ngithub.com/kong/kong-operator/controller/controlplane.(*Reconciler).Reconcile\n\t/workspace/controller/controlplane/controller.go:388\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/home/aldo/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/controller/controller.go:119\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/home/aldo/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/controller/controller.go:340\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/home/aldo/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/controller/controller.go:300\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.1\n\t/home/aldo/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/controller/controller.go:202"
}
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
