### PR TITLE
fix: do not validate internal `Secret`s and `ConfigMap`s, use proper certificate for validation webhook with `cert-manager`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@
 
 ## Unreleased
 
+### Fixes
+
+- Do not validate `Secret`s and `ConfigMap`s that are used internally by the operator.
+  This prevents issues when those resources are created during bootstrapping of the
+  operator, before the validating webhook is ready.
+  [#2356](https://github.com/Kong/kong-operator/pull/2356)
+
 ### Added
 
 - Hybrid Gateway support: Gateway API objects bound to `Gateway`s programmed in Konnect

--- a/charts/kong-operator/CHANGELOG.md
+++ b/charts/kong-operator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Use proper certificate for validating webhook when `cert-manager` is used.
+  [#2356](https://github.com/Kong/kong-operator/pull/2356)
+
 ## 1.0.1
 
 ### Added

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -54110,8 +54110,8 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: default/chartsnap-kong-operator-webhook-serving-cert
-    cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "true" } }'
+    cert-manager.io/inject-ca-from: default/chartsnap-kong-operator-webhook-validating-serving-cert
+    cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "internal" } }'
   labels:
     app.kubernetes.io/name: kong-operator
     helm.sh/chart: kong-operator-1.0.1

--- a/charts/kong-operator/templates/validating-webhook.yaml
+++ b/charts/kong-operator/templates/validating-webhook.yaml
@@ -48,8 +48,8 @@ kind: ValidatingWebhookConfiguration
 metadata:
 {{- if .Values.global.webhooks.options.certManager.enabled }}
   annotations:
-    cert-manager.io/inject-ca-from: {{ template "kong.namespace" . }}/{{ template "kong.webhookServiceName" . }}-serving-cert
-    cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "true" } }'
+    cert-manager.io/inject-ca-from: {{ template "kong.namespace" . }}/{{ template "kong.webhookServiceName" . }}-validating-serving-cert
+    cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "internal" } }'
 {{- end }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}

--- a/config/default/validating_webhook/zz_generated_validating_webhook.yaml
+++ b/config/default/validating_webhook/zz_generated_validating_webhook.yaml
@@ -3,8 +3,8 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: controlplane-configuration-validations
   annotations:
-    cert-manager.io/inject-ca-from: kong-system/gateway-operator-serving-cert
-    cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "true" } }'
+    cert-manager.io/inject-ca-from: kong-system/gateway-operator-validating-serving-cert
+    cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "internal" } }'
   labels:
     app.kubernetes.io/component: ko
 webhooks:

--- a/controller/controlplane_extensions/metricsscraper/manager.go
+++ b/controller/controlplane_extensions/metricsscraper/manager.go
@@ -169,7 +169,7 @@ func (msm *Manager) getCASecretAndKey(ctx context.Context) (*x509.Certificate, c
 	var caSecret corev1.Secret
 	err := msm.client.Get(ctx, msm.caSecretNN, &caSecret)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to get CA secret %s: %w", msm.caSecretNN, err)
 	}
 
 	ca, ok := caSecret.Data[consts.TLSCRT]

--- a/controller/kongplugininstallation/controller.go
+++ b/controller/kongplugininstallation/controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kong/kong-operator/controller/kongplugininstallation/image"
 	"github.com/kong/kong-operator/controller/pkg/log"
 	"github.com/kong/kong-operator/controller/pkg/secrets/ref"
+	mgrconfig "github.com/kong/kong-operator/modules/manager/config"
 	"github.com/kong/kong-operator/modules/manager/logging"
 	k8sutils "github.com/kong/kong-operator/pkg/utils/kubernetes"
 	k8sresources "github.com/kong/kong-operator/pkg/utils/kubernetes/resources"
@@ -176,7 +177,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		} else {
 			cm.GenerateName = kpi.Name + "-"
 		}
-		k8sresources.SetLabel(&cm, r.ConfigMapLabelSelector, "true")
+		k8sresources.SetLabel(&cm, r.ConfigMapLabelSelector, mgrconfig.LabelValueForSelectorInternal)
 		k8sresources.LabelObjectAsKongPluginInstallationManaged(&cm)
 		k8sresources.AnnotateConfigMapWithKongPluginInstallation(&cm, kpi)
 		cm.Namespace = kpi.Namespace

--- a/hack/generators/validating-webhook/main.go
+++ b/hack/generators/validating-webhook/main.go
@@ -102,8 +102,8 @@ func templateInjectCAAnnotationForCertManager(yaml string) string {
 	// Replacement block with Helm templating
 	replacement := `{{- if .Values.global.webhooks.options.certManager.enabled }}
   annotations:
-    cert-manager.io/inject-ca-from: {{ template "kong.namespace" . }}/{{ template "kong.webhookServiceName" . }}-serving-cert
-    cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "true" } }'
+    cert-manager.io/inject-ca-from: {{ template "kong.namespace" . }}/{{ template "kong.webhookServiceName" . }}-validating-serving-cert
+    cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "internal" } }'
 {{- end }}
   labels:`
 

--- a/modules/manager/config/consts.go
+++ b/modules/manager/config/consts.go
@@ -4,8 +4,21 @@ package config
 const DefaultClusterCAKeySize = 4096
 
 const (
-	// DefaultSecretLabelSelector is the deafult label selector to filter reconciled `Secret`s.
+	// DefaultSecretLabelSelector is the default label selector to filter reconciled `Secret`s.
+	// Value true vs internal
 	DefaultSecretLabelSelector = "konghq.com/secret"
 	// DefaultConfigMapLabelSelector is the default label selector to filter reconciled `ConfigMap`s.
 	DefaultConfigMapLabelSelector = "konghq.com/configmap"
+)
+
+const (
+	// LabelValueForSelectorTrue is the label value used to select resources managed by the operator.
+	// Those resource are user facing, they will be fetched by operator and validated by validating webhook.
+	LabelValueForSelectorTrue = "true"
+	// LabelValueForSelectorInternal is the label value used to select resources managed by the operator.
+	// Those resources are not user facing, they will be fetched by operator and by-pass the validating webhook.
+	// Otherwise it leads to chicken egg problem when operator creates a Secret and validating webhook is not
+	// running yet, furthermore validation for objects created by operator is pointless and sometimes locks the
+	// operator reconciliation.
+	LabelValueForSelectorInternal = "internal"
 )

--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -286,7 +286,7 @@ func Run(
 	}
 	if cfg.SecretLabelSelector != "" {
 		caMgr.SecretLabels = map[string]string{
-			cfg.SecretLabelSelector: "true",
+			cfg.SecretLabelSelector: mgrconfig.LabelValueForSelectorInternal,
 		}
 	}
 	if err = mgr.Add(caMgr); err != nil {
@@ -502,7 +502,7 @@ func setByObjectFor[
 	selector string,
 	byObject map[client.Object]cache.ByObject,
 ) error {
-	req, err := labels.NewRequirement(selector, selection.Equals, []string{"true"})
+	req, err := labels.NewRequirement(selector, selection.In, []string{mgrconfig.LabelValueForSelectorTrue, mgrconfig.LabelValueForSelectorInternal})
 	if err != nil {
 		return fmt.Errorf("failed to make label requirement for secrets: %w", err)
 	}

--- a/modules/manager/run_test.go
+++ b/modules/manager/run_test.go
@@ -21,7 +21,7 @@ func TestSetByObjectFor(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify the label selector was set correctly.
-		expectedReq, err := labels.NewRequirement(selector, selection.Equals, []string{"true"})
+		expectedReq, err := labels.NewRequirement(selector, selection.In, []string{"true", "internal"})
 		require.NoError(t, err)
 		expectedSelector := labels.NewSelector().Add(*expectedReq)
 
@@ -58,7 +58,7 @@ func TestSetByObjectFor(t *testing.T) {
 		require.Contains(t, byObject, &configMap)
 
 		// Verify the label selector was set correctly
-		expectedReq, err := labels.NewRequirement(selector, selection.Equals, []string{"true"})
+		expectedReq, err := labels.NewRequirement(selector, selection.In, []string{"true", "internal"})
 		require.NoError(t, err)
 		expectedSelector := labels.NewSelector().Add(*expectedReq)
 
@@ -117,11 +117,11 @@ func TestSetByObjectFor(t *testing.T) {
 		require.Contains(t, byObject, (&corev1.ConfigMap{}))
 
 		// Verify each has the correct selector
-		secretReq, err := labels.NewRequirement(secretSelector, selection.Equals, []string{"true"})
+		secretReq, err := labels.NewRequirement(secretSelector, selection.In, []string{"true", "internal"})
 		require.NoError(t, err)
 		secretExpectedSelector := labels.NewSelector().Add(*secretReq)
 
-		configMapReq, err := labels.NewRequirement(configMapSelector, selection.Equals, []string{"true"})
+		configMapReq, err := labels.NewRequirement(configMapSelector, selection.In, []string{"true", "internal"})
 		require.NoError(t, err)
 		configMapExpectedSelector := labels.NewSelector().Add(*configMapReq)
 

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -151,7 +151,7 @@ func TestHTTPRouteWithTLS(t *testing.T) {
 			Namespace: namespace.Name,
 			Name:      host,
 			Labels: map[string]string{
-				config.DefaultSecretLabelSelector: "true",
+				config.DefaultSecretLabelSelector: config.LabelValueForSelectorTrue,
 			},
 		},
 		Type: corev1.SecretTypeTLS,

--- a/test/integration/kongplugininstallation_test.go
+++ b/test/integration/kongplugininstallation_test.go
@@ -186,7 +186,7 @@ func TestKongPluginInstallationEssentials(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: string(secretRef.Name),
 				Labels: map[string]string{
-					config.DefaultSecretLabelSelector: "true",
+					config.DefaultSecretLabelSelector: config.LabelValueForSelectorTrue,
 				},
 			},
 			Type: corev1.SecretTypeDockerConfigJson,


### PR DESCRIPTION
**What this PR does / why we need it**:

Two fixes are included in this PR

-  **do not validate internal `Secret`s and `ConfigMap`s**
    KO watches only `Secret`s and `ConfigMap`s that have a configurable label (by default `konghq.com/configmap` and `konghq.com/secret`) set to `true`. Furthermore, in the configuration `charts/kong-operator/templates/validating-webhook.yaml` webhook validates such `Secret`s. This leads to a problem: the `Secret` created by the operator and labeled accordingly cannot be validated because the webhook is not yet ready. Hence, this PR introduces additional value `internal` for those labels to indicate watched `Secret` or `ConfigMap` by the operator, which was previously created by it. It allows bypassing the webhook.
    
- **Use a proper certificate for the validation webhook with `cert-manager`**
   To support webhooks in Chars without `cert-manager`, several adjustments were made. Instead of using a single certificate for validation and conversion webhooks, two different certificates are now used. This PR adjusts templates to refer to the proper one for the validation webhook in a scenario with `cert-manager`.

**Special notes for your reviewer**:




Please verify manually the e2e behavior of two webhooks (validation and conversion) **with the image build from this branch and Helm Chart from the repo** two distinctive scenarios on fresh clusters. The below does it.

Building image & loading to local kind cluster

```
make docker.build
```

```
kind load docker-image docker.io/kong/kong-operator:v2.0.0-63-gc29b303b6 --name <YOUR-KIND-CLUSTER>
```

- with `cert-manger`

   ```
   helm install \
  cert-manager jetstack/cert-manager \
  --namespace cert-manager \
  --create-namespace \
  --version v1.18.2 \
  --set crds.enabled=true
  ```
  
  ```
  helm upgrade --install kong-operator ./charts/kong-operator -n kong-system \                                                                                                                                                                        
  --create-namespace \
  --set image.tag=v2.0.0-63-gc29b303b6
  --set global.webhooks.options.certManager.enabled=true
  ```
  
- without `cert-manager`

  ```
  helm upgrade --install kong-operator kong/kong-operator -n kong-system \
  --create-namespace \
  --set image.tag=v2.0.0-63-gc29b303b6
  ```
  
Those problems could be discovered with better testing:

 - #1903 (so it's worth testing for both above installation methods)
 - #152 (it manifested with dev target too, because it uses `cert-manager`
 
 So it will be covered with tests end-to-end soon (it's out of scope for this PR)

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
