### PR TITLE
feat: Hybrid Gateway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -860,6 +860,7 @@ _run:
 		-enable-controller-kongplugininstallation \
 		-enable-controller-aigateway \
 		-enable-controller-konnect \
+		-enable-controller-konnect-hybrid \
 		-enable-controller-controlplaneextensions \
 		-enable-conversion-webhook=false \
 		-zap-time-encoding iso8601 \

--- a/api/gateway-operator/gateway/conditions.go
+++ b/api/gateway-operator/gateway/conditions.go
@@ -15,6 +15,11 @@ const (
 
 	// DataPlaneReadyType the DataPlane is deployed and Ready
 	DataPlaneReadyType consts.ConditionType = "DataPlaneReady"
+
+	// KonnectExtensionReadyType the KonnectExtension is deployed and Ready
+	KonnectExtensionReadyType consts.ConditionType = "KonnectExtensionReady"
+
+	KonnectGatewayControlPlaneProgrammedType consts.ConditionType = "KonnectGatewayControlPlaneProgrammed"
 )
 
 // -----------------------------------------------------------------------------

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -53647,8 +53647,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -53673,6 +53671,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -53647,8 +53647,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -53673,6 +53671,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -53647,8 +53647,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -53673,6 +53671,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -53647,8 +53647,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -53673,6 +53671,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -53647,8 +53647,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -53673,6 +53671,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -53648,8 +53648,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -53674,6 +53672,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -53647,8 +53647,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -53673,6 +53671,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -53647,8 +53647,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -53673,6 +53671,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -53647,8 +53647,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -53673,6 +53671,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -53647,8 +53647,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -53673,6 +53671,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -53647,8 +53647,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -53673,6 +53671,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -53647,8 +53647,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -53673,6 +53671,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -28459,8 +28459,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -28485,6 +28483,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -53597,8 +53597,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -53623,6 +53621,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -28434,8 +28434,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -28460,6 +28458,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/templates/cluster-role.yaml
+++ b/charts/kong-operator/templates/cluster-role.yaml
@@ -415,8 +415,6 @@ rules:
       - konnectcloudgatewaydataplanegroupconfigurations
       - konnectcloudgatewaynetworks
       - konnectcloudgatewaytransitgateways
-      - konnectextensions
-      - konnectgatewaycontrolplanes
     verbs:
       - get
       - list
@@ -441,6 +439,19 @@ rules:
     verbs:
       - patch
       - update
+  - apiGroups:
+      - konnect.konghq.com
+    resources:
+      - konnectextensions
+      - konnectgatewaycontrolplanes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:

--- a/config/debug/manager_debug.yaml
+++ b/config/debug/manager_debug.yaml
@@ -33,6 +33,8 @@ spec:
             - -zap-log-level=debug
             - -enable-controller-kongplugininstallation
             - -enable-controller-konnect
+            - -enable-controller-konnect-hybrid
+            - -enable-controller-konnect-hybrid
             - -enable-controller-controlplaneextensions
           name: manager
           env:

--- a/config/dev/manager_dev.yaml
+++ b/config/dev/manager_dev.yaml
@@ -24,6 +24,7 @@ spec:
             - -zap-devel=true
             - -enable-controller-kongplugininstallation
             - -enable-controller-konnect
+            - -enable-controller-konnect-hybrid
             - -enable-controller-controlplaneextensions
           name: manager
           env:

--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -415,8 +415,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -441,6 +439,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/controller/gateway/controller_rbac.go
+++ b/controller/gateway/controller_rbac.go
@@ -13,3 +13,6 @@ package gateway
 //+kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=controlplanes,verbs=create;get;list;watch;update;patch;delete
 //+kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=gatewayconfigurations,verbs=get;list;watch
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;get;update;patch;list;watch;delete
+
+//+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectgatewaycontrolplanes,verbs=create;get;list;watch;update;patch;delete
+//+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectextensions,verbs=create;get;list;watch;update;patch;delete

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -25,6 +25,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	kcfgconsts "github.com/kong/kong-operator/api/common/consts"
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
 	kcfgdataplane "github.com/kong/kong-operator/api/gateway-operator/dataplane"
 	kcfggateway "github.com/kong/kong-operator/api/gateway-operator/gateway"
 	operatorv1beta1 "github.com/kong/kong-operator/api/gateway-operator/v1beta1"
@@ -47,7 +48,8 @@ import (
 // GatewayReconciler - Reconciler Helpers
 // -----------------------------------------------------------------------------
 
-func (r *Reconciler) createDataPlane(ctx context.Context,
+func (r *Reconciler) createDataPlane(
+	ctx context.Context,
 	gateway *gwtypes.Gateway,
 	gatewayConfig *GatewayConfiguration,
 ) (*operatorv1beta1.DataPlane, error) {
@@ -577,6 +579,18 @@ func (r *Reconciler) isGatewayHybrid(
 		break
 	}
 	return isHybrid, requeue, nil
+}
+
+// isGatewayKonnect checks if the given GatewayConfiguration is in konnect mode by inspecting its fields.
+func isGatewayKonnect(
+	gatewayConfiguration *GatewayConfiguration,
+) (isKonnect bool) {
+	if k := gatewayConfiguration.Spec.Konnect; k != nil {
+		if lo.FromPtrOr(k.Source, commonv1alpha1.EntitySourceOrigin) == commonv1alpha1.EntitySourceOrigin && k.APIAuthConfigurationRef != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // -----------------------------------------------------------------------------

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -552,7 +552,9 @@ func (r *Reconciler) ensureOwnedNetworkPoliciesDeleted(ctx context.Context, gate
 
 // isGatewayHybrid checks if the given GatewayConfiguration is in hybrid mode by inspecting its extensions.
 // It returns true if a KonnectExtension with ClusterTypeControlPlane is found, and a requeue flag if any extension status is not yet set.
-func (r *Reconciler) isGatewayHybrid(ctx context.Context, logger logr.Logger, gatewayConfiguration *GatewayConfiguration) (isHybrid bool, requeue bool, err error) {
+func (r *Reconciler) isGatewayHybrid(
+	ctx context.Context, logger logr.Logger, gatewayConfiguration *GatewayConfiguration,
+) (isHybrid bool, requeue bool, err error) {
 	for _, ext := range gatewayConfiguration.Spec.Extensions {
 		if ext.Group != konnectv1alpha2.SchemeGroupVersion.Group ||
 			ext.Kind != konnectv1alpha2.KonnectExtensionKind {

--- a/controller/hybridgateway/controller.go
+++ b/controller/hybridgateway/controller.go
@@ -100,7 +100,7 @@ func (r *HybridGatewayReconciler[t, tPtr]) Reconcile(ctx context.Context, req ct
 	}
 
 	gvk := obj.GetObjectKind().GroupVersionKind()
-	log.Debug(logger, "Reconciling object", "Group", gvk.Group, "Kind", gvk.Kind)
+	log.Info(logger, ">>> Reconciling object", "Group", gvk.Group, "Kind", gvk.Kind)
 
 	conv, err := converter.NewConverter(rootObj, r.Client)
 	if err != nil {

--- a/controller/hybridgateway/watch/conversion.go
+++ b/controller/hybridgateway/watch/conversion.go
@@ -62,6 +62,7 @@ func filterByService(cl client.Client) func(obj client.Object) bool {
 
 func filterByHTTPRoute(cl client.Client) func(obj client.Object) bool {
 	return func(obj client.Object) bool {
+		fmt.Println(">>> FILTER BY HTTPRoute")
 		httpRoute, ok := obj.(*gwtypes.HTTPRoute)
 		if !ok {
 			// In case of an error, enqueue the event and in case the error persists
@@ -74,6 +75,9 @@ func filterByHTTPRoute(cl client.Client) func(obj client.Object) bool {
 			// In case of an error, enqueue the event and in case the error persists
 			// the reconciler will log it and act accordingly.
 			return true
+		}
+		for _, pRef := range konnectGatewayControlPlaneRefs {
+			fmt.Println(">>> REF:", pRef)
 		}
 		// in case the HTTPRoute needs to be configured in Konnect a Konnect Gateway ControlPlane should exist, we filter the service in
 		if len(konnectGatewayControlPlaneRefs) > 0 {

--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -174,6 +174,7 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		cleanup = true
 	}
 
+	//TODO: controlplane from konnect
 	switch {
 	case len(dataPlaneList.Items)+len(controlPlaneList.Items) == 0:
 		updated = controllerutil.RemoveFinalizer(&ext, consts.ExtensionInUseFinalizer)

--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -487,16 +487,16 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 				// if the syncPeriod is set to zero, the controller won't requeue.
 				return ctrl.Result{Requeue: true, RequeueAfter: r.SyncPeriod}, err
 			}
-			updated, res, err := patch.WithFinalizer(ctx, r.Client, client.Object(certificateSecret), KonnectCleanupFinalizer)
-			if err != nil || !res.IsZero() {
-				return res, err
-			}
-			if updated {
-				log.Info(logger, "konnect-cleanup finalizer on the referenced secret updated")
-				// Setting "Requeue: true" along with RequeueAfter makes the controller bulletproof, as
-				// if the syncPeriod is set to zero, the controller won't requeue.
-				return ctrl.Result{Requeue: true, RequeueAfter: r.SyncPeriod}, err
-			}
+			// updated, res, err := patch.WithFinalizer(ctx, r.Client, client.Object(certificateSecret), KonnectCleanupFinalizer)
+			// if err != nil || !res.IsZero() {
+			// 	return res, err
+			// }
+			// if updated {
+			// 	log.Info(logger, "konnect-cleanup finalizer on the referenced secret updated")
+			// 	// Setting "Requeue: true" along with RequeueAfter makes the controller bulletproof, as
+			// 	// if the syncPeriod is set to zero, the controller won't requeue.
+			// 	return ctrl.Result{Requeue: true, RequeueAfter: r.SyncPeriod}, err
+			// }
 		}
 		updated, res, err := patch.WithFinalizer(ctx, r.Client, &ext, KonnectCleanupFinalizer)
 		if err != nil || !res.IsZero() {

--- a/modules/cli/cli.go
+++ b/modules/cli/cli.go
@@ -78,8 +78,8 @@ func New(m metadata.Info) *CLI {
 	flagSet.BoolVar(&cfg.GatewayAPIExperimentalEnabled, "enable-gateway-api-experimental", false, "Enable the Gateway API experimental features.")
 
 	// controllers for Konnect APIs
-	flagSet.BoolVar(&cfg.KonnectControllersEnabled, "enable-controller-konnect", false, "Enable the Konnect controllers.")
-	flagSet.BoolVar(&cfg.KonnectHybridControllersEnabled, "enable-controller-konnect-hybrid", false, "Enable the Konnect Hybrid controllers.")
+	flagSet.BoolVar(&cfg.KonnectControllersEnabled, "enable-controller-konnect", true, "Enable the Konnect controllers.")
+	flagSet.BoolVar(&cfg.KonnectHybridControllersEnabled, "enable-controller-konnect-hybrid", true, "Enable the Konnect Hybrid controllers.")
 	flagSet.DurationVar(&cfg.KonnectSyncPeriod, "konnect-sync-period", consts.DefaultKonnectSyncPeriod, "Sync period for Konnect entities. After a successful reconciliation of Konnect entities the controller will wait this duration before enforcing configuration on Konnect once again.")
 	flagSet.UintVar(&cfg.KonnectMaxConcurrentReconciles, "konnect-controller-max-concurrent-reconciles", consts.DefaultKonnectMaxConcurrentReconciles, "Maximum number of concurrent reconciles for Konnect entities.")
 

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -627,7 +627,7 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 		)
 
 		if c.KonnectHybridControllersEnabled {
-
+			fmt.Println("HYBRID CONTROLLERS ENABLED")
 			controllers = append(controllers,
 				newGatewayAPIHybridController[gwtypes.HTTPRoute](mgr),
 				// TODO: Add more Hybrid controllers here


### PR DESCRIPTION
**What this PR does / why we need it**:


❗ Helm Chart has to be used from this branch, checkout repo on this PR, and execute the below command:

Where `image.tag` is set according to your processor architecture to `sha-4696d9e-amd64` or `sha-4696d9e-arm64` (all new MacBooks).

```sh
helm upgrade --install kong-operator ./charts/kong-operator -n kong-system \
  --create-namespace \
  --set image.repository=kong/nightly-kong-operator \
  --set image.tag=<TO_FILL> \
  --set env.ENABLE_CONTROLLER_KONNECT=true \
  --set env.ENABLE_CONTROLLER_KONNECT_HYBRID=true
```



Next example scenario to run with dev Konnect

```sh
kind: KonnectAPIAuthConfiguration
apiVersion: konnect.konghq.com/v1alpha1
metadata:
  name: konnect-api-auth
  namespace: default
spec:
  type: token
  token: XYZ
  serverURL: us.api.konghq.tech
```

after 

```sh
kind: GatewayConfiguration
apiVersion: gateway-operator.konghq.com/v2beta1
metadata:
  name: jw-gwc
  namespace: default
spec:
  konnect:
    authRef:
      name: konnect-api-auth
  dataPlaneOptions:
    deployment:
      podTemplateSpec:
        spec:
          containers:
          - name: proxy
            image: kong/kong-gateway:3.12
---
kind: GatewayClass
apiVersion: gateway.networking.k8s.io/v1
metadata:
  name: kong-v2beta1
spec:
  controllerName: konghq.com/gateway-operator
  parametersRef:
    group: gateway-operator.konghq.com
    kind: GatewayConfiguration
    name: jw-gwc
    namespace: default
---
kind: Gateway
apiVersion: gateway.networking.k8s.io/v1
metadata:
  name: jw-gw
  namespace: default
spec:
  gatewayClassName: kong-v2beta1
  listeners:
  - name: http
    protocol: HTTP
    port: 80
```

It can be observed in Konnec and the statuses of respective objects in K8s cluster

```sh
kubectl get gateways
kubectl get konnectgatewaycontrolplanes
kubectl get dataplanes
```

next

 
```yml
apiVersion: v1
kind: Service
metadata:
  name: echo
spec:
  ports:
    - protocol: TCP
      name: http
      port: 80
      targetPort: http
  selector:
    app: echo
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: echo
  name: echo
spec:
  replicas: 1
  selector:
    matchLabels:
      app: echo
  template:
    metadata:
      labels:
        app: echo
    spec:
      containers:
        - name: echo
          image: registry.k8s.io/e2e-test-images/agnhost:2.40
          command:
            - /agnhost
            - netexec
            - --http-port=8080
          ports:
            - containerPort: 8080
              name: http
          env:
            - name: NODE_NAME
              valueFrom:
                fieldRef:
                  fieldPath: spec.nodeName
            - name: POD_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
            - name: NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
            - name: POD_IP
              valueFrom:
                fieldRef:
                  fieldPath: status.podIP
          resources:
            requests:
              cpu: 10m
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: httproute-echo
  namespace: default
spec:
  parentRefs:
  - name: jw-gw
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /echo
    backendRefs:
    - name: echo
      kind: Service
      port: 80
```

And traffic after a couple of seconds is routed

<img width="1468" height="840" alt="image" src="https://github.com/user-attachments/assets/9f48186a-e532-47f7-9dc6-3b07d0e55db2" />

Resources can be deleted accordingly, and Konnect will update.



**Which issue this PR fixes**

Part of 
- https://github.com/Kong/kong-operator/issues/2377

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
