### PR TITLE
feat(hybridgateway): add filters to kongplugins conversion

### DIFF
--- a/controller/hybridgateway/builder/kongplugin.go
+++ b/controller/hybridgateway/builder/kongplugin.go
@@ -175,9 +175,7 @@ func translateRequestModifier(filter gwtypes.HTTPRouteFilter) (requestTransforme
 		}
 	}
 	if len(filter.RequestHeaderModifier.Remove) > 0 {
-		for _, v := range filter.RequestHeaderModifier.Remove {
-			plugin.Remove.Headers = append(plugin.Remove.Headers, v)
-		}
+		plugin.Remove.Headers = append(plugin.Remove.Headers, filter.RequestHeaderModifier.Remove...)
 	}
 
 	if len(plugin.Add.Headers) == 0 && len(plugin.Remove.Headers) == 0 {
@@ -215,9 +213,7 @@ func translateResponseModifier(filter gwtypes.HTTPRouteFilter) (responseTransfor
 		}
 	}
 	if len(filter.ResponseHeaderModifier.Remove) > 0 {
-		for _, v := range filter.ResponseHeaderModifier.Remove {
-			plugin.Remove.Headers = append(plugin.Remove.Headers, v)
-		}
+		plugin.Remove.Headers = append(plugin.Remove.Headers, filter.ResponseHeaderModifier.Remove...)
 	}
 
 	if len(plugin.Add.Headers) == 0 && len(plugin.Remove.Headers) == 0 {

--- a/controller/hybridgateway/builder/kongplugin.go
+++ b/controller/hybridgateway/builder/kongplugin.go
@@ -1,0 +1,174 @@
+package builder
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	configurationv1 "github.com/kong/kong-operator/api/configuration/v1"
+	"github.com/kong/kong-operator/controller/hybridgateway/metadata"
+	gwtypes "github.com/kong/kong-operator/internal/types"
+	"github.com/kong/kong-operator/modules/manager/scheme"
+)
+
+// KongPluginBuilder is a builder for configurationv1.KongPlugin resources.
+type KongPluginBuilder struct {
+	plugin configurationv1.KongPlugin
+	errors []error
+}
+
+// NewKongPlugin creates and returns a new KongPluginBuilder instance.
+func NewKongPlugin() *KongPluginBuilder {
+	return &KongPluginBuilder{
+		plugin: configurationv1.KongPlugin{},
+		errors: make([]error, 0),
+	}
+}
+
+// WithName sets the name for the KongPlugin being built.
+func (b *KongPluginBuilder) WithName(name string) *KongPluginBuilder {
+	b.plugin.Name = name
+	return b
+}
+
+// WithNamespace sets the namespace for the KongPlugin being built.
+func (b *KongPluginBuilder) WithNamespace(namespace string) *KongPluginBuilder {
+	b.plugin.Namespace = namespace
+	return b
+}
+
+// WithLabels sets the labels for the KongPlugin resource based on the given HTTPRoute.
+func (b *KongPluginBuilder) WithLabels(route *gwtypes.HTTPRoute) *KongPluginBuilder {
+	labels := metadata.BuildLabels(route)
+	if b.plugin.Labels == nil {
+		b.plugin.Labels = make(map[string]string)
+	}
+	maps.Copy(b.plugin.Labels, labels)
+	return b
+}
+
+// WithAnnotations sets the annotations for the KongPlugin resource based on the given HTTPRoute and parent reference.
+func (b *KongPluginBuilder) WithAnnotations(route *gwtypes.HTTPRoute, parentRef *gwtypes.ParentReference) *KongPluginBuilder {
+	if route == nil {
+		b.errors = append(b.errors, errors.New("route cannot be nil"))
+		return b
+	}
+	if parentRef == nil {
+		b.errors = append(b.errors, errors.New("parentRef cannot be nil"))
+		return b
+	}
+	annotations := metadata.BuildAnnotations(route, parentRef)
+	if b.plugin.Annotations == nil {
+		b.plugin.Annotations = make(map[string]string)
+	}
+	maps.Copy(b.plugin.Annotations, annotations)
+	return b
+}
+
+// WithOwner sets the owner reference for the KongPlugin to the given HTTPRoute.
+func (b *KongPluginBuilder) WithOwner(owner *gwtypes.HTTPRoute) *KongPluginBuilder {
+	if owner == nil {
+		b.errors = append(b.errors, errors.New("owner cannot be nil"))
+		return b
+	}
+
+	err := controllerutil.SetOwnerReference(owner, &b.plugin, scheme.Get(), controllerutil.WithBlockOwnerDeletion(true))
+	if err != nil {
+		b.errors = append(b.errors, fmt.Errorf("failed to set owner reference: %w", err))
+	}
+	return b
+}
+
+// Build returns the constructed KongPlugin resource and any accumulated errors.
+func (b *KongPluginBuilder) Build() (configurationv1.KongPlugin, error) {
+	if len(b.errors) > 0 {
+		return configurationv1.KongPlugin{}, errors.Join(b.errors...)
+	}
+	return b.plugin, nil
+}
+
+// MustBuild returns the constructed KongPlugin resource, panicking on any errors.
+// Useful for tests or when you're certain the build will succeed.
+func (b *KongPluginBuilder) MustBuild() configurationv1.KongPlugin {
+	plugin, err := b.Build()
+	if err != nil {
+		panic(fmt.Errorf("failed to build KongPlugin: %w", err))
+	}
+	return plugin
+}
+
+// WithFilter sets the KongPlugin configuration based on the given HTTPRouteFilter.
+func (b *KongPluginBuilder) WithFilter(filter gwtypes.HTTPRouteFilter) *KongPluginBuilder {
+
+	switch filter.Type {
+	case v1.HTTPRouteFilterRequestHeaderModifier:
+		rt, err := translateRequestModifier(filter)
+		if err != nil {
+			b.errors = append(b.errors, err)
+			return b
+		}
+
+		b.plugin.PluginName = "request-transformer"
+
+		configJSON, err := json.Marshal(rt)
+		if err != nil {
+			b.errors = append(b.errors, fmt.Errorf("failed to marshal %q plugin config: %w", b.plugin.PluginName, err))
+			return b
+		}
+		b.plugin.Config.Raw = []byte(configJSON)
+
+	default:
+		b.errors = append(b.errors, fmt.Errorf("unsupported filter type: %s", filter.Type))
+	}
+	return b
+}
+
+// internal functions and types for translating HTTPRouteFilter to KongPlugin configurations
+
+type requestTransformerTargetSlice struct {
+	Headers []string `json:"headers,omitempty"`
+}
+
+type requestTransformer struct {
+	Add    requestTransformerTargetSlice `json:"add,omitzero"`
+	Remove requestTransformerTargetSlice `json:"remove,omitzero"`
+}
+
+func translateRequestModifier(filter gwtypes.HTTPRouteFilter) (plugin requestTransformer, err error) {
+	plugin = requestTransformer{}
+	err = nil
+
+	if filter.RequestHeaderModifier == nil {
+		err = errors.New("RequestHeaderModifier filter config is missing")
+		return
+	}
+	plugin.Remove.Headers = []string{}
+	plugin.Add.Headers = []string{}
+
+	if len(filter.RequestHeaderModifier.Set) > 0 {
+		for _, v := range filter.RequestHeaderModifier.Set {
+			plugin.Remove.Headers = append(plugin.Remove.Headers, string(v.Name))
+			plugin.Add.Headers = append(plugin.Add.Headers, string(v.Name)+":"+v.Value)
+		}
+	}
+	if len(filter.RequestHeaderModifier.Add) > 0 {
+		for _, v := range filter.RequestHeaderModifier.Add {
+			plugin.Add.Headers = append(plugin.Add.Headers, string(v.Name)+":"+v.Value)
+		}
+	}
+	if len(filter.RequestHeaderModifier.Remove) > 0 {
+		for _, v := range filter.RequestHeaderModifier.Remove {
+			plugin.Remove.Headers = append(plugin.Remove.Headers, string(v))
+		}
+	}
+
+	if len(plugin.Add.Headers) == 0 && len(plugin.Remove.Headers) == 0 {
+		err = errors.New("RequestHeaderModifier filter config is empty")
+		plugin = requestTransformer{}
+	}
+	return
+}

--- a/controller/hybridgateway/builder/kongplugin_test.go
+++ b/controller/hybridgateway/builder/kongplugin_test.go
@@ -1,0 +1,380 @@
+package builder
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	configurationv1 "github.com/kong/kong-operator/api/configuration/v1"
+	gwtypes "github.com/kong/kong-operator/internal/types"
+)
+
+func TestNewKongPlugin(t *testing.T) {
+	builder := NewKongPlugin()
+
+	assert.NotNil(t, builder)
+	assert.Empty(t, builder.errors)
+	assert.Equal(t, configurationv1.KongPlugin{}, builder.plugin)
+}
+
+func TestKongPluginBuilder_WithName(t *testing.T) {
+	builder := NewKongPlugin().WithName("test-plugin")
+
+	plugin, err := builder.Build()
+	require.NoError(t, err)
+	assert.Equal(t, "test-plugin", plugin.Name)
+}
+
+func TestKongPluginBuilder_WithNamespace(t *testing.T) {
+	builder := NewKongPlugin().WithNamespace("test-namespace")
+
+	plugin, err := builder.Build()
+	require.NoError(t, err)
+	assert.Equal(t, "test-namespace", plugin.Namespace)
+}
+
+func TestKongPluginBuilder_WithLabels(t *testing.T) {
+	route := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "default",
+		},
+	}
+
+	builder := NewKongPlugin().WithLabels(route)
+
+	plugin, err := builder.Build()
+	require.NoError(t, err)
+
+	assert.NotNil(t, plugin.Labels)
+	assert.NotEmpty(t, plugin.Labels)
+}
+
+func TestKongPluginBuilder_WithAnnotations(t *testing.T) {
+	route := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "default",
+		},
+	}
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	builder := NewKongPlugin().WithAnnotations(route, parentRef)
+
+	plugin, err := builder.Build()
+	require.NoError(t, err)
+
+	assert.NotNil(t, plugin.Annotations)
+	assert.NotEmpty(t, plugin.Annotations)
+}
+
+func TestKongPluginBuilder_WithOwner(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-http-route",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+		},
+	}
+
+	t.Run("valid owner", func(t *testing.T) {
+		builder := NewKongPlugin().
+			WithNamespace("test-namespace").
+			WithOwner(httpRoute)
+
+		plugin, err := builder.Build()
+		require.NoError(t, err)
+
+		require.Len(t, plugin.OwnerReferences, 1)
+		ownerRef := plugin.OwnerReferences[0]
+		assert.Equal(t, "HTTPRoute", ownerRef.Kind)
+		assert.Equal(t, "gateway.networking.k8s.io/v1", ownerRef.APIVersion)
+		assert.Equal(t, "test-http-route", ownerRef.Name)
+		assert.Equal(t, "test-uid", string(ownerRef.UID))
+		assert.True(t, *ownerRef.BlockOwnerDeletion)
+	})
+
+	t.Run("nil owner", func(t *testing.T) {
+		builder := NewKongPlugin().WithOwner(nil)
+
+		_, err := builder.Build()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "owner cannot be nil")
+	})
+
+	t.Run("owner reference error", func(t *testing.T) {
+		builder := NewKongPlugin().
+			WithNamespace("wrong-namespace").
+			WithOwner(httpRoute)
+		_, err := builder.Build()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to set owner reference")
+	})
+}
+
+func TestKongPluginBuilder_MustBuild(t *testing.T) {
+	t.Run("successful must build", func(t *testing.T) {
+		builder := NewKongPlugin().WithName("test-plugin")
+
+		plugin := builder.MustBuild()
+		assert.Equal(t, "test-plugin", plugin.Name)
+	})
+
+	t.Run("must build panics on error", func(t *testing.T) {
+		builder := NewKongPlugin().WithOwner(nil)
+
+		assert.Panics(t, func() {
+			builder.MustBuild()
+		})
+	})
+}
+
+func TestKongPluginBuilder_WithFilter_RequestHeaderModifier(t *testing.T) {
+	tests := []struct {
+		name           string
+		filter         gwtypes.HTTPRouteFilter
+		expectedPlugin string
+		expectedConfig requestTransformer
+		expectError    bool
+	}{
+		{
+			name: "add headers only",
+			filter: gwtypes.HTTPRouteFilter{
+				Type: v1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &v1.HTTPHeaderFilter{
+					Add: []v1.HTTPHeader{
+						{Name: "X-Custom-Header", Value: "custom-value"},
+						{Name: "X-Another-Header", Value: "another-value"},
+					},
+				},
+			},
+			expectedPlugin: "request-transformer",
+			expectedConfig: requestTransformer{
+				Add: requestTransformerTargetSlice{
+					Headers: []string{"X-Custom-Header:custom-value", "X-Another-Header:another-value"},
+				},
+				Remove: requestTransformerTargetSlice{
+					Headers: []string{},
+				},
+			},
+		},
+		{
+			name: "remove headers only",
+			filter: gwtypes.HTTPRouteFilter{
+				Type: v1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &v1.HTTPHeaderFilter{
+					Remove: []string{"X-Remove-Header", "custom-value"},
+				},
+			},
+			expectedPlugin: "request-transformer",
+			expectedConfig: requestTransformer{
+				Add: requestTransformerTargetSlice{
+					Headers: []string{},
+				},
+				Remove: requestTransformerTargetSlice{
+					Headers: []string{"X-Remove-Header", "custom-value"},
+				},
+			},
+		},
+		{
+			name: "set headers (remove + add)",
+			filter: gwtypes.HTTPRouteFilter{
+				Type: v1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &v1.HTTPHeaderFilter{
+					Set: []v1.HTTPHeader{
+						{Name: "Authorization", Value: "Bearer token123"},
+					},
+				},
+			},
+			expectedPlugin: "request-transformer",
+			expectedConfig: requestTransformer{
+				Add: requestTransformerTargetSlice{
+					Headers: []string{"Authorization:Bearer token123"},
+				},
+				Remove: requestTransformerTargetSlice{
+					Headers: []string{"Authorization"},
+				},
+			},
+		},
+		{
+			name: "mixed operations",
+			filter: gwtypes.HTTPRouteFilter{
+				Type: v1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &v1.HTTPHeaderFilter{
+					Add: []v1.HTTPHeader{
+						{Name: "X-Add-Header", Value: "add-value"},
+					},
+					Set: []v1.HTTPHeader{
+						{Name: "X-Set-Header", Value: "set-value"},
+					},
+					Remove: []string{"X-Remove-Header"},
+				},
+			},
+			expectedPlugin: "request-transformer",
+			expectedConfig: requestTransformer{
+				Add: requestTransformerTargetSlice{
+					Headers: []string{"X-Set-Header:set-value", "X-Add-Header:add-value"},
+				},
+				Remove: requestTransformerTargetSlice{
+					Headers: []string{"X-Set-Header", "X-Remove-Header"},
+				},
+			},
+		},
+		{
+			name: "nil RequestHeaderModifier",
+			filter: gwtypes.HTTPRouteFilter{
+				Type:                  v1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: nil,
+			},
+			expectError: true,
+		},
+		{
+			name: "empty RequestHeaderModifier",
+			filter: gwtypes.HTTPRouteFilter{
+				Type:                  v1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &v1.HTTPHeaderFilter{},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewKongPlugin().WithFilter(tt.filter)
+
+			plugin, err := builder.Build()
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedPlugin, plugin.PluginName)
+
+			var actualConfig requestTransformer
+			err = json.Unmarshal(plugin.Config.Raw, &actualConfig)
+			require.NoError(t, err)
+
+			assert.ElementsMatch(t, tt.expectedConfig.Add.Headers, actualConfig.Add.Headers)
+			assert.ElementsMatch(t, tt.expectedConfig.Remove.Headers, actualConfig.Remove.Headers)
+		})
+	}
+}
+
+func TestKongPluginBuilder_WithFilter_UnsupportedType(t *testing.T) {
+	filter := gwtypes.HTTPRouteFilter{
+		Type: v1.HTTPRouteFilterCORS, // Unsupported type
+	}
+
+	builder := NewKongPlugin().WithFilter(filter)
+
+	_, err := builder.Build()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported filter type")
+}
+
+func TestTranslateRequestModifier(t *testing.T) {
+	tests := []struct {
+		name        string
+		filter      gwtypes.HTTPRouteFilter
+		expected    requestTransformer
+		expectError bool
+	}{
+		{
+			name: "successful translation with all operations",
+			filter: gwtypes.HTTPRouteFilter{
+				RequestHeaderModifier: &v1.HTTPHeaderFilter{
+					Add: []v1.HTTPHeader{
+						{Name: "X-Add", Value: "add-val"},
+					},
+					Set: []v1.HTTPHeader{
+						{Name: "X-Set", Value: "set-val"},
+					},
+					Remove: []string{"X-Remove"},
+				},
+			},
+			expected: requestTransformer{
+				Add: requestTransformerTargetSlice{
+					Headers: []string{"X-Set:set-val", "X-Add:add-val"},
+				},
+				Remove: requestTransformerTargetSlice{
+					Headers: []string{"X-Set", "X-Remove"},
+				},
+			},
+		},
+		{
+			name: "nil RequestHeaderModifier",
+			filter: gwtypes.HTTPRouteFilter{
+				RequestHeaderModifier: nil,
+			},
+			expectError: true,
+		},
+		{
+			name: "empty RequestHeaderModifier",
+			filter: gwtypes.HTTPRouteFilter{
+				RequestHeaderModifier: &v1.HTTPHeaderFilter{},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := translateRequestModifier(tt.filter)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Equal(t, requestTransformer{}, result)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.expected.Add.Headers, result.Add.Headers)
+			assert.ElementsMatch(t, tt.expected.Remove.Headers, result.Remove.Headers)
+		})
+	}
+}
+
+func TestKongPluginBuilder_ChainedCalls(t *testing.T) {
+	route := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "default",
+		},
+	}
+
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	filter := gwtypes.HTTPRouteFilter{
+		Type: v1.HTTPRouteFilterRequestHeaderModifier,
+		RequestHeaderModifier: &v1.HTTPHeaderFilter{
+			Add: []v1.HTTPHeader{
+				{Name: "X-Test", Value: "test-value"},
+			},
+		},
+	}
+
+	plugin := NewKongPlugin().
+		WithName("test-plugin").
+		WithNamespace("test-ns").
+		WithLabels(route).
+		WithAnnotations(route, parentRef).
+		WithFilter(filter).
+		MustBuild()
+
+	assert.Equal(t, "test-plugin", plugin.Name)
+	assert.Equal(t, "test-ns", plugin.Namespace)
+	assert.Equal(t, "request-transformer", plugin.PluginName)
+	assert.NotNil(t, plugin.Labels)
+	assert.NotNil(t, plugin.Annotations)
+	assert.NotEmpty(t, plugin.Config.Raw)
+}

--- a/controller/hybridgateway/builder/kongplugin_test.go
+++ b/controller/hybridgateway/builder/kongplugin_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	configurationv1 "github.com/kong/kong-operator/api/configuration/v1"
 	gwtypes "github.com/kong/kong-operator/internal/types"
@@ -146,9 +146,9 @@ func TestKongPluginBuilder_WithFilter_RequestHeaderModifier(t *testing.T) {
 		{
 			name: "add headers only",
 			filter: gwtypes.HTTPRouteFilter{
-				Type: v1.HTTPRouteFilterRequestHeaderModifier,
-				RequestHeaderModifier: &v1.HTTPHeaderFilter{
-					Add: []v1.HTTPHeader{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Add: []gatewayv1.HTTPHeader{
 						{Name: "X-Custom-Header", Value: "custom-value"},
 						{Name: "X-Another-Header", Value: "another-value"},
 					},
@@ -167,8 +167,8 @@ func TestKongPluginBuilder_WithFilter_RequestHeaderModifier(t *testing.T) {
 		{
 			name: "remove headers only",
 			filter: gwtypes.HTTPRouteFilter{
-				Type: v1.HTTPRouteFilterRequestHeaderModifier,
-				RequestHeaderModifier: &v1.HTTPHeaderFilter{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
 					Remove: []string{"X-Remove-Header", "custom-value"},
 				},
 			},
@@ -185,9 +185,9 @@ func TestKongPluginBuilder_WithFilter_RequestHeaderModifier(t *testing.T) {
 		{
 			name: "set headers (remove + add)",
 			filter: gwtypes.HTTPRouteFilter{
-				Type: v1.HTTPRouteFilterRequestHeaderModifier,
-				RequestHeaderModifier: &v1.HTTPHeaderFilter{
-					Set: []v1.HTTPHeader{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Set: []gatewayv1.HTTPHeader{
 						{Name: "Authorization", Value: "Bearer token123"},
 					},
 				},
@@ -205,12 +205,12 @@ func TestKongPluginBuilder_WithFilter_RequestHeaderModifier(t *testing.T) {
 		{
 			name: "mixed operations",
 			filter: gwtypes.HTTPRouteFilter{
-				Type: v1.HTTPRouteFilterRequestHeaderModifier,
-				RequestHeaderModifier: &v1.HTTPHeaderFilter{
-					Add: []v1.HTTPHeader{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Add: []gatewayv1.HTTPHeader{
 						{Name: "X-Add-Header", Value: "add-value"},
 					},
-					Set: []v1.HTTPHeader{
+					Set: []gatewayv1.HTTPHeader{
 						{Name: "X-Set-Header", Value: "set-value"},
 					},
 					Remove: []string{"X-Remove-Header"},
@@ -229,7 +229,7 @@ func TestKongPluginBuilder_WithFilter_RequestHeaderModifier(t *testing.T) {
 		{
 			name: "nil RequestHeaderModifier",
 			filter: gwtypes.HTTPRouteFilter{
-				Type:                  v1.HTTPRouteFilterRequestHeaderModifier,
+				Type:                  gatewayv1.HTTPRouteFilterRequestHeaderModifier,
 				RequestHeaderModifier: nil,
 			},
 			expectError: true,
@@ -237,8 +237,8 @@ func TestKongPluginBuilder_WithFilter_RequestHeaderModifier(t *testing.T) {
 		{
 			name: "empty RequestHeaderModifier",
 			filter: gwtypes.HTTPRouteFilter{
-				Type:                  v1.HTTPRouteFilterRequestHeaderModifier,
-				RequestHeaderModifier: &v1.HTTPHeaderFilter{},
+				Type:                  gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{},
 			},
 			expectError: true,
 		},
@@ -270,7 +270,7 @@ func TestKongPluginBuilder_WithFilter_RequestHeaderModifier(t *testing.T) {
 
 func TestKongPluginBuilder_WithFilter_UnsupportedType(t *testing.T) {
 	filter := gwtypes.HTTPRouteFilter{
-		Type: v1.HTTPRouteFilterCORS, // Unsupported type
+		Type: gatewayv1.HTTPRouteFilterCORS, // Unsupported type
 	}
 
 	builder := NewKongPlugin().WithFilter(filter)
@@ -290,11 +290,11 @@ func TestTranslateRequestModifier(t *testing.T) {
 		{
 			name: "successful translation with all operations",
 			filter: gwtypes.HTTPRouteFilter{
-				RequestHeaderModifier: &v1.HTTPHeaderFilter{
-					Add: []v1.HTTPHeader{
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Add: []gatewayv1.HTTPHeader{
 						{Name: "X-Add", Value: "add-val"},
 					},
-					Set: []v1.HTTPHeader{
+					Set: []gatewayv1.HTTPHeader{
 						{Name: "X-Set", Value: "set-val"},
 					},
 					Remove: []string{"X-Remove"},
@@ -319,7 +319,7 @@ func TestTranslateRequestModifier(t *testing.T) {
 		{
 			name: "empty RequestHeaderModifier",
 			filter: gwtypes.HTTPRouteFilter{
-				RequestHeaderModifier: &v1.HTTPHeaderFilter{},
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{},
 			},
 			expectError: true,
 		},
@@ -355,9 +355,9 @@ func TestKongPluginBuilder_ChainedCalls(t *testing.T) {
 	}
 
 	filter := gwtypes.HTTPRouteFilter{
-		Type: v1.HTTPRouteFilterRequestHeaderModifier,
-		RequestHeaderModifier: &v1.HTTPHeaderFilter{
-			Add: []v1.HTTPHeader{
+		Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+		RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+			Add: []gatewayv1.HTTPHeader{
 				{Name: "X-Test", Value: "test-value"},
 			},
 		},

--- a/controller/hybridgateway/builder/kongpluginbinding.go
+++ b/controller/hybridgateway/builder/kongpluginbinding.go
@@ -1,0 +1,131 @@
+package builder
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/controller/hybridgateway/metadata"
+	gwtypes "github.com/kong/kong-operator/internal/types"
+	"github.com/kong/kong-operator/modules/manager/scheme"
+)
+
+// KongPluginBindingBuilder is a builder for configurationv1alpha1.KongPluginBinding resources.
+type KongPluginBindingBuilder struct {
+	binding configurationv1alpha1.KongPluginBinding
+	errors  []error
+}
+
+// NewKongPluginBinding creates and returns a new KongPluginBindingBuilder instance.
+func NewKongPluginBinding() *KongPluginBindingBuilder {
+	return &KongPluginBindingBuilder{
+		binding: configurationv1alpha1.KongPluginBinding{},
+		errors:  make([]error, 0),
+	}
+}
+
+// WithName sets the name for the KongPluginBinding being built.
+func (b *KongPluginBindingBuilder) WithName(name string) *KongPluginBindingBuilder {
+	b.binding.Name = name
+	return b
+}
+
+// WithNamespace sets the namespace for the KongPluginBinding being built.
+func (b *KongPluginBindingBuilder) WithNamespace(namespace string) *KongPluginBindingBuilder {
+	b.binding.Namespace = namespace
+	return b
+}
+
+// WithLabels sets the labels for the KongPluginBinding resource based on the given HTTPRoute.
+func (b *KongPluginBindingBuilder) WithLabels(route *gwtypes.HTTPRoute) *KongPluginBindingBuilder {
+	labels := metadata.BuildLabels(route)
+	if b.binding.Labels == nil {
+		b.binding.Labels = make(map[string]string)
+	}
+	maps.Copy(b.binding.Labels, labels)
+	return b
+}
+
+// WithAnnotations sets the annotations for the KongPluginBinding resource based on the given HTTPRoute and parent reference.
+func (b *KongPluginBindingBuilder) WithAnnotations(route *gwtypes.HTTPRoute, parentRef *gwtypes.ParentReference) *KongPluginBindingBuilder {
+	annotations := metadata.BuildAnnotations(route, parentRef)
+	if b.binding.Annotations == nil {
+		b.binding.Annotations = make(map[string]string)
+	}
+	maps.Copy(b.binding.Annotations, annotations)
+	return b
+}
+
+// WithPluginRef sets the plugin reference for the KongPluginBinding.
+func (b *KongPluginBindingBuilder) WithPluginRef(name string) *KongPluginBindingBuilder {
+	b.binding.Spec.PluginReference.Name = name
+	return b
+}
+
+// WithRouteRef sets the KongRoute reference for the KongPluginBinding.
+func (b *KongPluginBindingBuilder) WithRouteRef(name string) *KongPluginBindingBuilder {
+	if b.binding.Spec.Targets == nil {
+		b.binding.Spec.Targets = &configurationv1alpha1.KongPluginBindingTargets{}
+	}
+	b.binding.Spec.Targets.RouteReference = &configurationv1alpha1.TargetRefWithGroupKind{
+		Name:  name,
+		Group: "configuration.konghq.com",
+		Kind:  "KongRoute",
+	}
+	return b
+}
+
+// WithServiceRef sets the KongService reference for the KongPluginBinding.
+func (b *KongPluginBindingBuilder) WithServiceRef(name string) *KongPluginBindingBuilder {
+	if b.binding.Spec.Targets == nil {
+		b.binding.Spec.Targets = &configurationv1alpha1.KongPluginBindingTargets{}
+	}
+	b.binding.Spec.Targets.ServiceReference = &configurationv1alpha1.TargetRefWithGroupKind{
+		Name:  name,
+		Group: "configuration.konghq.com",
+		Kind:  "KongService",
+	}
+	return b
+}
+
+// WithControlPlaneRef sets the ControlPlaneRef for the KongPluginBinding being built.
+func (b *KongPluginBindingBuilder) WithControlPlaneRef(cpr commonv1alpha1.ControlPlaneRef) *KongPluginBindingBuilder {
+	b.binding.Spec.ControlPlaneRef = cpr
+	return b
+}
+
+// WithOwner sets the owner reference for the KongPluginBinding to the given HTTPRoute.
+func (b *KongPluginBindingBuilder) WithOwner(owner *gwtypes.HTTPRoute) *KongPluginBindingBuilder {
+	if owner == nil {
+		b.errors = append(b.errors, errors.New("owner cannot be nil"))
+		return b
+	}
+
+	err := controllerutil.SetOwnerReference(owner, &b.binding, scheme.Get(), controllerutil.WithBlockOwnerDeletion(true))
+	if err != nil {
+		b.errors = append(b.errors, fmt.Errorf("failed to set owner reference: %w", err))
+	}
+	return b
+}
+
+// Build returns the constructed KongPluginBinding resource and any accumulated errors.
+func (b *KongPluginBindingBuilder) Build() (configurationv1alpha1.KongPluginBinding, error) {
+	if len(b.errors) > 0 {
+		return configurationv1alpha1.KongPluginBinding{}, errors.Join(b.errors...)
+	}
+	return b.binding, nil
+}
+
+// MustBuild returns the constructed KongPluginBinding resource, panicking on any errors.
+// Useful for tests or when you're certain the build will succeed.
+func (b *KongPluginBindingBuilder) MustBuild() configurationv1alpha1.KongPluginBinding {
+	binding, err := b.Build()
+	if err != nil {
+		panic(fmt.Errorf("failed to build KongPluginBinding: %w", err))
+	}
+	return binding
+}

--- a/controller/hybridgateway/builder/kongpluginbinding_test.go
+++ b/controller/hybridgateway/builder/kongpluginbinding_test.go
@@ -1,0 +1,286 @@
+package builder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	gwtypes "github.com/kong/kong-operator/internal/types"
+)
+
+func TestNewKongPluginBinding(t *testing.T) {
+	builder := NewKongPluginBinding()
+
+	assert.NotNil(t, builder)
+	assert.Empty(t, builder.errors)
+	assert.Equal(t, configurationv1alpha1.KongPluginBinding{}, builder.binding)
+}
+
+func TestKongPluginBindingBuilder_WithName(t *testing.T) {
+	builder := NewKongPluginBinding().WithName("test-binding")
+
+	binding, err := builder.Build()
+	require.NoError(t, err)
+	assert.Equal(t, "test-binding", binding.Name)
+}
+
+func TestKongPluginBindingBuilder_WithNamespace(t *testing.T) {
+	builder := NewKongPluginBinding().WithNamespace("test-namespace")
+
+	binding, err := builder.Build()
+	require.NoError(t, err)
+	assert.Equal(t, "test-namespace", binding.Namespace)
+}
+
+func TestKongPluginBindingBuilder_WithLabels(t *testing.T) {
+	route := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "default",
+		},
+	}
+
+	builder := NewKongPluginBinding().WithLabels(route)
+
+	binding, err := builder.Build()
+	require.NoError(t, err)
+
+	assert.NotNil(t, binding.Labels)
+}
+
+func TestKongPluginBindingBuilder_WithAnnotations(t *testing.T) {
+	route := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "default",
+		},
+	}
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	builder := NewKongPluginBinding().WithAnnotations(route, parentRef)
+
+	binding, err := builder.Build()
+	require.NoError(t, err)
+
+	assert.NotNil(t, binding.Annotations)
+}
+
+func TestKongPluginBindingBuilder_WithPluginRef(t *testing.T) {
+	builder := NewKongPluginBinding().WithPluginRef("test-plugin")
+
+	binding, err := builder.Build()
+	require.NoError(t, err)
+	assert.Equal(t, "test-plugin", binding.Spec.PluginReference.Name)
+}
+
+func TestKongPluginBindingBuilder_WithRouteRef(t *testing.T) {
+	builder := NewKongPluginBinding().WithRouteRef("test-route")
+
+	binding, err := builder.Build()
+	require.NoError(t, err)
+
+	require.NotNil(t, binding.Spec.Targets)
+	require.NotNil(t, binding.Spec.Targets.RouteReference)
+	assert.Equal(t, "test-route", binding.Spec.Targets.RouteReference.Name)
+	assert.Equal(t, "configuration.konghq.com", binding.Spec.Targets.RouteReference.Group)
+	assert.Equal(t, "KongRoute", binding.Spec.Targets.RouteReference.Kind)
+}
+
+func TestKongPluginBindingBuilder_WithServiceRef(t *testing.T) {
+	builder := NewKongPluginBinding().WithServiceRef("test-service")
+
+	binding, err := builder.Build()
+	require.NoError(t, err)
+
+	require.NotNil(t, binding.Spec.Targets)
+	require.NotNil(t, binding.Spec.Targets.ServiceReference)
+	assert.Equal(t, "test-service", binding.Spec.Targets.ServiceReference.Name)
+	assert.Equal(t, "configuration.konghq.com", binding.Spec.Targets.ServiceReference.Group)
+	assert.Equal(t, "KongService", binding.Spec.Targets.ServiceReference.Kind)
+}
+
+func TestKongPluginBindingBuilder_WithControlPlaneRef(t *testing.T) {
+	controlPlaneRef := commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: "test-control-plane",
+		},
+	}
+
+	builder := NewKongPluginBinding().WithControlPlaneRef(controlPlaneRef)
+
+	binding, err := builder.Build()
+	require.NoError(t, err)
+
+	assert.Equal(t, controlPlaneRef, binding.Spec.ControlPlaneRef)
+	assert.Equal(t, commonv1alpha1.ControlPlaneRefKonnectNamespacedRef, binding.Spec.ControlPlaneRef.Type)
+	require.NotNil(t, binding.Spec.ControlPlaneRef.KonnectNamespacedRef)
+	assert.Equal(t, "test-control-plane", binding.Spec.ControlPlaneRef.KonnectNamespacedRef.Name)
+}
+
+func TestKongPluginBindingBuilder_WithOwner(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-http-route",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+		},
+	}
+	t.Run("valid owner", func(t *testing.T) {
+		builder := NewKongPluginBinding().
+			WithNamespace("test-namespace").
+			WithOwner(httpRoute)
+
+		binding, err := builder.Build()
+		require.NoError(t, err)
+
+		require.Len(t, binding.OwnerReferences, 1)
+		ownerRef := binding.OwnerReferences[0]
+		assert.Equal(t, "HTTPRoute", ownerRef.Kind)
+		assert.Equal(t, "gateway.networking.k8s.io/v1", ownerRef.APIVersion)
+		assert.Equal(t, "test-http-route", ownerRef.Name)
+		assert.Equal(t, "test-uid", string(ownerRef.UID))
+		assert.True(t, *ownerRef.BlockOwnerDeletion)
+	})
+
+	t.Run("nil owner", func(t *testing.T) {
+		builder := NewKongPluginBinding().WithOwner(nil)
+
+		_, err := builder.Build()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "owner cannot be nil")
+	})
+}
+
+func TestKongPluginBindingBuilder_MustBuild(t *testing.T) {
+	t.Run("successful build", func(t *testing.T) {
+		builder := NewKongPluginBinding().
+			WithName("test-binding").
+			WithPluginRef("test-plugin").
+			WithRouteRef("test-route")
+
+		binding := builder.MustBuild()
+		assert.Equal(t, "test-binding", binding.Name)
+		assert.Equal(t, "test-plugin", binding.Spec.PluginReference.Name)
+		assert.Equal(t, "test-route", binding.Spec.Targets.RouteReference.Name)
+	})
+	t.Run("build with errors panics", func(t *testing.T) {
+		builder := NewKongPluginBinding().WithOwner(nil)
+
+		assert.Panics(t, func() {
+			builder.MustBuild()
+		})
+	})
+}
+
+func TestKongPluginBindingBuilder_ChainedCalls(t *testing.T) {
+	route := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "default",
+		},
+	}
+
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	controlPlaneRef := commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: "test-control-plane",
+		},
+	}
+
+	binding := NewKongPluginBinding().
+		WithName("chained-binding").
+		WithNamespace("test-ns").
+		WithLabels(route).
+		WithAnnotations(route, parentRef).
+		WithPluginRef("test-plugin").
+		WithRouteRef("test-route").
+		WithServiceRef("test-service").
+		WithControlPlaneRef(controlPlaneRef).
+		MustBuild()
+
+	assert.Equal(t, "chained-binding", binding.Name)
+	assert.Equal(t, "test-ns", binding.Namespace)
+	assert.Equal(t, "test-plugin", binding.Spec.PluginReference.Name)
+	assert.Equal(t, "test-route", binding.Spec.Targets.RouteReference.Name)
+	assert.Equal(t, "test-service", binding.Spec.Targets.ServiceReference.Name)
+	assert.Equal(t, controlPlaneRef, binding.Spec.ControlPlaneRef)
+	assert.NotNil(t, binding.Labels)
+	assert.NotNil(t, binding.Annotations)
+}
+
+func TestKongPluginBindingBuilder_FullBinding(t *testing.T) {
+	route := &gwtypes.HTTPRoute{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "gateway.networking.k8s.io/v1",
+			Kind:       "HTTPRoute",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+		},
+	}
+
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	controlPlaneRef := commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: "test-control-plane",
+		},
+	}
+
+	binding := NewKongPluginBinding().
+		WithName("complete-binding").
+		WithNamespace("test-namespace").
+		WithLabels(route).
+		WithAnnotations(route, parentRef).
+		WithPluginRef("rate-limiting").
+		WithRouteRef("api-route").
+		WithServiceRef("api-service").
+		WithControlPlaneRef(controlPlaneRef).
+		WithOwner(route).
+		MustBuild()
+
+	// Verify all fields are set correctly
+	assert.Equal(t, "complete-binding", binding.Name)
+	assert.Equal(t, "test-namespace", binding.Namespace)
+	assert.NotNil(t, binding.Labels)
+	assert.NotNil(t, binding.Annotations)
+
+	// Verify spec
+	assert.Equal(t, "rate-limiting", binding.Spec.PluginReference.Name)
+	assert.Equal(t, controlPlaneRef, binding.Spec.ControlPlaneRef)
+
+	// Verify targets
+	require.NotNil(t, binding.Spec.Targets)
+	require.NotNil(t, binding.Spec.Targets.RouteReference)
+	assert.Equal(t, "api-route", binding.Spec.Targets.RouteReference.Name)
+	assert.Equal(t, "configuration.konghq.com", binding.Spec.Targets.RouteReference.Group)
+	assert.Equal(t, "KongRoute", binding.Spec.Targets.RouteReference.Kind)
+
+	require.NotNil(t, binding.Spec.Targets.ServiceReference)
+	assert.Equal(t, "api-service", binding.Spec.Targets.ServiceReference.Name)
+	assert.Equal(t, "configuration.konghq.com", binding.Spec.Targets.ServiceReference.Group)
+	assert.Equal(t, "KongService", binding.Spec.Targets.ServiceReference.Kind)
+
+	// Verify owner reference
+	require.Len(t, binding.OwnerReferences, 1)
+	ownerRef := binding.OwnerReferences[0]
+	assert.Equal(t, "HTTPRoute", ownerRef.Kind)
+	assert.Equal(t, "test-route", ownerRef.Name)
+	assert.True(t, *ownerRef.BlockOwnerDeletion)
+}

--- a/controller/hybridgateway/intermediate/http_route.go
+++ b/controller/hybridgateway/intermediate/http_route.go
@@ -29,6 +29,8 @@ type BackendRef struct {
 	BackendRef gwtypes.HTTPBackendRef
 }
 
+// Filter represents a filter applied to an HTTPRoute rule.
+// It defines transformations or actions to be performed on requests that match the rule.
 type Filter struct {
 	Name
 	Filter gwtypes.HTTPRouteFilter

--- a/controller/hybridgateway/intermediate/http_route.go
+++ b/controller/hybridgateway/intermediate/http_route.go
@@ -11,6 +11,7 @@ import (
 type Rule struct {
 	Name
 	Matches     map[string]Match
+	Filters     map[string]Filter
 	BackendRefs map[string]BackendRef
 }
 
@@ -26,6 +27,11 @@ type Match struct {
 type BackendRef struct {
 	Name
 	BackendRef gwtypes.HTTPBackendRef
+}
+
+type Filter struct {
+	Name
+	Filter gwtypes.HTTPRouteFilter
 }
 
 // ControlPlaneRef represents a control plane reference for Kong configuration.
@@ -84,6 +90,13 @@ func NewHTTPRouteRepresentation(route *gwtypes.HTTPRoute) *HTTPRouteRepresentati
 					Match: match,
 				})
 			}
+			for k, filter := range rule.Filters {
+				filterName := NameFromHTTPRoute(route, "", i, j, k)
+				repr.AddFilterForRule(ruleName, Filter{
+					Name:   filterName,
+					Filter: filter,
+				})
+			}
 			for k, bRef := range rule.BackendRefs {
 				bRefName := NameFromHTTPRoute(route, "", i, j, k)
 				repr.AddBackenRefForRule(ruleName, BackendRef{
@@ -131,8 +144,34 @@ func (t *HTTPRouteRepresentation) AddMatchForRule(rName Name, match Match) {
 			Matches: make(map[string]Match),
 		}
 	}
+	if rule.Matches == nil {
+		rule.Matches = make(map[string]Match)
+	}
 	matchKey := match.String()
 	rule.Matches[matchKey] = match
+	t.Rules[ruleKey] = rule
+}
+
+// AddFilterForRule adds a filter to a specific rule in the HTTPRoute representation.
+// If the rule doesn't exist, it creates a new rule with the provided name.
+// The filter is stored using its name as the key for easy retrieval.
+func (t *HTTPRouteRepresentation) AddFilterForRule(rName Name, filter Filter) {
+	if t.Rules == nil {
+		t.Rules = make(map[string]Rule)
+	}
+	ruleKey := rName.String()
+	rule, exists := t.Rules[ruleKey]
+	if !exists {
+		rule = Rule{
+			Name:    rName,
+			Filters: make(map[string]Filter),
+		}
+	}
+	if rule.Filters == nil {
+		rule.Filters = make(map[string]Filter)
+	}
+	filterKey := filter.String()
+	rule.Filters[filterKey] = filter
 	t.Rules[ruleKey] = rule
 }
 

--- a/controller/hybridgateway/intermediate/name.go
+++ b/controller/hybridgateway/intermediate/name.go
@@ -88,3 +88,8 @@ func (n *Name) GetMatchIndex() int {
 	}
 	return n.indexes[2]
 }
+
+// GetFilterIndex is an alias for GetMatchIndex.
+func (n *Name) GetFilterIndex() int {
+	return n.GetMatchIndex()
+}

--- a/internal/types/gatewaytypes.go
+++ b/internal/types/gatewaytypes.go
@@ -5,36 +5,37 @@ import (
 )
 
 type (
+	AllowedRoutes          = gatewayv1.AllowedRoutes
+	BackendObjectReference = gatewayv1.BackendObjectReference
+	BackendRef             = gatewayv1.BackendRef
+	CommonRouteSpec        = gatewayv1.CommonRouteSpec
+	GRPCRoute              = gatewayv1.GRPCRoute
 	Gateway                = gatewayv1.Gateway
-	GatewayController      = gatewayv1.GatewayController
-	GatewayList            = gatewayv1.GatewayList
 	GatewayClass           = gatewayv1.GatewayClass
 	GatewayClassSpec       = gatewayv1.GatewayClassSpec
+	GatewayController      = gatewayv1.GatewayController
+	GatewayList            = gatewayv1.GatewayList
 	GatewaySpec            = gatewayv1.GatewaySpec
 	GatewayStatusAddress   = gatewayv1.GatewayStatusAddress
-	Listener               = gatewayv1.Listener
+	Group                  = gatewayv1.Group
+	HTTPBackendRef         = gatewayv1.HTTPBackendRef
 	HTTPRoute              = gatewayv1.HTTPRoute
-	HTTPRouteSpec          = gatewayv1.HTTPRouteSpec
-	HTTPRouteRule          = gatewayv1.HTTPRouteRule
+	HTTPRouteFilter        = gatewayv1.HTTPRouteFilter
 	HTTPRouteList          = gatewayv1.HTTPRouteList
 	HTTPRouteMatch         = gatewayv1.HTTPRouteMatch
-	RouteParentStatus      = gatewayv1.RouteParentStatus
-	GRPCRoute              = gatewayv1.GRPCRoute
-	ParentReference        = gatewayv1.ParentReference
-	CommonRouteSpec        = gatewayv1.CommonRouteSpec
+	HTTPRouteRule          = gatewayv1.HTTPRouteRule
+	HTTPRouteSpec          = gatewayv1.HTTPRouteSpec
 	Kind                   = gatewayv1.Kind
+	Listener               = gatewayv1.Listener
 	Namespace              = gatewayv1.Namespace
-	Group                  = gatewayv1.Group
-	AllowedRoutes          = gatewayv1.AllowedRoutes
+	ObjectName             = gatewayv1.ObjectName
+	ParametersReference    = gatewayv1.ParametersReference
+	ParentReference        = gatewayv1.ParentReference
+	PortNumber             = gatewayv1.PortNumber
 	RouteGroupKind         = gatewayv1.RouteGroupKind
 	RouteNamespaces        = gatewayv1.RouteNamespaces
-	ObjectName             = gatewayv1.ObjectName
+	RouteParentStatus      = gatewayv1.RouteParentStatus
 	SectionName            = gatewayv1.SectionName
-	PortNumber             = gatewayv1.PortNumber
-	BackendRef             = gatewayv1.BackendRef
-	BackendObjectReference = gatewayv1.BackendObjectReference
-	HTTPBackendRef         = gatewayv1.HTTPBackendRef
-	ParametersReference    = gatewayv1.ParametersReference
 )
 
 var GroupVersion = gatewayv1.GroupVersion


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds HTTPRoute filters to KongPlugin conversion to the hybridgateway controller.

**Which issue this PR fixes**

Fixes #2334 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
