### PR TITLE
chore(ci): fix release docs PR

### DIFF
--- a/.github/workflows/__release-workflow.yaml
+++ b/.github/workflows/__release-workflow.yaml
@@ -399,7 +399,7 @@ jobs:
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.6
         if: steps.detect-changes.outputs.has_changes
         with:
-          path: docs
+          path: ${{ env.DOCS_REPO }}
           commit-message: "chore(deps): update ${{github.repository}} docs from repo source"
           signoff: true
           branch: chore/docs-sync-${{github.repository}}


### PR DESCRIPTION
**What this PR does / why we need it**:

The `create-docs-pr` job incorrectly used `docs` path for the documentation repo path.

It is now stored in the `${{ env.DOCS_REPO }}` so this PR changes it to use that.

Attempts to fix:

```
Configuring credential for HTTPS authentication
  /usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
  /usr/bin/git rev-parse --git-dir
  /home/runner/work/kong-operator/kong-operator/.git
  Error: ENOENT: no such file or directory, open '/home/runner/work/kong-operator/kong-operator/docs/home/runner/work/kong-operator/kong-operator/.git/config'
```

https://github.com/Kong/kong-operator/actions/runs/17917918621/job/50946720666

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
