### PR TITLE
chore: mark chart so not a prerelease anymore

### DIFF
--- a/charts/kong-operator/Chart.yaml
+++ b/charts/kong-operator/Chart.yaml
@@ -11,7 +11,15 @@ sources:
 version: 1.0.0
 appVersion: "2.0.0"
 annotations:
-  artifacthub.io/prerelease: "true"
+  artifacthub.io/category: networking
+  artifacthub.io/prerelease: "false"
+  artifacthub.io/operator: "true"
+  artifacthub.io/operatorCapabilities: Seamless Upgrades
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://developer.konghq.com/operator/
+    - name: Repository
+      url: https://github.com/Kong/kong-operator
 dependencies:
   - name: ko-crds
     version: 1.0.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Moreover set some additional artifacthub annotations (https://artifacthub.io/docs/topics/annotations/helm/) on chart for nice presentation on https://artifacthub.io/packages/helm/kong/kong-operator

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
