### PR TITLE
[Backport release/2.0.x]Fix(konnect): KonnectExtension get CP cluster type from KonnectGatewayCotrolPlane's status (#2343)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@
   This prevents issues when those resources are created during bootstrapping of the
   operator, before the validating webhook is ready.
   [#2356](https://github.com/Kong/kong-operator/pull/2356)
+- Add the `status.clusterType` in `KonnectGatewayControlPlane` and set it when
+  KO attached the `KonnectGatewayControlPlane` with the control plane in
+  Konnect. The `KonnectExtension` now get the cluster type to fill its
+  `status.konnect.clusterType` from the `statusType` of `KonnectGatewayControlPlane`
+  to fix the incorrect cluster type filled in the status when the control plane
+  is mirrored from an existing control plane in Konnect.
+  [#2343](https://github.com/Kong/kong-operator/pull/2343)
 
 ### Added
 

--- a/charts/kong-operator/charts/kic-crds/crds/kic-crds.yaml
+++ b/charts/kong-operator/charts/kic-crds/crds/kic-crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v2.0.0
+    kubernetes-configuration.konghq.com/version: v2.0.1
   name: ingressclassparameterses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -61,7 +61,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v2.0.0
+    kubernetes-configuration.konghq.com/version: v2.0.1
   name: kongclusterplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -369,7 +369,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v2.0.0
+    kubernetes-configuration.konghq.com/version: v2.0.1
   name: kongcustomentities.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/charts/kong-operator/charts/ko-crds/templates/ko-crds.yaml
+++ b/charts/kong-operator/charts/ko-crds/templates/ko-crds.yaml
@@ -56046,6 +56046,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -52389,6 +52389,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -52389,6 +52389,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -52389,6 +52389,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -52389,6 +52389,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -52389,6 +52389,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -52390,6 +52390,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrest-values.snap
@@ -52389,6 +52389,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -52389,6 +52389,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -52389,6 +52389,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -52389,6 +52389,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -52389,6 +52389,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -52389,6 +52389,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -27208,6 +27208,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -52339,6 +52339,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -27183,6 +27183,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/config/crd/kong-operator/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
+++ b/config/crd/kong-operator/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
@@ -576,6 +576,12 @@ spec:
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
+              clusterType:
+                description: |-
+                  ClusterType is the cluster type of the Konnect control plane.
+                  When the KonnectGatewayControlPlane is attached to a control plane in Konnect,
+                  ClusterType is filled with the cluster type of the control plane.
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/controller/konnect/konnectextension_controller_utils.go
+++ b/controller/konnect/konnectextension_controller_utils.go
@@ -260,9 +260,7 @@ func enforceKonnectExtensionStatus(cp konnectv1alpha2.KonnectGatewayControlPlane
 	var toUpdate bool
 	expectedKonnectStatus := &konnectv1alpha2.KonnectExtensionControlPlaneStatus{
 		ControlPlaneID: cp.Status.ID,
-		ClusterType: konnectClusterTypeToCRDClusterType(
-			sdkkonnectcomp.ControlPlaneClusterType(lo.FromPtrOr(cp.GetKonnectClusterType(), "")),
-		),
+		ClusterType:    konnectClusterTypeToCRDClusterType(cp.Status.ClusterType),
 	}
 
 	if cp.Status.Endpoints != nil {

--- a/controller/konnect/ops/ops_controlplane.go
+++ b/controller/konnect/ops/ops_controlplane.go
@@ -34,15 +34,17 @@ func ensureControlPlane(
 	case commonv1alpha1.EntitySourceOrigin:
 		return createControlPlane(ctx, sdk, sdkGroups, cl, cp)
 	case commonv1alpha1.EntitySourceMirror:
-		if _, err := GetControlPlaneByID(
+		resp, err := GetControlPlaneByID(
 			ctx,
 			sdk,
 			// not nilness is ensured by CEL rules
 			string(cp.Spec.Mirror.Konnect.ID),
-		); err != nil {
+		)
+		if err != nil {
 			return err
 		}
 		cp.SetKonnectID(string(cp.Spec.Mirror.Konnect.ID))
+		cp.Status.ClusterType = resp.Config.ClusterType
 		return nil
 	default:
 		// This should never happen, as the source type is validated by CEL rules.
@@ -76,6 +78,7 @@ func createControlPlane(
 	// At this point, the ControlPlane has been created in Konnect.
 	id := resp.ControlPlane.ID
 	cp.SetKonnectID(id)
+	cp.Status.ClusterType = resp.ControlPlane.Config.ClusterType
 
 	if err := setGroupMembers(ctx, cl, cp, id, sdkGroups); err != nil {
 		// If we failed to set group membership, we should return a specific error with a reason

--- a/go.mod
+++ b/go.mod
@@ -29,8 +29,8 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/jpillora/backoff v1.0.0
 	github.com/kong/go-database-reconciler v1.27.1
-	github.com/kong/go-kong v0.68.0
-	github.com/kong/kubernetes-configuration/v2 v2.0.0
+	github.com/kong/go-kong v0.69.0
+	github.com/kong/kubernetes-configuration/v2 v2.0.1-0.20250929141838-330804193777
 	github.com/kong/kubernetes-telemetry v0.1.10
 	github.com/kong/kubernetes-testing-framework v0.47.3
 	github.com/kong/semver/v4 v4.0.1

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/jpillora/backoff v1.0.0
 	github.com/kong/go-database-reconciler v1.27.1
 	github.com/kong/go-kong v0.69.0
-	github.com/kong/kubernetes-configuration/v2 v2.0.1-0.20250929141838-330804193777
+	github.com/kong/kubernetes-configuration/v2 v2.0.1
 	github.com/kong/kubernetes-telemetry v0.1.10
 	github.com/kong/kubernetes-testing-framework v0.47.3
 	github.com/kong/semver/v4 v4.0.1

--- a/go.sum
+++ b/go.sum
@@ -347,8 +347,8 @@ github.com/kong/go-database-reconciler v1.27.1 h1:a5EyqQsY5BF2p964J2PQW9BMIMvTz3
 github.com/kong/go-database-reconciler v1.27.1/go.mod h1:6EnCqJqkYWwf9UjkiIKXCv29kapPFUBQ2+FVjR9ZslE=
 github.com/kong/go-kong v0.69.0 h1:1LHU3y+i23X+RxxXT/bKml5bsxeUfKTfWFa3RK85cSU=
 github.com/kong/go-kong v0.69.0/go.mod h1:J0vGB3wsZ2i99zly1zTRe3v7rOKpkhQZRwbcTFP76qM=
-github.com/kong/kubernetes-configuration/v2 v2.0.1-0.20250929141838-330804193777 h1:QoPokLPOGjkl04PmYhWA/lEK9mqMfBSHugUOQO9WNKg=
-github.com/kong/kubernetes-configuration/v2 v2.0.1-0.20250929141838-330804193777/go.mod h1:trKGeJdNp0sdhrX+0o6P8keEY/PTSXoLO6RFYRI6O9Y=
+github.com/kong/kubernetes-configuration/v2 v2.0.1 h1:JoYvJc1nb7DIIWRFzIbdq78T11fYGTHG1pXjF0yJkdg=
+github.com/kong/kubernetes-configuration/v2 v2.0.1/go.mod h1:trKGeJdNp0sdhrX+0o6P8keEY/PTSXoLO6RFYRI6O9Y=
 github.com/kong/kubernetes-telemetry v0.1.10 h1:V+/Lco8VFY/CzoELwOPcGTyg0zbj/HAvoFkH50UsKYs=
 github.com/kong/kubernetes-telemetry v0.1.10/go.mod h1:/r/FevTOGegCqaxXCJyGkbE1E3IcYUGJd7xX7D73s2Y=
 github.com/kong/kubernetes-testing-framework v0.47.3 h1:2qqWxIQXAd/r1f+b+d/kuHZfN22IjgKouktyIA0B5so=

--- a/go.sum
+++ b/go.sum
@@ -345,10 +345,10 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kong/go-database-reconciler v1.27.1 h1:a5EyqQsY5BF2p964J2PQW9BMIMvTz30A2FInIAf1TcA=
 github.com/kong/go-database-reconciler v1.27.1/go.mod h1:6EnCqJqkYWwf9UjkiIKXCv29kapPFUBQ2+FVjR9ZslE=
-github.com/kong/go-kong v0.68.0 h1:rQrLYRKXD6/xf41GBXj9Ns+woAH9p6a4VvcXNMiPZPI=
-github.com/kong/go-kong v0.68.0/go.mod h1:J0vGB3wsZ2i99zly1zTRe3v7rOKpkhQZRwbcTFP76qM=
-github.com/kong/kubernetes-configuration/v2 v2.0.0 h1:dEi4UQcBqb/W1s/Vj8VU+L55OBJbe7fLcmyA3yUQoU4=
-github.com/kong/kubernetes-configuration/v2 v2.0.0/go.mod h1:hQybPzqfX7hVDjLvMjWvg9DtcKeT0mnOl1qtklPQN8E=
+github.com/kong/go-kong v0.69.0 h1:1LHU3y+i23X+RxxXT/bKml5bsxeUfKTfWFa3RK85cSU=
+github.com/kong/go-kong v0.69.0/go.mod h1:J0vGB3wsZ2i99zly1zTRe3v7rOKpkhQZRwbcTFP76qM=
+github.com/kong/kubernetes-configuration/v2 v2.0.1-0.20250929141838-330804193777 h1:QoPokLPOGjkl04PmYhWA/lEK9mqMfBSHugUOQO9WNKg=
+github.com/kong/kubernetes-configuration/v2 v2.0.1-0.20250929141838-330804193777/go.mod h1:trKGeJdNp0sdhrX+0o6P8keEY/PTSXoLO6RFYRI6O9Y=
 github.com/kong/kubernetes-telemetry v0.1.10 h1:V+/Lco8VFY/CzoELwOPcGTyg0zbj/HAvoFkH50UsKYs=
 github.com/kong/kubernetes-telemetry v0.1.10/go.mod h1:/r/FevTOGegCqaxXCJyGkbE1E3IcYUGJd7xX7D73s2Y=
 github.com/kong/kubernetes-testing-framework v0.47.3 h1:2qqWxIQXAd/r1f+b+d/kuHZfN22IjgKouktyIA0B5so=

--- a/test/crdsvalidation/dataplane_validatingadmissionpolicy_test.go
+++ b/test/crdsvalidation/dataplane_validatingadmissionpolicy_test.go
@@ -51,6 +51,10 @@ func TestKonnectValidationAdmissionPolicy(t *testing.T) {
 			GenerateName: "dp-",
 			Namespace:    ns.Name,
 		}
+		dpgcTypeMeta = metav1.TypeMeta{
+			APIVersion: "konnect.konghq.com/v1alpha1",
+			Kind:       "KonnectCloudGatewayDataPlaneGroupConfiguration",
+		}
 	)
 
 	logger := zapr.NewLogger(zap.New(zapcore.NewNopCore()))
@@ -73,8 +77,10 @@ func TestKonnectValidationAdmissionPolicy(t *testing.T) {
 			{
 				Name: "deprecate message with static autoscale type",
 				TestObject: &konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration{
+					TypeMeta:   dpgcTypeMeta,
 					ObjectMeta: commonObjectMeta,
 					Spec: konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationSpec{
+						Version: "3.11",
 						DataplaneGroups: []konnectv1alpha1.KonnectConfigurationDataPlaneGroup{
 							{
 								Provider: "aws",

--- a/test/integration/konnect_entities_test.go
+++ b/test/integration/konnect_entities_test.go
@@ -79,6 +79,9 @@ func TestKonnectEntities(t *testing.T) {
 		require.True(t, strings.HasPrefix(cp.Status.Endpoints.ControlPlaneEndpoint, "https://"), "must start with https://")
 		// Example: https://e7b5c7de43.us.tp.konghq.tech
 		require.True(t, strings.HasPrefix(cp.Status.Endpoints.TelemetryEndpoint, "https://"), "must start with https://")
+		// Check if the status.clusterType is set.
+		require.Equal(t, sdkkonnectcomp.ControlPlaneClusterTypeClusterTypeControlPlane, cp.Status.ClusterType,
+			"status.clusterType must be set to "+sdkkonnectcomp.ControlPlaneClusterTypeClusterTypeControlPlane)
 	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
 	t.Run("with Origin ControlPlane", func(t *testing.T) {
@@ -115,6 +118,10 @@ func TestKonnectEntities(t *testing.T) {
 			).Match(mirrorCP),
 			testutils.ControlPlaneCondDeadline, 2*testutils.ControlPlaneCondTick,
 		)
+
+		// Check if the status.clusterType is set.
+		require.Equal(t, sdkkonnectcomp.ControlPlaneClusterTypeClusterTypeControlPlane, cp.Status.ClusterType,
+			"status.clusterType must be set to "+sdkkonnectcomp.ControlPlaneClusterTypeClusterTypeControlPlane)
 
 		KonnectEntitiesTestCase(t, konnectEntitiesTestCaseParams{
 			cp:     mirrorCP,


### PR DESCRIPTION

(cherry picked from commit f1b84dfbab7d6213149dc5dbbc8185784f12c685)

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:
Requires releasing of kubernetes-configuration to update the CRDs.
Blocked by https://github.com/Kong/kubernetes-configuration/pull/626
**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
