### PR TITLE
feat(hybridgateway): Using endpointslices as upstreams

### DIFF
--- a/controller/hybridgateway/builder/kongtarget.go
+++ b/controller/hybridgateway/builder/kongtarget.go
@@ -52,25 +52,19 @@ func (b *KongTargetBuilder) WithLabels(route *gwtypes.HTTPRoute) *KongTargetBuil
 	return b
 }
 
-// WithBackendRef sets the target specification based on the given HTTPRoute and backend reference.
-func (b *KongTargetBuilder) WithBackendRef(httpRoute *gwtypes.HTTPRoute, bRef *gwtypes.HTTPBackendRef) *KongTargetBuilder {
-	// Build the dns name of the service for the backendRef.
-	// TODO(alacuku): We need to handle the cluster domain properly for the cluster where we are running.
-	var namespace string
-	if bRef.Namespace == nil || *bRef.Namespace == "" {
-		namespace = httpRoute.Namespace
-	} else {
-		namespace = string(*bRef.Namespace)
-	}
-
-	host := string(bRef.Name) + "." + namespace + ".svc.cluster.local"
-	port := strconv.Itoa(int(*bRef.Port))
-	target := net.JoinHostPort(host, port)
+func (b *KongTargetBuilder) WithTarget(host string, port gwtypes.PortNumber) *KongTargetBuilder {
+	target := net.JoinHostPort(host, strconv.Itoa(int(port)))
 	b.target.Spec.Target = target
 
-	// Weight is optional, default to 100 if not specified
-	if bRef.Weight != nil {
-		b.target.Spec.Weight = int(*bRef.Weight)
+	return b
+}
+
+func (b *KongTargetBuilder) WithWeight(weight *int32) *KongTargetBuilder {
+	b.target.Spec.Weight = 100 // Weight is optional, default to 100 if not specified
+	if weight != nil {
+		newWeight := new(int)
+		*newWeight = int(*weight)
+		b.target.Spec.Weight = *newWeight
 	}
 	return b
 }

--- a/controller/hybridgateway/builder/kongtarget.go
+++ b/controller/hybridgateway/builder/kongtarget.go
@@ -52,6 +52,7 @@ func (b *KongTargetBuilder) WithLabels(route *gwtypes.HTTPRoute) *KongTargetBuil
 	return b
 }
 
+// WithTarget sets the target (host:port) for the KongTarget.
 func (b *KongTargetBuilder) WithTarget(host string, port gwtypes.PortNumber) *KongTargetBuilder {
 	target := net.JoinHostPort(host, strconv.Itoa(int(port)))
 	b.target.Spec.Target = target
@@ -59,6 +60,7 @@ func (b *KongTargetBuilder) WithTarget(host string, port gwtypes.PortNumber) *Ko
 	return b
 }
 
+// WithWeight sets the weight for the KongTarget. If weight is nil, it defaults to 100.
 func (b *KongTargetBuilder) WithWeight(weight *int32) *KongTargetBuilder {
 	b.target.Spec.Weight = 100 // Weight is optional, default to 100 if not specified
 	if weight != nil {

--- a/controller/hybridgateway/builder/kongtarget_test.go
+++ b/controller/hybridgateway/builder/kongtarget_test.go
@@ -1,9 +1,9 @@
 package builder
 
 import (
-	"github.com/samber/lo"
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controller/hybridgateway/controller.go
+++ b/controller/hybridgateway/controller.go
@@ -173,24 +173,12 @@ func (r *HybridGatewayReconciler[t, tPtr]) httpRoutesForService(ctx context.Cont
 
 	requests := make(map[reconcile.Request]struct{})
 	for _, httpRoute := range httpRoutes.Items {
-		for _, rule := range httpRoute.Spec.Rules {
-			for _, backendRef := range rule.BackendRefs {
-				if backendRef.Kind != nil && *backendRef.Kind == "Service" && backendRef.Name == gatewayv1.ObjectName(service.Name) {
-					namespace := httpRoute.Namespace
-					if backendRef.Namespace != nil {
-						namespace = string(*backendRef.Namespace)
-					}
-					if namespace == service.Namespace {
-						requests[reconcile.Request{
-							NamespacedName: types.NamespacedName{
-								Namespace: httpRoute.Namespace,
-								Name:      httpRoute.Name,
-							},
-						}] = struct{}{}
-					}
-				}
-			}
-		}
+		requests[reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: httpRoute.Namespace,
+				Name:      httpRoute.Name,
+			},
+		}] = struct{}{}
 	}
 
 	reqs := make([]reconcile.Request, 0, len(requests))

--- a/controller/hybridgateway/controller.go
+++ b/controller/hybridgateway/controller.go
@@ -3,23 +3,23 @@ package hybridgateway
 import (
 	"context"
 	"fmt"
-	"github.com/kong/kong-operator/internal/utils/index"
-	discoveryv1 "k8s.io/api/discovery/v1"
-	"k8s.io/apimachinery/pkg/types"
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kong/kong-operator/controller/hybridgateway/converter"
 	"github.com/kong/kong-operator/controller/hybridgateway/route"
 	"github.com/kong/kong-operator/controller/hybridgateway/watch"
 	"github.com/kong/kong-operator/controller/pkg/log"
+	"github.com/kong/kong-operator/internal/utils/index"
 )
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongroutes,verbs=get;list;watch;create;update;patch;delete
@@ -151,7 +151,7 @@ func (r *HybridGatewayReconciler[t, tPtr]) findHTTPRoutesForEndpointSlice(ctx co
 	}
 
 	service := &corev1.Service{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: endpointSlice.Namespace, Name: serviceName}, service); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Namespace: endpointSlice.Namespace, Name: serviceName}, service); err != nil {
 		logger.Error(err, "failed to get service for endpointslice", "servicename", serviceName, "endpointslicenamespace", endpointSlice.Namespace)
 		return nil
 	}
@@ -162,7 +162,7 @@ func (r *HybridGatewayReconciler[t, tPtr]) findHTTPRoutesForEndpointSlice(ctx co
 func (r *HybridGatewayReconciler[t, tPtr]) httpRoutesForService(ctx context.Context, service *corev1.Service) []reconcile.Request {
 	logger := ctrllog.FromContext(ctx).WithName("HybridGatewayWatcher")
 	var httpRoutes gatewayv1.HTTPRouteList
-	if err := r.Client.List(ctx, &httpRoutes,
+	if err := r.List(ctx, &httpRoutes,
 		client.MatchingFields{
 			index.BackendServicesOnHTTPRouteIndex: service.Namespace + "/" + service.Name,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

this PR handles upstream's targets looking at `Service`'s `EndpointSlices`

**Which issue this PR fixes**

Fixes #2264 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
- [x] handling watchers on `Service` and `EndpointSlices`
- [x] route reconciliation on `Service` and `EndpointSlices` changes
- [ ] add an option to control if upsteam's targets are built on `EndpointSlices` (true by default) or on `Service` FQDN
