### PR TITLE
fix(hybridgateway): accept all connections when no hostname is specified

### DIFF
--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -266,15 +266,23 @@ func (c *httpRouteConverter) addHostnames(ctx context.Context) error {
 					// This listener doesn't match the section reference, skip it
 					continue
 				}
+				if listener.Port != *pRef.Port {
+					// This listener doesn't match the port reference, skip it
+					continue
+				}
 			}
 
-			// If the listener has no hostname, it means it accepts all hostnames.
-			// In this case, we add all hostnames from the HTTPRoute.
+			// If the listener has no hostname, it means it accepts all HTTPRoute hostnames.
+			// No need to do further checks.
 			if listener.Hostname == nil || *listener.Hostname == "" {
 				for _, hostname := range c.route.Spec.Hostnames {
 					hosts = append(hosts, string(hostname))
 				}
-				break
+				c.ir.AddHostnames(intermediate.Hostnames{
+					Name:      hostnamesName,
+					Hostnames: hosts,
+				})
+				return nil
 			}
 
 			// Handle wildcard hostnames - get intersection

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -266,7 +267,7 @@ func (c *httpRouteConverter) addHostnames(ctx context.Context) error {
 					// This listener doesn't match the section reference, skip it
 					continue
 				}
-				if listener.Port != *pRef.Port {
+				if listener.Port != lo.FromPtr(pRef.Port) {
 					// This listener doesn't match the port reference, skip it
 					continue
 				}

--- a/controller/hybridgateway/converter/http_route_test.go
+++ b/controller/hybridgateway/converter/http_route_test.go
@@ -97,6 +97,16 @@ func TestAddHostnames(t *testing.T) {
 		expectedOutput []*configurationv1alpha1.KongRoute
 	}{
 		{
+			name:  "listener with no hostname (accepts all) and route with no hostnames (accepts all)",
+			route: newHTTPRouteWithHostnames(),
+			objects: append([]client.Object{
+				newGatewayWithListenerHostnames(),
+			}, newKonnectGatewayStandardObjects()...),
+			expectedOutput: newExpectedKongRoutesWithHostnames(map[string][]string{
+				"httproute.default.test-route.0.0.0": nil,
+			}),
+		},
+		{
 			name:  "single listener and route with specific hostname",
 			route: newHTTPRouteWithHostnames("api.example.com"),
 			objects: append([]client.Object{


### PR DESCRIPTION
**What this PR does / why we need it**:

accept all connections when no hostname is specified in both the `Gatway` listener and the `HTTPRoute`.

**Which issue this PR fixes**

related to #2335 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes

(No need to update the CHANGELOG as the hostname support in hybridgateway has already  been added and not released yet)
