### PR TITLE
fix(ci): require `unit-tests` to pass CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -715,6 +715,7 @@ jobs:
       - install-with-kustomize
       - build
       - CRDs-validation
+      - unit-tests
       - envtest-tests
       - kongintegration-tests
       - conformance-tests


### PR DESCRIPTION
**What this PR does / why we need it**:

PR can be merged without passing `unit-tests` suite, see

<img width="1035" height="781" alt="image" src="https://github.com/user-attachments/assets/e144f8b2-15ba-4eb4-bfb8-09333b16fdf5" />


This PR fixes it

