### PR TITLE
chore(ci): bring CRDs tests from `kubernetes-configuration`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -359,7 +359,7 @@ jobs:
         name: tests-report-unit-tests
         path: unit-tests.xml
 
-  CRDs-validation:
+  CRDs:
     runs-on: ubuntu-latest
     needs: [check-docs-only]
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
@@ -380,6 +380,20 @@ jobs:
 
     - name: Run the crds validation tests
       run: make test.crds-validation
+    
+    # TODO: https://github.com/Kong/kong-operator/issues/2386
+    - name: Create k8s KinD Cluster
+      uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+      with:
+        # NOTE: default is 0.26.0 https://github.com/helm/kind-action/blob/a1b0e391336a6ee6713a0583f8c6240d70863de3/kind.sh#L21
+        # so bump this manually
+        version: v0.27.0
+
+    - name: Verify installing CRDs via kustomize works
+      run: make install.only
+
+    - name: Run the rest of CRDs tests
+      run: make test.crds
 
   envtest-tests:
     runs-on: ubuntu-latest
@@ -717,7 +731,7 @@ jobs:
       - samples
       - install-with-kustomize
       - build
-      - CRDs-validation
+      - CRDs
       - unit-tests
       - envtest-tests
       - kongintegration-tests

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -193,6 +193,10 @@ linters:
           - forbidigo
         path: internal/types/operatortypes.go
         text: use of `operatorv2beta1.(ControlPlane\w*)` forbidden
+      - linters:
+          - forbidigo
+        path: api/test
+        text: use of `operatorv1beta1.(ControlPlane\w*)` forbidden
     paths:
       - pkg/clientset
       - config/

--- a/Makefile
+++ b/Makefile
@@ -602,6 +602,31 @@ test.crds-validation:
 test.crds-validation.pretty:
 	$(MAKE) _test.envtest GOTESTSUM_FORMAT=testname ENVTEST_TEST_PATHS=./test/crdsvalidation/...
 
+# --- Section just to run tests that require CRDs to be installed in the cluste.r ---
+# TODO: https://github.com/Kong/kong-operator/issues/2386
+
+# Define a constant list of channels
+CHANNELS := ingress-controller-incubator gateway-operator kong-operator
+
+.PHONY: install.only
+install.only: kustomize
+	@for channel in $(CHANNELS); do \
+		$(KUSTOMIZE) build config/crd/$$channel | kubectl apply --server-side -f -; \
+	done
+
+# Running this target requires to have a cluster with the CRDs installed (make install.only) available.
+.PHONY: test.crds
+test.crds: gotestsum
+	GOFLAGS=$(GOFLAGS) \
+	GOTESTSUM_FORMAT=$(GOTESTSUM_FORMAT) \
+	$(GOTESTSUM) -- $(GOTESTFLAGS) \
+	-timeout $(INTEGRATION_TEST_TIMEOUT) \
+	-ldflags "$(LDFLAGS_COMMON) $(LDFLAGS) $(LDFLAGS_METADATA)" \
+	-race \
+	-coverprofile=$(COVERPROFILE) \
+	./api/test/...
+# --- End of section just to run tests that require CRDs to be installed in the cluster. ---
+
 .PHONY: _test.integration
 _test.integration: gotestsum download.telepresence
 	KUBECONFIG=$(KUBECONFIG) \

--- a/api/test/conversion/gateway-operator.konghq.com/v1beta1/common.go
+++ b/api/test/conversion/gateway-operator.konghq.com/v1beta1/common.go
@@ -1,0 +1,30 @@
+package v1beta1_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// dummyHub implements conversion.Hub but is not the expected type for conversion.
+type dummyHub struct{}
+
+// Hub implements conversion.Hub for dummyHub
+func (d *dummyHub) Hub() {}
+
+// GetObjectKind implements runtime.Object methods for dummyHub
+func (d *dummyHub) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
+
+// DeepCopyObject implements runtime.Object for dummyHub
+func (d *dummyHub) DeepCopyObject() runtime.Object { return &dummyHub{} }
+
+func testConversionError(t *testing.T, testFunc func() error, expectedMsgFormat string) {
+	t.Helper()
+	err := testFunc()
+	require.Error(t, err)
+	expectedMsg := fmt.Sprintf(expectedMsgFormat, &dummyHub{})
+	require.EqualError(t, err, expectedMsg)
+}

--- a/api/test/conversion/gateway-operator.konghq.com/v1beta1/controlplane_test.go
+++ b/api/test/conversion/gateway-operator.konghq.com/v1beta1/controlplane_test.go
@@ -1,0 +1,587 @@
+package v1beta1_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	operatorv1beta1 "github.com/kong/kong-operator/api/gateway-operator/v1beta1"
+	operatorv2beta1 "github.com/kong/kong-operator/api/gateway-operator/v2beta1"
+)
+
+func TestControlPlane_ConvertTo(t *testing.T) {
+	t.Run("error: wrong hub type", func(t *testing.T) {
+		obj := &operatorv1beta1.ControlPlane{}
+		testConversionError(t, func() error {
+			return obj.ConvertTo(&dummyHub{})
+		}, "ControlPlane ConvertTo: expected *operatorv2beta1.ControlPlane, got %T")
+	})
+
+	cases := []struct {
+		name                 string
+		spec                 operatorv1beta1.ControlPlaneSpec
+		objPatchFunc         func(obj *operatorv1beta1.ControlPlane)
+		expectsDataPlane     bool
+		expectedIngressClass *string
+		expectedFeatureGates []operatorv2beta1.ControlPlaneFeatureGate
+		expectedControllers  []operatorv2beta1.ControlPlaneController
+		expectedError        error
+	}{
+		{
+			name: "With DataPlane ref",
+			spec: operatorv1beta1.ControlPlaneSpec{
+				ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+					DataPlane: lo.ToPtr("test-dataplane"),
+					WatchNamespaces: &operatorv1beta1.WatchNamespaces{
+						Type: operatorv1beta1.WatchNamespacesTypeAll,
+					},
+					Extensions: []commonv1alpha1.ExtensionRef{
+						{
+							Group: "konnect.konghq.com",
+							Kind:  "KonnectExtension",
+							NamespacedRef: commonv1alpha1.NamespacedRef{
+								Name: "test-extension",
+							},
+						},
+					},
+					Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{
+						Replicas: lo.ToPtr(int32(2)),
+						PodTemplateSpec: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "controller",
+										Image: "kong/controller:latest",
+										Env: []corev1.EnvVar{
+											{
+												Name:  "CONTROLLER_FEATURE_GATES",
+												Value: "GatewayAlpha=true,ExperimentalFeature=false",
+											},
+											{
+												Name:  "CONTROLLER_ENABLE_CONTROLLER_INGRESS_CLASS_NETWORKINGV1",
+												Value: "true",
+											},
+											{
+												Name:  "CONTROLLER_ENABLE_CONTROLLER_KONG_PLUGIN",
+												Value: "false",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedIngressClass: lo.ToPtr("kong"),
+			expectsDataPlane:     true,
+			expectedFeatureGates: []operatorv2beta1.ControlPlaneFeatureGate{
+				{Name: "GatewayAlpha", State: operatorv2beta1.FeatureGateStateEnabled},
+				{Name: "ExperimentalFeature", State: operatorv2beta1.FeatureGateStateDisabled},
+			},
+			expectedControllers: []operatorv2beta1.ControlPlaneController{
+				{Name: "INGRESS_CLASS_NETWORKINGV1", State: operatorv2beta1.ControllerStateEnabled},
+				{Name: "KONG_PLUGIN", State: operatorv2beta1.ControllerStateDisabled},
+			},
+		},
+		{
+			name: "With EnvFrom and ValueFrom returns error",
+			spec: operatorv1beta1.ControlPlaneSpec{
+				ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+					DataPlane: lo.ToPtr("test-dataplane"),
+					Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{
+						PodTemplateSpec: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "controller",
+										Image: "kong/controller:latest",
+										Env: []corev1.EnvVar{
+											{
+												Name: "POD_NAME",
+												ValueFrom: &corev1.EnvVarSource{
+													FieldRef: &corev1.ObjectFieldSelector{
+														FieldPath: "metadata.name",
+													},
+												},
+											},
+											{
+												Name: "POD_NAMESPACE",
+												ValueFrom: &corev1.EnvVarSource{
+													FieldRef: &corev1.ObjectFieldSelector{
+														FieldPath: "metadata.namespace",
+													},
+												},
+											},
+											{
+												Name: "CONTROLLER_FEATURE_GATES",
+												ValueFrom: &corev1.EnvVarSource{
+													SecretKeyRef: &corev1.SecretKeySelector{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "secret-with-fg",
+														},
+														Key: "fg-key",
+													},
+												},
+											},
+											{
+												Name: "CONTROLLER_ENABLE_CONTROLLER_KONG_PLUGIN",
+												ValueFrom: &corev1.EnvVarSource{
+													SecretKeyRef: &corev1.SecretKeySelector{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "configmap-controllers",
+														},
+														Key: "kp-key",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				IngressClass: lo.ToPtr("kong"),
+			},
+			expectedError: errors.New("ControlPlane v1beta1 can't be converted, because environment variable: CONTROLLER_FEATURE_GATES is populated with EnvFrom, manual adjustment is needed"),
+		},
+		{
+			name: "With EnvFrom on container level",
+			spec: operatorv1beta1.ControlPlaneSpec{
+				ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+					DataPlane: lo.ToPtr("test-dataplane"),
+					Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{
+						PodTemplateSpec: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "controller",
+										Image: "kong/controller:latest",
+										EnvFrom: []corev1.EnvFromSource{
+											{
+												ConfigMapRef: &corev1.ConfigMapEnvSource{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: "configmap-controllers",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				IngressClass: lo.ToPtr("kong"),
+			},
+			expectedError: errors.New("ControlPlane v1beta1 can't be converted, because EnvFrom is used on container level (converter can't reason about values), manual adjustment is needed"),
+		},
+		{
+			name: "Without DataPlane ref (managed by owner)",
+			spec: operatorv1beta1.ControlPlaneSpec{
+				ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+					WatchNamespaces: &operatorv1beta1.WatchNamespaces{
+						Type: operatorv1beta1.WatchNamespacesTypeList,
+						List: []string{"namespace1", "namespace2"},
+					},
+				},
+				IngressClass: lo.ToPtr("test"),
+			},
+			expectedIngressClass: lo.ToPtr("test"),
+			expectsDataPlane:     false,
+		},
+		{
+			name: "With DataPlane ref but managed by Gateway",
+			spec: operatorv1beta1.ControlPlaneSpec{
+				ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+					DataPlane: lo.ToPtr("test-dataplane"),
+				},
+			},
+			objPatchFunc: func(obj *operatorv1beta1.ControlPlane) {
+				obj.OwnerReferences = []metav1.OwnerReference{
+					{
+						APIVersion: "gateway.networking.k8s.io/v1",
+						Kind:       "Gateway",
+						Name:       "test-gateway",
+						UID:        "12345",
+					},
+				}
+			},
+			expectsDataPlane: false,
+		},
+		{
+			name: "With own namespace watching",
+			spec: operatorv1beta1.ControlPlaneSpec{
+				ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+					WatchNamespaces: &operatorv1beta1.WatchNamespaces{
+						Type: operatorv1beta1.WatchNamespacesTypeOwn,
+					},
+				},
+			},
+			expectedIngressClass: lo.ToPtr("kong"),
+			expectsDataPlane:     false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &operatorv1beta1.ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-controlplane",
+					Namespace: "test-namespace",
+				},
+				Spec: tc.spec,
+				Status: operatorv1beta1.ControlPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   "Ready",
+							Status: metav1.ConditionTrue,
+							Reason: "AllGood",
+						},
+					},
+				},
+			}
+			if tc.objPatchFunc != nil {
+				tc.objPatchFunc(obj)
+			}
+
+			dst := &operatorv2beta1.ControlPlane{}
+			err := obj.ConvertTo(dst)
+			if tc.expectedError != nil {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedError.Error())
+				return
+			}
+			require.NoError(t, err)
+
+			require.Equal(t, obj.ObjectMeta, dst.ObjectMeta)
+
+			if tc.expectsDataPlane {
+				require.Equal(t, operatorv2beta1.ControlPlaneDataPlaneTargetRefType, dst.Spec.DataPlane.Type)
+				require.NotNil(t, dst.Spec.DataPlane.Ref)
+				require.Equal(t, lo.FromPtr(tc.spec.DataPlane), dst.Spec.DataPlane.Ref.Name)
+			} else {
+				require.Equal(t, operatorv2beta1.ControlPlaneDataPlaneTargetManagedByType, dst.Spec.DataPlane.Type)
+				require.Nil(t, dst.Spec.DataPlane.Ref)
+			}
+
+			require.Equal(t, tc.expectedIngressClass, dst.Spec.IngressClass)
+
+			if tc.spec.WatchNamespaces != nil {
+				require.NotNil(t, dst.Spec.WatchNamespaces)
+				require.Equal(t, operatorv2beta1.WatchNamespacesType(tc.spec.WatchNamespaces.Type), dst.Spec.WatchNamespaces.Type)
+				require.Equal(t, tc.spec.WatchNamespaces.List, dst.Spec.WatchNamespaces.List)
+			} else {
+				require.Empty(t, dst.Spec.WatchNamespaces)
+			}
+
+			require.Equal(t, tc.spec.Extensions, dst.Spec.Extensions)
+
+			if tc.expectedFeatureGates != nil {
+				require.ElementsMatch(t, tc.expectedFeatureGates, dst.Spec.FeatureGates)
+			}
+
+			if tc.expectedControllers != nil {
+				require.ElementsMatch(t, tc.expectedControllers, dst.Spec.Controllers)
+			}
+
+			require.Equal(t, obj.Status.Conditions, dst.Status.Conditions)
+		})
+	}
+}
+
+func TestControlPlane_ConvertFrom(t *testing.T) {
+	t.Run("error: wrong hub type", func(t *testing.T) {
+		obj := &operatorv1beta1.ControlPlane{}
+		testConversionError(t, func() error {
+			return obj.ConvertFrom(&dummyHub{})
+		}, "ControlPlane ConvertFrom: expected *operatorv2beta1.ControlPlane, got %T")
+	})
+
+	cases := []struct {
+		name             string
+		src              operatorv2beta1.ControlPlaneSpec
+		expectsDataPlane bool
+	}{
+		{
+			name: "With DataPlane ref",
+			src: operatorv2beta1.ControlPlaneSpec{
+				DataPlane: operatorv2beta1.ControlPlaneDataPlaneTarget{
+					Type: operatorv2beta1.ControlPlaneDataPlaneTargetRefType,
+					Ref: &operatorv2beta1.ControlPlaneDataPlaneTargetRef{
+						Name: "test-dataplane",
+					},
+				},
+				ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+					IngressClass: lo.ToPtr("kong"),
+					WatchNamespaces: &operatorv2beta1.WatchNamespaces{
+						Type: operatorv2beta1.WatchNamespacesTypeAll,
+					},
+					FeatureGates: []operatorv2beta1.ControlPlaneFeatureGate{
+						{Name: "GatewayAlpha", State: operatorv2beta1.FeatureGateStateEnabled},
+						{Name: "ExperimentalFeature", State: operatorv2beta1.FeatureGateStateDisabled},
+					},
+				},
+				Extensions: []commonv1alpha1.ExtensionRef{
+					{
+						Group: "konnect.konghq.com",
+						Kind:  "KonnectExtension",
+						NamespacedRef: commonv1alpha1.NamespacedRef{
+							Name: "test-extension",
+						},
+					},
+				},
+			},
+			expectsDataPlane: true,
+		},
+		{
+			name: "With managedByOwner DataPlane",
+			src: operatorv2beta1.ControlPlaneSpec{
+				DataPlane: operatorv2beta1.ControlPlaneDataPlaneTarget{
+					Type: operatorv2beta1.ControlPlaneDataPlaneTargetManagedByType,
+				},
+				ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+					IngressClass: lo.ToPtr("kong"),
+					WatchNamespaces: &operatorv2beta1.WatchNamespaces{
+						Type: operatorv2beta1.WatchNamespacesTypeList,
+						List: []string{"namespace1", "namespace2"},
+					},
+				},
+			},
+			expectsDataPlane: false,
+		},
+		{
+			name: "With own namespace watching",
+			src: operatorv2beta1.ControlPlaneSpec{
+				DataPlane: operatorv2beta1.ControlPlaneDataPlaneTarget{
+					Type: operatorv2beta1.ControlPlaneDataPlaneTargetManagedByType,
+				},
+				ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+					WatchNamespaces: &operatorv2beta1.WatchNamespaces{
+						Type: operatorv2beta1.WatchNamespacesTypeOwn,
+					},
+				},
+			},
+			expectsDataPlane: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &operatorv1beta1.ControlPlane{}
+
+			src := &operatorv2beta1.ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-controlplane",
+					Namespace: "test-namespace",
+				},
+				Spec: tc.src,
+				Status: operatorv2beta1.ControlPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   "Ready",
+							Status: metav1.ConditionTrue,
+							Reason: "AllGood",
+						},
+					},
+					FeatureGates: []operatorv2beta1.ControlPlaneFeatureGate{
+						{Name: "StatusFeatureGate", State: operatorv2beta1.FeatureGateStateEnabled},
+					},
+					Controllers: []operatorv2beta1.ControlPlaneController{
+						{Name: "StatusController", State: operatorv2beta1.ControllerStateEnabled},
+					},
+				},
+			}
+
+			require.NoError(t, obj.ConvertFrom(src))
+
+			require.Equal(t, src.ObjectMeta, obj.ObjectMeta)
+
+			if tc.expectsDataPlane {
+				require.NotNil(t, obj.Spec.DataPlane)
+				require.Equal(t, tc.src.DataPlane.Ref.Name, *obj.Spec.DataPlane)
+			} else {
+				require.Nil(t, obj.Spec.DataPlane)
+			}
+
+			require.Equal(t, tc.src.IngressClass, obj.Spec.IngressClass)
+
+			if tc.src.WatchNamespaces != nil {
+				require.NotNil(t, obj.Spec.WatchNamespaces)
+				require.Equal(t, operatorv1beta1.WatchNamespacesType(tc.src.WatchNamespaces.Type), obj.Spec.WatchNamespaces.Type)
+				require.Equal(t, tc.src.WatchNamespaces.List, obj.Spec.WatchNamespaces.List)
+			} else {
+				require.Nil(t, obj.Spec.WatchNamespaces)
+			}
+
+			require.Equal(t, tc.src.Extensions, obj.Spec.Extensions)
+
+			require.Equal(t, src.Status.Conditions, obj.Status.Conditions)
+		})
+	}
+}
+
+func TestControlPlane_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		src  operatorv2beta1.ControlPlaneSpec
+	}{
+		{
+			name: "Complete configuration with all options",
+			src: operatorv2beta1.ControlPlaneSpec{
+				DataPlane: operatorv2beta1.ControlPlaneDataPlaneTarget{
+					Type: operatorv2beta1.ControlPlaneDataPlaneTargetRefType,
+					Ref: &operatorv2beta1.ControlPlaneDataPlaneTargetRef{
+						Name: "test-dataplane",
+					},
+				},
+				ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+					IngressClass: lo.ToPtr("kong"),
+					WatchNamespaces: &operatorv2beta1.WatchNamespaces{
+						Type: operatorv2beta1.WatchNamespacesTypeAll,
+					},
+					FeatureGates: []operatorv2beta1.ControlPlaneFeatureGate{
+						{Name: "GatewayAlpha", State: operatorv2beta1.FeatureGateStateEnabled},
+						{Name: "ExperimentalFeature", State: operatorv2beta1.FeatureGateStateDisabled},
+					},
+					Controllers: []operatorv2beta1.ControlPlaneController{
+						{Name: "INGRESS_CLASS_NETWORKINGV1", State: operatorv2beta1.ControllerStateEnabled},
+						{Name: "KONG_PLUGIN", State: operatorv2beta1.ControllerStateDisabled},
+					},
+					DataPlaneSync: &operatorv2beta1.ControlPlaneDataPlaneSync{
+						ReverseSync: lo.ToPtr(operatorv2beta1.ControlPlaneReverseSyncStateEnabled),
+					},
+					GatewayDiscovery: &operatorv2beta1.ControlPlaneGatewayDiscovery{
+						ReadinessCheckInterval: &metav1.Duration{Duration: 30 * time.Second},
+						ReadinessCheckTimeout:  &metav1.Duration{Duration: 5 * time.Second},
+					},
+					Cache: &operatorv2beta1.ControlPlaneK8sCache{
+						InitSyncDuration: &metav1.Duration{Duration: 60 * time.Second},
+					},
+					Translation: &operatorv2beta1.ControlPlaneTranslationOptions{
+						CombinedServicesFromDifferentHTTPRoutes: lo.ToPtr(operatorv2beta1.ControlPlaneCombinedServicesFromDifferentHTTPRoutesStateEnabled),
+						FallbackConfiguration: &operatorv2beta1.ControlPlaneFallbackConfiguration{
+							UseLastValidConfig: lo.ToPtr(operatorv2beta1.ControlPlaneFallbackConfigurationStateDisabled),
+						},
+						DrainSupport: lo.ToPtr(operatorv2beta1.ControlPlaneDrainSupportStateEnabled),
+					},
+					ConfigDump: &operatorv2beta1.ControlPlaneConfigDump{
+						State:         operatorv2beta1.ConfigDumpStateEnabled,
+						DumpSensitive: operatorv2beta1.ConfigDumpStateDisabled,
+					},
+					Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+						ConsumersSync: lo.ToPtr(operatorv2beta1.ControlPlaneKonnectConsumersSyncStateEnabled),
+						Licensing: &operatorv2beta1.ControlPlaneKonnectLicensing{
+							State:                lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
+							InitialPollingPeriod: &metav1.Duration{Duration: 10 * time.Second},
+							PollingPeriod:        &metav1.Duration{Duration: 60 * time.Second},
+							StorageState:         lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateDisabled),
+						},
+						NodeRefreshPeriod:  &metav1.Duration{Duration: 30 * time.Second},
+						ConfigUploadPeriod: &metav1.Duration{Duration: 10 * time.Second},
+					},
+				},
+				Extensions: []commonv1alpha1.ExtensionRef{
+					{
+						Group: "konnect.konghq.com",
+						Kind:  "KonnectExtension",
+						NamespacedRef: commonv1alpha1.NamespacedRef{
+							Name: "test-extension",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Minimal configuration with managed dataplane",
+			src: operatorv2beta1.ControlPlaneSpec{
+				DataPlane: operatorv2beta1.ControlPlaneDataPlaneTarget{
+					Type: operatorv2beta1.ControlPlaneDataPlaneTargetManagedByType,
+				},
+				ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+					IngressClass: lo.ToPtr("kong"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			original := &operatorv2beta1.ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-controlplane",
+					Namespace: "test-namespace",
+				},
+				Spec: tc.src,
+				Status: operatorv2beta1.ControlPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   "Ready",
+							Status: metav1.ConditionTrue,
+							Reason: "AllGood",
+						},
+					},
+				},
+			}
+
+			intermediate := &operatorv1beta1.ControlPlane{}
+			err := intermediate.ConvertFrom(original)
+			require.NoError(t, err)
+
+			roundTrip := &operatorv2beta1.ControlPlane{}
+			err = intermediate.ConvertTo(roundTrip)
+			require.NoError(t, err)
+
+			require.Equal(t, original.ObjectMeta, roundTrip.ObjectMeta)
+			require.Equal(t, original.Spec.DataPlane, roundTrip.Spec.DataPlane)
+			require.Equal(t, original.Spec.IngressClass, roundTrip.Spec.IngressClass)
+
+			if original.Spec.WatchNamespaces == nil {
+				if roundTrip.Spec.WatchNamespaces != nil {
+					require.Empty(t, roundTrip.Spec.WatchNamespaces.Type)
+					require.Nil(t, roundTrip.Spec.WatchNamespaces.List)
+				}
+			} else {
+				require.Equal(t, original.Spec.WatchNamespaces, roundTrip.Spec.WatchNamespaces)
+			}
+
+			require.Equal(t, original.Spec.Extensions, roundTrip.Spec.Extensions)
+			require.ElementsMatch(t, original.Spec.FeatureGates, roundTrip.Spec.FeatureGates)
+			require.ElementsMatch(t, original.Spec.Controllers, roundTrip.Spec.Controllers)
+			require.Equal(t, original.Status.Conditions, roundTrip.Status.Conditions)
+
+			if original.Spec.DataPlaneSync != nil {
+				require.NotNil(t, roundTrip.Spec.DataPlaneSync)
+				require.Equal(t, original.Spec.DataPlaneSync.ReverseSync, roundTrip.Spec.DataPlaneSync.ReverseSync)
+			}
+			if original.Spec.GatewayDiscovery != nil {
+				require.NotNil(t, roundTrip.Spec.GatewayDiscovery)
+				require.Equal(t, original.Spec.GatewayDiscovery.ReadinessCheckInterval, roundTrip.Spec.GatewayDiscovery.ReadinessCheckInterval)
+				require.Equal(t, original.Spec.GatewayDiscovery.ReadinessCheckTimeout, roundTrip.Spec.GatewayDiscovery.ReadinessCheckTimeout)
+			}
+			if original.Spec.Cache != nil {
+				require.NotNil(t, roundTrip.Spec.Cache)
+				require.Equal(t, original.Spec.Cache.InitSyncDuration, roundTrip.Spec.Cache.InitSyncDuration)
+			}
+			if original.Spec.Translation != nil {
+				require.NotNil(t, roundTrip.Spec.Translation)
+				require.Equal(t, original.Spec.Translation, roundTrip.Spec.Translation)
+			}
+			if original.Spec.ConfigDump != nil {
+				require.NotNil(t, roundTrip.Spec.ConfigDump)
+				require.Equal(t, original.Spec.ConfigDump, roundTrip.Spec.ConfigDump)
+			}
+			if original.Spec.Konnect != nil {
+				require.NotNil(t, roundTrip.Spec.Konnect)
+				require.Equal(t, original.Spec.Konnect, roundTrip.Spec.Konnect)
+			}
+		})
+	}
+}

--- a/api/test/conversion/gateway-operator.konghq.com/v1beta1/gatewayconfiguration_test.go
+++ b/api/test/conversion/gateway-operator.konghq.com/v1beta1/gatewayconfiguration_test.go
@@ -1,0 +1,628 @@
+package v1beta1_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	operatorv1beta1 "github.com/kong/kong-operator/api/gateway-operator/v1beta1"
+	operatorv2beta1 "github.com/kong/kong-operator/api/gateway-operator/v2beta1"
+)
+
+func TestGatewayConfiguration_ConvertTo(t *testing.T) {
+	t.Run("error: wrong hub type", func(t *testing.T) {
+		obj := &operatorv1beta1.GatewayConfiguration{}
+		testConversionError(t, func() error {
+			return obj.ConvertTo(&dummyHub{})
+		}, "GatewayConfiguration ConvertTo: expected *operatorv2beta1.GatewayConfiguration, got %T")
+	})
+
+	cases := []struct {
+		name                     string
+		spec                     operatorv1beta1.GatewayConfigurationSpec
+		expectedDataPlane        *operatorv2beta1.GatewayConfigDataPlaneOptions
+		expectedControlPlane     *operatorv2beta1.GatewayConfigControlPlaneOptions
+		expectedListenersOptions []operatorv2beta1.GatewayConfigurationListenerOptions
+		expectedExtensions       []commonv1alpha1.ExtensionRef
+		expectedError            error
+	}{
+		{
+			name: "empty spec",
+			spec: operatorv1beta1.GatewayConfigurationSpec{},
+		},
+		{
+			name: "DataPlane Options",
+			spec: operatorv1beta1.GatewayConfigurationSpec{
+				DataPlaneOptions: &operatorv1beta1.GatewayConfigDataPlaneOptions{
+					Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+						DeploymentOptions: operatorv1beta1.DeploymentOptions{
+							Replicas: lo.ToPtr(int32(2)),
+						},
+					},
+				},
+			},
+			expectedDataPlane: &operatorv2beta1.GatewayConfigDataPlaneOptions{
+				Deployment: operatorv2beta1.DataPlaneDeploymentOptions{
+					DeploymentOptions: operatorv2beta1.DeploymentOptions{
+						Replicas: lo.ToPtr(int32(2)),
+					},
+				},
+			},
+		},
+		{
+			name: "ControlPlane IngressClass Option",
+			spec: operatorv1beta1.GatewayConfigurationSpec{
+				ControlPlaneOptions: &operatorv1beta1.ControlPlaneOptions{
+					Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{
+						PodTemplateSpec: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "controller",
+										Image: "kong/controller:latest",
+										Env: []corev1.EnvVar{
+											{
+												Name:  "CONTROLLER_INGRESS_CLASS",
+												Value: "kong",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedControlPlane: &operatorv2beta1.GatewayConfigControlPlaneOptions{
+				ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+					IngressClass: lo.ToPtr("kong"),
+				},
+			},
+		},
+		{
+			name: "DataPlane and ControlPlane Options",
+			spec: operatorv1beta1.GatewayConfigurationSpec{
+				Extensions: []commonv1alpha1.ExtensionRef{
+					{
+						NamespacedRef: commonv1alpha1.NamespacedRef{
+							Name: "test-extension",
+						},
+						Group: "test.group",
+						Kind:  "Konnect",
+					},
+				},
+				DataPlaneOptions: &operatorv1beta1.GatewayConfigDataPlaneOptions{
+					Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+						DeploymentOptions: operatorv1beta1.DeploymentOptions{
+							Replicas: lo.ToPtr(int32(2)),
+						},
+					},
+					Extensions: []commonv1alpha1.ExtensionRef{
+						{
+							NamespacedRef: commonv1alpha1.NamespacedRef{
+								Name: "test-extension",
+							},
+							Group: "test.group",
+							Kind:  "Konnect",
+						},
+					},
+				},
+				ControlPlaneOptions: &operatorv1beta1.ControlPlaneOptions{
+					Extensions: []commonv1alpha1.ExtensionRef{
+						{
+							NamespacedRef: commonv1alpha1.NamespacedRef{
+								Name: "extension-1",
+							},
+							Group: "test.group",
+							Kind:  "Test1",
+						},
+						{
+							NamespacedRef: commonv1alpha1.NamespacedRef{
+								Name: "extension-2",
+							},
+							Group: "test.group",
+							Kind:  "Test2",
+						},
+					},
+					Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{
+						PodTemplateSpec: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "controller",
+										Image: "kong/controller:latest",
+										Env: []corev1.EnvVar{
+											{
+												Name:  "CONTROLLER_FEATURE_GATES",
+												Value: "GatewayAlpha=true,ExperimentalFeature=false",
+											},
+											{
+												Name:  "CONTROLLER_ENABLE_CONTROLLER_INGRESS_CLASS_NETWORKINGV1",
+												Value: "true",
+											},
+											{
+												Name:  "CONTROLLER_ENABLE_CONTROLLER_KONG_PLUGIN",
+												Value: "false",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDataPlane: &operatorv2beta1.GatewayConfigDataPlaneOptions{
+				Deployment: operatorv2beta1.DataPlaneDeploymentOptions{
+					DeploymentOptions: operatorv2beta1.DeploymentOptions{
+						Replicas: lo.ToPtr(int32(2)),
+					},
+				},
+			},
+			expectedControlPlane: &operatorv2beta1.GatewayConfigControlPlaneOptions{
+				ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+					FeatureGates: []operatorv2beta1.ControlPlaneFeatureGate{
+						{Name: "GatewayAlpha", State: operatorv2beta1.FeatureGateStateEnabled},
+						{Name: "ExperimentalFeature", State: operatorv2beta1.FeatureGateStateDisabled},
+					},
+					Controllers: []operatorv2beta1.ControlPlaneController{
+						{Name: "INGRESS_CLASS_NETWORKINGV1", State: operatorv2beta1.ControllerStateEnabled},
+						{Name: "KONG_PLUGIN", State: operatorv2beta1.ControllerStateDisabled},
+					},
+				},
+			},
+			expectedExtensions: []commonv1alpha1.ExtensionRef{
+				{
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "extension-1",
+					},
+					Group: "test.group",
+					Kind:  "Test1",
+				},
+				{
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "extension-2",
+					},
+					Group: "test.group",
+					Kind:  "Test2",
+				},
+			},
+		},
+		{
+			name: "With ListenersOptions",
+			spec: operatorv1beta1.GatewayConfigurationSpec{
+				ListenersOptions: []operatorv1beta1.GatewayConfigurationListenerOptions{
+					{
+						Name:     "listener-1",
+						NodePort: int32(3000),
+					},
+				},
+			},
+			expectedListenersOptions: []operatorv2beta1.GatewayConfigurationListenerOptions{
+				{
+					Name:     "listener-1",
+					NodePort: int32(3000),
+				},
+			},
+		},
+		{
+			name: "With ControlPlane's Dataplane option set",
+			spec: operatorv1beta1.GatewayConfigurationSpec{
+				DataPlaneOptions: &operatorv1beta1.GatewayConfigDataPlaneOptions{
+					Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+						DeploymentOptions: operatorv1beta1.DeploymentOptions{
+							Replicas: lo.ToPtr(int32(2)),
+						},
+					},
+				},
+				ControlPlaneOptions: &operatorv1beta1.ControlPlaneOptions{
+					DataPlane: lo.ToPtr("test-data-plane"),
+				},
+			},
+			expectedError: errors.New("GatewayConfiguration ConvertTo: ControlPlaneOptions.DataPlane is not supported"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &operatorv1beta1.GatewayConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-controlplane",
+					Namespace: "test-namespace",
+				},
+				Spec: tc.spec,
+				Status: operatorv1beta1.GatewayConfigurationStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   "Ready",
+							Status: metav1.ConditionTrue,
+							Reason: "AllGood",
+						},
+					},
+				},
+			}
+
+			dst := &operatorv2beta1.GatewayConfiguration{}
+			err := obj.ConvertTo(dst)
+			if tc.expectedError != nil {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedError.Error())
+				return
+			}
+			require.NoError(t, err)
+
+			require.Equal(t, obj.ObjectMeta, dst.ObjectMeta)
+			if tc.expectedControlPlane != nil {
+				require.Equal(t, tc.expectedControlPlane.IngressClass, dst.Spec.ControlPlaneOptions.IngressClass)
+
+				if tc.expectedControlPlane.WatchNamespaces != nil {
+					require.NotNil(t, dst.Spec.ControlPlaneOptions.WatchNamespaces)
+					require.Equal(t, tc.expectedControlPlane.WatchNamespaces.Type, dst.Spec.ControlPlaneOptions.WatchNamespaces.Type)
+					require.Equal(t, tc.expectedControlPlane.WatchNamespaces.List, dst.Spec.ControlPlaneOptions.WatchNamespaces.List)
+				} else {
+					require.Empty(t, dst.Spec.ControlPlaneOptions.WatchNamespaces)
+				}
+
+				if tc.expectedControlPlane.FeatureGates != nil {
+					require.ElementsMatch(t, tc.expectedControlPlane.FeatureGates, dst.Spec.ControlPlaneOptions.FeatureGates)
+				}
+
+				if tc.expectedControlPlane.Controllers != nil {
+					require.ElementsMatch(t, tc.expectedControlPlane.Controllers, dst.Spec.ControlPlaneOptions.Controllers)
+				}
+			}
+			require.Equal(t, tc.expectedDataPlane, dst.Spec.DataPlaneOptions)
+			require.Equal(t, tc.expectedListenersOptions, dst.Spec.ListenersOptions)
+			require.Equal(t, tc.expectedExtensions, dst.Spec.Extensions)
+			require.Equal(t, obj.Status.Conditions, dst.Status.Conditions)
+		})
+	}
+}
+
+func TestGatewayConfiguration_ConvertFrom(t *testing.T) {
+	t.Run("error: wrong hub type", func(t *testing.T) {
+		obj := &operatorv1beta1.GatewayConfiguration{}
+		testConversionError(t, func() error {
+			return obj.ConvertFrom(&dummyHub{})
+		}, "GatewayConfiguration ConvertFrom: expected *operatorv2beta1.GatewayConfiguration, got %T")
+	})
+
+	cases := []struct {
+		name                     string
+		spec                     operatorv2beta1.GatewayConfigurationSpec
+		expectedDataPlane        *operatorv1beta1.GatewayConfigDataPlaneOptions
+		expectedControlPlane     *operatorv1beta1.ControlPlaneOptions
+		expectedListenersOptions []operatorv2beta1.GatewayConfigurationListenerOptions
+		expectedExtensions       []commonv1alpha1.ExtensionRef
+		expectedError            error
+	}{
+		{
+			name: "Full fledged case",
+			spec: operatorv2beta1.GatewayConfigurationSpec{
+				ControlPlaneOptions: &operatorv2beta1.GatewayConfigControlPlaneOptions{
+					ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+						IngressClass: lo.ToPtr("kong"),
+						WatchNamespaces: &operatorv2beta1.WatchNamespaces{
+							Type: operatorv2beta1.WatchNamespacesTypeAll,
+						},
+						Controllers: []operatorv2beta1.ControlPlaneController{
+							{Name: "FEATURE_A", State: operatorv2beta1.ControllerStateEnabled},
+							{Name: "FEATURE_B", State: operatorv2beta1.ControllerStateDisabled},
+						},
+						FeatureGates: []operatorv2beta1.ControlPlaneFeatureGate{
+							{Name: "GatewayAlpha", State: operatorv2beta1.FeatureGateStateEnabled},
+							{Name: "ExperimentalFeature", State: operatorv2beta1.FeatureGateStateDisabled},
+						},
+					},
+				},
+				DataPlaneOptions: &operatorv2beta1.GatewayConfigDataPlaneOptions{
+					Deployment: operatorv2beta1.DataPlaneDeploymentOptions{
+						DeploymentOptions: operatorv2beta1.DeploymentOptions{
+							Replicas: lo.ToPtr(int32(2)),
+						},
+					},
+				},
+				ListenersOptions: []operatorv2beta1.GatewayConfigurationListenerOptions{
+					{
+						Name:     "listener-1",
+						NodePort: int32(3000),
+					},
+				},
+				Extensions: []commonv1alpha1.ExtensionRef{
+					{
+						Group: "konnect.konghq.com",
+						Kind:  "KonnectExtension",
+						NamespacedRef: commonv1alpha1.NamespacedRef{
+							Name: "konnect-extension",
+						},
+					},
+					{
+						Group: "gateway-operator.konghq.com",
+						Kind:  "DataPlaneMetricsExtension",
+						NamespacedRef: commonv1alpha1.NamespacedRef{
+							Name: "metrics-extension",
+						},
+					},
+				},
+			},
+			expectedDataPlane: &operatorv1beta1.GatewayConfigDataPlaneOptions{
+				Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+					DeploymentOptions: operatorv1beta1.DeploymentOptions{
+						Replicas: lo.ToPtr(int32(2)),
+					},
+				},
+			},
+			expectedControlPlane: &operatorv1beta1.ControlPlaneOptions{
+				Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{
+					PodTemplateSpec: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "controller",
+									Image: "kong/controller:latest",
+									Env: []corev1.EnvVar{
+										{
+											Name:  "CONTROLLER_FEATURE_GATES",
+											Value: "GatewayAlpha=true,ExperimentalFeature=false",
+										},
+										{
+											Name:  "CONTROLLER_ENABLE_CONTROLLER_FEATURE_A",
+											Value: "true",
+										},
+										{
+											Name:  "CONTROLLER_ENABLE_CONTROLLER_FEATURE_B",
+											Value: "false",
+										},
+										{
+											Name:  "CONTROLLER_INGRESS_CLASS",
+											Value: "kong",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Extensions: []commonv1alpha1.ExtensionRef{
+					{
+						Group: "gateway-operator.konghq.com",
+						Kind:  "DataPlaneMetricsExtension",
+						NamespacedRef: commonv1alpha1.NamespacedRef{
+							Name: "metrics-extension",
+						},
+					},
+				},
+			},
+			expectedExtensions: []commonv1alpha1.ExtensionRef{
+				{
+					Group: "konnect.konghq.com",
+					Kind:  "KonnectExtension",
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "konnect-extension",
+					},
+				},
+			},
+			expectedListenersOptions: []operatorv2beta1.GatewayConfigurationListenerOptions{
+				{
+					Name:     "listener-1",
+					NodePort: int32(3000),
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &operatorv1beta1.GatewayConfiguration{}
+
+			src := &operatorv2beta1.GatewayConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-controlplane",
+					Namespace: "test-namespace",
+				},
+				Spec: tc.spec,
+				Status: operatorv2beta1.GatewayConfigurationStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   "Ready",
+							Status: metav1.ConditionTrue,
+							Reason: "AllGood",
+						},
+					},
+				},
+			}
+
+			require.NoError(t, obj.ConvertFrom(src))
+
+			require.Equal(t, src.ObjectMeta, obj.ObjectMeta)
+
+			require.EqualValues(t,
+				tc.expectedControlPlane.Deployment.PodTemplateSpec.Spec.Containers[0].Env,
+				obj.Spec.ControlPlaneOptions.Deployment.PodTemplateSpec.Spec.Containers[0].Env)
+			require.Equal(t, tc.expectedControlPlane.Extensions, obj.Spec.ControlPlaneOptions.Extensions)
+			require.Equal(t, tc.expectedExtensions, obj.Spec.Extensions)
+			require.Equal(t, src.Status.Conditions, obj.Status.Conditions)
+		})
+	}
+}
+
+func TestGatewayConfiguration_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		src  operatorv2beta1.GatewayConfiguration
+	}{
+		{
+			name: "Complete configuration with all options",
+			src: operatorv2beta1.GatewayConfiguration{
+				Spec: operatorv2beta1.GatewayConfigurationSpec{
+					ControlPlaneOptions: &operatorv2beta1.GatewayConfigControlPlaneOptions{
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+							WatchNamespaces: &operatorv2beta1.WatchNamespaces{
+								Type: operatorv2beta1.WatchNamespacesTypeAll,
+							},
+							FeatureGates: []operatorv2beta1.ControlPlaneFeatureGate{
+								{Name: "GatewayAlpha", State: operatorv2beta1.FeatureGateStateEnabled},
+								{Name: "ExperimentalFeature", State: operatorv2beta1.FeatureGateStateDisabled},
+							},
+							Controllers: []operatorv2beta1.ControlPlaneController{
+								{Name: "INGRESS_CLASS_NETWORKINGV1", State: operatorv2beta1.ControllerStateEnabled},
+								{Name: "KONG_PLUGIN", State: operatorv2beta1.ControllerStateDisabled},
+							},
+							DataPlaneSync: &operatorv2beta1.ControlPlaneDataPlaneSync{
+								ReverseSync: lo.ToPtr(operatorv2beta1.ControlPlaneReverseSyncStateEnabled),
+							},
+							GatewayDiscovery: &operatorv2beta1.ControlPlaneGatewayDiscovery{
+								ReadinessCheckInterval: &metav1.Duration{Duration: 30 * time.Second},
+								ReadinessCheckTimeout:  &metav1.Duration{Duration: 5 * time.Second},
+							},
+							Cache: &operatorv2beta1.ControlPlaneK8sCache{
+								InitSyncDuration: &metav1.Duration{Duration: 60 * time.Second},
+							},
+							Translation: &operatorv2beta1.ControlPlaneTranslationOptions{
+								CombinedServicesFromDifferentHTTPRoutes: lo.ToPtr(operatorv2beta1.ControlPlaneCombinedServicesFromDifferentHTTPRoutesStateEnabled),
+								FallbackConfiguration: &operatorv2beta1.ControlPlaneFallbackConfiguration{
+									UseLastValidConfig: lo.ToPtr(operatorv2beta1.ControlPlaneFallbackConfigurationStateDisabled),
+								},
+								DrainSupport: lo.ToPtr(operatorv2beta1.ControlPlaneDrainSupportStateEnabled),
+							},
+							ConfigDump: &operatorv2beta1.ControlPlaneConfigDump{
+								State:         operatorv2beta1.ConfigDumpStateEnabled,
+								DumpSensitive: operatorv2beta1.ConfigDumpStateDisabled,
+							},
+							Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+								ConsumersSync: lo.ToPtr(operatorv2beta1.ControlPlaneKonnectConsumersSyncStateEnabled),
+								Licensing: &operatorv2beta1.ControlPlaneKonnectLicensing{
+									State:                lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
+									InitialPollingPeriod: &metav1.Duration{Duration: 10 * time.Second},
+									PollingPeriod:        &metav1.Duration{Duration: 60 * time.Second},
+									StorageState:         lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateDisabled),
+								},
+								NodeRefreshPeriod:  &metav1.Duration{Duration: 30 * time.Second},
+								ConfigUploadPeriod: &metav1.Duration{Duration: 10 * time.Second},
+							},
+						},
+					},
+					DataPlaneOptions: &operatorv2beta1.GatewayConfigDataPlaneOptions{
+						Deployment: operatorv2beta1.DataPlaneDeploymentOptions{
+							DeploymentOptions: operatorv2beta1.DeploymentOptions{
+								Replicas: lo.ToPtr(int32(2)),
+								PodTemplateSpec: &corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										Containers: []corev1.Container{
+											{
+												Name:  "gateway",
+												Image: "kong-gateway:latest",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Extensions: []commonv1alpha1.ExtensionRef{
+						{
+							Group: "konnect.konghq.com",
+							Kind:  "KonnectExtension",
+							NamespacedRef: commonv1alpha1.NamespacedRef{
+								Name: "konnect-extension",
+							},
+						},
+						{
+							Group: "gateway-operator.konghq.com",
+							Kind:  "DataPlaneMetricsExtension",
+							NamespacedRef: commonv1alpha1.NamespacedRef{
+								Name: "metrics-extension",
+							},
+						},
+					},
+				},
+				Status: operatorv2beta1.GatewayConfigurationStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   "Ready",
+							Status: metav1.ConditionTrue,
+							Reason: "AllGood",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			original := &operatorv2beta1.GatewayConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-controlplane",
+					Namespace: "test-namespace",
+				},
+				Spec: tc.src.Spec,
+				Status: operatorv2beta1.GatewayConfigurationStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   "Ready",
+							Status: metav1.ConditionTrue,
+							Reason: "AllGood",
+						},
+					},
+				},
+			}
+
+			intermediate := &operatorv1beta1.GatewayConfiguration{}
+			require.NoError(t, intermediate.ConvertFrom(original))
+
+			roundTrip := &operatorv2beta1.GatewayConfiguration{}
+			require.NoError(t, intermediate.ConvertTo(roundTrip))
+
+			require.Equal(t, original.ObjectMeta, roundTrip.ObjectMeta)
+			require.Equal(t, original.Spec.ControlPlaneOptions.IngressClass, roundTrip.Spec.ControlPlaneOptions.IngressClass)
+
+			if original.Spec.ControlPlaneOptions.WatchNamespaces == nil {
+				if roundTrip.Spec.ControlPlaneOptions.WatchNamespaces != nil {
+					require.Empty(t, roundTrip.Spec.ControlPlaneOptions.WatchNamespaces.Type)
+					require.Nil(t, roundTrip.Spec.ControlPlaneOptions.WatchNamespaces.List)
+				}
+			} else {
+				require.Equal(t, original.Spec.ControlPlaneOptions.WatchNamespaces, roundTrip.Spec.ControlPlaneOptions.WatchNamespaces)
+			}
+
+			require.Equal(t, original.Spec.Extensions, roundTrip.Spec.Extensions)
+			require.ElementsMatch(t, original.Spec.ControlPlaneOptions.FeatureGates, roundTrip.Spec.ControlPlaneOptions.FeatureGates)
+			require.ElementsMatch(t, original.Spec.ControlPlaneOptions.Controllers, roundTrip.Spec.ControlPlaneOptions.Controllers)
+			require.Equal(t, original.Status.Conditions, roundTrip.Status.Conditions)
+
+			if original.Spec.ControlPlaneOptions.DataPlaneSync != nil {
+				require.NotNil(t, roundTrip.Spec.ControlPlaneOptions.DataPlaneSync)
+				require.Equal(t, original.Spec.ControlPlaneOptions.DataPlaneSync.ReverseSync, roundTrip.Spec.ControlPlaneOptions.DataPlaneSync.ReverseSync)
+			}
+			if original.Spec.ControlPlaneOptions.GatewayDiscovery != nil {
+				require.NotNil(t, roundTrip.Spec.ControlPlaneOptions.GatewayDiscovery)
+				require.Equal(t, original.Spec.ControlPlaneOptions.GatewayDiscovery.ReadinessCheckInterval, roundTrip.Spec.ControlPlaneOptions.GatewayDiscovery.ReadinessCheckInterval)
+				require.Equal(t, original.Spec.ControlPlaneOptions.GatewayDiscovery.ReadinessCheckTimeout, roundTrip.Spec.ControlPlaneOptions.GatewayDiscovery.ReadinessCheckTimeout)
+			}
+			if original.Spec.ControlPlaneOptions.Cache != nil {
+				require.NotNil(t, roundTrip.Spec.ControlPlaneOptions.Cache)
+				require.Equal(t, original.Spec.ControlPlaneOptions.Cache.InitSyncDuration, roundTrip.Spec.ControlPlaneOptions.Cache.InitSyncDuration)
+			}
+			if original.Spec.ControlPlaneOptions.Translation != nil {
+				require.NotNil(t, roundTrip.Spec.ControlPlaneOptions.Translation)
+				require.Equal(t, original.Spec.ControlPlaneOptions.Translation, roundTrip.Spec.ControlPlaneOptions.Translation)
+			}
+			if original.Spec.ControlPlaneOptions.ConfigDump != nil {
+				require.NotNil(t, roundTrip.Spec.ControlPlaneOptions.ConfigDump)
+				require.Equal(t, original.Spec.ControlPlaneOptions.ConfigDump, roundTrip.Spec.ControlPlaneOptions.ConfigDump)
+			}
+			if original.Spec.ControlPlaneOptions.Konnect != nil {
+				require.NotNil(t, roundTrip.Spec.ControlPlaneOptions.Konnect)
+				require.Equal(t, original.Spec.ControlPlaneOptions.Konnect, roundTrip.Spec.ControlPlaneOptions.Konnect)
+			}
+		})
+	}
+}

--- a/api/test/conversion/konnect.konghq.com/v1alpha1/konnectgatewaycontrolplane_test.go
+++ b/api/test/conversion/konnect.konghq.com/v1alpha1/konnectgatewaycontrolplane_test.go
@@ -1,0 +1,210 @@
+package v1alpha1_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	v1alpha1 "github.com/kong/kong-operator/api/konnect/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
+)
+
+// dummyHub implements conversion.Hub but is not the expected type for conversion.
+type dummyHub struct{}
+
+func (d *dummyHub) Hub() {}
+
+// Implement runtime.Object methods for dummyHub
+func (d *dummyHub) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
+func (d *dummyHub) DeepCopyObject() runtime.Object   { return &dummyHub{} }
+
+func TestKonnectGatewayControlPlane_ConvertTo(t *testing.T) {
+	cases := []struct {
+		name             string
+		spec             v1alpha1.KonnectGatewayControlPlaneSpec
+		mirror           *v1alpha1.MirrorSpec
+		expectsCreateReq bool
+		expectError      bool
+	}{
+		{
+			name: "Origin with all fields",
+			spec: v1alpha1.KonnectGatewayControlPlaneSpec{
+				CreateControlPlaneRequest: v1alpha1.CreateControlPlaneRequest{
+					Name:         lo.ToPtr("test-name"),
+					Description:  lo.ToPtr("desc"),
+					ClusterType:  lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+					AuthType:     lo.ToPtr(sdkkonnectcomp.AuthTypePkiClientCerts),
+					CloudGateway: lo.ToPtr(true),
+					ProxyUrls: []sdkkonnectcomp.ProxyURL{
+						{Host: "host1", Port: 8080, Protocol: "http"},
+						{Host: "host2", Port: 8443, Protocol: "https"},
+					},
+					Labels: map[string]string{"foo": "bar"},
+				},
+				Source: lo.ToPtr(commonv1alpha1.EntitySourceOrigin),
+				Members: []corev1.LocalObjectReference{
+					{Name: "member1"},
+					{Name: "member2"},
+				},
+				KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{},
+			},
+			mirror:           nil,
+			expectsCreateReq: true,
+		},
+		{
+			name: "Mirror with MirrorSpec",
+			spec: v1alpha1.KonnectGatewayControlPlaneSpec{
+				Source: lo.ToPtr(commonv1alpha1.EntitySourceMirror),
+			},
+			mirror:           &v1alpha1.MirrorSpec{Konnect: v1alpha1.MirrorKonnect{ID: commonv1alpha1.KonnectIDType("mirror-id")}},
+			expectsCreateReq: false,
+		},
+		{
+			name:        "error: wrong hub type",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &v1alpha1.KonnectGatewayControlPlane{
+				Spec: tc.spec,
+			}
+			obj.Spec.Mirror = tc.mirror
+			if tc.expectError {
+				err := obj.ConvertTo(&dummyHub{})
+				assert.Error(t, err)
+				expectedMsg := fmt.Sprintf("KonnectGatewayControlPlane ConvertTo: expected *konnectv1alpha2.KonnectGatewayControlPlane, got %T", &dummyHub{})
+				assert.EqualError(t, err, expectedMsg)
+				return
+			}
+			dst := &konnectv1alpha2.KonnectGatewayControlPlane{}
+			err := obj.ConvertTo(dst)
+			assert.NoError(t, err)
+			if tc.expectsCreateReq {
+				require.NotNil(t, dst.Spec.CreateControlPlaneRequest)
+				assert.Equal(t, lo.FromPtr(tc.spec.Name), dst.Spec.CreateControlPlaneRequest.Name)
+				assert.Equal(t, tc.spec.Description, dst.Spec.CreateControlPlaneRequest.Description)
+				assert.Equal(t, tc.spec.ClusterType, dst.Spec.CreateControlPlaneRequest.ClusterType)
+				assert.Equal(t, tc.spec.AuthType, dst.Spec.CreateControlPlaneRequest.AuthType)
+				assert.Equal(t, tc.spec.CloudGateway, dst.Spec.CreateControlPlaneRequest.CloudGateway)
+				assert.Equal(t, tc.spec.ProxyUrls, dst.Spec.CreateControlPlaneRequest.ProxyUrls)
+				assert.Equal(t, tc.spec.Labels, dst.Spec.CreateControlPlaneRequest.Labels)
+			} else {
+				assert.Nil(t, dst.Spec.CreateControlPlaneRequest)
+			}
+			if tc.mirror != nil {
+				require.NotNil(t, dst.Spec.Mirror)
+				assert.Equal(t, tc.mirror.Konnect.ID, dst.Spec.Mirror.Konnect.ID)
+			} else {
+				assert.Nil(t, dst.Spec.Mirror)
+			}
+			assert.Equal(t, tc.spec.Source, dst.Spec.Source)
+			assert.Equal(t, tc.spec.Members, dst.Spec.Members)
+			assert.Equal(t, tc.spec.KonnectConfiguration, dst.Spec.KonnectConfiguration)
+		})
+	}
+}
+
+func TestKonnectGatewayControlPlane_ConvertFrom(t *testing.T) {
+	name := "test-name"
+	desc := "desc"
+	clusterType := sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane
+	authType := sdkkonnectcomp.AuthTypePkiClientCerts
+	cloudGateway := true
+	proxyUrls := []sdkkonnectcomp.ProxyURL{
+		{Host: "host1", Port: 8080, Protocol: "http"},
+		{Host: "host2", Port: 8443, Protocol: "https"},
+	}
+	labels := map[string]string{"foo": "bar"}
+	source := commonv1alpha1.EntitySourceOrigin
+	members := []corev1.LocalObjectReference{{Name: "member1"}, {Name: "member2"}}
+	konnectConfig := konnectv1alpha2.KonnectConfiguration{}
+
+	cases := []struct {
+		name             string
+		src              konnectv1alpha2.KonnectGatewayControlPlaneSpec
+		mirror           *konnectv1alpha2.MirrorSpec
+		expectsCreateReq bool
+		expectError      bool
+	}{
+		{
+			name: "With CreateControlPlaneRequest and Mirror",
+			src: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+				CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+					Name:         name,
+					Description:  &desc,
+					ClusterType:  &clusterType,
+					AuthType:     &authType,
+					CloudGateway: &cloudGateway,
+					ProxyUrls:    proxyUrls,
+					Labels:       labels,
+				},
+				Source:               lo.ToPtr(source),
+				Members:              members,
+				KonnectConfiguration: konnectConfig,
+			},
+			mirror:           &konnectv1alpha2.MirrorSpec{Konnect: konnectv1alpha2.MirrorKonnect{ID: commonv1alpha1.KonnectIDType("mirror-id")}},
+			expectsCreateReq: true,
+		},
+		{
+			name: "No CreateControlPlaneRequest, no Mirror",
+			src: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+				Source: lo.ToPtr(source),
+			},
+			mirror:           nil,
+			expectsCreateReq: false,
+		},
+		{
+			name:        "error: wrong hub type",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &v1alpha1.KonnectGatewayControlPlane{}
+			if tc.expectError {
+				err := obj.ConvertFrom(&dummyHub{})
+				assert.Error(t, err)
+				expectedMsg := fmt.Sprintf("KonnectGatewayControlPlane ConvertFrom: expected *konnectv1alpha2.KonnectGatewayControlPlane, got %T", &dummyHub{})
+				assert.EqualError(t, err, expectedMsg)
+				return
+			}
+			src := &konnectv1alpha2.KonnectGatewayControlPlane{
+				Spec: tc.src,
+			}
+			src.Spec.Mirror = tc.mirror
+			require.NoError(t, obj.ConvertFrom(src))
+			if tc.expectsCreateReq {
+				require.NotNil(t, obj.Spec.CreateControlPlaneRequest)
+				assert.Equal(t, lo.ToPtr(tc.src.CreateControlPlaneRequest.Name), obj.Spec.Name)
+				assert.Equal(t, tc.src.CreateControlPlaneRequest.Description, obj.Spec.Description)
+				assert.Equal(t, tc.src.CreateControlPlaneRequest.ClusterType, obj.Spec.ClusterType)
+				assert.Equal(t, tc.src.CreateControlPlaneRequest.AuthType, obj.Spec.AuthType)
+				assert.Equal(t, tc.src.CreateControlPlaneRequest.CloudGateway, obj.Spec.CloudGateway)
+				assert.Equal(t, tc.src.CreateControlPlaneRequest.ProxyUrls, obj.Spec.ProxyUrls)
+				assert.Equal(t, tc.src.CreateControlPlaneRequest.Labels, obj.Spec.Labels)
+			} else {
+				assert.Equal(t, obj.Spec.CreateControlPlaneRequest, v1alpha1.CreateControlPlaneRequest{})
+			}
+			if tc.mirror != nil {
+				require.NotNil(t, obj.Spec.Mirror)
+				assert.Equal(t, tc.mirror.Konnect.ID, obj.Spec.Mirror.Konnect.ID)
+			} else {
+				assert.Nil(t, obj.Spec.Mirror)
+			}
+			assert.Equal(t, tc.src.Source, obj.Spec.Source)
+			assert.Equal(t, tc.src.Members, obj.Spec.Members)
+			assert.Equal(t, tc.src.KonnectConfiguration, obj.Spec.KonnectConfiguration)
+		})
+	}
+}

--- a/api/test/crdsvalidation/common/common.go
+++ b/api/test/crdsvalidation/common/common.go
@@ -1,0 +1,9 @@
+package common
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// CommonObjectMeta is a common object meta used in tests.
+var CommonObjectMeta = metav1.ObjectMeta{
+	GenerateName: "test-",
+	Namespace:    "default",
+}

--- a/api/test/crdsvalidation/common/suite_crd_ref_change.go
+++ b/api/test/crdsvalidation/common/suite_crd_ref_change.go
@@ -1,0 +1,298 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/restmapper"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+)
+
+// Scope represents the scope of the object
+type Scope byte
+
+const (
+	// ScopeCluster represents the cluster scope
+	ScopeCluster Scope = iota
+	// ScopeNamespace represents the namespace scope
+	ScopeNamespace
+)
+
+// GetGroupKindScope returns the scope of the object
+func getGroupKindScope(t *testing.T, obj client.Object) meta.RESTScopeName {
+	config, err := config.GetConfig()
+	require.NoError(t, err)
+
+	dc := discovery.NewDiscoveryClientForConfigOrDie(config)
+	groupResources, err := restmapper.GetAPIGroupResources(dc)
+	require.NoError(t, err)
+
+	gk := obj.GetObjectKind().GroupVersionKind().GroupKind()
+	r, err := restmapper.NewDiscoveryRESTMapper(groupResources).RESTMapping(gk)
+	require.NoError(t, err)
+	return r.Scope.Name()
+}
+
+// SupportedByKicT is a type to specify whether an object is supported by KIC or not
+type SupportedByKicT bool
+
+const (
+	// SupportedByKIC represents that the object is supported by KIC
+	SupportedByKIC SupportedByKicT = true
+	// NotSupportedByKIC represents that the object is not supported by KIC
+	NotSupportedByKIC SupportedByKicT = false
+)
+
+// ControlPlaneRefRequiredT is a type to specify whether control plane ref is required or not
+type ControlPlaneRefRequiredT bool
+
+const (
+	// ControlPlaneRefRequired represents that control plane ref is required
+	ControlPlaneRefRequired ControlPlaneRefRequiredT = true
+	// ControlPlaneRefNotRequired represents that control plane ref is not required
+	ControlPlaneRefNotRequired ControlPlaneRefRequiredT = false
+)
+
+// NewCRDValidationTestCasesGroupCPRefChange creates a test cases group for control plane ref change
+func NewCRDValidationTestCasesGroupCPRefChange[
+	T interface {
+		client.Object
+		DeepCopy() T
+		SetConditions([]metav1.Condition)
+		SetControlPlaneRef(*commonv1alpha1.ControlPlaneRef)
+		GetControlPlaneRef() *commonv1alpha1.ControlPlaneRef
+	},
+](
+	t *testing.T,
+	obj T,
+	supportedByKIC SupportedByKicT,
+	controlPlaneRefRequired ControlPlaneRefRequiredT,
+) TestCasesGroup[T] {
+	var (
+		ret = TestCasesGroup[T]{}
+
+		programmedConditionTrue = metav1.Condition{
+			Type:               "Programmed",
+			Status:             metav1.ConditionTrue,
+			Reason:             "Valid",
+			LastTransitionTime: metav1.Now(),
+		}
+		programmedConditionFalse = metav1.Condition{
+			Type:               "Programmed",
+			Status:             metav1.ConditionFalse,
+			Reason:             "NotProgrammed",
+			LastTransitionTime: metav1.Now(),
+		}
+		objScope = getGroupKindScope(t, obj)
+	)
+
+	{
+		if supportedByKIC == SupportedByKIC {
+			// Since objects managed by KIC do not require spec.controlPlane,
+			// object without spec.controlPlaneRef should be allowed.
+			obj := obj.DeepCopy()
+			obj.SetControlPlaneRef(nil)
+			ret = append(ret, TestCase[T]{
+				Name:       "no cpRef is valid",
+				TestObject: obj,
+			})
+		}
+	}
+	{
+		if objScope == meta.RESTScopeNameNamespace {
+			obj := obj.DeepCopy()
+			obj.SetControlPlaneRef(&commonv1alpha1.ControlPlaneRef{
+				Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+				KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+					Name:      "test-konnect-control-plane",
+					Namespace: "another-namespace",
+				},
+			})
+			ret = append(ret, TestCase[T]{
+				Name:                 "cpRef (type=konnectNamespacedRef) cannot have namespace",
+				TestObject:           obj,
+				ExpectedErrorMessage: lo.ToPtr("spec.controlPlaneRef cannot specify namespace for namespaced resource"),
+			})
+		}
+	}
+	{
+		obj := obj.DeepCopy()
+		obj.SetControlPlaneRef(&commonv1alpha1.ControlPlaneRef{
+			Type: commonv1alpha1.ControlPlaneRefKIC,
+			KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+				Name: "test-konnect-control-plane",
+			},
+		})
+		ret = append(ret, TestCase[T]{
+			Name:                 "providing konnectNamespaceRef when type is kic yields an error",
+			TestObject:           obj,
+			ExpectedErrorMessage: lo.ToPtr("when type is kic, konnectNamespacedRef must not be set"),
+		})
+	}
+	{
+		if supportedByKIC == SupportedByKIC {
+			obj := obj.DeepCopy()
+			obj.SetControlPlaneRef(&commonv1alpha1.ControlPlaneRef{
+				Type: commonv1alpha1.ControlPlaneRefKIC,
+			})
+			ret = append(ret, TestCase[T]{
+				Name:       "kic control plane ref is allowed",
+				TestObject: obj,
+			})
+		}
+	}
+
+	// Updates: KonnectNamespacedRef
+	{
+		obj := obj.DeepCopy()
+		obj.SetControlPlaneRef(&commonv1alpha1.ControlPlaneRef{
+			Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+			KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+				Name: "test-konnect-control-plane",
+			},
+		})
+		obj.SetConditions([]metav1.Condition{programmedConditionTrue})
+		ret = append(ret, TestCase[T]{
+			Name:       "cpRef change (type=konnectNamespacedRef) is not allowed for Programmed=True",
+			TestObject: obj,
+			Update: func(obj T) {
+				cpRef := obj.GetControlPlaneRef()
+				cpRef.KonnectNamespacedRef.Name = "new-konnect-control-plane"
+				obj.SetControlPlaneRef(cpRef)
+			},
+			ExpectedUpdateErrorMessage: lo.ToPtr("spec.controlPlaneRef is immutable when an entity is already Programmed"),
+		})
+	}
+	{
+		obj := obj.DeepCopy()
+		obj.SetControlPlaneRef(&commonv1alpha1.ControlPlaneRef{
+			Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+			KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+				Name: "test-konnect-control-plane",
+			},
+		})
+		obj.SetConditions([]metav1.Condition{programmedConditionFalse})
+		ret = append(ret, TestCase[T]{
+			Name:       "cpRef change (type=konnectNamespacedRef) is allowed when object is Programmed=False",
+			TestObject: obj,
+			Update: func(obj T) {
+				cpRef := &commonv1alpha1.ControlPlaneRef{
+					Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+					KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+						Name: "new-konnect-control-plane",
+					},
+				}
+				obj.SetControlPlaneRef(cpRef)
+			},
+		})
+	}
+
+	// Updates: KIC
+	{
+		if supportedByKIC == SupportedByKIC {
+			obj := obj.DeepCopy()
+			obj.SetControlPlaneRef(&commonv1alpha1.ControlPlaneRef{
+				Type: commonv1alpha1.ControlPlaneRefKIC,
+			})
+			obj.SetConditions([]metav1.Condition{programmedConditionTrue})
+			ret = append(ret, TestCase[T]{
+				Name:       "cpRef change (type=kic) is not allowed for Programmed=True",
+				TestObject: obj,
+				Update: func(obj T) {
+					cpRef := &commonv1alpha1.ControlPlaneRef{
+						Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+						KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+							Name: "new-konnect-control-plane",
+						},
+					}
+					obj.SetControlPlaneRef(cpRef)
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.controlPlaneRef is immutable when an entity is already Programmed"),
+			})
+		}
+	}
+	{
+		if supportedByKIC == SupportedByKIC {
+			obj := obj.DeepCopy()
+			obj.SetControlPlaneRef(&commonv1alpha1.ControlPlaneRef{
+				Type: commonv1alpha1.ControlPlaneRefKIC,
+			})
+			obj.SetConditions([]metav1.Condition{programmedConditionFalse})
+			ret = append(ret, TestCase[T]{
+				Name:       "cpRef change (type=kic) is allowed when object is not Programmed=True",
+				TestObject: obj,
+				Update: func(obj T) {
+					cpRef := &commonv1alpha1.ControlPlaneRef{
+						Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+						KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+							Name: "new-konnect-control-plane",
+						},
+					}
+					obj.SetControlPlaneRef(cpRef)
+				},
+			})
+		}
+	}
+
+	// Updates: ControlPlane ref is unset
+	{
+		if supportedByKIC == SupportedByKIC {
+			obj := obj.DeepCopy()
+			obj.SetConditions([]metav1.Condition{programmedConditionFalse})
+			ret = append(ret, TestCase[T]{
+				Name:       "cpRef change (type=<unset>) is allowed when object is Programmed=False",
+				TestObject: obj,
+				Update: func(obj T) {
+					cpRef := &commonv1alpha1.ControlPlaneRef{
+						Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+						KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+							Name: "new-konnect-control-plane",
+						},
+					}
+					obj.SetControlPlaneRef(cpRef)
+				},
+			})
+		}
+	}
+	{
+		if supportedByKIC == SupportedByKIC {
+			obj := obj.DeepCopy()
+			obj.SetControlPlaneRef(&commonv1alpha1.ControlPlaneRef{})
+			obj.SetConditions([]metav1.Condition{programmedConditionTrue})
+			ret = append(ret, TestCase[T]{
+				Name:       "cpRef change (type=<unset>) is not allowed for Programmed=True",
+				TestObject: obj,
+				Update: func(obj T) {
+					cpRef := &commonv1alpha1.ControlPlaneRef{
+						Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+						KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+							Name: "new-konnect-control-plane",
+						},
+					}
+					obj.SetControlPlaneRef(cpRef)
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.controlPlaneRef is immutable when an entity is already Programmed"),
+			})
+		}
+	}
+	{
+		if controlPlaneRefRequired == ControlPlaneRefRequired {
+			obj := obj.DeepCopy()
+			obj.SetControlPlaneRef(nil)
+			ret = append(ret, TestCase[T]{
+				Name:                 "cpRef is required",
+				TestObject:           obj,
+				ExpectedErrorMessage: lo.ToPtr("spec.controlPlaneRef: Required value"),
+			})
+		}
+	}
+
+	return ret
+}

--- a/api/test/crdsvalidation/common/suite_crd_ref_change_kic_unsupported.go
+++ b/api/test/crdsvalidation/common/suite_crd_ref_change_kic_unsupported.go
@@ -1,0 +1,69 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+)
+
+// EmptyControlPlaneRefAllowedT is a type to specify whether an empty control plane ref is allowed or not
+type EmptyControlPlaneRefAllowedT bool
+
+const (
+	// EmptyControlPlaneRefAllowed is a value to specify that an empty control plane ref is allowed
+	EmptyControlPlaneRefAllowed EmptyControlPlaneRefAllowedT = true
+	// EmptyControlPlaneRefNotAllowed is a value to specify that an empty control plane ref is not allowed
+	EmptyControlPlaneRefNotAllowed EmptyControlPlaneRefAllowedT = false
+)
+
+// NewCRDValidationTestCasesGroupCPRefChangeKICUnsupportedTypes returns a test cases group for testing control plane ref change to KIC unsupported types
+func NewCRDValidationTestCasesGroupCPRefChangeKICUnsupportedTypes[
+	T interface {
+		client.Object
+		DeepCopy() T
+		SetConditions([]metav1.Condition)
+		SetControlPlaneRef(*commonv1alpha1.ControlPlaneRef)
+		GetControlPlaneRef() *commonv1alpha1.ControlPlaneRef
+	},
+](
+	t *testing.T,
+	obj T,
+	emptyControlPlaneRefAllowed EmptyControlPlaneRefAllowedT,
+) TestCasesGroup[T] {
+	ret := TestCasesGroup[T]{}
+
+	{
+		obj := obj.DeepCopy()
+		obj.SetControlPlaneRef(&commonv1alpha1.ControlPlaneRef{
+			Type: commonv1alpha1.ControlPlaneRefKIC,
+		})
+		ret = append(ret, TestCase[T]{
+			Name:                 "kic control plane ref is not allowed",
+			TestObject:           obj,
+			ExpectedErrorMessage: lo.ToPtr("KIC is not supported as control plane"),
+		})
+	}
+	{
+		obj := obj.DeepCopy()
+		obj.SetControlPlaneRef(nil)
+		switch emptyControlPlaneRefAllowed {
+		case EmptyControlPlaneRefNotAllowed:
+			ret = append(ret, TestCase[T]{
+				Name:                 "<unset> control plane ref is not allowed",
+				TestObject:           obj,
+				ExpectedErrorMessage: lo.ToPtr("controlPlaneRef"),
+			})
+		case EmptyControlPlaneRefAllowed:
+			ret = append(ret, TestCase[T]{
+				Name:       "<unset> control plane ref is allowed",
+				TestObject: obj,
+			})
+		}
+	}
+
+	return ret
+}

--- a/api/test/crdsvalidation/common/testcase.go
+++ b/api/test/crdsvalidation/common/testcase.go
@@ -1,0 +1,252 @@
+package common
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/kong/kong-operator/pkg/clientset/scheme"
+)
+
+// TestCasesGroup is a group of test cases related to CRD validation.
+type TestCasesGroup[T client.Object] []TestCase[T]
+
+// RunWithConfig runs all test cases in the group against the provided rest.Config's cluster.
+func (g TestCasesGroup[T]) RunWithConfig(t *testing.T, cfg *rest.Config, scheme *runtime.Scheme) {
+	for _, tc := range g {
+		tc.RunWithConfig(t, cfg, scheme)
+	}
+}
+
+// Run runs all test cases in the group.
+func (g TestCasesGroup[T]) Run(t *testing.T) {
+	cfg, err := config.GetConfig()
+	require.NoError(t, err)
+	g.RunWithConfig(t, cfg, scheme.Scheme)
+}
+
+const (
+	// DefaultEventuallyTimeout is the default timeout for EventuallyConfig.
+	DefaultEventuallyTimeout = 1 * time.Second
+	// DefaultEventuallyPeriod is the default period for EventuallyConfig.
+	DefaultEventuallyPeriod = 10 * time.Millisecond
+)
+
+// EventuallyConfig is the configuration for assert.Eventually() which is used to assert errors.
+type EventuallyConfig struct {
+	// Timeout is the maximum time to wait for the condition to be true.
+	Timeout time.Duration
+	// Period is the time to wait between retries.
+	Period time.Duration
+}
+
+// WarningCollector implements the rest.WarningHandler interface.
+type WarningCollector struct {
+	sync.Mutex
+	warnings []string
+}
+
+// HandleWarningHeader implements the rest.WarningHandler interface.
+func (wc *WarningCollector) HandleWarningHeader(_ int, _ string, warning string) {
+	wc.Lock()
+	defer wc.Unlock()
+	wc.warnings = append(wc.warnings, warning)
+}
+
+// GetWarnings returns the collected warnings.
+func (wc *WarningCollector) GetWarnings() []string {
+	wc.Lock()
+	defer wc.Unlock()
+	// Return a copy to avoid race conditions if the slice is modified elsewhere
+	warningsCopy := make([]string, len(wc.warnings))
+	copy(warningsCopy, wc.warnings)
+	return warningsCopy
+}
+
+// TestCase represents a test case for CRD validation.
+type TestCase[T client.Object] struct {
+	// Name is the name of the test case.
+	Name string
+
+	// SkipReason is the reason to skip the test case.
+	SkipReason string
+
+	// TestObject is the object to be tested.
+	TestObject T
+
+	// ExpectedErrorMessage is the expected error message when creating the object.
+	ExpectedErrorMessage *string
+
+	// ExpectedErrorEventuallyConfig is the configuration for assert.Eventually() which is used to assert the create error.
+	// If not provided the error is checked immediately, just once.
+	ExpectedErrorEventuallyConfig EventuallyConfig
+
+	// ExpectedUpdateErrorMessage is the expected error message when updating the object.
+	ExpectedUpdateErrorMessage *string
+
+	// ExpectedWarningMessage is the expected warning message when creating the object. It requires WarningCollector to be set.
+	ExpectedWarningMessage *string
+
+	// WarningCollector collects warnings from the API server. It must implement the rest.WarningHandler interface and be set
+	// in the rest.Config used to create the client.
+	WarningCollector *WarningCollector
+
+	// Update is a function that updates the object in the test case after it's created.
+	// It can be used to verify CEL rules that verify the previous object's version against the new one.
+	Update func(T)
+}
+
+// RunWithConfig runs the test case against the provided rest.Config's cluster.
+func (tc *TestCase[T]) RunWithConfig(t *testing.T, cfg *rest.Config, scheme *runtime.Scheme) {
+	if tc.SkipReason != "" {
+		t.Skip(tc.SkipReason)
+	}
+
+	timeout := DefaultEventuallyTimeout
+	if tc.ExpectedErrorEventuallyConfig.Timeout != 0 {
+		timeout = tc.ExpectedErrorEventuallyConfig.Timeout
+	}
+	period := DefaultEventuallyPeriod
+	if tc.ExpectedErrorEventuallyConfig.Period != 0 {
+		period = tc.ExpectedErrorEventuallyConfig.Period
+	}
+
+	require.NotNil(t, tc.TestObject, "TestObject is nil in test %s", tc.Name)
+
+	// Run the test case.
+	t.Run(tc.Name, func(t *testing.T) {
+		require.NotNil(t, tc.TestObject, "TestObject is nil in test %s", tc.Name)
+
+		if tc.ExpectedWarningMessage != nil {
+			require.NotNil(t, tc.WarningCollector, "WarningCollector is nil in test %s", tc.Name)
+		}
+
+		t.Parallel()
+		ctx := context.Background()
+
+		// Create a new controller-runtime client.Client.
+		cl, err := client.New(cfg, client.Options{
+			Scheme: scheme,
+		})
+		require.NoError(t, err)
+
+		// Take a copy so that we can update the status field if needed. Without copying, the Create call
+		// overwrites the status field in tc.TestObject with the default server returns, and we lose the status
+		// set in the test case.
+		desiredObj := tc.TestObject.DeepCopyObject().(T)
+
+		tCleanupObject := func(ctx context.Context, t *testing.T, obj client.Object) {
+			// NOTE: Deep copy the object as without this we end up causing a data race:
+			objToDelete := obj.DeepCopyObject().(T)
+			t.Cleanup(func() {
+				assert.NoError(t, client.IgnoreNotFound(cl.Delete(ctx, objToDelete)))
+			})
+		}
+
+		if !assert.EventuallyWithT(
+			t,
+			func(c *assert.CollectT) {
+				toCreate := tc.TestObject.DeepCopyObject().(T)
+
+				// Create the object and set a cleanup function to delete it after the test if created successfully.
+				err = cl.Create(ctx, toCreate)
+				if err == nil {
+					tCleanupObject(ctx, t, toCreate)
+				}
+
+				// Check for expected warning message
+				if tc.ExpectedWarningMessage != nil {
+					found := false
+					for _, w := range tc.WarningCollector.GetWarnings() {
+						if strings.Contains(w, *tc.ExpectedWarningMessage) {
+							found = true
+							break
+						}
+					}
+					if !assert.True(c, found, "Warning message not found: %s", *tc.ExpectedWarningMessage) {
+						return
+					}
+				}
+
+				// If the error message is expected, check if the error message contains the expected message and return.
+				if tc.ExpectedErrorMessage != nil {
+					if !assert.ErrorContains(c, err, *tc.ExpectedErrorMessage) {
+						return
+					}
+				} else {
+					if !assert.NoError(t, err) {
+						return
+					}
+				}
+
+				tc.TestObject = toCreate
+			},
+			timeout, period,
+		) {
+			return
+		}
+
+		// Check with reflect if the status field is set and Update the status if so before updating the object.
+		// That's required to populate Status that is not set on Create.
+		if status := reflect.ValueOf(desiredObj).Elem().FieldByName("Status"); status.IsValid() && !status.IsZero() {
+			// Populate name and resource version obtained from the server on Create.
+			desiredObj.SetName(tc.TestObject.GetName())
+			desiredObj.SetResourceVersion(tc.TestObject.GetResourceVersion())
+
+			err = cl.Status().Update(ctx, desiredObj)
+			require.NoError(t, err)
+
+			err = cl.Get(ctx, client.ObjectKeyFromObject(tc.TestObject), tc.TestObject)
+			require.NoError(t, err)
+		}
+
+		// If the Update function was defined, update the object and check if the update is allowed.
+		if tc.Update != nil {
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				err := cl.Get(ctx, client.ObjectKeyFromObject(tc.TestObject), tc.TestObject)
+				require.NoError(c, err)
+				// Update the object state and push the update to the server.
+				tc.Update(tc.TestObject)
+				err = cl.Update(ctx, tc.TestObject)
+				if tc.ExpectedWarningMessage != nil {
+					found := false
+					for _, w := range tc.WarningCollector.GetWarnings() {
+						if strings.Contains(w, *tc.ExpectedWarningMessage) {
+							found = true
+							break
+						}
+					}
+					if !assert.True(c, found, "Warning message not found: %s", *tc.ExpectedWarningMessage) {
+						return
+					}
+				}
+				// If the expected update error message is defined, check if the error message contains the expected message
+				// and return. Otherwise, expect no error.
+				if tc.ExpectedUpdateErrorMessage != nil {
+					require.NotNil(c, err)
+					assert.Contains(c, err.Error(), *tc.ExpectedUpdateErrorMessage)
+					return
+				}
+				require.NoError(c, err)
+			}, timeout, period)
+		}
+	})
+}
+
+// Run runs the test case.
+func (tc *TestCase[T]) Run(t *testing.T) {
+	cfg, err := config.GetConfig()
+	require.NoError(t, err)
+
+	tc.RunWithConfig(t, cfg, scheme.Scheme)
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongcacertificate_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongcacertificate_test.go
@@ -1,0 +1,52 @@
+package configuration_test
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongCACertificate(t *testing.T) {
+	t.Run("required fields validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongCACertificate]{
+			{
+				Name: "cert field is required",
+				TestObject: &configurationv1alpha1.KongCACertificate{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCACertificateSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongCACertificateAPISpec: configurationv1alpha1.KongCACertificateAPISpec{},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.cert: Required value"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("cp ref", func(t *testing.T) {
+		obj := &configurationv1alpha1.KongCACertificate{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KongCACertificate",
+				APIVersion: configurationv1alpha1.GroupVersion.String(),
+			},
+			ObjectMeta: common.CommonObjectMeta,
+			Spec: configurationv1alpha1.KongCACertificateSpec{
+				KongCACertificateAPISpec: configurationv1alpha1.KongCACertificateAPISpec{
+					Cert: "cert",
+				},
+			},
+		}
+
+		common.NewCRDValidationTestCasesGroupCPRefChange(t, obj, common.NotSupportedByKIC, common.ControlPlaneRefRequired).Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongcertificate_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongcertificate_test.go
@@ -1,0 +1,170 @@
+package configuration_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongCertificate(t *testing.T) {
+	t.Run("cp ref", func(t *testing.T) {
+		obj := &configurationv1alpha1.KongCertificate{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KongCertificate",
+				APIVersion: configurationv1alpha1.GroupVersion.String(),
+			},
+			ObjectMeta: common.CommonObjectMeta,
+			Spec: configurationv1alpha1.KongCertificateSpec{
+				KongCertificateAPISpec: configurationv1alpha1.KongCertificateAPISpec{
+					Cert: "test-cert",
+					Key:  "test-key",
+				},
+			},
+		}
+
+		common.NewCRDValidationTestCasesGroupCPRefChange(t, obj, common.NotSupportedByKIC, common.ControlPlaneRefRequired).Run(t)
+	})
+
+	t.Run("required fields", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongCertificate]{
+			{
+				Name: "cert field is required",
+				TestObject: &configurationv1alpha1.KongCertificate{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCertificateSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongCertificateAPISpec: configurationv1alpha1.KongCertificateAPISpec{
+							Key: "test-key",
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.cert: Required value"),
+			},
+			{
+				Name: "key field is required",
+				TestObject: &configurationv1alpha1.KongCertificate{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCertificateSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongCertificateAPISpec: configurationv1alpha1.KongCertificateAPISpec{
+							Cert: "test-cert",
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.key: Required value"),
+			},
+			{
+				Name: "cert and key fields are required",
+				TestObject: &configurationv1alpha1.KongCertificate{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCertificateSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongCertificateAPISpec: configurationv1alpha1.KongCertificateAPISpec{
+							Cert: "test-cert",
+							Key:  "test-key",
+						},
+					},
+				},
+			},
+		}.Run(t)
+
+		t.Run("tags validation", func(t *testing.T) {
+			common.TestCasesGroup[*configurationv1alpha1.KongCertificate]{
+				{
+					Name: "up to 20 tags are allowed",
+					TestObject: &configurationv1alpha1.KongCertificate{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: configurationv1alpha1.KongCertificateSpec{
+							ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+								Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+								KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+									Name: "test-konnect-control-plane",
+								},
+							},
+							KongCertificateAPISpec: configurationv1alpha1.KongCertificateAPISpec{
+								Key:  "key",
+								Cert: "cert",
+								Tags: func() []string {
+									var tags []string
+									for i := range 20 {
+										tags = append(tags, fmt.Sprintf("tag-%d", i))
+									}
+									return tags
+								}(),
+							},
+						},
+					},
+				},
+				{
+					Name: "more than 20 tags are not allowed",
+					TestObject: &configurationv1alpha1.KongCertificate{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: configurationv1alpha1.KongCertificateSpec{
+							ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+								Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+								KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+									Name: "test-konnect-control-plane",
+								},
+							},
+							KongCertificateAPISpec: configurationv1alpha1.KongCertificateAPISpec{
+								Key:  "key",
+								Cert: "cert",
+								Tags: func() []string {
+									var tags []string
+									for i := range 21 {
+										tags = append(tags, fmt.Sprintf("tag-%d", i))
+									}
+									return tags
+								}(),
+							},
+						},
+					},
+					ExpectedErrorMessage: lo.ToPtr("spec.tags: Too many: 21: must have at most 20 items"),
+				},
+				{
+					Name: "tags entries must not be longer than 128 characters",
+					TestObject: &configurationv1alpha1.KongCertificate{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: configurationv1alpha1.KongCertificateSpec{
+							ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+								Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+								KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+									Name: "test-konnect-control-plane",
+								},
+							},
+							KongCertificateAPISpec: configurationv1alpha1.KongCertificateAPISpec{
+								Key:  "key",
+								Cert: "cert",
+								Tags: []string{
+									lo.RandomString(129, lo.AlphanumericCharset),
+								},
+							},
+						},
+					},
+					ExpectedErrorMessage: lo.ToPtr("tags entries must not be longer than 128 characters"),
+				},
+			}.Run(t)
+		})
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongclusterplugin_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongclusterplugin_test.go
@@ -1,0 +1,132 @@
+package configuration_test
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	configurationv1 "github.com/kong/kong-operator/api/configuration/v1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongClusterPlugin(t *testing.T) {
+	t.Run("config and configFrom fields validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1.KongClusterPlugin]{
+			{
+				Name: "using both config and configFrom should fail",
+				TestObject: &configurationv1.KongClusterPlugin{
+					ObjectMeta: common.CommonObjectMeta,
+					PluginName: "rate-limiting",
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"minute": 5}`),
+					},
+					ConfigFrom: &configurationv1.NamespacedConfigSource{
+						SecretValue: configurationv1.NamespacedSecretValueFromSource{
+							Namespace: "default",
+							Secret:    "test-secret",
+							Key:       "config",
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Using both config and configFrom fields is not allowed."),
+			},
+			{
+				Name: "using both configFrom and configPatches should fail",
+				TestObject: &configurationv1.KongClusterPlugin{
+					ObjectMeta: common.CommonObjectMeta,
+					PluginName: "rate-limiting",
+					ConfigFrom: &configurationv1.NamespacedConfigSource{
+						SecretValue: configurationv1.NamespacedSecretValueFromSource{
+							Namespace: "default",
+							Secret:    "test-secret",
+							Key:       "config",
+						},
+					},
+					ConfigPatches: []configurationv1.NamespacedConfigPatch{
+						{
+							Path: "/minute",
+							ValueFrom: configurationv1.NamespacedConfigSource{
+								SecretValue: configurationv1.NamespacedSecretValueFromSource{
+									Namespace: "default",
+									Secret:    "test-secret",
+									Key:       "minute",
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Using both configFrom and configPatches fields is not allowed."),
+			},
+			{
+				Name: "using only config should succeed",
+				TestObject: &configurationv1.KongClusterPlugin{
+					ObjectMeta: common.CommonObjectMeta,
+					PluginName: "rate-limiting",
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"minute": 5}`),
+					},
+				},
+			},
+			{
+				Name: "using only configFrom should succeed",
+				TestObject: &configurationv1.KongClusterPlugin{
+					ObjectMeta: common.CommonObjectMeta,
+					PluginName: "rate-limiting",
+					ConfigFrom: &configurationv1.NamespacedConfigSource{
+						SecretValue: configurationv1.NamespacedSecretValueFromSource{
+							Namespace: "default",
+							Secret:    "test-secret",
+							Key:       "config",
+						},
+					},
+				},
+			},
+			{
+				Name: "using only configPatches should succeed",
+				TestObject: &configurationv1.KongClusterPlugin{
+					ObjectMeta: common.CommonObjectMeta,
+					PluginName: "rate-limiting",
+					ConfigPatches: []configurationv1.NamespacedConfigPatch{
+						{
+							Path: "/minute",
+							ValueFrom: configurationv1.NamespacedConfigSource{
+								SecretValue: configurationv1.NamespacedSecretValueFromSource{
+									Namespace: "default",
+									Secret:    "test-secret",
+									Key:       "minute",
+								},
+							},
+						},
+					},
+				},
+			},
+		}.Run(t)
+	})
+
+	t.Run("plugin field immutability", func(t *testing.T) {
+		// Note: This test validates that the plugin field is immutable on update
+		// The actual immutability check requires an update operation which is tested
+		// via the CRD validation framework during actual cluster operations
+		common.TestCasesGroup[*configurationv1.KongClusterPlugin]{
+			{
+				Name: "plugin field should be present",
+				TestObject: &configurationv1.KongClusterPlugin{
+					ObjectMeta: common.CommonObjectMeta,
+					PluginName: "rate-limiting",
+				},
+			},
+			{
+				Name: "plugin field change should fail on update",
+				TestObject: &configurationv1.KongClusterPlugin{
+					ObjectMeta: common.CommonObjectMeta,
+					PluginName: "rate-limiting",
+				},
+				Update: func(obj *configurationv1.KongClusterPlugin) {
+					obj.PluginName = "cors"
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("The plugin field is immutable"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongconsumer_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongconsumer_test.go
@@ -1,0 +1,148 @@
+package configuration_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1 "github.com/kong/kong-operator/api/configuration/v1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongConsumer(t *testing.T) {
+	t.Run("cp ref", func(t *testing.T) {
+		obj := &configurationv1.KongConsumer{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KongConsumer",
+				APIVersion: configurationv1.GroupVersion.String(),
+			},
+			ObjectMeta: common.CommonObjectMeta,
+			Username:   "username-1",
+		}
+
+		common.NewCRDValidationTestCasesGroupCPRefChange(t, obj, common.SupportedByKIC, common.ControlPlaneRefNotRequired).Run(t)
+	})
+
+	t.Run("required fields", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1.KongConsumer]{
+			{
+				Name: "username or custom_id required (username provided)",
+				TestObject: &configurationv1.KongConsumer{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1.KongConsumerSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+					},
+					Username: "username-1",
+				},
+			},
+			{
+				Name: "username or custom_id required (custom_id provided)",
+				TestObject: &configurationv1.KongConsumer{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1.KongConsumerSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+					},
+					CustomID: "customid-1",
+				},
+			},
+			{
+				Name: "username or custom_id required (none provided)",
+				TestObject: &configurationv1.KongConsumer{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1.KongConsumerSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Need to provide either username or custom_id"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("tags validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1.KongConsumer]{
+			{
+				Name: "up to 20 tags are allowed",
+				TestObject: &configurationv1.KongConsumer{
+					ObjectMeta: common.CommonObjectMeta,
+					Username:   "username-1",
+					Spec: configurationv1.KongConsumerSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						Tags: func() []string {
+							var tags []string
+							for i := range 20 {
+								tags = append(tags, fmt.Sprintf("tag-%d", i))
+							}
+							return tags
+						}(),
+					},
+				},
+			},
+			{
+				Name: "more than 20 tags are not allowed",
+				TestObject: &configurationv1.KongConsumer{
+					ObjectMeta: common.CommonObjectMeta,
+					Username:   "username-1",
+					Spec: configurationv1.KongConsumerSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						Tags: func() []string {
+							var tags []string
+							for i := range 21 {
+								tags = append(tags, fmt.Sprintf("tag-%d", i))
+							}
+							return tags
+						}(),
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.tags: Too many: 21: must have at most 20 items"),
+			},
+			{
+				Name: "tags entries must not be longer than 128 characters",
+				TestObject: &configurationv1.KongConsumer{
+					ObjectMeta: common.CommonObjectMeta,
+					Username:   "username-1",
+					Spec: configurationv1.KongConsumerSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						Tags: []string{
+							lo.RandomString(129, lo.AlphanumericCharset),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("tags entries must not be longer than 128 characters"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongconsumergroup_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongconsumergroup_test.go
@@ -1,0 +1,205 @@
+package configuration_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	configurationv1beta1 "github.com/kong/kong-operator/api/configuration/v1beta1"
+	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongConsumerGroup(t *testing.T) {
+	t.Run("cp ref", func(t *testing.T) {
+		obj := &configurationv1beta1.KongConsumerGroup{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KongConsumerGroup",
+				APIVersion: configurationv1beta1.GroupVersion.String(),
+			},
+			ObjectMeta: common.CommonObjectMeta,
+			Spec: configurationv1beta1.KongConsumerGroupSpec{
+				Name: "group1",
+			},
+		}
+
+		common.NewCRDValidationTestCasesGroupCPRefChange(t, obj, common.SupportedByKIC, common.ControlPlaneRefNotRequired).Run(t)
+	})
+
+	t.Run("cp ref update", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1beta1.KongConsumerGroup]{
+			{
+				Name: "cpRef change is not allowed for Programmed=True",
+				TestObject: &configurationv1beta1.KongConsumerGroup{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongConsumerGroupSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+					},
+					Status: configurationv1beta1.KongConsumerGroupStatus{
+						Konnect: &konnectv1alpha2.KonnectEntityStatusWithControlPlaneRef{},
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionTrue,
+								Reason:             "Valid",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(c *configurationv1beta1.KongConsumerGroup) {
+					c.Spec.ControlPlaneRef.KonnectNamespacedRef.Name = "new-konnect-control-plane"
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.controlPlaneRef is immutable when an entity is already Programmed"),
+			},
+			{
+				Name: "cpRef change is allowed when cp is not Programmed=True nor APIAuthValid=True",
+				TestObject: &configurationv1beta1.KongConsumerGroup{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongConsumerGroupSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+					},
+					Status: configurationv1beta1.KongConsumerGroupStatus{
+						Konnect: &konnectv1alpha2.KonnectEntityStatusWithControlPlaneRef{},
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionFalse,
+								Reason:             "NotProgrammed",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(c *configurationv1beta1.KongConsumerGroup) {
+					c.Spec.ControlPlaneRef.KonnectNamespacedRef.Name = "new-konnect-control-plane"
+				},
+			},
+			{
+				Name: "updates with Programmed = True when no cpRef is allowed",
+				TestObject: &configurationv1beta1.KongConsumerGroup{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongConsumerGroupSpec{
+						Name: "group1",
+					},
+					Status: configurationv1beta1.KongConsumerGroupStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionFalse,
+								Reason:             "NotProgrammed",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(c *configurationv1beta1.KongConsumerGroup) {
+					c.Spec.Name = "group2"
+				},
+			},
+		}.Run(t)
+	})
+
+	t.Run("fields", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1beta1.KongConsumerGroup]{
+			{
+				Name: "name field can be set",
+				TestObject: &configurationv1beta1.KongConsumerGroup{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongConsumerGroupSpec{
+						Name: "test-consumer-group",
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+					},
+				},
+			},
+		}.Run(t)
+	})
+
+	t.Run("tags validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1beta1.KongConsumerGroup]{
+			{
+				Name: "up to 20 tags are allowed",
+				TestObject: &configurationv1beta1.KongConsumerGroup{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongConsumerGroupSpec{
+						Name: "cg-1",
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						Tags: func() []string {
+							var tags []string
+							for i := range 20 {
+								tags = append(tags, fmt.Sprintf("tag-%d", i))
+							}
+							return tags
+						}(),
+					},
+				},
+			},
+			{
+				Name: "more than 20 tags are not allowed",
+				TestObject: &configurationv1beta1.KongConsumerGroup{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongConsumerGroupSpec{
+						Name: "cg-1",
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						Tags: func() []string {
+							var tags []string
+							for i := range 21 {
+								tags = append(tags, fmt.Sprintf("tag-%d", i))
+							}
+							return tags
+						}(),
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.tags: Too many: 21: must have at most 20 items"),
+			},
+			{
+				Name: "tags entries must not be longer than 128 characters",
+				TestObject: &configurationv1beta1.KongConsumerGroup{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongConsumerGroupSpec{
+						Name: "cg-1",
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						Tags: []string{
+							lo.RandomString(129, lo.AlphanumericCharset),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("tags entries must not be longer than 128 characters"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongcredentialacl_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongcredentialacl_test.go
@@ -1,0 +1,175 @@
+package configuration_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongCredentialACL(t *testing.T) {
+	t.Run("updates not allowed for status conditions", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongCredentialACL]{
+			{
+				Name: "consumerRef change is not allowed for Programmed=True",
+				TestObject: &configurationv1alpha1.KongCredentialACL{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialACLSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialACLAPISpec: configurationv1alpha1.KongCredentialACLAPISpec{
+							Group: "group1",
+						},
+					},
+					Status: configurationv1alpha1.KongCredentialACLStatus{
+						Konnect: &konnectv1alpha2.KonnectEntityStatusWithControlPlaneAndConsumerRefs{},
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionTrue,
+								Reason:             "Valid",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(c *configurationv1alpha1.KongCredentialACL) {
+					c.Spec.ConsumerRef.Name = "new-consumer"
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.consumerRef is immutable when an entity is already Programmed"),
+			},
+			{
+				Name: "consumerRef change is allowed when consumer is not Programmed=True nor APIAuthValid=True",
+				TestObject: &configurationv1alpha1.KongCredentialACL{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialACLSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialACLAPISpec: configurationv1alpha1.KongCredentialACLAPISpec{
+							Group: "group1",
+						},
+					},
+					Status: configurationv1alpha1.KongCredentialACLStatus{
+						Konnect: &konnectv1alpha2.KonnectEntityStatusWithControlPlaneAndConsumerRefs{},
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionFalse,
+								Reason:             "Invalid",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(c *configurationv1alpha1.KongCredentialACL) {
+					c.Spec.ConsumerRef.Name = "new-consumer"
+				},
+			},
+		}.Run(t)
+	})
+
+	t.Run("required fields validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongCredentialACL]{
+			{
+				Name: "group is required",
+				TestObject: &configurationv1alpha1.KongCredentialACL{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialACLSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialACLAPISpec: configurationv1alpha1.KongCredentialACLAPISpec{
+							Group: "group1",
+						},
+					},
+				},
+			},
+			{
+				Name: "group is required and error is returned if not set",
+				TestObject: &configurationv1alpha1.KongCredentialACL{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialACLSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+					},
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("group is required"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("tags validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongCredentialACL]{
+			{
+				Name: "up to 20 tags are allowed",
+				TestObject: &configurationv1alpha1.KongCredentialACL{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialACLSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialACLAPISpec: configurationv1alpha1.KongCredentialACLAPISpec{
+							Group: "group1",
+							Tags: func() []string {
+								var tags []string
+								for i := range 20 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+			},
+			{
+				Name: "more than 20 tags are not allowed",
+				TestObject: &configurationv1alpha1.KongCredentialACL{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialACLSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialACLAPISpec: configurationv1alpha1.KongCredentialACLAPISpec{
+							Group: "group1",
+							Tags: func() []string {
+								var tags []string
+								for i := range 21 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.tags: Too many: 21: must have at most 20 items"),
+			},
+			{
+				Name: "tags entries must not be longer than 128 characters",
+				TestObject: &configurationv1alpha1.KongCredentialACL{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialACLSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialACLAPISpec: configurationv1alpha1.KongCredentialACLAPISpec{
+							Group: "group1",
+							Tags: []string{
+								lo.RandomString(129, lo.AlphanumericCharset),
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("tags entries must not be longer than 128 characters"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongcredentialapikey_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongcredentialapikey_test.go
@@ -1,0 +1,175 @@
+package configuration_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongCredentialAPIKey(t *testing.T) {
+	t.Run("updates not allowed for status conditions", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongCredentialAPIKey]{
+			{
+				Name: "consumerRef change is not allowed for Programmed=True",
+				TestObject: &configurationv1alpha1.KongCredentialAPIKey{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialAPIKeySpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialAPIKeyAPISpec: configurationv1alpha1.KongCredentialAPIKeyAPISpec{
+							Key: "key",
+						},
+					},
+					Status: configurationv1alpha1.KongCredentialAPIKeyStatus{
+						Konnect: &konnectv1alpha2.KonnectEntityStatusWithControlPlaneAndConsumerRefs{},
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionTrue,
+								Reason:             "Valid",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(c *configurationv1alpha1.KongCredentialAPIKey) {
+					c.Spec.ConsumerRef.Name = "new-consumer"
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.consumerRef is immutable when an entity is already Programmed"),
+			},
+			{
+				Name: "consumerRef change is allowed when consumer is not Programmed=True nor APIAuthValid=True",
+				TestObject: &configurationv1alpha1.KongCredentialAPIKey{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialAPIKeySpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialAPIKeyAPISpec: configurationv1alpha1.KongCredentialAPIKeyAPISpec{
+							Key: "key",
+						},
+					},
+					Status: configurationv1alpha1.KongCredentialAPIKeyStatus{
+						Konnect: &konnectv1alpha2.KonnectEntityStatusWithControlPlaneAndConsumerRefs{},
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionFalse,
+								Reason:             "Invalid",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(c *configurationv1alpha1.KongCredentialAPIKey) {
+					c.Spec.ConsumerRef.Name = "new-consumer"
+				},
+			},
+		}.Run(t)
+	})
+
+	t.Run("required fields validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongCredentialAPIKey]{
+			{
+				Name: "key is required",
+				TestObject: &configurationv1alpha1.KongCredentialAPIKey{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialAPIKeySpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialAPIKeyAPISpec: configurationv1alpha1.KongCredentialAPIKeyAPISpec{
+							Key: "key",
+						},
+					},
+				},
+			},
+			{
+				Name: "key is required and error is returned if not set",
+				TestObject: &configurationv1alpha1.KongCredentialAPIKey{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialAPIKeySpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+					},
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("key is required"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("tags validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongCredentialAPIKey]{
+			{
+				Name: "up to 20 tags are allowed",
+				TestObject: &configurationv1alpha1.KongCredentialAPIKey{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialAPIKeySpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialAPIKeyAPISpec: configurationv1alpha1.KongCredentialAPIKeyAPISpec{
+							Key: "key-1",
+							Tags: func() []string {
+								var tags []string
+								for i := range 20 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+			},
+			{
+				Name: "more than 20 tags are not allowed",
+				TestObject: &configurationv1alpha1.KongCredentialAPIKey{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialAPIKeySpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialAPIKeyAPISpec: configurationv1alpha1.KongCredentialAPIKeyAPISpec{
+							Key: "key-1",
+							Tags: func() []string {
+								var tags []string
+								for i := range 21 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.tags: Too many: 21: must have at most 20 items"),
+			},
+			{
+				Name: "tags entries must not be longer than 128 characters",
+				TestObject: &configurationv1alpha1.KongCredentialAPIKey{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialAPIKeySpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialAPIKeyAPISpec: configurationv1alpha1.KongCredentialAPIKeyAPISpec{
+							Key: "key-1",
+							Tags: []string{
+								lo.RandomString(129, lo.AlphanumericCharset),
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("tags entries must not be longer than 128 characters"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongcredentialbasicauth_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongcredentialbasicauth_test.go
@@ -1,0 +1,199 @@
+package configuration_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongCredentialBasicAuth(t *testing.T) {
+	t.Run("updates not allowed for status conditions", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongCredentialBasicAuth]{
+			{
+				Name: "consumerRef change is not allowed for Programmed=True",
+				TestObject: &configurationv1alpha1.KongCredentialBasicAuth{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialBasicAuthSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialBasicAuthAPISpec: configurationv1alpha1.KongCredentialBasicAuthAPISpec{
+							Password: "password",
+							Username: "username",
+						},
+					},
+					Status: configurationv1alpha1.KongCredentialBasicAuthStatus{
+						Konnect: &konnectv1alpha2.KonnectEntityStatusWithControlPlaneAndConsumerRefs{},
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionTrue,
+								Reason:             "Valid",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(c *configurationv1alpha1.KongCredentialBasicAuth) {
+					c.Spec.ConsumerRef.Name = "new-consumer"
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.consumerRef is immutable when an entity is already Programmed"),
+			},
+			{
+				Name: "consumerRef change is allowed when consumer is not Programmed=True nor APIAuthValid=True",
+				TestObject: &configurationv1alpha1.KongCredentialBasicAuth{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialBasicAuthSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialBasicAuthAPISpec: configurationv1alpha1.KongCredentialBasicAuthAPISpec{
+							Password: "password",
+							Username: "username",
+						},
+					},
+					Status: configurationv1alpha1.KongCredentialBasicAuthStatus{
+						Konnect: &konnectv1alpha2.KonnectEntityStatusWithControlPlaneAndConsumerRefs{},
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionFalse,
+								Reason:             "Invalid",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(c *configurationv1alpha1.KongCredentialBasicAuth) {
+					c.Spec.ConsumerRef.Name = "new-consumer"
+				},
+			},
+		}.Run(t)
+	})
+
+	t.Run("required fields validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongCredentialBasicAuth]{
+			{
+				Name: "password is required",
+				TestObject: &configurationv1alpha1.KongCredentialBasicAuth{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialBasicAuthSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialBasicAuthAPISpec: configurationv1alpha1.KongCredentialBasicAuthAPISpec{
+							Username: "username",
+						},
+					},
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.consumerREf is immutable when an entity is already Programmed"),
+			},
+			{
+				Name: "username is required",
+				TestObject: &configurationv1alpha1.KongCredentialBasicAuth{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialBasicAuthSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialBasicAuthAPISpec: configurationv1alpha1.KongCredentialBasicAuthAPISpec{
+							Password: "password",
+						},
+					},
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.consumerREf is immutable when an entity is already Programmed"),
+			},
+			{
+				Name: "password and username are required",
+				TestObject: &configurationv1alpha1.KongCredentialBasicAuth{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialBasicAuthSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialBasicAuthAPISpec: configurationv1alpha1.KongCredentialBasicAuthAPISpec{
+							Username: "username",
+							Password: "password",
+						},
+					},
+				},
+			},
+		}.Run(t)
+	})
+
+	t.Run("tags validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongCredentialBasicAuth]{
+			{
+				Name: "up to 20 tags are allowed",
+				TestObject: &configurationv1alpha1.KongCredentialBasicAuth{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialBasicAuthSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialBasicAuthAPISpec: configurationv1alpha1.KongCredentialBasicAuthAPISpec{
+							Password: "pass",
+							Username: "user",
+							Tags: func() []string {
+								var tags []string
+								for i := range 20 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+			},
+			{
+				Name: "more than 20 tags are not allowed",
+				TestObject: &configurationv1alpha1.KongCredentialBasicAuth{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialBasicAuthSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialBasicAuthAPISpec: configurationv1alpha1.KongCredentialBasicAuthAPISpec{
+							Password: "pass",
+							Username: "user",
+							Tags: func() []string {
+								var tags []string
+								for i := range 21 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.tags: Too many: 21: must have at most 20 items"),
+			},
+			{
+				Name: "tags entries must not be longer than 128 characters",
+				TestObject: &configurationv1alpha1.KongCredentialBasicAuth{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialBasicAuthSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialBasicAuthAPISpec: configurationv1alpha1.KongCredentialBasicAuthAPISpec{
+							Password: "pass",
+							Username: "user",
+							Tags: []string{
+								lo.RandomString(129, lo.AlphanumericCharset),
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("tags entries must not be longer than 128 characters"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongcredentialhmac_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongcredentialhmac_test.go
@@ -1,0 +1,181 @@
+package configuration_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongCredentialHMAC(t *testing.T) {
+	t.Run("updates not allowed for status conditions", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongCredentialHMAC]{
+			{
+				Name: "consumerRef change is not allowed for Programmed=True",
+				TestObject: &configurationv1alpha1.KongCredentialHMAC{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialHMACSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialHMACAPISpec: configurationv1alpha1.KongCredentialHMACAPISpec{
+							Secret:   lo.ToPtr("secret"),
+							Username: lo.ToPtr("test-username"),
+						},
+					},
+					Status: configurationv1alpha1.KongCredentialHMACStatus{
+						Konnect: &konnectv1alpha2.KonnectEntityStatusWithControlPlaneAndConsumerRefs{},
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionTrue,
+								Reason:             "Valid",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(c *configurationv1alpha1.KongCredentialHMAC) {
+					c.Spec.ConsumerRef.Name = "new-consumer"
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.consumerRef is immutable when an entity is already Programmed"),
+			},
+			{
+				Name: "consumerRef change is allowed when consumer is not Programmed=True nor APIAuthValid=True",
+				TestObject: &configurationv1alpha1.KongCredentialHMAC{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialHMACSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialHMACAPISpec: configurationv1alpha1.KongCredentialHMACAPISpec{
+							Secret:   lo.ToPtr("secret"),
+							Username: lo.ToPtr("test-username"),
+						},
+					},
+					Status: configurationv1alpha1.KongCredentialHMACStatus{
+						Konnect: &konnectv1alpha2.KonnectEntityStatusWithControlPlaneAndConsumerRefs{},
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionFalse,
+								Reason:             "Invalid",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(c *configurationv1alpha1.KongCredentialHMAC) {
+					c.Spec.ConsumerRef.Name = "new-consumer"
+				},
+			},
+		}.Run(t)
+	})
+
+	t.Run("fields validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongCredentialHMAC]{
+			{
+				Name: "username is required",
+				TestObject: &configurationv1alpha1.KongCredentialHMAC{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialHMACSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialHMACAPISpec: configurationv1alpha1.KongCredentialHMACAPISpec{
+							Secret: lo.ToPtr("secret"),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.username: Required value"),
+			},
+			{
+				Name: "username is required and no error is expected when it is set",
+				TestObject: &configurationv1alpha1.KongCredentialHMAC{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialHMACSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialHMACAPISpec: configurationv1alpha1.KongCredentialHMACAPISpec{
+							Secret:   lo.ToPtr("secret"),
+							Username: lo.ToPtr("test-username"),
+						},
+					},
+				},
+			},
+		}.Run(t)
+	})
+
+	t.Run("tags validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongCredentialHMAC]{
+			{
+				Name: "up to 20 tags are allowed",
+				TestObject: &configurationv1alpha1.KongCredentialHMAC{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialHMACSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialHMACAPISpec: configurationv1alpha1.KongCredentialHMACAPISpec{
+							Username: lo.ToPtr("user"),
+							Tags: func() []string {
+								var tags []string
+								for i := range 20 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+			},
+			{
+				Name: "more than 20 tags are not allowed",
+				TestObject: &configurationv1alpha1.KongCredentialHMAC{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialHMACSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialHMACAPISpec: configurationv1alpha1.KongCredentialHMACAPISpec{
+							Username: lo.ToPtr("user"),
+							Tags: func() []string {
+								var tags []string
+								for i := range 21 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.tags: Too many: 21: must have at most 20 items"),
+			},
+			{
+				Name: "tags entries must not be longer than 128 characters",
+				TestObject: &configurationv1alpha1.KongCredentialHMAC{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialHMACSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialHMACAPISpec: configurationv1alpha1.KongCredentialHMACAPISpec{
+							Username: lo.ToPtr("user"),
+							Tags: []string{
+								lo.RandomString(129, lo.AlphanumericCharset),
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("tags entries must not be longer than 128 characters"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongcredentialjwt_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongcredentialjwt_test.go
@@ -1,0 +1,355 @@
+package configuration_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongCredentialJWT(t *testing.T) {
+	t.Run("updates not allowed for status conditions", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongCredentialJWT]{
+			{
+				Name: "consumerRef change is not allowed for Programmed=True",
+				TestObject: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Key: lo.ToPtr("key"),
+						},
+					},
+					Status: configurationv1alpha1.KongCredentialJWTStatus{
+						Konnect: &konnectv1alpha2.KonnectEntityStatusWithControlPlaneAndConsumerRefs{},
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionTrue,
+								Reason:             "Valid",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(c *configurationv1alpha1.KongCredentialJWT) {
+					c.Spec.ConsumerRef.Name = "new-consumer"
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.consumerRef is immutable when an entity is already Programmed"),
+			},
+			{
+				Name: "consumerRef change is allowed when consumer is not Programmed=True nor APIAuthValid=True",
+				TestObject: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Key: lo.ToPtr("key"),
+						},
+					},
+					Status: configurationv1alpha1.KongCredentialJWTStatus{
+						Konnect: &konnectv1alpha2.KonnectEntityStatusWithControlPlaneAndConsumerRefs{},
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionFalse,
+								Reason:             "Invalid",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(c *configurationv1alpha1.KongCredentialJWT) {
+					c.Spec.ConsumerRef.Name = "new-consumer"
+				},
+			},
+		}.Run(t)
+	})
+
+	t.Run("fields validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongCredentialJWT]{
+			{
+				Name: "rsa_public_key is required when algorithm is RS256",
+				TestObject: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Key:       lo.ToPtr("key"),
+							Algorithm: string(sdkkonnectcomp.AlgorithmRs384),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.rsa_public_key is required when algorithm is RS*, ES*, PS* or EdDSA*"),
+			},
+			{
+				Name: "rsa_public_key is required when algorithm is RS384",
+				TestObject: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Key:       lo.ToPtr("key"),
+							Algorithm: string(sdkkonnectcomp.AlgorithmRs384),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.rsa_public_key is required when algorithm is RS*, ES*, PS* or EdDSA*"),
+			},
+			{
+				Name: "rsa_public_key is required when algorithm is RS512",
+				TestObject: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Key:       lo.ToPtr("key"),
+							Algorithm: string(sdkkonnectcomp.AlgorithmRs512),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.rsa_public_key is required when algorithm is RS*, ES*, PS* or EdDSA*"),
+			},
+			{
+				Name: "rsa_public_key is required when algorithm is PS256",
+				TestObject: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Key:       lo.ToPtr("key"),
+							Algorithm: string(sdkkonnectcomp.AlgorithmPs384),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.rsa_public_key is required when algorithm is RS*, ES*, PS* or EdDSA*"),
+			},
+			{
+				Name: "rsa_public_key is required when algorithm is PS384",
+				TestObject: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Key:       lo.ToPtr("key"),
+							Algorithm: string(sdkkonnectcomp.AlgorithmPs384),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.rsa_public_key is required when algorithm is RS*, ES*, PS* or EdDSA*"),
+			},
+			{
+				Name: "rsa_public_key is required when algorithm is PS512",
+				TestObject: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Key:       lo.ToPtr("key"),
+							Algorithm: string(sdkkonnectcomp.AlgorithmPs512),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.rsa_public_key is required when algorithm is RS*, ES*, PS* or EdDSA*"),
+			},
+			{
+				Name: "rsa_public_key is required when algorithm is ES256",
+				TestObject: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Key:       lo.ToPtr("key"),
+							Algorithm: string(sdkkonnectcomp.AlgorithmEs384),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.rsa_public_key is required when algorithm is RS*, ES*, PS* or EdDSA*"),
+			},
+			{
+				Name: "rsa_public_key is required when algorithm is ES384",
+				TestObject: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Key:       lo.ToPtr("key"),
+							Algorithm: string(sdkkonnectcomp.AlgorithmEs384),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.rsa_public_key is required when algorithm is RS*, ES*, PS* or EdDSA*"),
+			},
+			{
+				Name: "rsa_public_key is required when algorithm is ES512",
+				TestObject: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Key:       lo.ToPtr("key"),
+							Algorithm: string(sdkkonnectcomp.AlgorithmEs512),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.rsa_public_key is required when algorithm is RS*, ES*, PS* or EdDSA*"),
+			},
+			{
+				Name: "rsa_public_key is required when algorithm is EdDSA",
+				TestObject: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Key:       lo.ToPtr("key"),
+							Algorithm: string(sdkkonnectcomp.AlgorithmEdDsa),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.rsa_public_key is required when algorithm is RS*, ES*, PS* or EdDSA*"),
+			},
+			{
+				Name: "rsa_public_key is not required when algorithm is Hs256",
+				TestObject: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Key:       lo.ToPtr("key"),
+							Algorithm: string(sdkkonnectcomp.AlgorithmHs256),
+						},
+					},
+				},
+			},
+			{
+				Name: "rsa_public_key is not required when algorithm is Hs384",
+				TestObject: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Key:       lo.ToPtr("key"),
+							Algorithm: string(sdkkonnectcomp.AlgorithmHs384),
+						},
+					},
+				},
+			},
+			{
+				Name: "rsa_public_key is not required when algorithm is Hs512",
+				TestObject: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Key:       lo.ToPtr("key"),
+							Algorithm: string(sdkkonnectcomp.AlgorithmHs512),
+						},
+					},
+				},
+			},
+		}.Run(t)
+	})
+
+	t.Run("tags validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongCredentialJWT]{
+			{
+				Name: "up to 20 tags are allowed",
+				TestObject: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Key: lo.ToPtr("key"),
+							Tags: func() []string {
+								var tags []string
+								for i := range 20 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+			},
+			{
+				Name: "more than 20 tags are not allowed",
+				TestObject: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Key: lo.ToPtr("key"),
+							Tags: func() []string {
+								var tags []string
+								for i := range 21 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.tags: Too many: 21: must have at most 20 items"),
+			},
+			{
+				Name: "tags entries must not be longer than 128 characters",
+				TestObject: &configurationv1alpha1.KongCredentialJWT{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCredentialJWTSpec{
+						ConsumerRef: corev1.LocalObjectReference{
+							Name: "test-kong-consumer",
+						},
+						KongCredentialJWTAPISpec: configurationv1alpha1.KongCredentialJWTAPISpec{
+							Key: lo.ToPtr("key"),
+							Tags: []string{
+								lo.RandomString(129, lo.AlphanumericCharset),
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("tags entries must not be longer than 128 characters"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongcustomentity_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongcustomentity_test.go
@@ -1,0 +1,228 @@
+package configuration_test
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongCustomEntity(t *testing.T) {
+	t.Run("spec", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongCustomEntity]{
+			{
+				Name: "basic allowed spec",
+				TestObject: &configurationv1alpha1.KongCustomEntity{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCustomEntitySpec{
+						Fields: apiextensionsv1.JSON{
+							Raw: []byte(
+								`{}`,
+							),
+						},
+						ParentRef: &configurationv1alpha1.ObjectReference{
+							Kind: lo.ToPtr("KongPlugin"),
+						},
+					},
+				},
+			},
+			{
+				Name: "spec.fields is required",
+				TestObject: &configurationv1alpha1.KongCustomEntity{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec:       configurationv1alpha1.KongCustomEntitySpec{},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.fields: Required value"),
+			},
+			{
+				Name: "spec.type cannot be known Kong entity type - services",
+				TestObject: &configurationv1alpha1.KongCustomEntity{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCustomEntitySpec{
+						EntityType: "services",
+						Fields: apiextensionsv1.JSON{
+							Raw: []byte(
+								`{}`,
+							),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("The type field cannot be one of the known Kong entity types"),
+			},
+			{
+				Name: "spec.type cannot be known Kong entity type - routes",
+				TestObject: &configurationv1alpha1.KongCustomEntity{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCustomEntitySpec{
+						EntityType: "routes",
+						Fields: apiextensionsv1.JSON{
+							Raw: []byte(
+								`{}`,
+							),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("The type field cannot be one of the known Kong entity types"),
+			},
+			{
+				Name: "spec.type cannot be known Kong entity type - upstreams",
+				TestObject: &configurationv1alpha1.KongCustomEntity{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCustomEntitySpec{
+						EntityType: "upstreams",
+						Fields: apiextensionsv1.JSON{
+							Raw: []byte(
+								`{}`,
+							),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("The type field cannot be one of the known Kong entity types"),
+			},
+			{
+				Name: "spec.type cannot be known Kong entity type - targets",
+				TestObject: &configurationv1alpha1.KongCustomEntity{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCustomEntitySpec{
+						EntityType: "targets",
+						Fields: apiextensionsv1.JSON{
+							Raw: []byte(
+								`{}`,
+							),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("The type field cannot be one of the known Kong entity types"),
+			},
+			{
+				Name: "spec.type cannot be known Kong entity type - plugins",
+				TestObject: &configurationv1alpha1.KongCustomEntity{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCustomEntitySpec{
+						EntityType: "plugins",
+						Fields: apiextensionsv1.JSON{
+							Raw: []byte(
+								`{}`,
+							),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("The type field cannot be one of the known Kong entity types"),
+			},
+			{
+				Name: "spec.type cannot be known Kong entity type - consumers",
+				TestObject: &configurationv1alpha1.KongCustomEntity{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCustomEntitySpec{
+						EntityType: "consumers",
+						Fields: apiextensionsv1.JSON{
+							Raw: []byte(
+								`{}`,
+							),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("The type field cannot be one of the known Kong entity types"),
+			},
+			{
+				Name: "spec.type cannot be known Kong entity type - consumer_groups",
+				TestObject: &configurationv1alpha1.KongCustomEntity{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCustomEntitySpec{
+						EntityType: "consumer_groups",
+						Fields: apiextensionsv1.JSON{
+							Raw: []byte(
+								`{}`,
+							),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("The type field cannot be one of the known Kong entity types"),
+			},
+			{
+				Name: "spec.type can be set",
+				TestObject: &configurationv1alpha1.KongCustomEntity{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCustomEntitySpec{
+						EntityType: "dummy",
+						Fields: apiextensionsv1.JSON{
+							Raw: []byte(
+								`{}`,
+							),
+						},
+					},
+				},
+			},
+			{
+				Name: "spec.type cannot be changed",
+				TestObject: &configurationv1alpha1.KongCustomEntity{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCustomEntitySpec{
+						EntityType: "dummy",
+						Fields: apiextensionsv1.JSON{
+							Raw: []byte(
+								`{}`,
+							),
+						},
+					},
+				},
+				Update: func(kce *configurationv1alpha1.KongCustomEntity) {
+					kce.Spec.EntityType = "new-dummy"
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("The spec.type field is immutable"),
+			},
+			{
+				Name: "spec.parentRef.kind KongPlugin is supported",
+				TestObject: &configurationv1alpha1.KongCustomEntity{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCustomEntitySpec{
+						Fields: apiextensionsv1.JSON{
+							Raw: []byte(
+								`{}`,
+							),
+						},
+						ParentRef: &configurationv1alpha1.ObjectReference{
+							Kind: lo.ToPtr("KongPlugin"),
+						},
+					},
+				},
+			},
+			{
+				Name: "spec.parentRef.kind KongClusterPlugin is supported",
+				TestObject: &configurationv1alpha1.KongCustomEntity{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCustomEntitySpec{
+						Fields: apiextensionsv1.JSON{
+							Raw: []byte(
+								`{}`,
+							),
+						},
+						ParentRef: &configurationv1alpha1.ObjectReference{
+							Kind: lo.ToPtr("KongClusterPlugin"),
+						},
+					},
+				},
+			},
+			{
+				Name: "other types for spec.parentRef.kind are not allowed",
+				TestObject: &configurationv1alpha1.KongCustomEntity{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongCustomEntitySpec{
+						Fields: apiextensionsv1.JSON{
+							Raw: []byte(
+								`{}`,
+							),
+						},
+						ParentRef: &configurationv1alpha1.ObjectReference{
+							Kind: lo.ToPtr("CustomKind"),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.parentRef.kind: Unsupported value: \"CustomKind\": supported values: \"KongPlugin\", \"KongClusterPlugin\""),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongdataplaneclientcertificate_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongdataplaneclientcertificate_test.go
@@ -1,0 +1,125 @@
+package configuration_test
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongDataPlaneClientCertificate(t *testing.T) {
+	obj := &configurationv1alpha1.KongDataPlaneClientCertificate{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KongDataPlaneClientCertificate",
+			APIVersion: configurationv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: common.CommonObjectMeta,
+		Spec: configurationv1alpha1.KongDataPlaneClientCertificateSpec{
+			KongDataPlaneClientCertificateAPISpec: configurationv1alpha1.KongDataPlaneClientCertificateAPISpec{
+				Cert: "cert",
+			},
+		},
+	}
+
+	t.Run("cp ref", func(t *testing.T) {
+		common.NewCRDValidationTestCasesGroupCPRefChange(t, obj, common.NotSupportedByKIC, common.ControlPlaneRefRequired).Run(t)
+	})
+
+	t.Run("cp ref, type=kic", func(t *testing.T) {
+		common.NewCRDValidationTestCasesGroupCPRefChangeKICUnsupportedTypes(t, obj, common.EmptyControlPlaneRefNotAllowed).Run(t)
+	})
+
+	t.Run("spec", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongDataPlaneClientCertificate]{
+			{
+				Name: "valid KongDataPlaneClientCertificate",
+				TestObject: &configurationv1alpha1.KongDataPlaneClientCertificate{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongDataPlaneClientCertificateSpec{
+						KongDataPlaneClientCertificateAPISpec: configurationv1alpha1.KongDataPlaneClientCertificateAPISpec{
+							Cert: "cert",
+						},
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "cert is required",
+				TestObject: &configurationv1alpha1.KongDataPlaneClientCertificate{
+					ObjectMeta: common.CommonObjectMeta,
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.cert in body should be at least 1 chars long"),
+			},
+			{
+				Name: "cert can be altered before programmed",
+				TestObject: &configurationv1alpha1.KongDataPlaneClientCertificate{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongDataPlaneClientCertificateSpec{
+						KongDataPlaneClientCertificateAPISpec: configurationv1alpha1.KongDataPlaneClientCertificateAPISpec{
+							Cert: "cert",
+						},
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+					},
+					Status: configurationv1alpha1.KongDataPlaneClientCertificateStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionFalse,
+								Reason:             "Pending",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(k *configurationv1alpha1.KongDataPlaneClientCertificate) {
+					k.Spec.Cert = "cert2"
+				},
+			},
+			{
+				Name: "cert becomes immutable after programmed",
+				TestObject: &configurationv1alpha1.KongDataPlaneClientCertificate{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongDataPlaneClientCertificateSpec{
+						KongDataPlaneClientCertificateAPISpec: configurationv1alpha1.KongDataPlaneClientCertificateAPISpec{
+							Cert: "cert",
+						},
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+					},
+					Status: configurationv1alpha1.KongDataPlaneClientCertificateStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionTrue,
+								Reason:             "Programmed",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(k *configurationv1alpha1.KongDataPlaneClientCertificate) {
+					k.Spec.Cert = "cert2"
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.cert is immutable when an entity is already Programmed"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongkey_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongkey_test.go
@@ -1,0 +1,260 @@
+package configuration_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongKey(t *testing.T) {
+	t.Run("jwk/cp ref", func(t *testing.T) {
+		obj := &configurationv1alpha1.KongKey{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KongKey",
+				APIVersion: configurationv1alpha1.GroupVersion.String(),
+			},
+			ObjectMeta: common.CommonObjectMeta,
+			Spec: configurationv1alpha1.KongKeySpec{
+				KongKeyAPISpec: configurationv1alpha1.KongKeyAPISpec{
+					KID: "1",
+					JWK: lo.ToPtr("jwk"),
+				},
+			},
+		}
+
+		common.NewCRDValidationTestCasesGroupCPRefChange(t, obj, common.NotSupportedByKIC, common.ControlPlaneRefNotRequired).Run(t)
+	})
+
+	t.Run("pem/cp ref", func(t *testing.T) {
+		obj := &configurationv1alpha1.KongKey{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KongKey",
+				APIVersion: configurationv1alpha1.GroupVersion.String(),
+			},
+			ObjectMeta: common.CommonObjectMeta,
+			Spec: configurationv1alpha1.KongKeySpec{
+				KongKeyAPISpec: configurationv1alpha1.KongKeyAPISpec{
+					KID: "1",
+					PEM: &configurationv1alpha1.PEMKeyPair{
+						PublicKey:  "public",
+						PrivateKey: "private",
+					},
+				},
+			},
+		}
+
+		common.NewCRDValidationTestCasesGroupCPRefChange(t, obj, common.NotSupportedByKIC, common.ControlPlaneRefNotRequired).Run(t)
+	})
+
+	t.Run("spec", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongKey]{
+			{
+				Name: "KID must be set",
+				TestObject: &configurationv1alpha1.KongKey{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongKeySpec{
+						KongKeyAPISpec: configurationv1alpha1.KongKeyAPISpec{
+							JWK: lo.ToPtr("{}"),
+						},
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.kid in body should be at least 1 chars long"),
+			},
+			{
+				Name: "one of JWK or PEM must be set",
+				TestObject: &configurationv1alpha1.KongKey{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongKeySpec{
+						KongKeyAPISpec: configurationv1alpha1.KongKeyAPISpec{
+							KID: "1",
+						},
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Either 'jwk' or 'pem' must be set"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("key set ref", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongKey]{
+			{
+				Name: "when type is 'namespacedRef', namespacedRef is required",
+				TestObject: &configurationv1alpha1.KongKey{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongKeySpec{
+						KeySetRef: &configurationv1alpha1.KeySetRef{
+							Type: configurationv1alpha1.KeySetRefNamespacedRef,
+						},
+						KongKeyAPISpec: configurationv1alpha1.KongKeyAPISpec{
+							KID: "1",
+							JWK: lo.ToPtr("{}"),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("when type is namespacedRef, namespacedRef must be set"),
+			},
+			{
+				Name: "'namespacedRef' type is accepted",
+				TestObject: &configurationv1alpha1.KongKey{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongKeySpec{
+						KeySetRef: &configurationv1alpha1.KeySetRef{
+							Type: configurationv1alpha1.KeySetRefNamespacedRef,
+							NamespacedRef: &commonv1alpha1.NameRef{
+								Name: "keyset-1",
+							},
+						},
+						KongKeyAPISpec: configurationv1alpha1.KongKeyAPISpec{
+							KID: "1",
+							JWK: lo.ToPtr("{}"),
+						},
+					},
+				},
+			},
+			{
+				Name: "'konnectID' type is accepted",
+				TestObject: &configurationv1alpha1.KongKey{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongKeySpec{
+						KeySetRef: &configurationv1alpha1.KeySetRef{
+							Type:      configurationv1alpha1.KeySetRefKonnectID,
+							KonnectID: lo.ToPtr("keyset-1"),
+						},
+						KongKeyAPISpec: configurationv1alpha1.KongKeyAPISpec{
+							KID: "1",
+							JWK: lo.ToPtr("{}"),
+						},
+					},
+				},
+			},
+			{
+				Name: "when type is 'konnectID', konnectID is required",
+				TestObject: &configurationv1alpha1.KongKey{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongKeySpec{
+						KeySetRef: &configurationv1alpha1.KeySetRef{
+							Type: configurationv1alpha1.KeySetRefKonnectID,
+						},
+						KongKeyAPISpec: configurationv1alpha1.KongKeyAPISpec{
+							KID: "1",
+							JWK: lo.ToPtr("{}"),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectID must be set"),
+			},
+			{
+				Name: "unknown type is not accepted",
+				TestObject: &configurationv1alpha1.KongKey{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongKeySpec{
+						KeySetRef: &configurationv1alpha1.KeySetRef{
+							Type: configurationv1alpha1.KeySetRefType("unknown"),
+						},
+						KongKeyAPISpec: configurationv1alpha1.KongKeyAPISpec{
+							KID: "1",
+							JWK: lo.ToPtr("{}"),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr(`Unsupported value: "unknown": supported values: "konnectID", "namespacedRef"`),
+			},
+		}.Run(t)
+	})
+
+	t.Run("tags validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongKey]{
+			{
+				Name: "up to 20 tags are allowed",
+				TestObject: &configurationv1alpha1.KongKey{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongKeySpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongKeyAPISpec: configurationv1alpha1.KongKeyAPISpec{
+							KID: "1",
+							JWK: lo.ToPtr("{}"),
+							Tags: func() []string {
+								var tags []string
+								for i := range 20 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+			},
+			{
+				Name: "more than 20 tags are not allowed",
+				TestObject: &configurationv1alpha1.KongKey{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongKeySpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongKeyAPISpec: configurationv1alpha1.KongKeyAPISpec{
+							KID: "1",
+							JWK: lo.ToPtr("{}"),
+							Tags: func() []string {
+								var tags []string
+								for i := range 21 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.tags: Too many: 21: must have at most 20 items"),
+			},
+			{
+				Name: "tags entries must not be longer than 128 characters",
+				TestObject: &configurationv1alpha1.KongKey{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongKeySpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongKeyAPISpec: configurationv1alpha1.KongKeyAPISpec{
+							KID: "1",
+							JWK: lo.ToPtr("{}"),
+							Tags: []string{
+								lo.RandomString(129, lo.AlphanumericCharset),
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("tags entries must not be longer than 128 characters"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongkeyset_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongkeyset_test.go
@@ -1,0 +1,126 @@
+package configuration_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongKeySet(t *testing.T) {
+	obj := &configurationv1alpha1.KongKeySet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KongKeySet",
+			APIVersion: configurationv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: common.CommonObjectMeta,
+		Spec: configurationv1alpha1.KongKeySetSpec{
+			KongKeySetAPISpec: configurationv1alpha1.KongKeySetAPISpec{
+				Name: "keyset",
+			},
+		},
+	}
+
+	t.Run("cp ref", func(t *testing.T) {
+		common.NewCRDValidationTestCasesGroupCPRefChange(t, obj, common.NotSupportedByKIC, common.ControlPlaneRefRequired).Run(t)
+	})
+
+	t.Run("cp ref, type=kic", func(t *testing.T) {
+		common.NewCRDValidationTestCasesGroupCPRefChangeKICUnsupportedTypes(t, obj, common.EmptyControlPlaneRefNotAllowed).Run(t)
+	})
+
+	t.Run("spec", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongKeySet]{
+			{
+				Name: "name must be set",
+				TestObject: &configurationv1alpha1.KongKeySet{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongKeySetSpec{
+						KongKeySetAPISpec: configurationv1alpha1.KongKeySetAPISpec{},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.name in body should be at least 1 chars long"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("tags validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongKeySet]{
+			{
+				Name: "up to 20 tags are allowed",
+				TestObject: &configurationv1alpha1.KongKeySet{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongKeySetSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongKeySetAPISpec: configurationv1alpha1.KongKeySetAPISpec{
+							Name: "keyset",
+							Tags: func() []string {
+								var tags []string
+								for i := range 20 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+			},
+			{
+				Name: "more than 20 tags are not allowed",
+				TestObject: &configurationv1alpha1.KongKeySet{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongKeySetSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongKeySetAPISpec: configurationv1alpha1.KongKeySetAPISpec{
+							Name: "keyset",
+							Tags: func() []string {
+								var tags []string
+								for i := range 21 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.tags: Too many: 21: must have at most 20 items"),
+			},
+			{
+				Name: "tags entries must not be longer than 128 characters",
+				TestObject: &configurationv1alpha1.KongKeySet{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongKeySetSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongKeySetAPISpec: configurationv1alpha1.KongKeySetAPISpec{
+							Name: "keyset",
+							Tags: []string{
+								lo.RandomString(129, lo.AlphanumericCharset),
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("tags entries must not be longer than 128 characters"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongpluginbindings_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongpluginbindings_test.go
@@ -1,0 +1,681 @@
+package configuration_test
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongPluginBindings(t *testing.T) {
+	validTestCPRef := func() commonv1alpha1.ControlPlaneRef {
+		return commonv1alpha1.ControlPlaneRef{
+			Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+			KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+				Name: "test-control-plane",
+			},
+		}
+	}
+
+	t.Run("cp ref", func(t *testing.T) {
+		obj := &configurationv1alpha1.KongPluginBinding{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KongPluginBinding",
+				APIVersion: configurationv1alpha1.GroupVersion.String(),
+			},
+			ObjectMeta: common.CommonObjectMeta,
+			Spec: configurationv1alpha1.KongPluginBindingSpec{
+				PluginReference: configurationv1alpha1.PluginRef{
+					Name: "rate-limiting",
+				},
+				Targets: &configurationv1alpha1.KongPluginBindingTargets{
+					ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+						Name:  "test-service",
+						Kind:  "KongService",
+						Group: "configuration.konghq.com",
+					},
+				},
+			},
+		}
+
+		common.NewCRDValidationTestCasesGroupCPRefChange(t, obj, common.NotSupportedByKIC, common.ControlPlaneRefRequired).Run(t)
+	})
+
+	t.Run("plugin ref", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongPluginBinding]{
+			{
+				Name: "no plugin reference",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-service",
+								Kind:  "Service",
+								Group: "core",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("pluginRef name must be set"),
+			},
+			{
+				Name: "empty plugin reference",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-service",
+								Kind:  "Service",
+								Group: "core",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("pluginRef name must be set"),
+			},
+			{
+				Name: "valid KongPlugin reference",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "test-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-service",
+								Kind:  "Service",
+								Group: "core",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+			},
+			{
+				Name: "valid KongClusterPlugin reference",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "test-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-service",
+								Kind:  "Service",
+								Group: "core",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+			},
+			{
+				Name: "wrong plugin kind",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("WrongPluginKind"),
+							Name: "test-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-service",
+								Kind:  "Service",
+								Group: "core",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr(`spec.pluginRef.kind: Unsupported value: "WrongPluginKind"`),
+			},
+		}.Run(t)
+	})
+
+	t.Run("target combinations", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongPluginBinding]{
+			{
+				Name: "consumer, route, service targets",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ConsumerReference: &configurationv1alpha1.TargetRef{
+								Name: "test-consumer",
+							},
+							RouteReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-route",
+								Kind:  "KongRoute",
+								Group: "configuration.konghq.com",
+							},
+							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-service",
+								Kind:  "KongService",
+								Group: "configuration.konghq.com",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+			},
+			{
+				Name: "consumerGroup, route, service targets",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ConsumerGroupReference: &configurationv1alpha1.TargetRef{
+								Name: "test-consumer-group",
+							},
+							RouteReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-route",
+								Kind:  "KongRoute",
+								Group: "configuration.konghq.com",
+							},
+							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-service",
+								Kind:  "KongService",
+								Group: "configuration.konghq.com",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+			},
+			{
+				Name: "consumer, route targets",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ConsumerReference: &configurationv1alpha1.TargetRef{
+								Name: "test-consumer",
+							},
+							RouteReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-route",
+								Kind:  "KongRoute",
+								Group: "configuration.konghq.com",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+			},
+			{
+				Name: "consumer, service targets",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ConsumerReference: &configurationv1alpha1.TargetRef{
+								Name: "test-consumer",
+							},
+							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-route",
+								Kind:  "KongService",
+								Group: "configuration.konghq.com",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+			},
+			{
+				Name: "consumerGroup, route targets",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ConsumerGroupReference: &configurationv1alpha1.TargetRef{
+								Name: "test-consumer-group",
+							},
+							RouteReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-route",
+								Kind:  "KongRoute",
+								Group: "configuration.konghq.com",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+			},
+			{
+				Name: "consumerGroup, service targets",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ConsumerGroupReference: &configurationv1alpha1.TargetRef{
+								Name: "test-consumer-group",
+							},
+							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-route",
+								Kind:  "KongService",
+								Group: "configuration.konghq.com",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+			},
+			{
+				Name: "route, service targets",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ConsumerGroupReference: &configurationv1alpha1.TargetRef{
+								Name: "test-consumer-group",
+							},
+							RouteReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-route",
+								Kind:  "KongRoute",
+								Group: "configuration.konghq.com",
+							},
+							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-service",
+								Kind:  "KongService",
+								Group: "configuration.konghq.com",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+			},
+			{
+				Name: "consumer target",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ConsumerReference: &configurationv1alpha1.TargetRef{
+								Name: "test-consumer",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+			},
+			{
+				Name: "consumerGroup target",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ConsumerGroupReference: &configurationv1alpha1.TargetRef{
+								Name: "test-consumer",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+			},
+			{
+				Name: "route target",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							RouteReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-route",
+								Kind:  "KongRoute",
+								Group: "configuration.konghq.com",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+			},
+			{
+				Name: "service target",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-service",
+								Kind:  "Service",
+								Group: "core",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+			},
+			{
+				Name: "kongConsumer, kongConsumerGroup, service, route targets",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ConsumerReference: &configurationv1alpha1.TargetRef{
+								Name: "test-consumer",
+							},
+							ConsumerGroupReference: &configurationv1alpha1.TargetRef{
+								Name: "test-consumer-group",
+							},
+							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-service",
+								Kind:  "KongService",
+								Group: "configuration.konghq.com",
+							},
+							RouteReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-route",
+								Kind:  "KongRoute",
+								Group: "configuration.konghq.com",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Cannot set Consumer and ConsumerGroup at the same time"),
+			},
+			{
+				Name: "kongConsumer, kongConsumerGroup, route targets",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ConsumerReference: &configurationv1alpha1.TargetRef{
+								Name: "test-consumer",
+							},
+							ConsumerGroupReference: &configurationv1alpha1.TargetRef{
+								Name: "test-consumer-group",
+							},
+							RouteReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-route",
+								Kind:  "KongRoute",
+								Group: "configuration.konghq.com",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Cannot set Consumer and ConsumerGroup at the same time"),
+			},
+			{
+				Name: "kongConsumer, kongConsumerGroup, service targets",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ConsumerReference: &configurationv1alpha1.TargetRef{
+								Name: "test-consumer",
+							},
+							ConsumerGroupReference: &configurationv1alpha1.TargetRef{
+								Name: "test-consumer-group",
+							},
+							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-service",
+								Kind:  "KongService",
+								Group: "configuration.konghq.com",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Cannot set Consumer and ConsumerGroup at the same time"),
+			},
+			{
+				Name: "kongConsumer, kongConsumerGroup targets",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ConsumerReference: &configurationv1alpha1.TargetRef{
+								Name: "test-consumer",
+							},
+							ConsumerGroupReference: &configurationv1alpha1.TargetRef{
+								Name: "test-consumer-group",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Cannot set Consumer and ConsumerGroup at the same time"),
+			},
+			{
+				Name: "no targets",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("At least one target reference must be set when scope is 'OnlyTargets'"),
+			},
+			{
+				Name: "empty targets",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets:         &configurationv1alpha1.KongPluginBindingTargets{},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("At least one target reference must be set when scope is 'OnlyTargets'"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("targets group/kind", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongPluginBinding]{
+			{
+				Name: "networking.k8s.io/Ingress, as service target",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-service",
+								Kind:  "Ingress",
+								Group: "networking.k8s.io",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("group/kind not allowed for the serviceRef"),
+			},
+			{
+				Name: "core/Service, as route target",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							RouteReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-route",
+								Kind:  "Service",
+								Group: "core",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("group/kind not allowed for the routeRef"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("cross targets validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongPluginBinding]{
+			{
+				Name: "core/Service, configuration.konghq.com/KongRoute targets",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-service",
+								Kind:  "Service",
+								Group: "core",
+							},
+							RouteReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-route",
+								Kind:  "KongRoute",
+								Group: "configuration.konghq.com",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr(" KongRoute can be used only when serviceRef is unset or set to KongService"),
+			},
+			{
+				Name: "configuration.konghq.com/KongService, networking.k8s.io/Ingress targets",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
+							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-service",
+								Kind:  "KongService",
+								Group: "configuration.konghq.com",
+							},
+							RouteReference: &configurationv1alpha1.TargetRefWithGroupKind{
+								Name:  "test-route",
+								Kind:  "Ingress",
+								Group: "networking.k8s.io",
+							},
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("KongService can be used only when routeRef is unset or set to KongRoute"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("scope=GlobalInControlPlane validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongPluginBinding]{
+			{
+				Name: "GlobalInControlPlane allow nil targets",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						Scope: configurationv1alpha1.KongPluginBindingScopeGlobalInControlPlane,
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						ControlPlaneRef: validTestCPRef(),
+					},
+				},
+			},
+			{
+				Name: "GlobalInControlPlane rejects non-nil targets",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						Scope: configurationv1alpha1.KongPluginBindingScopeGlobalInControlPlane,
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						ControlPlaneRef: validTestCPRef(),
+						Targets:         &configurationv1alpha1.KongPluginBindingTargets{},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("No targets must be set when scope is 'GlobalInControlPlane'"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongroute_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongroute_test.go
@@ -1,0 +1,272 @@
+package configuration_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongRoute(t *testing.T) {
+	obj := &configurationv1alpha1.KongRoute{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KongRoute",
+			APIVersion: configurationv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: common.CommonObjectMeta,
+	}
+
+	t.Run("cp ref", func(t *testing.T) {
+		common.NewCRDValidationTestCasesGroupCPRefChange(t, obj, common.NotSupportedByKIC, common.ControlPlaneRefNotRequired).Run(t)
+	})
+
+	t.Run("service ref", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongRoute]{
+			{
+				Name: "bind servicebound to controlplane too",
+				TestObject: &configurationv1alpha1.KongRoute{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongRouteSpec{
+						ServiceRef: &configurationv1alpha1.ServiceRef{
+							Type: configurationv1alpha1.ServiceRefNamespacedRef,
+							NamespacedRef: &commonv1alpha1.NameRef{
+								Name: "test-konnect-service",
+							},
+						},
+					},
+				},
+				Update: func(kr *configurationv1alpha1.KongRoute) {
+					kr.Spec.ControlPlaneRef = &commonv1alpha1.ControlPlaneRef{
+						Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+						KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+							Name: "test-konnect-control-plane",
+						},
+					}
+				},
+			},
+			{
+				Name: "make serviceless",
+				TestObject: &configurationv1alpha1.KongRoute{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongRouteSpec{
+						ServiceRef: &configurationv1alpha1.ServiceRef{
+							Type: configurationv1alpha1.ServiceRefNamespacedRef,
+							NamespacedRef: &commonv1alpha1.NameRef{
+								Name: "test-konnect-service",
+							},
+						},
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+					},
+				},
+				Update: func(kr *configurationv1alpha1.KongRoute) {
+					kr.Spec.ServiceRef = nil
+				},
+			},
+		}.Run(t)
+	})
+
+	t.Run("protocols", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongRoute]{
+			{
+				Name: "no http in protocols implies no other requirements",
+				TestObject: &configurationv1alpha1.KongRoute{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongRouteSpec{
+						ServiceRef: &configurationv1alpha1.ServiceRef{
+							Type:          configurationv1alpha1.ServiceRefNamespacedRef,
+							NamespacedRef: &commonv1alpha1.NameRef{Name: "svc"},
+						},
+						KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+							Paths: []string{"/"},
+						},
+					},
+				},
+			},
+			{
+				Name: "http in protocols with hosts set yields no error",
+				TestObject: &configurationv1alpha1.KongRoute{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongRouteSpec{
+						ServiceRef: &configurationv1alpha1.ServiceRef{
+							Type:          configurationv1alpha1.ServiceRefNamespacedRef,
+							NamespacedRef: &commonv1alpha1.NameRef{Name: "svc"},
+						},
+						KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+							Protocols: []sdkkonnectcomp.RouteJSONProtocols{"http"},
+							Hosts:     []string{"example.com"},
+						},
+					},
+				},
+			},
+			{
+				Name: "http in protocols no hosts, methods, paths or headers yields an error",
+				TestObject: &configurationv1alpha1.KongRoute{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongRouteSpec{
+						ServiceRef: &configurationv1alpha1.ServiceRef{
+							Type:          configurationv1alpha1.ServiceRefNamespacedRef,
+							NamespacedRef: &commonv1alpha1.NameRef{Name: "svc"},
+						},
+						KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+							Protocols: []sdkkonnectcomp.RouteJSONProtocols{"http"},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("If protocols has 'http', at least one of 'hosts', 'methods', 'paths' or 'headers' must be set"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("service ref", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongRoute]{
+			{
+				Name: "NamespacedRef reference is valid",
+				TestObject: &configurationv1alpha1.KongRoute{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongRouteSpec{
+						ServiceRef: &configurationv1alpha1.ServiceRef{
+							Type: configurationv1alpha1.ServiceRefNamespacedRef,
+							NamespacedRef: &commonv1alpha1.NameRef{
+								Name: "test-konnect-service",
+							},
+						},
+						KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+							Paths: []string{"/"},
+						},
+					},
+				},
+			},
+			{
+				Name: "NamespacedRef reference is invalid when empty name is provided",
+				TestObject: &configurationv1alpha1.KongRoute{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongRouteSpec{
+						ServiceRef: &configurationv1alpha1.ServiceRef{
+							Type: configurationv1alpha1.ServiceRefNamespacedRef,
+							NamespacedRef: &commonv1alpha1.NameRef{
+								Name: "",
+							},
+						},
+						KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+							Paths: []string{"/"},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.serviceRef.namespacedRef.name in body should be at least 1 chars long"),
+			},
+			{
+				Name: "NamespacedRef reference is invalid when name is not provided",
+				TestObject: &configurationv1alpha1.KongRoute{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongRouteSpec{
+						ServiceRef: &configurationv1alpha1.ServiceRef{
+							Type: configurationv1alpha1.ServiceRefNamespacedRef,
+						},
+						KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+							Paths: []string{"/"},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("when type is namespacedRef, namespacedRef must be set"),
+			},
+			{
+				Name: "not providing namespacedRef when type is namespacedRef yields an error",
+				TestObject: &configurationv1alpha1.KongRoute{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongRouteSpec{
+						ServiceRef: &configurationv1alpha1.ServiceRef{
+							Type: configurationv1alpha1.ServiceRefNamespacedRef,
+						},
+						KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+							Paths: []string{"/"},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("when type is namespacedRef, namespacedRef must be set"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("tags validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongRoute]{
+			{
+				Name: "up to 20 tags are allowed",
+				TestObject: &configurationv1alpha1.KongRoute{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongRouteSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+							Tags: func() []string {
+								var tags []string
+								for i := range 20 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+			},
+			{
+				Name: "more than 20 tags are not allowed",
+				TestObject: &configurationv1alpha1.KongRoute{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongRouteSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+							Tags: func() []string {
+								var tags []string
+								for i := range 21 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.tags: Too many: 21: must have at most 20 items"),
+			},
+			{
+				Name: "tags entries must not be longer than 128 characters",
+				TestObject: &configurationv1alpha1.KongRoute{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongRouteSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+							Tags: []string{
+								lo.RandomString(129, lo.AlphanumericCharset),
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("tags entries must not be longer than 128 characters"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongservice_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongservice_test.go
@@ -1,0 +1,103 @@
+package configuration_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongService(t *testing.T) {
+	obj := &configurationv1alpha1.KongService{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KongService",
+			APIVersion: configurationv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: common.CommonObjectMeta,
+	}
+
+	t.Run("cp ref", func(t *testing.T) {
+		common.NewCRDValidationTestCasesGroupCPRefChange(t, obj, common.NotSupportedByKIC, common.ControlPlaneRefRequired).Run(t)
+	})
+
+	t.Run("cp ref, type=kic", func(t *testing.T) {
+		common.NewCRDValidationTestCasesGroupCPRefChangeKICUnsupportedTypes(t, obj, common.EmptyControlPlaneRefNotAllowed).Run(t)
+	})
+
+	t.Run("tags validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongService]{
+			{
+				Name: "up to 20 tags are allowed",
+				TestObject: &configurationv1alpha1.KongService{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongServiceSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongServiceAPISpec: configurationv1alpha1.KongServiceAPISpec{
+							Tags: func() []string {
+								var tags []string
+								for i := range 20 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+			},
+			{
+				Name: "more than 20 tags are not allowed",
+				TestObject: &configurationv1alpha1.KongService{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongServiceSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongServiceAPISpec: configurationv1alpha1.KongServiceAPISpec{
+							Tags: func() []string {
+								var tags []string
+								for i := range 21 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.tags: Too many: 21: must have at most 20 items"),
+			},
+			{
+				Name: "tags entries must not be longer than 128 characters",
+				TestObject: &configurationv1alpha1.KongService{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongServiceSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongServiceAPISpec: configurationv1alpha1.KongServiceAPISpec{
+							Tags: []string{
+								lo.RandomString(129, lo.AlphanumericCharset),
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("tags entries must not be longer than 128 characters"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongsni_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongsni_test.go
@@ -1,0 +1,166 @@
+package configuration_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongSNI(t *testing.T) {
+	t.Run("certificate ref", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongSNI]{
+			{
+				Name: "certificate ref name is required",
+				TestObject: &configurationv1alpha1.KongSNI{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongSNISpec{
+						CertificateRef: commonv1alpha1.NameRef{},
+						KongSNIAPISpec: configurationv1alpha1.KongSNIAPISpec{
+							Name: "example.com",
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.certificateRef.name in body should be at least 1 chars long"),
+			},
+			{
+				Name: "certificate ref can be changed before programmed",
+				TestObject: &configurationv1alpha1.KongSNI{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongSNISpec{
+						CertificateRef: commonv1alpha1.NameRef{
+							Name: "cert1",
+						},
+						KongSNIAPISpec: configurationv1alpha1.KongSNIAPISpec{
+							Name: "example.com",
+						},
+					},
+				},
+				Update: func(sni *configurationv1alpha1.KongSNI) {
+					sni.Spec.CertificateRef = commonv1alpha1.NameRef{
+						Name: "cert-2",
+					}
+				},
+			},
+			{
+				Name: "certiifacate ref is immutable after programmed",
+				TestObject: &configurationv1alpha1.KongSNI{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongSNISpec{
+						CertificateRef: commonv1alpha1.NameRef{
+							Name: "cert1",
+						},
+						KongSNIAPISpec: configurationv1alpha1.KongSNIAPISpec{
+							Name: "example.com",
+						},
+					},
+					Status: configurationv1alpha1.KongSNIStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionTrue,
+								Reason:             "programmed",
+								ObservedGeneration: int64(1),
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(sni *configurationv1alpha1.KongSNI) {
+					sni.Spec.CertificateRef = commonv1alpha1.NameRef{
+						Name: "cert-2",
+					}
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.certificateRef is immutable when programmed"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("spec", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongSNI]{
+			{
+				Name: "spec.name must not be empty",
+				TestObject: &configurationv1alpha1.KongSNI{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongSNISpec{
+						CertificateRef: commonv1alpha1.NameRef{
+							Name: "cert1",
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.name in body should be at least 1 chars long"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("tags validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongSNI]{
+			{
+				Name: "up to 20 tags are allowed",
+				TestObject: &configurationv1alpha1.KongSNI{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongSNISpec{
+						CertificateRef: commonv1alpha1.NameRef{
+							Name: "cert1",
+						},
+						KongSNIAPISpec: configurationv1alpha1.KongSNIAPISpec{
+							Name: "example.com",
+							Tags: func() []string {
+								var tags []string
+								for i := range 20 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+			},
+			{
+				Name: "more than 20 tags are not allowed",
+				TestObject: &configurationv1alpha1.KongSNI{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongSNISpec{
+						CertificateRef: commonv1alpha1.NameRef{
+							Name: "cert1",
+						},
+						KongSNIAPISpec: configurationv1alpha1.KongSNIAPISpec{
+							Name: "example.com",
+							Tags: func() []string {
+								var tags []string
+								for i := range 21 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.tags: Too many: 21: must have at most 20 items"),
+			},
+			{
+				Name: "tags entries must not be longer than 128 characters",
+				TestObject: &configurationv1alpha1.KongSNI{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongSNISpec{
+						CertificateRef: commonv1alpha1.NameRef{
+							Name: "cert1",
+						},
+						KongSNIAPISpec: configurationv1alpha1.KongSNIAPISpec{
+							Name: "example.com",
+							Tags: []string{
+								lo.RandomString(129, lo.AlphanumericCharset),
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("tags entries must not be longer than 128 characters"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongtarget_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongtarget_test.go
@@ -1,0 +1,146 @@
+package configuration_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/samber/lo"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongTarget(t *testing.T) {
+	t.Run("spec", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongTarget]{
+			{
+				Name: "weight must between 0 and 65535",
+				TestObject: &configurationv1alpha1.KongTarget{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongTargetSpec{
+						UpstreamRef: commonv1alpha1.NameRef{
+							Name: "upstream",
+						},
+						KongTargetAPISpec: configurationv1alpha1.KongTargetAPISpec{
+							Target: "example.com",
+							Weight: 100000,
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.weight: Invalid value: 100000"),
+			},
+			{
+				Name: "weight must between 0 and 65535",
+				TestObject: &configurationv1alpha1.KongTarget{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongTargetSpec{
+						UpstreamRef: commonv1alpha1.NameRef{
+							Name: "upstream",
+						},
+						KongTargetAPISpec: configurationv1alpha1.KongTargetAPISpec{
+							Target: "example.com",
+							Weight: -1,
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.weight: Invalid value: -1"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("upstream ref", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongTarget]{
+			{
+				Name: "upstream ref is immutable",
+				TestObject: &configurationv1alpha1.KongTarget{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongTargetSpec{
+						UpstreamRef: commonv1alpha1.NameRef{
+							Name: "upstream",
+						},
+						KongTargetAPISpec: configurationv1alpha1.KongTargetAPISpec{
+							Target: "example.com",
+							Weight: 100,
+						},
+					},
+				},
+				Update: func(kt *configurationv1alpha1.KongTarget) {
+					kt.Spec.UpstreamRef = commonv1alpha1.NameRef{
+						Name: "upstream-2",
+					}
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.upstreamRef is immutable"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("tags validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongTarget]{
+			{
+				Name: "up to 20 tags are allowed",
+				TestObject: &configurationv1alpha1.KongTarget{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongTargetSpec{
+						UpstreamRef: commonv1alpha1.NameRef{
+							Name: "upstream",
+						},
+						KongTargetAPISpec: configurationv1alpha1.KongTargetAPISpec{
+							Target: "example.com",
+							Weight: 100,
+							Tags: func() []string {
+								var tags []string
+								for i := range 20 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+			},
+			{
+				Name: "more than 20 tags are not allowed",
+				TestObject: &configurationv1alpha1.KongTarget{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongTargetSpec{
+						UpstreamRef: commonv1alpha1.NameRef{
+							Name: "upstream",
+						},
+						KongTargetAPISpec: configurationv1alpha1.KongTargetAPISpec{
+							Target: "example.com",
+							Weight: 100,
+							Tags: func() []string {
+								var tags []string
+								for i := range 21 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.tags: Too many: 21: must have at most 20 items"),
+			},
+			{
+				Name: "tags entries must not be longer than 128 characters",
+				TestObject: &configurationv1alpha1.KongTarget{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongTargetSpec{
+						UpstreamRef: commonv1alpha1.NameRef{
+							Name: "upstream",
+						},
+						KongTargetAPISpec: configurationv1alpha1.KongTargetAPISpec{
+							Target: "example.com",
+							Weight: 100,
+							Tags: []string{
+								lo.RandomString(129, lo.AlphanumericCharset),
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("tags entries must not be longer than 128 characters"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongupstream_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongupstream_test.go
@@ -1,0 +1,463 @@
+package configuration_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongUpstream(t *testing.T) {
+	obj := &configurationv1alpha1.KongUpstream{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KongUpstream",
+			APIVersion: configurationv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: common.CommonObjectMeta,
+	}
+
+	t.Run("cp ref", func(t *testing.T) {
+		common.NewCRDValidationTestCasesGroupCPRefChange(t, obj, common.NotSupportedByKIC, common.ControlPlaneRefRequired).Run(t)
+	})
+
+	t.Run("cp ref, type=kic", func(t *testing.T) {
+		common.NewCRDValidationTestCasesGroupCPRefChangeKICUnsupportedTypes(t, obj, common.EmptyControlPlaneRefNotAllowed).Run(t)
+	})
+
+	t.Run("required fields", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongUpstream]{
+			{
+				Name: "hash_fallback_header is required when hash_fallback is set to 'header'",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashFallback:       lo.ToPtr(sdkkonnectcomp.HashFallbackHeader),
+							HashFallbackHeader: lo.ToPtr("X-Hash-Fallback"),
+						},
+					},
+				},
+			},
+			{
+				Name: "validation fails when hash_fallback_header is not provided when hash_fallback is set to 'header'",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashFallback: lo.ToPtr(sdkkonnectcomp.HashFallbackHeader),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Invalid value: \"object\": hash_fallback_header is required when `hash_fallback` is set to `header`"),
+			},
+			{
+				Name: "hash_fallback_query_arg is required when hash_fallback is set to 'query_arg'",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashFallback:         lo.ToPtr(sdkkonnectcomp.HashFallbackQueryArg),
+							HashFallbackQueryArg: lo.ToPtr("arg"),
+						},
+					},
+				},
+			},
+			{
+				Name: "validation fails when hash_fallback_query_arg is not provided when hash_fallback is set to 'query_arg'",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashFallback: lo.ToPtr(sdkkonnectcomp.HashFallbackQueryArg),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Invalid value: \"object\": hash_fallback_query_arg is required when `hash_fallback` is set to `query_arg`"),
+			},
+			{
+				Name: "hash_fallback_uri_capture is required when hash_fallback is set to 'uri_capture'",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashFallback:           lo.ToPtr(sdkkonnectcomp.HashFallbackURICapture),
+							HashFallbackURICapture: lo.ToPtr("arg"),
+						},
+					},
+				},
+			},
+			{
+				Name: "validation fails when hash_fallback_uri_capture is not provided when hash_fallback is set to 'uri_capture'",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashFallback: lo.ToPtr(sdkkonnectcomp.HashFallbackURICapture),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Invalid value: \"object\": hash_fallback_uri_capture is required when `hash_fallback` is set to `uri_capture`"),
+			},
+			{
+				Name: "hash_on_cookie and hash_on_cookie_path are required when hash_on is set to 'cookie'",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashOn:           lo.ToPtr(sdkkonnectcomp.HashOnCookie),
+							HashOnCookie:     lo.ToPtr("cookie"),
+							HashOnCookiePath: lo.ToPtr("X-Hash-On-Cookie-Path"),
+						},
+					},
+				},
+			},
+			{
+				Name: "hash_on_cookie and hash_on_cookie_path are required when hash_fallback is set to 'cookie'",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashFallback:     lo.ToPtr(sdkkonnectcomp.HashFallbackCookie),
+							HashOnCookie:     lo.ToPtr("cookie"),
+							HashOnCookiePath: lo.ToPtr("X-Hash-On-Cookie-Path"),
+						},
+					},
+				},
+			},
+			{
+				Name: "validation fails when hash_on_cookie is not provided when hash_on is set to 'cookie'",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashOn:           lo.ToPtr(sdkkonnectcomp.HashOnCookie),
+							HashOnCookiePath: lo.ToPtr("X-Hash-On-Cookie-Path"),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("hash_on_cookie is required when hash_on is set to `cookie`."),
+			},
+			{
+				Name: "validation fails when hash_on_cookie is not provided when hash_fallback is set to 'cookie'",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashFallback:     lo.ToPtr(sdkkonnectcomp.HashFallbackCookie),
+							HashOnCookiePath: lo.ToPtr("X-Hash-On-Cookie-Path"),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("hash_on_cookie is required when hash_fallback is set to `cookie`."),
+			},
+			{
+				Name: "validation fails when hash_on_cookie_path is not provided when hash_on is set to 'cookie'",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashOn:       lo.ToPtr(sdkkonnectcomp.HashOnCookie),
+							HashOnCookie: lo.ToPtr("cookie"),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("hash_on_cookie_path is required when hash_on is set to `cookie`."),
+			},
+			{
+				Name: "validation fails when hash_on_cookie_path is not provided when hash_fallback is set to 'cookie'",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashFallback: lo.ToPtr(sdkkonnectcomp.HashFallbackCookie),
+							HashOnCookie: lo.ToPtr("cookie"),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("hash_on_cookie_path is required when hash_fallback is set to `cookie`."),
+			},
+			{
+				Name: "validation fails when hash_on_cookie_path nor hash_on_cookie are provided when hash_fallback is set to 'cookie'",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashFallback: lo.ToPtr(sdkkonnectcomp.HashFallbackCookie),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("hash_on_cookie_path is required when hash_fallback is set to `cookie`."),
+			},
+			{
+				Name: "validation fails when hash_on_cookie_path nor hash_on_cookie are provided when hash_on is set to 'cookie'",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashOn: lo.ToPtr(sdkkonnectcomp.HashOnCookie),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("hash_on_cookie_path is required when hash_on is set to `cookie`."),
+			},
+			{
+				Name: "validation fails when hash_on_header is not provided when hash_on is set to 'header'",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashOn: lo.ToPtr(sdkkonnectcomp.HashOnHeader),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Invalid value: \"object\": hash_on_header is required when hash_on is set to `header`"),
+			},
+			{
+				Name: "hash_on_query_arg is required when hash_on is set to 'query_arg'",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashOn:         lo.ToPtr(sdkkonnectcomp.HashOnQueryArg),
+							HashOnQueryArg: lo.ToPtr("arg"),
+						},
+					},
+				},
+			},
+			{
+				Name: "validation fails when hash_on_query_arg is not provided when hash_on is set to 'query_arg'",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashOn: lo.ToPtr(sdkkonnectcomp.HashOnQueryArg),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Invalid value: \"object\": hash_on_query_arg is required when `hash_on` is set to `query_arg`"),
+			},
+			{
+				Name: "hash_on_uri_capture is required when hash_on is set to 'uri_capture'",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashOn:           lo.ToPtr(sdkkonnectcomp.HashOnURICapture),
+							HashOnURICapture: lo.ToPtr("arg"),
+						},
+					},
+				},
+			},
+			{
+				Name: "validation fails when hash_on_uri_capture is not provided when hash_on is set to 'uri_capture'",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashOn: lo.ToPtr(sdkkonnectcomp.HashOnURICapture),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Invalid value: \"object\": hash_on_uri_capture is required when `hash_on` is set to `uri_capture`"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("tags validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongUpstream]{
+			{
+				Name: "up to 20 tags are allowed",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashOn:         lo.ToPtr(sdkkonnectcomp.HashOnQueryArg),
+							HashOnQueryArg: lo.ToPtr("arg"),
+							Tags: func() []string {
+								var tags []string
+								for i := range 20 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+			},
+			{
+				Name: "more than 20 tags are not allowed",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashOn:         lo.ToPtr(sdkkonnectcomp.HashOnQueryArg),
+							HashOnQueryArg: lo.ToPtr("arg"),
+							Tags: func() []string {
+								var tags []string
+								for i := range 21 {
+									tags = append(tags, fmt.Sprintf("tag-%d", i))
+								}
+								return tags
+							}(),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.tags: Too many: 21: must have at most 20 items"),
+			},
+			{
+				Name: "tags entries must not be longer than 128 characters",
+				TestObject: &configurationv1alpha1.KongUpstream{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongUpstreamSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
+							HashOn:         lo.ToPtr(sdkkonnectcomp.HashOnQueryArg),
+							HashOnQueryArg: lo.ToPtr("arg"),
+							Tags: []string{
+								lo.RandomString(129, lo.AlphanumericCharset),
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("tags entries must not be longer than 128 characters"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongupstreampolicy_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongupstreampolicy_test.go
@@ -1,0 +1,357 @@
+package configuration_test
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+
+	configurationv1beta1 "github.com/kong/kong-operator/api/configuration/v1beta1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongUpstreamPolicy(t *testing.T) {
+	t.Run("sticky sessions validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1beta1.KongUpstreamPolicy]{
+			{
+				Name: "valid sticky sessions with hashOn.input=none",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("sticky-sessions"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Input: lo.ToPtr(configurationv1beta1.HashInput("none")),
+						},
+						StickySessions: &configurationv1beta1.KongUpstreamStickySessions{
+							Cookie: "session-cookie",
+						},
+					},
+				},
+			},
+			{
+				Name: "consistent-hashing with stickySessions should fail",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("consistent-hashing"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Input: lo.ToPtr(configurationv1beta1.HashInput("none")),
+						},
+						StickySessions: &configurationv1beta1.KongUpstreamStickySessions{
+							Cookie: "session-cookie",
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.algorithm must be set to 'sticky-sessions' when spec.stickySessions is set."),
+			},
+
+			{
+				Name: "sticky sessions without hashOn should fail",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						StickySessions: &configurationv1beta1.KongUpstreamStickySessions{
+							Cookie: "session-cookie",
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("When spec.stickySessions is set, spec.hashOn.input must be set to 'none' (no other hash_on fields allowed)."),
+			},
+			{
+				Name: "sticky sessions with hashOn but no input should fail",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("sticky-sessions"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Header: lo.ToPtr("X-Custom-Header"),
+						},
+						StickySessions: &configurationv1beta1.KongUpstreamStickySessions{
+							Cookie: "session-cookie",
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("When spec.stickySessions is set, spec.hashOn.input must be set to 'none' (no other hash_on fields allowed)."),
+			},
+			{
+				Name: "sticky sessions with hashOn.input not 'none' should fail",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("sticky-sessions"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Input: lo.ToPtr(configurationv1beta1.HashInput("ip")),
+						},
+						StickySessions: &configurationv1beta1.KongUpstreamStickySessions{
+							Cookie: "session-cookie",
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("When spec.stickySessions is set, spec.hashOn.input must be set to 'none' (no other hash_on fields allowed)."),
+			},
+			{
+				Name: "sticky sessions with hashOn.input=none but other hash fields should fail",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("sticky-sessions"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Input:  lo.ToPtr(configurationv1beta1.HashInput("none")),
+							Header: lo.ToPtr("X-Custom-Header"),
+						},
+						StickySessions: &configurationv1beta1.KongUpstreamStickySessions{
+							Cookie: "session-cookie",
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("When spec.stickySessions is set, spec.hashOn.input must be set to 'none' (no other hash_on fields allowed)."),
+			},
+			{
+				Name: "sticky sessions with hashOn.input=none but cookie field should fail",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("sticky-sessions"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Input:  lo.ToPtr(configurationv1beta1.HashInput("none")),
+							Cookie: lo.ToPtr("hash-cookie"),
+						},
+						StickySessions: &configurationv1beta1.KongUpstreamStickySessions{
+							Cookie: "session-cookie",
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("When spec.stickySessions is set, spec.hashOn.input must be set to 'none' (no other hash_on fields allowed)."),
+			},
+			{
+				Name: "sticky sessions with hashOn.input=none but cookiePath field should fail",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("sticky-sessions"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Input:      lo.ToPtr(configurationv1beta1.HashInput("none")),
+							CookiePath: lo.ToPtr("/path"),
+						},
+						StickySessions: &configurationv1beta1.KongUpstreamStickySessions{
+							Cookie: "session-cookie",
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("When spec.stickySessions is set, spec.hashOn.input must be set to 'none' (no other hash_on fields allowed)."),
+			},
+			{
+				Name: "sticky sessions with hashOn.input=none but uriCapture field should fail",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("sticky-sessions"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Input:      lo.ToPtr(configurationv1beta1.HashInput("none")),
+							URICapture: lo.ToPtr("capture"),
+						},
+						StickySessions: &configurationv1beta1.KongUpstreamStickySessions{
+							Cookie: "session-cookie",
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("When spec.stickySessions is set, spec.hashOn.input must be set to 'none' (no other hash_on fields allowed)."),
+			},
+			{
+				Name: "sticky sessions with hashOn.input=none but queryArg field should fail",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("sticky-sessions"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Input:    lo.ToPtr(configurationv1beta1.HashInput("none")),
+							QueryArg: lo.ToPtr("arg"),
+						},
+						StickySessions: &configurationv1beta1.KongUpstreamStickySessions{
+							Cookie: "session-cookie",
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("When spec.stickySessions is set, spec.hashOn.input must be set to 'none' (no other hash_on fields allowed)."),
+			},
+			{
+				Name: "sticky sessions without cookie should fail",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("sticky-sessions"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Input: lo.ToPtr(configurationv1beta1.HashInput("none")),
+						},
+						StickySessions: &configurationv1beta1.KongUpstreamStickySessions{},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.stickySessions.cookie in body should be at least 1 chars long"),
+			},
+			{
+				Name: "valid configuration without sticky sessions",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("round-robin"),
+						Slots:     lo.ToPtr(100),
+					},
+				},
+			},
+			{
+				Name: "valid configuration with hashOn but no sticky sessions",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("sticky-sessions"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Input: lo.ToPtr(configurationv1beta1.HashInput("ip")),
+						},
+					},
+				},
+			},
+			{
+				Name: "valid configuration with sticky-sessions algorithm and hashOn",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("sticky-sessions"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Input: lo.ToPtr(configurationv1beta1.HashInput("none")),
+						},
+					},
+				},
+			},
+			{
+				Name: "invalid configuration with round-robin algorithm and hashOn should fail",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("round-robin"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Input: lo.ToPtr(configurationv1beta1.HashInput("ip")),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.algorithm must be set to either 'consistent-hashing' or 'sticky-sessions' when spec.hashOn is set."),
+			},
+			{
+				Name: "invalid configuration with least-connections algorithm and hashOn should fail",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("least-connections"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Input: lo.ToPtr(configurationv1beta1.HashInput("ip")),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.algorithm must be set to either 'consistent-hashing' or 'sticky-sessions' when spec.hashOn is set."),
+			},
+			{
+				Name: "invalid configuration with latency algorithm and hashOn should fail",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("latency"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Input: lo.ToPtr(configurationv1beta1.HashInput("ip")),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.algorithm must be set to either 'consistent-hashing' or 'sticky-sessions' when spec.hashOn is set."),
+			},
+		}.Run(t)
+	})
+
+	t.Run("consistent-hashing", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1beta1.KongUpstreamPolicy]{
+			{
+				Name: "hash on cookie with valid input",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("consistent-hashing"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Cookie:     lo.ToPtr("session-cookie-name"),
+							CookiePath: lo.ToPtr("/cookie-path"),
+						},
+					},
+				},
+			},
+			{
+				Name: "hash on cookie requires cookiePath field to be set",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("consistent-hashing"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Cookie: lo.ToPtr("session-cookie-name"),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("When spec.hashOn.cookie is set, spec.hashOn.cookiePath is required."),
+			},
+			{
+				Name: "hash on cookiePath requires cookie field to be set",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("consistent-hashing"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							CookiePath: lo.ToPtr("/cookie-path"),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("When spec.hashOn.cookiePath is set, spec.hashOn.cookie is required."),
+			},
+			{
+				Name: "hash on header with valid input",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("consistent-hashing"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Header: lo.ToPtr("X-Custom-Header"),
+						},
+					},
+				},
+			},
+			{
+				Name: "hash on header, hash on fallback cookie with valid input",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("consistent-hashing"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Header: lo.ToPtr("X-Custom-Header"),
+						},
+						HashOnFallback: &configurationv1beta1.KongUpstreamHash{
+							Cookie:     lo.ToPtr("fallback-cookie"),
+							CookiePath: lo.ToPtr("/fallback-cookie-path"),
+						},
+					},
+				},
+			},
+			{
+				// NOTE: Per https://developer.konghq.com/gateway/entities/upstream/#consistent-hashing
+				// > The hash_fallback setting is invalid and can’t be used if cookie is the primary hashing mechanism.
+				Name: "hash on fallback (cookie) cannot be set when hash on cookie is set",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("consistent-hashing"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Cookie:     lo.ToPtr("cookie"),
+							CookiePath: lo.ToPtr("/cookie-path"),
+						},
+						HashOnFallback: &configurationv1beta1.KongUpstreamHash{
+							Cookie:     lo.ToPtr("fallback-cookie"),
+							CookiePath: lo.ToPtr("/fallback-cookie-path"),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.hashOnFallback must not be set when spec.hashOn.cookie is set."),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/configuration.konghq.com/kongvault_test.go
+++ b/api/test/crdsvalidation/configuration.konghq.com/kongvault_test.go
@@ -1,0 +1,142 @@
+package configuration_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKongVault(t *testing.T) {
+	t.Run("cp ref", func(t *testing.T) {
+		obj := &configurationv1alpha1.KongVault{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KongVault",
+				APIVersion: configurationv1alpha1.GroupVersion.String(),
+			},
+			ObjectMeta: common.CommonObjectMeta,
+			Spec: configurationv1alpha1.KongVaultSpec{
+				Backend: "aws",
+				Prefix:  "aws-vault",
+			},
+		}
+
+		common.NewCRDValidationTestCasesGroupCPRefChange(t, obj, common.SupportedByKIC, common.ControlPlaneRefNotRequired).Run(t)
+	})
+
+	t.Run("spec", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongVault]{
+			{
+				Name: "backend must be non-empty",
+				TestObject: &configurationv1alpha1.KongVault{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongVaultSpec{
+						Prefix: "aws-vault",
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.backend: Invalid value"),
+			},
+			{
+				Name: "prefix must be non-empty",
+				TestObject: &configurationv1alpha1.KongVault{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongVaultSpec{
+						Backend: "aws",
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.prefix: Invalid value"),
+			},
+			{
+				Name: "prefix is immutatble",
+				TestObject: &configurationv1alpha1.KongVault{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongVaultSpec{
+						Backend: "aws",
+						Prefix:  "aws-vault",
+					},
+				},
+				Update: func(v *configurationv1alpha1.KongVault) {
+					v.Spec.Prefix += "-1"
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("The spec.prefix field is immutable"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("tags validation", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongVault]{
+			{
+				Name: "up to 20 tags are allowed",
+				TestObject: &configurationv1alpha1.KongVault{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongVaultSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						Backend: "aws",
+						Prefix:  "aws-vault",
+						Tags: func() []string {
+							var tags []string
+							for i := range 20 {
+								tags = append(tags, fmt.Sprintf("tag-%d", i))
+							}
+							return tags
+						}(),
+					},
+				},
+			},
+			{
+				Name: "more than 20 tags are not allowed",
+				TestObject: &configurationv1alpha1.KongVault{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongVaultSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						Backend: "aws",
+						Prefix:  "aws-vault",
+						Tags: func() []string {
+							var tags []string
+							for i := range 21 {
+								tags = append(tags, fmt.Sprintf("tag-%d", i))
+							}
+							return tags
+						}(),
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.tags: Too many: 21: must have at most 20 items"),
+			},
+			{
+				Name: "tags entries must not be longer than 128 characters",
+				TestObject: &configurationv1alpha1.KongVault{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongVaultSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						Backend: "aws",
+						Prefix:  "aws-vault",
+						Tags: []string{
+							lo.RandomString(129, lo.AlphanumericCharset),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("tags entries must not be longer than 128 characters"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/gateway-operator.konghq.com/controlplane_test.go
+++ b/api/test/crdsvalidation/gateway-operator.konghq.com/controlplane_test.go
@@ -1,0 +1,293 @@
+package crdsvalidation_test
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	operatorv1beta1 "github.com/kong/kong-operator/api/gateway-operator/v1beta1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestControlPlane(t *testing.T) {
+	validDeploymentOptions := operatorv1beta1.ControlPlaneDeploymentOptions{
+		PodTemplateSpec: &corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "controller",
+						Image: "kong:over9000",
+					},
+				},
+			},
+		},
+	}
+	validControlPlaneOptions := operatorv1beta1.ControlPlaneOptions{
+		Deployment: validDeploymentOptions,
+	}
+
+	t.Run("extensions", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv1beta1.ControlPlane]{
+			{
+				Name: "no extensions",
+				TestObject: &operatorv1beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.ControlPlaneSpec{
+						ControlPlaneOptions: validControlPlaneOptions,
+					},
+				},
+			},
+			{
+				Name: "konnectExtension set",
+				TestObject: &operatorv1beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.ControlPlaneSpec{
+						ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+							Deployment: validControlPlaneOptions.Deployment,
+							Extensions: []commonv1alpha1.ExtensionRef{
+								{
+									Group: "konnect.konghq.com",
+									Kind:  "KonnectExtension",
+									NamespacedRef: commonv1alpha1.NamespacedRef{
+										Name: "my-konnect-extension",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "konnectExtension and DataPlaneMetricsExtension set",
+				TestObject: &operatorv1beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.ControlPlaneSpec{
+						ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+							Deployment: validControlPlaneOptions.Deployment,
+							Extensions: []commonv1alpha1.ExtensionRef{
+								{
+									Group: "konnect.konghq.com",
+									Kind:  "KonnectExtension",
+									NamespacedRef: commonv1alpha1.NamespacedRef{
+										Name: "my-konnect-extension",
+									},
+								},
+								{
+									Group: "gateway-operator.konghq.com",
+									Kind:  "DataPlaneMetricsExtension",
+									NamespacedRef: commonv1alpha1.NamespacedRef{
+										Name: "my-metrics-extension",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "invalid extension",
+				TestObject: &operatorv1beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.ControlPlaneSpec{
+						ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+							Extensions: []commonv1alpha1.ExtensionRef{
+								{
+									Group: "invalid.konghq.com",
+									Kind:  "KonnectExtension",
+									NamespacedRef: commonv1alpha1.NamespacedRef{
+										Name: "my-konnect-extension",
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Extension not allowed for ControlPlane"),
+			},
+		}.Run(t)
+	})
+	t.Run("pod spec", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv1beta1.ControlPlane]{
+			{
+				Name: "no deploymentSpec",
+				TestObject: &operatorv1beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec:       operatorv1beta1.ControlPlaneSpec{},
+				},
+				ExpectedErrorMessage: lo.ToPtr("ControlPlane requires an image to be set on controller container"),
+			},
+			{
+				Name: "with deploymentSpec",
+				TestObject: &operatorv1beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.ControlPlaneSpec{
+						ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+							Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("ControlPlane requires an image to be set on controller container"),
+			},
+			{
+				Name: "missing container",
+				TestObject: &operatorv1beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.ControlPlaneSpec{
+						ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+							Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{
+								PodTemplateSpec: &corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										Containers: []corev1.Container{
+											{
+												Name: "my-container",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("ControlPlane requires an image to be set on controller container"),
+			},
+			{
+				Name: "controller container, no image",
+				TestObject: &operatorv1beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.ControlPlaneSpec{
+						ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+							Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{
+								PodTemplateSpec: &corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										Containers: []corev1.Container{
+											{
+												Name: "controller",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("ControlPlane requires an image to be set on controller container"),
+			},
+			{
+				Name: "controller container, image",
+				TestObject: &operatorv1beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.ControlPlaneSpec{
+						ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+							Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{
+								PodTemplateSpec: &corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										Containers: []corev1.Container{
+											{
+												Name:  "controller",
+												Image: "kong:over9000",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}.Run(t)
+	})
+
+	t.Run("watch namespaces", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv1beta1.ControlPlane]{
+			{
+				Name: "no watch namespaces",
+				TestObject: &operatorv1beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.ControlPlaneSpec{
+						ControlPlaneOptions: validControlPlaneOptions,
+					},
+				},
+			},
+			{
+				Name: "watch namespaces all",
+				TestObject: &operatorv1beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.ControlPlaneSpec{
+						ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+							Deployment: validDeploymentOptions,
+							WatchNamespaces: &operatorv1beta1.WatchNamespaces{
+								Type: operatorv1beta1.WatchNamespacesTypeAll,
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "watch namespaces list",
+				TestObject: &operatorv1beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.ControlPlaneSpec{
+						ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+							Deployment: validDeploymentOptions,
+							WatchNamespaces: &operatorv1beta1.WatchNamespaces{
+								Type: operatorv1beta1.WatchNamespacesTypeList,
+								List: []string{
+									"namespace1",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "watch namespaces list, no list is an error",
+				TestObject: &operatorv1beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.ControlPlaneSpec{
+						ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+							Deployment: validDeploymentOptions,
+							WatchNamespaces: &operatorv1beta1.WatchNamespaces{
+								Type: operatorv1beta1.WatchNamespacesTypeList,
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("list is required when type is 'list'"),
+			},
+			{
+				Name: "watch namespaces own",
+				TestObject: &operatorv1beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.ControlPlaneSpec{
+						ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+							Deployment: validDeploymentOptions,
+							WatchNamespaces: &operatorv1beta1.WatchNamespaces{
+								Type: operatorv1beta1.WatchNamespacesTypeOwn,
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "watch namespaces list, list cannot be specified when type is not List",
+				TestObject: &operatorv1beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.ControlPlaneSpec{
+						ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+							Deployment: validDeploymentOptions,
+							WatchNamespaces: &operatorv1beta1.WatchNamespaces{
+								Type: operatorv1beta1.WatchNamespacesTypeOwn,
+								List: []string{
+									"namespace1",
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("list must not be specified when type is not 'list'"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/gateway-operator.konghq.com/controlplane_v2_test.go
+++ b/api/test/crdsvalidation/gateway-operator.konghq.com/controlplane_v2_test.go
@@ -1,0 +1,1078 @@
+package crdsvalidation_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	operatorv2beta1 "github.com/kong/kong-operator/api/gateway-operator/v2beta1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestControlPlaneV2(t *testing.T) {
+	validDataPlaneTarget := operatorv2beta1.ControlPlaneDataPlaneTarget{
+		Type: operatorv2beta1.ControlPlaneDataPlaneTargetRefType,
+		Ref: &operatorv2beta1.ControlPlaneDataPlaneTargetRef{
+			Name: "dataplane-1",
+		},
+	}
+
+	t.Run("extensions", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv2beta1.ControlPlane]{
+			{
+				Name: "no extensions",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+						},
+					},
+				},
+			},
+			{
+				Name: "konnectExtension set",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+						},
+						Extensions: []commonv1alpha1.ExtensionRef{
+							{
+								Group: "konnect.konghq.com",
+								Kind:  "KonnectExtension",
+								NamespacedRef: commonv1alpha1.NamespacedRef{
+									Name: "my-konnect-extension",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "konnectExtension and DataPlaneMetricsExtension set",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+						},
+						Extensions: []commonv1alpha1.ExtensionRef{
+							{
+								Group: "konnect.konghq.com",
+								Kind:  "KonnectExtension",
+								NamespacedRef: commonv1alpha1.NamespacedRef{
+									Name: "my-konnect-extension",
+								},
+							},
+							{
+								Group: "gateway-operator.konghq.com",
+								Kind:  "DataPlaneMetricsExtension",
+								NamespacedRef: commonv1alpha1.NamespacedRef{
+									Name: "my-metrics-extension",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "invalid extension",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+						},
+						Extensions: []commonv1alpha1.ExtensionRef{
+							{
+								Group: "invalid.konghq.com",
+								Kind:  "KonnectExtension",
+								NamespacedRef: commonv1alpha1.NamespacedRef{
+									Name: "my-konnect-extension",
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Extension not allowed for ControlPlane"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("dataplane", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv2beta1.ControlPlane]{
+			{
+				Name: "missing dataplane causes an error",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.dataplane.type: Unsupported value: \"\""),
+			},
+			{
+				Name: "when dataplane.type is set to name, name must be specified",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: operatorv2beta1.ControlPlaneDataPlaneTarget{
+							Type: operatorv2beta1.ControlPlaneDataPlaneTargetRefType,
+						},
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Ref has to be provided when type is set to ref"),
+			},
+			{
+				Name: "specifying dataplane ref name when type is ref passes",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: operatorv2beta1.ControlPlaneDataPlaneTarget{
+							Type: operatorv2beta1.ControlPlaneDataPlaneTargetRefType,
+							Ref: &operatorv2beta1.ControlPlaneDataPlaneTargetRef{
+								Name: "dataplane-1",
+							},
+						},
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+						},
+					},
+				},
+			},
+			{
+				// NOTE: used by operator's Gateway controller
+				Name: "managedByOwner is allowed and doesn't require ingressClass to be set",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: operatorv2beta1.ControlPlaneDataPlaneTarget{
+							Type: operatorv2beta1.ControlPlaneDataPlaneTargetManagedByType,
+						},
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{},
+					},
+				},
+			},
+			{
+				// NOTE: used by operator's Gateway controller
+				Name: "managedByOwner is allowed and ingressClass can be set",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: operatorv2beta1.ControlPlaneDataPlaneTarget{
+							Type: operatorv2beta1.ControlPlaneDataPlaneTargetManagedByType,
+						},
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+						},
+					},
+				},
+			},
+			{
+				// NOTE: used by operator's Gateway controller
+				Name: "can't set ref when type is managedByOwner",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: operatorv2beta1.ControlPlaneDataPlaneTarget{
+							Type: operatorv2beta1.ControlPlaneDataPlaneTargetManagedByType,
+							Ref: &operatorv2beta1.ControlPlaneDataPlaneTargetRef{
+								Name: "dataplane-1",
+							},
+						},
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Ref cannot be provided when type is set to managedByOwner"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("feature gates", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv2beta1.ControlPlane]{
+			{
+				Name: "no feature gates",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+						},
+					},
+				},
+			},
+			{
+				Name: "feature gate set",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+							FeatureGates: []operatorv2beta1.ControlPlaneFeatureGate{
+								{
+									Name:  "KongCustomEntity",
+									State: operatorv2beta1.FeatureGateStateEnabled,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "feature gate disabled",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+							FeatureGates: []operatorv2beta1.ControlPlaneFeatureGate{
+								{
+									Name:  "KongCustomEntity",
+									State: operatorv2beta1.FeatureGateStateDisabled,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "feature gate set and then removed",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+							FeatureGates: []operatorv2beta1.ControlPlaneFeatureGate{
+								{
+									Name:  "KongCustomEntity",
+									State: operatorv2beta1.FeatureGateStateEnabled,
+								},
+							},
+						},
+					},
+				},
+				Update: func(cp *operatorv2beta1.ControlPlane) {
+					cp.Spec.ControlPlaneOptions = operatorv2beta1.ControlPlaneOptions{
+						IngressClass: lo.ToPtr("kong"),
+					}
+				},
+			},
+			{
+				Name: "cannot provide a feature gate with enabled unset",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+							FeatureGates: []operatorv2beta1.ControlPlaneFeatureGate{
+								{
+									Name: "KongCustomEntity",
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.featureGates[0].state: Unsupported value: \"\": supported values: \"enabled\", \"disabled\""),
+			},
+		}.Run(t)
+	})
+
+	t.Run("controllers", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv2beta1.ControlPlane]{
+			{
+				Name: "no controller overrides specified",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+						},
+					},
+				},
+			},
+			{
+				Name: "controller overrides specified",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+							Controllers: []operatorv2beta1.ControlPlaneController{
+								{
+									Name:  "KONG_PLUGIN",
+									State: operatorv2beta1.ControllerStateEnabled,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "controller overrides specified - disabled",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+							Controllers: []operatorv2beta1.ControlPlaneController{
+								{
+									Name:  "KONG_PLUGIN",
+									State: operatorv2beta1.ControllerStateDisabled,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "controller overrides specified and then removed",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+							Controllers: []operatorv2beta1.ControlPlaneController{
+								{
+									Name:  "KONG_PLUGIN",
+									State: operatorv2beta1.ControllerStateEnabled,
+								},
+							},
+						},
+					},
+				},
+				Update: func(cp *operatorv2beta1.ControlPlane) {
+					cp.Spec.ControlPlaneOptions = operatorv2beta1.ControlPlaneOptions{
+						IngressClass: lo.ToPtr("kong"),
+					}
+				},
+			},
+			{
+				Name: "cannot provide a controller with enabled unset",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+							Controllers: []operatorv2beta1.ControlPlaneController{
+								{
+									Name: "KONG_PLUGIN",
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.controllers[0].state: Unsupported value: \"\": supported values: \"enabled\", \"disabled\""),
+			},
+		}.Run(t)
+	})
+
+	t.Run("translation", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv2beta1.ControlPlane]{
+			{
+				Name: "combinedServicesFromDifferentHTTPRoutes set to enabled",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+							Translation: &operatorv2beta1.ControlPlaneTranslationOptions{
+								CombinedServicesFromDifferentHTTPRoutes: lo.ToPtr(operatorv2beta1.ControlPlaneCombinedServicesFromDifferentHTTPRoutesStateEnabled),
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "combinedServicesFromDifferentHTTPRoutes set to disabled",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+							Translation: &operatorv2beta1.ControlPlaneTranslationOptions{
+								CombinedServicesFromDifferentHTTPRoutes: lo.ToPtr(operatorv2beta1.ControlPlaneCombinedServicesFromDifferentHTTPRoutesStateEnabled),
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "combinedServicesFromDifferentHTTPRoutes set to disallowed value",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+							Translation: &operatorv2beta1.ControlPlaneTranslationOptions{
+								CombinedServicesFromDifferentHTTPRoutes: lo.ToPtr(operatorv2beta1.ControlPlaneCombinedServicesFromDifferentHTTPRoutesState("invalid")),
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.translation.combinedServicesFromDifferentHTTPRoutes: Unsupported value: \"invalid\": supported values: \"enabled\", \"disabled\""),
+			},
+			{
+				Name: "drainSupport set to enabled",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+							Translation: &operatorv2beta1.ControlPlaneTranslationOptions{
+								DrainSupport: lo.ToPtr(operatorv2beta1.ControlPlaneDrainSupportStateEnabled),
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "drainSupport set to disabled",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+							Translation: &operatorv2beta1.ControlPlaneTranslationOptions{
+								DrainSupport: lo.ToPtr(operatorv2beta1.ControlPlaneDrainSupportStateDisabled),
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "drainSupport set to disallowed value",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+							Translation: &operatorv2beta1.ControlPlaneTranslationOptions{
+								DrainSupport: lo.ToPtr(operatorv2beta1.ControlPlaneDrainSupportState("invalid")),
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.translation.drainSupport: Unsupported value: \"invalid\": supported values: \"enabled\", \"disabled\""),
+			},
+			{
+				Name: "both combinedServicesFromDifferentHTTPRoutes and drainSupport set",
+				TestObject: &operatorv2beta1.ControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.ControlPlaneSpec{
+						DataPlane: validDataPlaneTarget,
+						ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+							IngressClass: lo.ToPtr("kong"),
+							Translation: &operatorv2beta1.ControlPlaneTranslationOptions{
+								CombinedServicesFromDifferentHTTPRoutes: lo.ToPtr(operatorv2beta1.ControlPlaneCombinedServicesFromDifferentHTTPRoutesStateEnabled),
+								DrainSupport:                            lo.ToPtr(operatorv2beta1.ControlPlaneDrainSupportStateDisabled),
+							},
+						},
+					},
+				},
+			},
+		}.Run(t)
+
+		t.Run("fallbackConfiguration", func(t *testing.T) {
+			common.TestCasesGroup[*operatorv2beta1.ControlPlane]{
+				{
+					Name: "fallbackConfiguration.useLastValidConfig set to enabled",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								Translation: &operatorv2beta1.ControlPlaneTranslationOptions{
+									FallbackConfiguration: &operatorv2beta1.ControlPlaneFallbackConfiguration{
+										UseLastValidConfig: lo.ToPtr(operatorv2beta1.ControlPlaneFallbackConfigurationStateEnabled),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "fallbackConfiguration.useLastValidConfig set to disabled",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								Translation: &operatorv2beta1.ControlPlaneTranslationOptions{
+									FallbackConfiguration: &operatorv2beta1.ControlPlaneFallbackConfiguration{
+										UseLastValidConfig: lo.ToPtr(operatorv2beta1.ControlPlaneFallbackConfigurationStateDisabled),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "fallbackConfiguration.useLastValidConfig set to disallowed value",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								Translation: &operatorv2beta1.ControlPlaneTranslationOptions{
+									FallbackConfiguration: &operatorv2beta1.ControlPlaneFallbackConfiguration{
+										UseLastValidConfig: lo.ToPtr(operatorv2beta1.ControlPlaneFallbackConfigurationState("invalid")),
+									},
+								},
+							},
+						},
+					},
+					ExpectedErrorMessage: lo.ToPtr("spec.translation.fallbackConfiguration.useLastValidConfig: Unsupported value: \"invalid\": supported values: \"enabled\", \"disabled\""),
+				},
+			}.Run(t)
+		})
+
+		t.Run("configDump", func(t *testing.T) {
+			common.TestCasesGroup[*operatorv2beta1.ControlPlane]{
+				{
+					Name: "configDump.state and configDump.dumpsensitive set to enabled",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								ConfigDump: &operatorv2beta1.ControlPlaneConfigDump{
+									State:         operatorv2beta1.ConfigDumpStateEnabled,
+									DumpSensitive: operatorv2beta1.ConfigDumpStateEnabled,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "configDump.state and configDump.dumpSensitive set to disabled",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								ConfigDump: &operatorv2beta1.ControlPlaneConfigDump{
+									State:         operatorv2beta1.ConfigDumpStateDisabled,
+									DumpSensitive: operatorv2beta1.ConfigDumpStateDisabled,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "configDump.state set to enabled and configDump.dumpSensitive set to disabled",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								ConfigDump: &operatorv2beta1.ControlPlaneConfigDump{
+									State:         operatorv2beta1.ConfigDumpStateEnabled,
+									DumpSensitive: operatorv2beta1.ConfigDumpStateDisabled,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "configDump.state set to disabled and configDump.dumpSensitive set to enabled is invalid",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								ConfigDump: &operatorv2beta1.ControlPlaneConfigDump{
+									State:         operatorv2beta1.ConfigDumpStateDisabled,
+									DumpSensitive: operatorv2beta1.ConfigDumpStateEnabled,
+								},
+							},
+						},
+					},
+					ExpectedErrorMessage: lo.ToPtr("Cannot enable dumpSensitive when state is disabled"),
+				},
+				{
+					Name: "configDump.state set to disallowed value",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								ConfigDump: &operatorv2beta1.ControlPlaneConfigDump{
+									State:         operatorv2beta1.ConfigDumpState("invalid"),
+									DumpSensitive: operatorv2beta1.ConfigDumpStateEnabled,
+								},
+							},
+						},
+					},
+					ExpectedErrorMessage: lo.ToPtr(`spec.configDump.state: Unsupported value: "invalid": supported values: "enabled", "disabled"`),
+				},
+				{
+					Name: "configDump.dumpSensitive is set to disallowed value",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								ConfigDump: &operatorv2beta1.ControlPlaneConfigDump{
+									State:         operatorv2beta1.ConfigDumpStateEnabled,
+									DumpSensitive: operatorv2beta1.ConfigDumpState("invalid"),
+								},
+							},
+						},
+					},
+					ExpectedErrorMessage: lo.ToPtr(`spec.configDump.dumpSensitive: Unsupported value: "invalid": supported values: "enabled", "disabled"`),
+				},
+			}.Run(t)
+		})
+
+		t.Run("objectFilters", func(t *testing.T) {
+			common.TestCasesGroup[*operatorv2beta1.ControlPlane]{
+				{
+					Name: "objectFilters.secrets and objectFilters.configMaps are set",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								ObjectFilters: &operatorv2beta1.ControlPlaneObjectFilters{
+									Secrets: &operatorv2beta1.ControlPlaneFilterForObjectType{
+										MatchLabels: map[string]string{"konghq.com/secret": "true"},
+									},
+									ConfigMaps: &operatorv2beta1.ControlPlaneFilterForObjectType{
+										MatchLabels: map[string]string{"konghq.com/configmap": "true"},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "maximum items in matchLabels is 8",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								ObjectFilters: &operatorv2beta1.ControlPlaneObjectFilters{
+									Secrets: &operatorv2beta1.ControlPlaneFilterForObjectType{
+										MatchLabels: map[string]string{
+											"konghq.com/secret": "true",
+											"label1":            "value1",
+											"label2":            "value2",
+											"label3":            "value3",
+											"label4":            "value4",
+											"label5":            "value5",
+											"label6":            "value6",
+											"label7":            "value7",
+											"label8":            "value8",
+										},
+									},
+								},
+							},
+						},
+					},
+					ExpectedErrorMessage: lo.ToPtr("spec.objectFilters.secrets.matchLabels: Too many: 9: must have at most 8 items"),
+				},
+				{
+					Name: "key of objectFilters.*.matchLabels must have minimum length 1",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								ObjectFilters: &operatorv2beta1.ControlPlaneObjectFilters{
+									Secrets: &operatorv2beta1.ControlPlaneFilterForObjectType{
+										MatchLabels: map[string]string{"konghq.com/secret": "true"},
+									},
+									ConfigMaps: &operatorv2beta1.ControlPlaneFilterForObjectType{
+										MatchLabels: map[string]string{"": "aaa"},
+									},
+								},
+							},
+						},
+					},
+					ExpectedErrorMessage: lo.ToPtr("Minimum length of key in matchLabels is 1"),
+				},
+				{
+					Name: "value of objectFilters.*.matchLabels must have maximum length 63",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								ObjectFilters: &operatorv2beta1.ControlPlaneObjectFilters{
+									Secrets: &operatorv2beta1.ControlPlaneFilterForObjectType{
+										MatchLabels: map[string]string{"konghq.com/secret": "this-is-a-very-very-long-label-which-is-longer-than-63-characters"},
+									},
+								},
+							},
+						},
+					},
+					ExpectedErrorMessage: lo.ToPtr("Maximum length of value in matchLabels is 63"),
+				},
+			}.Run(t)
+		})
+	})
+
+	t.Run("konnect", func(t *testing.T) {
+		t.Run("basic configuration", func(t *testing.T) {
+			common.TestCasesGroup[*operatorv2beta1.ControlPlane]{
+				{
+					Name: "no konnect configuration",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+							},
+						},
+					},
+				},
+				{
+					Name: "konnect configuration with all options set",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+									ConsumersSync: lo.ToPtr(operatorv2beta1.ControlPlaneKonnectConsumersSyncStateEnabled),
+									Licensing: &operatorv2beta1.ControlPlaneKonnectLicensing{
+										State:                lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
+										InitialPollingPeriod: lo.ToPtr(metav1.Duration{Duration: 30 * time.Second}),
+										PollingPeriod:        lo.ToPtr(metav1.Duration{Duration: 300 * time.Second}),
+										StorageState:         lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
+									},
+									NodeRefreshPeriod:  lo.ToPtr(metav1.Duration{Duration: 60 * time.Second}),
+									ConfigUploadPeriod: lo.ToPtr(metav1.Duration{Duration: 30 * time.Second}),
+								},
+							},
+						},
+					},
+				},
+			}.Run(t)
+		})
+
+		t.Run("consumersSync", func(t *testing.T) {
+			common.TestCasesGroup[*operatorv2beta1.ControlPlane]{
+				{
+					Name: "consumersSync set to enabled",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+									ConsumersSync: lo.ToPtr(operatorv2beta1.ControlPlaneKonnectConsumersSyncStateEnabled),
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "consumersSync set to disabled",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+									ConsumersSync: lo.ToPtr(operatorv2beta1.ControlPlaneKonnectConsumersSyncStateDisabled),
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "consumersSync set to disallowed value",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+									ConsumersSync: lo.ToPtr(operatorv2beta1.ControlPlaneKonnectConsumersSyncState("invalid")),
+								},
+							},
+						},
+					},
+					ExpectedErrorMessage: lo.ToPtr("spec.konnect.consumersSync: Unsupported value: \"invalid\": supported values: \"enabled\", \"disabled\""),
+				},
+			}.Run(t)
+		})
+
+		t.Run("licensing", func(t *testing.T) {
+			common.TestCasesGroup[*operatorv2beta1.ControlPlane]{
+				{
+					Name: "licensing set to enabled without polling periods is allowed",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+									Licensing: &operatorv2beta1.ControlPlaneKonnectLicensing{
+										State: lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "licensing set to disabled",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+									Licensing: &operatorv2beta1.ControlPlaneKonnectLicensing{
+										State:        lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateDisabled),
+										StorageState: lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateDisabled),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "licensing with polling periods and storage",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+									Licensing: &operatorv2beta1.ControlPlaneKonnectLicensing{
+										State:                lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
+										InitialPollingPeriod: lo.ToPtr(metav1.Duration{Duration: 30 * time.Second}),
+										PollingPeriod:        lo.ToPtr(metav1.Duration{Duration: 300 * time.Second}),
+										StorageState:         lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "licensing with storage disabled",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+									Licensing: &operatorv2beta1.ControlPlaneKonnectLicensing{
+										State:                lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
+										InitialPollingPeriod: lo.ToPtr(metav1.Duration{Duration: 30 * time.Second}),
+										PollingPeriod:        lo.ToPtr(metav1.Duration{Duration: 300 * time.Second}),
+										StorageState:         lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateDisabled),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "licensing storage set to disallowed value",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+									Licensing: &operatorv2beta1.ControlPlaneKonnectLicensing{
+										State:        lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
+										StorageState: lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingState("invalid")),
+									},
+								},
+							},
+						},
+					},
+					ExpectedErrorMessage: lo.ToPtr("spec.konnect.licensing.storageState: Unsupported value: \"invalid\": supported values: \"enabled\", \"disabled\""),
+				},
+				{
+					Name: "storageState set when licensing is disabled",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+									Licensing: &operatorv2beta1.ControlPlaneKonnectLicensing{
+										State:        lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateDisabled),
+										StorageState: lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
+									},
+								},
+							},
+						},
+					},
+					ExpectedErrorMessage: lo.ToPtr("storageState can only be set to enabled when licensing is enabled"),
+				},
+				{
+					Name: "licensing set to disabled with initialPollingPeriod",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+									Licensing: &operatorv2beta1.ControlPlaneKonnectLicensing{
+										State:                lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateDisabled),
+										InitialPollingPeriod: lo.ToPtr(metav1.Duration{Duration: 30 * time.Second}),
+									},
+								},
+							},
+						},
+					},
+					ExpectedErrorMessage: lo.ToPtr("initialPollingPeriod can only be set when licensing is enabled"),
+				},
+				{
+					Name: "licensing set to disabled with pollingPeriod",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+									Licensing: &operatorv2beta1.ControlPlaneKonnectLicensing{
+										State:         lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateDisabled),
+										PollingPeriod: lo.ToPtr(metav1.Duration{Duration: 300 * time.Second}),
+									},
+								},
+							},
+						},
+					},
+					ExpectedErrorMessage: lo.ToPtr("pollingPeriod can only be set when licensing is enabled"),
+				},
+				{
+					Name: "licensing set to disallowed value",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+									Licensing: &operatorv2beta1.ControlPlaneKonnectLicensing{
+										State: lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingState("invalid")),
+									},
+								},
+							},
+						},
+					},
+					ExpectedErrorMessage: lo.ToPtr("spec.konnect.licensing.state: Unsupported value: \"invalid\": supported values: \"enabled\", \"disabled\""),
+				},
+			}.Run(t)
+		})
+
+		t.Run("periods", func(t *testing.T) {
+			common.TestCasesGroup[*operatorv2beta1.ControlPlane]{
+				{
+					Name: "nodeRefreshPeriod set",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+									NodeRefreshPeriod: lo.ToPtr(metav1.Duration{Duration: 60 * time.Second}),
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "configUploadPeriod set",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+									ConfigUploadPeriod: lo.ToPtr(metav1.Duration{Duration: 30 * time.Second}),
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "both periods set",
+					TestObject: &operatorv2beta1.ControlPlane{
+						ObjectMeta: common.CommonObjectMeta,
+						Spec: operatorv2beta1.ControlPlaneSpec{
+							DataPlane: validDataPlaneTarget,
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								IngressClass: lo.ToPtr("kong"),
+								Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+									NodeRefreshPeriod:  lo.ToPtr(metav1.Duration{Duration: 60 * time.Second}),
+									ConfigUploadPeriod: lo.ToPtr(metav1.Duration{Duration: 30 * time.Second}),
+								},
+							},
+						},
+					},
+				},
+			}.Run(t)
+		})
+	})
+}

--- a/api/test/crdsvalidation/gateway-operator.konghq.com/dataplane_test.go
+++ b/api/test/crdsvalidation/gateway-operator.konghq.com/dataplane_test.go
@@ -1,0 +1,561 @@
+package crdsvalidation_test
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	"github.com/kong/kong-operator/api/gateway-operator/dataplane"
+	operatorv1beta1 "github.com/kong/kong-operator/api/gateway-operator/v1beta1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestDataplane(t *testing.T) {
+	validDataplaneOptions := operatorv1beta1.DataPlaneOptions{
+		Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+			DeploymentOptions: operatorv1beta1.DeploymentOptions{
+				PodTemplateSpec: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "proxy",
+								Image: "kong:over9000",
+								Env: []corev1.EnvVar{
+									{
+										Name:  "KONG_DATABASE",
+										Value: "off",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	t.Run("extensions", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv1beta1.DataPlane]{
+			{
+				Name: "no extensions",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: validDataplaneOptions,
+					},
+				},
+			},
+			{
+				Name: "konnectExtension set",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: validDataplaneOptions.Deployment,
+							Extensions: []commonv1alpha1.ExtensionRef{
+								{
+									Group: "konnect.konghq.com",
+									Kind:  "KonnectExtension",
+									NamespacedRef: commonv1alpha1.NamespacedRef{
+										Name: "my-konnect-extension",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "invalid extension",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: validDataplaneOptions.Deployment,
+							Extensions: []commonv1alpha1.ExtensionRef{
+								{
+									Group: "invalid.konghq.com",
+									Kind:  "KonnectExtension",
+									NamespacedRef: commonv1alpha1.NamespacedRef{
+										Name: "my-konnect-extension",
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Extension not allowed for DataPlane"),
+			},
+		}.Run(t)
+	})
+	t.Run("pod spec", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv1beta1.DataPlane]{
+			{
+				Name: "no deploymentSpec",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec:       operatorv1beta1.DataPlaneSpec{},
+				},
+				ExpectedErrorMessage: lo.ToPtr("DataPlane requires an image to be set on proxy container"),
+			},
+			{
+				Name: "with deploymentSpec",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+								DeploymentOptions: operatorv1beta1.DeploymentOptions{},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("DataPlane requires an image to be set on proxy container"),
+			},
+			{
+				Name: "missing container",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+								DeploymentOptions: operatorv1beta1.DeploymentOptions{
+									PodTemplateSpec: &corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "my-container",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("DataPlane requires an image to be set on proxy container"),
+			},
+			{
+				Name: "proxy container, no image",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+								DeploymentOptions: operatorv1beta1.DeploymentOptions{
+									PodTemplateSpec: &corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "proxy",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("DataPlane requires an image to be set on proxy container"),
+			},
+			{
+				Name: "proxy container, image",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+								DeploymentOptions: operatorv1beta1.DeploymentOptions{
+									PodTemplateSpec: &corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name:  "proxy",
+													Image: "kong:over9000",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}.Run(t)
+	})
+	t.Run("db mode", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv1beta1.DataPlane]{
+			{
+				Name: "db mode on",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+								DeploymentOptions: operatorv1beta1.DeploymentOptions{
+									PodTemplateSpec: &corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name:  "proxy",
+													Image: "kong:over9000",
+													Env: []corev1.EnvVar{
+														{
+															Name:  "KONG_DATABASE",
+															Value: "on",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("DataPlane supports only db mode 'off'"),
+			},
+			{
+				Name: "db mode off",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: validDataplaneOptions,
+					},
+				},
+			},
+		}.Run(t)
+	})
+	t.Run("service options", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv1beta1.DataPlane]{
+			{
+				Name: "nodePort can be specified when service type is set to NodePort",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: validDataplaneOptions.Deployment,
+							Network: operatorv1beta1.DataPlaneNetworkOptions{
+								Services: &operatorv1beta1.DataPlaneServices{
+									Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+										ServiceOptions: operatorv1beta1.ServiceOptions{
+											Type: corev1.ServiceTypeNodePort,
+										},
+										Ports: []operatorv1beta1.DataPlaneServicePort{
+											{
+												Name:       "http",
+												Port:       80,
+												NodePort:   30080,
+												TargetPort: intstr.FromInt(80),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "can leave nodePort empty when when service type is not specified",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: validDataplaneOptions.Deployment,
+							Network: operatorv1beta1.DataPlaneNetworkOptions{
+								Services: &operatorv1beta1.DataPlaneServices{
+									Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+										Ports: []operatorv1beta1.DataPlaneServicePort{
+											{
+												Name:       "http",
+												Port:       80,
+												TargetPort: intstr.FromInt(80),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "nodePort can be specified when service type is set to LoadBalancer",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: validDataplaneOptions.Deployment,
+							Network: operatorv1beta1.DataPlaneNetworkOptions{
+								Services: &operatorv1beta1.DataPlaneServices{
+									Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+										ServiceOptions: operatorv1beta1.ServiceOptions{
+											Type: corev1.ServiceTypeLoadBalancer,
+										},
+										Ports: []operatorv1beta1.DataPlaneServicePort{
+											{
+												Name:       "http",
+												Port:       80,
+												NodePort:   30080,
+												TargetPort: intstr.FromInt(80),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "cannot specify nodePort when service type is ClusterIP",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: validDataplaneOptions.Deployment,
+							Network: operatorv1beta1.DataPlaneNetworkOptions{
+								Services: &operatorv1beta1.DataPlaneServices{
+									Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+										ServiceOptions: operatorv1beta1.ServiceOptions{
+											Type: corev1.ServiceTypeClusterIP,
+										},
+										Ports: []operatorv1beta1.DataPlaneServicePort{
+											{
+												Name:       "http",
+												Port:       80,
+												NodePort:   30080,
+												TargetPort: intstr.FromInt(80),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Cannot set NodePort when service type is not NodePort or LoadBalancer"),
+			},
+			{
+				Name: "can specify nodePort when service type is not set (default LoadBalancer)",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: validDataplaneOptions.Deployment,
+							Network: operatorv1beta1.DataPlaneNetworkOptions{
+								Services: &operatorv1beta1.DataPlaneServices{
+									Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+										Ports: []operatorv1beta1.DataPlaneServicePort{
+											{
+												Name:       "http",
+												Port:       80,
+												NodePort:   30080,
+												TargetPort: intstr.FromInt(80),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}.Run(t)
+	})
+	t.Run("service ingress type", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv1beta1.DataPlane]{
+			{
+				Name: "service ingress type LoadBalancer",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: validDataplaneOptions.Deployment,
+							Network: operatorv1beta1.DataPlaneNetworkOptions{
+								Services: &operatorv1beta1.DataPlaneServices{
+									Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+										ServiceOptions: operatorv1beta1.ServiceOptions{
+											Type: corev1.ServiceTypeLoadBalancer,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "service ingress type NodePort",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: validDataplaneOptions.Deployment,
+							Network: operatorv1beta1.DataPlaneNetworkOptions{
+								Services: &operatorv1beta1.DataPlaneServices{
+									Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+										ServiceOptions: operatorv1beta1.ServiceOptions{
+											Type: corev1.ServiceTypeNodePort,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "service ingress type ClusterIP",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: validDataplaneOptions.Deployment,
+							Network: operatorv1beta1.DataPlaneNetworkOptions{
+								Services: &operatorv1beta1.DataPlaneServices{
+									Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+										ServiceOptions: operatorv1beta1.ServiceOptions{
+											Type: corev1.ServiceTypeClusterIP,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "service ingress type ExternalName",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: validDataplaneOptions.Deployment,
+							Network: operatorv1beta1.DataPlaneNetworkOptions{
+								Services: &operatorv1beta1.DataPlaneServices{
+									Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+										ServiceOptions: operatorv1beta1.ServiceOptions{
+											Type: corev1.ServiceTypeExternalName,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Unsupported value: \"ExternalName\""),
+			},
+		}.Run(t)
+	})
+
+	t.Run("spec update", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv1beta1.DataPlane]{
+			{
+				Name: "cannot update spec when in the middle of promotion",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: validDataplaneOptions.Deployment,
+						},
+					},
+					Status: operatorv1beta1.DataPlaneStatus{
+						RolloutStatus: &operatorv1beta1.DataPlaneRolloutStatus{
+							Conditions: []metav1.Condition{
+								{
+									Type:               string(dataplane.DataPlaneConditionTypeRolledOut),
+									Status:             metav1.ConditionFalse,
+									Reason:             string(dataplane.DataPlaneConditionReasonRolloutPromotionInProgress),
+									LastTransitionTime: metav1.Now(),
+								},
+							},
+						},
+					},
+				},
+				Update: func(d *operatorv1beta1.DataPlane) {
+					d.Spec.Deployment.PodTemplateSpec.Labels = map[string]string{"foo": "bar"}
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("DataPlane spec cannot be updated when promotion is in progress"),
+			},
+			{
+				Name: "rollout status without conditions doesn't prevent spec updates",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: validDataplaneOptions.Deployment,
+						},
+					},
+					Status: operatorv1beta1.DataPlaneStatus{
+						RolloutStatus: &operatorv1beta1.DataPlaneRolloutStatus{
+							Services: &operatorv1beta1.DataPlaneRolloutStatusServices{
+								Ingress: &operatorv1beta1.RolloutStatusService{
+									Name: "ingress",
+									Addresses: []operatorv1beta1.Address{
+										{
+											Type:       lo.ToPtr(operatorv1beta1.IPAddressType),
+											Value:      "10.1.2.3",
+											SourceType: operatorv1beta1.PublicIPAddressSourceType,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Update: func(d *operatorv1beta1.DataPlane) {
+					d.Spec.Deployment.PodTemplateSpec.Labels = map[string]string{"foo": "bar"}
+				},
+			},
+			{
+				Name: "can update spec when promotion complete",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: validDataplaneOptions.Deployment,
+						},
+					},
+					Status: operatorv1beta1.DataPlaneStatus{
+						RolloutStatus: &operatorv1beta1.DataPlaneRolloutStatus{
+							Conditions: []metav1.Condition{
+								{
+									Type:               string(dataplane.DataPlaneConditionTypeRolledOut),
+									Status:             metav1.ConditionTrue,
+									Reason:             string(dataplane.DataPlaneConditionReasonRolloutPromotionDone),
+									LastTransitionTime: metav1.Now(),
+								},
+							},
+						},
+					},
+				},
+				Update: func(d *operatorv1beta1.DataPlane) {
+					d.Spec.Deployment.PodTemplateSpec.Labels = map[string]string{"foo": "bar"}
+				},
+			},
+			{
+				Name: "can update spec when rollout is not in progress",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: validDataplaneOptions.Deployment,
+						},
+					},
+				},
+				Update: func(d *operatorv1beta1.DataPlane) {
+					d.Spec.Deployment.PodTemplateSpec.Labels = map[string]string{"foo": "bar"}
+				},
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/gateway-operator.konghq.com/gatewayconfiguration_test.go
+++ b/api/test/crdsvalidation/gateway-operator.konghq.com/gatewayconfiguration_test.go
@@ -1,0 +1,220 @@
+package crdsvalidation_test
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	operatorv1beta1 "github.com/kong/kong-operator/api/gateway-operator/v1beta1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestGatewayConfiguration(t *testing.T) {
+	t.Run("extensions", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv1beta1.GatewayConfiguration]{
+			{
+				Name: "no extensions",
+				TestObject: &operatorv1beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec:       operatorv1beta1.GatewayConfigurationSpec{},
+				},
+			},
+			{
+				Name: "valid konnectExtension at the gatewayConfiguration level",
+				TestObject: &operatorv1beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.GatewayConfigurationSpec{
+						Extensions: []commonv1alpha1.ExtensionRef{
+							{
+								Group: "konnect.konghq.com",
+								Kind:  "KonnectExtension",
+								NamespacedRef: commonv1alpha1.NamespacedRef{
+									Name: "my-konnect-extension",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "invalid konnectExtension",
+				TestObject: &operatorv1beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.GatewayConfigurationSpec{
+						Extensions: []commonv1alpha1.ExtensionRef{
+							{
+								Group: "wrong.konghq.com",
+								Kind:  "wrongExtension",
+								NamespacedRef: commonv1alpha1.NamespacedRef{
+									Name: "my-konnect-extension",
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Extension not allowed for GatewayConfiguration"),
+			},
+			{
+				Name: "konnectExtension at the DataPlane level",
+				TestObject: &operatorv1beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.GatewayConfigurationSpec{
+						DataPlaneOptions: &operatorv1beta1.GatewayConfigDataPlaneOptions{
+							Extensions: []commonv1alpha1.ExtensionRef{
+								{
+									Group: "konnect.konghq.com",
+									Kind:  "KonnectExtension",
+									NamespacedRef: commonv1alpha1.NamespacedRef{
+										Name: "my-konnect-extension",
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("KonnectExtension must be set at the Gateway level"),
+			},
+			{
+				Name: "konnectExtension at the ControlPlane level",
+				TestObject: &operatorv1beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.GatewayConfigurationSpec{
+						ControlPlaneOptions: &operatorv1beta1.ControlPlaneOptions{
+							Extensions: []commonv1alpha1.ExtensionRef{
+								{
+									Group: "konnect.konghq.com",
+									Kind:  "KonnectExtension",
+									NamespacedRef: commonv1alpha1.NamespacedRef{
+										Name: "my-konnect-extension",
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("KonnectExtension must be set at the Gateway level"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("DataPlaneOptions", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv1beta1.GatewayConfiguration]{
+			{
+				Name: "no DataPlaneOptions",
+				TestObject: &operatorv1beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.GatewayConfigurationSpec{
+						DataPlaneOptions: nil,
+					},
+				},
+			},
+			{
+				Name: "specifying resources.PodDisruptionBudget",
+				TestObject: &operatorv1beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.GatewayConfigurationSpec{
+						DataPlaneOptions: &operatorv1beta1.GatewayConfigDataPlaneOptions{
+							Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+								DeploymentOptions: operatorv1beta1.DeploymentOptions{
+									Replicas: lo.ToPtr(int32(4)),
+								},
+							},
+							Resources: &operatorv1beta1.GatewayConfigDataPlaneResources{
+								PodDisruptionBudget: &operatorv1beta1.PodDisruptionBudget{
+									Spec: operatorv1beta1.PodDisruptionBudgetSpec{
+										MinAvailable:               lo.ToPtr(intstr.FromInt(1)),
+										UnhealthyPodEvictionPolicy: lo.ToPtr(policyv1.IfHealthyBudget),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "specifying resources.PodDisruptionBudget can only specify onf of maxUnavailable and minAvailable",
+				TestObject: &operatorv1beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.GatewayConfigurationSpec{
+						DataPlaneOptions: &operatorv1beta1.GatewayConfigDataPlaneOptions{
+							Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+								DeploymentOptions: operatorv1beta1.DeploymentOptions{
+									Replicas: lo.ToPtr(int32(4)),
+								},
+							},
+							Resources: &operatorv1beta1.GatewayConfigDataPlaneResources{
+								PodDisruptionBudget: &operatorv1beta1.PodDisruptionBudget{
+									Spec: operatorv1beta1.PodDisruptionBudgetSpec{
+										MinAvailable:   lo.ToPtr(intstr.FromInt(1)),
+										MaxUnavailable: lo.ToPtr(intstr.FromInt(1)),
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("You can specify only one of maxUnavailable and minAvailable in a single PodDisruptionBudgetSpec."),
+			},
+		}.Run(t)
+	})
+
+	t.Run("ControlPlaneOptions", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv1beta1.GatewayConfiguration]{
+			{
+				Name: "no ControlPlaneOptions",
+				TestObject: &operatorv1beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.GatewayConfigurationSpec{
+						ControlPlaneOptions: nil,
+					},
+				},
+			},
+			{
+				Name: "specifying watch namespaces, type=all",
+				TestObject: &operatorv1beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.GatewayConfigurationSpec{
+						ControlPlaneOptions: &operatorv1beta1.ControlPlaneOptions{
+							WatchNamespaces: &operatorv1beta1.WatchNamespaces{
+								Type: operatorv1beta1.WatchNamespacesTypeAll,
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "specifying watch namespaces, type=own",
+				TestObject: &operatorv1beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.GatewayConfigurationSpec{
+						ControlPlaneOptions: &operatorv1beta1.ControlPlaneOptions{
+							WatchNamespaces: &operatorv1beta1.WatchNamespaces{
+								Type: operatorv1beta1.WatchNamespacesTypeOwn,
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "specifying watch namespaces, type=list",
+				TestObject: &operatorv1beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.GatewayConfigurationSpec{
+						ControlPlaneOptions: &operatorv1beta1.ControlPlaneOptions{
+							WatchNamespaces: &operatorv1beta1.WatchNamespaces{
+								Type: operatorv1beta1.WatchNamespacesTypeList,
+								List: []string{
+									"namespace1",
+									"namespace2",
+								},
+							},
+						},
+					},
+				},
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/gateway-operator.konghq.com/gatewayconfiguration_v2_test.go
+++ b/api/test/crdsvalidation/gateway-operator.konghq.com/gatewayconfiguration_v2_test.go
@@ -1,0 +1,380 @@
+package crdsvalidation_test
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	operatorv2beta1 "github.com/kong/kong-operator/api/gateway-operator/v2beta1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestGatewayConfigurationV2(t *testing.T) {
+	t.Run("extensions", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv2beta1.GatewayConfiguration]{
+			{
+				Name: "it is valid to specify no extensions",
+				TestObject: &operatorv2beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec:       operatorv2beta1.GatewayConfigurationSpec{},
+				},
+			},
+			{
+				Name: "valid konnectExtension at the gatewayConfiguration level",
+				TestObject: &operatorv2beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.GatewayConfigurationSpec{
+						Extensions: []commonv1alpha1.ExtensionRef{
+							{
+								Group: "konnect.konghq.com",
+								Kind:  "KonnectExtension",
+								NamespacedRef: commonv1alpha1.NamespacedRef{
+									Name: "my-konnect-extension",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "valid DataPlaneMetricsExtension at the gatewayConfiguration level",
+				TestObject: &operatorv2beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.GatewayConfigurationSpec{
+						Extensions: []commonv1alpha1.ExtensionRef{
+							{
+								Group: "gateway-operator.konghq.com",
+								Kind:  "DataPlaneMetricsExtension",
+								NamespacedRef: commonv1alpha1.NamespacedRef{
+									Name: "my-dataplane-metrics-extension",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "valid DataPlaneMetricsExtension and KonnectExtension at the gatewayConfiguration level",
+				TestObject: &operatorv2beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.GatewayConfigurationSpec{
+						Extensions: []commonv1alpha1.ExtensionRef{
+							{
+								Group: "gateway-operator.konghq.com",
+								Kind:  "DataPlaneMetricsExtension",
+								NamespacedRef: commonv1alpha1.NamespacedRef{
+									Name: "my-dataplane-metrics-extension",
+								},
+							},
+							{
+								Group: "konnect.konghq.com",
+								Kind:  "KonnectExtension",
+								NamespacedRef: commonv1alpha1.NamespacedRef{
+									Name: "my-konnect-extension",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "invalid 3 extensions (max 2 are allowed) at the gatewayConfiguration level",
+				TestObject: &operatorv2beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.GatewayConfigurationSpec{
+						Extensions: []commonv1alpha1.ExtensionRef{
+							{
+								Group: "gateway-operator.konghq.com",
+								Kind:  "DataPlaneMetricsExtension",
+								NamespacedRef: commonv1alpha1.NamespacedRef{
+									Name: "my-dataplane-metrics-extension",
+								},
+							},
+							{
+								Group: "konnect.konghq.com",
+								Kind:  "KonnectExtension",
+								NamespacedRef: commonv1alpha1.NamespacedRef{
+									Name: "my-konnect-extension",
+								},
+							},
+							{
+								Group: "konnect.konghq.com",
+								Kind:  "KonnectExtension",
+								NamespacedRef: commonv1alpha1.NamespacedRef{
+									Name: "my-konnect-extension-2",
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.extensions: Too many: 3: must have at most 2 items"),
+			},
+			{
+				Name: "invalid konnectExtension",
+				TestObject: &operatorv2beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.GatewayConfigurationSpec{
+						Extensions: []commonv1alpha1.ExtensionRef{
+							{
+								Group: "wrong.konghq.com",
+								Kind:  "wrongExtension",
+								NamespacedRef: commonv1alpha1.NamespacedRef{
+									Name: "my-konnect-extension",
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Extension not allowed for GatewayConfiguration"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("DataPlaneOptions", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv2beta1.GatewayConfiguration]{
+			{
+				Name: "it is valid to specify no DataPlaneOptions",
+				TestObject: &operatorv2beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.GatewayConfigurationSpec{
+						DataPlaneOptions: nil,
+					},
+				},
+			},
+			{
+				Name: "specifying resources.PodDisruptionBudget",
+				TestObject: &operatorv2beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.GatewayConfigurationSpec{
+						DataPlaneOptions: &operatorv2beta1.GatewayConfigDataPlaneOptions{
+							Deployment: operatorv2beta1.DataPlaneDeploymentOptions{
+								DeploymentOptions: operatorv2beta1.DeploymentOptions{
+									Replicas: lo.ToPtr(int32(4)),
+								},
+							},
+							Resources: &operatorv2beta1.GatewayConfigDataPlaneResources{
+								PodDisruptionBudget: &operatorv2beta1.PodDisruptionBudget{
+									Spec: operatorv2beta1.PodDisruptionBudgetSpec{
+										MinAvailable:               lo.ToPtr(intstr.FromInt(1)),
+										UnhealthyPodEvictionPolicy: lo.ToPtr(policyv1.IfHealthyBudget),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "specifying resources.PodDisruptionBudget can only specify onf of maxUnavailable and minAvailable",
+				TestObject: &operatorv2beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.GatewayConfigurationSpec{
+						DataPlaneOptions: &operatorv2beta1.GatewayConfigDataPlaneOptions{
+							Deployment: operatorv2beta1.DataPlaneDeploymentOptions{
+								DeploymentOptions: operatorv2beta1.DeploymentOptions{
+									Replicas: lo.ToPtr(int32(4)),
+								},
+							},
+							Resources: &operatorv2beta1.GatewayConfigDataPlaneResources{
+								PodDisruptionBudget: &operatorv2beta1.PodDisruptionBudget{
+									Spec: operatorv2beta1.PodDisruptionBudgetSpec{
+										MinAvailable:   lo.ToPtr(intstr.FromInt(1)),
+										MaxUnavailable: lo.ToPtr(intstr.FromInt(1)),
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("You can specify only one of maxUnavailable and minAvailable in a single PodDisruptionBudgetSpec."),
+			},
+		}.Run(t)
+	})
+
+	t.Run("ControlPlaneOptions", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv2beta1.GatewayConfiguration]{
+			{
+				Name: "it is valid to specify no ControlPlaneOptions",
+				TestObject: &operatorv2beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.GatewayConfigurationSpec{
+						ControlPlaneOptions: nil,
+					},
+				},
+			},
+			{
+				Name: "specifying watch namespaces, type=all",
+				TestObject: &operatorv2beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.GatewayConfigurationSpec{
+						ControlPlaneOptions: &operatorv2beta1.GatewayConfigControlPlaneOptions{
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								WatchNamespaces: &operatorv2beta1.WatchNamespaces{
+									Type: operatorv2beta1.WatchNamespacesTypeAll,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "specifying watch namespaces, type=own",
+				TestObject: &operatorv2beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.GatewayConfigurationSpec{
+						ControlPlaneOptions: &operatorv2beta1.GatewayConfigControlPlaneOptions{
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								WatchNamespaces: &operatorv2beta1.WatchNamespaces{
+									Type: operatorv2beta1.WatchNamespacesTypeOwn,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "specifying watch namespaces, type=list",
+				TestObject: &operatorv2beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.GatewayConfigurationSpec{
+						ControlPlaneOptions: &operatorv2beta1.GatewayConfigControlPlaneOptions{
+							ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+								WatchNamespaces: &operatorv2beta1.WatchNamespaces{
+									Type: operatorv2beta1.WatchNamespacesTypeList,
+									List: []string{
+										"namespace1",
+										"namespace2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}.Run(t)
+	})
+
+	t.Run("ListenerOptions", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv2beta1.GatewayConfiguration]{
+			{
+				Name: "specify nodeport for listeners with 'NodePort' dataplane ingress service",
+				TestObject: &operatorv2beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.GatewayConfigurationSpec{
+						DataPlaneOptions: &operatorv2beta1.GatewayConfigDataPlaneOptions{
+							Network: operatorv2beta1.GatewayConfigDataPlaneNetworkOptions{
+								Services: &operatorv2beta1.GatewayConfigDataPlaneServices{
+									Ingress: &operatorv2beta1.GatewayConfigServiceOptions{
+										ServiceOptions: operatorv2beta1.ServiceOptions{
+											Type: corev1.ServiceTypeNodePort,
+										},
+									},
+								},
+							},
+						},
+						ListenersOptions: []operatorv2beta1.GatewayConfigurationListenerOptions{
+							{
+								Name:     "http",
+								NodePort: int32(30080),
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "nodePort out of range",
+				TestObject: &operatorv2beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.GatewayConfigurationSpec{
+						DataPlaneOptions: &operatorv2beta1.GatewayConfigDataPlaneOptions{
+							Network: operatorv2beta1.GatewayConfigDataPlaneNetworkOptions{
+								Services: &operatorv2beta1.GatewayConfigDataPlaneServices{
+									Ingress: &operatorv2beta1.GatewayConfigServiceOptions{
+										ServiceOptions: operatorv2beta1.ServiceOptions{
+											Type: corev1.ServiceTypeNodePort,
+										},
+									},
+								},
+							},
+						},
+						ListenersOptions: []operatorv2beta1.GatewayConfigurationListenerOptions{
+							{
+								Name:     "http",
+								NodePort: int32(0),
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.listenersOptions[0].nodePort in body should be greater than or equal to 1"),
+			},
+			{
+				Name: "Cannot specify nodeport for listeners with 'ClusterIP' dataplane ingress service",
+				TestObject: &operatorv2beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.GatewayConfigurationSpec{
+						DataPlaneOptions: &operatorv2beta1.GatewayConfigDataPlaneOptions{
+							Network: operatorv2beta1.GatewayConfigDataPlaneNetworkOptions{
+								Services: &operatorv2beta1.GatewayConfigDataPlaneServices{
+									Ingress: &operatorv2beta1.GatewayConfigServiceOptions{
+										ServiceOptions: operatorv2beta1.ServiceOptions{
+											Type: corev1.ServiceTypeClusterIP,
+										},
+									},
+								},
+							},
+						},
+						ListenersOptions: []operatorv2beta1.GatewayConfigurationListenerOptions{
+							{
+								Name:     "http",
+								NodePort: int32(30080),
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Can only specify listener's NodePort when the type of service for dataplane to receive ingress traffic ('spec.dataPlaneOptions.network.services.ingress') is NodePort or LoadBalancer"),
+			},
+			{
+				Name: "Name must be unique in listener options",
+				TestObject: &operatorv2beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.GatewayConfigurationSpec{
+						ListenersOptions: []operatorv2beta1.GatewayConfigurationListenerOptions{
+							{
+								Name:     "http",
+								NodePort: int32(30080),
+							},
+							{
+								Name:     "http",
+								NodePort: int32(30081),
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Listener name must be unique within the Gateway"),
+			},
+			{
+				Name: "Nodeport must be unique in listener options",
+				TestObject: &operatorv2beta1.GatewayConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv2beta1.GatewayConfigurationSpec{
+						ListenersOptions: []operatorv2beta1.GatewayConfigurationListenerOptions{
+							{
+								Name:     "http",
+								NodePort: int32(30080),
+							},
+							{
+								Name:     "http-1",
+								NodePort: int32(30080),
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Nodeport must be unique within the Gateway if specified"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/gateway-operator.konghq.com/watchnamespacegrant_test.go
+++ b/api/test/crdsvalidation/gateway-operator.konghq.com/watchnamespacegrant_test.go
@@ -1,0 +1,75 @@
+package crdsvalidation_test
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+
+	operatorv1alpha1 "github.com/kong/kong-operator/api/gateway-operator/v1alpha1"
+	operatorv1beta1 "github.com/kong/kong-operator/api/gateway-operator/v1beta1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestWatchNamespaceGrant(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		common.TestCasesGroup[*operatorv1alpha1.WatchNamespaceGrant]{
+			{
+				Name: "empty from is invalid",
+				TestObject: &operatorv1alpha1.WatchNamespaceGrant{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1alpha1.WatchNamespaceGrantSpec{
+						From: []operatorv1alpha1.WatchNamespaceGrantFrom{},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.from in body should have at least 1 items"),
+			},
+			{
+				Name: "valid",
+				TestObject: &operatorv1alpha1.WatchNamespaceGrant{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1alpha1.WatchNamespaceGrantSpec{
+						From: []operatorv1alpha1.WatchNamespaceGrantFrom{
+							{
+								Group:     operatorv1beta1.SchemeGroupVersion.Group,
+								Kind:      "ControlPlane",
+								Namespace: "test",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "unsupported group",
+				TestObject: &operatorv1alpha1.WatchNamespaceGrant{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1alpha1.WatchNamespaceGrantSpec{
+						From: []operatorv1alpha1.WatchNamespaceGrantFrom{
+							{
+								Group:     "invalid.group",
+								Kind:      "ControlPlane",
+								Namespace: "test",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.from[0].group: Unsupported value: \"invalid.group\": supported values: \"gateway-operator.konghq.com\""),
+			},
+			{
+				Name: "unsupported kind",
+				TestObject: &operatorv1alpha1.WatchNamespaceGrant{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1alpha1.WatchNamespaceGrantSpec{
+						From: []operatorv1alpha1.WatchNamespaceGrantFrom{
+							{
+								Group:     operatorv1beta1.SchemeGroupVersion.Group,
+								Kind:      "invalid.kind",
+								Namespace: "test",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.from[0].kind: Unsupported value: \"invalid.kind\": supported values: \"ControlPlane\""),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/konnect.konghq.com/konnectapiauthconfiguration_test.go
+++ b/api/test/crdsvalidation/konnect.konghq.com/konnectapiauthconfiguration_test.go
@@ -1,0 +1,163 @@
+package crdsvalidation_test
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+
+	konnectv1alpha1 "github.com/kong/kong-operator/api/konnect/v1alpha1"
+	common "github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKonnectAPIAuthConfiguration(t *testing.T) {
+	t.Run("spec", func(t *testing.T) {
+		common.TestCasesGroup[*konnectv1alpha1.KonnectAPIAuthConfiguration]{
+			{
+				Name: "valid token type - spat prefix",
+				TestObject: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+						Type:      konnectv1alpha1.KonnectAPIAuthTypeToken,
+						Token:     "spat_token",
+						ServerURL: "api.us.konghq.com",
+					},
+				},
+			},
+			{
+				Name: "valid token type - kpat prefix",
+				TestObject: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+						Type:      konnectv1alpha1.KonnectAPIAuthTypeToken,
+						Token:     "kpat_token",
+						ServerURL: "api.us.konghq.com",
+					},
+				},
+			},
+			{
+				Name: "invalid token type - no prefix",
+				TestObject: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+						Type:      konnectv1alpha1.KonnectAPIAuthTypeToken,
+						Token:     "token",
+						ServerURL: "api.us.konghq.com",
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Konnect tokens have to start with spat_ or kpat_"),
+			},
+			{
+				Name: "invalid token type - missing token",
+				TestObject: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+						Type:      konnectv1alpha1.KonnectAPIAuthTypeToken,
+						ServerURL: "api.us.konghq.com",
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Konnect tokens have to start with spat_ or kpat_"),
+			},
+			{
+				Name: "token is required once set",
+				TestObject: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+						Type:      konnectv1alpha1.KonnectAPIAuthTypeToken,
+						Token:     "kpat_token",
+						ServerURL: "api.us.konghq.com",
+					},
+				},
+				Update: func(obj *konnectv1alpha1.KonnectAPIAuthConfiguration) {
+					obj.Spec.Token = ""
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("Token is required once set"),
+			},
+			{
+				Name: "valid secretRef type",
+				TestObject: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+						Type: konnectv1alpha1.KonnectAPIAuthTypeSecretRef,
+						SecretRef: &corev1.SecretReference{
+							Name: "secret",
+						},
+						ServerURL: "api.us.konghq.com",
+					},
+				},
+			},
+			{
+				Name: "invalid secretRef type - missing secretRef",
+				TestObject: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+						Type:      konnectv1alpha1.KonnectAPIAuthTypeSecretRef,
+						ServerURL: "api.us.konghq.com",
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.secretRef is required if auth type is set to secretRef"),
+			},
+			{
+				Name: "server URL is required",
+				TestObject: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+						Type:  konnectv1alpha1.KonnectAPIAuthTypeToken,
+						Token: "spat_token",
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Server URL is required"),
+			},
+			{
+				Name: "server URL is immutable",
+				TestObject: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+						Type:      konnectv1alpha1.KonnectAPIAuthTypeToken,
+						Token:     "spat_token",
+						ServerURL: "api.us.konghq.com",
+					},
+				},
+				Update: func(obj *konnectv1alpha1.KonnectAPIAuthConfiguration) {
+					obj.Spec.ServerURL = "api.eu.konghq.com"
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("Server URL is immutable"),
+			},
+			{
+				Name: "server URL is valid when using HTTPs scheme",
+				TestObject: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+						Type:      konnectv1alpha1.KonnectAPIAuthTypeToken,
+						Token:     "spat_token",
+						ServerURL: "https://api.us.konghq.com",
+					},
+				},
+			},
+			{
+				Name: "server URL must use HTTPs if specifying scheme",
+				TestObject: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+						Type:      konnectv1alpha1.KonnectAPIAuthTypeToken,
+						Token:     "spat_token",
+						ServerURL: "http://api.us.konghq.com",
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Server URL must use HTTPs if specifying scheme"),
+			},
+			{
+				Name: "server URL must satisfy hostname (RFC 1123) regex if not a valid absolute URL",
+				TestObject: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+						Type:      konnectv1alpha1.KonnectAPIAuthTypeToken,
+						Token:     "spat_token",
+						ServerURL: "%%%invalid%%%hostname",
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Server URL must satisfy hostname (RFC 1123) regex if not a valid absolute URL"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/konnect.konghq.com/konnectcloudgatewaydataplanegroupconfiguration_test.go
+++ b/api/test/crdsvalidation/konnect.konghq.com/konnectcloudgatewaydataplanegroupconfiguration_test.go
@@ -1,0 +1,334 @@
+package crdsvalidation_test
+
+import (
+	"testing"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/samber/lo"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/api/konnect/v1alpha1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKonnectDataPlaneGroupConfiguration(t *testing.T) {
+	cpRef := commonv1alpha1.ControlPlaneRef{
+		Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: "test-konnect-control-plane-cloud-gateway",
+		},
+	}
+	networkRefKonnectID := commonv1alpha1.ObjectRef{
+		Type:      "konnectID",
+		KonnectID: lo.ToPtr("12345"),
+	}
+	autoscaleConfiguration := konnectv1alpha1.ConfigurationDataPlaneGroupAutoscale{
+		Type: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleTypeStatic,
+		Static: &konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleStatic{
+			InstanceType:       sdkkonnectcomp.InstanceTypeNameSmall,
+			RequestedInstances: 3,
+		},
+	}
+
+	t.Run("spec", func(t *testing.T) {
+		common.TestCasesGroup[*konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration]{
+			{
+				Name: "all required fields are set",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationSpec{
+						ControlPlaneRef: cpRef,
+						Version:         "3.9",
+						APIAccess:       lo.ToPtr(sdkkonnectcomp.APIAccessPrivatePlusPublic),
+						DataplaneGroups: []konnectv1alpha1.KonnectConfigurationDataPlaneGroup{
+							{
+								Provider:   sdkkonnectcomp.ProviderNameAws,
+								Region:     "us-west-2",
+								NetworkRef: networkRefKonnectID,
+								Autoscale: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscale{
+									Type: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleTypeStatic,
+									Static: &konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleStatic{
+										InstanceType:       sdkkonnectcomp.InstanceTypeNameSmall,
+										RequestedInstances: 3,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "autopilot: providing autopilot configuration when type is static should fail",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationSpec{
+						ControlPlaneRef: cpRef,
+						Version:         "3.9",
+						APIAccess:       lo.ToPtr(sdkkonnectcomp.APIAccessPrivatePlusPublic),
+						DataplaneGroups: []konnectv1alpha1.KonnectConfigurationDataPlaneGroup{
+							{
+								Provider:   sdkkonnectcomp.ProviderNameAws,
+								Region:     "us-west-2",
+								NetworkRef: networkRefKonnectID,
+								Autoscale: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscale{
+									Type: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleTypeStatic,
+									Autopilot: &konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleAutopilot{
+										BaseRps: 123,
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("static is required when type is static"),
+			},
+			{
+				Name: "autopilot: providing static configuration when type is autopilot should fail",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationSpec{
+						ControlPlaneRef: cpRef,
+						Version:         "3.9",
+						APIAccess:       lo.ToPtr(sdkkonnectcomp.APIAccessPrivatePlusPublic),
+						DataplaneGroups: []konnectv1alpha1.KonnectConfigurationDataPlaneGroup{
+							{
+								Provider:   sdkkonnectcomp.ProviderNameAws,
+								Region:     "us-west-2",
+								NetworkRef: networkRefKonnectID,
+								Autoscale: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscale{
+									Type: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleTypeAutopilot,
+									Static: &konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleStatic{
+										InstanceType:       sdkkonnectcomp.InstanceTypeNameSmall,
+										RequestedInstances: 3,
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("autopilot is required when type is autopilot"),
+			},
+			{
+				Name: "can't provide both autopilot and static configuration",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationSpec{
+						ControlPlaneRef: cpRef,
+						Version:         "3.9",
+						APIAccess:       lo.ToPtr(sdkkonnectcomp.APIAccessPrivatePlusPublic),
+						DataplaneGroups: []konnectv1alpha1.KonnectConfigurationDataPlaneGroup{
+							{
+								Provider:   sdkkonnectcomp.ProviderNameAws,
+								Region:     "us-west-2",
+								NetworkRef: networkRefKonnectID,
+								Autoscale: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscale{
+									Type: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleTypeAutopilot,
+									Static: &konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleStatic{
+										InstanceType:       sdkkonnectcomp.InstanceTypeNameSmall,
+										RequestedInstances: 3,
+									},
+									Autopilot: &konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleAutopilot{
+										BaseRps: 123,
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("can't provide both autopilot and static configuration"),
+			},
+			{
+				Name: "envs have to start with KONG_",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationSpec{
+						ControlPlaneRef: cpRef,
+						Version:         "3.9",
+						APIAccess:       lo.ToPtr(sdkkonnectcomp.APIAccessPrivatePlusPublic),
+						DataplaneGroups: []konnectv1alpha1.KonnectConfigurationDataPlaneGroup{
+							{
+								Provider:   sdkkonnectcomp.ProviderNameAws,
+								Region:     "us-west-2",
+								NetworkRef: networkRefKonnectID,
+								Environment: []konnectv1alpha1.ConfigurationDataPlaneGroupEnvironmentField{
+									{
+										Name:  "KONG_LOG_LEVEL",
+										Value: "debug",
+									},
+								},
+								Autoscale: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscale{
+									Type: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleTypeStatic,
+									Static: &konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleStatic{
+										InstanceType:       sdkkonnectcomp.InstanceTypeNameSmall,
+										RequestedInstances: 3,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "envs that do not start with KONG_ cause errors",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationSpec{
+						ControlPlaneRef: cpRef,
+						Version:         "3.9",
+						APIAccess:       lo.ToPtr(sdkkonnectcomp.APIAccessPrivatePlusPublic),
+						DataplaneGroups: []konnectv1alpha1.KonnectConfigurationDataPlaneGroup{
+							{
+								Provider:   sdkkonnectcomp.ProviderNameAws,
+								Region:     "us-west-2",
+								NetworkRef: networkRefKonnectID,
+								Environment: []konnectv1alpha1.ConfigurationDataPlaneGroupEnvironmentField{
+									{
+										Name:  "RANDOM_ENV",
+										Value: "debug",
+									},
+								},
+								Autoscale: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscale{
+									Type: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleTypeStatic,
+									Static: &konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleStatic{
+										InstanceType:       sdkkonnectcomp.InstanceTypeNameSmall,
+										RequestedInstances: 3,
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Invalid value: \"RANDOM_ENV\": spec.dataplane_groups[0].environment[0].name in body should match '^KONG_."),
+			},
+		}.Run(t)
+	})
+
+	t.Run("networkRef", func(t *testing.T) {
+		common.TestCasesGroup[*konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration]{
+			{
+				Name: "networkRef konnectID is supported",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationSpec{
+						ControlPlaneRef: cpRef,
+						Version:         "3.9",
+						APIAccess:       lo.ToPtr(sdkkonnectcomp.APIAccessPrivatePlusPublic),
+						DataplaneGroups: []konnectv1alpha1.KonnectConfigurationDataPlaneGroup{
+							{
+								Provider: sdkkonnectcomp.ProviderNameAws,
+								Region:   "us-west-2",
+								NetworkRef: commonv1alpha1.ObjectRef{
+									Type:      "konnectID",
+									KonnectID: lo.ToPtr("12345"),
+								},
+								Autoscale: autoscaleConfiguration,
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "networkRef konnectID is required when type is konnectID",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationSpec{
+						ControlPlaneRef: cpRef,
+						Version:         "3.9",
+						APIAccess:       lo.ToPtr(sdkkonnectcomp.APIAccessPrivatePlusPublic),
+						DataplaneGroups: []konnectv1alpha1.KonnectConfigurationDataPlaneGroup{
+							{
+								Provider: sdkkonnectcomp.ProviderNameAws,
+								Region:   "us-west-2",
+								NetworkRef: commonv1alpha1.ObjectRef{
+									Type: "konnectID",
+									NamespacedRef: &commonv1alpha1.NamespacedRef{
+										Name: "network-1",
+									},
+								},
+								Autoscale: autoscaleConfiguration,
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectID must be set"),
+			},
+			{
+				Name: "networkRef namespacedRef is supported",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationSpec{
+						ControlPlaneRef: cpRef,
+						Version:         "3.9",
+						APIAccess:       lo.ToPtr(sdkkonnectcomp.APIAccessPrivatePlusPublic),
+						DataplaneGroups: []konnectv1alpha1.KonnectConfigurationDataPlaneGroup{
+							{
+								Provider: sdkkonnectcomp.ProviderNameAws,
+								Region:   "us-west-2",
+								NetworkRef: commonv1alpha1.ObjectRef{
+									Type: "namespacedRef",
+									NamespacedRef: &commonv1alpha1.NamespacedRef{
+										Name: "network-1",
+									},
+								},
+								Autoscale: autoscaleConfiguration,
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "networkRef namespacedRef is required when type is namespacedRef",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationSpec{
+						ControlPlaneRef: cpRef,
+						Version:         "3.9",
+						APIAccess:       lo.ToPtr(sdkkonnectcomp.APIAccessPrivatePlusPublic),
+						DataplaneGroups: []konnectv1alpha1.KonnectConfigurationDataPlaneGroup{
+							{
+								Provider: sdkkonnectcomp.ProviderNameAws,
+								Region:   "us-west-2",
+								NetworkRef: commonv1alpha1.ObjectRef{
+									Type:      "namespacedRef",
+									KonnectID: lo.ToPtr("12345"),
+								},
+								Autoscale: autoscaleConfiguration,
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("when type is namespacedRef, namespacedRef must be set"),
+			},
+			{
+				Name: "networkRef namespacedRef cannot specify namespace",
+				SkipReason: "cross namespace references are not allowed but using the CEL reserved fields like 'namespace' " +
+					"is only allowed in Kubernetes 1.32+ (https://github.com/kubernetes/kubernetes/pull/126977). " +
+					"Re-enable this test and reintroduce the rule that enforces this when 1.32 becomes the oldest supported version.",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationSpec{
+						ControlPlaneRef: cpRef,
+						Version:         "3.9",
+						APIAccess:       lo.ToPtr(sdkkonnectcomp.APIAccessPrivatePlusPublic),
+						DataplaneGroups: []konnectv1alpha1.KonnectConfigurationDataPlaneGroup{
+							{
+								Provider: sdkkonnectcomp.ProviderNameAws,
+								Region:   "us-west-2",
+								NetworkRef: commonv1alpha1.ObjectRef{
+									Type: "namespacedRef",
+									NamespacedRef: &commonv1alpha1.NamespacedRef{
+										Name:      "network-1",
+										Namespace: lo.ToPtr("ns-1"),
+									},
+								},
+								Autoscale: autoscaleConfiguration,
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("cross namespace references are not supported for networkRef of type namespacedRef"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/konnect.konghq.com/konnectcloudgatewaynetwork_test.go
+++ b/api/test/crdsvalidation/konnect.konghq.com/konnectcloudgatewaynetwork_test.go
@@ -1,0 +1,153 @@
+package crdsvalidation_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	konnectv1alpha1 "github.com/kong/kong-operator/api/konnect/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKonnectNetwork(t *testing.T) {
+	t.Run("mutability based on Programmed status condition", func(t *testing.T) {
+		t.Run("name", func(t *testing.T) {
+			fieldMutabilityBasedOnProgrammedTest(t, "name", func(n *konnectv1alpha1.KonnectCloudGatewayNetwork) {
+				n.Spec.Name = "new-name"
+			})
+		})
+
+		t.Run("availability_zones", func(t *testing.T) {
+			fieldMutabilityBasedOnProgrammedTest(t, "availability_zones", func(n *konnectv1alpha1.KonnectCloudGatewayNetwork) {
+				n.Spec.AvailabilityZones = []string{
+					"us-west-1b",
+				}
+			})
+		})
+
+		t.Run("cidr_block", func(t *testing.T) {
+			fieldMutabilityBasedOnProgrammedTest(t, "cidr_block", func(n *konnectv1alpha1.KonnectCloudGatewayNetwork) {
+				n.Spec.CidrBlock = "10.0.0.2/16"
+			})
+		})
+
+		t.Run("cloud_gateway_provider_account_id", func(t *testing.T) {
+			fieldMutabilityBasedOnProgrammedTest(t, "cloud_gateway_provider_account_id", func(n *konnectv1alpha1.KonnectCloudGatewayNetwork) {
+				n.Spec.CloudGatewayProviderAccountID = "id-new-1234567890"
+			})
+		})
+
+		t.Run("region", func(t *testing.T) {
+			fieldMutabilityBasedOnProgrammedTest(t, "region", func(n *konnectv1alpha1.KonnectCloudGatewayNetwork) {
+				n.Spec.Region = "us-east"
+			})
+		})
+	})
+
+	t.Run("spec", func(t *testing.T) {
+		common.TestCasesGroup[*konnectv1alpha1.KonnectCloudGatewayNetwork]{
+			{
+				Name: "all required fields are set",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayNetwork{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayNetworkSpec{
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "test-konnect-api-auth-configuration",
+							},
+						},
+						Name:   "test-network",
+						Region: "us-west",
+						AvailabilityZones: []string{
+							"us-west-1a",
+							"us-west-1b",
+						},
+						CidrBlock:                     "10.0.0.1/24",
+						CloudGatewayProviderAccountID: "test-cloud-gateway-provider-account-id",
+					},
+				},
+			},
+		}.Run(t)
+	})
+}
+
+func fieldMutabilityBasedOnProgrammedTest(
+	t *testing.T,
+	field string,
+	update func(*konnectv1alpha1.KonnectCloudGatewayNetwork),
+) {
+	t.Helper()
+
+	var (
+		programmedConditionTrue = metav1.Condition{
+			Type:               "Programmed",
+			Status:             metav1.ConditionTrue,
+			Reason:             "Valid",
+			LastTransitionTime: metav1.Now(),
+		}
+		programmedConditionFalse = metav1.Condition{
+			Type:               "Programmed",
+			Status:             metav1.ConditionFalse,
+			Reason:             "NotProgrammed",
+			LastTransitionTime: metav1.Now(),
+		}
+		spec = konnectv1alpha1.KonnectCloudGatewayNetworkSpec{
+			KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+				APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+					Name: "test-konnect-api-auth-configuration",
+				},
+			},
+			Name:   "test-network",
+			Region: "us-west",
+			AvailabilityZones: []string{
+				"us-west-1a",
+				"us-west-1b",
+			},
+			CidrBlock:                     "10.0.0.1/24",
+			CloudGatewayProviderAccountID: "test-cloud-gateway-provider-account-id",
+		}
+	)
+
+	common.TestCasesGroup[*konnectv1alpha1.KonnectCloudGatewayNetwork]{
+		{
+			Name: "is immutable when Programmed=true",
+			TestObject: &konnectv1alpha1.KonnectCloudGatewayNetwork{
+				ObjectMeta: common.CommonObjectMeta,
+				Spec:       spec,
+				Status: konnectv1alpha1.KonnectCloudGatewayNetworkStatus{
+					Conditions: []metav1.Condition{
+						programmedConditionTrue,
+					},
+				},
+			},
+			Update: update,
+			ExpectedUpdateErrorMessage: lo.ToPtr(
+				fmt.Sprintf("spec.%s is immutable when an entity is already Programmed", field),
+			),
+		},
+		{
+			Name: "is mutable when Programmed=false",
+			TestObject: &konnectv1alpha1.KonnectCloudGatewayNetwork{
+				ObjectMeta: common.CommonObjectMeta,
+				Spec:       spec,
+				Status: konnectv1alpha1.KonnectCloudGatewayNetworkStatus{
+					Conditions: []metav1.Condition{
+						programmedConditionFalse,
+					},
+				},
+			},
+			Update: update,
+		},
+		{
+			Name: "is mutable when Programmed status condition is missing",
+			TestObject: &konnectv1alpha1.KonnectCloudGatewayNetwork{
+				ObjectMeta: common.CommonObjectMeta,
+				Spec:       spec,
+			},
+			Update: update,
+		},
+	}.Run(t)
+}

--- a/api/test/crdsvalidation/konnect.konghq.com/konnectcloudgatewaytransitgateway_test.go
+++ b/api/test/crdsvalidation/konnect.konghq.com/konnectcloudgatewaytransitgateway_test.go
@@ -1,0 +1,316 @@
+package crdsvalidation
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/api/konnect/v1alpha1"
+	"github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKonnectCloudGatewayTransitGateway(t *testing.T) {
+	konnectTransitGatewayTypeMeta := metav1.TypeMeta{
+		APIVersion: konnectv1alpha1.GroupVersion.String(),
+		Kind:       "KonnectCloudGatewayTransitGateway",
+	}
+
+	testAWSTransitGatewayConfig := &konnectv1alpha1.AWSTransitGateway{
+		Name: "aws-transit-gateway",
+		CIDRBlocks: []string{
+			"10.11.12.0/24",
+		},
+		AttachmentConfig: konnectv1alpha1.AwsTransitGatewayAttachmentConfig{
+			TransitGatewayID: "transit-gateway",
+			RAMShareArn:      "ram_share_arn",
+		},
+	}
+
+	testAzureTransitGatewayConfig := &konnectv1alpha1.AzureTransitGateway{
+		Name: "azure-transit-gateway",
+		AttachmentConfig: konnectv1alpha1.AzureVNETPeeringAttachmentConfig{
+			TenantID:          "azure-tenant",
+			SubscriptionID:    "azure-subscription",
+			ResourceGroupName: "azure-resource-group",
+			VnetName:          "azure-vnet",
+		},
+	}
+
+	namespacedNetworkRef := commonv1alpha1.ObjectRef{
+		Type: commonv1alpha1.ObjectRefTypeNamespacedRef,
+		NamespacedRef: &commonv1alpha1.NamespacedRef{
+			Name: "konnect-network",
+		},
+	}
+
+	programmedCondition := metav1.Condition{
+		Type:               "Programmed",
+		Status:             metav1.ConditionTrue,
+		Reason:             "Valid",
+		LastTransitionTime: metav1.Now(),
+	}
+
+	t.Run("spec", func(t *testing.T) {
+		common.TestCasesGroup[*konnectv1alpha1.KonnectCloudGatewayTransitGateway]{
+			{
+				Name: "spec.networkRef can only use namespaced ref",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayTransitGateway{
+					TypeMeta:   konnectTransitGatewayTypeMeta,
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayTransitGatewaySpec{
+						NetworkRef: commonv1alpha1.ObjectRef{
+							Type:      commonv1alpha1.ObjectRefTypeKonnectID,
+							KonnectID: lo.ToPtr("konnect-id"),
+						},
+						KonnectTransitGatewayAPISpec: konnectv1alpha1.KonnectTransitGatewayAPISpec{
+							Type:              konnectv1alpha1.TransitGatewayTypeAWSTransitGateway,
+							AWSTransitGateway: testAWSTransitGatewayConfig,
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("only namespacedRef is supported currently"),
+			},
+			{
+				Name: "spec.type must in supported value",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayTransitGateway{
+					TypeMeta:   konnectTransitGatewayTypeMeta,
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayTransitGatewaySpec{
+						NetworkRef: namespacedNetworkRef,
+						KonnectTransitGatewayAPISpec: konnectv1alpha1.KonnectTransitGatewayAPISpec{
+							Type: konnectv1alpha1.TransitGatewayType("unsupported-type"),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.type: Unsupported value"),
+			},
+			{
+				Name: "spec.awsTransitGateway.name cannot be empty",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayTransitGateway{
+					TypeMeta:   konnectTransitGatewayTypeMeta,
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayTransitGatewaySpec{
+						NetworkRef: namespacedNetworkRef,
+						KonnectTransitGatewayAPISpec: konnectv1alpha1.KonnectTransitGatewayAPISpec{
+							Type: konnectv1alpha1.TransitGatewayTypeAWSTransitGateway,
+							AWSTransitGateway: &konnectv1alpha1.AWSTransitGateway{
+								Name: "",
+								CIDRBlocks: []string{
+									"10.11.12.0/24",
+								},
+								AttachmentConfig: konnectv1alpha1.AwsTransitGatewayAttachmentConfig{
+									TransitGatewayID: "transit-gateway",
+									RAMShareArn:      "ram_share_arn",
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.awsTransitGateway.name: Invalid value"),
+			},
+			{
+				Name: "spec.awsTransitGateway.cidr_blocks is required",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayTransitGateway{
+					TypeMeta:   konnectTransitGatewayTypeMeta,
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayTransitGatewaySpec{
+						NetworkRef: namespacedNetworkRef,
+						KonnectTransitGatewayAPISpec: konnectv1alpha1.KonnectTransitGatewayAPISpec{
+							Type: konnectv1alpha1.TransitGatewayTypeAWSTransitGateway,
+							AWSTransitGateway: &konnectv1alpha1.AWSTransitGateway{
+								Name: "aws-transit-gateway",
+								AttachmentConfig: konnectv1alpha1.AwsTransitGatewayAttachmentConfig{
+									TransitGatewayID: "transit-gateway",
+									RAMShareArn:      "ram_share_arn",
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.awsTransitGateway.cidr_blocks: Required value"),
+			},
+			{
+				Name: "spec.azureTransitGateway.name cannot be empty",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayTransitGateway{
+					TypeMeta:   konnectTransitGatewayTypeMeta,
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayTransitGatewaySpec{
+						NetworkRef: namespacedNetworkRef,
+						KonnectTransitGatewayAPISpec: konnectv1alpha1.KonnectTransitGatewayAPISpec{
+							Type: konnectv1alpha1.TransitGatewayTypeAzureTransitGateway,
+							AzureTransitGateway: &konnectv1alpha1.AzureTransitGateway{
+								Name: "",
+								AttachmentConfig: konnectv1alpha1.AzureVNETPeeringAttachmentConfig{
+									TenantID:          "azure-tenant",
+									SubscriptionID:    "azure-subscription",
+									ResourceGroupName: "azure-resource-group",
+									VnetName:          "azure-vnet",
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.azureTransitGateway.name: Invalid value"),
+			},
+
+			{
+				Name: "Must set awsTransitGateway when type = awsTransitConfig",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayTransitGateway{
+					TypeMeta:   konnectTransitGatewayTypeMeta,
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayTransitGatewaySpec{
+						NetworkRef: namespacedNetworkRef,
+						KonnectTransitGatewayAPISpec: konnectv1alpha1.KonnectTransitGatewayAPISpec{
+							Type: konnectv1alpha1.TransitGatewayTypeAWSTransitGateway,
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("must set spec.awsTransitGateway when spec.type is 'AWSTransitGateway'"),
+			},
+			{
+				Name: "Must not set awsTransitGateway when type != awsTransitConfig",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayTransitGateway{
+					TypeMeta:   konnectTransitGatewayTypeMeta,
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayTransitGatewaySpec{
+						NetworkRef: namespacedNetworkRef,
+						KonnectTransitGatewayAPISpec: konnectv1alpha1.KonnectTransitGatewayAPISpec{
+							Type:                konnectv1alpha1.TransitGatewayTypeAzureTransitGateway,
+							AWSTransitGateway:   testAWSTransitGatewayConfig,
+							AzureTransitGateway: testAzureTransitGatewayConfig,
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("must not set spec.awsTransitGateway when spec.type is not 'AWSTransitGateway'"),
+			},
+			{
+				Name: "Must set azureTransitGatway when spec.type = azureTransitGateway",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayTransitGateway{
+					TypeMeta:   konnectTransitGatewayTypeMeta,
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayTransitGatewaySpec{
+						NetworkRef: namespacedNetworkRef,
+						KonnectTransitGatewayAPISpec: konnectv1alpha1.KonnectTransitGatewayAPISpec{
+							Type: konnectv1alpha1.TransitGatewayTypeAzureTransitGateway,
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("must set spec.azureTransitGateway when spec.type is 'AzureTransitGateway'"),
+			},
+			{
+				Name: "Must not set azureTransitGateway when type != azureTransitGateway",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayTransitGateway{
+					TypeMeta:   konnectTransitGatewayTypeMeta,
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayTransitGatewaySpec{
+						NetworkRef: namespacedNetworkRef,
+						KonnectTransitGatewayAPISpec: konnectv1alpha1.KonnectTransitGatewayAPISpec{
+							Type:                konnectv1alpha1.TransitGatewayTypeAWSTransitGateway,
+							AWSTransitGateway:   testAWSTransitGatewayConfig,
+							AzureTransitGateway: testAzureTransitGatewayConfig,
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("must not set spec.azureTransitGateway when spec.type is not 'AzureTransitGateway'"),
+			},
+			{
+				Name: "spec.type is immutable",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayTransitGateway{
+					TypeMeta:   konnectTransitGatewayTypeMeta,
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayTransitGatewaySpec{
+						NetworkRef: namespacedNetworkRef,
+						KonnectTransitGatewayAPISpec: konnectv1alpha1.KonnectTransitGatewayAPISpec{
+							Type:              konnectv1alpha1.TransitGatewayTypeAWSTransitGateway,
+							AWSTransitGateway: testAWSTransitGatewayConfig,
+						},
+					},
+				},
+				Update: func(ktg *konnectv1alpha1.KonnectCloudGatewayTransitGateway) {
+					ktg.Spec.Type = konnectv1alpha1.TransitGatewayTypeAzureTransitGateway
+					ktg.Spec.AWSTransitGateway = nil
+					ktg.Spec.AzureTransitGateway = testAzureTransitGatewayConfig
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.type is immutable"),
+			},
+			{
+				Name: "spec.awsTransitGateway.name is mutable when not programmed",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayTransitGateway{
+					TypeMeta:   konnectTransitGatewayTypeMeta,
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayTransitGatewaySpec{
+						NetworkRef: namespacedNetworkRef,
+						KonnectTransitGatewayAPISpec: konnectv1alpha1.KonnectTransitGatewayAPISpec{
+							Type:              konnectv1alpha1.TransitGatewayTypeAWSTransitGateway,
+							AWSTransitGateway: testAWSTransitGatewayConfig,
+						},
+					},
+				},
+				Update: func(ktg *konnectv1alpha1.KonnectCloudGatewayTransitGateway) {
+					ktg.Spec.AWSTransitGateway.Name = "yet-another-name"
+				},
+			},
+			{
+				Name: "spec.awsTransitGateway.name is immutable when programmed",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayTransitGateway{
+					TypeMeta:   konnectTransitGatewayTypeMeta,
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayTransitGatewaySpec{
+						NetworkRef: namespacedNetworkRef,
+						KonnectTransitGatewayAPISpec: konnectv1alpha1.KonnectTransitGatewayAPISpec{
+							Type:              konnectv1alpha1.TransitGatewayTypeAWSTransitGateway,
+							AWSTransitGateway: testAWSTransitGatewayConfig,
+						},
+					},
+					Status: konnectv1alpha1.KonnectCloudGatewayTransitGatewayStatus{
+						Conditions: []metav1.Condition{programmedCondition},
+					},
+				},
+				Update: func(ktg *konnectv1alpha1.KonnectCloudGatewayTransitGateway) {
+					ktg.Spec.AWSTransitGateway.Name = "yet-another-name"
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.awsTransitGateway.name is immutable when transit gateway is already Programmed"),
+			},
+			{
+				Name: "spec.azureTransitGateway.name is mutable when not programmed",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayTransitGateway{
+					TypeMeta:   konnectTransitGatewayTypeMeta,
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayTransitGatewaySpec{
+						NetworkRef: namespacedNetworkRef,
+						KonnectTransitGatewayAPISpec: konnectv1alpha1.KonnectTransitGatewayAPISpec{
+							Type:                konnectv1alpha1.TransitGatewayTypeAzureTransitGateway,
+							AzureTransitGateway: testAzureTransitGatewayConfig,
+						},
+					},
+				},
+				Update: func(ktg *konnectv1alpha1.KonnectCloudGatewayTransitGateway) {
+					ktg.Spec.AzureTransitGateway.Name = "yet-another-name"
+				},
+			},
+			{
+				Name: "spec.azureTransitGateway.name is immutable when programmed",
+				TestObject: &konnectv1alpha1.KonnectCloudGatewayTransitGateway{
+					TypeMeta:   konnectTransitGatewayTypeMeta,
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectCloudGatewayTransitGatewaySpec{
+						NetworkRef: namespacedNetworkRef,
+						KonnectTransitGatewayAPISpec: konnectv1alpha1.KonnectTransitGatewayAPISpec{
+							Type:                konnectv1alpha1.TransitGatewayTypeAzureTransitGateway,
+							AzureTransitGateway: testAzureTransitGatewayConfig,
+						},
+					},
+					Status: konnectv1alpha1.KonnectCloudGatewayTransitGatewayStatus{
+						Conditions: []metav1.Condition{programmedCondition},
+					},
+				},
+				Update: func(ktg *konnectv1alpha1.KonnectCloudGatewayTransitGateway) {
+					ktg.Spec.AzureTransitGateway.Name = "yet-another-name"
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.azureTransitGateway.name is immutable when transit gateway is already Programmed"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/konnect.konghq.com/konnectextension_test.go
+++ b/api/test/crdsvalidation/konnect.konghq.com/konnectextension_test.go
@@ -1,0 +1,373 @@
+package crdsvalidation_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
+	common "github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKonnectExtension(t *testing.T) {
+	t.Run("spec", func(t *testing.T) {
+		common.TestCasesGroup[*konnectv1alpha2.KonnectExtension]{
+			{
+				Name: "konnect controlplane, manual provisioning, valid secret",
+				TestObject: &konnectv1alpha2.KonnectExtension{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-konnect-control-plane",
+									},
+								},
+							},
+						},
+						ClientAuth: &konnectv1alpha2.KonnectExtensionClientAuth{
+							CertificateSecret: konnectv1alpha2.CertificateSecret{
+								Provisioning: lo.ToPtr(konnectv1alpha2.ManualSecretProvisioning),
+								CertificateSecretRef: &konnectv1alpha2.SecretRef{
+									Name: "test-secret",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "konnect controlplane, manual provisioning, secret",
+				ExpectedErrorEventuallyConfig: common.EventuallyConfig{
+					Timeout: 1 * time.Second,
+				},
+				TestObject: &konnectv1alpha2.KonnectExtension{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-konnect-control-plane",
+									},
+								},
+							},
+						},
+						ClientAuth: &konnectv1alpha2.KonnectExtensionClientAuth{
+							CertificateSecret: konnectv1alpha2.CertificateSecret{
+								Provisioning: lo.ToPtr(konnectv1alpha2.ManualSecretProvisioning),
+								CertificateSecretRef: &konnectv1alpha2.SecretRef{
+									Name: "test-secret",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "konnect controlplane, manual provisioning, no secret",
+				ExpectedErrorEventuallyConfig: common.EventuallyConfig{
+					Timeout: 1 * time.Second,
+				},
+				TestObject: &konnectv1alpha2.KonnectExtension{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-konnect-control-plane",
+									},
+								},
+							},
+						},
+						ClientAuth: &konnectv1alpha2.KonnectExtensionClientAuth{
+							CertificateSecret: konnectv1alpha2.CertificateSecret{
+								Provisioning: lo.ToPtr(konnectv1alpha2.ManualSecretProvisioning),
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("secretRef must be set when provisioning is set to Manual."),
+			},
+			{
+				Name: "konnect controlplane, automatic provisioning, secret",
+				ExpectedErrorEventuallyConfig: common.EventuallyConfig{
+					Timeout: 1 * time.Second,
+				},
+				TestObject: &konnectv1alpha2.KonnectExtension{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-konnect-control-plane",
+									},
+								},
+							},
+						},
+						ClientAuth: &konnectv1alpha2.KonnectExtensionClientAuth{
+							CertificateSecret: konnectv1alpha2.CertificateSecret{
+								Provisioning: lo.ToPtr(konnectv1alpha2.AutomaticSecretProvisioning),
+								CertificateSecretRef: &konnectv1alpha2.SecretRef{
+									Name: "test-secret",
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("secretRef must not be set when provisioning is set to Automatic."),
+			},
+			{
+				Name: "kic controlplane",
+				TestObject: &konnectv1alpha2.KonnectExtension{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: configurationv1alpha1.ControlPlaneRefKIC,
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr(`Unsupported value: "kic"`),
+			},
+		}.Run(t)
+	})
+	t.Run("dataPlane labels", func(t *testing.T) {
+		common.TestCasesGroup[*konnectv1alpha2.KonnectExtension]{
+			{
+				Name: "valid labels",
+				TestObject: &konnectv1alpha2.KonnectExtension{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-konnect-control-plane",
+									},
+								},
+							},
+							DataPlane: &konnectv1alpha2.KonnectExtensionDataPlane{
+								Labels: map[string]konnectv1alpha2.DataPlaneLabelValue{
+									"valid-key": "valid.value",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "invalid label value 1",
+				TestObject: &konnectv1alpha2.KonnectExtension{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-konnect-control-plane",
+									},
+								},
+							},
+							DataPlane: &konnectv1alpha2.KonnectExtensionDataPlane{
+								Labels: map[string]konnectv1alpha2.DataPlaneLabelValue{
+									"valid-key": ".invalid.value",
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("'^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$'"),
+			},
+			{
+				Name: "invalid label value 2",
+				TestObject: &konnectv1alpha2.KonnectExtension{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-konnect-control-plane",
+									},
+								},
+							},
+							DataPlane: &konnectv1alpha2.KonnectExtensionDataPlane{
+								Labels: map[string]konnectv1alpha2.DataPlaneLabelValue{
+									"valid-key": "invalid.value.",
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("'^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$'"),
+			},
+			{
+				Name: "invalid label value 3",
+				TestObject: &konnectv1alpha2.KonnectExtension{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-konnect-control-plane",
+									},
+								},
+							},
+							DataPlane: &konnectv1alpha2.KonnectExtensionDataPlane{
+								Labels: map[string]konnectv1alpha2.DataPlaneLabelValue{
+									"valid-key": "invalid$value.",
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("'^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$'"),
+			},
+			{
+				Name: "invalid label value 4",
+				TestObject: &konnectv1alpha2.KonnectExtension{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-konnect-control-plane",
+									},
+								},
+							},
+							DataPlane: &konnectv1alpha2.KonnectExtensionDataPlane{
+								Labels: map[string]konnectv1alpha2.DataPlaneLabelValue{
+									"valid-key": "Xv9gTq2LmNZp4WJdCYKfRB86oAhsMEytkPUOQGV7Dbx53cHFnwzjL1rS0vqIXv9gTq2LmNZp4WJdCYKfRB86oAhsMEytkPUOQGV7Dbx53cHFnwzjL1rS0vqI",
+								},
+							},
+						},
+					},
+				},
+				// NOTE: Kubernetes 1.32 changed the validation error for values exceeding the maximum length.
+				// It used to be:
+				// "Too long: may not be longer than 63"
+				// In 1.32+ it is:
+				// "Too long: may not be more than 63 bytes"
+				// We're using here the common part of the error message to avoid breaking the test when upgrading Kubernetes.
+				ExpectedErrorMessage: lo.ToPtr("Too long: may not be "),
+			},
+			{
+				Name: "invalid label key 1",
+				TestObject: &konnectv1alpha2.KonnectExtension{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-konnect-control-plane",
+									},
+								},
+							},
+							DataPlane: &konnectv1alpha2.KonnectExtensionDataPlane{
+								Labels: map[string]konnectv1alpha2.DataPlaneLabelValue{
+									".invalid.key": "valid.value",
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("'^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$'"),
+			},
+			{
+				Name: "invalid label value 2",
+				TestObject: &konnectv1alpha2.KonnectExtension{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-konnect-control-plane",
+									},
+								},
+							},
+							DataPlane: &konnectv1alpha2.KonnectExtensionDataPlane{
+								Labels: map[string]konnectv1alpha2.DataPlaneLabelValue{
+									"invalid.key.": "valid.value",
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("'^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$'"),
+			},
+			{
+				Name: "invalid label value 3",
+				TestObject: &konnectv1alpha2.KonnectExtension{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-konnect-control-plane",
+									},
+								},
+							},
+							DataPlane: &konnectv1alpha2.KonnectExtensionDataPlane{
+								Labels: map[string]konnectv1alpha2.DataPlaneLabelValue{
+									"invalid$key": "valid.value",
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("'^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$'"),
+			},
+			{
+				Name: "invalid label value 4",
+				TestObject: &konnectv1alpha2.KonnectExtension{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-konnect-control-plane",
+									},
+								},
+							},
+							DataPlane: &konnectv1alpha2.KonnectExtensionDataPlane{
+								Labels: map[string]konnectv1alpha2.DataPlaneLabelValue{
+									"Xv9gTq2LmNZp4WJdCYKfRB86oAhsMEytkPUOQGV7Dbx53cHFnwzjL1rS0vqIXv9gTq2LmNZp4WJdCYKfRB86oAhsMEytkPUOQGV7Dbx53cHFnwzjL1rS0vqI": "valid.value",
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Too long: may not be more than 63 bytes"),
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/konnect.konghq.com/konnectgatewaycontrolplane_test.go
+++ b/api/test/crdsvalidation/konnect.konghq.com/konnectgatewaycontrolplane_test.go
@@ -1,0 +1,902 @@
+package crdsvalidation_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/api/konnect/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
+	common "github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKonnectGatewayControlPlane(t *testing.T) {
+	t.Run("members can only be set on groups", func(t *testing.T) {
+		common.TestCasesGroup[*konnectv1alpha1.KonnectGatewayControlPlane]{
+			{
+				Name: "members can be set on control-plane group",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cpg-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup),
+						},
+						Members: []corev1.LocalObjectReference{
+							{
+								Name: "cp-1",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "members cannot be set on regular control-planes",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cpg-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+						},
+						Members: []corev1.LocalObjectReference{
+							{
+								Name: "cp-1",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.members is only applicable for ControlPlanes that are created as groups"),
+			},
+			{
+				Name: "members cannot be set on a KIC control-planes",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cpg-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeK8SIngressController),
+						},
+						Members: []corev1.LocalObjectReference{
+							{
+								Name: "cp-1",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.members is only applicable for ControlPlanes that are created as groups"),
+			},
+			{
+				Name: "members cannot be set on serverless control-planes",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cpg-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeServerless),
+						},
+						Members: []corev1.LocalObjectReference{
+							{
+								Name: "cp-1",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.members is only applicable for ControlPlanes that are created as groups"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("updates not allowed for status conditions", func(t *testing.T) {
+		common.TestCasesGroup[*konnectv1alpha1.KonnectGatewayControlPlane]{
+			{
+				Name: "konnect.authRef change is not allowed for Programmed=True",
+				// Tracking issue: https://github.com/Kong/kubernetes-configuration/issues/504
+				SkipReason: "Fails when v1alpha2 is the storage version due to missing conversion logic. This test could be re-enabled by implementing conversion logic using a conversion webhook: https://github.com/Kong/kubernetes-configuration/issues/504",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+					Status: konnectv1alpha1.KonnectGatewayControlPlaneStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionTrue,
+								Reason:             "Valid",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(kcp *konnectv1alpha1.KonnectGatewayControlPlane) {
+					kcp.Spec.KonnectConfiguration.APIAuthConfigurationRef.Name = "name-2"
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.konnect.authRef is immutable when an entity is already Programme"),
+			},
+			{
+				Name: "konnect.authRef change is not allowed for APIAuthValid=True",
+				// Tracking issue: https://github.com/Kong/kubernetes-configuration/issues/504
+				SkipReason: "Fails when v1alpha2 is the storage version due to missing conversion logic. This test could be re-enabled by implementing conversion logic using a conversion webhook: https://github.com/Kong/kubernetes-configuration/issues/504",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+					Status: konnectv1alpha1.KonnectGatewayControlPlaneStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               "APIAuthValid",
+								Status:             metav1.ConditionTrue,
+								Reason:             "Valid",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(kcp *konnectv1alpha1.KonnectGatewayControlPlane) {
+					kcp.Spec.KonnectConfiguration.APIAuthConfigurationRef.Name = "name-2"
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration"),
+			},
+			{
+				Name: "konnect.authRef change is allowed when cp is not Programmed=True nor APIAuthValid=True",
+				// Tracking issue: https://github.com/Kong/kubernetes-configuration/issues/504
+				SkipReason: "Fails when v1alpha2 is the storage version due to missing conversion logic. This test could be re-enabled by implementing conversion logic using a conversion webhook: https://github.com/Kong/kubernetes-configuration/issues/504",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+					Status: konnectv1alpha1.KonnectGatewayControlPlaneStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               "APIAuthValid",
+								Status:             metav1.ConditionFalse,
+								Reason:             "Invalid",
+								LastTransitionTime: metav1.Now(),
+							},
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionFalse,
+								Reason:             "NotProgrammed",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(kcp *konnectv1alpha1.KonnectGatewayControlPlane) {
+					kcp.Spec.KonnectConfiguration.APIAuthConfigurationRef.Name = "name-2"
+				},
+			},
+			{
+				Name: "cluster_type change is not allowed",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				Update: func(kcp *konnectv1alpha1.KonnectGatewayControlPlane) {
+					kcp.Spec.ClusterType = sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup.ToPointer()
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.cluster_type is immutable"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("labels constraints", func(t *testing.T) {
+		common.TestCasesGroup[*konnectv1alpha1.KonnectGatewayControlPlane]{
+			{
+				Name: "spec.labels of length 40 is allowed",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: func() map[string]string {
+								labels := make(map[string]string)
+								for i := range 40 {
+									labels[fmt.Sprintf("key-%d", i)] = fmt.Sprintf("value-%d", i)
+								}
+								return labels
+							}(),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "spec.labels length must not be greater than 40",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: func() map[string]string {
+								labels := make(map[string]string)
+								for i := range 41 {
+									labels[fmt.Sprintf("key-%d", i)] = fmt.Sprintf("value-%d", i)
+								}
+								return labels
+							}(),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels must not have more than 40 entries"),
+			},
+			{
+				Name: "spec.labels keys' length must not be greater than 63",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								lo.RandomString(64, lo.AllCharset): "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must be of length 1-63 characters"),
+			},
+			{
+				Name: "spec.labels keys' length must at least 1 character long",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must be of length 1-63 characters"),
+			},
+			//
+			{
+				Name: "spec.labels values' length must not be greater than 63",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"key": lo.RandomString(64, lo.AllCharset),
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels values must be of length 1-63 characters"),
+			},
+			{
+				Name: "spec.labels values' length must at least 1 character long",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"key": "",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels values must be of length 1-63 characters"),
+			},
+			{
+				Name: "spec.labels keys must not start with k8s",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"k8s_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.labels keys must not start with kong",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"kong_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.labels keys must not start with konnect",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"konnect_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.labels keys must not start with mesh",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"mesh_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.labels keys must not start with kic",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"kic_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.labels keys must not start with insomnia",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"insomnia_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.labels keys must not start with underscore",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.labels keys must satisfy the '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$' pattern",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"key-": "value",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must satisfy the '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$' pattern"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("restriction on cluster types", func(t *testing.T) {
+		common.TestCasesGroup[*konnectv1alpha1.KonnectGatewayControlPlane]{
+			{
+				Name: "unspecified cluster type (defaulting to CLUSTR_TYPE_CONTROL_PLANE) is allowed",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name: lo.ToPtr("cp-1"),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "CLUSTER_TYPE_CONTROL_PLANE_GROUP is supported",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup.ToPointer(),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "CLUSTER_TYPE_CONTROL_PLANE is supported",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane.ToPointer(),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "CLUSTER_TYPE_K8S_INGRESS_CONTROLLER is supported",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeK8SIngressController.ToPointer(),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "CLUSTER_TYPE_SERVERLESS is not supported",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeServerless.ToPointer(),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.cluster_type must be one of 'CLUSTER_TYPE_CONTROL_PLANE_GROUP', 'CLUSTER_TYPE_CONTROL_PLANE' or 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'"),
+			},
+			{
+				Name: "CLUSTER_TYPE_CUSTOM is not supported",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterType("CLUSTER_TYPE_CUSTOM").ToPointer(),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.cluster_type must be one of 'CLUSTER_TYPE_CONTROL_PLANE_GROUP', 'CLUSTER_TYPE_CONTROL_PLANE' or 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'"),
+			},
+			{
+				Name: "cluster type is immutable",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name: lo.ToPtr("cp-1"),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				Update: func(cp *konnectv1alpha1.KonnectGatewayControlPlane) {
+					cp.Spec.ClusterType = sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup.ToPointer()
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.cluster_type is immutable"),
+			},
+			{
+				Name: "cluster type is immutable when having it set and then trying to unset it",
+				// Tracking issue: https://github.com/Kong/kubernetes-configuration/issues/504
+				SkipReason: "Fails when v1alpha2 is the storage version due to missing conversion logic. This test could be re-enabled by implementing conversion logic using a conversion webhook: https://github.com/Kong/kubernetes-configuration/issues/504",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane.ToPointer(),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				Update: func(cp *konnectv1alpha1.KonnectGatewayControlPlane) {
+					cp.Spec.ClusterType = nil
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.cluster_type is immutable"),
+			},
+			{
+				Name: "cannot set cloud_gateway to true for cluster_type CLUSTER_TYPE_K8S_INGRESS_CONTROLLER",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:         lo.ToPtr("cp-1"),
+							ClusterType:  sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeK8SIngressController.ToPointer(),
+							CloudGateway: lo.ToPtr(true),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("cloud_gateway cannot be set for cluster_type 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'"),
+			},
+			{
+				Name: "cannot set cloud_gateway to false for cluster_type CLUSTER_TYPE_K8S_INGRESS_CONTROLLER",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:         lo.ToPtr("cp-1"),
+							ClusterType:  sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeK8SIngressController.ToPointer(),
+							CloudGateway: lo.ToPtr(false),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("cloud_gateway cannot be set for cluster_type 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'"),
+			},
+			{
+				Name: "not setting cloud_gateway for cluster_type CLUSTER_TYPE_K8S_INGRESS_CONTROLLER passes",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        lo.ToPtr("cp-1"),
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeK8SIngressController.ToPointer(),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+		}.Run(t)
+	})
+
+	t.Run("controlPlane types", func(t *testing.T) {
+		common.TestCasesGroup[*konnectv1alpha1.KonnectGatewayControlPlane]{
+			{
+				Name: "no type specificed, no KonnectID specified",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name: lo.ToPtr("cp-1"),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "mirror type, no KonnectID specified",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						Source: lo.ToPtr(commonv1alpha1.EntitySourceMirror),
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("mirror field must be set for type Mirror"),
+			},
+			{
+				Name: "mirror type, well-formed KonnectID specified",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						Source: lo.ToPtr(commonv1alpha1.EntitySourceMirror),
+						Mirror: &konnectv1alpha1.MirrorSpec{
+							Konnect: konnectv1alpha1.MirrorKonnect{
+								ID: commonv1alpha1.KonnectIDType("8ae65120-cdec-4310-84c1-4b19caf67967"),
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "mirror type, malformed KonnectID specified",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						Source: lo.ToPtr(commonv1alpha1.EntitySourceMirror),
+						Mirror: &konnectv1alpha1.MirrorSpec{
+							Konnect: konnectv1alpha1.MirrorKonnect{
+								ID: commonv1alpha1.KonnectIDType("malformed-id"),
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.mirror.konnect.id in body should match '^[0-9a-f]{8}(?:\\-[0-9a-f]{4}){3}-[0-9a-f]{12}$'"),
+			},
+			{
+				Name: "mirror type, KonnectID specified, controlPlane spec specified",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						Source: lo.ToPtr(commonv1alpha1.EntitySourceMirror),
+						Mirror: &konnectv1alpha1.MirrorSpec{
+							Konnect: konnectv1alpha1.MirrorKonnect{
+								ID: commonv1alpha1.KonnectIDType("8ae65120-cdec-4310-84c1-4b19caf67967"),
+							},
+						},
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name: lo.ToPtr("cp-1"),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("createControlPlaneRequest fields cannot be set for type Mirror"),
+			},
+			{
+				Name: "origin type, KonnectID specified",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						Source: lo.ToPtr(commonv1alpha1.EntitySourceOrigin),
+						Mirror: &konnectv1alpha1.MirrorSpec{
+							Konnect: konnectv1alpha1.MirrorKonnect{
+								ID: commonv1alpha1.KonnectIDType("8ae65120-cdec-4310-84c1-4b19caf67967"),
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("mirror field cannot be set for type Origin"),
+			},
+			{
+				Name: "origin type, no KonnectID specified, empty controlPlane spec",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						Source: lo.ToPtr(commonv1alpha1.EntitySourceOrigin),
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Name must be set for type Origin"),
+			},
+			{
+				Name: "origin type, no KonnectID specified, with controlPlane name",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						Source: lo.ToPtr(commonv1alpha1.EntitySourceOrigin),
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name: lo.ToPtr("cp-1"),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/crdsvalidation/konnect.konghq.com/konnectgatewaycontrolplane_v1alpha2_test.go
+++ b/api/test/crdsvalidation/konnect.konghq.com/konnectgatewaycontrolplane_v1alpha2_test.go
@@ -1,0 +1,931 @@
+package crdsvalidation_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
+	common "github.com/kong/kong-operator/test/crdsvalidation/common"
+)
+
+func TestKonnectGatewayControlPlaneV1alpha2(t *testing.T) {
+	t.Run("members can only be set on groups", func(t *testing.T) {
+		common.TestCasesGroup[*konnectv1alpha2.KonnectGatewayControlPlane]{
+			{
+				Name: "members can be set on control-plane group",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cpg-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup),
+						},
+						Members: []corev1.LocalObjectReference{
+							{
+								Name: "cp-1",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "members cannot be set on regular control-planes",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cpg-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+						},
+						Members: []corev1.LocalObjectReference{
+							{
+								Name: "cp-1",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.members is only applicable for ControlPlanes that are created as groups"),
+			},
+			{
+				Name: "members cannot be set on a KIC control-planes",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cpg-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeK8SIngressController),
+						},
+						Members: []corev1.LocalObjectReference{
+							{
+								Name: "cp-1",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.members is only applicable for ControlPlanes that are created as groups"),
+			},
+			{
+				Name: "members cannot be set on serverless control-planes",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cpg-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeServerless),
+						},
+						Members: []corev1.LocalObjectReference{
+							{
+								Name: "cp-1",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.members is only applicable for ControlPlanes that are created as groups"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("updates not allowed for status conditions", func(t *testing.T) {
+		common.TestCasesGroup[*konnectv1alpha2.KonnectGatewayControlPlane]{
+			{
+				Name: "konnect.authRef change is not allowed for Programmed=True",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+					Status: konnectv1alpha2.KonnectGatewayControlPlaneStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionTrue,
+								Reason:             "Valid",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(kcp *konnectv1alpha2.KonnectGatewayControlPlane) {
+					kcp.Spec.KonnectConfiguration.APIAuthConfigurationRef.Name = "name-2"
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.konnect.authRef is immutable when an entity is already Programme"),
+			},
+			{
+				Name: "konnect.authRef change is not allowed for APIAuthValid=True",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+					Status: konnectv1alpha2.KonnectGatewayControlPlaneStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               "APIAuthValid",
+								Status:             metav1.ConditionTrue,
+								Reason:             "Valid",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(kcp *konnectv1alpha2.KonnectGatewayControlPlane) {
+					kcp.Spec.KonnectConfiguration.APIAuthConfigurationRef.Name = "name-2"
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration"),
+			},
+			{
+				Name: "konnect.authRef change is allowed when cp is not Programmed=True nor APIAuthValid=True",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+					Status: konnectv1alpha2.KonnectGatewayControlPlaneStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               "APIAuthValid",
+								Status:             metav1.ConditionFalse,
+								Reason:             "Invalid",
+								LastTransitionTime: metav1.Now(),
+							},
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionFalse,
+								Reason:             "NotProgrammed",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(kcp *konnectv1alpha2.KonnectGatewayControlPlane) {
+					kcp.Spec.KonnectConfiguration.APIAuthConfigurationRef.Name = "name-2"
+				},
+			},
+			{
+				Name: "spec.createControlPlaneRequest.cluster_type change is not allowed",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				Update: func(kcp *konnectv1alpha2.KonnectGatewayControlPlane) {
+					kcp.Spec.CreateControlPlaneRequest.ClusterType = sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup.ToPointer()
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.cluster_type is immutable"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("labels constraints", func(t *testing.T) {
+		common.TestCasesGroup[*konnectv1alpha2.KonnectGatewayControlPlane]{
+			{
+				Name: "spec.createControlPlaneRequest.labels of length 40 is allowed",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: func() map[string]string {
+								labels := make(map[string]string)
+								for i := range 40 {
+									labels[fmt.Sprintf("key-%d", i)] = fmt.Sprintf("value-%d", i)
+								}
+								return labels
+							}(),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "spec.createControlPlaneRequest.labels length must not be greater than 40",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: func() map[string]string {
+								labels := make(map[string]string)
+								for i := range 41 {
+									labels[fmt.Sprintf("key-%d", i)] = fmt.Sprintf("value-%d", i)
+								}
+								return labels
+							}(),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.labels must not have more than 40 entries"),
+			},
+			{
+				Name: "spec.createControlPlaneRequest.labels keys' length must not be greater than 63",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								lo.RandomString(64, lo.AllCharset): "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.labels keys must be of length 1-63 characters"),
+			},
+			{
+				Name: "spec.createControlPlaneRequest.labels keys' length must at least 1 character long",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.labels keys must be of length 1-63 characters"),
+			},
+			//
+			{
+				Name: "spec.createControlPlaneRequest.labels values' length must not be greater than 63",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"key": lo.RandomString(64, lo.AllCharset),
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.labels values must be of length 1-63 characters"),
+			},
+			{
+				Name: "spec.createControlPlaneRequest.labels values' length must at least 1 character long",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"key": "",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.labels values must be of length 1-63 characters"),
+			},
+			{
+				Name: "spec.createControlPlaneRequest.labels keys must not start with k8s",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"k8s_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.createControlPlaneRequest.labels keys must not start with kong",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"kong_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.createControlPlaneRequest.labels keys must not start with konnect",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"konnect_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.createControlPlaneRequest.labels keys must not start with mesh",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"mesh_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.createControlPlaneRequest.labels keys must not start with kic",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"kic_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.createControlPlaneRequest.labels keys must not start with insomnia",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"insomnia_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.createControlPlaneRequest.labels keys must not start with underscore",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.createControlPlaneRequest.labels keys must satisfy the '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$' pattern",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"key-": "value",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.labels keys must satisfy the '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$' pattern"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("restriction on cluster types", func(t *testing.T) {
+		common.TestCasesGroup[*konnectv1alpha2.KonnectGatewayControlPlane]{
+			{
+				Name: "unspecified cluster type (defaulting to CLUSTR_TYPE_CONTROL_PLANE) is allowed",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name: "cp-1",
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "CLUSTER_TYPE_CONTROL_PLANE_GROUP is supported",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup.ToPointer(),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "CLUSTER_TYPE_CONTROL_PLANE is supported",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane.ToPointer(),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "CLUSTER_TYPE_K8S_INGRESS_CONTROLLER is supported",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeK8SIngressController.ToPointer(),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "CLUSTER_TYPE_SERVERLESS is not supported",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeServerless.ToPointer(),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.cluster_type must be one of 'CLUSTER_TYPE_CONTROL_PLANE_GROUP', 'CLUSTER_TYPE_CONTROL_PLANE' or 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'"),
+			},
+			{
+				Name: "CLUSTER_TYPE_CUSTOM is not supported",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterType("CLUSTER_TYPE_CUSTOM").ToPointer(),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.cluster_type must be one of 'CLUSTER_TYPE_CONTROL_PLANE_GROUP', 'CLUSTER_TYPE_CONTROL_PLANE' or 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'"),
+			},
+			{
+				Name: "cluster type is immutable",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name: "cp-1",
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				Update: func(cp *konnectv1alpha2.KonnectGatewayControlPlane) {
+					cp.Spec.CreateControlPlaneRequest.ClusterType = sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup.ToPointer()
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.cluster_type is immutable"),
+			},
+			{
+				Name: "cluster type is immutable when having it set and then trying to unset it",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane.ToPointer(),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				Update: func(cp *konnectv1alpha2.KonnectGatewayControlPlane) {
+					cp.Spec.CreateControlPlaneRequest.ClusterType = nil
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.cluster_type is immutable"),
+			},
+			{
+				Name: "cannot set spec.createControlPlaneRequest.cloud_gateway to true for spec.createControlPlaneRequest.cluster_type CLUSTER_TYPE_K8S_INGRESS_CONTROLLER",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:         "cp-1",
+							ClusterType:  sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeK8SIngressController.ToPointer(),
+							CloudGateway: lo.ToPtr(true),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.cloud_gateway cannot be set for spec.createControlPlaneRequest.cluster_type 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'"),
+			},
+			{
+				Name: "cannot set spec.createControlPlaneRequest.cloud_gateway to false for spec.createControlPlaneRequest.cluster_type CLUSTER_TYPE_K8S_INGRESS_CONTROLLER",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:         "cp-1",
+							ClusterType:  sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeK8SIngressController.ToPointer(),
+							CloudGateway: lo.ToPtr(false),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.createControlPlaneRequest.cloud_gateway cannot be set for spec.createControlPlaneRequest.cluster_type 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'"),
+			},
+			{
+				Name: "not setting spec.createControlPlaneRequest.cloud_gateway for spec.createControlPlaneRequest.cluster_type CLUSTER_TYPE_K8S_INGRESS_CONTROLLER passes",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeK8SIngressController.ToPointer(),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "update status with CreateControlPlaneRequest nil, validation should pass",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: nil,
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+						Source: lo.ToPtr(commonv1alpha1.EntitySourceMirror),
+						Mirror: &konnectv1alpha2.MirrorSpec{
+							Konnect: konnectv1alpha2.MirrorKonnect{
+								ID: commonv1alpha1.KonnectIDType("8ae65120-cdec-4310-84c1-4b19caf67967"),
+							},
+						},
+					},
+					Status: konnectv1alpha2.KonnectGatewayControlPlaneStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Programmed",
+								Status:             metav1.ConditionTrue,
+								Reason:             "Valid",
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				Update: func(cp *konnectv1alpha2.KonnectGatewayControlPlane) {
+					cp.Status.Conditions = append(cp.Status.Conditions, metav1.Condition{
+						Type:               "APIAuthValid",
+						Status:             metav1.ConditionTrue,
+						Reason:             "Valid",
+						LastTransitionTime: metav1.Now(),
+					})
+				},
+			},
+		}.Run(t)
+	})
+
+	t.Run("controlPlane types", func(t *testing.T) {
+		common.TestCasesGroup[*konnectv1alpha2.KonnectGatewayControlPlane]{
+			{
+				Name: "no type specificed, no KonnectID specified",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name: "cp-1",
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "mirror type, no KonnectID specified",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						Source: lo.ToPtr(commonv1alpha1.EntitySourceMirror),
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("mirror field must be set for type Mirror"),
+			},
+			{
+				Name: "mirror type, well-formed KonnectID specified",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						Source: lo.ToPtr(commonv1alpha1.EntitySourceMirror),
+						Mirror: &konnectv1alpha2.MirrorSpec{
+							Konnect: konnectv1alpha2.MirrorKonnect{
+								ID: commonv1alpha1.KonnectIDType("8ae65120-cdec-4310-84c1-4b19caf67967"),
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "mirror type, malformed KonnectID specified",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						Source: lo.ToPtr(commonv1alpha1.EntitySourceMirror),
+						Mirror: &konnectv1alpha2.MirrorSpec{
+							Konnect: konnectv1alpha2.MirrorKonnect{
+								ID: commonv1alpha1.KonnectIDType("malformed-id"),
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.mirror.konnect.id in body should match '^[0-9a-f]{8}(?:\\-[0-9a-f]{4}){3}-[0-9a-f]{12}$'"),
+			},
+			{
+				Name: "mirror type, KonnectID specified, controlPlane spec specified",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						Source: lo.ToPtr(commonv1alpha1.EntitySourceMirror),
+						Mirror: &konnectv1alpha2.MirrorSpec{
+							Konnect: konnectv1alpha2.MirrorKonnect{
+								ID: commonv1alpha1.KonnectIDType("8ae65120-cdec-4310-84c1-4b19caf67967"),
+							},
+						},
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name: "cp-1",
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("createControlPlaneRequest fields cannot be set for type Mirror"),
+			},
+			{
+				Name: "origin type, KonnectID specified",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						Source: lo.ToPtr(commonv1alpha1.EntitySourceOrigin),
+						Mirror: &konnectv1alpha2.MirrorSpec{
+							Konnect: konnectv1alpha2.MirrorKonnect{
+								ID: commonv1alpha1.KonnectIDType("8ae65120-cdec-4310-84c1-4b19caf67967"),
+							},
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("mirror field cannot be set for type Origin"),
+			},
+			{
+				Name: "origin type, no KonnectID specified, empty controlPlane spec",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						Source: lo.ToPtr(commonv1alpha1.EntitySourceOrigin),
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.createControlPlaneRequest must be set for type Origin"),
+			},
+			{
+				Name: "origin type, no KonnectID specified, with controlPlane name",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						Source: lo.ToPtr(commonv1alpha1.EntitySourceOrigin),
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name: "cp-1",
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+		}.Run(t)
+	})
+}

--- a/api/test/unit/konnect_funcs_test.go
+++ b/api/test/unit/konnect_funcs_test.go
@@ -1,0 +1,427 @@
+package test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	configurationv1 "github.com/kong/kong-operator/api/configuration/v1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	configurationv1beta1 "github.com/kong/kong-operator/api/configuration/v1beta1"
+	konnectv1alpha1 "github.com/kong/kong-operator/api/konnect/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
+)
+
+func TestKonnectFuncs(t *testing.T) {
+	type KonnectEntity interface {
+		client.Object
+		GetTypeName() string
+		SetControlPlaneID(string)
+		GetControlPlaneID() string
+		GetKonnectStatus() *konnectv1alpha2.KonnectEntityStatus
+		GetConditions() []metav1.Condition
+		SetConditions([]metav1.Condition)
+	}
+
+	testcases := []struct {
+		object   KonnectEntity
+		typeName string
+	}{
+		{
+			typeName: "KongConsumer",
+			object:   &configurationv1.KongConsumer{},
+		},
+		{
+			typeName: "KongCACertificate",
+			object:   &configurationv1alpha1.KongCACertificate{},
+		},
+		{
+			typeName: "KongConsumerGroup",
+			object:   &configurationv1beta1.KongConsumerGroup{},
+		},
+		{
+			typeName: "KongPluginBinding",
+			object:   &configurationv1alpha1.KongPluginBinding{},
+		},
+		{
+			typeName: "KongUpstream",
+			object:   &configurationv1alpha1.KongUpstream{},
+		},
+		{
+			typeName: "KongTarget",
+			object:   &configurationv1alpha1.KongTarget{},
+		},
+		{
+			typeName: "KongService",
+			object:   &configurationv1alpha1.KongService{},
+		},
+		{
+			typeName: "KongVault",
+			object:   &configurationv1alpha1.KongVault{},
+		},
+		{
+			typeName: "KongKey",
+			object:   &configurationv1alpha1.KongKey{},
+		},
+		{
+			typeName: "KongSNI",
+			object:   &configurationv1alpha1.KongSNI{},
+		},
+		{
+			typeName: "KongCredentialBasicAuth",
+			object:   &configurationv1alpha1.KongCredentialBasicAuth{},
+		},
+		{
+			typeName: "KongCredentialACL",
+			object:   &configurationv1alpha1.KongCredentialACL{},
+		},
+		{
+			typeName: "KongCredentialAPIKey",
+			object:   &configurationv1alpha1.KongCredentialAPIKey{},
+		},
+		{
+			typeName: "KongCredentialJWT",
+			object:   &configurationv1alpha1.KongCredentialJWT{},
+		},
+		{
+			typeName: "KongCredentialHMAC",
+			object:   &configurationv1alpha1.KongCredentialHMAC{},
+		},
+		{
+			typeName: "KongDataPlaneClientCertificate",
+			object:   &configurationv1alpha1.KongDataPlaneClientCertificate{},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.object.GetTypeName(), func(t *testing.T) {
+			obj := tc.object
+
+			require.Equal(t, obj.GetTypeName(), tc.typeName)
+			require.Nil(t, obj.GetKonnectStatus())
+			require.Empty(t, obj.GetKonnectStatus().GetKonnectID())
+			require.Empty(t, obj.GetKonnectStatus().GetOrgID())
+			require.Empty(t, obj.GetKonnectStatus().GetServerURL())
+
+			require.Equal(t, "", obj.GetControlPlaneID())
+			obj.SetControlPlaneID("123")
+			require.Equal(t, "123", obj.GetControlPlaneID())
+
+			require.Empty(t, obj.GetConditions())
+			obj.SetConditions([]metav1.Condition{
+				{
+					Type:   "Ready",
+					Status: metav1.ConditionTrue,
+				},
+			})
+			require.Equal(t,
+				[]metav1.Condition{
+					{
+						Type:   "Ready",
+						Status: metav1.ConditionTrue,
+					},
+				},
+				obj.GetConditions(),
+			)
+		})
+	}
+}
+
+func TestKonnectFuncsNoKonnectStatus(t *testing.T) {
+	type KonnectEntity interface {
+		client.Object
+		GetTypeName() string
+		GetConditions() []metav1.Condition
+		SetConditions([]metav1.Condition)
+	}
+
+	testcases := []struct {
+		object   KonnectEntity
+		typeName string
+	}{
+		{
+			typeName: "KonnectAPIAuthConfiguration",
+			object:   &konnectv1alpha1.KonnectAPIAuthConfiguration{},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.object.GetTypeName(), func(t *testing.T) {
+			obj := tc.object
+
+			require.Equal(t, obj.GetTypeName(), tc.typeName)
+			require.Empty(t, obj.GetConditions())
+			obj.SetConditions([]metav1.Condition{
+				{
+					Type:   "Ready",
+					Status: metav1.ConditionTrue,
+				},
+			})
+			require.Equal(t,
+				[]metav1.Condition{
+					{
+						Type:   "Ready",
+						Status: metav1.ConditionTrue,
+					},
+				},
+				obj.GetConditions(),
+			)
+		})
+	}
+}
+
+func TestKonnectFuncsStandAlone(t *testing.T) {
+	type KonnectEntity interface {
+		client.Object
+		GetTypeName() string
+		GetKonnectStatus() *konnectv1alpha2.KonnectEntityStatus
+		GetConditions() []metav1.Condition
+		SetConditions([]metav1.Condition)
+	}
+
+	testcases := []struct {
+		object   KonnectEntity
+		typeName string
+	}{
+		{
+			typeName: "KonnectGatewayControlPlane",
+			object:   &konnectv1alpha2.KonnectGatewayControlPlane{},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.object.GetTypeName(), func(t *testing.T) {
+			obj := tc.object
+
+			require.Equal(t, obj.GetTypeName(), tc.typeName)
+			require.Empty(t, obj.GetKonnectStatus())
+			require.Empty(t, obj.GetKonnectStatus().GetKonnectID())
+			require.Empty(t, obj.GetKonnectStatus().GetOrgID())
+			require.Empty(t, obj.GetKonnectStatus().GetServerURL())
+			require.Empty(t, obj.GetConditions())
+			obj.SetConditions([]metav1.Condition{
+				{
+					Type:   "Ready",
+					Status: metav1.ConditionTrue,
+				},
+			})
+			require.Equal(t,
+				[]metav1.Condition{
+					{
+						Type:   "Ready",
+						Status: metav1.ConditionTrue,
+					},
+				},
+				obj.GetConditions(),
+			)
+		})
+	}
+}
+
+func TestKonnectFuncsNetworkRef(t *testing.T) {
+	type KonnectEntity interface {
+		client.Object
+		GetTypeName() string
+		GetKonnectStatus() *konnectv1alpha2.KonnectEntityStatus
+		GetConditions() []metav1.Condition
+		SetConditions([]metav1.Condition)
+		GetNetworkID() string
+		SetNetworkID(string)
+	}
+
+	testcases := []struct {
+		object   KonnectEntity
+		typeName string
+	}{
+		{
+			typeName: "KonnectCloudGatewayTransitGateway",
+			object:   &konnectv1alpha1.KonnectCloudGatewayTransitGateway{},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.object.GetTypeName(), func(t *testing.T) {
+			obj := tc.object
+
+			require.Equal(t, obj.GetTypeName(), tc.typeName)
+			require.Empty(t, obj.GetKonnectStatus())
+			require.Empty(t, obj.GetKonnectStatus().GetKonnectID())
+			require.Empty(t, obj.GetKonnectStatus().GetOrgID())
+			require.Empty(t, obj.GetKonnectStatus().GetServerURL())
+			require.Empty(t, obj.GetConditions())
+
+			obj.SetConditions([]metav1.Condition{
+				{
+					Type:   "Ready",
+					Status: metav1.ConditionTrue,
+				},
+			})
+			require.Equal(t,
+				[]metav1.Condition{
+					{
+						Type:   "Ready",
+						Status: metav1.ConditionTrue,
+					},
+				},
+				obj.GetConditions(),
+			)
+
+			obj.SetNetworkID("network")
+			require.Equal(t, "network", obj.GetNetworkID())
+		})
+	}
+}
+
+func TestServiceRef(t *testing.T) {
+	type CfgEntity interface {
+		client.Object
+		GetTypeName() string
+		GetServiceRef() *configurationv1alpha1.ServiceRef
+		SetServiceRef(*configurationv1alpha1.ServiceRef)
+	}
+
+	testcases := []struct {
+		object   CfgEntity
+		typeName string
+	}{
+		{
+			typeName: "KongRoute",
+			object:   &configurationv1alpha1.KongRoute{},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.object.GetTypeName(), func(t *testing.T) {
+			obj := tc.object
+
+			require.Equal(t, obj.GetTypeName(), tc.typeName)
+			require.Nil(t, obj.GetServiceRef())
+
+			serviceRef := &configurationv1alpha1.ServiceRef{
+				Type: configurationv1alpha1.ServiceRefNamespacedRef,
+				NamespacedRef: &commonv1alpha1.NameRef{
+					Name: "test-service",
+				},
+			}
+			obj.SetServiceRef(serviceRef)
+			require.Equal(t, serviceRef, obj.GetServiceRef())
+		})
+	}
+}
+
+func TestCredentialTypes(t *testing.T) {
+	type KonnectEntity interface {
+		client.Object
+		GetTypeName() string
+		SetKonnectConsumerIDInStatus(id string)
+		GetConsumerRefName() string
+	}
+	consumerRef := corev1.LocalObjectReference{
+		Name: "test-kong-consumer",
+	}
+
+	testcases := []struct {
+		object KonnectEntity
+	}{
+		{
+			object: &configurationv1alpha1.KongCredentialBasicAuth{
+				Spec: configurationv1alpha1.KongCredentialBasicAuthSpec{
+					ConsumerRef: consumerRef,
+				},
+			},
+		},
+		{
+			object: &configurationv1alpha1.KongCredentialACL{
+				Spec: configurationv1alpha1.KongCredentialACLSpec{
+					ConsumerRef: consumerRef,
+				},
+			},
+		},
+		{
+			object: &configurationv1alpha1.KongCredentialAPIKey{
+				Spec: configurationv1alpha1.KongCredentialAPIKeySpec{
+					ConsumerRef: consumerRef,
+				},
+			},
+		},
+		{
+			object: &configurationv1alpha1.KongCredentialJWT{
+				Spec: configurationv1alpha1.KongCredentialJWTSpec{
+					ConsumerRef: consumerRef,
+				},
+			},
+		},
+		{
+			object: &configurationv1alpha1.KongCredentialHMAC{
+				Spec: configurationv1alpha1.KongCredentialHMACSpec{
+					ConsumerRef: consumerRef,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.object.GetTypeName(), func(t *testing.T) {
+			obj := tc.object
+
+			require.Equal(t, "test-kong-consumer", obj.GetConsumerRefName())
+			obj.SetKonnectConsumerIDInStatus("123456")
+		})
+	}
+}
+
+func TestLists(t *testing.T) {
+	testKonnectEntityList(t, &configurationv1.KongPluginList{}, 0)
+	testKonnectEntityList(t, &configurationv1.KongPluginList{
+		Items: []configurationv1.KongPlugin{
+			{},
+		},
+	}, 1)
+	testKonnectEntityList(t, &configurationv1.KongConsumerList{}, 0)
+	testKonnectEntityList(t, &configurationv1.KongConsumerList{
+		Items: []configurationv1.KongConsumer{
+			{},
+		},
+	}, 1)
+	testKonnectEntityList(t, &configurationv1beta1.KongConsumerGroupList{}, 0)
+	testKonnectEntityList(t, &configurationv1beta1.KongConsumerGroupList{
+		Items: []configurationv1beta1.KongConsumerGroup{
+			{},
+		},
+	}, 1)
+	testKonnectEntityList(t, &configurationv1alpha1.KongCredentialACLList{}, 0)
+	testKonnectEntityList(t, &configurationv1alpha1.KongCredentialAPIKeyList{}, 0)
+	testKonnectEntityList(t, &configurationv1alpha1.KongCredentialBasicAuthList{}, 0)
+	testKonnectEntityList(t, &configurationv1alpha1.KongCredentialJWTList{}, 0)
+	testKonnectEntityList(t, &configurationv1alpha1.KongCredentialHMACList{}, 0)
+}
+
+type ClientObject[T any] interface {
+	GetTypeName() string
+	GetName() string
+	GetNamespace() string
+	*T
+}
+
+func testKonnectEntityList[
+	TList interface {
+		client.ObjectList
+		GetItems() []T
+	},
+	T any,
+	TT ClientObject[T],
+](t *testing.T, list TList, count int) {
+	t.Helper()
+	var obj TT = new(T)
+	t.Run(
+		obj.GetTypeName()+"/"+strconv.Itoa(count),
+		func(t *testing.T) {
+			require.Len(t, list.GetItems(), count)
+		},
+	)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The initial migration of CRD definitions from `kubernetes-configuration` does not include linter configurations (already covered in https://github.com/Kong/kong-operator/pull/2382) or tests. This PR ports tests of CRDs and ensures that they're run in CI.

This PR cuts corners to ensure coverage (the whole `api/tests/*` is copy-pasted). Spin-off issue to handle it properly has been created -  https://github.com/Kong/kong-operator/issues/2386


**Which issue this PR fixes**

Part of 

- https://github.com/Kong/kong-operator/issues/2193

discovered during work on modifying a CRD in 

- https://github.com/Kong/kong-operator/issues/2375