### PR TITLE
release(charts): ko-crds 1.0.1 and kong-operator 1.0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -488,7 +488,7 @@ KONG_OPERATOR_CHART_YAML_PATH = $(KONG_OPERATOR_CHART_DIR)/Chart.yaml
 manifests.charts.kong-operator.chart.yaml: yq
 	@echo "Generating $(KONG_OPERATOR_CHART_YAML_PATH)"
 	@$(YQ) eval \
-		'.dependencies = [ {"name":"ko-crds","version":"1.0.0"}]' \
+		'.dependencies = [ {"name":"ko-crds","version":"1.0.1"}]' \
 		-i $(KONG_OPERATOR_CHART_YAML_PATH)
 	@$(YQ) eval \
 		'.dependencies += [ {"name":"gwapi-standard-crds","version":"$(GATEWAY_API_VERSION:v%=%)","condition":"gwapi-standard-crds.enabled"}]' \

--- a/charts/kong-operator/CHANGELOG.md
+++ b/charts/kong-operator/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
-## Unreleased
+## 1.0.2
 
 ### Fixes
 
 - Use proper certificate for validating webhook when `cert-manager` is used.
   [#2356](https://github.com/Kong/kong-operator/pull/2356)
+- Bump `ko-crds` subchart to `1.0.1`, which includes:
+  - Add the `status.clusterType` field in `KonnectGatewayControlPlane` CRD.
+    [#2311](https://github.com/Kong/kong-operator/pull/2311)
 
 ## 1.0.1
 

--- a/charts/kong-operator/Chart.lock
+++ b/charts/kong-operator/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: ko-crds
   repository: ""
-  version: 1.0.0
+  version: 1.0.1
 - name: gwapi-standard-crds
   repository: ""
   version: 1.3.0
 - name: gwapi-experimental-crds
   repository: ""
   version: 1.3.0
-digest: sha256:96fba1d921e6a9e95de104f0c064c3a235e24465991f9cbad09d0b9272a73c36
-generated: "2025-09-16T16:13:01.679478578+08:00"
+digest: sha256:a8f11fae93e4fbca0454f52c4eb037953000cb445db571ac40b98841019e3f12
+generated: "2025-09-30T16:42:41.790242+02:00"

--- a/charts/kong-operator/Chart.yaml
+++ b/charts/kong-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong-operator
 sources:
   - https://github.com/Kong/kong-operator/charts/kong-operator/
-version: 1.0.1
+version: 1.0.2
 appVersion: "2.0"
 annotations:
   artifacthub.io/category: networking
@@ -22,7 +22,7 @@ annotations:
       url: https://github.com/Kong/kong-operator
 dependencies:
   - name: ko-crds
-    version: 1.0.0
+    version: 1.0.1
   - name: gwapi-standard-crds
     version: 1.3.0
     condition: gwapi-standard-crds.enabled

--- a/charts/kong-operator/charts/ko-crds/Chart.yaml
+++ b/charts/kong-operator/charts/ko-crds/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: ko-crds
-version: 1.0.0
+version: 1.0.1
 appVersion: "1.0.0"
 description: A Helm chart for Kong Operators's CRDs

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -15,7 +15,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: ko-crds
-    helm.sh/chart: ko-crds-1.0.0
+    helm.sh/chart: ko-crds-1.0.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/component: ko
@@ -40,7 +40,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53857,7 +53857,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53879,7 +53879,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.1
+        helm.sh/chart: kong-operator-1.0.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.0"
         app.kubernetes.io/component: ko
@@ -54121,7 +54121,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -15,7 +15,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: ko-crds
-    helm.sh/chart: ko-crds-1.0.0
+    helm.sh/chart: ko-crds-1.0.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/component: ko
@@ -40,7 +40,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53874,7 +53874,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53896,7 +53896,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.1
+        helm.sh/chart: kong-operator-1.0.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.0"
         app.kubernetes.io/component: ko
@@ -54134,7 +54134,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -15,7 +15,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: ko-crds
-    helm.sh/chart: ko-crds-1.0.0
+    helm.sh/chart: ko-crds-1.0.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/component: ko
@@ -40,7 +40,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53857,7 +53857,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53879,7 +53879,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.1
+        helm.sh/chart: kong-operator-1.0.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.0"
         app.kubernetes.io/component: ko
@@ -54113,7 +54113,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -15,7 +15,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: ko-crds
-    helm.sh/chart: ko-crds-1.0.0
+    helm.sh/chart: ko-crds-1.0.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/component: ko
@@ -40,7 +40,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53857,7 +53857,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53879,7 +53879,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.1
+        helm.sh/chart: kong-operator-1.0.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.0"
         app.kubernetes.io/component: ko
@@ -54115,7 +54115,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -15,7 +15,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: ko-crds
-    helm.sh/chart: ko-crds-1.0.0
+    helm.sh/chart: ko-crds-1.0.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/component: ko
@@ -40,7 +40,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53857,7 +53857,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53879,7 +53879,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.1
+        helm.sh/chart: kong-operator-1.0.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.0"
         app.kubernetes.io/component: ko
@@ -54115,7 +54115,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -15,7 +15,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: ko-crds
-    helm.sh/chart: ko-crds-1.0.0
+    helm.sh/chart: ko-crds-1.0.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/component: ko
@@ -40,7 +40,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     a: "b"
@@ -53858,7 +53858,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     a: "b"
@@ -53881,7 +53881,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.1
+        helm.sh/chart: kong-operator-1.0.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.0"
         a: "b"
@@ -54114,7 +54114,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     a: "b"

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -15,7 +15,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: ko-crds
-    helm.sh/chart: ko-crds-1.0.0
+    helm.sh/chart: ko-crds-1.0.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/component: ko
@@ -40,7 +40,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53857,7 +53857,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53879,7 +53879,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.1
+        helm.sh/chart: kong-operator-1.0.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.0"
         app.kubernetes.io/component: ko
@@ -54113,7 +54113,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -15,7 +15,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: ko-crds
-    helm.sh/chart: ko-crds-1.0.0
+    helm.sh/chart: ko-crds-1.0.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/component: ko
@@ -40,7 +40,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53857,7 +53857,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53879,7 +53879,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.1
+        helm.sh/chart: kong-operator-1.0.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.0"
         app.kubernetes.io/component: ko
@@ -54111,7 +54111,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -15,7 +15,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: ko-crds
-    helm.sh/chart: ko-crds-1.0.0
+    helm.sh/chart: ko-crds-1.0.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/component: ko
@@ -40,7 +40,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53857,7 +53857,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53880,7 +53880,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.1
+        helm.sh/chart: kong-operator-1.0.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.0"
         app.kubernetes.io/component: ko
@@ -54112,7 +54112,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -15,7 +15,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: ko-crds
-    helm.sh/chart: ko-crds-1.0.0
+    helm.sh/chart: ko-crds-1.0.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/component: ko
@@ -40,7 +40,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53857,7 +53857,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53879,7 +53879,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.1
+        helm.sh/chart: kong-operator-1.0.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.0"
         app.kubernetes.io/component: ko
@@ -54113,7 +54113,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -15,7 +15,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: ko-crds
-    helm.sh/chart: ko-crds-1.0.0
+    helm.sh/chart: ko-crds-1.0.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/component: ko
@@ -40,7 +40,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53857,7 +53857,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53879,7 +53879,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.1
+        helm.sh/chart: kong-operator-1.0.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.0"
         app.kubernetes.io/component: ko
@@ -54115,7 +54115,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -15,7 +15,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: ko-crds
-    helm.sh/chart: ko-crds-1.0.0
+    helm.sh/chart: ko-crds-1.0.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/component: ko
@@ -40,7 +40,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53857,7 +53857,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53879,7 +53879,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.1
+        helm.sh/chart: kong-operator-1.0.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.0"
         app.kubernetes.io/component: ko
@@ -54017,7 +54017,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -15,7 +15,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -28676,7 +28676,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -28698,7 +28698,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.1
+        helm.sh/chart: kong-operator-1.0.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.0"
         app.kubernetes.io/component: ko
@@ -28922,7 +28922,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -53807,7 +53807,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53829,7 +53829,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.1
+        helm.sh/chart: kong-operator-1.0.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.0"
         app.kubernetes.io/component: ko
@@ -53932,7 +53932,7 @@ kind: Certificate
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53953,7 +53953,7 @@ kind: Certificate
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -53974,7 +53974,7 @@ kind: Issuer
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -54121,7 +54121,7 @@ metadata:
     cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "internal" } }'
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -28634,7 +28634,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.1
+    helm.sh/chart: kong-operator-1.0.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.0"
     app.kubernetes.io/component: ko
@@ -28656,7 +28656,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.1
+        helm.sh/chart: kong-operator-1.0.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.0"
         app.kubernetes.io/component: ko


### PR DESCRIPTION
**What this PR does / why we need it**:

Part of https://github.com/Kong/kong-operator/issues/2370

Version of `ko-crds` hardcoded in `Makefile` will be fixed in a separate PR. In this PR, it's only updated to make the release possible.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
