### PR TITLE
fix(tests): adjust address of konghq.tech

### DIFF
--- a/config/samples/dataplane-konnect.yaml
+++ b/config/samples/dataplane-konnect.yaml
@@ -44,13 +44,13 @@ spec:
             - name: KONG_CLUSTER_MTLS
               value: pki
             - name: KONG_CLUSTER_CONTROL_PLANE
-              value: <YOUR_CP_ID>.cp0.konghq.tech:443
+              value: <YOUR_CP_ID>.cp.konghq.tech:443
             - name: KONG_CLUSTER_SERVER_NAME
-              value: <YOUR_CP_ID>.cp0.konghq.tech
+              value: <YOUR_CP_ID>.cp.konghq.tech
             - name: KONG_CLUSTER_TELEMETRY_ENDPOINT
-              value: <YOUR_CP_ID>.tp0.konghq.tech:443
+              value: <YOUR_CP_ID>.tp.konghq.tech:443
             - name: KONG_CLUSTER_TELEMETRY_SERVER_NAME
-              value: <YOUR_CP_ID>.tp0.konghq.tech
+              value: <YOUR_CP_ID>.tp.konghq.tech
             - name: KONG_CLUSTER_CERT
               value: /etc/secrets/kong-cluster-cert/tls.crt
             - name: KONG_CLUSTER_CERT_KEY

--- a/controller/pkg/extensions/konnect/controlplane.go
+++ b/controller/pkg/extensions/konnect/controlplane.go
@@ -121,7 +121,7 @@ func kicInKonnectDefaults(ctx context.Context, cl client.Client, konnectExtensio
 }
 
 // buildKonnectAddress builds the Konnect address out of the control plane endpoint.
-// input: "https://7b46471d3b.us.tp0.konghq.tech:443"
+// input: "https://7b46471d3b.us.tp.konghq.tech:443"
 // output: "https://us.kic.api.konghq.tech"
 func buildKonnectAddress(endpoint string) string {
 	portlessEndpoint := strings.TrimSuffix(endpoint, ":443")

--- a/controller/pkg/extensions/konnect/controlplane_test.go
+++ b/controller/pkg/extensions/konnect/controlplane_test.go
@@ -30,17 +30,17 @@ func TestBuildKonnectAddress(t *testing.T) {
 	}{
 		{
 			name:     "standard endpoint",
-			endpoint: "https://7b46471d3b.us.tp0.konghq.tech:443",
+			endpoint: "https://7b46471d3b.us.tp.konghq.tech:443",
 			expected: "https://us.kic.api.konghq.tech",
 		},
 		{
 			name:     "different region",
-			endpoint: "https://abcd1234.eu.tp0.konghq.tech:443",
+			endpoint: "https://abcd1234.eu.tp.konghq.tech:443",
 			expected: "https://eu.kic.api.konghq.tech",
 		},
 		{
 			name:     "longer hostname",
-			endpoint: "https://abcd1234.us.tp0.konghq.foo.bar.tech:443",
+			endpoint: "https://abcd1234.us.tp.konghq.foo.bar.tech:443",
 			expected: "https://us.kic.api.konghq.foo.bar.tech",
 		},
 	}
@@ -330,8 +330,8 @@ func TestControlPlaneKonnectExtensionProcessor_Process(t *testing.T) {
 				Konnect: &konnectv1alpha2.KonnectExtensionControlPlaneStatus{
 					ControlPlaneID: controlPlaneID,
 					Endpoints: konnectv1alpha2.KonnectEndpoints{
-						ControlPlaneEndpoint: "7b46471d3b.us.tp0.konghq.tech:443",
-						TelemetryEndpoint:    "7b46471d3b.us.tp0.konghq.tech",
+						ControlPlaneEndpoint: "7b46471d3b.us.tp.konghq.tech:443",
+						TelemetryEndpoint:    "7b46471d3b.us.tp.konghq.tech",
 					},
 					ClusterType: konnectv1alpha2.ClusterTypeK8sIngressController,
 				},

--- a/controller/pkg/extensions/konnect/konnectextension_test.go
+++ b/controller/pkg/extensions/konnect/konnectextension_test.go
@@ -36,8 +36,8 @@ func TestApplyDataPlaneKonnectExtension(t *testing.T) {
 		Konnect: &konnectv1alpha2.KonnectExtensionControlPlaneStatus{
 			ControlPlaneID: "konnect-id",
 			Endpoints: konnectv1alpha2.KonnectEndpoints{
-				ControlPlaneEndpoint: "7078163243.us.cp0.konghq.com",
-				TelemetryEndpoint:    "7078163243.us.tp0.konghq.com",
+				ControlPlaneEndpoint: "7078163243.us.cp.konghq.com",
+				TelemetryEndpoint:    "7078163243.us.tp.konghq.com",
 			},
 			ClusterType: konnectv1alpha2.ClusterTypeControlPlane,
 		},
@@ -322,7 +322,7 @@ func TestApplyDataPlaneKonnectExtension(t *testing.T) {
 				},
 				{
 					Name:  "KONG_CLUSTER_CONTROL_PLANE",
-					Value: "7078163243.us.cp0.konghq.com:443",
+					Value: "7078163243.us.cp.konghq.com:443",
 				},
 				{
 					Name:  "KONG_CLUSTER_DP_LABELS",
@@ -334,15 +334,15 @@ func TestApplyDataPlaneKonnectExtension(t *testing.T) {
 				},
 				{
 					Name:  "KONG_CLUSTER_SERVER_NAME",
-					Value: "7078163243.us.cp0.konghq.com",
+					Value: "7078163243.us.cp.konghq.com",
 				},
 				{
 					Name:  "KONG_CLUSTER_TELEMETRY_ENDPOINT",
-					Value: "7078163243.us.tp0.konghq.com:443",
+					Value: "7078163243.us.tp.konghq.com:443",
 				},
 				{
 					Name:  "KONG_CLUSTER_TELEMETRY_SERVER_NAME",
-					Value: "7078163243.us.tp0.konghq.com",
+					Value: "7078163243.us.tp.konghq.com",
 				},
 				{
 					Name:  "KONG_KONNECT_MODE",

--- a/test/integration/konnect_entities_test.go
+++ b/test/integration/konnect_entities_test.go
@@ -74,12 +74,12 @@ func TestKonnectEntities(t *testing.T) {
 		err := GetClients().MgrClient.Get(GetCtx(), types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace}, cp)
 		require.NoError(t, err)
 		require.NotEmpty(t, cp.Status.Endpoints)
-		// Example: https://e7b5c7de43.us.cp0.konghq.tech - always it will include ".cp0.".
+		// Example: https://e7b5c7de43.us.cp.konghq.tech - always it will include ".cp.".
 		require.True(t, strings.HasPrefix(cp.Status.Endpoints.ControlPlaneEndpoint, "https://"), "must start with https://")
-		require.Contains(t, cp.Status.Endpoints.ControlPlaneEndpoint, ".cp0.", "must contain .cp0.")
-		// Example: https://e7b5c7de43.us.tp0.konghq.tech - always it will include ".tp0.".
+		require.Contains(t, cp.Status.Endpoints.ControlPlaneEndpoint, ".cp.", "must contain .cp.")
+		// Example: https://e7b5c7de43.us.tp.konghq.tech - always it will include ".tp.".
 		require.True(t, strings.HasPrefix(cp.Status.Endpoints.TelemetryEndpoint, "https://"), "must start with https://")
-		require.Contains(t, cp.Status.Endpoints.TelemetryEndpoint, ".tp0.", "must contain .tp0.")
+		require.Contains(t, cp.Status.Endpoints.TelemetryEndpoint, ".tp.", "must contain .tp.")
 	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
 	t.Run("with Origin ControlPlane", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR resolves the problem with CI

<img width="1260" height="309" alt="image" src="https://github.com/user-attachments/assets/c706aef5-5b84-4a9c-8320-23a5df11027a" />

It's changed, and we do not have control over this address, but it's still better to have this assertion than not (even taking into account that it may break) to ensure that URLs are set as expected by the controller. 