### PR TITLE
chore(ci): use kind version from file for manifest tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -199,8 +199,22 @@ jobs:
       with:
         go-version-file: go.mod
 
+    - name: pick kind version from .github/supported_k8s_node_versions.yaml
+      id: kind-version
+      run: |
+        (
+          echo 'version<<EOF'
+          yq eval -r -o=json '.[0]' .github/supported_k8s_node_versions.yaml
+          echo 'EOF'
+        ) >> "${GITHUB_OUTPUT}"
+
     - name: Create k8s KinD Cluster
       uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+      with:
+        # NOTE: default is 0.29.0 https://github.com/helm/kind-action/blob/a1b0e391336a6ee6713a0583f8c6240d70863de3/kind.sh#L21
+        # so bump this manually
+        version: v0.30.0
+        node_image: kindest/node:${{ steps.kind-version.outputs.version }}
 
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
@@ -241,10 +255,23 @@ jobs:
     - name: build docker image
       run: make docker.build
 
+    - name: pick kind version from .github/supported_k8s_node_versions.yaml
+      id: kind-version
+      run: |
+        (
+          echo 'version<<EOF'
+          yq eval -r -o=json '.[0]' .github/supported_k8s_node_versions.yaml
+          echo 'EOF'
+        ) >> "${GITHUB_OUTPUT}"
+
     - name: Create k8s KinD Cluster
       uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
       with:
         cluster_name: ${{ env.CLUSTER_NAME }}
+        # NOTE: default is 0.29.0 https://github.com/helm/kind-action/blob/a1b0e391336a6ee6713a0583f8c6240d70863de3/kind.sh#L21
+        # so bump this manually
+        version: v0.30.0
+        node_image: kindest/node:${{ steps.kind-version.outputs.version }}
 
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent issues like:

https://github.com/Kong/kong-operator/actions/runs/17642652050/job/50133127361?pr=2273

```
Installing kind...
/opt/hostedtoolcache/kind/v0.26.0/amd64/kind/bin ~/work/kong-operator/kong-operator
kind-linux-amd64: OK
~/work/kong-operator/kong-operator
Adding kind directory to PATH...
Installing kubectl...
Adding kubectl directory to PATH...
kind v0.26.0 go1.23.4 linux/amd64
Client Version: v1.31.4
Kustomize Version: v5.4.2
Creating kind cluster...
Creating cluster "install-with-kustomize" ...
 • Ensuring node image (kindest/node:v1.32.0) 🖼  ...
 ✗ Ensuring node image (kindest/node:v1.32.0) 🖼
ERROR: failed to create cluster: failed to pull image "kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027": command "docker pull kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027" failed with error: exit status 1
```

Additionally always use what's defined in https://github.com/Kong/kong-operator/blob/183c52e53cad1553062fd0ae0201fd2ad45fa440/.github/supported_k8s_node_versions.yaml (the first entry).

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
