### PR TITLE
chore: make `ko-crds` autogenerated by `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -488,7 +488,7 @@ KONG_OPERATOR_CHART_YAML_PATH = $(KONG_OPERATOR_CHART_DIR)/Chart.yaml
 manifests.charts.kong-operator.chart.yaml: yq
 	@echo "Generating $(KONG_OPERATOR_CHART_YAML_PATH)"
 	@$(YQ) eval \
-		'.dependencies = [ {"name":"ko-crds","version":"1.0.1"}]' \
+		'.dependencies = [ {"name":"ko-crds","version":"$(shell $(YQ) -r '.version' < $(KONG_OPERATOR_CHART_DIR)/charts/ko-crds/Chart.yaml)"}]' \
 		-i $(KONG_OPERATOR_CHART_YAML_PATH)
 	@$(YQ) eval \
 		'.dependencies += [ {"name":"gwapi-standard-crds","version":"$(GATEWAY_API_VERSION:v%=%)","condition":"gwapi-standard-crds.enabled"}]' \


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not hardcode the version of `ko-crds` in `Makefile`. Pull it from the Chart definition
