### PR TITLE
chore: add Konnect hybrid CLI flag for Konnect hybrid controllers

### DIFF
--- a/controller/hybridgateway/controller.go
+++ b/controller/hybridgateway/controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kong/kong-operator/controller/hybridgateway/converter"
 	"github.com/kong/kong-operator/controller/hybridgateway/route"
 	"github.com/kong/kong-operator/controller/hybridgateway/watch"
+	"github.com/kong/kong-operator/controller/pkg/log"
 )
 
 // HybridGatewayReconciler is a generic reconciler for handling Gateway API resources
@@ -36,7 +37,7 @@ func NewHybridGatewayReconciler[t converter.RootObject, tPtr converter.RootObjec
 // SetupWithManager sets up the controller with the provided manager.
 // It registers the reconciler to watch and manage resources of type 'u'.
 func (r *HybridGatewayReconciler[t, tPtr]) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
-	var obj = any(new(t)).(tPtr)
+	obj := any(new(t)).(tPtr)
 	filter, err := watch.FilterBy(r.Client, obj)
 	if err != nil {
 		return err
@@ -62,7 +63,8 @@ func (r *HybridGatewayReconciler[t, tPtr]) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, fmt.Errorf("failed to convert object of type %T to route object type %T", obj, rootObj)
 	}
 
-	logger.Info("Reconciling Object", "Group", obj.GetObjectKind().GroupVersionKind().Group, "Kind", obj.GetObjectKind().GroupVersionKind().Kind, "namespace", (obj).GetNamespace(), "name", (obj).GetName())
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	log.Debug(logger, "Reconciling object", "Group", gvk.Group, "Kind", gvk.Kind)
 
 	conv, err := converter.NewConverter(rootObj, r.Client, r.sharedStatusMap)
 	if err != nil {

--- a/controller/hybridgateway/statuscontroller.go
+++ b/controller/hybridgateway/statuscontroller.go
@@ -10,6 +10,7 @@ import (
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kong/kong-operator/controller/hybridgateway/route"
+	"github.com/kong/kong-operator/controller/pkg/log"
 	"github.com/kong/kong-operator/controller/pkg/op"
 )
 
@@ -30,7 +31,7 @@ func NewRouteStatusReconciler[t route.RouteObject, tPtr route.RouteObjectPtr[t]]
 
 // SetupWithManager registers the reconciler with the controller manager for the specific route type.
 func (r *RouteStatusReconciler[t, tPtr]) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
-	var obj = any(new(t)).(tPtr)
+	obj := any(new(t)).(tPtr)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(obj).
 		Complete(r)
@@ -51,7 +52,8 @@ func (r *RouteStatusReconciler[t, tPtr]) Reconcile(ctx context.Context, req ctrl
 		return ctrl.Result{}, fmt.Errorf("failed to convert object of type %T to route object type %T", obj, routeObj)
 	}
 
-	logger.Info("Reconciling Object", "Group", obj.GetObjectKind().GroupVersionKind().Group, "Kind", obj.GetObjectKind().GroupVersionKind().Kind, "namespace", (obj).GetNamespace(), "name", (obj).GetName())
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	log.Debug(logger, "Reconciling object", "Group", gvk.Group, "Kind", gvk.Kind)
 
 	statusUpdater, err := route.NewRouteStatusUpdater(routeObj, r.Client, logger, r.sharedStatusMap)
 	if err != nil {

--- a/docs/cli-arguments-for-developer-konghq-com.md
+++ b/docs/cli-arguments-for-developer-konghq-com.md
@@ -144,6 +144,10 @@ rows:
     type: '`bool`'
     description: "Enable the Konnect controllers."
     default: '`false`'
+  - flag: '`--enable-controller-konnect-hybrid`'
+    type: '`bool`'
+    description: "Enable the Konnect Hybrid controllers."
+    default: '`false`'
   - flag: '`--enable-controlplane-config-dump`'
     type: '`bool`'
     description: "Enable the server to dump generated Kong configuration from ControlPlanes. Only effective when ControlPlane controller is enabled."

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -105,6 +105,10 @@ rows:
     type: '`bool`'
     description: "Enable the Konnect controllers."
     default: '`false`'
+  - flag: '`--enable-controller-konnect-hybrid`'
+    type: '`bool`'
+    description: "Enable the Konnect Hybrid controllers."
+    default: '`false`'
   - flag: '`--enable-controlplane-config-dump`'
     type: '`bool`'
     description: "Enable the server to dump generated Kong configuration from ControlPlanes. Only effective when ControlPlane controller is enabled."

--- a/modules/cli/cli.go
+++ b/modules/cli/cli.go
@@ -79,6 +79,7 @@ func New(m metadata.Info) *CLI {
 
 	// controllers for Konnect APIs
 	flagSet.BoolVar(&cfg.KonnectControllersEnabled, "enable-controller-konnect", false, "Enable the Konnect controllers.")
+	flagSet.BoolVar(&cfg.KonnectHybridControllersEnabled, "enable-controller-konnect-hybrid", false, "Enable the Konnect Hybrid controllers.")
 	flagSet.DurationVar(&cfg.KonnectSyncPeriod, "konnect-sync-period", consts.DefaultKonnectSyncPeriod, "Sync period for Konnect entities. After a successful reconciliation of Konnect entities the controller will wait this duration before enforcing configuration on Konnect once again.")
 	flagSet.UintVar(&cfg.KonnectMaxConcurrentReconciles, "konnect-controller-max-concurrent-reconciles", consts.DefaultKonnectMaxConcurrentReconciles, "Maximum number of concurrent reconciles for Konnect entities.")
 

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -627,12 +627,14 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 			newKonnectEntityController[configurationv1alpha1.KongSNI](controllerFactory),
 		)
 
-		sharedStatusMap := route.NewSharedStatusMap()
-		controllers = append(controllers,
-			newGatewayAPIHybridController[corev1.Service](mgr, sharedStatusMap),
-			newRouteStatusController[gwtypes.HTTPRoute](mgr, sharedStatusMap),
-			// TODO: Add more Hybrid controllers here
-		)
+		if c.KonnectHybridControllersEnabled {
+			sharedStatusMap := route.NewSharedStatusMap()
+			controllers = append(controllers,
+				newGatewayAPIHybridController[corev1.Service](mgr, sharedStatusMap),
+				newRouteStatusController[gwtypes.HTTPRoute](mgr, sharedStatusMap),
+				// TODO: Add more Hybrid controllers here
+			)
+		}
 	}
 
 	return controllers, nil

--- a/modules/manager/controller_setup_test.go
+++ b/modules/manager/controller_setup_test.go
@@ -23,7 +23,7 @@ func TestSetupControllers(t *testing.T) {
 	controllerDefs, err := manager.SetupControllers(mgr, &cfg, nil)
 	require.NoError(t, err)
 
-	const expectedControllerCount = 44
+	const expectedControllerCount = 42
 	require.Len(t, controllerDefs, expectedControllerCount)
 
 	seenControllerTypes := make(map[string]int, expectedControllerCount)

--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -115,7 +115,8 @@ type Config struct {
 	ControlPlaneExtensionsControllerEnabled bool
 
 	// Controllers for Konnect APIs.
-	KonnectControllersEnabled bool
+	KonnectControllersEnabled       bool
+	KonnectHybridControllersEnabled bool
 
 	// Webhook options.
 	ConversionWebhookEnabled bool


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR:

- adds `--enable-controller-konnect-hybrid` cli flag for enabling hybrid konnect controllers (disabled by default)
  - This flag can be changed (and will most likely be enabled by default in 2.1). Feel free to propose an alternative approach than this.
- moves the hybrid controller logs to debug to prevent spam in logs
- removes name and namespace from logger calls (already logged with the context logger

Final result log:

```
{"level":"debug","ts":"2025-09-19T12:01:14.494+0200","msg":"Reconciling object","controller":"httproute","controllerGroup":"gateway.networking.k8s.io","controllerKind":"HTTPRoute","HTTPRoute":{"name":"httproute-echo","namespace":"default"},"namespace":"default","name":"httproute-echo","reconcileID":"c7662f04-4fc5-44b3-bf36-1f876aa98a9b","Group":"gateway.networking.k8s.io","Kind":"HTTPRoute"}
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
