### PR TITLE
test(dataplane): Unit and integration tests for dataplane

### DIFF
--- a/controller/dataplane/owned_deployment_test.go
+++ b/controller/dataplane/owned_deployment_test.go
@@ -1,0 +1,744 @@
+package dataplane
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	operatorv1beta1 "github.com/kong/kong-operator/api/gateway-operator/v1beta1"
+	"github.com/kong/kong-operator/pkg/consts"
+	k8sresources "github.com/kong/kong-operator/pkg/utils/kubernetes/resources"
+)
+
+func TestNewDeploymentBuilder(t *testing.T) {
+	logger := logr.Discard()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, operatorv1beta1.AddToScheme(scheme))
+
+	fakeClient := fakectrlruntimeclient.
+		NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	builder := NewDeploymentBuilder(logger, fakeClient)
+	assert.NotNil(t, builder)
+	assert.Equal(t, logger, builder.logger)
+	assert.Equal(t, fakeClient, builder.client)
+}
+
+func TestDeploymentBuilderWithOptions(t *testing.T) {
+	logger := logr.Discard()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, operatorv1beta1.AddToScheme(scheme))
+
+	dataplane := &operatorv1beta1.DataPlane{}
+	dataplane.Status.Selector = "test-selector"
+
+	fakeClient := fakectrlruntimeclient.
+		NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	builder := NewDeploymentBuilder(logger, fakeClient)
+
+	// Test WithClusterCertificate
+	certName := "test-cert"
+	builder = builder.WithClusterCertificate(certName)
+	assert.Equal(t, certName, builder.clusterCertificateName)
+
+	// Test WithAdditionalLabels
+	labels := client.MatchingLabels{"test": "label"}
+	builder = builder.WithAdditionalLabels(labels)
+	assert.Equal(t, labels, builder.additionalLabels)
+
+	// Test WithDefaultImage
+	image := "test-image:latest"
+	builder = builder.WithDefaultImage(image)
+	assert.Equal(t, image, builder.defaultImage)
+
+	// Test WithSecretLabelSelector
+	selector := "test-selector"
+	builder = builder.WithSecretLabelSelector(selector)
+	assert.Equal(t, selector, builder.secretLabelSelector)
+
+	// Test WithOpts
+	opts := []k8sresources.DeploymentOpt{
+		labelSelectorFromDataPlaneStatusSelectorDeploymentOpt(dataplane),
+	}
+	builder = builder.WithOpts(opts...)
+	assert.Equal(t, opts, builder.opts)
+}
+
+func TestDeploymentBuilder_BuildAndDeploy(t *testing.T) {
+	type dataplaneGenParams struct {
+		image   string
+		volumes []corev1.Volume
+	}
+	// Helper to generate a DataPlane with specified image and volumes
+	dataplaneGen := func(params dataplaneGenParams) *operatorv1beta1.DataPlane {
+		return &operatorv1beta1.DataPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-dataplane",
+				Namespace: "default",
+				UID:       "test-uid",
+			},
+			Spec: operatorv1beta1.DataPlaneSpec{
+				DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+					Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+						DeploymentOptions: operatorv1beta1.DeploymentOptions{
+							PodTemplateSpec: &corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name:  consts.DataPlaneProxyContainerName,
+											Image: params.image,
+										},
+									},
+									Volumes: params.volumes,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+	testCases := []struct {
+		name                   string
+		dataplane              *operatorv1beta1.DataPlane
+		enforceConfig          bool
+		validateDataPlaneImage bool
+		expectError            bool
+	}{
+		{
+			name: "custom image fails validation",
+			dataplane: dataplaneGen(
+				dataplaneGenParams{
+					image: "custom-kong:2.8",
+				},
+			),
+			enforceConfig:          true,
+			validateDataPlaneImage: true,
+			expectError:            true,
+		},
+		{
+			name: "custom image passes validation",
+			dataplane: dataplaneGen(
+				dataplaneGenParams{
+					image: "custom-kong:2.8",
+				},
+			),
+			enforceConfig:          true,
+			validateDataPlaneImage: false,
+			expectError:            false,
+		},
+		{
+			name: "kong image succeeds validation",
+			dataplane: dataplaneGen(
+				dataplaneGenParams{
+					image: "kong/kong-gateway:3.11",
+				},
+			),
+			enforceConfig:          true,
+			validateDataPlaneImage: true,
+			expectError:            false,
+		},
+		{
+			name: "custom volume succeeds",
+			dataplane: dataplaneGen(
+				dataplaneGenParams{
+					image: "kong/kong-gateway:3.11",
+					volumes: []corev1.Volume{
+						{
+							Name: "custom-volume",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									Medium: corev1.StorageMediumMemory,
+								},
+							},
+						},
+					},
+				},
+			),
+			enforceConfig:          true,
+			validateDataPlaneImage: true,
+			expectError:            false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := logr.Discard()
+			scheme := runtime.NewScheme()
+			require.NoError(t, corev1.AddToScheme(scheme))
+			require.NoError(t, appsv1.AddToScheme(scheme))
+			require.NoError(t, operatorv1beta1.AddToScheme(scheme))
+
+			fakeClient := fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tc.dataplane).
+				Build()
+
+			builder := NewDeploymentBuilder(logger, fakeClient).
+				WithDefaultImage("kong:3.0").
+				WithClusterCertificate("test-cert").
+				WithAdditionalLabels(map[string]string{"app": "test"}).
+				WithSecretLabelSelector("test-selector").
+				WithOpts(
+					labelSelectorFromDataPlaneStatusSelectorDeploymentOpt(tc.dataplane),
+				)
+
+			deployment, res, err := builder.BuildAndDeploy(t.Context(), tc.dataplane, tc.enforceConfig, tc.validateDataPlaneImage)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.NotNil(t, deployment)
+			assert.NotNil(t, res)
+
+			// Verify deployment exists in fake client
+			var fetchedDeployment appsv1.Deployment
+			err = fakeClient.Get(t.Context(), client.ObjectKey{
+				Name:      deployment.Name,
+				Namespace: deployment.Namespace,
+			}, &fetchedDeployment)
+			require.NoError(t, err)
+			assert.Equal(t, deployment.Name, fetchedDeployment.Name)
+			assert.Equal(t, deployment.Namespace, fetchedDeployment.Namespace)
+		})
+	}
+}
+
+func TestGenerateDataPlaneDeployment(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		dataplane              *operatorv1beta1.DataPlane
+		defaultImage           string
+		validateDataPlaneImage bool
+		additionalLabels       map[string]string
+		expectError            bool
+		expectedImage          string
+	}{
+		{
+			name: "default image is used when not specified in dataplane",
+			dataplane: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-dataplane",
+					Namespace: "default",
+					UID:       "test-uid",
+				},
+				Spec: operatorv1beta1.DataPlaneSpec{
+					DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+						Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+							DeploymentOptions: operatorv1beta1.DeploymentOptions{
+								PodTemplateSpec: &corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										Containers: []corev1.Container{
+											{
+												Name: consts.DataPlaneProxyContainerName,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			defaultImage:           "kong:3.0",
+			validateDataPlaneImage: false,
+			additionalLabels:       map[string]string{"app": "test"},
+			expectError:            false,
+			expectedImage:          "kong:3.0",
+		},
+		{
+			name: "dataplane image is used when specified",
+			dataplane: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-dataplane",
+					Namespace: "default",
+					UID:       "test-uid",
+				},
+				Spec: operatorv1beta1.DataPlaneSpec{
+					DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+						Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+							DeploymentOptions: operatorv1beta1.DeploymentOptions{
+								PodTemplateSpec: &corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										Containers: []corev1.Container{
+											{
+												Name:  consts.DataPlaneProxyContainerName,
+												Image: "custom-kong:2.8",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			defaultImage:           "kong:3.0",
+			validateDataPlaneImage: false,
+			additionalLabels:       map[string]string{"app": "test"},
+			expectError:            false,
+			expectedImage:          "custom-kong:2.8",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			additionalLabels := map[string]string{}
+			for k, v := range tc.additionalLabels {
+				additionalLabels[k] = v
+			}
+
+			deployment, err := generateDataPlaneDeployment(tc.validateDataPlaneImage, tc.dataplane, tc.defaultImage, additionalLabels)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.NotNil(t, deployment)
+
+			// Check if labels were applied correctly
+			for k, v := range tc.additionalLabels {
+				assert.Equal(t, v, deployment.Labels[k])
+			}
+
+			// Find the proxy container and check its image
+			var proxyContainer *corev1.Container
+			for i, container := range deployment.Spec.Template.Spec.Containers {
+				if container.Name == consts.DataPlaneProxyContainerName {
+					proxyContainer = &deployment.Spec.Template.Spec.Containers[i]
+					break
+				}
+			}
+
+			require.NotNil(t, proxyContainer, "Proxy container not found")
+			assert.Equal(t, tc.expectedImage, proxyContainer.Image)
+		})
+	}
+}
+
+func TestApplyDeploymentUserPatchesForDataPlane(t *testing.T) {
+	testCases := []struct {
+		name           string
+		dataplane      *operatorv1beta1.DataPlane
+		deployment     *k8sresources.Deployment
+		expectError    bool
+		expectedEnvVar string
+		expectedValue  string
+	}{
+		{
+			name: "user patch is applied correctly",
+			dataplane: &operatorv1beta1.DataPlane{
+				Spec: operatorv1beta1.DataPlaneSpec{
+					DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+						Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+							DeploymentOptions: operatorv1beta1.DeploymentOptions{
+								PodTemplateSpec: &corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										Containers: []corev1.Container{
+											{
+												Name: consts.DataPlaneProxyContainerName,
+												Env: []corev1.EnvVar{
+													{
+														Name:  "TEST_VAR",
+														Value: "test-value",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			deployment: &k8sresources.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: consts.DataPlaneProxyContainerName,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError:    false,
+			expectedEnvVar: "TEST_VAR",
+			expectedValue:  "test-value",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := applyDeploymentUserPatchesForDataPlane(tc.dataplane, tc.deployment)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+
+			// Find the proxy container and check if env var was applied
+			var proxyContainer *corev1.Container
+			for i, container := range result.Spec.Template.Spec.Containers {
+				if container.Name == consts.DataPlaneProxyContainerName {
+					proxyContainer = &result.Spec.Template.Spec.Containers[i]
+					break
+				}
+			}
+
+			require.NotNil(t, proxyContainer, "Proxy container not found")
+
+			var foundEnvVar *corev1.EnvVar
+			for i, env := range proxyContainer.Env {
+				if env.Name == tc.expectedEnvVar {
+					foundEnvVar = &proxyContainer.Env[i]
+					break
+				}
+			}
+
+			require.NotNil(t, foundEnvVar, "Expected env var not found")
+			assert.Equal(t, tc.expectedValue, foundEnvVar.Value)
+		})
+	}
+}
+
+func TestSetClusterCertVars(t *testing.T) {
+	deployment := &k8sresources.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: consts.DataPlaneProxyContainerName,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	secretName := "test-cert-secret"
+	result := setClusterCertVars(deployment, secretName)
+
+	// Check if volume was added
+	volumeFound := false
+	for _, vol := range result.Spec.Template.Spec.Volumes {
+		if vol.Name == consts.ClusterCertificateVolume {
+			volumeFound = true
+			assert.Equal(t, secretName, vol.Secret.SecretName)
+			break
+		}
+	}
+	assert.True(t, volumeFound, "Volume not found")
+
+	// Find proxy container
+	var proxyContainer *corev1.Container
+	for i, container := range result.Spec.Template.Spec.Containers {
+		if container.Name == consts.DataPlaneProxyContainerName {
+			proxyContainer = &result.Spec.Template.Spec.Containers[i]
+			break
+		}
+	}
+	require.NotNil(t, proxyContainer, "Proxy container not found")
+
+	// Check if volume mount was added
+	volumeMountFound := false
+	for _, mount := range proxyContainer.VolumeMounts {
+		if mount.Name == consts.ClusterCertificateVolume {
+			volumeMountFound = true
+			assert.Equal(t, consts.ClusterCertificateVolumeMountPath, mount.MountPath)
+			break
+		}
+	}
+	assert.True(t, volumeMountFound, "Volume mount not found")
+
+	// Check if env vars were set
+	certEnvFound := false
+	keyEnvFound := false
+	for _, env := range proxyContainer.Env {
+		if env.Name == "KONG_CLUSTER_CERT" {
+			certEnvFound = true
+			assert.Contains(t, env.Value, "tls.crt")
+		}
+		if env.Name == "KONG_CLUSTER_CERT_KEY" {
+			keyEnvFound = true
+			assert.Contains(t, env.Value, "tls.key")
+		}
+	}
+	assert.True(t, certEnvFound, "KONG_CLUSTER_CERT env var not found")
+	assert.True(t, keyEnvFound, "KONG_CLUSTER_CERT_KEY env var not found")
+}
+
+func TestPodTemplateSpecHasRestartAnnotation(t *testing.T) {
+	testCases := []struct {
+		name           string
+		podTemplate    *corev1.PodTemplateSpec
+		expectedValue  string
+		expectedResult bool
+	}{
+		{
+			name:           "nil pod template",
+			podTemplate:    nil,
+			expectedValue:  "",
+			expectedResult: false,
+		},
+		{
+			name: "pod template without annotations",
+			podTemplate: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			expectedValue:  "",
+			expectedResult: false,
+		},
+		{
+			name: "pod template with empty restart annotation",
+			podTemplate: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						restartAnnotationKey: "",
+					},
+				},
+			},
+			expectedValue:  "",
+			expectedResult: false,
+		},
+		{
+			name: "pod template with valid restart annotation",
+			podTemplate: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						restartAnnotationKey: "2023-10-01T10:00:00Z",
+					},
+				},
+			},
+			expectedValue:  "2023-10-01T10:00:00Z",
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			value, result := podTemplateSpecHasRestartAnnotation(tc.podTemplate)
+			assert.Equal(t, tc.expectedValue, value)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestListOrReduceDataPlaneDeployments(t *testing.T) {
+	testCases := []struct {
+		name                string
+		existingDeployments []appsv1.Deployment
+		expectedReduced     bool
+		expectError         bool
+		expectedDeployment  string
+	}{
+		{
+			name:                "no deployments",
+			existingDeployments: []appsv1.Deployment{},
+			expectedReduced:     false,
+			expectError:         false,
+			expectedDeployment:  "",
+		},
+		{
+			name: "one deployment",
+			existingDeployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "deployment-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app":                                    "test",
+							"gateway-operator.konghq.com/managed-by": "dataplane",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "gateway-operator.konghq.com/v1beta1",
+								Kind:       "DataPlane",
+								UID:        "test-uid",
+							},
+						},
+					},
+				},
+			},
+			expectedReduced:    false,
+			expectError:        false,
+			expectedDeployment: "deployment-1",
+		},
+		{
+			name: "multiple deployments",
+			existingDeployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "deployment-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app":                                    "test",
+							"gateway-operator.konghq.com/managed-by": "dataplane",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "gateway-operator.konghq.com/v1beta1",
+								Kind:       "DataPlane",
+								UID:        "test-uid",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "deployment-2",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app":                                    "test",
+							"gateway-operator.konghq.com/managed-by": "dataplane",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "gateway-operator.konghq.com/v1beta1",
+								Kind:       "DataPlane",
+								UID:        "test-uid",
+							},
+						},
+					},
+				},
+			},
+			expectedReduced:    true,
+			expectError:        true,
+			expectedDeployment: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, corev1.AddToScheme(scheme))
+			require.NoError(t, appsv1.AddToScheme(scheme))
+			require.NoError(t, operatorv1beta1.AddToScheme(scheme))
+			require.NoError(t, gatewayv1.Install(scheme))
+
+			dataplane := &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+					UID:       "test-uid",
+				},
+			}
+
+			clientBuilder := fakectrlruntimeclient.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(dataplane)
+
+			for i := range tc.existingDeployments {
+				clientBuilder = clientBuilder.WithObjects(&tc.existingDeployments[i])
+			}
+
+			client := clientBuilder.Build()
+
+			reduced, deployment, err := listOrReduceDataPlaneDeployments(t.Context(), client, dataplane, map[string]string{})
+
+			assert.Equal(t, tc.expectedReduced, reduced)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			if tc.expectedDeployment == "" {
+				assert.Nil(t, deployment)
+				return
+			}
+
+			require.NotNil(t, deployment)
+			assert.Equal(t, tc.expectedDeployment, deployment.Name)
+		})
+	}
+}
+
+func TestIsRecentDeploymentRestart(t *testing.T) {
+	currentTime := metav1.Now()
+	oldTime := metav1.NewTime(currentTime.Add(-10 * 60 * time.Minute)) // 10 minutes old
+
+	testCases := []struct {
+		name           string
+		podTemplate    *corev1.PodTemplateSpec
+		expectedResult bool
+	}{
+		{
+			name:           "nil pod template",
+			podTemplate:    nil,
+			expectedResult: false,
+		},
+		{
+			name: "pod template with recent restart annotation",
+			podTemplate: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						restartAnnotationKey: currentTime.Format(time.RFC3339),
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "pod template with old restart annotation",
+			podTemplate: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						restartAnnotationKey: oldTime.Format(time.RFC3339),
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "pod template with invalid restart annotation",
+			podTemplate: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						restartAnnotationKey: "invalid-time",
+					},
+				},
+			},
+			expectedResult: true, // Unparseable times are treated as restart for safety
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, result := isRecentDeploymentRestart(tc.podTemplate, logr.Discard())
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}

--- a/test/integration/dataplane_test.go
+++ b/test/integration/dataplane_test.go
@@ -2,6 +2,11 @@ package integration
 
 import (
 	"context"
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/api/konnect/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
+	"github.com/kong/kong-operator/test"
+	"github.com/kong/kong-operator/test/helpers/deploy"
 	"testing"
 	"time"
 
@@ -32,7 +37,7 @@ import (
 )
 
 const (
-	waitTime = 90 * time.Second
+	waitTime = 3 * time.Minute
 	tickTime = 250 * time.Millisecond
 )
 
@@ -1306,4 +1311,193 @@ func TestDataPlaneKonnectCert(t *testing.T) {
 	require.NotEmpty(t, GetVolumeByName(deployment.Spec.Template.Spec.Volumes, certificates.DataPlaneKonnectClientCertificateName))
 	mount := GetVolumeMountsByVolumeName(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, certificates.DataPlaneKonnectClientCertificateName)[0]
 	require.Equal(t, certificates.DataPlaneKonnectClientCertificatePath, mount.MountPath)
+}
+
+func TestDataPlaneWithKonnectExtension(t *testing.T) {
+	t.Parallel()
+	namespace, cleaner := helpers.SetupTestEnv(t, GetCtx(), GetEnv())
+
+	// Generate a test ID for labeling resources
+	// in order to easily identify them in Konnect
+	testID := uuid.NewString()[:8]
+	t.Logf("Test ID: %s", testID)
+
+	ctx := GetCtx()
+
+	// Build a namespaced client for convenience
+	clientNamespaced := client.NewNamespacedClient(GetClients().MgrClient, namespace.Name)
+
+	// Create a KonnectAPIAuthConfiguration
+	// using the token from the test environment
+	// and the Konnect server URL from the test environment
+	authCfg := deploy.KonnectAPIAuthConfiguration(t, GetCtx(), clientNamespaced,
+		deploy.WithTestIDLabel(testID),
+		func(obj client.Object) {
+			authCfg := obj.(*konnectv1alpha1.KonnectAPIAuthConfiguration)
+			authCfg.Spec.Type = konnectv1alpha1.KonnectAPIAuthTypeToken
+			authCfg.Spec.Token = test.KonnectAccessToken()
+			authCfg.Spec.ServerURL = test.KonnectServerURL()
+		},
+	)
+
+	// Deploy a KonnectGatewayControlPlane
+	// that will be referenced by the KonnectExtension
+	// and that will be automatically registered in Konnect
+	// thanks to the presence of the KonnectAPIAuthConfiguration
+	cp := deploy.KonnectGatewayControlPlane(t, GetCtx(), clientNamespaced, authCfg,
+		deploy.WithTestIDLabel(testID),
+		deploy.KonnectGatewayControlPlaneLabel(deploy.KonnectTestIDLabel, testID),
+	)
+	t.Cleanup(deleteObjectAndWaitForDeletionFn(t, cp.DeepCopy()))
+
+	t.Logf("Waiting for a Konnect ID for KonnectGatewayControlPlane %s/%s", cp.Namespace, cp.Name)
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		err := GetClients().MgrClient.Get(GetCtx(), types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace}, cp)
+		require.NoError(t, err)
+		assertKonnectEntityProgrammed(t, cp)
+	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
+
+	// Creating a KonnectExtension that references the ControlPlane created above
+	konnectExtension := deploy.KonnectExtension(
+		t, ctx, clientNamespaced,
+		deploy.WithKonnectExtensionKonnectNamespacedRefControlPlaneRef(cp),
+	)
+	t.Cleanup(deleteObjectAndWaitForDeletionFn(t, konnectExtension.DeepCopy()))
+
+	t.Logf("Waiting for KonnectExtension %s/%s to have all conditions set to True", konnectExtension.Namespace, konnectExtension.Name)
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		ok, msg := checkKonnectExtensionConditions(t,
+			konnectExtension,
+			helpers.CheckAllConditionsTrue,
+			konnectv1alpha1.ControlPlaneRefValidConditionType,
+			konnectv1alpha1.DataPlaneCertificateProvisionedConditionType,
+			konnectv1alpha2.KonnectExtensionReadyConditionType)
+		assert.Truef(t, ok, "condition check failed: %s, conditions: %+v", msg, konnectExtension.Status.Conditions)
+	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
+
+	t.Logf("Waiting for status.konnect and status.dataPlaneClientAuth to be set for KonnectExtension %s/%s", konnectExtension.Namespace, konnectExtension.Name)
+	require.EventuallyWithT(t,
+		checkKonnectExtensionStatus(konnectExtension, cp.GetKonnectID(), ""),
+		testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
+
+	// Now creating a DataPlane that uses the KonnectExtension according to the provided manifest
+	t.Log("Creating a DataPlane that uses the KonnectExtension")
+	dataplane := &operatorv1beta1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace.Name,
+			Name:      "dataplane-prod",
+		},
+		Spec: operatorv1beta1.DataPlaneSpec{
+			DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+				Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+					DeploymentOptions: operatorv1beta1.DeploymentOptions{
+						PodTemplateSpec: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  consts.DataPlaneProxyContainerName,
+										Image: helpers.GetDefaultDataPlaneImage(),
+										Env: []corev1.EnvVar{
+											{
+												Name:  "TEST_ENV",
+												Value: "test",
+											},
+										},
+										VolumeMounts: []corev1.VolumeMount{
+											{
+												Name:      "custom-vol",
+												MountPath: "/usr/local/lib/custom",
+											},
+										},
+									},
+								},
+								Volumes: []corev1.Volume{
+									{
+										Name: "custom-vol",
+										VolumeSource: corev1.VolumeSource{
+											EmptyDir: &corev1.EmptyDirVolumeSource{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Extensions: []commonv1alpha1.ExtensionRef{
+					{
+						Group: konnectv1alpha1.GroupVersion.Group,
+						Kind:  "KonnectExtension",
+						NamespacedRef: commonv1alpha1.NamespacedRef{
+							Name: konnectExtension.Name,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dataplaneClient := GetClients().OperatorClient.GatewayOperatorV1beta1().DataPlanes(namespace.Name)
+	dataplane, err := dataplaneClient.Create(GetCtx(), dataplane, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(dataplane)
+
+	dataplaneName := client.ObjectKeyFromObject(dataplane)
+
+	t.Log("Verifying that the dataplane is marked as ready")
+	require.Eventually(t, testutils.DataPlaneIsReady(t, GetCtx(), dataplaneName, GetClients().OperatorClient), waitTime, tickTime)
+
+	t.Log("Verifying deployments managed by the dataplane")
+	require.Eventually(t, testutils.DataPlaneHasActiveDeployment(t, GetCtx(), dataplaneName, &appsv1.Deployment{}, client.MatchingLabels{
+		consts.GatewayOperatorManagedByLabel: consts.DataPlaneManagedLabelValue,
+	}, clients), waitTime, tickTime)
+
+	t.Log("Verifying that the dataplane service receives IP addresses")
+	var dataplaneIngressService corev1.Service
+	require.Eventually(t, testutils.DataPlaneHasActiveService(t, GetCtx(), dataplaneName, &dataplaneIngressService, clients, client.MatchingLabels{
+		consts.GatewayOperatorManagedByLabel: consts.DataPlaneManagedLabelValue,
+		consts.DataPlaneServiceTypeLabel:     string(consts.DataPlaneIngressServiceLabelValue),
+	}), waitTime, tickTime)
+
+	var dataplaneIP string
+	require.Eventually(t, func() bool {
+		dataplaneService, err := GetClients().K8sClient.CoreV1().Services(dataplane.Namespace).Get(GetCtx(), dataplaneIngressService.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		if len(dataplaneService.Status.LoadBalancer.Ingress) > 0 {
+			dataplaneIP = dataplaneService.Status.LoadBalancer.Ingress[0].IP
+			return true
+		}
+		return false
+	}, waitTime, tickTime)
+
+	require.Eventually(t, Expect404WithNoRouteFunc(t, GetCtx(), "http://"+dataplaneIP), waitTime, tickTime)
+
+	// Verify that the custom volume is configured correctly
+	t.Log("Verifying that the custom volume is configured correctly")
+	deployments := testutils.MustListDataPlaneDeployments(t, GetCtx(), dataplane, clients, client.MatchingLabels{
+		consts.GatewayOperatorManagedByLabel: consts.DataPlaneManagedLabelValue,
+	})
+	require.Len(t, deployments, 1, "There must be only one DataPlane deployment")
+	deployment := &deployments[0]
+
+	// Verify the custom volume
+	customVol := GetVolumeByName(deployment.Spec.Template.Spec.Volumes, "custom-vol")
+	require.NotNil(t, customVol, "The dataplane pod should have the custom-vol volume")
+	require.NotNil(t, customVol.EmptyDir, "custom-vol should be an emptyDir volume")
+
+	// Verify the custom volume mount and env var in the proxy container
+	proxyContainer := k8sutils.GetPodContainerByName(
+		&deployment.Spec.Template.Spec, consts.DataPlaneProxyContainerName)
+	require.NotNil(t, proxyContainer)
+	// Check that the TEST_ENV env var is set
+	envs := proxyContainer.Env
+	testEnv := GetEnvValueByName(envs, "TEST_ENV")
+	require.Equal(t, "test", testEnv, "The TEST_ENV environment variable should be set to 'test' in the proxy container")
+	// Check for the custom volume mount
+	customVolMount := GetVolumeMountsByVolumeName(proxyContainer.VolumeMounts, "custom-vol")
+	require.Len(t, customVolMount, 1, "The proxy container should mount the custom-vol volume")
+	require.Equal(t, "/usr/local/lib/custom", customVolMount[0].MountPath, "The proxy container should mount custom-vol at path /usr/local/lib/custom")
+
+	// Verify dataplane status
+	t.Log("Verifying that the dataplane status is correctly populated with the backup service name and its addresses")
+	require.Eventually(t, testutils.DataPlaneHasServiceAndAddressesInStatus(t, GetCtx(), dataplaneName, clients), waitTime, tickTime)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

In this PR i'm adding:
- unit tests for `owned_deployment.go` in dataplane controller
- integration tests for `DataPlane` with a `KonnectExtension` and a `podTemplateSpec` with envs, volumeMounts and volumes 

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
