### PR TITLE
fix(managedfields): fix pruning of empty fields in unstructured objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,16 @@
   This enables more robust troubleshooting and visibility for users, ensuring HTTPRoute status accurately reflects
   the readiness and configuration of all associated Kong resources.
   [2400](https://github.com/Kong/kong-operator/pull/2400)
+- ManagedFields: improve pruning of empty fields in unstructured objects
+  - Enhance pruneEmptyFields to recursively remove empty maps from slices and maps, including those that become empty after nested pruning.
+  - Update logic to remove empty slices and zero-value fields more robustly.
+  - Expand and refine unit tests in prune_test.go to cover all edge cases, including:
+    - Nested empty maps and slices
+    - Removal of empty maps from slices
+    - Handling of mixed-type slices
+    - Deeply nested pruning scenarios
+    - Preservation of non-map elements in slices
+  [2413](https://github.com/Kong/kong-operator/pull/2413)
 
 ### Changed
 

--- a/controller/hybridgateway/managedfields/prune.go
+++ b/controller/hybridgateway/managedfields/prune.go
@@ -15,14 +15,39 @@ func pruneEmptyFields(m map[string]any) {
 				delete(m, k)
 			} else {
 				pruneEmptyFields(val)
+				// Check if the map became empty after pruning.
+				if len(val) == 0 {
+					delete(m, k)
+				}
 			}
 		case []any:
+			// First pass: prune all maps in the slice.
 			for i := range val {
 				if subMap, ok := val[i].(map[string]any); ok {
 					pruneEmptyFields(subMap)
 				}
 			}
-			// Remove empty slices
+
+			// Second pass: collect indices of empty maps to remove.
+			var emptyIndices []int
+			for i := range val {
+				if subMap, ok := val[i].(map[string]any); ok && len(subMap) == 0 {
+					emptyIndices = append(emptyIndices, i)
+				}
+			}
+
+			// Remove empty maps from slice (in reverse order to maintain correct indices).
+			for i := len(emptyIndices) - 1; i >= 0; i-- {
+				idx := emptyIndices[i]
+				val = append(val[:idx], val[idx+1:]...)
+			}
+
+			// Update the slice in the map if we removed items.
+			if len(emptyIndices) > 0 {
+				m[k] = val
+			}
+
+			// Remove empty slices.
 			if len(val) == 0 {
 				delete(m, k)
 			}

--- a/controller/hybridgateway/managedfields/prune_test.go
+++ b/controller/hybridgateway/managedfields/prune_test.go
@@ -41,18 +41,117 @@ func TestPruneEmptyFields_AllBranches(t *testing.T) {
 		{
 			name:   "recursively prunes nested empty map",
 			input:  map[string]any{"a": map[string]any{"b": map[string]any{}}},
-			expect: map[string]any{"a": map[string]any{}},
+			expect: map[string]any{},
+		},
+		{
+			name: "removes map that becomes empty after pruning",
+			input: map[string]any{
+				"outer": map[string]any{
+					"inner": map[string]any{
+						"empty": map[string]any{},
+						"zero":  "",
+					},
+				},
+			},
+			expect: map[string]any{},
+		},
+		{
+			name: "removes empty maps from slice",
+			input: map[string]any{
+				"items": []any{
+					map[string]any{},
+					map[string]any{"keep": "value"},
+					map[string]any{"remove": ""},
+				},
+			},
+			expect: map[string]any{
+				"items": []any{
+					map[string]any{"keep": "value"},
+				},
+			},
+		},
+		{
+			name: "removes slice that becomes empty after removing empty maps",
+			input: map[string]any{
+				"items": []any{
+					map[string]any{},
+					map[string]any{"zero": ""},
+				},
+			},
+			expect: map[string]any{},
+		},
+		{
+			name: "handles mixed slice with empty maps and other types",
+			input: map[string]any{
+				"mixed": []any{
+					map[string]any{}, // should be removed
+					"string",         // should be kept
+					map[string]any{"nested": map[string]any{}}, // should be removed (becomes empty)
+					42, // should be kept
+				},
+			},
+			expect: map[string]any{
+				"mixed": []any{"string", 42},
+			},
+		},
+		{
+			name: "deeply nested pruning with maps and slices",
+			input: map[string]any{
+				"level1": map[string]any{
+					"level2": []any{
+						map[string]any{
+							"level3": map[string]any{
+								"empty": map[string]any{},
+							},
+						},
+						map[string]any{
+							"keep": "value",
+						},
+					},
+				},
+			},
+			expect: map[string]any{
+				"level1": map[string]any{
+					"level2": []any{
+						map[string]any{
+							"keep": "value",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "preserves non-map elements in slice",
+			input: map[string]any{
+				"items": []any{
+					"string1",
+					map[string]any{}, // empty map should be removed
+					123,
+					map[string]any{"key": "value"}, // non-empty map should be kept
+					true,
+				},
+			},
+			expect: map[string]any{
+				"items": []any{
+					"string1",
+					123,
+					map[string]any{"key": "value"},
+					true,
+				},
+			},
 		},
 		{
 			name:   "recursively prunes nested empty slice",
 			input:  map[string]any{"a": []any{map[string]any{}, 1}},
-			expect: map[string]any{"a": []any{map[string]any{}, 1}},
+			expect: map[string]any{"a": []any{1}},
 		},
 	}
 
 	for _, tc := range cases {
-		u := &unstructured.Unstructured{Object: tc.input}
-		PruneEmptyFields(u)
-		assert.Equal(t, tc.expect, u.Object, tc.name)
+		t.Run(tc.name, func(t *testing.T) {
+			u := &unstructured.Unstructured{Object: tc.input}
+			PruneEmptyFields(u)
+			assert.Equal(t, tc.expect, u.Object, tc.name)
+		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- Enhance pruneEmptyFields to recursively remove empty maps from slices and maps, including those that become empty after nested pruning.
- Update logic to remove empty slices and zero-value fields more robustly.
- Expand and refine unit tests in prune_test.go to cover all edge cases, including:
  - Nested empty maps and slices
  - Removal of empty maps from slices
  - Handling of mixed-type slices
  - Deeply nested pruning scenarios
  - Preservation of non-map elements in slices

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
