### PR TITLE
feat(hybridgateway): add Owns function and unit tests for HTTPRoute ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@
   enforcement and translation logic.
   This enables more robust troubleshooting and visibility for users, ensuring HTTPRoute status accurately reflects
   the readiness and configuration of all associated Kong resources.
-  [2400](https://github.com/Kong/kong-operator/pull/2400)
+  [#2400](https://github.com/Kong/kong-operator/pull/2400)
 - ManagedFields: improve pruning of empty fields in unstructured objects
   - Enhance pruneEmptyFields to recursively remove empty maps from slices and maps, including those that become empty after nested pruning.
   - Update logic to remove empty slices and zero-value fields more robustly.
@@ -82,7 +82,7 @@
     - Handling of mixed-type slices
     - Deeply nested pruning scenarios
     - Preservation of non-map elements in slices
-  [2413](https://github.com/Kong/kong-operator/pull/2413)
+  [#2413](https://github.com/Kong/kong-operator/pull/2413)
 - Entity Adoption support: support adopting an existing entity from Konnect to
   a Kubernetes custom resource for managing the existing entity by KO.
   - Add adoption options to the CRDs supporting adopting entities from Konnect.
@@ -121,6 +121,8 @@
 - Fix issue with deletion of `KonnectExtension` when the referenced
   `KonnectGatewayControlPlane` is deleted (it used to hang indefinitely).
   [#2423](https://github.com/Kong/kong-operator/pull/2423)
+- Hybrid Gateway: add watchers for KongPlugin and KongPluginBinding
+  [#2427](https://github.com/Kong/kong-operator/pull/2427)
 
 ## [v2.0.4]
 

--- a/controller/hybridgateway/watch/own.go
+++ b/controller/hybridgateway/watch/own.go
@@ -3,6 +3,7 @@ package watch
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	configurationv1 "github.com/kong/kong-operator/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
 	gwtypes "github.com/kong/kong-operator/internal/types"
 )
@@ -17,6 +18,8 @@ func Owns(obj client.Object) []client.Object {
 			&configurationv1alpha1.KongService{},
 			&configurationv1alpha1.KongUpstream{},
 			&configurationv1alpha1.KongTarget{},
+			&configurationv1alpha1.KongPluginBinding{},
+			&configurationv1.KongPlugin{},
 		}
 	default:
 		return nil

--- a/controller/hybridgateway/watch/own_test.go
+++ b/controller/hybridgateway/watch/own_test.go
@@ -1,0 +1,54 @@
+package watch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configurationv1 "github.com/kong/kong-operator/api/configuration/v1"
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	gwtypes "github.com/kong/kong-operator/internal/types"
+)
+
+func TestOwns(t *testing.T) {
+	tests := []struct {
+		name    string
+		obj     client.Object
+		wantLen int
+		want    []any
+	}{
+		{
+			name:    "HTTPRoute",
+			obj:     &gwtypes.HTTPRoute{},
+			wantLen: 6,
+			want: []any{
+				&configurationv1alpha1.KongRoute{},
+				&configurationv1alpha1.KongService{},
+				&configurationv1alpha1.KongUpstream{},
+				&configurationv1alpha1.KongTarget{},
+				&configurationv1alpha1.KongPluginBinding{},
+				&configurationv1.KongPlugin{},
+			},
+		},
+		{
+			name:    "OtherType",
+			obj:     &gwtypes.Gateway{},
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owned := Owns(tt.obj)
+			if tt.wantLen == 0 {
+				require.Nil(t, owned)
+			} else {
+				require.Len(t, owned, tt.wantLen)
+				for i, want := range tt.want {
+					require.IsType(t, want, owned[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Implement the Owns function to return owned Kong configuration objects for HTTPRoute. Add table-driven unit tests to verify ownership mapping and type coverage.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
