### PR TITLE
chore: remove `dedent` dependency and retract directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,6 @@ module github.com/kong/kong-operator
 
 go 1.24.6
 
-// 1.2.2 was released on main branch with a breaking change that was not
-// intended to be released in 1.2.x:
-// https://github.com/kong/kong-operator/commit/3876430e09e61edce58bd8464989e33236bd1872
-// This retraction is to prevent it from being used and from breaking builds of dependent projects.
-retract v1.2.2
-
 require (
 	cloud.google.com/go/container v1.44.0
 	dario.cat/mergo v1.0.2
@@ -41,7 +35,6 @@ require (
 	github.com/kong/kubernetes-testing-framework v0.47.3
 	github.com/kong/semver/v4 v4.0.1
 	github.com/kr/pretty v0.3.1
-	github.com/lithammer/dedent v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/moul/pb v0.0.0-20220425114252-bca18df4138c
 	github.com/opencontainers/image-spec v1.1.1

--- a/ingress-controller/internal/dataplane/kong_client_golden_test.go
+++ b/ingress-controller/internal/dataplane/kong_client_golden_test.go
@@ -260,7 +260,7 @@ func runKongClientGoldenTest(t *testing.T, tc kongClientGoldenTestCase) {
 	// Create the translator.
 	logger := zapr.NewLogger(zap.NewNop())
 	s := store.New(cacheStores, "kong", logger)
-	p, err := translator.NewTranslator(logger, s, "", semver.MustParse("3.9.1"), tc.featureFlags, fakeSchemaServiceProvier{},
+	p, err := translator.NewTranslator(logger, s, "", semver.MustParse("3.9.1"), tc.featureFlags, fakeSchemaServiceProvider{},
 		translator.Config{
 			ClusterDomain:      managercfg.DefaultClusterDomain,
 			EnableDrainSupport: consts.DefaultEnableDrainSupport,
@@ -372,11 +372,11 @@ func extractObjectsFromYAML(t *testing.T, filePath string) [][]byte {
 	})
 }
 
-// fakeSchemaServiceProvier is a stub implementation of the SchemaServiceProvider interface that returns an
+// fakeSchemaServiceProvider is a stub implementation of the SchemaServiceProvider interface that returns an
 // UnavailableSchemaService. It's used to avoid hitting the Kong Admin API during tests.
-type fakeSchemaServiceProvier struct{}
+type fakeSchemaServiceProvider struct{}
 
-func (p fakeSchemaServiceProvier) GetSchemaService() kong.AbstractSchemaService {
+func (p fakeSchemaServiceProvider) GetSchemaService() kong.AbstractSchemaService {
 	return fakeSchemaService{}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- package `v1.2.2` has been successfully redacted, so there is no point in keeping this directive any longer
- `dedent` dependency is redundant, everything works perfectly without it
- some opportunistic typo fixes 


**Which issue this PR fixes**

Part of #1658 