### PR TITLE
[Backport release/2.0.x]fix: do not validate internal `Secret`s and `ConfigMap`s, use proper certificate for validation webhook with `cert-manager` (#2356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@
 
 ## Unreleased
 
+### Fixes
+
+- Do not validate `Secret`s and `ConfigMap`s that are used internally by the operator.
+  This prevents issues when those resources are created during bootstrapping of the
+  operator, before the validating webhook is ready.
+  [#2356](https://github.com/Kong/kong-operator/pull/2356)
+
 ### Added
 
 - Hybrid Gateway support: Gateway API objects bound to `Gateway`s programmed in Konnect

--- a/charts/kong-operator/CHANGELOG.md
+++ b/charts/kong-operator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Use proper certificate for validating webhook when `cert-manager` is used.
+  [#2356](https://github.com/Kong/kong-operator/pull/2356)
+
 ## 1.0.0
 
 This is the first release of the new Helm Chart dedicated to install

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -53560,8 +53560,8 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: default/chartsnap-kong-operator-webhook-serving-cert
-    cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "true" } }'
+    cert-manager.io/inject-ca-from: default/chartsnap-kong-operator-webhook-validating-serving-cert
+    cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "internal" } }'
   labels:
     app.kubernetes.io/name: kong-operator
     helm.sh/chart: kong-operator-1.0.0

--- a/charts/kong-operator/templates/validating-webhook.yaml
+++ b/charts/kong-operator/templates/validating-webhook.yaml
@@ -48,8 +48,8 @@ kind: ValidatingWebhookConfiguration
 metadata:
 {{- if .Values.global.webhooks.options.certManager.enabled }}
   annotations:
-    cert-manager.io/inject-ca-from: {{ template "kong.namespace" . }}/{{ template "kong.webhookServiceName" . }}-serving-cert
-    cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "true" } }'
+    cert-manager.io/inject-ca-from: {{ template "kong.namespace" . }}/{{ template "kong.webhookServiceName" . }}-validating-serving-cert
+    cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "internal" } }'
 {{- end }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}

--- a/config/default/validating_webhook/zz_generated_validating_webhook.yaml
+++ b/config/default/validating_webhook/zz_generated_validating_webhook.yaml
@@ -3,8 +3,8 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: controlplane-configuration-validations
   annotations:
-    cert-manager.io/inject-ca-from: kong-system/gateway-operator-serving-cert
-    cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "true" } }'
+    cert-manager.io/inject-ca-from: kong-system/gateway-operator-validating-serving-cert
+    cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "internal" } }'
   labels:
     app.kubernetes.io/component: ko
 webhooks:

--- a/controller/controlplane_extensions/metricsscraper/manager.go
+++ b/controller/controlplane_extensions/metricsscraper/manager.go
@@ -170,7 +170,7 @@ func (msm *Manager) getCASecretAndKey(ctx context.Context) (*x509.Certificate, c
 	var caSecret corev1.Secret
 	err := msm.client.Get(ctx, msm.caSecretNN, &caSecret)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to get CA secret %s: %w", msm.caSecretNN, err)
 	}
 
 	ca, ok := caSecret.Data[consts.TLSCRT]

--- a/controller/kongplugininstallation/controller.go
+++ b/controller/kongplugininstallation/controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kong/kong-operator/controller/kongplugininstallation/image"
 	"github.com/kong/kong-operator/controller/pkg/log"
 	"github.com/kong/kong-operator/controller/pkg/secrets/ref"
+	mgrconfig "github.com/kong/kong-operator/modules/manager/config"
 	"github.com/kong/kong-operator/modules/manager/logging"
 	k8sutils "github.com/kong/kong-operator/pkg/utils/kubernetes"
 	k8sresources "github.com/kong/kong-operator/pkg/utils/kubernetes/resources"
@@ -177,7 +178,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		} else {
 			cm.GenerateName = kpi.Name + "-"
 		}
-		k8sresources.SetLabel(&cm, r.ConfigMapLabelSelector, "true")
+		k8sresources.SetLabel(&cm, r.ConfigMapLabelSelector, mgrconfig.LabelValueForSelectorInternal)
 		k8sresources.LabelObjectAsKongPluginInstallationManaged(&cm)
 		k8sresources.AnnotateConfigMapWithKongPluginInstallation(&cm, kpi)
 		cm.Namespace = kpi.Namespace

--- a/hack/generators/validating-webhook/main.go
+++ b/hack/generators/validating-webhook/main.go
@@ -102,8 +102,8 @@ func templateInjectCAAnnotationForCertManager(yaml string) string {
 	// Replacement block with Helm templating
 	replacement := `{{- if .Values.global.webhooks.options.certManager.enabled }}
   annotations:
-    cert-manager.io/inject-ca-from: {{ template "kong.namespace" . }}/{{ template "kong.webhookServiceName" . }}-serving-cert
-    cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "true" } }'
+    cert-manager.io/inject-ca-from: {{ template "kong.namespace" . }}/{{ template "kong.webhookServiceName" . }}-validating-serving-cert
+    cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "internal" } }'
 {{- end }}
   labels:`
 

--- a/modules/manager/config/consts.go
+++ b/modules/manager/config/consts.go
@@ -4,8 +4,21 @@ package config
 const DefaultClusterCAKeySize = 4096
 
 const (
-	// DefaultSecretLabelSelector is the deafult label selector to filter reconciled `Secret`s.
+	// DefaultSecretLabelSelector is the default label selector to filter reconciled `Secret`s.
+	// Value true vs internal
 	DefaultSecretLabelSelector = "konghq.com/secret"
 	// DefaultConfigMapLabelSelector is the default label selector to filter reconciled `ConfigMap`s.
 	DefaultConfigMapLabelSelector = "konghq.com/configmap"
+)
+
+const (
+	// LabelValueForSelectorTrue is the label value used to select resources managed by the operator.
+	// Those resource are user facing, they will be fetched by operator and validated by validating webhook.
+	LabelValueForSelectorTrue = "true"
+	// LabelValueForSelectorInternal is the label value used to select resources managed by the operator.
+	// Those resources are not user facing, they will be fetched by operator and by-pass the validating webhook.
+	// Otherwise it leads to chicken egg problem when operator creates a Secret and validating webhook is not
+	// running yet, furthermore validation for objects created by operator is pointless and sometimes locks the
+	// operator reconciliation.
+	LabelValueForSelectorInternal = "internal"
 )

--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -285,7 +285,7 @@ func Run(
 	}
 	if cfg.SecretLabelSelector != "" {
 		caMgr.SecretLabels = map[string]string{
-			cfg.SecretLabelSelector: "true",
+			cfg.SecretLabelSelector: mgrconfig.LabelValueForSelectorInternal,
 		}
 	}
 	if err = mgr.Add(caMgr); err != nil {
@@ -501,7 +501,7 @@ func setByObjectFor[
 	selector string,
 	byObject map[client.Object]cache.ByObject,
 ) error {
-	req, err := labels.NewRequirement(selector, selection.Equals, []string{"true"})
+	req, err := labels.NewRequirement(selector, selection.In, []string{mgrconfig.LabelValueForSelectorTrue, mgrconfig.LabelValueForSelectorInternal})
 	if err != nil {
 		return fmt.Errorf("failed to make label requirement for secrets: %w", err)
 	}

--- a/modules/manager/run_test.go
+++ b/modules/manager/run_test.go
@@ -21,7 +21,7 @@ func TestSetByObjectFor(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify the label selector was set correctly.
-		expectedReq, err := labels.NewRequirement(selector, selection.Equals, []string{"true"})
+		expectedReq, err := labels.NewRequirement(selector, selection.In, []string{"true", "internal"})
 		require.NoError(t, err)
 		expectedSelector := labels.NewSelector().Add(*expectedReq)
 
@@ -58,7 +58,7 @@ func TestSetByObjectFor(t *testing.T) {
 		require.Contains(t, byObject, &configMap)
 
 		// Verify the label selector was set correctly
-		expectedReq, err := labels.NewRequirement(selector, selection.Equals, []string{"true"})
+		expectedReq, err := labels.NewRequirement(selector, selection.In, []string{"true", "internal"})
 		require.NoError(t, err)
 		expectedSelector := labels.NewSelector().Add(*expectedReq)
 
@@ -117,11 +117,11 @@ func TestSetByObjectFor(t *testing.T) {
 		require.Contains(t, byObject, (&corev1.ConfigMap{}))
 
 		// Verify each has the correct selector
-		secretReq, err := labels.NewRequirement(secretSelector, selection.Equals, []string{"true"})
+		secretReq, err := labels.NewRequirement(secretSelector, selection.In, []string{"true", "internal"})
 		require.NoError(t, err)
 		secretExpectedSelector := labels.NewSelector().Add(*secretReq)
 
-		configMapReq, err := labels.NewRequirement(configMapSelector, selection.Equals, []string{"true"})
+		configMapReq, err := labels.NewRequirement(configMapSelector, selection.In, []string{"true", "internal"})
 		require.NoError(t, err)
 		configMapExpectedSelector := labels.NewSelector().Add(*configMapReq)
 

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -152,7 +152,7 @@ func TestHTTPRouteWithTLS(t *testing.T) {
 			Namespace: namespace.Name,
 			Name:      host,
 			Labels: map[string]string{
-				config.DefaultSecretLabelSelector: "true",
+				config.DefaultSecretLabelSelector: config.LabelValueForSelectorTrue,
 			},
 		},
 		Type: corev1.SecretTypeTLS,

--- a/test/integration/kongplugininstallation_test.go
+++ b/test/integration/kongplugininstallation_test.go
@@ -187,7 +187,7 @@ func TestKongPluginInstallationEssentials(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: string(secretRef.Name),
 				Labels: map[string]string{
-					config.DefaultSecretLabelSelector: "true",
+					config.DefaultSecretLabelSelector: config.LabelValueForSelectorTrue,
 				},
 			},
 			Type: corev1.SecretTypeDockerConfigJson,


### PR DESCRIPTION


(cherry picked from commit 7bc80536c1cd313c1baad2edafca5dcf7cb0dde1)

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
