### PR TITLE
feat: don't run controlplane for hybrid Gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@
 - Fix incorrect error handling during cluster CA secret creation
   [#2250](https://github.com/Kong/kong-operator/pull/2250)
 
+### Changed
+
+- For Hybrid `Gateway`s the operator does not run the `ControlPlane` anymore, as
+  the `DataPlane` is configured to use `Koko` as Konnect control plane.
+  [#2253](https://github.com/Kong/kong-operator/pull/2253)
+
 ## [v2.0.0]
 
 > Release date: 2025-09-09

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -1,9 +1,11 @@
 package gateway
 
 import (
+	"context"
 	"errors"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,9 +18,11 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	kcfgconsts "github.com/kong/kubernetes-configuration/v2/api/common/consts"
+	commonv1alpha1 "github.com/kong/kubernetes-configuration/v2/api/common/v1alpha1"
 	kcfggateway "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/gateway"
 	operatorv1beta1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1beta1"
 	operatorv2beta1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v2beta1"
+	konnectv1alpha2 "github.com/kong/kubernetes-configuration/v2/api/konnect/v1alpha2"
 
 	gwtypes "github.com/kong/kong-operator/internal/types"
 	"github.com/kong/kong-operator/modules/manager/scheme"
@@ -1815,6 +1819,153 @@ func TestCountAttachedRoutesForGatewayListener(t *testing.T) {
 				assert.Equal(t, tc.ExpectedRoutes[i], routes, "#%d", i)
 				assert.Equal(t, tc.ExpectedError[i], err, "#%d", i)
 			}
+		})
+	}
+}
+
+func TestIsGatewayHybrid(t *testing.T) {
+	require.NoError(t, konnectv1alpha2.AddToScheme(scheme.Get()))
+
+	type testCase struct {
+		name                      string
+		extensions                []commonv1alpha1.ExtensionRef
+		konnectControlPlaneStatus *konnectv1alpha2.KonnectExtensionControlPlaneStatus
+		konnectExtensionNotFound  bool
+		expectHybrid              bool
+		expectRequeue             bool
+	}
+
+	konnectExtName := "konnect-ext"
+	konnectExtNamespace := "test-ns"
+
+	tests := []testCase{
+		{
+			name:          "no extensions",
+			extensions:    nil,
+			expectHybrid:  false,
+			expectRequeue: false,
+		},
+		{
+			name: "extension not konnect",
+			extensions: []commonv1alpha1.ExtensionRef{
+				{
+					Group: "some.other.group",
+					Kind:  "OtherKind",
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "other-ext",
+					},
+				},
+			},
+			expectHybrid:  false,
+			expectRequeue: false,
+		},
+		{
+			name: "konnect extension, status set, not control plane",
+			extensions: []commonv1alpha1.ExtensionRef{
+				{
+					Group: konnectv1alpha2.SchemeGroupVersion.Group,
+					Kind:  konnectv1alpha2.KonnectExtensionKind,
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: konnectExtName,
+					},
+				},
+			},
+			konnectControlPlaneStatus: &konnectv1alpha2.KonnectExtensionControlPlaneStatus{
+				ClusterType: konnectv1alpha2.ClusterTypeK8sIngressController,
+			},
+			expectHybrid:  false,
+			expectRequeue: false,
+		},
+		{
+			name: "konnect extension, status set, control plane",
+			extensions: []commonv1alpha1.ExtensionRef{
+				{
+					Group: konnectv1alpha2.SchemeGroupVersion.Group,
+					Kind:  konnectv1alpha2.KonnectExtensionKind,
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: konnectExtName,
+					},
+				},
+			},
+			konnectControlPlaneStatus: &konnectv1alpha2.KonnectExtensionControlPlaneStatus{
+				ClusterType: konnectv1alpha2.ClusterTypeControlPlane,
+			},
+			expectHybrid:  true,
+			expectRequeue: false,
+		},
+		{
+			name: "konnect extension reference, no status set yet",
+			extensions: []commonv1alpha1.ExtensionRef{
+				{
+					Group: konnectv1alpha2.SchemeGroupVersion.Group,
+					Kind:  konnectv1alpha2.KonnectExtensionKind,
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: konnectExtName,
+					},
+				},
+			},
+			expectHybrid:  false,
+			expectRequeue: true,
+		},
+		{
+			name: "konnect extension reference, no konnect extension found",
+			extensions: []commonv1alpha1.ExtensionRef{
+				{
+					Group: konnectv1alpha2.SchemeGroupVersion.Group,
+					Kind:  konnectv1alpha2.KonnectExtensionKind,
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: konnectExtName,
+					},
+				},
+			},
+			konnectExtensionNotFound: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+
+			var objs []client.Object
+			if !tc.konnectExtensionNotFound {
+				konnectExt := &konnectv1alpha2.KonnectExtension{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      konnectExtName,
+						Namespace: konnectExtNamespace,
+					},
+				}
+				if tc.konnectControlPlaneStatus != nil {
+					konnectExt.Status = konnectv1alpha2.KonnectExtensionStatus{
+						Konnect: tc.konnectControlPlaneStatus,
+					}
+				}
+				objs = append(objs, konnectExt)
+			}
+
+			cl := fakectrlruntimeclient.NewClientBuilder().
+				WithScheme(scheme.Get()).
+				WithObjects(objs...).
+				Build()
+
+			r := &Reconciler{
+				Client: cl,
+			}
+			gatewayConfig := &GatewayConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: konnectExtNamespace,
+				},
+				Spec: GatewayConfigurationSpec{
+					Extensions: tc.extensions,
+				},
+			}
+
+			isHybrid, requeue, err := r.isGatewayHybrid(context.Background(), logr.Discard(), gatewayConfig)
+			if tc.konnectExtensionNotFound {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectHybrid, isHybrid)
+			assert.Equal(t, tc.expectRequeue, requeue)
 		})
 	}
 }

--- a/controller/gateway/types.go
+++ b/controller/gateway/types.go
@@ -14,6 +14,9 @@ type (
 	// GatewayConfiguration is an alias for the internally used GatewayConfiguration version type.
 	GatewayConfiguration = gwtypes.GatewayConfiguration
 
+	// GatewayConfigurationSpec is an alias for the internally used GatewayConfigurationSpec version type.
+	GatewayConfigurationSpec = gwtypes.GatewayConfigurationSpec
+
 	// GatewayConfigDataPlaneOptions is an alias for the internally used GatewayConfigDataPlaneOptions version type.
 	GatewayConfigDataPlaneOptions = gwtypes.GatewayConfigDataPlaneOptions
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

For hybrid Gateways don't run the `ControlPlane`, as the `Dataplane` connects to Konnect and uses Koko as `ControlPlane`

**Which issue this PR fixes**

Fixes #2248 

**Special notes for your reviewer**:

This PR is built on top of #2177. We need to merge that one before reviewing this one.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
