### PR TITLE
chore: `enable-controller-konnect-hybrid` for dev, remove unused paths from `.golangci.yaml`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -199,8 +199,6 @@ linters:
     paths:
       - pkg/clientset
       - config/
-      - third_party$
-      - builtin$
       - examples$
 issues:
   max-same-issues: 0
@@ -222,6 +220,4 @@ formatters:
     paths:
       - pkg/clientset
       - config/
-      - third_party$
-      - builtin$
       - examples$

--- a/Makefile
+++ b/Makefile
@@ -856,6 +856,7 @@ _run:
 		-enable-controller-kongplugininstallation \
 		-enable-controller-aigateway \
 		-enable-controller-konnect \
+		-enable-controller-konnect-hybrid \
 		-enable-controller-controlplaneextensions \
 		-enable-conversion-webhook=false \
 		-zap-time-encoding iso8601 \

--- a/config/debug/manager_debug.yaml
+++ b/config/debug/manager_debug.yaml
@@ -33,6 +33,7 @@ spec:
             - -zap-log-level=debug
             - -enable-controller-kongplugininstallation
             - -enable-controller-konnect
+            - -enable-controller-konnect-hybrid
             - -enable-controller-controlplaneextensions
           name: manager
           env:

--- a/config/dev/manager_dev.yaml
+++ b/config/dev/manager_dev.yaml
@@ -24,6 +24,7 @@ spec:
             - -zap-devel=true
             - -enable-controller-kongplugininstallation
             - -enable-controller-konnect
+            - -enable-controller-konnect-hybrid
             - -enable-controller-controlplaneextensions
           name: manager
           env:


### PR DESCRIPTION
**What this PR does / why we need it**:

Add for dev configs `-enable-controller-konnect-hybrid` to have this controller run out of the box, the same as it is with other ones. 

From `.golangci.yaml`, remove paths that do not exist anymore. Adjustments don't affect linting, so it's clear that those entries are redundant.
