### PR TITLE
fix(hybridgateway): use hashed based names for KongPlugins

### DIFF
--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -2,7 +2,6 @@ package converter
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/samber/lo"
@@ -250,7 +249,7 @@ func (c *httpRouteConverter) translate(ctx context.Context) error {
 			for _, match := range val.Matches {
 				routeName := match.String()
 				bbuild := builder.NewKongPluginBinding().
-					WithName(routeName+fmt.Sprintf(".%d", filter.Name.GetFilterIndex())).
+					WithName(strings.Join([]string{routeName, filter.GetHash()}, "-")).
 					WithNamespace(c.route.Namespace).
 					WithLabels(c.route).
 					WithAnnotations(c.route, c.ir.GetParentRefByName(match.Name)).

--- a/controller/hybridgateway/intermediate/hash_name.go
+++ b/controller/hybridgateway/intermediate/hash_name.go
@@ -1,0 +1,48 @@
+package intermediate
+
+import (
+	"strings"
+)
+
+// HashName represents a structured naming scheme for Kong entities to be identified by a hash value.
+type HashName struct {
+	prefix    string
+	namespace string
+	hash      string
+}
+
+// String returns the full hash name as a dot-separated string.
+func (h *HashName) String() string {
+	const maxLen = 253
+
+	parts := []string{h.prefix, h.namespace, h.hash}
+	fullName := strings.Join(parts, ".")
+
+	if len(fullName) <= maxLen {
+		return fullName
+	}
+
+	reserved := len(h.hash) + 2 // hash + 2 dots
+	// We need at least one dot between prefix, namespace, and hash
+	remaining := maxLen - reserved
+	// Truncate prefix and namespace proportionally if needed
+	prefixMax := remaining / 2
+	namespaceMax := remaining - prefixMax
+
+	truncPrefix := h.prefix
+	truncNamespace := h.namespace
+	if len(truncPrefix) > prefixMax {
+		truncPrefix = truncPrefix[:prefixMax]
+	}
+	if len(truncNamespace) > namespaceMax {
+		truncNamespace = truncNamespace[:namespaceMax]
+	}
+
+	parts = []string{truncPrefix, truncNamespace, h.hash}
+	return strings.Join(parts, ".")
+}
+
+// GetHash returns the hash part of the HashName.
+func (h *HashName) GetHash() string {
+	return h.hash
+}

--- a/controller/hybridgateway/intermediate/hash_name_test.go
+++ b/controller/hybridgateway/intermediate/hash_name_test.go
@@ -1,0 +1,152 @@
+package intermediate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHashName_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		hashName HashName
+		expected string
+	}{
+		{
+			name: "basic hash name",
+			hashName: HashName{
+				prefix:    "prefix",
+				namespace: "namespace",
+				hash:      "abc123",
+			},
+			expected: "prefix.namespace.abc123",
+		},
+		{
+			name: "all fields empty",
+			hashName: HashName{
+				prefix:    "",
+				namespace: "",
+				hash:      "",
+			},
+			expected: "..",
+		},
+		{
+			name: "exactly at 253 character limit",
+			hashName: HashName{
+				prefix:    strings.Repeat("a", 100),
+				namespace: strings.Repeat("b", 100),
+				hash:      strings.Repeat("c", 51), // 100 + 1 + 100 + 1 + 51 = 253
+			},
+			expected: strings.Repeat("a", 100) + "." + strings.Repeat("b", 100) + "." + strings.Repeat("c", 51),
+		},
+		{
+			name: "truncation needed - long prefix and namespace",
+			hashName: HashName{
+				prefix:    strings.Repeat("prefix", 50),    // 300 chars
+				namespace: strings.Repeat("namespace", 30), // 270 chars
+				hash:      "hash123",                       // 7 chars
+			},
+			// With hash = 7 chars, reserved = 9 (7 + 2 dots)
+			// Remaining = 253 - 9 = 244
+			// prefixMax = 244 / 2 = 122
+			// namespaceMax = 244 - 122 = 122
+			expected: strings.Repeat("prefix", 50)[:122] + "." + strings.Repeat("namespace", 30)[:122] + ".hash123",
+		},
+		{
+			name: "truncation needed - very long prefix",
+			hashName: HashName{
+				prefix:    strings.Repeat("verylongprefix", 30), // 420 chars
+				namespace: "short",
+				hash:      "hash456",
+			},
+			// With hash = 7 chars, reserved = 9
+			// Remaining = 244, prefixMax = 122, namespaceMax = 122
+			expected: strings.Repeat("verylongprefix", 30)[:122] + ".short.hash456",
+		},
+		{
+			name: "truncation needed - very long namespace",
+			hashName: HashName{
+				prefix:    "short",
+				namespace: strings.Repeat("verylongnamespace", 25), // 425 chars
+				hash:      "hash789",
+			},
+			// With hash = 7 chars, reserved = 9
+			// Remaining = 244, prefixMax = 122, namespaceMax = 122
+			expected: "short." + strings.Repeat("verylongnamespace", 25)[:122] + ".hash789",
+		},
+		{
+			name: "very long hash",
+			hashName: HashName{
+				prefix:    "prefix",
+				namespace: "namespace",
+				hash:      strings.Repeat("h", 200), // 200 chars
+			},
+			// With hash = 200 chars, reserved = 201
+			// Remaining = 52, prefixMax = 26, namespaceMax = 26
+			// Since "prefix" (6 chars) < 26 and "namespace" (9 chars) < 26, they won't be truncated
+			expected: "prefix" + "." + "namespace" + "." + strings.Repeat("h", 200),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.hashName.String()
+			assert.Equal(t, tt.expected, result)
+
+			// Verify the result doesn't exceed 253 characters
+			assert.LessOrEqual(t, len(result), 253, "Result should not exceed 253 characters")
+
+			// Verify the result always contains exactly 2 dots
+			dotCount := strings.Count(result, ".")
+			assert.Equal(t, 2, dotCount, "Result should contain exactly 2 dots")
+
+			// Verify the hash is always preserved at the end
+			parts := strings.Split(result, ".")
+			assert.Equal(t, tt.hashName.hash, parts[2], "Hash should be preserved")
+		})
+	}
+}
+
+func TestHashName_GetHash(t *testing.T) {
+	tests := []struct {
+		name     string
+		hashName HashName
+		expected string
+	}{
+		{
+			name: "basic hash",
+			hashName: HashName{
+				prefix:    "prefix",
+				namespace: "namespace",
+				hash:      "abc123",
+			},
+			expected: "abc123",
+		},
+		{
+			name: "empty hash",
+			hashName: HashName{
+				prefix:    "prefix",
+				namespace: "namespace",
+				hash:      "",
+			},
+			expected: "",
+		},
+		{
+			name: "long hash",
+			hashName: HashName{
+				prefix:    "prefix",
+				namespace: "namespace",
+				hash:      strings.Repeat("abcdef", 50),
+			},
+			expected: strings.Repeat("abcdef", 50),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.hashName.GetHash()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/controller/hybridgateway/intermediate/http_route.go
+++ b/controller/hybridgateway/intermediate/http_route.go
@@ -3,6 +3,7 @@ package intermediate
 import (
 	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
 	"github.com/kong/kong-operator/controller/hybridgateway/metadata"
+	"github.com/kong/kong-operator/controller/hybridgateway/utils"
 	gwtypes "github.com/kong/kong-operator/internal/types"
 )
 
@@ -32,7 +33,7 @@ type BackendRef struct {
 // Filter represents a filter applied to an HTTPRoute rule.
 // It defines transformations or actions to be performed on requests that match the rule.
 type Filter struct {
-	Name
+	HashName
 	Filter gwtypes.HTTPRouteFilter
 }
 
@@ -92,11 +93,11 @@ func NewHTTPRouteRepresentation(route *gwtypes.HTTPRoute) *HTTPRouteRepresentati
 					Match: match,
 				})
 			}
-			for k, filter := range rule.Filters {
-				filterName := NameFromHTTPRoute(route, "", i, j, k)
+			for _, filter := range rule.Filters {
+				filterName := NameFromHash("filter", route.Namespace, utils.Hash32(filter))
 				repr.AddFilterForRule(ruleName, Filter{
-					Name:   filterName,
-					Filter: filter,
+					HashName: filterName,
+					Filter:   filter,
 				})
 			}
 			for k, bRef := range rule.BackendRefs {
@@ -128,6 +129,15 @@ func NameFromHTTPRoute(route *gwtypes.HTTPRoute, prefix string, indexes ...int) 
 		namespace: route.Namespace,
 		name:      route.Name,
 		indexes:   indexes,
+	}
+}
+
+// NameFromHash creates a Name instance using a specified prefix, namespace, and hash value.
+func NameFromHash(prefix, namespace, hash string) HashName {
+	return HashName{
+		prefix:    prefix,
+		namespace: namespace,
+		hash:      hash,
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes reconciling HTTPRoutes where filters get overwritten or removed: with this patch, the `KongPlugin`s and `KongPluginBinding`s get recreated with a different name.
Previously the controlled tried to overwrite older ones causing Konnect API errors.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
