### PR TITLE
feat(hybridgateway): add watches for Gateway and GatewayClass to HTTPRoute reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@
   - HTTPRoutes are now reconciled when related Gateway or GatewayClass resources change.
   - Improved event mapping and indexing logic for efficient reconciliation.
   - Added unit tests for new watch and index logic.
-  [2419](https://github.com/Kong/kong-operator/pull/2419)
+  [#2419](https://github.com/Kong/kong-operator/pull/2419)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,12 @@
   a Kubernetes custom resource for managing the existing entity by KO.
   - Add adoption options to the CRDs supporting adopting entities from Konnect.
     [#2336](https://github.com/Kong/kong-operator/pull/2336)
+- HybridGateway:
+  - Added controller-runtime watches for Gateway and GatewayClass resources to the hybridgateway controller.
+  - HTTPRoutes are now reconciled when related Gateway or GatewayClass resources change.
+  - Improved event mapping and indexing logic for efficient reconciliation.
+  - Added unit tests for new watch and index logic.
+  [2419](https://github.com/Kong/kong-operator/pull/2419)
 
 ### Changed
 

--- a/controller/hybridgateway/controller.go
+++ b/controller/hybridgateway/controller.go
@@ -8,6 +8,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -78,6 +79,11 @@ func (r *HybridGatewayReconciler[t, tPtr]) SetupWithManager(ctx context.Context,
 	// Add watches for owned resources.
 	for _, owned := range watch.Owns(obj) {
 		builder = builder.Owns(owned)
+	}
+
+	// Add watches for other resources.
+	for _, w := range watch.Watches(obj, r.Client) {
+		builder = builder.Watches(w.Object, handler.EnqueueRequestsFromMapFunc(w.MapFunc))
 	}
 
 	return builder.Complete(r)

--- a/controller/hybridgateway/watch/mapfuncs.go
+++ b/controller/hybridgateway/watch/mapfuncs.go
@@ -1,0 +1,84 @@
+package watch
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	gwtypes "github.com/kong/kong-operator/internal/types"
+	"github.com/kong/kong-operator/internal/utils/index"
+)
+
+// listHTTPRoutesForGateway returns all reconcile.Requests for HTTPRoutes referencing the given Gateway.
+func listHTTPRoutesForGateway(ctx context.Context, cl client.Client, gatewayNamespace, gatewayName string) ([]reconcile.Request, error) {
+	httpRoutes := &gwtypes.HTTPRouteList{}
+	err := cl.List(ctx, httpRoutes, client.MatchingFields{
+		index.GatewayOnHTTPRouteIndex: gatewayNamespace + "/" + gatewayName,
+	})
+	if err != nil {
+		return nil, err
+	}
+	requests := make([]reconcile.Request, len(httpRoutes.Items))
+	for i, httpRoute := range httpRoutes.Items {
+		requests[i] = reconcile.Request{
+			NamespacedName: client.ObjectKey{
+				Namespace: httpRoute.Namespace,
+				Name:      httpRoute.Name,
+			},
+		}
+	}
+	return requests, nil
+}
+
+// MapHTTPRouteForGateway returns a handler.MapFunc that, given a Gateway object,
+// lists all HTTPRoutes referencing that Gateway (via ParentRefs) using the GatewayOnHTTPRouteIndex.
+// It returns a slice of reconcile.Requests for each matching HTTPRoute, enabling efficient event handling
+// and reconciliation when a Gateway changes.
+func MapHTTPRouteForGateway(cl client.Client) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		gateway, ok := obj.(*gwtypes.Gateway)
+		if !ok {
+			return nil
+		}
+		requests, err := listHTTPRoutesForGateway(ctx, cl, gateway.Namespace, gateway.Name)
+		if err != nil {
+			return nil
+		}
+		return requests
+	}
+}
+
+// MapHTTPRouteForGatewayClass returns a handler.MapFunc that, given a GatewayClass object,
+// lists all Gateways referencing that GatewayClass (using GatewayClassOnGatewayIndex),
+// then for each Gateway, lists all HTTPRoutes referencing it (via ParentRefs and GatewayOnHTTPRouteIndex).
+// It returns a slice of reconcile.Requests for each matching HTTPRoute, enabling efficient event handling
+// and reconciliation when a GatewayClass changes.
+func MapHTTPRouteForGatewayClass(cl client.Client) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		gc, ok := obj.(*gwtypes.GatewayClass)
+		if !ok {
+			return nil
+		}
+
+		// List all Gateways that reference this GatewayClass using the index.
+		gateways := &gwtypes.GatewayList{}
+		err := cl.List(ctx, gateways, client.MatchingFields{
+			index.GatewayClassOnGatewayIndex: gc.Name,
+		})
+		if err != nil {
+			return nil
+		}
+
+		var requests []reconcile.Request
+		for _, gateway := range gateways.Items {
+			gwRequests, err := listHTTPRoutesForGateway(ctx, cl, gateway.Namespace, gateway.Name)
+			if err != nil {
+				return nil
+			}
+			requests = append(requests, gwRequests...)
+		}
+		return requests
+	}
+}

--- a/controller/hybridgateway/watch/mapfuncs_test.go
+++ b/controller/hybridgateway/watch/mapfuncs_test.go
@@ -1,0 +1,270 @@
+package watch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	gwtypes "github.com/kong/kong-operator/internal/types"
+	"github.com/kong/kong-operator/internal/utils/index"
+)
+
+// partialErrorClient simulates a client.Client that returns an error only when listing HTTPRoutes for a Gateway.
+type partialErrorClient struct {
+	client.Client
+	gateways *gwtypes.GatewayList
+}
+
+func (f *partialErrorClient) List(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
+	switch o := obj.(type) {
+	case *gwtypes.GatewayList:
+		*o = *f.gateways
+		return nil
+	case *gwtypes.HTTPRouteList:
+		return assert.AnError
+	default:
+		return nil
+	}
+}
+
+// fakeErrorClient simulates a client.Client that always returns an error on List.
+type fakeErrorClient struct {
+	client.Client
+}
+
+func (f *fakeErrorClient) List(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
+	return assert.AnError
+}
+
+func Test_listHTTPRoutesForGateway_table(t *testing.T) {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypes(
+		schema.GroupVersion{Group: gatewayv1.GroupVersion.Group, Version: gatewayv1.GroupVersion.Version},
+		&gwtypes.HTTPRoute{}, &gwtypes.Gateway{},
+	)
+	_ = gatewayv1.Install(scheme)
+
+	gateway := &gwtypes.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-ns",
+			Name:      "test-gw",
+		},
+		Spec: gwtypes.GatewaySpec{
+			GatewayClassName: "test-class",
+		},
+	}
+
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-ns",
+			Name:      "route-1",
+		},
+		Spec: gwtypes.HTTPRouteSpec{
+			CommonRouteSpec: gwtypes.CommonRouteSpec{
+				ParentRefs: []gwtypes.ParentReference{{
+					Name: gwtypes.ObjectName("test-gw"),
+				}},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gateway, httpRoute).
+		WithIndex(&gwtypes.HTTPRoute{}, index.GatewayOnHTTPRouteIndex, index.GatewaysOnHTTPRoute).
+		Build()
+
+	tests := []struct {
+		name      string
+		client    client.Client
+		wantErr   bool
+		wantCount int
+	}{
+		{
+			name:      "success",
+			client:    cl,
+			wantErr:   false,
+			wantCount: 1,
+		},
+		{
+			name:      "error branch",
+			client:    &fakeErrorClient{},
+			wantErr:   true,
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			requests, err := listHTTPRoutesForGateway(ctx, tt.client, "test-ns", "test-gw")
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Nil(t, requests)
+			} else {
+				require.NoError(t, err)
+				require.Len(t, requests, tt.wantCount)
+				if tt.wantCount > 0 {
+					require.Equal(t, "route-1", requests[0].Name)
+					require.Equal(t, "test-ns", requests[0].Namespace)
+				}
+			}
+		})
+	}
+}
+
+func Test_MapHTTPRouteForGateway(t *testing.T) {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypes(
+		schema.GroupVersion{Group: gatewayv1.GroupVersion.Group, Version: gatewayv1.GroupVersion.Version},
+		&gwtypes.HTTPRoute{}, &gwtypes.Gateway{},
+	)
+	_ = gatewayv1.Install(scheme)
+
+	gateway := &gwtypes.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-ns",
+			Name:      "test-gw",
+		},
+		Spec: gwtypes.GatewaySpec{
+			GatewayClassName: "test-class",
+		},
+	}
+
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-ns",
+			Name:      "route-1",
+		},
+		Spec: gwtypes.HTTPRouteSpec{
+			CommonRouteSpec: gwtypes.CommonRouteSpec{
+				ParentRefs: []gwtypes.ParentReference{{
+					Name: gwtypes.ObjectName("test-gw"),
+				}},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gateway, httpRoute).
+		WithIndex(&gwtypes.HTTPRoute{}, index.GatewayOnHTTPRouteIndex, index.GatewaysOnHTTPRoute).
+		Build()
+
+	mapFunc := MapHTTPRouteForGateway(cl)
+
+	t.Run("success", func(t *testing.T) {
+		ctx := context.Background()
+		obj := gateway
+		requests := mapFunc(ctx, obj)
+		require.Len(t, requests, 1)
+		require.Equal(t, "route-1", requests[0].Name)
+		require.Equal(t, "test-ns", requests[0].Namespace)
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		ctx := context.Background()
+		obj := &gwtypes.GatewayClass{}
+		requests := mapFunc(ctx, obj)
+		require.Nil(t, requests)
+	})
+
+	t.Run("error branch", func(t *testing.T) {
+		// Use a fake client that always errors.
+		errorMapFunc := MapHTTPRouteForGateway(&fakeErrorClient{})
+		ctx := context.Background()
+		obj := gateway
+		requests := errorMapFunc(ctx, obj)
+		require.Nil(t, requests)
+	})
+}
+
+func Test_MapHTTPRouteForGatewayClass(t *testing.T) {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypes(
+		schema.GroupVersion{Group: gatewayv1.GroupVersion.Group, Version: gatewayv1.GroupVersion.Version},
+		&gwtypes.HTTPRoute{}, &gwtypes.Gateway{}, &gwtypes.GatewayClass{},
+	)
+	_ = gatewayv1.Install(scheme)
+
+	gatewayClass := &gwtypes.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-class",
+		},
+	}
+
+	gateway := &gwtypes.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-ns",
+			Name:      "test-gw",
+		},
+		Spec: gwtypes.GatewaySpec{
+			GatewayClassName: "test-class",
+		},
+	}
+
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-ns",
+			Name:      "route-1",
+		},
+		Spec: gwtypes.HTTPRouteSpec{
+			CommonRouteSpec: gwtypes.CommonRouteSpec{
+				ParentRefs: []gwtypes.ParentReference{{
+					Name: gwtypes.ObjectName("test-gw"),
+				}},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gatewayClass, gateway, httpRoute).
+		WithIndex(&gwtypes.Gateway{}, index.GatewayClassOnGatewayIndex, index.GatewayClassOnGateway).
+		WithIndex(&gwtypes.HTTPRoute{}, index.GatewayOnHTTPRouteIndex, index.GatewaysOnHTTPRoute).
+		Build()
+
+	mapFunc := MapHTTPRouteForGatewayClass(cl)
+
+	t.Run("success", func(t *testing.T) {
+		ctx := context.Background()
+		obj := gatewayClass
+		requests := mapFunc(ctx, obj)
+		require.Len(t, requests, 1)
+		require.Equal(t, "route-1", requests[0].Name)
+		require.Equal(t, "test-ns", requests[0].Namespace)
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		ctx := context.Background()
+		obj := &gwtypes.Gateway{}
+		requests := mapFunc(ctx, obj)
+		require.Nil(t, requests)
+	})
+
+	t.Run("error branch - gatewayclass list", func(t *testing.T) {
+		errorMapFunc := MapHTTPRouteForGatewayClass(&fakeErrorClient{})
+		ctx := context.Background()
+		obj := gatewayClass
+		requests := errorMapFunc(ctx, obj)
+		require.Nil(t, requests)
+	})
+
+	t.Run("error branch - httproute list in loop", func(t *testing.T) {
+		gateways := &gwtypes.GatewayList{Items: []gwtypes.Gateway{*gateway}}
+		cl := &partialErrorClient{gateways: gateways}
+		errorMapFunc := MapHTTPRouteForGatewayClass(cl)
+		ctx := context.Background()
+		obj := gatewayClass
+		requests := errorMapFunc(ctx, obj)
+		require.Nil(t, requests)
+	})
+}

--- a/controller/hybridgateway/watch/watch.go
+++ b/controller/hybridgateway/watch/watch.go
@@ -1,0 +1,35 @@
+package watch
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+
+	gwtypes "github.com/kong/kong-operator/internal/types"
+)
+
+// Watcher defines a resource and a mapping function for controller-runtime watches.
+// It is used to specify which objects should be watched and how events on those objects
+// should be mapped to reconciliation requests for the parent resource.
+type Watcher struct {
+	Object client.Object
+	handler.MapFunc
+}
+
+// Watches returns a list of Watcher objects for the given resource type.
+func Watches(obj client.Object, cl client.Client) []Watcher {
+	switch obj.(type) {
+	case *gwtypes.HTTPRoute:
+		return []Watcher{
+			{
+				&gwtypes.Gateway{},
+				MapHTTPRouteForGateway(cl),
+			},
+			{
+				&gwtypes.GatewayClass{},
+				MapHTTPRouteForGatewayClass(cl),
+			},
+		}
+	default:
+		return nil
+	}
+}

--- a/controller/hybridgateway/watch/watch_test.go
+++ b/controller/hybridgateway/watch/watch_test.go
@@ -1,0 +1,52 @@
+package watch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gwtypes "github.com/kong/kong-operator/internal/types"
+)
+
+// fakeClient is a minimal stub for client.Client, not used for actual List calls here.
+type fakeClient struct{ client.Client }
+
+func TestWatches(t *testing.T) {
+	cl := &fakeClient{}
+	tests := []struct {
+		name     string
+		obj      client.Object
+		wantLen  int
+		wantType []any
+	}{
+		{
+			name:    "HTTPRoute",
+			obj:     &gwtypes.HTTPRoute{},
+			wantLen: 2,
+			wantType: []any{
+				&gwtypes.Gateway{},
+				&gwtypes.GatewayClass{},
+			},
+		},
+		{
+			name:    "OtherType",
+			obj:     &gwtypes.Gateway{},
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			watchers := Watches(tt.obj, cl)
+			if tt.wantLen == 0 {
+				require.Nil(t, watchers)
+			} else {
+				require.Len(t, watchers, tt.wantLen)
+				for i, want := range tt.wantType {
+					require.IsType(t, want, watchers[i].Object)
+				}
+			}
+		})
+	}
+}

--- a/internal/utils/index/gateway.go
+++ b/internal/utils/index/gateway.go
@@ -1,0 +1,35 @@
+package index
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gwtypes "github.com/kong/kong-operator/internal/types"
+)
+
+const (
+	// GatewayClassOnGatewayIndex is the name of the index that maps GatewayClass names to Gateways referencing them.
+	GatewayClassOnGatewayIndex = "GatewayClassOnGateway"
+)
+
+// OptionsForGateway returns a slice of Option configured for indexing Gateway objects by GatewayClass name.
+func OptionsForGateway() []Option {
+	return []Option{
+		{
+			Object:         &gwtypes.Gateway{},
+			Field:          GatewayClassOnGatewayIndex,
+			ExtractValueFn: GatewayClassOnGateway,
+		},
+	}
+}
+
+// GatewayClassOnGateway extracts and returns the GatewayClass name referenced by the given Gateway object.
+func GatewayClassOnGateway(o client.Object) []string {
+	gateway, ok := o.(*gwtypes.Gateway)
+	if !ok {
+		return nil
+	}
+	if gateway.Spec.GatewayClassName == "" {
+		return nil
+	}
+	return []string{string(gateway.Spec.GatewayClassName)}
+}

--- a/internal/utils/index/gateway_test.go
+++ b/internal/utils/index/gateway_test.go
@@ -1,0 +1,58 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gwtypes "github.com/kong/kong-operator/internal/types"
+)
+
+func TestOptionsForGateway(t *testing.T) {
+	options := OptionsForGateway()
+	require.Len(t, options, 1)
+	opt := options[0]
+	require.IsType(t, &gwtypes.Gateway{}, opt.Object)
+	require.Equal(t, GatewayClassOnGatewayIndex, opt.Field)
+	require.NotNil(t, opt.ExtractValueFn)
+}
+
+func TestGatewayClassOnGateway(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  client.Object
+		want []string
+	}{
+		{
+			name: "valid GatewayClassName",
+			obj: &gwtypes.Gateway{
+				Spec: gwtypes.GatewaySpec{
+					GatewayClassName: "my-class",
+				},
+			},
+			want: []string{"my-class"},
+		},
+		{
+			name: "empty GatewayClassName",
+			obj: &gwtypes.Gateway{
+				Spec: gwtypes.GatewaySpec{
+					GatewayClassName: "",
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "wrong type",
+			obj:  &gwtypes.HTTPRoute{},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GatewayClassOnGateway(tt.obj)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/utils/index/httproute.go
+++ b/internal/utils/index/httproute.go
@@ -11,6 +11,9 @@ const (
 	// BackendServicesOnHTTPRouteIndex is the name of the index that maps Services to HTTPRoutes
 	// referencing them in their backendRefs.
 	BackendServicesOnHTTPRouteIndex = "BackendServicesOnHTTPRoute"
+
+	// GatewayOnHTTPRouteIndex is the name of the index that maps Gateways to HTTPRoutes referencing them in their ParentRefs.
+	GatewayOnHTTPRouteIndex = "GatewayOnHTTPRoute"
 )
 
 // OptionsForHTTPRoute returns a slice of Option configured for indexing HTTPRoute objects.
@@ -21,6 +24,11 @@ func OptionsForHTTPRoute() []Option {
 			Object:         &gwtypes.HTTPRoute{},
 			Field:          BackendServicesOnHTTPRouteIndex,
 			ExtractValueFn: backendServicesOnHTTPRoute,
+		},
+		{
+			Object:         &gwtypes.HTTPRoute{},
+			Field:          GatewayOnHTTPRouteIndex,
+			ExtractValueFn: GatewaysOnHTTPRoute,
 		},
 	}
 }
@@ -58,4 +66,30 @@ func backendServicesOnHTTPRoute(o client.Object) []string {
 		}
 	}
 	return lo.Uniq(services)
+}
+
+// GatewaysOnHTTPRoute extracts and returns a list of unique Gateway references (in "namespace/name" format)
+// from the ParentRefs of the given HTTPRoute object.
+func GatewaysOnHTTPRoute(o client.Object) []string {
+	httpRoute, ok := o.(*gwtypes.HTTPRoute)
+	if !ok {
+		return nil
+	}
+
+	var gateways []string
+	for _, parentRef := range httpRoute.Spec.ParentRefs {
+		// Only consider ParentRefs that refer to Gateways
+		if parentRef.Group != nil && *parentRef.Group != "" && *parentRef.Group != "gateway.networking.k8s.io" {
+			continue
+		}
+		if parentRef.Kind != nil && *parentRef.Kind != "Gateway" {
+			continue
+		}
+		ns := httpRoute.Namespace
+		if parentRef.Namespace != nil {
+			ns = string(*parentRef.Namespace)
+		}
+		gateways = append(gateways, ns+"/"+string(parentRef.Name))
+	}
+	return lo.Uniq(gateways)
 }

--- a/internal/utils/index/httproute_test.go
+++ b/internal/utils/index/httproute_test.go
@@ -1,0 +1,129 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	gwtypes "github.com/kong/kong-operator/internal/types"
+)
+
+func TestGatewaysOnHTTPRoute(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  client.Object
+		want []string
+	}{
+		{
+			name: "single parentref, default ns",
+			obj: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
+				Spec: gwtypes.HTTPRouteSpec{
+					CommonRouteSpec: gwtypes.CommonRouteSpec{
+						ParentRefs: []gwtypes.ParentReference{
+							{
+								Name: "gw1",
+							},
+						},
+					},
+				},
+			},
+			want: []string{"ns1/gw1"},
+		},
+		{
+			name: "parentref with explicit ns",
+			obj: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
+				Spec: gwtypes.HTTPRouteSpec{
+					CommonRouteSpec: gwtypes.CommonRouteSpec{
+						ParentRefs: []gwtypes.ParentReference{
+							{
+								Name:      "gw2",
+								Namespace: ptrNamespace("ns2"),
+							},
+						},
+					},
+				},
+			},
+			want: []string{"ns2/gw2"},
+		},
+		{
+			name: "parentref with non-Gateway kind",
+			obj: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
+				Spec: gwtypes.HTTPRouteSpec{
+					CommonRouteSpec: gwtypes.CommonRouteSpec{
+						ParentRefs: []gwtypes.ParentReference{
+							{
+								Name: "gw3",
+								Kind: ptrKind("OtherKind"),
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "parentref with non-gateway group",
+			obj: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
+				Spec: gwtypes.HTTPRouteSpec{
+					CommonRouteSpec: gwtypes.CommonRouteSpec{
+						ParentRefs: []gwtypes.ParentReference{
+							{
+								Name:  "gw4",
+								Group: ptrGroup("other.group"),
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "multiple parentrefs, dedup",
+			obj: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
+				Spec: gwtypes.HTTPRouteSpec{
+					CommonRouteSpec: gwtypes.CommonRouteSpec{
+						ParentRefs: []gwtypes.ParentReference{
+							{Name: "gw1"},
+							{Name: "gw1"},
+							{Name: "gw2", Namespace: ptrNamespace("ns2")},
+						},
+					},
+				},
+			},
+			want: []string{"ns1/gw1", "ns2/gw2"},
+		},
+		{
+			name: "wrong type",
+			obj:  &gwtypes.Gateway{},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GatewaysOnHTTPRoute(tt.obj)
+			require.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+func ptrNamespace(s string) *gatewayv1.Namespace {
+	ns := gatewayv1.Namespace(s)
+	return &ns
+}
+func ptrKind(s string) *gatewayv1.Kind {
+	k := gatewayv1.Kind(s)
+	return &k
+}
+func ptrGroup(s string) *gatewayv1.Group {
+	g := gatewayv1.Group(s)
+	return &g
+}

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -128,6 +128,7 @@ func SetupCacheIndexes(ctx context.Context, mgr manager.Manager, cfg Config) err
 			index.OptionsForKonnectExtension(),
 			index.OptionsForKonnectCloudGatewayDataPlaneGroupConfiguration(cl),
 			index.OptionsForHTTPRoute(),
+			index.OptionsForGateway(),
 		)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Added controller-runtime watches for Gateway and GatewayClass resources in the hybridgateway controller.
- Ensures that changes to Gateway and GatewayClass trigger reconciliation of affected HTTPRoutes.
- Implemented MapFuncs and index logic to efficiently map Gateway/GatewayClass changes to HTTPRoute events.
- Added unit tests for new watch logic and index functions.

**Which issue this PR fixes**

Fixes #2418

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
