### PR TITLE
feat(konnect/crd): add the Match mode for adoption for Konnect cloud gateway…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,8 @@
   a Kubernetes custom resource for managing the existing entity by KO.
   - Add adoption options to the CRDs supporting adopting entities from Konnect.
     [#2336](https://github.com/Kong/kong-operator/pull/2336)
-  - Add `adopt.mode=match` to the CRDs.
+  - Add `adopt.mode` field to the CRDs that support adopting existing entities. Supported modes:
+    - `match`: read-only adoption. The operator adopts the referenced remote entity only when this CR's spec matches the remote configuration (no writes to the remote system). If they differ, adoption fails and the operator does not take ownership until the spec is aligned.
     [#2421](https://github.com/Kong/kong-operator/pull/2421)
 - HybridGateway:
   - Added controller-runtime watches for Gateway and GatewayClass resources to the hybridgateway controller.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@
   a Kubernetes custom resource for managing the existing entity by KO.
   - Add adoption options to the CRDs supporting adopting entities from Konnect.
     [#2336](https://github.com/Kong/kong-operator/pull/2336)
+  - Add `adopt.mode=match` to the CRDs.
+    [#2421](https://github.com/Kong/kong-operator/pull/2421)
 - HybridGateway:
   - Added controller-runtime watches for Gateway and GatewayClass resources to the hybridgateway controller.
   - HTTPRoutes are now reconciled when related Gateway or GatewayClass resources change.

--- a/api/common/v1alpha1/adopt_types.go
+++ b/api/common/v1alpha1/adopt_types.go
@@ -12,6 +12,11 @@ type AdoptOptions struct {
 	// +required
 	// +kubebuilder:validation:Enum=konnect
 	From AdoptSource `json:"from"`
+	// Mode defines the strategy to use when adopting an existing entity.
+	// When unset, "match" is assumed.
+	// +optional
+	// +kubebuilder:validation:Enum=match
+	Mode AdoptMode `json:"mode,omitempty"`
 	// Konnect is the options for adopting the entity from Konnect.
 	// Required when from == 'konnect'.
 	// +optional
@@ -24,6 +29,14 @@ type AdoptSource string
 const (
 	// AdoptSourceKonnect indicates that the entity is adopted from Konnect.
 	AdoptSourceKonnect AdoptSource = "konnect"
+)
+
+// AdoptMode is the strategy to use when adopting an existing entity.
+type AdoptMode string
+
+const (
+	// AdoptModeMatch ensures that the spec matches the configuration of the existing entity in Konnect.
+	AdoptModeMatch AdoptMode = "match"
 )
 
 // AdoptKonnectOptions specifies the options for adopting the entity from Konnect.

--- a/api/konnect/conditions.go
+++ b/api/konnect/conditions.go
@@ -43,6 +43,9 @@ const (
 	// KonnectEntitiesFailedToUpdateReason is the reason assigned to Konnect entities that failed to get updated.
 	// It must be used when Programmed condition is set to False.
 	KonnectEntitiesFailedToUpdateReason consts.ConditionReason = "FailedToUpdate"
+	// KonnectEntitiesFailedToAdoptReason is the reason assigned to Konnect entities that failed to get adopted.
+	// It must be used when Programmed condition is set to False.
+	KonnectEntitiesFailedToAdoptReason consts.ConditionReason = "FailedToAdopt"
 	// FailedToAttachConsumerToConsumerGroupReason is the reason assigned to KonnConsumers when failed to attach it to any consumer group.
 	// It must be used when Programmed condition is set to False.
 	FailedToAttachConsumerToConsumerGroupReason consts.ConditionReason = "FailedToAttachConsumerToConsumerGroup"

--- a/charts/kong-operator/charts/ko-crds/templates/ko-crds.yaml
+++ b/charts/kong-operator/charts/ko-crds/templates/ko-crds.yaml
@@ -46928,8 +46928,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47229,8 +47243,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47864,8 +47892,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -48193,8 +48235,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -48494,8 +48550,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -48732,8 +48802,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -48970,8 +49054,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49212,8 +49310,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49456,8 +49568,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -50172,8 +50298,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -50549,8 +50689,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51061,8 +51215,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52003,8 +52171,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52482,8 +52664,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52836,8 +53032,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -53073,8 +53283,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -54040,8 +54264,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -54589,8 +54827,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -55137,8 +55389,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -55650,8 +55916,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -55943,8 +56223,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/charts/kong-operator/charts/ko-crds/templates/ko-crds.yaml
+++ b/charts/kong-operator/charts/ko-crds/templates/ko-crds.yaml
@@ -46926,6 +46926,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47220,6 +47227,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47848,6 +47862,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -48170,6 +48191,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -48464,6 +48492,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -48695,6 +48730,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -48926,6 +48968,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49161,6 +49210,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49398,6 +49454,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -50107,6 +50170,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -50477,6 +50547,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -50982,6 +51059,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51917,6 +52001,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -52389,6 +52480,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -52736,6 +52834,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -52966,6 +53071,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -53926,6 +54038,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -54468,6 +54587,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -55009,6 +55135,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -55515,6 +55648,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -55801,6 +55941,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -44033,6 +44033,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44304,6 +44311,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44901,6 +44915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45200,6 +45221,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45470,6 +45498,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45689,6 +45724,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45908,6 +45950,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46131,6 +46180,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46356,6 +46412,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47021,6 +47084,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47364,6 +47434,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47838,6 +47915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -48719,6 +48803,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49118,6 +49209,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49431,6 +49529,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49647,6 +49752,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -50525,6 +50637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51009,6 +51128,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51511,6 +51637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51972,6 +52105,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -52232,6 +52372,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -44035,8 +44035,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44313,8 +44327,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44917,8 +44945,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45223,8 +45265,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45500,8 +45556,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45726,8 +45796,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45952,8 +46036,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46182,8 +46280,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46414,8 +46526,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47086,8 +47212,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47436,8 +47576,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47917,8 +48071,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -48805,8 +48973,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49211,8 +49393,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49531,8 +49727,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49754,8 +49964,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -50639,8 +50863,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51130,8 +51368,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51639,8 +51891,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52107,8 +52373,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52374,8 +52654,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -44033,6 +44033,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44304,6 +44311,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44901,6 +44915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45200,6 +45221,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45470,6 +45498,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45689,6 +45724,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45908,6 +45950,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46131,6 +46180,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46356,6 +46412,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47021,6 +47084,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47364,6 +47434,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47838,6 +47915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -48719,6 +48803,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49118,6 +49209,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49431,6 +49529,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49647,6 +49752,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -50525,6 +50637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51009,6 +51128,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51511,6 +51637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51972,6 +52105,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -52232,6 +52372,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -44035,8 +44035,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44313,8 +44327,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44917,8 +44945,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45223,8 +45265,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45500,8 +45556,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45726,8 +45796,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45952,8 +46036,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46182,8 +46280,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46414,8 +46526,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47086,8 +47212,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47436,8 +47576,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47917,8 +48071,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -48805,8 +48973,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49211,8 +49393,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49531,8 +49727,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49754,8 +49964,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -50639,8 +50863,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51130,8 +51368,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51639,8 +51891,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52107,8 +52373,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52374,8 +52654,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -44033,6 +44033,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44304,6 +44311,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44901,6 +44915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45200,6 +45221,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45470,6 +45498,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45689,6 +45724,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45908,6 +45950,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46131,6 +46180,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46356,6 +46412,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47021,6 +47084,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47364,6 +47434,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47838,6 +47915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -48719,6 +48803,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49118,6 +49209,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49431,6 +49529,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49647,6 +49752,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -50525,6 +50637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51009,6 +51128,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51511,6 +51637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51972,6 +52105,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -52232,6 +52372,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -44035,8 +44035,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44313,8 +44327,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44917,8 +44945,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45223,8 +45265,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45500,8 +45556,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45726,8 +45796,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45952,8 +46036,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46182,8 +46280,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46414,8 +46526,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47086,8 +47212,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47436,8 +47576,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47917,8 +48071,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -48805,8 +48973,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49211,8 +49393,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49531,8 +49727,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49754,8 +49964,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -50639,8 +50863,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51130,8 +51368,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51639,8 +51891,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52107,8 +52373,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52374,8 +52654,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -44033,6 +44033,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44304,6 +44311,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44901,6 +44915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45200,6 +45221,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45470,6 +45498,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45689,6 +45724,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45908,6 +45950,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46131,6 +46180,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46356,6 +46412,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47021,6 +47084,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47364,6 +47434,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47838,6 +47915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -48719,6 +48803,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49118,6 +49209,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49431,6 +49529,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49647,6 +49752,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -50525,6 +50637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51009,6 +51128,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51511,6 +51637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51972,6 +52105,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -52232,6 +52372,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -44035,8 +44035,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44313,8 +44327,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44917,8 +44945,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45223,8 +45265,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45500,8 +45556,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45726,8 +45796,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45952,8 +46036,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46182,8 +46280,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46414,8 +46526,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47086,8 +47212,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47436,8 +47576,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47917,8 +48071,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -48805,8 +48973,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49211,8 +49393,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49531,8 +49727,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49754,8 +49964,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -50639,8 +50863,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51130,8 +51368,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51639,8 +51891,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52107,8 +52373,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52374,8 +52654,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -44033,6 +44033,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44304,6 +44311,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44901,6 +44915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45200,6 +45221,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45470,6 +45498,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45689,6 +45724,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45908,6 +45950,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46131,6 +46180,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46356,6 +46412,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47021,6 +47084,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47364,6 +47434,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47838,6 +47915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -48719,6 +48803,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49118,6 +49209,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49431,6 +49529,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49647,6 +49752,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -50525,6 +50637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51009,6 +51128,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51511,6 +51637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51972,6 +52105,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -52232,6 +52372,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -44035,8 +44035,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44313,8 +44327,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44917,8 +44945,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45223,8 +45265,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45500,8 +45556,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45726,8 +45796,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45952,8 +46036,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46182,8 +46280,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46414,8 +46526,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47086,8 +47212,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47436,8 +47576,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47917,8 +48071,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -48805,8 +48973,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49211,8 +49393,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49531,8 +49727,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49754,8 +49964,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -50639,8 +50863,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51130,8 +51368,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51639,8 +51891,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52107,8 +52373,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52374,8 +52654,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -44034,6 +44034,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44305,6 +44312,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44902,6 +44916,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45201,6 +45222,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45471,6 +45499,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45690,6 +45725,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45909,6 +45951,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46132,6 +46181,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46357,6 +46413,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47022,6 +47085,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47365,6 +47435,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47839,6 +47916,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -48720,6 +48804,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49119,6 +49210,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49432,6 +49530,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49648,6 +49753,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -50526,6 +50638,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51010,6 +51129,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51512,6 +51638,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51973,6 +52106,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -52233,6 +52373,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -44036,8 +44036,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44314,8 +44328,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44918,8 +44946,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45224,8 +45266,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45501,8 +45557,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45727,8 +45797,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45953,8 +46037,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46183,8 +46281,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46415,8 +46527,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47087,8 +47213,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47437,8 +47577,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47918,8 +48072,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -48806,8 +48974,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49212,8 +49394,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49532,8 +49728,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49755,8 +49965,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -50640,8 +50864,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51131,8 +51369,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51640,8 +51892,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52108,8 +52374,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52375,8 +52655,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -44033,6 +44033,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44304,6 +44311,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44901,6 +44915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45200,6 +45221,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45470,6 +45498,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45689,6 +45724,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45908,6 +45950,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46131,6 +46180,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46356,6 +46412,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47021,6 +47084,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47364,6 +47434,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47838,6 +47915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -48719,6 +48803,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49118,6 +49209,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49431,6 +49529,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49647,6 +49752,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -50525,6 +50637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51009,6 +51128,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51511,6 +51637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51972,6 +52105,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -52232,6 +52372,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -44035,8 +44035,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44313,8 +44327,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44917,8 +44945,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45223,8 +45265,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45500,8 +45556,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45726,8 +45796,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45952,8 +46036,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46182,8 +46280,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46414,8 +46526,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47086,8 +47212,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47436,8 +47576,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47917,8 +48071,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -48805,8 +48973,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49211,8 +49393,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49531,8 +49727,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49754,8 +49964,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -50639,8 +50863,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51130,8 +51368,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51639,8 +51891,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52107,8 +52373,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52374,8 +52654,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -44033,6 +44033,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44304,6 +44311,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44901,6 +44915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45200,6 +45221,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45470,6 +45498,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45689,6 +45724,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45908,6 +45950,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46131,6 +46180,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46356,6 +46412,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47021,6 +47084,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47364,6 +47434,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47838,6 +47915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -48719,6 +48803,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49118,6 +49209,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49431,6 +49529,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49647,6 +49752,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -50525,6 +50637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51009,6 +51128,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51511,6 +51637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51972,6 +52105,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -52232,6 +52372,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -44035,8 +44035,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44313,8 +44327,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44917,8 +44945,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45223,8 +45265,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45500,8 +45556,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45726,8 +45796,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45952,8 +46036,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46182,8 +46280,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46414,8 +46526,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47086,8 +47212,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47436,8 +47576,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47917,8 +48071,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -48805,8 +48973,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49211,8 +49393,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49531,8 +49727,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49754,8 +49964,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -50639,8 +50863,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51130,8 +51368,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51639,8 +51891,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52107,8 +52373,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52374,8 +52654,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -44033,6 +44033,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44304,6 +44311,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44901,6 +44915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45200,6 +45221,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45470,6 +45498,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45689,6 +45724,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45908,6 +45950,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46131,6 +46180,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46356,6 +46412,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47021,6 +47084,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47364,6 +47434,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47838,6 +47915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -48719,6 +48803,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49118,6 +49209,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49431,6 +49529,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49647,6 +49752,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -50525,6 +50637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51009,6 +51128,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51511,6 +51637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51972,6 +52105,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -52232,6 +52372,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -44035,8 +44035,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44313,8 +44327,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44917,8 +44945,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45223,8 +45265,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45500,8 +45556,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45726,8 +45796,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45952,8 +46036,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46182,8 +46280,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46414,8 +46526,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47086,8 +47212,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47436,8 +47576,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47917,8 +48071,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -48805,8 +48973,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49211,8 +49393,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49531,8 +49727,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49754,8 +49964,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -50639,8 +50863,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51130,8 +51368,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51639,8 +51891,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52107,8 +52373,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52374,8 +52654,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -44033,6 +44033,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44304,6 +44311,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44901,6 +44915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45200,6 +45221,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45470,6 +45498,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45689,6 +45724,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45908,6 +45950,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46131,6 +46180,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46356,6 +46412,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47021,6 +47084,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47364,6 +47434,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47838,6 +47915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -48719,6 +48803,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49118,6 +49209,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49431,6 +49529,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49647,6 +49752,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -50525,6 +50637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51009,6 +51128,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51511,6 +51637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51972,6 +52105,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -52232,6 +52372,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -44035,8 +44035,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44313,8 +44327,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44917,8 +44945,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45223,8 +45265,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45500,8 +45556,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45726,8 +45796,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45952,8 +46036,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46182,8 +46280,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46414,8 +46526,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47086,8 +47212,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47436,8 +47576,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47917,8 +48071,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -48805,8 +48973,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49211,8 +49393,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49531,8 +49727,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49754,8 +49964,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -50639,8 +50863,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51130,8 +51368,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51639,8 +51891,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52107,8 +52373,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52374,8 +52654,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -44033,6 +44033,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44304,6 +44311,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44901,6 +44915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45200,6 +45221,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45470,6 +45498,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45689,6 +45724,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45908,6 +45950,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46131,6 +46180,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46356,6 +46412,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47021,6 +47084,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47364,6 +47434,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47838,6 +47915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -48719,6 +48803,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49118,6 +49209,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49431,6 +49529,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49647,6 +49752,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -50525,6 +50637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51009,6 +51128,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51511,6 +51637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51972,6 +52105,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -52232,6 +52372,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -44035,8 +44035,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44313,8 +44327,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44917,8 +44945,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45223,8 +45265,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45500,8 +45556,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45726,8 +45796,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45952,8 +46036,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46182,8 +46280,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46414,8 +46526,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47086,8 +47212,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47436,8 +47576,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47917,8 +48071,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -48805,8 +48973,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49211,8 +49393,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49531,8 +49727,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49754,8 +49964,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -50639,8 +50863,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51130,8 +51368,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51639,8 +51891,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52107,8 +52373,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52374,8 +52654,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -44033,6 +44033,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44304,6 +44311,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44901,6 +44915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45200,6 +45221,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45470,6 +45498,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45689,6 +45724,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45908,6 +45950,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46131,6 +46180,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46356,6 +46412,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47021,6 +47084,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47364,6 +47434,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47838,6 +47915,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -48719,6 +48803,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49118,6 +49209,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49431,6 +49529,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49647,6 +49752,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -50525,6 +50637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51009,6 +51128,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51511,6 +51637,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51972,6 +52105,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -52232,6 +52372,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -44035,8 +44035,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44313,8 +44327,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44917,8 +44945,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45223,8 +45265,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45500,8 +45556,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45726,8 +45796,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45952,8 +46036,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46182,8 +46280,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46414,8 +46526,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47086,8 +47212,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47436,8 +47576,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47917,8 +48071,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -48805,8 +48973,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49211,8 +49393,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49531,8 +49727,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49754,8 +49964,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -50639,8 +50863,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51130,8 +51368,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51639,8 +51891,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52107,8 +52373,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52374,8 +52654,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -19523,6 +19523,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -19794,6 +19801,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -20391,6 +20405,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -20690,6 +20711,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -20960,6 +20988,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -21179,6 +21214,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -21398,6 +21440,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -21621,6 +21670,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -21846,6 +21902,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -22511,6 +22574,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -22854,6 +22924,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -23328,6 +23405,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -24209,6 +24293,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -24608,6 +24699,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -24921,6 +25019,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -25137,6 +25242,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -26015,6 +26127,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -26499,6 +26618,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -27001,6 +27127,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -27462,6 +27595,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -27722,6 +27862,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -19525,8 +19525,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -19803,8 +19817,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -20407,8 +20435,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -20713,8 +20755,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -20990,8 +21046,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -21216,8 +21286,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -21442,8 +21526,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -21672,8 +21770,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -21904,8 +22016,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -22576,8 +22702,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -22926,8 +23066,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -23407,8 +23561,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -24295,8 +24463,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -24701,8 +24883,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -25021,8 +25217,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -25244,8 +25454,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -26129,8 +26353,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -26620,8 +26858,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -27129,8 +27381,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -27597,8 +27863,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -27864,8 +28144,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -43983,6 +43983,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44254,6 +44261,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -44851,6 +44865,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45150,6 +45171,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45420,6 +45448,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45639,6 +45674,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -45858,6 +45900,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46081,6 +46130,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46306,6 +46362,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -46971,6 +47034,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47314,6 +47384,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -47788,6 +47865,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -48669,6 +48753,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49068,6 +49159,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49381,6 +49479,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -49597,6 +49702,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -50475,6 +50587,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -50959,6 +51078,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51461,6 +51587,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -51922,6 +52055,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -52182,6 +52322,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -43985,8 +43985,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44263,8 +44277,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -44867,8 +44895,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45173,8 +45215,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45450,8 +45506,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45676,8 +45746,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -45902,8 +45986,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46132,8 +46230,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -46364,8 +46476,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47036,8 +47162,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47386,8 +47526,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -47867,8 +48021,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -48755,8 +48923,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49161,8 +49343,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49481,8 +49677,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -49704,8 +49914,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -50589,8 +50813,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51080,8 +51318,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -51589,8 +51841,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52057,8 +52323,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -52324,8 +52604,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -19498,6 +19498,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -19769,6 +19776,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -20366,6 +20380,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -20665,6 +20686,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -20935,6 +20963,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -21154,6 +21189,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -21373,6 +21415,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -21596,6 +21645,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -21821,6 +21877,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -22486,6 +22549,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -22829,6 +22899,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -23303,6 +23380,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -24184,6 +24268,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -24583,6 +24674,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -24896,6 +24994,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -25112,6 +25217,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -25990,6 +26102,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -26474,6 +26593,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -26976,6 +27102,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -27437,6 +27570,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object
@@ -27697,6 +27837,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -19500,8 +19500,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -19778,8 +19792,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -20382,8 +20410,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -20688,8 +20730,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -20965,8 +21021,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -21191,8 +21261,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -21417,8 +21501,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -21647,8 +21745,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -21879,8 +21991,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -22551,8 +22677,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -22901,8 +23041,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -23382,8 +23536,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -24270,8 +24438,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -24676,8 +24858,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -24996,8 +25192,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -25219,8 +25429,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -26104,8 +26328,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -26595,8 +26833,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -27104,8 +27356,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -27572,8 +27838,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string
@@ -27839,8 +28119,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/configuration.konghq.com_kongcacertificates.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcacertificates.yaml
@@ -74,8 +74,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/configuration.konghq.com_kongcacertificates.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcacertificates.yaml
@@ -72,6 +72,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/configuration.konghq.com_kongcertificates.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcertificates.yaml
@@ -73,8 +73,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/configuration.konghq.com_kongcertificates.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcertificates.yaml
@@ -71,6 +71,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/configuration.konghq.com_kongconsumergroups.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongconsumergroups.yaml
@@ -76,6 +76,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/configuration.konghq.com_kongconsumergroups.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongconsumergroups.yaml
@@ -78,8 +78,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongconsumers.yaml
@@ -103,8 +103,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongconsumers.yaml
@@ -101,6 +101,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/configuration.konghq.com_kongcredentialacls.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcredentialacls.yaml
@@ -73,8 +73,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/configuration.konghq.com_kongcredentialacls.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcredentialacls.yaml
@@ -71,6 +71,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/configuration.konghq.com_kongcredentialapikeys.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcredentialapikeys.yaml
@@ -73,8 +73,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/configuration.konghq.com_kongcredentialapikeys.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcredentialapikeys.yaml
@@ -71,6 +71,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/configuration.konghq.com_kongcredentialbasicauths.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcredentialbasicauths.yaml
@@ -73,8 +73,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/configuration.konghq.com_kongcredentialbasicauths.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcredentialbasicauths.yaml
@@ -71,6 +71,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/configuration.konghq.com_kongcredentialhmacs.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcredentialhmacs.yaml
@@ -73,8 +73,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/configuration.konghq.com_kongcredentialhmacs.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcredentialhmacs.yaml
@@ -71,6 +71,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/configuration.konghq.com_kongcredentialjwts.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcredentialjwts.yaml
@@ -73,8 +73,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/configuration.konghq.com_kongcredentialjwts.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcredentialjwts.yaml
@@ -71,6 +71,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/configuration.konghq.com_kongkeys.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongkeys.yaml
@@ -73,8 +73,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/configuration.konghq.com_kongkeys.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongkeys.yaml
@@ -71,6 +71,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/configuration.konghq.com_kongkeysets.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongkeysets.yaml
@@ -73,8 +73,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/configuration.konghq.com_kongkeysets.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongkeysets.yaml
@@ -71,6 +71,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/configuration.konghq.com_kongpluginbindings.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongpluginbindings.yaml
@@ -79,6 +79,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/configuration.konghq.com_kongpluginbindings.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongpluginbindings.yaml
@@ -81,8 +81,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/configuration.konghq.com_kongroutes.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongroutes.yaml
@@ -70,6 +70,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/configuration.konghq.com_kongroutes.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongroutes.yaml
@@ -72,8 +72,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/configuration.konghq.com_kongservices.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongservices.yaml
@@ -79,6 +79,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/configuration.konghq.com_kongservices.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongservices.yaml
@@ -81,8 +81,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/configuration.konghq.com_kongsnis.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongsnis.yaml
@@ -70,6 +70,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/configuration.konghq.com_kongsnis.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongsnis.yaml
@@ -72,8 +72,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/configuration.konghq.com_kongtargets.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongtargets.yaml
@@ -73,8 +73,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/configuration.konghq.com_kongtargets.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongtargets.yaml
@@ -71,6 +71,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/configuration.konghq.com_kongupstreams.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongupstreams.yaml
@@ -73,8 +73,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/configuration.konghq.com_kongupstreams.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongupstreams.yaml
@@ -71,6 +71,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/configuration.konghq.com_kongvaults.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongvaults.yaml
@@ -94,8 +94,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/configuration.konghq.com_kongvaults.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongvaults.yaml
@@ -92,6 +92,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaydataplanegroupconfigurations.yaml
+++ b/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaydataplanegroupconfigurations.yaml
@@ -91,8 +91,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaydataplanegroupconfigurations.yaml
+++ b/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaydataplanegroupconfigurations.yaml
@@ -89,6 +89,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaynetworks.yaml
+++ b/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaynetworks.yaml
@@ -86,8 +86,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaynetworks.yaml
+++ b/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaynetworks.yaml
@@ -84,6 +84,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object

--- a/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaytransitgateways.yaml
+++ b/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaytransitgateways.yaml
@@ -90,8 +90,22 @@ spec:
                     type: object
                   mode:
                     description: |-
-                      Mode defines the strategy to use when adopting an existing entity.
-                      When unset, "match" is assumed.
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      Default: when unset, "match" is assumed.
                     enum:
                     - match
                     type: string

--- a/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaytransitgateways.yaml
+++ b/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaytransitgateways.yaml
@@ -88,6 +88,13 @@ spec:
                     required:
                     - id
                     type: object
+                  mode:
+                    description: |-
+                      Mode defines the strategy to use when adopting an existing entity.
+                      When unset, "match" is assumed.
+                    enum:
+                    - match
+                    type: string
                 required:
                 - from
                 type: object


### PR DESCRIPTION
… entities

**What this PR does / why we need it**:

Add `adopt.mode=match` to CRDs

**Which issue this PR fixes**

part of https://github.com/Kong/kong-operator/issues/2116

**Special notes for your reviewer**:

About the comment from https://github.com/Kong/kong-operator/pull/2336#discussion_r2387337742
I use the `adopt.mode` instead of `OnImmutable`, I think it can be more flexible.


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
