### PR TITLE
chore: mark charts `__snapshots__` as generated files in `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 controller/konnect/ops/*_mock_test.go linguist-generated=true
 docs/api-reference.md linguist-generated=true
 ingress-controller/internal/dataplane/testdata/golden/**/*_golden.yaml linguist-generated=true
+charts/kong-operator/ci/__snapshots__/*.snap linguist-generated=true


### PR DESCRIPTION
**What this PR does / why we need it**:

Content of `charts/kong-operator/ci/__snapshots__/*.snap` is generated by `Makefile` target, so in GH PR it should be marked as generated and folded by default.

