### PR TITLE
fix: mark Gateway's listeners are Programmed when DataPlane and its Services are ready

### DIFF
--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -366,7 +366,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// to DataPlane.
 	// This solves the problem of intermittent failures due to incomplete configuration
 	// being sent to DataPlane.
-	gwConditionAware.setListenersStatus()
+	gwConditionAware.setListenersStatus(metav1.ConditionTrue)
 	_, err = patch.ApplyStatusPatchIfNotEmpty(ctx, r.Client, logger, &gateway, oldGateway)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -387,6 +387,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 			conditionOld, foundOld := k8sutils.GetCondition(kcfggateway.ControlPlaneReadyType, oldGwConditionsAware)
 			if !foundOld || conditionOld.Status == metav1.ConditionTrue {
+				gwConditionAware.setProgrammed(metav1.ConditionFalse)
 				if err := r.patchStatus(ctx, &gateway, oldGateway); err != nil {
 					return ctrl.Result{}, err
 				}
@@ -436,7 +437,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			gatewayConditionsAndListenersAware(&gateway))
 	}
 
-	gwConditionAware.setProgrammed()
+	gwConditionAware.setProgrammed(metav1.ConditionTrue)
 	_, err = patch.ApplyStatusPatchIfNotEmpty(ctx, r.Client, logger, &gateway, oldGateway)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -721,7 +721,8 @@ func dataPlaneSpecDeepEqual(spec1, spec2 *operatorv1beta1.DataPlaneOptions) bool
 	return deploymentOptionsDeepEqual(&spec1.Deployment.DeploymentOptions, &spec2.Deployment.DeploymentOptions) &&
 		compare.NetworkOptionsDeepEqual(&spec1.Network, &spec2.Network) &&
 		compare.DataPlaneResourceOptionsDeepEqual(&spec1.Resources, &spec2.Resources) &&
-		reflect.DeepEqual(spec1.Extensions, spec2.Extensions)
+		reflect.DeepEqual(spec1.Extensions, spec2.Extensions) &&
+		reflect.DeepEqual(spec1.PluginsToInstall, spec2.PluginsToInstall)
 }
 
 func controlPlaneSpecDeepEqual(spec1, spec2 *gwtypes.ControlPlaneOptions) bool {

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/kong/kong-operator/controller/pkg/extensions"
 	"github.com/kong/kong-operator/controller/pkg/log"
-	"github.com/kong/kong-operator/controller/pkg/op"
 	"github.com/kong/kong-operator/controller/pkg/patch"
 	"github.com/kong/kong-operator/controller/pkg/secrets/ref"
 	"github.com/kong/kong-operator/controller/pkg/watch"
@@ -368,12 +367,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// This solves the problem of intermittent failures due to incomplete configuration
 	// being sent to DataPlane.
 	gwConditionAware.setListenersStatus()
-	res, err := patch.ApplyStatusPatchIfNotEmpty(ctx, r.Client, logger, &gateway, oldGateway)
+	_, err = patch.ApplyStatusPatchIfNotEmpty(ctx, r.Client, logger, &gateway, oldGateway)
 	if err != nil {
 		return ctrl.Result{}, err
-	}
-	if res != op.Noop {
-		return ctrl.Result{}, nil // gateway patch will trigger new reconciliation loop
 	}
 
 	if !hybridGateway {
@@ -441,12 +437,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	gwConditionAware.setProgrammed()
-	res, err = patch.ApplyStatusPatchIfNotEmpty(ctx, r.Client, logger, &gateway, oldGateway)
+	_, err = patch.ApplyStatusPatchIfNotEmpty(ctx, r.Client, logger, &gateway, oldGateway)
 	if err != nil {
 		return ctrl.Result{}, err
-	}
-	if res != op.Noop {
-		return ctrl.Result{}, nil // gateway patch will trigger new reconciliation loop
 	}
 
 	if k8sutils.IsProgrammed(gwConditionAware) && !k8sutils.IsProgrammed(oldGwConditionsAware) {

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -195,6 +195,16 @@ func gatewayConfigDataPlaneOptionsToDataPlaneOptions(
 				},
 			},
 		}
+	} else {
+		dataPlaneOptions.Network = operatorv1beta1.DataPlaneNetworkOptions{
+			Services: &operatorv1beta1.DataPlaneServices{
+				Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+					ServiceOptions: operatorv1beta1.ServiceOptions{
+						Type: corev1.ServiceTypeLoadBalancer,
+					},
+				},
+			},
+		}
 	}
 
 	return dataPlaneOptions

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -909,17 +909,17 @@ func (g *gatewayConditionsAndListenersAwareT) setConflicted() {
 // Gateway Programmed status to true.
 // It also sets the listeners Programmed condition by setting the underlying
 // Listener Programmed status to true.
-func (g *gatewayConditionsAndListenersAwareT) setProgrammed() {
+func (g *gatewayConditionsAndListenersAwareT) setProgrammed(listenersStatus metav1.ConditionStatus) {
 	k8sutils.SetProgrammed(g)
-	g.setListenersStatus()
+	g.setListenersStatus(listenersStatus)
 }
 
-func (g *gatewayConditionsAndListenersAwareT) setListenersStatus() {
+func (g *gatewayConditionsAndListenersAwareT) setListenersStatus(status metav1.ConditionStatus) {
 	for i := range g.Status.Listeners {
 		listener := &g.Status.Listeners[i]
 		programmedCondition := metav1.Condition{
 			Type:               string(gatewayv1.ListenerConditionProgrammed),
-			Status:             metav1.ConditionTrue,
+			Status:             status,
 			Reason:             string(gatewayv1.ListenerReasonProgrammed),
 			ObservedGeneration: g.GetGeneration(),
 			LastTransitionTime: metav1.Now(),

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -661,8 +661,8 @@ func (g *gatewayConditionsAndListenersAwareT) initProgrammedAndListenersStatus()
 				metav1.ConditionFalse,
 				kcfgconsts.ConditionReason(gatewayv1.GatewayReasonPending),
 				kcfgdataplane.DependenciesNotReadyMessage,
-				g.Generation),
-
+				g.Generation,
+			),
 			g,
 		)
 	}

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -1230,10 +1230,20 @@ func TestGatewayConfigDataPlaneOptionsToDataPlaneOptions(t *testing.T) {
 		expectedDataPlaneOpts *operatorv1beta1.DataPlaneOptions
 	}{
 		{
-			name:                  "empty options",
-			gatewayConfigNS:       "default",
-			opts:                  GatewayConfigDataPlaneOptions{},
-			expectedDataPlaneOpts: &operatorv1beta1.DataPlaneOptions{},
+			name:            "empty options",
+			gatewayConfigNS: "default",
+			opts:            GatewayConfigDataPlaneOptions{},
+			expectedDataPlaneOpts: &operatorv1beta1.DataPlaneOptions{
+				Network: operatorv1beta1.DataPlaneNetworkOptions{
+					Services: &operatorv1beta1.DataPlaneServices{
+						Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+							ServiceOptions: operatorv1beta1.ServiceOptions{
+								Type: corev1.ServiceTypeLoadBalancer,
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name:            "deployment options",
@@ -1267,6 +1277,15 @@ func TestGatewayConfigDataPlaneOptionsToDataPlaneOptions(t *testing.T) {
 						},
 					},
 				},
+				Network: operatorv1beta1.DataPlaneNetworkOptions{
+					Services: &operatorv1beta1.DataPlaneServices{
+						Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+							ServiceOptions: operatorv1beta1.ServiceOptions{
+								Type: corev1.ServiceTypeLoadBalancer,
+							},
+						},
+					},
+				},
 			},
 		},
 		{
@@ -1284,6 +1303,15 @@ func TestGatewayConfigDataPlaneOptionsToDataPlaneOptions(t *testing.T) {
 				},
 			},
 			expectedDataPlaneOpts: &operatorv1beta1.DataPlaneOptions{
+				Network: operatorv1beta1.DataPlaneNetworkOptions{
+					Services: &operatorv1beta1.DataPlaneServices{
+						Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+							ServiceOptions: operatorv1beta1.ServiceOptions{
+								Type: corev1.ServiceTypeLoadBalancer,
+							},
+						},
+					},
+				},
 				PluginsToInstall: []operatorv1beta1.NamespacedName{
 					{
 						Name:      "plugin1",
@@ -1311,6 +1339,15 @@ func TestGatewayConfigDataPlaneOptionsToDataPlaneOptions(t *testing.T) {
 				},
 			},
 			expectedDataPlaneOpts: &operatorv1beta1.DataPlaneOptions{
+				Network: operatorv1beta1.DataPlaneNetworkOptions{
+					Services: &operatorv1beta1.DataPlaneServices{
+						Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+							ServiceOptions: operatorv1beta1.ServiceOptions{
+								Type: corev1.ServiceTypeLoadBalancer,
+							},
+						},
+					},
+				},
 				PluginsToInstall: []operatorv1beta1.NamespacedName{
 					{
 						Name:      "plugin1",
@@ -1368,6 +1405,15 @@ func TestGatewayConfigDataPlaneOptionsToDataPlaneOptions(t *testing.T) {
 				},
 			},
 			expectedDataPlaneOpts: &operatorv1beta1.DataPlaneOptions{
+				Network: operatorv1beta1.DataPlaneNetworkOptions{
+					Services: &operatorv1beta1.DataPlaneServices{
+						Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+							ServiceOptions: operatorv1beta1.ServiceOptions{
+								Type: corev1.ServiceTypeLoadBalancer,
+							},
+						},
+					},
+				},
 				Resources: operatorv1beta1.DataPlaneResources{
 					PodDisruptionBudget: &operatorv1beta1.PodDisruptionBudget{
 						Spec: operatorv1beta1.PodDisruptionBudgetSpec{
@@ -1924,7 +1970,6 @@ func TestIsGatewayHybrid(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-
 			var objs []client.Object
 			if !tc.konnectExtensionNotFound {
 				konnectExt := &konnectv1alpha2.KonnectExtension{

--- a/controller/pkg/extensions/merge.go
+++ b/controller/pkg/extensions/merge.go
@@ -49,6 +49,9 @@ func MergeExtensions[
 			newExtensions = append(newExtensions, dext)
 		}
 	}
+	if len(extensions) == 0 && len(newExtensions) == 0 {
+		return nil
+	}
 	return append(newExtensions, extensions...)
 }
 

--- a/controller/pkg/extensions/merge_test.go
+++ b/controller/pkg/extensions/merge_test.go
@@ -233,7 +233,7 @@ func TestMergeExtensions(t *testing.T) {
 			name:              "both empty",
 			defaultExtensions: []commonv1alpha1.ExtensionRef{},
 			extendable:        &mockExtendable{extensions: []commonv1alpha1.ExtensionRef{}},
-			expected:          []commonv1alpha1.ExtensionRef{},
+			expected:          nil,
 		},
 		{
 			name: "nil user extensions",
@@ -392,7 +392,7 @@ func TestMergeExtensions(t *testing.T) {
 				},
 			},
 			extendable: &operatorv1beta1.DataPlane{},
-			expected:   []commonv1alpha1.ExtensionRef{},
+			expected:   nil,
 		},
 		{
 			name: "DataPlaneMetricsExtension is added to ControlPlane",


### PR DESCRIPTION
**What this PR does / why we need it**:

This change makes `Gateway`'s listeners ready when DataPlane and its Services are ready.

This allows the ControlPlane to not exclude configuration entities like HTTPRoutes that are attached to these listeners from the configuration sent to DataPlane.
This solves the problem of intermittent failures due to incomplete configuration being sent to DataPlane.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
