### PR TITLE
Fix(konnect): KonnectExtension get CP cluster type from KonnectGatewayCotrolPlane's status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@
   This prevents issues when those resources are created during bootstrapping of the
   operator, before the validating webhook is ready.
   [#2356](https://github.com/Kong/kong-operator/pull/2356)
+- Add the `status.clusterType` in `KonnectGatewayControlPlane` and set it when
+  KO attached the `KonnectGatewayControlPlane` with the control plane in
+  Konnect. The `KonnectExtension` now get the cluster type to fill its
+  `status.konnect.clusterType` from the `statusType` of `KonnectGatewayControlPlane`
+  to fix the incorrect cluster type filled in the status when the control plane
+  is mirrored from an existing control plane in Konnect.
+  [#2343](https://github.com/Kong/kong-operator/pull/2343)
 
 ### Added
 

--- a/api/konnect/v1alpha2/konnect_gateway_controlplane_types.go
+++ b/api/konnect/v1alpha2/konnect_gateway_controlplane_types.go
@@ -128,6 +128,13 @@ type KonnectGatewayControlPlaneStatus struct {
 
 	KonnectEntityStatus `json:",inline"`
 
+	// ClusterType is the cluster type of the Konnect control plane.
+	// When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+	// ClusterType is filled with the cluster type of the control plane.
+	//
+	// +optional
+	ClusterType sdkkonnectcomp.ControlPlaneClusterType `json:"clusterType,omitempty"`
+
 	// Endpoints defines the Konnect endpoints for the control plane.
 	// They are required by the DataPlane to be properly configured in
 	// Konnect and connect to the control plane.

--- a/charts/kong-operator/charts/ko-crds/templates/ko-crds.yaml
+++ b/charts/kong-operator/charts/ko-crds/templates/ko-crds.yaml
@@ -56614,6 +56614,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -52940,6 +52940,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -52940,6 +52940,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -52940,6 +52940,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -52940,6 +52940,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -52940,6 +52940,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -52941,6 +52941,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -52940,6 +52940,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -52940,6 +52940,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -52940,6 +52940,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -52940,6 +52940,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -52940,6 +52940,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -52940,6 +52940,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -27759,6 +27759,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -52890,6 +52890,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -27734,6 +27734,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/config/crd/kong-operator/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
+++ b/config/crd/kong-operator/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
@@ -576,6 +576,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/controller/konnect/konnectextension_controller_utils.go
+++ b/controller/konnect/konnectextension_controller_utils.go
@@ -259,9 +259,7 @@ func enforceKonnectExtensionStatus(cp konnectv1alpha2.KonnectGatewayControlPlane
 	var toUpdate bool
 	expectedKonnectStatus := &konnectv1alpha2.KonnectExtensionControlPlaneStatus{
 		ControlPlaneID: cp.Status.ID,
-		ClusterType: konnectClusterTypeToCRDClusterType(
-			sdkkonnectcomp.ControlPlaneClusterType(lo.FromPtrOr(cp.GetKonnectClusterType(), "")),
-		),
+		ClusterType:    konnectClusterTypeToCRDClusterType(cp.Status.ClusterType),
 	}
 
 	if cp.Status.Endpoints != nil {

--- a/test/integration/konnect_entities_test.go
+++ b/test/integration/konnect_entities_test.go
@@ -78,6 +78,9 @@ func TestKonnectEntities(t *testing.T) {
 		require.True(t, strings.HasPrefix(cp.Status.Endpoints.ControlPlaneEndpoint, "https://"), "must start with https://")
 		// Example: https://e7b5c7de43.us.tp.konghq.tech
 		require.True(t, strings.HasPrefix(cp.Status.Endpoints.TelemetryEndpoint, "https://"), "must start with https://")
+		// Check if the status.clusterType is set.
+		require.Equal(t, sdkkonnectcomp.ControlPlaneClusterTypeClusterTypeControlPlane, cp.Status.ClusterType,
+			"status.clusterType must be set to "+sdkkonnectcomp.ControlPlaneClusterTypeClusterTypeControlPlane)
 	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
 	t.Run("with Origin ControlPlane", func(t *testing.T) {
@@ -114,6 +117,10 @@ func TestKonnectEntities(t *testing.T) {
 			).Match(mirrorCP),
 			testutils.ControlPlaneCondDeadline, 2*testutils.ControlPlaneCondTick,
 		)
+
+		// Check if the status.clusterType is set.
+		require.Equal(t, sdkkonnectcomp.ControlPlaneClusterTypeClusterTypeControlPlane, cp.Status.ClusterType,
+			"status.clusterType must be set to "+sdkkonnectcomp.ControlPlaneClusterTypeClusterTypeControlPlane)
 
 		KonnectEntitiesTestCase(t, konnectEntitiesTestCaseParams{
 			cp:     mirrorCP,


### PR DESCRIPTION

**What this PR does / why we need it**:

Add `status.clusterType` in `KonnectGatewayControlPlane` to store cluster type of the Konnect control plane.
Based on this, set the source of `clusterType` in `KonnectExtension` from `KonnectGatewayControlPlane`'s status.

**Which issue this PR fixes**

Fixes #2337

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
