### PR TITLE
feat(hybridgateway): implement HTTPRoute to Kong entities translation in hybrid gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@
   [#2143](https://github.com/Kong/kong-operator/pull/2143)
   [#2177](https://github.com/Kong/kong-operator/pull/2177)
   [#2260](https://github.com/Kong/kong-operator/pull/2260)
+- Add comprehensive HTTPRoute reconciliation that translates Gateway API
+  HTTPRoutes into Kong-specific resources for hybrid gateway deployments.
+  [#2308](https://github.com/Kong/kong-operator/pull/2308)
 
 ### Changed
 

--- a/controller/hybridgateway/builder/kongroute.go
+++ b/controller/hybridgateway/builder/kongroute.go
@@ -1,0 +1,150 @@
+package builder
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/controller/hybridgateway/metadata"
+	gwtypes "github.com/kong/kong-operator/internal/types"
+	"github.com/kong/kong-operator/modules/manager/scheme"
+)
+
+// KongRouteBuilder is a builder for configurationv1alpha1.KongRoute resources.
+type KongRouteBuilder struct {
+	route  configurationv1alpha1.KongRoute
+	errors []error
+}
+
+// NewKongRoute creates and returns a new KongRouteBuilder instance.
+func NewKongRoute() *KongRouteBuilder {
+	return &KongRouteBuilder{
+		route:  configurationv1alpha1.KongRoute{},
+		errors: make([]error, 0),
+	}
+}
+
+// WithHosts sets the hosts for the KongRoute being built.
+func (b *KongRouteBuilder) WithHosts(hosts []string) *KongRouteBuilder {
+	b.route.Spec.Hosts = append(b.route.Spec.Hosts, hosts...)
+	return b
+}
+
+// WithHTTPRouteMatch sets the match criteria (path, method, headers) for the KongRoute.
+func (b *KongRouteBuilder) WithHTTPRouteMatch(match gwtypes.HTTPRouteMatch) *KongRouteBuilder {
+	// Path.
+	if match.Path != nil && match.Path.Value != nil {
+		b.route.Spec.Paths = append(b.route.Spec.Paths, *match.Path.Value)
+	}
+
+	// Method
+	if match.Method != nil {
+		b.route.Spec.Methods = append(b.route.Spec.Methods, string(*match.Method))
+	}
+
+	// Headers
+	if len(match.Headers) > 0 {
+		if b.route.Spec.Headers == nil {
+			b.route.Spec.Headers = make(map[string][]string)
+		}
+		for _, hdr := range match.Headers {
+			b.route.Spec.Headers[string(hdr.Name)] = append(b.route.Spec.Headers[string(hdr.Name)], hdr.Value)
+		}
+	}
+	// Note: QueryParams are not natively supported by KongRoute
+
+	return b
+}
+
+// WithKongService sets the KongService reference for the KongRoute.
+func (b *KongRouteBuilder) WithKongService(name string) *KongRouteBuilder {
+	if name != "" {
+		b.route.Spec.ServiceRef = &configurationv1alpha1.ServiceRef{
+			Type: configurationv1alpha1.ServiceRefNamespacedRef,
+			NamespacedRef: &commonv1alpha1.NameRef{
+				Name: name,
+			},
+		}
+	}
+	return b
+}
+
+// WithSpecName sets the name field in the KongRoute spec.
+func (b *KongRouteBuilder) WithSpecName(name string) *KongRouteBuilder {
+	b.route.Spec.Name = &name
+	return b
+}
+
+// WithStripPath sets the strip path option for the KongRoute.
+func (b *KongRouteBuilder) WithStripPath(stripPath bool) *KongRouteBuilder {
+	b.route.Spec.StripPath = &stripPath
+	return b
+}
+
+// WithOwner sets the owner reference for the KongRoute to the given HTTPRoute.
+func (b *KongRouteBuilder) WithOwner(owner *gwtypes.HTTPRoute) *KongRouteBuilder {
+	if owner == nil {
+		b.errors = append(b.errors, errors.New("owner cannot be nil"))
+		return b
+	}
+
+	err := controllerutil.SetOwnerReference(owner, &b.route, scheme.Get(), controllerutil.WithBlockOwnerDeletion(true))
+	if err != nil {
+		b.errors = append(b.errors, fmt.Errorf("failed to set owner reference: %w", err))
+	}
+	return b
+}
+
+// WithName sets the name field of the KongRoute resource.
+func (b *KongRouteBuilder) WithName(name string) *KongRouteBuilder {
+	b.route.Name = name
+	return b
+}
+
+// WithNamespace sets the namespace field of the KongRoute resource.
+func (b *KongRouteBuilder) WithNamespace(namespace string) *KongRouteBuilder {
+	b.route.Namespace = namespace
+	return b
+}
+
+// WithLabels sets the labels for the KongRoute resource based on the given HTTPRoute.
+func (b *KongRouteBuilder) WithLabels(route *gwtypes.HTTPRoute) *KongRouteBuilder {
+	labels := metadata.BuildLabels(route)
+	if b.route.Labels == nil {
+		b.route.Labels = make(map[string]string)
+	}
+	maps.Copy(b.route.Labels, labels)
+	return b
+}
+
+// WithAnnotations sets the annotations for the KongRoute resource based on the given HTTPRoute and parent reference.
+func (b *KongRouteBuilder) WithAnnotations(route *gwtypes.HTTPRoute, parentRef *gwtypes.ParentReference) *KongRouteBuilder {
+	annotations := metadata.BuildAnnotations(route, parentRef)
+	if b.route.Annotations == nil {
+		b.route.Annotations = make(map[string]string)
+	}
+	maps.Copy(b.route.Annotations, annotations)
+	return b
+}
+
+// Build returns the constructed KongRoute resource and any accumulated errors.
+func (b *KongRouteBuilder) Build() (configurationv1alpha1.KongRoute, error) {
+	if len(b.errors) > 0 {
+		return configurationv1alpha1.KongRoute{}, errors.Join(b.errors...)
+	}
+	return b.route, nil
+}
+
+// MustBuild returns the constructed KongRoute resource, panicking on any errors.
+// Useful for tests or when you're certain the build will succeed.
+func (b *KongRouteBuilder) MustBuild() configurationv1alpha1.KongRoute {
+	route, err := b.Build()
+	if err != nil {
+		panic(fmt.Errorf("failed to build KongRoute: %w", err))
+	}
+	return route
+}

--- a/controller/hybridgateway/builder/kongroute_test.go
+++ b/controller/hybridgateway/builder/kongroute_test.go
@@ -1,0 +1,508 @@
+package builder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	gwtypes "github.com/kong/kong-operator/internal/types"
+)
+
+func TestKongRouteBuilder_NewKongRoute(t *testing.T) {
+	builder := NewKongRoute()
+
+	assert.NotNil(t, builder)
+	assert.NotNil(t, builder.errors)
+	assert.Empty(t, builder.errors)
+	assert.Equal(t, configurationv1alpha1.KongRoute{}, builder.route)
+}
+
+func TestKongRouteBuilder_WithHosts(t *testing.T) {
+	tests := []struct {
+		name     string
+		hosts    []string
+		expected []string
+	}{
+		{
+			name:     "single host",
+			hosts:    []string{"example.com"},
+			expected: []string{"example.com"},
+		},
+		{
+			name:     "multiple hosts",
+			hosts:    []string{"example.com", "api.example.com"},
+			expected: []string{"example.com", "api.example.com"},
+		},
+		{
+			name:     "empty hosts",
+			hosts:    []string{},
+			expected: nil,
+		},
+		{
+			name:     "nil hosts",
+			hosts:    nil,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewKongRoute().WithHosts(tt.hosts)
+
+			route, err := builder.Build()
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, route.Spec.Hosts)
+		})
+	}
+}
+
+func TestKongRouteBuilder_WithHosts_Chainable(t *testing.T) {
+	builder := NewKongRoute().
+		WithHosts([]string{"example.com"}).
+		WithHosts([]string{"api.example.com", "test.example.com"})
+
+	route, err := builder.Build()
+	require.NoError(t, err)
+	expected := []string{"example.com", "api.example.com", "test.example.com"}
+	assert.Equal(t, expected, route.Spec.Hosts)
+}
+
+func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
+	pathType := gatewayv1.PathMatchPathPrefix
+	pathValue := "/api"
+	method := gatewayv1.HTTPMethodGet
+
+	tests := []struct {
+		name     string
+		match    gwtypes.HTTPRouteMatch
+		validate func(t *testing.T, route configurationv1alpha1.KongRoute)
+	}{
+		{
+			name: "with path",
+			match: gwtypes.HTTPRouteMatch{
+				Path: &gatewayv1.HTTPPathMatch{
+					Type:  &pathType,
+					Value: &pathValue,
+				},
+			},
+			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
+				assert.Equal(t, []string{"/api"}, route.Spec.Paths)
+				assert.Empty(t, route.Spec.Methods)
+				assert.Nil(t, route.Spec.Headers)
+			},
+		},
+		{
+			name: "with method",
+			match: gwtypes.HTTPRouteMatch{
+				Method: &method,
+			},
+			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
+				assert.Empty(t, route.Spec.Paths)
+				assert.Equal(t, []string{"GET"}, route.Spec.Methods)
+				assert.Nil(t, route.Spec.Headers)
+			},
+		},
+		{
+			name: "with headers",
+			match: gwtypes.HTTPRouteMatch{
+				Headers: []gatewayv1.HTTPHeaderMatch{
+					{
+						Type:  &[]gatewayv1.HeaderMatchType{gatewayv1.HeaderMatchExact}[0],
+						Name:  "Authorization",
+						Value: "Bearer token",
+					},
+					{
+						Type:  &[]gatewayv1.HeaderMatchType{gatewayv1.HeaderMatchExact}[0],
+						Name:  "Content-Type",
+						Value: "application/json",
+					},
+				},
+			},
+			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
+				assert.Empty(t, route.Spec.Paths)
+				assert.Empty(t, route.Spec.Methods)
+				require.NotNil(t, route.Spec.Headers)
+				assert.Equal(t, []string{"Bearer token"}, route.Spec.Headers["Authorization"])
+				assert.Equal(t, []string{"application/json"}, route.Spec.Headers["Content-Type"])
+			},
+		},
+		{
+			name: "with multiple headers same name",
+			match: gwtypes.HTTPRouteMatch{
+				Headers: []gatewayv1.HTTPHeaderMatch{
+					{
+						Type:  &[]gatewayv1.HeaderMatchType{gatewayv1.HeaderMatchExact}[0],
+						Name:  "Accept",
+						Value: "application/json",
+					},
+					{
+						Type:  &[]gatewayv1.HeaderMatchType{gatewayv1.HeaderMatchExact}[0],
+						Name:  "Accept",
+						Value: "text/plain",
+					},
+				},
+			},
+			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
+				require.NotNil(t, route.Spec.Headers)
+				assert.Equal(t, []string{"application/json", "text/plain"}, route.Spec.Headers["Accept"])
+			},
+		},
+		{
+			name: "complete match",
+			match: gwtypes.HTTPRouteMatch{
+				Path: &gatewayv1.HTTPPathMatch{
+					Type:  &pathType,
+					Value: &pathValue,
+				},
+				Method: &method,
+				Headers: []gatewayv1.HTTPHeaderMatch{
+					{
+						Type:  &[]gatewayv1.HeaderMatchType{gatewayv1.HeaderMatchExact}[0],
+						Name:  "Authorization",
+						Value: "Bearer token",
+					},
+				},
+			},
+			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
+				assert.Equal(t, []string{"/api"}, route.Spec.Paths)
+				assert.Equal(t, []string{"GET"}, route.Spec.Methods)
+				require.NotNil(t, route.Spec.Headers)
+				assert.Equal(t, []string{"Bearer token"}, route.Spec.Headers["Authorization"])
+			},
+		},
+		{
+			name: "nil path value",
+			match: gwtypes.HTTPRouteMatch{
+				Path: &gatewayv1.HTTPPathMatch{
+					Type:  &pathType,
+					Value: nil,
+				},
+			},
+			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
+				assert.Empty(t, route.Spec.Paths)
+			},
+		},
+		{
+			name:  "empty match",
+			match: gwtypes.HTTPRouteMatch{},
+			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
+				assert.Empty(t, route.Spec.Paths)
+				assert.Empty(t, route.Spec.Methods)
+				assert.Nil(t, route.Spec.Headers)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewKongRoute().WithHTTPRouteMatch(tt.match)
+
+			route, err := builder.Build()
+			require.NoError(t, err)
+			tt.validate(t, route)
+		})
+	}
+}
+
+func TestKongRouteBuilder_WithKongService(t *testing.T) {
+	tests := []struct {
+		name     string
+		service  string
+		expected *configurationv1alpha1.ServiceRef
+	}{
+		{
+			name:    "with service name",
+			service: "test-service",
+			expected: &configurationv1alpha1.ServiceRef{
+				Type: configurationv1alpha1.ServiceRefNamespacedRef,
+				NamespacedRef: &commonv1alpha1.NameRef{
+					Name: "test-service",
+				},
+			},
+		},
+		{
+			name:     "empty service name",
+			service:  "",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewKongRoute().WithKongService(tt.service)
+
+			route, err := builder.Build()
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, route.Spec.ServiceRef)
+		})
+	}
+}
+
+func TestKongRouteBuilder_WithSpecName(t *testing.T) {
+	tests := []struct {
+		name     string
+		specName string
+		expected *string
+	}{
+		{
+			name:     "with spec name",
+			specName: "test-route-spec",
+			expected: &[]string{"test-route-spec"}[0],
+		},
+		{
+			name:     "empty spec name",
+			specName: "",
+			expected: &[]string{""}[0],
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewKongRoute().WithSpecName(tt.specName)
+
+			route, err := builder.Build()
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, route.Spec.Name)
+		})
+	}
+}
+
+func TestKongRouteBuilder_WithStripPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		stripPath bool
+		expected  *bool
+	}{
+		{
+			name:      "strip path true",
+			stripPath: true,
+			expected:  &[]bool{true}[0],
+		},
+		{
+			name:      "strip path false",
+			stripPath: false,
+			expected:  &[]bool{false}[0],
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewKongRoute().WithStripPath(tt.stripPath)
+
+			route, err := builder.Build()
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, route.Spec.StripPath)
+		})
+	}
+}
+
+func TestKongRouteBuilder_WithName(t *testing.T) {
+	builder := NewKongRoute().WithName("test-route")
+
+	route, err := builder.Build()
+	require.NoError(t, err)
+	assert.Equal(t, "test-route", route.Name)
+}
+
+func TestKongRouteBuilder_WithNamespace(t *testing.T) {
+	builder := NewKongRoute().WithNamespace("test-namespace")
+
+	route, err := builder.Build()
+	require.NoError(t, err)
+	assert.Equal(t, "test-namespace", route.Namespace)
+}
+
+func TestKongRouteBuilder_WithOwner(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-http-route",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+		},
+	}
+
+	t.Run("valid owner", func(t *testing.T) {
+		builder := NewKongRoute().
+			WithNamespace("test-namespace").
+			WithOwner(httpRoute)
+
+		route, err := builder.Build()
+		require.NoError(t, err)
+
+		require.Len(t, route.OwnerReferences, 1)
+		ownerRef := route.OwnerReferences[0]
+		assert.Equal(t, "test-http-route", ownerRef.Name)
+		assert.Equal(t, "test-uid", string(ownerRef.UID))
+		assert.True(t, *ownerRef.BlockOwnerDeletion)
+	})
+
+	t.Run("nil owner", func(t *testing.T) {
+		builder := NewKongRoute().WithOwner(nil)
+
+		_, err := builder.Build()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "owner cannot be nil")
+	})
+
+	t.Run("owner reference error", func(t *testing.T) {
+		httpRouteWithoutTypeMeta := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-http-route",
+				Namespace: "test-namespace",
+				UID:       "test-uid",
+			},
+		}
+
+		builder := NewKongRoute().WithOwner(httpRouteWithoutTypeMeta)
+
+		_, err := builder.Build()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to set owner reference")
+	})
+}
+
+func TestKongRouteBuilder_WithLabels(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+	}
+
+	builder := NewKongRoute().WithLabels(httpRoute)
+
+	route, err := builder.Build()
+	require.NoError(t, err)
+
+	assert.NotNil(t, route.Labels)
+	assert.NotEmpty(t, route.Labels)
+}
+
+func TestKongRouteBuilder_WithAnnotations(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+	}
+
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	builder := NewKongRoute().WithAnnotations(httpRoute, parentRef)
+
+	route, err := builder.Build()
+	require.NoError(t, err)
+
+	assert.NotNil(t, route.Annotations)
+}
+
+func TestKongRouteBuilder_Build(t *testing.T) {
+	t.Run("successful build", func(t *testing.T) {
+		builder := NewKongRoute().
+			WithName("test-route").
+			WithNamespace("test-namespace").
+			WithHosts([]string{"example.com"})
+
+		route, err := builder.Build()
+		require.NoError(t, err)
+		assert.Equal(t, "test-route", route.Name)
+		assert.Equal(t, "test-namespace", route.Namespace)
+		assert.Equal(t, []string{"example.com"}, route.Spec.Hosts)
+	})
+
+	t.Run("build with errors", func(t *testing.T) {
+		builder := NewKongRoute().WithOwner(nil)
+
+		_, err := builder.Build()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "owner cannot be nil")
+	})
+}
+
+func TestKongRouteBuilder_MustBuild(t *testing.T) {
+	t.Run("successful must build", func(t *testing.T) {
+		builder := NewKongRoute().WithName("test-route")
+
+		route := builder.MustBuild()
+		assert.Equal(t, "test-route", route.Name)
+	})
+
+	t.Run("must build with errors panics", func(t *testing.T) {
+		builder := NewKongRoute().WithOwner(nil)
+
+		assert.Panics(t, func() {
+			builder.MustBuild()
+		})
+	})
+}
+
+func TestKongRouteBuilder_Chaining(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-http-route",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+		},
+	}
+
+	pathType := gatewayv1.PathMatchPathPrefix
+	pathValue := "/api"
+	method := gatewayv1.HTTPMethodGet
+
+	match := gwtypes.HTTPRouteMatch{
+		Path: &gatewayv1.HTTPPathMatch{
+			Type:  &pathType,
+			Value: &pathValue,
+		},
+		Method: &method,
+	}
+
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	route := NewKongRoute().
+		WithName("test-route").
+		WithNamespace("test-namespace").
+		WithSpecName("test-spec").
+		WithStripPath(true).
+		WithHosts([]string{"example.com"}).
+		WithHTTPRouteMatch(match).
+		WithKongService("test-service").
+		WithOwner(httpRoute).
+		WithLabels(httpRoute).
+		WithAnnotations(httpRoute, parentRef).
+		MustBuild()
+
+	assert.Equal(t, "test-route", route.Name)
+	assert.Equal(t, "test-namespace", route.Namespace)
+	assert.Equal(t, "test-spec", *route.Spec.Name)
+	assert.Equal(t, true, *route.Spec.StripPath)
+	assert.Equal(t, []string{"example.com"}, route.Spec.Hosts)
+	assert.Equal(t, []string{"/api"}, route.Spec.Paths)
+	assert.Equal(t, []string{"GET"}, route.Spec.Methods)
+	assert.Equal(t, "test-service", route.Spec.ServiceRef.NamespacedRef.Name)
+	assert.Len(t, route.OwnerReferences, 1)
+	assert.NotNil(t, route.Labels)
+	assert.NotNil(t, route.Annotations)
+}
+
+func TestKongRouteBuilder_MultipleErrors(t *testing.T) {
+	builder := NewKongRoute()
+
+	builder.WithOwner(nil)
+	builder.errors = append(builder.errors, assert.AnError)
+
+	_, err := builder.Build()
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "owner cannot be nil")
+	assert.Contains(t, err.Error(), assert.AnError.Error())
+}

--- a/controller/hybridgateway/builder/kongservice.go
+++ b/controller/hybridgateway/builder/kongservice.go
@@ -1,0 +1,111 @@
+package builder
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/controller/hybridgateway/metadata"
+	gwtypes "github.com/kong/kong-operator/internal/types"
+	"github.com/kong/kong-operator/modules/manager/scheme"
+)
+
+// KongServiceBuilder is a builder for configurationv1alpha1.KongService resources.
+type KongServiceBuilder struct {
+	service configurationv1alpha1.KongService
+	errors  []error
+}
+
+// NewKongService creates and returns a new KongServiceBuilder instance.
+func NewKongService() *KongServiceBuilder {
+	return &KongServiceBuilder{
+		service: configurationv1alpha1.KongService{},
+		errors:  make([]error, 0),
+	}
+}
+
+// WithName sets the name for the KongService being built.
+func (b *KongServiceBuilder) WithName(name string) *KongServiceBuilder {
+	b.service.Name = name
+	return b
+}
+
+// WithNamespace sets the namespace for the KongService being built.
+func (b *KongServiceBuilder) WithNamespace(namespace string) *KongServiceBuilder {
+	b.service.Namespace = namespace
+	return b
+}
+
+// WithLabels sets the labels for the KongService being built.
+func (b *KongServiceBuilder) WithLabels(route *gwtypes.HTTPRoute) *KongServiceBuilder {
+	labels := metadata.BuildLabels(route)
+	if b.service.Labels == nil {
+		b.service.Labels = make(map[string]string)
+	}
+	maps.Copy(b.service.Labels, labels)
+	return b
+}
+
+// WithAnnotations sets the annotations for the KongService being built.
+func (b *KongServiceBuilder) WithAnnotations(route *gwtypes.HTTPRoute, parentRef *gwtypes.ParentReference) *KongServiceBuilder {
+	annotations := metadata.BuildAnnotations(route, parentRef)
+	if b.service.Annotations == nil {
+		b.service.Annotations = make(map[string]string)
+	}
+	maps.Copy(b.service.Annotations, annotations)
+	return b
+}
+
+// WithSpecName sets the name field in the KongService spec.
+func (b *KongServiceBuilder) WithSpecName(name string) *KongServiceBuilder {
+	b.service.Spec.Name = &name
+	return b
+}
+
+// WithSpecHost sets the host field in the KongService spec.
+func (b *KongServiceBuilder) WithSpecHost(host string) *KongServiceBuilder {
+	b.service.Spec.Host = host
+	return b
+}
+
+// WithControlPlaneRef sets the ControlPlaneRef for the KongService being built.
+func (b *KongServiceBuilder) WithControlPlaneRef(cpr commonv1alpha1.ControlPlaneRef) *KongServiceBuilder {
+	b.service.Spec.ControlPlaneRef = &cpr
+	return b
+}
+
+// WithOwner sets the owner reference for the KongService to the given HTTPRoute.
+func (b *KongServiceBuilder) WithOwner(owner *gwtypes.HTTPRoute) *KongServiceBuilder {
+	if owner == nil {
+		b.errors = append(b.errors, errors.New("owner cannot be nil"))
+		return b
+	}
+
+	err := controllerutil.SetOwnerReference(owner, &b.service, scheme.Get(), controllerutil.WithBlockOwnerDeletion(true))
+	if err != nil {
+		b.errors = append(b.errors, fmt.Errorf("failed to set owner reference: %w", err))
+	}
+	return b
+}
+
+// Build returns the constructed KongService resource and any accumulated errors.
+func (b *KongServiceBuilder) Build() (configurationv1alpha1.KongService, error) {
+	if len(b.errors) > 0 {
+		return configurationv1alpha1.KongService{}, errors.Join(b.errors...)
+	}
+	return b.service, nil
+}
+
+// MustBuild returns the constructed KongService resource, panicking on any errors.
+// Useful for tests or when you're certain the build will succeed.
+func (b *KongServiceBuilder) MustBuild() configurationv1alpha1.KongService {
+	service, err := b.Build()
+	if err != nil {
+		panic(fmt.Errorf("failed to build KongService: %w", err))
+	}
+	return service
+}

--- a/controller/hybridgateway/builder/kongservice_test.go
+++ b/controller/hybridgateway/builder/kongservice_test.go
@@ -1,0 +1,302 @@
+package builder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	gwtypes "github.com/kong/kong-operator/internal/types"
+)
+
+func TestKongServiceBuilder_NewKongService(t *testing.T) {
+	builder := NewKongService()
+
+	assert.NotNil(t, builder)
+	assert.NotNil(t, builder.errors)
+	assert.Empty(t, builder.errors)
+	assert.Equal(t, configurationv1alpha1.KongService{}, builder.service)
+}
+
+func TestKongServiceBuilder_WithName(t *testing.T) {
+	builder := NewKongService().WithName("test-service")
+
+	service, err := builder.Build()
+	require.NoError(t, err)
+	assert.Equal(t, "test-service", service.Name)
+}
+
+func TestKongServiceBuilder_WithNamespace(t *testing.T) {
+	builder := NewKongService().WithNamespace("test-namespace")
+
+	service, err := builder.Build()
+	require.NoError(t, err)
+	assert.Equal(t, "test-namespace", service.Namespace)
+}
+
+func TestKongServiceBuilder_WithLabels(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+	}
+
+	builder := NewKongService().WithLabels(httpRoute)
+
+	service, err := builder.Build()
+	require.NoError(t, err)
+
+	assert.NotNil(t, service.Labels)
+	assert.NotEmpty(t, service.Labels)
+}
+
+func TestKongServiceBuilder_WithAnnotations(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+	}
+
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	builder := NewKongService().WithAnnotations(httpRoute, parentRef)
+
+	service, err := builder.Build()
+	require.NoError(t, err)
+
+	assert.NotNil(t, service.Annotations)
+}
+
+func TestKongServiceBuilder_WithSpecName(t *testing.T) {
+	tests := []struct {
+		name     string
+		specName string
+		expected *string
+	}{
+		{
+			name:     "with spec name",
+			specName: "test-service-spec",
+			expected: &[]string{"test-service-spec"}[0],
+		},
+		{
+			name:     "empty spec name",
+			specName: "",
+			expected: &[]string{""}[0],
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewKongService().WithSpecName(tt.specName)
+
+			service, err := builder.Build()
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, service.Spec.Name)
+		})
+	}
+}
+
+func TestKongServiceBuilder_WithSpecHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		expected string
+	}{
+		{
+			name:     "with host",
+			host:     "example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "empty host",
+			host:     "",
+			expected: "",
+		},
+		{
+			name:     "with service name and cluster domain",
+			host:     "my-service.my-namespace.svc.cluster.local",
+			expected: "my-service.my-namespace.svc.cluster.local",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewKongService().WithSpecHost(tt.host)
+
+			service, err := builder.Build()
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, service.Spec.Host)
+		})
+	}
+}
+
+func TestKongServiceBuilder_WithControlPlaneRef(t *testing.T) {
+	controlPlaneRef := commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name:      "test-konnect-cp",
+			Namespace: "test-namespace",
+		},
+	}
+
+	builder := NewKongService().WithControlPlaneRef(controlPlaneRef)
+
+	service, err := builder.Build()
+	require.NoError(t, err)
+
+	require.NotNil(t, service.Spec.ControlPlaneRef)
+	assert.Equal(t, controlPlaneRef, *service.Spec.ControlPlaneRef)
+}
+
+func TestKongServiceBuilder_WithOwner(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-http-route",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+		},
+	}
+
+	t.Run("valid owner", func(t *testing.T) {
+		builder := NewKongService().
+			WithNamespace("test-namespace").
+			WithOwner(httpRoute)
+
+		service, err := builder.Build()
+		require.NoError(t, err)
+
+		require.Len(t, service.OwnerReferences, 1)
+		ownerRef := service.OwnerReferences[0]
+		assert.Equal(t, "test-http-route", ownerRef.Name)
+		assert.Equal(t, "test-uid", string(ownerRef.UID))
+		assert.True(t, *ownerRef.BlockOwnerDeletion)
+	})
+
+	t.Run("nil owner", func(t *testing.T) {
+		builder := NewKongService().WithOwner(nil)
+
+		_, err := builder.Build()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "owner cannot be nil")
+	})
+
+	t.Run("owner reference error", func(t *testing.T) {
+		httpRouteWithoutTypeMeta := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-http-route",
+				Namespace: "test-namespace",
+				UID:       "test-uid",
+			},
+		}
+
+		builder := NewKongService().WithOwner(httpRouteWithoutTypeMeta)
+
+		_, err := builder.Build()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to set owner reference")
+	})
+}
+
+func TestKongServiceBuilder_Build(t *testing.T) {
+	t.Run("successful build", func(t *testing.T) {
+		builder := NewKongService().
+			WithName("test-service").
+			WithNamespace("test-namespace").
+			WithSpecName("test-spec").
+			WithSpecHost("example.com")
+
+		service, err := builder.Build()
+		require.NoError(t, err)
+		assert.Equal(t, "test-service", service.Name)
+		assert.Equal(t, "test-namespace", service.Namespace)
+		assert.Equal(t, "test-spec", *service.Spec.Name)
+		assert.Equal(t, "example.com", service.Spec.Host)
+	})
+
+	t.Run("build with errors", func(t *testing.T) {
+		builder := NewKongService().WithOwner(nil)
+
+		_, err := builder.Build()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "owner cannot be nil")
+	})
+}
+
+func TestKongServiceBuilder_MustBuild(t *testing.T) {
+	t.Run("successful must build", func(t *testing.T) {
+		builder := NewKongService().WithName("test-service")
+
+		service := builder.MustBuild()
+		assert.Equal(t, "test-service", service.Name)
+	})
+
+	t.Run("must build with errors panics", func(t *testing.T) {
+		builder := NewKongService().WithOwner(nil)
+
+		assert.Panics(t, func() {
+			builder.MustBuild()
+		})
+	})
+}
+
+func TestKongServiceBuilder_Chaining(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-http-route",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+		},
+	}
+
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	controlPlaneRef := commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name:      "test-konnect-cp",
+			Namespace: "test-namespace",
+		},
+	}
+
+	service := NewKongService().
+		WithName("test-service").
+		WithNamespace("test-namespace").
+		WithSpecName("test-spec").
+		WithSpecHost("example.com").
+		WithControlPlaneRef(controlPlaneRef).
+		WithOwner(httpRoute).
+		WithLabels(httpRoute).
+		WithAnnotations(httpRoute, parentRef).
+		MustBuild()
+
+	assert.Equal(t, "test-service", service.Name)
+	assert.Equal(t, "test-namespace", service.Namespace)
+	assert.Equal(t, "test-spec", *service.Spec.Name)
+	assert.Equal(t, "example.com", service.Spec.Host)
+	assert.Equal(t, controlPlaneRef, *service.Spec.ControlPlaneRef)
+	assert.Len(t, service.OwnerReferences, 1)
+	assert.NotNil(t, service.Labels)
+	assert.NotNil(t, service.Annotations)
+}
+
+func TestKongServiceBuilder_MultipleErrors(t *testing.T) {
+	builder := NewKongService()
+
+	builder.WithOwner(nil)
+	builder.errors = append(builder.errors, assert.AnError)
+
+	_, err := builder.Build()
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "owner cannot be nil")
+	assert.Contains(t, err.Error(), assert.AnError.Error())
+}

--- a/controller/hybridgateway/builder/kongtarget.go
+++ b/controller/hybridgateway/builder/kongtarget.go
@@ -1,0 +1,126 @@
+package builder
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"net"
+	"strconv"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/controller/hybridgateway/metadata"
+	gwtypes "github.com/kong/kong-operator/internal/types"
+	"github.com/kong/kong-operator/modules/manager/scheme"
+)
+
+// KongTargetBuilder is a builder for configurationv1alpha1.KongTarget resources.
+type KongTargetBuilder struct {
+	target configurationv1alpha1.KongTarget
+	errors []error
+}
+
+// NewKongTarget creates and returns a new KongTargetBuilder instance.
+func NewKongTarget() *KongTargetBuilder {
+	return &KongTargetBuilder{
+		target: configurationv1alpha1.KongTarget{},
+		errors: make([]error, 0),
+	}
+}
+
+// WithName sets the name for the KongTarget being built.
+func (b *KongTargetBuilder) WithName(name string) *KongTargetBuilder {
+	b.target.Name = name
+	return b
+}
+
+// WithNamespace sets the namespace for the KongTarget being built.
+func (b *KongTargetBuilder) WithNamespace(namespace string) *KongTargetBuilder {
+	b.target.Namespace = namespace
+	return b
+}
+
+// WithLabels sets the labels for the KongTarget being built.
+func (b *KongTargetBuilder) WithLabels(route *gwtypes.HTTPRoute) *KongTargetBuilder {
+	labels := metadata.BuildLabels(route)
+	if b.target.Labels == nil {
+		b.target.Labels = make(map[string]string)
+	}
+	maps.Copy(b.target.Labels, labels)
+	return b
+}
+
+// WithBackendRef sets the target specification based on the given HTTPRoute and backend reference.
+func (b *KongTargetBuilder) WithBackendRef(httpRoute *gwtypes.HTTPRoute, bRef *gwtypes.HTTPBackendRef) *KongTargetBuilder {
+	// Build the dns name of the service for the backendRef.
+	// TODO(alacuku): We need to handle the cluster domain properly for the cluster where we are running.
+	var namespace string
+	if bRef.Namespace == nil || *bRef.Namespace == "" {
+		namespace = httpRoute.Namespace
+	} else {
+		namespace = string(*bRef.Namespace)
+	}
+
+	host := string(bRef.Name) + "." + namespace + ".svc.cluster.local"
+	port := strconv.Itoa(int(*bRef.Port))
+	target := net.JoinHostPort(host, port)
+	b.target.Spec.Target = target
+
+	// Weight is optional, default to 100 if not specified
+	if bRef.Weight != nil {
+		b.target.Spec.Weight = int(*bRef.Weight)
+	}
+	return b
+}
+
+// WithUpstreamRef sets the upstream reference for the KongTarget.
+func (b *KongTargetBuilder) WithUpstreamRef(upstreamRef string) *KongTargetBuilder {
+	b.target.Spec.UpstreamRef = commonv1alpha1.NameRef{
+		Name: upstreamRef,
+	}
+	return b
+}
+
+// WithAnnotations sets the annotations for the KongTarget being built.
+func (b *KongTargetBuilder) WithAnnotations(route *gwtypes.HTTPRoute, parentRef *gwtypes.ParentReference) *KongTargetBuilder {
+	annotations := metadata.BuildAnnotations(route, parentRef)
+	if b.target.Annotations == nil {
+		b.target.Annotations = make(map[string]string)
+	}
+	maps.Copy(b.target.Annotations, annotations)
+	return b
+}
+
+// WithOwner sets the owner reference for the KongTarget to the given HTTPRoute.
+func (b *KongTargetBuilder) WithOwner(owner *gwtypes.HTTPRoute) *KongTargetBuilder {
+	if owner == nil {
+		b.errors = append(b.errors, errors.New("owner cannot be nil"))
+		return b
+	}
+
+	err := controllerutil.SetOwnerReference(owner, &b.target, scheme.Get(), controllerutil.WithBlockOwnerDeletion(true))
+	if err != nil {
+		b.errors = append(b.errors, fmt.Errorf("failed to set owner reference: %w", err))
+	}
+	return b
+}
+
+// Build returns the constructed KongTarget resource and any accumulated errors.
+func (b *KongTargetBuilder) Build() (configurationv1alpha1.KongTarget, error) {
+	if len(b.errors) > 0 {
+		return configurationv1alpha1.KongTarget{}, errors.Join(b.errors...)
+	}
+	return b.target, nil
+}
+
+// MustBuild returns the constructed KongTarget resource, panicking on any errors.
+// Useful for tests or when you're certain the build will succeed.
+func (b *KongTargetBuilder) MustBuild() configurationv1alpha1.KongTarget {
+	target, err := b.Build()
+	if err != nil {
+		panic(fmt.Errorf("failed to build KongTarget: %w", err))
+	}
+	return target
+}

--- a/controller/hybridgateway/builder/kongtarget_test.go
+++ b/controller/hybridgateway/builder/kongtarget_test.go
@@ -1,0 +1,359 @@
+package builder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	gwtypes "github.com/kong/kong-operator/internal/types"
+)
+
+func TestKongTargetBuilder_NewKongTarget(t *testing.T) {
+	builder := NewKongTarget()
+
+	assert.NotNil(t, builder)
+	assert.NotNil(t, builder.errors)
+	assert.Empty(t, builder.errors)
+	assert.Equal(t, configurationv1alpha1.KongTarget{}, builder.target)
+}
+
+func TestKongTargetBuilder_WithName(t *testing.T) {
+	builder := NewKongTarget().WithName("test-target")
+
+	target, err := builder.Build()
+	require.NoError(t, err)
+	assert.Equal(t, "test-target", target.Name)
+}
+
+func TestKongTargetBuilder_WithNamespace(t *testing.T) {
+	builder := NewKongTarget().WithNamespace("test-namespace")
+
+	target, err := builder.Build()
+	require.NoError(t, err)
+	assert.Equal(t, "test-namespace", target.Namespace)
+}
+
+func TestKongTargetBuilder_WithLabels(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+	}
+
+	builder := NewKongTarget().WithLabels(httpRoute)
+
+	target, err := builder.Build()
+	require.NoError(t, err)
+
+	assert.NotNil(t, target.Labels)
+	assert.NotEmpty(t, target.Labels)
+}
+
+func TestKongTargetBuilder_WithBackendRef(t *testing.T) {
+	port := gatewayv1.PortNumber(8080)
+	weight := int32(100)
+
+	tests := []struct {
+		name           string
+		httpRoute      *gwtypes.HTTPRoute
+		backendRef     *gwtypes.HTTPBackendRef
+		expectedTarget string
+		expectedWeight int
+	}{
+		{
+			name: "backend ref with same namespace",
+			httpRoute: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			backendRef: &gwtypes.HTTPBackendRef{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name: "test-service",
+						Port: &port,
+					},
+					Weight: &weight,
+				},
+			},
+			expectedTarget: "test-service.test-namespace.svc.cluster.local:8080",
+			expectedWeight: 100,
+		},
+		{
+			name: "backend ref with different namespace",
+			httpRoute: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			backendRef: &gwtypes.HTTPBackendRef{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name:      "test-service",
+						Namespace: &[]gatewayv1.Namespace{"other-namespace"}[0],
+						Port:      &port,
+					},
+					Weight: &weight,
+				},
+			},
+			expectedTarget: "test-service.other-namespace.svc.cluster.local:8080",
+			expectedWeight: 100,
+		},
+		{
+			name: "backend ref with empty namespace",
+			httpRoute: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			backendRef: &gwtypes.HTTPBackendRef{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name:      "test-service",
+						Namespace: &[]gatewayv1.Namespace{""}[0],
+						Port:      &port,
+					},
+					Weight: &weight,
+				},
+			},
+			expectedTarget: "test-service.test-namespace.svc.cluster.local:8080",
+			expectedWeight: 100,
+		},
+		{
+			name: "backend ref with nil namespace",
+			httpRoute: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			backendRef: &gwtypes.HTTPBackendRef{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name:      "test-service",
+						Namespace: nil,
+						Port:      &port,
+					},
+					Weight: &weight,
+				},
+			},
+			expectedTarget: "test-service.test-namespace.svc.cluster.local:8080",
+			expectedWeight: 100,
+		},
+		{
+			name: "backend ref without weight",
+			httpRoute: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			backendRef: &gwtypes.HTTPBackendRef{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name: "test-service",
+						Port: &port,
+					},
+					Weight: nil,
+				},
+			},
+			expectedTarget: "test-service.test-namespace.svc.cluster.local:8080",
+			expectedWeight: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewKongTarget().WithBackendRef(tt.httpRoute, tt.backendRef)
+
+			target, err := builder.Build()
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedTarget, target.Spec.Target)
+			assert.Equal(t, tt.expectedWeight, target.Spec.Weight)
+		})
+	}
+}
+
+func TestKongTargetBuilder_WithUpstreamRef(t *testing.T) {
+	builder := NewKongTarget().WithUpstreamRef("test-upstream")
+
+	target, err := builder.Build()
+	require.NoError(t, err)
+	assert.Equal(t, "test-upstream", target.Spec.UpstreamRef.Name)
+}
+
+func TestKongTargetBuilder_WithAnnotations(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+	}
+
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	builder := NewKongTarget().WithAnnotations(httpRoute, parentRef)
+
+	target, err := builder.Build()
+	require.NoError(t, err)
+
+	assert.NotNil(t, target.Annotations)
+}
+
+func TestKongTargetBuilder_WithOwner(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-http-route",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+		},
+	}
+
+	t.Run("valid owner", func(t *testing.T) {
+		builder := NewKongTarget().
+			WithNamespace("test-namespace").
+			WithOwner(httpRoute)
+
+		target, err := builder.Build()
+		require.NoError(t, err)
+
+		require.Len(t, target.OwnerReferences, 1)
+		ownerRef := target.OwnerReferences[0]
+		assert.Equal(t, "test-http-route", ownerRef.Name)
+		assert.Equal(t, "test-uid", string(ownerRef.UID))
+		assert.True(t, *ownerRef.BlockOwnerDeletion)
+	})
+
+	t.Run("nil owner", func(t *testing.T) {
+		builder := NewKongTarget().WithOwner(nil)
+
+		_, err := builder.Build()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "owner cannot be nil")
+	})
+
+	t.Run("owner reference error", func(t *testing.T) {
+		httpRouteWithoutTypeMeta := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-http-route",
+				Namespace: "test-namespace",
+				UID:       "test-uid",
+			},
+		}
+
+		builder := NewKongTarget().WithOwner(httpRouteWithoutTypeMeta)
+
+		_, err := builder.Build()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to set owner reference")
+	})
+}
+
+func TestKongTargetBuilder_Build(t *testing.T) {
+	t.Run("successful build", func(t *testing.T) {
+		builder := NewKongTarget().
+			WithName("test-target").
+			WithNamespace("test-namespace").
+			WithUpstreamRef("test-upstream")
+
+		target, err := builder.Build()
+		require.NoError(t, err)
+		assert.Equal(t, "test-target", target.Name)
+		assert.Equal(t, "test-namespace", target.Namespace)
+		assert.Equal(t, "test-upstream", target.Spec.UpstreamRef.Name)
+	})
+
+	t.Run("build with errors", func(t *testing.T) {
+		builder := NewKongTarget().WithOwner(nil)
+
+		_, err := builder.Build()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "owner cannot be nil")
+	})
+}
+
+func TestKongTargetBuilder_MustBuild(t *testing.T) {
+	t.Run("successful must build", func(t *testing.T) {
+		builder := NewKongTarget().WithName("test-target")
+
+		target := builder.MustBuild()
+		assert.Equal(t, "test-target", target.Name)
+	})
+
+	t.Run("must build with errors panics", func(t *testing.T) {
+		builder := NewKongTarget().WithOwner(nil)
+
+		assert.Panics(t, func() {
+			builder.MustBuild()
+		})
+	})
+}
+
+func TestKongTargetBuilder_Chaining(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-http-route",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+		},
+	}
+
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	port := gatewayv1.PortNumber(8080)
+	weight := int32(50)
+
+	backendRef := &gwtypes.HTTPBackendRef{
+		BackendRef: gatewayv1.BackendRef{
+			BackendObjectReference: gatewayv1.BackendObjectReference{
+				Name: "test-service",
+				Port: &port,
+			},
+			Weight: &weight,
+		},
+	}
+
+	target := NewKongTarget().
+		WithName("test-target").
+		WithNamespace("test-namespace").
+		WithBackendRef(httpRoute, backendRef).
+		WithUpstreamRef("test-upstream").
+		WithOwner(httpRoute).
+		WithLabels(httpRoute).
+		WithAnnotations(httpRoute, parentRef).
+		MustBuild()
+
+	assert.Equal(t, "test-target", target.Name)
+	assert.Equal(t, "test-namespace", target.Namespace)
+	assert.Equal(t, "test-service.test-namespace.svc.cluster.local:8080", target.Spec.Target)
+	assert.Equal(t, 50, target.Spec.Weight)
+	assert.Equal(t, "test-upstream", target.Spec.UpstreamRef.Name)
+	assert.Len(t, target.OwnerReferences, 1)
+	assert.NotNil(t, target.Labels)
+	assert.NotNil(t, target.Annotations)
+}
+
+func TestKongTargetBuilder_MultipleErrors(t *testing.T) {
+	builder := NewKongTarget()
+
+	builder.WithOwner(nil)
+	builder.errors = append(builder.errors, assert.AnError)
+
+	_, err := builder.Build()
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "owner cannot be nil")
+	assert.Contains(t, err.Error(), assert.AnError.Error())
+}

--- a/controller/hybridgateway/builder/kongupstream.go
+++ b/controller/hybridgateway/builder/kongupstream.go
@@ -1,0 +1,102 @@
+package builder
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/controller/hybridgateway/metadata"
+	gwtypes "github.com/kong/kong-operator/internal/types"
+	"github.com/kong/kong-operator/modules/manager/scheme"
+)
+
+// KongUpstreamBuilder is a builder for configurationv1alpha1.KongUpstream resources.
+type KongUpstreamBuilder struct {
+	upstream configurationv1alpha1.KongUpstream
+	errors   []error
+}
+
+// NewKongUpstream returns a new KongUpstreamBuilder.
+func NewKongUpstream() *KongUpstreamBuilder {
+	return &KongUpstreamBuilder{
+		upstream: configurationv1alpha1.KongUpstream{},
+		errors:   []error{},
+	}
+}
+
+// WithName sets the name for the KongUpstream being built.
+func (b *KongUpstreamBuilder) WithName(name string) *KongUpstreamBuilder {
+	b.upstream.Name = name
+	return b
+}
+
+// WithNamespace sets the namespace for the KongUpstream being built.
+func (b *KongUpstreamBuilder) WithNamespace(namespace string) *KongUpstreamBuilder {
+	b.upstream.Namespace = namespace
+	return b
+}
+
+// WithLabels sets the labels for the KongUpstream being built.
+func (b *KongUpstreamBuilder) WithLabels(route *gwtypes.HTTPRoute) *KongUpstreamBuilder {
+	labels := metadata.BuildLabels(route)
+	if b.upstream.Labels == nil {
+		b.upstream.Labels = make(map[string]string)
+	}
+	maps.Copy(b.upstream.Labels, labels)
+	return b
+}
+
+// WithAnnotations sets the annotations for the KongUpstream being built.
+func (b *KongUpstreamBuilder) WithAnnotations(route *gwtypes.HTTPRoute, parentRef *gwtypes.ParentReference) *KongUpstreamBuilder {
+	annotations := metadata.BuildAnnotations(route, parentRef)
+	if b.upstream.Annotations == nil {
+		b.upstream.Annotations = make(map[string]string)
+	}
+	maps.Copy(b.upstream.Annotations, annotations)
+	return b
+}
+
+// WithSpecName sets the name field in the KongUpstream spec.
+func (b *KongUpstreamBuilder) WithSpecName(name string) *KongUpstreamBuilder {
+	b.upstream.Spec.Name = name
+	return b
+}
+
+// WithOwner sets the owner reference for the KongUpstream to the given HTTPRoute.
+func (b *KongUpstreamBuilder) WithOwner(owner *gwtypes.HTTPRoute) *KongUpstreamBuilder {
+	if owner == nil {
+		b.errors = append(b.errors, fmt.Errorf("owner cannot be nil"))
+		return b
+	}
+	if err := controllerutil.SetOwnerReference(owner, &b.upstream, scheme.Get(), controllerutil.WithBlockOwnerDeletion(true)); err != nil {
+		b.errors = append(b.errors, fmt.Errorf("failed to set owner reference: %w", err))
+	}
+	return b
+}
+
+// WithControlPlaneRef sets the control plane reference for the KongUpstream.
+func (b *KongUpstreamBuilder) WithControlPlaneRef(cpr commonv1alpha1.ControlPlaneRef) *KongUpstreamBuilder {
+	b.upstream.Spec.ControlPlaneRef = &cpr
+	return b
+}
+
+// Build returns the constructed KongUpstream resource and any accumulated errors.
+func (b *KongUpstreamBuilder) Build() (configurationv1alpha1.KongUpstream, error) {
+	if len(b.errors) > 0 {
+		return configurationv1alpha1.KongUpstream{}, errors.Join(b.errors...)
+	}
+	return b.upstream, nil
+}
+
+// MustBuild returns the constructed KongUpstream resource, panicking if there are any errors.
+func (b *KongUpstreamBuilder) MustBuild() configurationv1alpha1.KongUpstream {
+	upstream, err := b.Build()
+	if err != nil {
+		panic(fmt.Sprintf("KongUpstreamBuilder.MustBuild(): %v", err))
+	}
+	return upstream
+}

--- a/controller/hybridgateway/builder/kongupstream_test.go
+++ b/controller/hybridgateway/builder/kongupstream_test.go
@@ -1,0 +1,257 @@
+package builder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	gwtypes "github.com/kong/kong-operator/internal/types"
+)
+
+func TestKongUpstreamBuilder_NewKongUpstream(t *testing.T) {
+	builder := NewKongUpstream()
+
+	assert.NotNil(t, builder)
+	assert.NotNil(t, builder.errors)
+	assert.Empty(t, builder.errors)
+	assert.Equal(t, configurationv1alpha1.KongUpstream{}, builder.upstream)
+}
+
+func TestKongUpstreamBuilder_WithName(t *testing.T) {
+	builder := NewKongUpstream().WithName("test-upstream")
+
+	upstream, err := builder.Build()
+	require.NoError(t, err)
+	assert.Equal(t, "test-upstream", upstream.Name)
+}
+
+func TestKongUpstreamBuilder_WithNamespace(t *testing.T) {
+	builder := NewKongUpstream().WithNamespace("test-namespace")
+
+	upstream, err := builder.Build()
+	require.NoError(t, err)
+	assert.Equal(t, "test-namespace", upstream.Namespace)
+}
+
+func TestKongUpstreamBuilder_WithLabels(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+	}
+
+	builder := NewKongUpstream().WithLabels(httpRoute)
+
+	upstream, err := builder.Build()
+	require.NoError(t, err)
+
+	assert.NotNil(t, upstream.Labels)
+	assert.NotEmpty(t, upstream.Labels)
+}
+
+func TestKongUpstreamBuilder_WithAnnotations(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+	}
+
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	builder := NewKongUpstream().WithAnnotations(httpRoute, parentRef)
+
+	upstream, err := builder.Build()
+	require.NoError(t, err)
+
+	assert.NotNil(t, upstream.Annotations)
+}
+
+func TestKongUpstreamBuilder_WithSpecName(t *testing.T) {
+	builder := NewKongUpstream().WithSpecName("test-upstream-spec")
+
+	upstream, err := builder.Build()
+	require.NoError(t, err)
+	assert.Equal(t, "test-upstream-spec", upstream.Spec.Name)
+}
+
+func TestKongUpstreamBuilder_WithControlPlaneRef(t *testing.T) {
+	controlPlaneRef := commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name:      "test-konnect-cp",
+			Namespace: "test-namespace",
+		},
+	}
+
+	builder := NewKongUpstream().WithControlPlaneRef(controlPlaneRef)
+
+	upstream, err := builder.Build()
+	require.NoError(t, err)
+
+	require.NotNil(t, upstream.Spec.ControlPlaneRef)
+	assert.Equal(t, controlPlaneRef, *upstream.Spec.ControlPlaneRef)
+}
+
+func TestKongUpstreamBuilder_WithOwner(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-http-route",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+		},
+	}
+
+	t.Run("valid owner", func(t *testing.T) {
+		builder := NewKongUpstream().
+			WithNamespace("test-namespace").
+			WithOwner(httpRoute)
+
+		upstream, err := builder.Build()
+		require.NoError(t, err)
+
+		require.Len(t, upstream.OwnerReferences, 1)
+		ownerRef := upstream.OwnerReferences[0]
+		assert.Equal(t, "test-http-route", ownerRef.Name)
+		assert.Equal(t, "test-uid", string(ownerRef.UID))
+		assert.True(t, *ownerRef.BlockOwnerDeletion)
+	})
+
+	t.Run("nil owner", func(t *testing.T) {
+		builder := NewKongUpstream().WithOwner(nil)
+
+		_, err := builder.Build()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "owner cannot be nil")
+	})
+
+	t.Run("owner reference error", func(t *testing.T) {
+		httpRouteWithoutTypeMeta := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-http-route",
+				Namespace: "test-namespace",
+				UID:       "test-uid",
+			},
+		}
+
+		builder := NewKongUpstream().WithOwner(httpRouteWithoutTypeMeta)
+
+		_, err := builder.Build()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to set owner reference")
+	})
+}
+
+func TestKongUpstreamBuilder_Build(t *testing.T) {
+	t.Run("successful build", func(t *testing.T) {
+		builder := NewKongUpstream().
+			WithName("test-upstream").
+			WithNamespace("test-namespace").
+			WithSpecName("test-spec")
+
+		upstream, err := builder.Build()
+		require.NoError(t, err)
+		assert.Equal(t, "test-upstream", upstream.Name)
+		assert.Equal(t, "test-namespace", upstream.Namespace)
+		assert.Equal(t, "test-spec", upstream.Spec.Name)
+	})
+
+	t.Run("build with errors", func(t *testing.T) {
+		builder := NewKongUpstream().WithOwner(nil)
+
+		_, err := builder.Build()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "owner cannot be nil")
+	})
+}
+
+func TestKongUpstreamBuilder_MustBuild(t *testing.T) {
+	t.Run("successful must build", func(t *testing.T) {
+		builder := NewKongUpstream().WithName("test-upstream")
+
+		upstream := builder.MustBuild()
+		assert.Equal(t, "test-upstream", upstream.Name)
+	})
+
+	t.Run("must build with errors panics", func(t *testing.T) {
+		builder := NewKongUpstream().WithOwner(nil)
+
+		assert.Panics(t, func() {
+			builder.MustBuild()
+		})
+	})
+}
+
+func TestKongUpstreamBuilder_Chaining(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-http-route",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+		},
+	}
+
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	controlPlaneRef := commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name:      "test-konnect-cp",
+			Namespace: "test-namespace",
+		},
+	}
+
+	upstream := NewKongUpstream().
+		WithName("test-upstream").
+		WithNamespace("test-namespace").
+		WithSpecName("test-spec").
+		WithControlPlaneRef(controlPlaneRef).
+		WithOwner(httpRoute).
+		WithLabels(httpRoute).
+		WithAnnotations(httpRoute, parentRef).
+		MustBuild()
+
+	assert.Equal(t, "test-upstream", upstream.Name)
+	assert.Equal(t, "test-namespace", upstream.Namespace)
+	assert.Equal(t, "test-spec", upstream.Spec.Name)
+	assert.Equal(t, controlPlaneRef, *upstream.Spec.ControlPlaneRef)
+	assert.Len(t, upstream.OwnerReferences, 1)
+	assert.NotNil(t, upstream.Labels)
+	assert.NotNil(t, upstream.Annotations)
+}
+
+func TestKongUpstreamBuilder_MultipleErrors(t *testing.T) {
+	builder := NewKongUpstream()
+
+	builder.WithOwner(nil)
+	builder.errors = append(builder.errors, assert.AnError)
+
+	_, err := builder.Build()
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "owner cannot be nil")
+	assert.Contains(t, err.Error(), assert.AnError.Error())
+}
+
+func TestKongUpstreamBuilder_ErrorAccumulation(t *testing.T) {
+	builder := NewKongUpstream().
+		WithOwner(nil).
+		WithName("test-upstream").
+		WithSpecName("test-spec")
+
+	_, err := builder.Build()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "owner cannot be nil")
+
+	assert.Equal(t, "test-upstream", builder.upstream.Name)
+	assert.Equal(t, "test-spec", builder.upstream.Spec.Name)
+}

--- a/controller/hybridgateway/converter/converter.go
+++ b/controller/hybridgateway/converter/converter.go
@@ -53,6 +53,8 @@ func NewConverter[t RootObject](obj t, cl client.Client, sharedStatusMap *route.
 	// TODO: add other types here
 	case corev1.Service:
 		return newServiceConverter(&o, cl, sharedStatusMap).(APIConverter[t]), nil
+	case gwtypes.HTTPRoute:
+		return newHTTPRouteConverter(&o, cl, sharedStatusMap).(APIConverter[t]), nil
 	default:
 		return nil, fmt.Errorf("unsupported root object type: %T", obj)
 	}

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -1,0 +1,223 @@
+package converter
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/controller/hybridgateway/builder"
+	"github.com/kong/kong-operator/controller/hybridgateway/intermediate"
+	"github.com/kong/kong-operator/controller/hybridgateway/refs"
+	"github.com/kong/kong-operator/controller/hybridgateway/route"
+	"github.com/kong/kong-operator/controller/hybridgateway/utils"
+	gwtypes "github.com/kong/kong-operator/internal/types"
+)
+
+var _ APIConverter[gwtypes.HTTPRoute] = &httpRouteConverter{}
+
+// httpRouteConverter is a concrete implementation of the APIConverter interface for HTTPRoute.
+type httpRouteConverter struct {
+	client.Client
+
+	route           *gwtypes.HTTPRoute
+	outputStore     []client.Object
+	sharedStatusMap *route.SharedRouteStatusMap
+	ir              *intermediate.HTTPRouteRepresentation
+}
+
+// NewHTTPRouteConverter returns a new instance of httpRouteConverter.
+func newHTTPRouteConverter(httpRoute *gwtypes.HTTPRoute, cl client.Client, sharedStatusMap *route.SharedRouteStatusMap) APIConverter[gwtypes.HTTPRoute] {
+	return &httpRouteConverter{
+		Client:          cl,
+		outputStore:     []client.Object{},
+		sharedStatusMap: sharedStatusMap,
+		route:           httpRoute,
+		ir:              intermediate.NewHTTPRouteRepresentation(httpRoute),
+	}
+}
+
+// GetRootObject implements APIConverter.
+func (c *httpRouteConverter) GetRootObject() gwtypes.HTTPRoute {
+	return *c.route
+}
+
+// Translate implements APIConverter.
+func (c *httpRouteConverter) Translate() error {
+	return c.translate(context.TODO())
+}
+
+// GetOutputStore implements APIConverter.
+func (c *httpRouteConverter) GetOutputStore(ctx context.Context) []unstructured.Unstructured {
+	objects := make([]unstructured.Unstructured, 0, len(c.outputStore))
+	for _, obj := range c.outputStore {
+		unstr, err := utils.ToUnstructured(obj, c.Scheme())
+		if err != nil {
+			continue
+		}
+		objects = append(objects, unstr)
+	}
+	return objects
+}
+
+// Reduce implements APIConverter.
+func (c *httpRouteConverter) Reduce(obj unstructured.Unstructured) []utils.ReduceFunc {
+	switch obj.GetKind() {
+	case "KongRoute":
+		return []utils.ReduceFunc{
+			utils.KeepProgrammed,
+			utils.KeepYoungest,
+		}
+	default:
+		return nil
+	}
+}
+
+// ListExistingObjects implements APIConverter.
+func (c *httpRouteConverter) ListExistingObjects(ctx context.Context) ([]unstructured.Unstructured, error) {
+	if c.route == nil {
+		return nil, nil
+	}
+
+	list := &configurationv1alpha1.KongRouteList{}
+	labels := map[string]string{
+		// TODO: Add appropriate labels for KongRoute objects managed by HTTPRoute
+	}
+	opts := []client.ListOption{
+		client.InNamespace(c.route.Namespace),
+		client.MatchingLabels(labels),
+	}
+	if err := c.List(ctx, list, opts...); err != nil {
+		return nil, err
+	}
+
+	unstructuredItems := make([]unstructured.Unstructured, 0, len(list.Items))
+	for _, item := range list.Items {
+		unstr, err := utils.ToUnstructured(&item, c.Scheme())
+		if err != nil {
+			return nil, err
+		}
+		unstructuredItems = append(unstructuredItems, unstr)
+	}
+
+	return unstructuredItems, nil
+}
+
+// UpdateSharedRouteStatus implements APIConverter.
+func (c *httpRouteConverter) UpdateSharedRouteStatus(objs []unstructured.Unstructured) error {
+	// TODO: Implement status update logic for HTTPRoute
+	return nil
+}
+
+// translate converts the HTTPRoute to KongRoute(s) and stores them in outputStore.
+func (c *httpRouteConverter) translate(ctx context.Context) error {
+	// Generate translation data.
+	if err := c.addControlPlaneRefs(ctx); err != nil {
+		return err
+	}
+
+	// Generate kong services, upstream and targets.
+	for _, val := range c.ir.Rules {
+		// Get the controlPlaneRef for the given Rule.
+		cpr := c.ir.GetControlPlaneRefByName(val.Name)
+		if cpr == nil {
+			continue
+		}
+		name := val.String()
+
+		// Build the upstream resource.
+		upstream, err := builder.NewKongUpstream().
+			WithName(name).
+			WithNamespace(c.route.Namespace).
+			WithLabels(c.route).
+			WithAnnotations(c.route, c.ir.GetParentRefByName(val.Name)).
+			WithSpecName(name).
+			WithControlPlaneRef(*cpr).
+			WithOwner(c.route).Build()
+		if err != nil {
+			// TODO: decide how to handle build errors in converter
+			// For now, skip this resource
+			continue
+		}
+		c.outputStore = append(c.outputStore, &upstream)
+
+		// Build the service resource.
+		service, err := builder.NewKongService().
+			WithName(name).
+			WithNamespace(c.route.Namespace).
+			WithLabels(c.route).
+			WithAnnotations(c.route, c.ir.GetParentRefByName(val.Name)).
+			WithSpecName(name).
+			WithSpecHost(name).
+			WithControlPlaneRef(*cpr).
+			WithOwner(c.route).Build()
+		if err != nil {
+			// TODO: decide how to handle build errors in converter
+			// For now, skip this resource
+			continue
+		}
+		c.outputStore = append(c.outputStore, &service)
+
+		// Build the target resources.
+		for _, bRef := range val.BackendRefs {
+			targetName := bRef.String()
+
+			target, err := builder.NewKongTarget().
+				WithName(targetName).
+				WithNamespace(c.route.Namespace).
+				WithLabels(c.route).
+				WithAnnotations(c.route, c.ir.GetParentRefByName(bRef.Name)).
+				WithUpstreamRef(name).
+				WithBackendRef(c.route, &bRef.BackendRef).
+				WithOwner(c.route).Build()
+			if err != nil {
+				// TODO: decide how to handle build errors in converter
+				// For now, skip this resource
+				continue
+			}
+			c.outputStore = append(c.outputStore, &target)
+		}
+
+		// Build the kong route resource.
+		for _, match := range val.Matches {
+			routeName := match.String()
+			serviceName := val.String()
+
+			route, err := builder.NewKongRoute().
+				WithName(routeName).
+				WithNamespace(c.route.Namespace).
+				WithLabels(c.route).
+				WithAnnotations(c.route, c.ir.GetParentRefByName(match.Name)).
+				WithSpecName(routeName).
+				WithStripPath(c.ir.StripPath).
+				WithKongService(serviceName).
+				WithHTTPRouteMatch(match.Match).
+				WithOwner(c.route).Build()
+			if err != nil {
+				// TODO: decide how to handle build errors in converter
+				// For now, skip this resource
+				continue
+			}
+			c.outputStore = append(c.outputStore, &route)
+		}
+
+	}
+
+	return nil
+}
+
+func (c *httpRouteConverter) addControlPlaneRefs(ctx context.Context) error {
+	for i, pRef := range c.route.Spec.ParentRefs {
+		pRefName := intermediate.NameFromHTTPRoute(c.route, "", i)
+		cpRef, err := refs.GetControlPlaneRefByParentRef(ctx, c.Client, c.route, pRef)
+		if err != nil {
+			return err
+		}
+		c.ir.AddControlPlaneRef(intermediate.ControlPlaneRef{
+			Name:            pRefName,
+			ControlPlaneRef: cpRef,
+		})
+	}
+	return nil
+}

--- a/controller/hybridgateway/intermediate/http_route.go
+++ b/controller/hybridgateway/intermediate/http_route.go
@@ -1,0 +1,212 @@
+package intermediate
+
+import (
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	"github.com/kong/kong-operator/controller/hybridgateway/metadata"
+	gwtypes "github.com/kong/kong-operator/internal/types"
+)
+
+// Rule represents a single HTTPRoute rule with its associated matches and backend references.
+// It encapsulates the routing logic for a specific rule within an HTTPRoute.
+type Rule struct {
+	Name
+	Matches     map[string]Match
+	BackendRefs map[string]BackendRef
+}
+
+// Match represents a single HTTPRoute match condition.
+// It contains the match criteria that determine when a request should be processed by this match.
+type Match struct {
+	Name
+	Match gwtypes.HTTPRouteMatch
+}
+
+// BackendRef represents a backend reference within an HTTPRoute rule.
+// It defines the target backend service that should handle requests matching this reference.
+type BackendRef struct {
+	Name
+	BackendRef gwtypes.HTTPBackendRef
+}
+
+// ControlPlaneRef represents a control plane reference for Kong configuration.
+// It associates Kong entities with their corresponding control plane instance.
+type ControlPlaneRef struct {
+	Name
+	ControlPlaneRef *commonv1alpha1.ControlPlaneRef
+}
+
+// ParentReference represents a parent reference in an HTTPRoute.
+// It defines the Gateway or other parent resource that this HTTPRoute is attached to.
+type ParentReference struct {
+	Name
+	ParentReference gwtypes.ParentReference
+}
+
+// HTTPRouteRepresentation provides an intermediate representation of an HTTPRoute resource.
+// It organizes HTTPRoute data into a structured format that facilitates conversion to Kong entities.
+// This representation includes rules, hostnames, control plane references, parent references, and routing options.
+type HTTPRouteRepresentation struct {
+	Rules            map[string]Rule
+	Hostnames        map[string][]string
+	ControlPlaneRefs map[string]ControlPlaneRef
+	ParentRefs       map[string]ParentReference
+	StripPath        bool
+}
+
+// NewHTTPRouteRepresentation creates a new HTTPRouteRepresentation from an HTTPRoute resource.
+// It initializes all the internal maps and extracts configuration like strip-path from annotations.
+func NewHTTPRouteRepresentation(route *gwtypes.HTTPRoute) *HTTPRouteRepresentation {
+	repr := HTTPRouteRepresentation{
+		Rules:            map[string]Rule{},
+		Hostnames:        map[string][]string{},
+		ControlPlaneRefs: map[string]ControlPlaneRef{},
+		ParentRefs:       map[string]ParentReference{},
+		StripPath:        metadata.ExtractStripPath(route.Annotations),
+	}
+
+	for i := range route.Spec.ParentRefs {
+		repr.AddParentRef(ParentReference{
+			Name:            NameFromHTTPRoute(route, "", i),
+			ParentReference: route.Spec.ParentRefs[i],
+		})
+		for j, rule := range route.Spec.Rules {
+			ruleName := NameFromHTTPRoute(route, "", i, j)
+			for k, match := range rule.Matches {
+				matchName := NameFromHTTPRoute(route, "", i, j, k)
+				repr.AddMatchForRule(ruleName, Match{
+					Name:  matchName,
+					Match: match,
+				})
+			}
+			for k, bRef := range rule.BackendRefs {
+				bRefName := NameFromHTTPRoute(route, "", i, j, k)
+				repr.AddBackenRefForRule(ruleName, BackendRef{
+					Name:       bRefName,
+					BackendRef: bRef,
+				})
+			}
+		}
+	}
+
+	return &repr
+}
+
+// NameFromHTTPRoute creates a Name instance from an HTTPRoute resource with optional prefix and indexes.
+// The prefix defaults to "httproute" if empty. Indexes are limited to 3 elements maximum.
+// This function is used to generate consistent names for Kong entities derived from HTTPRoute resources.
+func NameFromHTTPRoute(route *gwtypes.HTTPRoute, prefix string, indexes ...int) Name {
+	if prefix == "" {
+		prefix = "httproute"
+	}
+	// Only take up to 3 indexes
+	if len(indexes) > 3 {
+		indexes = indexes[:3]
+	}
+	return Name{
+		prefix:    prefix,
+		namespace: route.Namespace,
+		name:      route.Name,
+		indexes:   indexes,
+	}
+}
+
+// AddMatchForRule adds a match condition to a specific rule in the HTTPRoute representation.
+// If the rule doesn't exist, it creates a new rule with the provided name.
+// The match is stored using its name as the key for easy retrieval.
+func (t *HTTPRouteRepresentation) AddMatchForRule(rName Name, match Match) {
+	if t.Rules == nil {
+		t.Rules = make(map[string]Rule)
+	}
+	ruleKey := rName.String()
+	rule, exists := t.Rules[ruleKey]
+	if !exists {
+		rule = Rule{
+			Name:    rName,
+			Matches: make(map[string]Match),
+		}
+	}
+	matchKey := match.String()
+	rule.Matches[matchKey] = match
+	t.Rules[ruleKey] = rule
+}
+
+// AddBackenRefForRule adds a backend reference to a specific rule in the HTTPRoute representation.
+// If the rule doesn't exist, it creates a new rule with the provided name.
+// The backend reference is stored using its name as the key for easy retrieval.
+func (t *HTTPRouteRepresentation) AddBackenRefForRule(rName Name, backendRef BackendRef) {
+	if t.Rules == nil {
+		t.Rules = make(map[string]Rule)
+	}
+	ruleKey := rName.String()
+	rule, exists := t.Rules[ruleKey]
+	if !exists {
+		rule = Rule{
+			Name:        rName,
+			Matches:     make(map[string]Match),
+			BackendRefs: make(map[string]BackendRef),
+		}
+	}
+	if rule.BackendRefs == nil {
+		rule.BackendRefs = make(map[string]BackendRef)
+	}
+	backendRefKey := backendRef.String()
+	rule.BackendRefs[backendRefKey] = backendRef
+	t.Rules[ruleKey] = rule
+}
+
+// AddParentRef adds a parent reference to the HTTPRoute representation.
+// Parent references define the Gateway or other parent resource that this HTTPRoute is attached to.
+func (t *HTTPRouteRepresentation) AddParentRef(parentRef ParentReference) {
+	if t.ParentRefs == nil {
+		t.ParentRefs = make(map[string]ParentReference)
+	}
+	t.ParentRefs[parentRef.String()] = parentRef
+}
+
+// GetParentRefByName retrieves a parent reference by name from the HTTPRoute representation.
+// It normalizes the name by keeping only the parent reference index to ensure proper matching.
+// Returns nil if no parent reference is found with the given name.
+func (t *HTTPRouteRepresentation) GetParentRefByName(name Name) *gwtypes.ParentReference {
+	if t.ParentRefs == nil {
+		return nil
+	}
+
+	// Since the name for the parentRef is in the format prefix.<namespace>.<name>[.<parentRefIndex>]
+	// we make sure that when we receive a name from a different resource for which we want to get the parentRef we
+	// remove the unneeded indexes.
+	name.indexes = name.indexes[:1]
+
+	if pRef, ok := t.ParentRefs[name.String()]; ok {
+		return &pRef.ParentReference
+	}
+	return nil
+}
+
+// AddControlPlaneRef adds a control plane reference to the HTTPRoute representation.
+// Control plane references associate Kong entities with their corresponding control plane instance.
+func (t *HTTPRouteRepresentation) AddControlPlaneRef(cpr ControlPlaneRef) {
+	if t.ControlPlaneRefs == nil {
+		t.ControlPlaneRefs = make(map[string]ControlPlaneRef)
+	}
+
+	t.ControlPlaneRefs[cpr.String()] = cpr
+}
+
+// GetControlPlaneRefByName retrieves a control plane reference by name from the HTTPRoute representation.
+// It normalizes the name by keeping only the parent reference index to ensure proper matching.
+// Returns nil if no control plane reference is found with the given name.
+func (t *HTTPRouteRepresentation) GetControlPlaneRefByName(name Name) *commonv1alpha1.ControlPlaneRef {
+	if t.ControlPlaneRefs == nil {
+		return nil
+	}
+
+	// Since the name for the controlPlaneRef is in the format prefix.<namespace>.<name>[.<parentRefIndex>]
+	// we make sure that when we receive a name from a different resources for which we want to get the controlPlaneRef we
+	// remove the unneeded indexes.
+	name.indexes = name.indexes[:1]
+
+	if cpr, ok := t.ControlPlaneRefs[name.String()]; ok {
+		return cpr.ControlPlaneRef
+	}
+	return nil
+}

--- a/controller/hybridgateway/intermediate/http_route_test.go
+++ b/controller/hybridgateway/intermediate/http_route_test.go
@@ -1,0 +1,62 @@
+package intermediate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	gwtypes "github.com/kong/kong-operator/internal/types"
+)
+
+func TestNewHTTPRouteRepresentation_StripPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		route    *gwtypes.HTTPRoute
+		expected bool
+	}{
+		{
+			name: "HTTPRoute without strip-path annotation",
+			route: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "HTTPRoute with strip-path true",
+			route: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						"konghq.com/strip-path": "true",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "HTTPRoute with strip-path false",
+			route: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						"konghq.com/strip-path": "false",
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repr := NewHTTPRouteRepresentation(tt.route)
+			assert.Equal(t, tt.expected, repr.StripPath)
+		})
+	}
+}

--- a/controller/hybridgateway/intermediate/name.go
+++ b/controller/hybridgateway/intermediate/name.go
@@ -1,0 +1,90 @@
+package intermediate
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Name represents a structured naming scheme for Kong entities derived from HTTPRoute resources.
+// It provides a hierarchical naming structure with prefix, namespace, name, and optional indexes
+// for parent references, rules, and matches. The String() method ensures names stay within
+// Kubernetes resource name length limits through intelligent truncation.
+type Name struct {
+	prefix    string
+	namespace string
+	name      string
+	// indexes represents [parentRefIndex, ruleIndex, matchIndex] for hierarchical identification
+	indexes []int
+}
+
+// String returns the full name as a dot-separated string, truncating if necessary to stay within
+// the 253 character limit for Kubernetes resource names. It preserves the prefix and indexes
+// while proportionally truncating namespace and name if needed.
+func (n *Name) String() string {
+	const maxLen = 253
+
+	parts := []string{n.prefix, n.namespace, n.name}
+	for _, idx := range n.indexes {
+		parts = append(parts, strconv.Itoa(idx))
+	}
+	fullName := strings.Join(parts, ".")
+
+	if len(fullName) <= maxLen {
+		return fullName
+	}
+
+	// Calculate reserved length for prefix and indexes
+	reserved := len(n.prefix) + 1 // prefix + dot
+	for _, idx := range n.indexes {
+		reserved += len(strconv.Itoa(idx)) + 1 // index + dot
+	}
+	// We need at least one dot between prefix, namespace, name, and indexes
+	// Truncate namespace and name proportionally if needed
+	remaining := maxLen - reserved
+
+	// Split remaining between namespace and name
+	nsMax := remaining / 2
+	nameMax := remaining - nsMax
+
+	truncNamespace := n.namespace
+	truncName := n.name
+	if len(truncNamespace) > nsMax {
+		truncNamespace = truncNamespace[:nsMax]
+	}
+	if len(truncName) > nameMax {
+		truncName = truncName[:nameMax]
+	}
+
+	parts = []string{n.prefix, truncNamespace, truncName}
+	for _, idx := range n.indexes {
+		parts = append(parts, strconv.Itoa(idx))
+	}
+	return strings.Join(parts, ".")
+}
+
+// GetParentRefIndex returns the parent reference index from the indexes array.
+// Returns -1 if the Name is nil or if no parent reference index is available.
+func (n *Name) GetParentRefIndex() int {
+	if n == nil || len(n.indexes) < 1 {
+		return -1
+	}
+	return n.indexes[0]
+}
+
+// GetRuleIndex returns the rule index from the indexes array.
+// Returns -1 if the Name is nil or if no rule index is available.
+func (n *Name) GetRuleIndex() int {
+	if n == nil || len(n.indexes) < 2 {
+		return -1
+	}
+	return n.indexes[1]
+}
+
+// GetMatchIndex returns the match index from the indexes array.
+// Returns -1 if the Name is nil or if no match index is available.
+func (n *Name) GetMatchIndex() int {
+	if n == nil || len(n.indexes) < 3 {
+		return -1
+	}
+	return n.indexes[2]
+}

--- a/controller/hybridgateway/intermediate/name_test.go
+++ b/controller/hybridgateway/intermediate/name_test.go
@@ -1,0 +1,532 @@
+package intermediate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestName_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		nameObj  Name
+		expected string
+	}{
+		{
+			name: "basic name without indexes",
+			nameObj: Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{},
+			},
+			expected: "prefix.namespace.name",
+		},
+		{
+			name: "name with single index",
+			nameObj: Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{1},
+			},
+			expected: "prefix.namespace.name.1",
+		},
+		{
+			name: "name with multiple indexes",
+			nameObj: Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{1, 2, 3},
+			},
+			expected: "prefix.namespace.name.1.2.3",
+		},
+		{
+			name: "name with zero indexes",
+			nameObj: Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{0, 0, 0},
+			},
+			expected: "prefix.namespace.name.0.0.0",
+		},
+		{
+			name: "empty strings",
+			nameObj: Name{
+				prefix:    "",
+				namespace: "",
+				name:      "",
+				indexes:   []int{},
+			},
+			expected: "..",
+		},
+		{
+			name: "short name under max length",
+			nameObj: Name{
+				prefix:    "short",
+				namespace: "ns",
+				name:      "nm",
+				indexes:   []int{1},
+			},
+			expected: "short.ns.nm.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.nameObj.String()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestName_String_Truncation(t *testing.T) {
+	tests := []struct {
+		name        string
+		nameObj     Name
+		description string
+	}{
+		{
+			name: "long name requiring truncation",
+			nameObj: Name{
+				prefix:    "very-long-prefix-that-takes-up-space",
+				namespace: strings.Repeat("a", 100),
+				name:      strings.Repeat("b", 100),
+				indexes:   []int{1, 2, 3},
+			},
+			description: "should truncate namespace and name proportionally",
+		},
+		{
+			name: "extremely long namespace and name",
+			nameObj: Name{
+				prefix:    "prefix",
+				namespace: strings.Repeat("namespace", 20),
+				name:      strings.Repeat("name", 20),
+				indexes:   []int{10, 20, 30},
+			},
+			description: "should handle moderately long inputs",
+		},
+		{
+			name: "long prefix with short namespace and name",
+			nameObj: Name{
+				prefix:    strings.Repeat("prefix", 25),
+				namespace: "ns",
+				name:      "name",
+				indexes:   []int{1},
+			},
+			description: "should handle long prefix",
+		},
+		{
+			name: "large indexes",
+			nameObj: Name{
+				prefix:    "prefix",
+				namespace: strings.Repeat("a", 50),
+				name:      strings.Repeat("b", 50),
+				indexes:   []int{99999, 88888, 77777},
+			},
+			description: "should handle large index values",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.nameObj.String()
+			assert.LessOrEqual(t, len(result), 260, "Result should be within reasonable bounds")
+			if tt.nameObj.prefix != "" {
+				assert.Contains(t, result, tt.nameObj.prefix, "Should contain the prefix")
+			}
+			parts := strings.Split(result, ".")
+			assert.GreaterOrEqual(t, len(parts), 3, "Should have at least prefix, namespace, and name parts")
+		})
+	}
+}
+
+func TestName_String_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		nameObj     Name
+		description string
+	}{
+		{
+			name: "moderate length calculation",
+			nameObj: Name{
+				prefix:    "prefix",
+				namespace: strings.Repeat("a", 80),
+				name:      strings.Repeat("b", 80),
+				indexes:   []int{1},
+			},
+			description: "should handle names requiring truncation",
+		},
+		{
+			name: "nil indexes",
+			nameObj: Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   nil,
+			},
+			description: "should handle nil indexes",
+		},
+		{
+			name: "negative indexes",
+			nameObj: Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{-1, -2, -3},
+			},
+			description: "should handle negative indexes",
+		},
+		{
+			name: "extremely long prefix consuming most space",
+			nameObj: Name{
+				prefix:    strings.Repeat("x", 240), // Very long prefix
+				namespace: strings.Repeat("a", 50),
+				name:      strings.Repeat("b", 50),
+				indexes:   []int{12345},
+			},
+			description: "should handle cases where prefix consumes most space",
+		},
+		{
+			name: "edge case with very large indexes",
+			nameObj: Name{
+				prefix:    strings.Repeat("prefix", 20),  // 120 chars
+				namespace: strings.Repeat("ns", 50),      // 100 chars
+				name:      strings.Repeat("nm", 50),      // 100 chars
+				indexes:   []int{999999, 888888, 777777}, // Large indexes
+			},
+			description: "should handle large indexes that affect reserved space calculation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.nameObj.String()
+			assert.LessOrEqual(t, len(result), 260, "Should respect reasonable max length")
+			assert.NotEmpty(t, result, "Result should not be empty")
+		})
+	}
+}
+
+func TestName_GetParentRefIndex(t *testing.T) {
+	tests := []struct {
+		name     string
+		nameObj  *Name
+		expected int
+	}{
+		{
+			name: "valid parent ref index",
+			nameObj: &Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{5, 2, 3},
+			},
+			expected: 5,
+		},
+		{
+			name: "zero parent ref index",
+			nameObj: &Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{0, 2, 3},
+			},
+			expected: 0,
+		},
+		{
+			name: "negative parent ref index",
+			nameObj: &Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{-1, 2, 3},
+			},
+			expected: -1,
+		},
+		{
+			name: "empty indexes",
+			nameObj: &Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{},
+			},
+			expected: -1,
+		},
+		{
+			name: "nil indexes",
+			nameObj: &Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   nil,
+			},
+			expected: -1,
+		},
+		{
+			name:     "nil name object",
+			nameObj:  nil,
+			expected: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.nameObj.GetParentRefIndex()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestName_GetRuleIndex(t *testing.T) {
+	tests := []struct {
+		name     string
+		nameObj  *Name
+		expected int
+	}{
+		{
+			name: "valid rule index",
+			nameObj: &Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{1, 7, 3},
+			},
+			expected: 7,
+		},
+		{
+			name: "zero rule index",
+			nameObj: &Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{1, 0, 3},
+			},
+			expected: 0,
+		},
+		{
+			name: "negative rule index",
+			nameObj: &Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{1, -5, 3},
+			},
+			expected: -5,
+		},
+		{
+			name: "only one index",
+			nameObj: &Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{1},
+			},
+			expected: -1,
+		},
+		{
+			name: "empty indexes",
+			nameObj: &Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{},
+			},
+			expected: -1,
+		},
+		{
+			name: "nil indexes",
+			nameObj: &Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   nil,
+			},
+			expected: -1,
+		},
+		{
+			name:     "nil name object",
+			nameObj:  nil,
+			expected: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.nameObj.GetRuleIndex()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestName_GetMatchIndex(t *testing.T) {
+	tests := []struct {
+		name     string
+		nameObj  *Name
+		expected int
+	}{
+		{
+			name: "valid match index",
+			nameObj: &Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{1, 2, 9},
+			},
+			expected: 9,
+		},
+		{
+			name: "zero match index",
+			nameObj: &Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{1, 2, 0},
+			},
+			expected: 0,
+		},
+		{
+			name: "negative match index",
+			nameObj: &Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{1, 2, -10},
+			},
+			expected: -10,
+		},
+		{
+			name: "only two indexes",
+			nameObj: &Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{1, 2},
+			},
+			expected: -1,
+		},
+		{
+			name: "only one index",
+			nameObj: &Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{1},
+			},
+			expected: -1,
+		},
+		{
+			name: "empty indexes",
+			nameObj: &Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{},
+			},
+			expected: -1,
+		},
+		{
+			name: "nil indexes",
+			nameObj: &Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   nil,
+			},
+			expected: -1,
+		},
+		{
+			name:     "nil name object",
+			nameObj:  nil,
+			expected: -1,
+		},
+		{
+			name: "more than three indexes",
+			nameObj: &Name{
+				prefix:    "prefix",
+				namespace: "namespace",
+				name:      "name",
+				indexes:   []int{1, 2, 3, 4, 5},
+			},
+			expected: 3, // Should return the third index (index 2)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.nameObj.GetMatchIndex()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestName_ComprehensiveScenarios(t *testing.T) {
+	tests := []struct {
+		name        string
+		nameObj     Name
+		description string
+	}{
+		{
+			name: "real world scenario - kong route",
+			nameObj: Name{
+				prefix:    "kong-route",
+				namespace: "default",
+				name:      "api-gateway-route",
+				indexes:   []int{0, 1, 2},
+			},
+			description: "typical Kong route naming scenario",
+		},
+		{
+			name: "long namespace scenario",
+			nameObj: Name{
+				prefix:    "kong-service",
+				namespace: "very-long-namespace-with-many-characters",
+				name:      "short-service",
+				indexes:   []int{10, 20},
+			},
+			description: "scenario with long namespace requiring truncation",
+		},
+		{
+			name: "unicode characters",
+			nameObj: Name{
+				prefix:    "kong-测试",
+				namespace: "命名空间",
+				name:      "服务名称",
+				indexes:   []int{1},
+			},
+			description: "unicode characters in names",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test String method
+			result := tt.nameObj.String()
+			assert.NotEmpty(t, result, "String result should not be empty")
+			assert.LessOrEqual(t, len(result), 260, "Should respect reasonable max length")
+
+			// Test index getters
+			if len(tt.nameObj.indexes) >= 1 {
+				assert.Equal(t, tt.nameObj.indexes[0], tt.nameObj.GetParentRefIndex())
+			} else {
+				assert.Equal(t, -1, tt.nameObj.GetParentRefIndex())
+			}
+
+			if len(tt.nameObj.indexes) >= 2 {
+				assert.Equal(t, tt.nameObj.indexes[1], tt.nameObj.GetRuleIndex())
+			} else {
+				assert.Equal(t, -1, tt.nameObj.GetRuleIndex())
+			}
+
+			if len(tt.nameObj.indexes) >= 3 {
+				assert.Equal(t, tt.nameObj.indexes[2], tt.nameObj.GetMatchIndex())
+			} else {
+				assert.Equal(t, -1, tt.nameObj.GetMatchIndex())
+			}
+		})
+	}
+}

--- a/controller/hybridgateway/metadata/annotation.go
+++ b/controller/hybridgateway/metadata/annotation.go
@@ -1,0 +1,54 @@
+package metadata
+
+import (
+	"strconv"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	routepkg "github.com/kong/kong-operator/controller/hybridgateway/route"
+	gwtypes "github.com/kong/kong-operator/internal/types"
+	"github.com/kong/kong-operator/pkg/consts"
+)
+
+const (
+	// Annotation constants matching those in the ingress controller
+	annotationPrefix = "konghq.com"
+	stripPathKey     = "/strip-path"
+)
+
+// ExtractStripPath extracts the strip-path annotation value and returns a boolean.
+// Returns true by default if the annotation is not present or cannot be parsed.
+func ExtractStripPath(anns map[string]string) bool {
+	if anns == nil {
+		return true
+	}
+
+	val := anns[annotationPrefix+stripPathKey]
+	if val == "" {
+		return true // Default to true when not specified
+	}
+
+	stripPath, err := strconv.ParseBool(val)
+	if err != nil {
+		return true // Default to true when invalid value
+	}
+
+	return stripPath
+}
+
+// BuildAnnotations creates the standard annotations map for Kong resources managed by HTTPRoute.
+func BuildAnnotations(route *gwtypes.HTTPRoute, parentRef *gwtypes.ParentReference) map[string]string {
+	gwObjKey := client.ObjectKey{
+		Name: string(parentRef.Name),
+	}
+	if parentRef.Namespace != nil && *parentRef.Namespace != "" {
+		gwObjKey.Namespace = string(*parentRef.Namespace)
+	} else {
+		gwObjKey.Namespace = route.GetNamespace()
+	}
+
+	return map[string]string{
+		consts.GatewayOperatorHybridRouteAnnotation:    routepkg.HTTPRouteKey + "|" + client.ObjectKeyFromObject(route).String(),
+		consts.GatewayOperatorHybridGatewaysAnnotation: gwObjKey.String(),
+	}
+}

--- a/controller/hybridgateway/metadata/annotation_test.go
+++ b/controller/hybridgateway/metadata/annotation_test.go
@@ -1,0 +1,204 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kong-operator/controller/hybridgateway/route"
+	gwtypes "github.com/kong/kong-operator/internal/types"
+	"github.com/kong/kong-operator/pkg/consts"
+)
+
+func TestExtractStripPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			expected:    true,
+		},
+		{
+			name:        "empty annotations",
+			annotations: map[string]string{},
+			expected:    true,
+		},
+		{
+			name: "strip-path true",
+			annotations: map[string]string{
+				"konghq.com/strip-path": "true",
+			},
+			expected: true,
+		},
+		{
+			name: "strip-path false",
+			annotations: map[string]string{
+				"konghq.com/strip-path": "false",
+			},
+			expected: false,
+		},
+		{
+			name: "strip-path invalid value",
+			annotations: map[string]string{
+				"konghq.com/strip-path": "invalid",
+			},
+			expected: true,
+		},
+		{
+			name: "strip-path empty value",
+			annotations: map[string]string{
+				"konghq.com/strip-path": "",
+			},
+			expected: true,
+		},
+		{
+			name: "other annotations present",
+			annotations: map[string]string{
+				"other-annotation":      "value",
+				"konghq.com/strip-path": "false",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractStripPath(tt.annotations)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBuildAnnotations(t *testing.T) {
+	tests := []struct {
+		name        string
+		httpRoute   *gwtypes.HTTPRoute
+		parentRef   *gwtypes.ParentReference
+		expected    map[string]string
+		description string
+	}{
+		{
+			name: "with explicit parent namespace",
+			httpRoute: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			parentRef: &gwtypes.ParentReference{
+				Name:      "test-gateway",
+				Namespace: func() *gwtypes.Namespace { ns := gwtypes.Namespace("gateway-namespace"); return &ns }(),
+			},
+			expected: map[string]string{
+				consts.GatewayOperatorHybridRouteAnnotation:    route.HTTPRouteKey + "|" + "test-namespace/test-route",
+				consts.GatewayOperatorHybridGatewaysAnnotation: "gateway-namespace/test-gateway",
+			},
+			description: "should use explicit parent namespace when provided",
+		},
+		{
+			name: "with nil parent namespace",
+			httpRoute: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			parentRef: &gwtypes.ParentReference{
+				Name:      "test-gateway",
+				Namespace: nil,
+			},
+			expected: map[string]string{
+				consts.GatewayOperatorHybridRouteAnnotation:    route.HTTPRouteKey + "|" + "test-namespace/test-route",
+				consts.GatewayOperatorHybridGatewaysAnnotation: "test-namespace/test-gateway",
+			},
+			description: "should use HTTPRoute namespace when parent namespace is nil",
+		},
+		{
+			name: "with empty parent namespace",
+			httpRoute: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			parentRef: &gwtypes.ParentReference{
+				Name:      "test-gateway",
+				Namespace: func() *gwtypes.Namespace { ns := gwtypes.Namespace(""); return &ns }(),
+			},
+			expected: map[string]string{
+				consts.GatewayOperatorHybridRouteAnnotation:    route.HTTPRouteKey + "|" + "test-namespace/test-route",
+				consts.GatewayOperatorHybridGatewaysAnnotation: "test-namespace/test-gateway",
+			},
+			description: "should use HTTPRoute namespace when parent namespace is empty",
+		},
+		{
+			name: "with different route and gateway namespaces",
+			httpRoute: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-route",
+					Namespace: "apps",
+				},
+			},
+			parentRef: &gwtypes.ParentReference{
+				Name:      "my-gateway",
+				Namespace: func() *gwtypes.Namespace { ns := gwtypes.Namespace("infrastructure"); return &ns }(),
+			},
+			expected: map[string]string{
+				consts.GatewayOperatorHybridRouteAnnotation:    route.HTTPRouteKey + "|" + "apps/my-route",
+				consts.GatewayOperatorHybridGatewaysAnnotation: "infrastructure/my-gateway",
+			},
+			description: "should handle different namespaces correctly",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BuildAnnotations(tt.httpRoute, tt.parentRef)
+			assert.Equal(t, tt.expected, result, tt.description)
+		})
+	}
+}
+
+func TestBuildAnnotationsObjectKeyCreation(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+	}
+
+	t.Run("creates correct ObjectKey for gateway", func(t *testing.T) {
+		parentRef := &gwtypes.ParentReference{
+			Name:      "test-gateway",
+			Namespace: func() *gwtypes.Namespace { ns := gwtypes.Namespace("gateway-namespace"); return &ns }(),
+		}
+
+		result := BuildAnnotations(httpRoute, parentRef)
+		gatewayAnnotation := result[consts.GatewayOperatorHybridGatewaysAnnotation]
+
+		expectedGatewayKey := client.ObjectKey{
+			Name:      "test-gateway",
+			Namespace: "gateway-namespace",
+		}
+		assert.Equal(t, expectedGatewayKey.String(), gatewayAnnotation)
+	})
+
+	t.Run("creates correct ObjectKey for HTTPRoute", func(t *testing.T) {
+		parentRef := &gwtypes.ParentReference{
+			Name:      "test-gateway",
+			Namespace: nil,
+		}
+
+		result := BuildAnnotations(httpRoute, parentRef)
+		routeAnnotation := result[consts.GatewayOperatorHybridRouteAnnotation]
+
+		expectedRouteKey := client.ObjectKeyFromObject(httpRoute)
+		assert.Contains(t, routeAnnotation, expectedRouteKey.String())
+		assert.Equal(t, route.HTTPRouteKey+"|"+expectedRouteKey.String(), routeAnnotation)
+	})
+}

--- a/controller/hybridgateway/metadata/label.go
+++ b/controller/hybridgateway/metadata/label.go
@@ -1,0 +1,15 @@
+package metadata
+
+import (
+	gwtypes "github.com/kong/kong-operator/internal/types"
+	"github.com/kong/kong-operator/pkg/consts"
+)
+
+// BuildLabels creates the standard labels map for Kong resources managed by HTTPRoute.
+func BuildLabels(route *gwtypes.HTTPRoute) map[string]string {
+	return map[string]string{
+		consts.GatewayOperatorManagedByLabel:          consts.HTTPRouteManagedByLabel,
+		consts.GatewayOperatorManagedByNameLabel:      route.GetName(),
+		consts.GatewayOperatorManagedByNamespaceLabel: route.GetNamespace(),
+	}
+}

--- a/controller/hybridgateway/metadata/label_test.go
+++ b/controller/hybridgateway/metadata/label_test.go
@@ -1,0 +1,160 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	gwtypes "github.com/kong/kong-operator/internal/types"
+	"github.com/kong/kong-operator/pkg/consts"
+)
+
+func TestBuildLabels(t *testing.T) {
+	tests := []struct {
+		name        string
+		httpRoute   *gwtypes.HTTPRoute
+		expected    map[string]string
+		description string
+	}{
+		{
+			name: "basic HTTPRoute",
+			httpRoute: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			expected: map[string]string{
+				consts.GatewayOperatorManagedByLabel:          consts.HTTPRouteManagedByLabel,
+				consts.GatewayOperatorManagedByNameLabel:      "test-route",
+				consts.GatewayOperatorManagedByNamespaceLabel: "test-namespace",
+			},
+			description: "should create correct labels for basic HTTPRoute",
+		},
+		{
+			name: "HTTPRoute with different name and namespace",
+			httpRoute: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-api-route",
+					Namespace: "production",
+				},
+			},
+			expected: map[string]string{
+				consts.GatewayOperatorManagedByLabel:          consts.HTTPRouteManagedByLabel,
+				consts.GatewayOperatorManagedByNameLabel:      "my-api-route",
+				consts.GatewayOperatorManagedByNamespaceLabel: "production",
+			},
+			description: "should handle different names and namespaces correctly",
+		},
+		{
+			name: "HTTPRoute with empty name",
+			httpRoute: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "",
+					Namespace: "test-namespace",
+				},
+			},
+			expected: map[string]string{
+				consts.GatewayOperatorManagedByLabel:          consts.HTTPRouteManagedByLabel,
+				consts.GatewayOperatorManagedByNameLabel:      "",
+				consts.GatewayOperatorManagedByNamespaceLabel: "test-namespace",
+			},
+			description: "should handle empty name correctly",
+		},
+		{
+			name: "HTTPRoute with empty namespace",
+			httpRoute: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "",
+				},
+			},
+			expected: map[string]string{
+				consts.GatewayOperatorManagedByLabel:          consts.HTTPRouteManagedByLabel,
+				consts.GatewayOperatorManagedByNameLabel:      "test-route",
+				consts.GatewayOperatorManagedByNamespaceLabel: "",
+			},
+			description: "should handle empty namespace correctly",
+		},
+		{
+			name: "HTTPRoute with hyphenated names",
+			httpRoute: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "multi-word-route-name",
+					Namespace: "my-app-namespace",
+				},
+			},
+			expected: map[string]string{
+				consts.GatewayOperatorManagedByLabel:          consts.HTTPRouteManagedByLabel,
+				consts.GatewayOperatorManagedByNameLabel:      "multi-word-route-name",
+				consts.GatewayOperatorManagedByNamespaceLabel: "my-app-namespace",
+			},
+			description: "should handle hyphenated names correctly",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BuildLabels(tt.httpRoute)
+			assert.Equal(t, tt.expected, result, tt.description)
+		})
+	}
+}
+
+func TestBuildLabelsConstants(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+	}
+
+	result := BuildLabels(httpRoute)
+
+	t.Run("includes managed-by label", func(t *testing.T) {
+		managedBy, exists := result[consts.GatewayOperatorManagedByLabel]
+		assert.True(t, exists, "should include managed-by label")
+		assert.Equal(t, consts.HTTPRouteManagedByLabel, managedBy, "should use correct managed-by value")
+	})
+
+	t.Run("includes name label", func(t *testing.T) {
+		name, exists := result[consts.GatewayOperatorManagedByNameLabel]
+		assert.True(t, exists, "should include name label")
+		assert.Equal(t, httpRoute.GetName(), name, "should use HTTPRoute name")
+	})
+
+	t.Run("includes namespace label", func(t *testing.T) {
+		namespace, exists := result[consts.GatewayOperatorManagedByNamespaceLabel]
+		assert.True(t, exists, "should include namespace label")
+		assert.Equal(t, httpRoute.GetNamespace(), namespace, "should use HTTPRoute namespace")
+	})
+
+	t.Run("returns exactly three labels", func(t *testing.T) {
+		assert.Len(t, result, 3, "should return exactly three labels")
+	})
+}
+
+func TestBuildLabelsImmutability(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+	}
+
+	// Call the function multiple times
+	result1 := BuildLabels(httpRoute)
+	result2 := BuildLabels(httpRoute)
+
+	t.Run("returns consistent results", func(t *testing.T) {
+		assert.Equal(t, result1, result2, "should return consistent results across multiple calls")
+	})
+
+	t.Run("returns independent maps", func(t *testing.T) {
+		// Modify one map and ensure the other is not affected
+		result1["test-key"] = "test-value"
+		_, exists := result2["test-key"]
+		assert.False(t, exists, "modifying one result should not affect another")
+	})
+}

--- a/controller/hybridgateway/reconciler_utils.go
+++ b/controller/hybridgateway/reconciler_utils.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,9 +56,11 @@ func EnforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 			existingObject.hits++
 		} else {
 			if err := cl.Create(ctx, &expectedObject); err != nil {
-				return false, false, err
+				if errors.IsAlreadyExists(err) {
+					continue
+				}
 			}
-			return false, true, nil
+			continue
 		}
 
 		// TODO: ensure the spec is up to date. This print is meant

--- a/controller/hybridgateway/refs/get.go
+++ b/controller/hybridgateway/refs/get.go
@@ -15,15 +15,21 @@ import (
 func GetGatewaysByHTTPRoute(ctx context.Context, cl client.Client, r gwtypes.HTTPRoute) []gwtypes.Gateway {
 	gatewayRefs := []gwtypes.Gateway{}
 	for _, ref := range r.Spec.ParentRefs {
+		var namespace string
 		if ref.Group == nil || *ref.Group != "gateway.networking.k8s.io" {
 			continue
 		}
 		if ref.Kind == nil || *ref.Kind != "Gateway" {
 			continue
 		}
+		if ref.Namespace != nil && *ref.Namespace != "" {
+			namespace = string(*ref.Namespace)
+		} else {
+			namespace = r.Namespace
+		}
 		gw := &gwtypes.Gateway{}
 		err := cl.Get(ctx, client.ObjectKey{
-			Namespace: r.Namespace,
+			Namespace: namespace,
 			Name:      string(ref.Name),
 		}, gw)
 		if err != nil {

--- a/controller/hybridgateway/route/httproute_test.go
+++ b/controller/hybridgateway/route/httproute_test.go
@@ -102,7 +102,7 @@ func TestHTTPRouteStatusUpdater(t *testing.T) {
 					Spec: gwtypes.HTTPRouteSpec{
 						CommonRouteSpec: gwtypes.CommonRouteSpec{
 							ParentRefs: []gwtypes.ParentReference{
-								{Name: "test-gateway"}, // This has nil Namespace.
+								{Name: "test-gateway"},
 							},
 						},
 						Rules: []gwtypes.HTTPRouteRule{
@@ -125,7 +125,7 @@ func TestHTTPRouteStatusUpdater(t *testing.T) {
 					{
 						ParentRef: gwtypes.ParentReference{
 							Name:      "test-gateway",
-							Namespace: &someNamespace, // Non-nil namespace.
+							Namespace: &someNamespace,
 						},
 						ControllerName: gwtypes.GatewayController("kong.konghq.com/kong-operator"),
 						Conditions:     []metav1.Condition{},

--- a/internal/types/gatewaytypes.go
+++ b/internal/types/gatewaytypes.go
@@ -17,6 +17,7 @@ type (
 	HTTPRouteSpec          = gatewayv1.HTTPRouteSpec
 	HTTPRouteRule          = gatewayv1.HTTPRouteRule
 	HTTPRouteList          = gatewayv1.HTTPRouteList
+	HTTPRouteMatch         = gatewayv1.HTTPRouteMatch
 	RouteParentStatus      = gatewayv1.RouteParentStatus
 	GRPCRoute              = gatewayv1.GRPCRoute
 	ParentReference        = gatewayv1.ParentReference

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -630,7 +630,7 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 		if c.KonnectHybridControllersEnabled {
 			sharedStatusMap := route.NewSharedStatusMap()
 			controllers = append(controllers,
-				newGatewayAPIHybridController[corev1.Service](mgr, sharedStatusMap),
+				newGatewayAPIHybridController[gwtypes.HTTPRoute](mgr, sharedStatusMap),
 				newRouteStatusController[gwtypes.HTTPRoute](mgr, sharedStatusMap),
 				// TODO: Add more Hybrid controllers here
 			)

--- a/pkg/consts/hybridgateway.go
+++ b/pkg/consts/hybridgateway.go
@@ -5,6 +5,8 @@ const (
 	// by the Service controller.
 	ServiceManagedByLabel = "service"
 
+	HTTPRouteManagedByLabel = "httproute"
+
 	// HashSpecValueLabel is the label's suffix used to indicate the hash of an object's spec.
 	HashSpecValueLabel = "hash-spec"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add comprehensive HTTPRoute reconciliation that translates Gateway API
HTTPRoutes into Kong-specific resources for hybrid gateway deployments.

Key components:
- HTTPRoute converter with full translation pipeline
- Builder pattern for Kong entities (KongRoute, KongService, KongUpstream, KongTarget)
- Intermediate representation for HTTPRoute processing
- Metadata utilities for consistent labeling and annotation handling
- Strip-path annotation extraction from HTTPRoute annotations

This PR implements some of the tasks of #2262 and #2263 

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
