### PR TITLE
chore: remove obsolete references to `kubernetes-configuration` and `wg.Done()`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,6 @@ generate.crd-kustomize:
 generate.api: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/generators/boilerplate.go.txt" paths="./$(API_DIR)/..."
 
-# Alias for consistency with kubernetes-configuration naming
 .PHONY: generate.deepcopy
 generate.deepcopy: generate.api
 

--- a/ingress-controller/test/envtest/kongadminapi_controller_envtest_test.go
+++ b/ingress-controller/test/envtest/kongadminapi_controller_envtest_test.go
@@ -106,12 +106,10 @@ func startKongAdminAPIServiceReconciler(ctx context.Context, t *testing.T, clien
 	)
 	// This wait group makes it so that we wait for manager to exit.
 	// This way we get clean test logs not mixing between tests.
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	var wg sync.WaitGroup
+	wg.Go(func() {
 		assert.NoError(t, mgr.Start(ctx))
-	}()
+	})
 	t.Cleanup(func() { wg.Wait() })
 
 	return adminService, adminPod, n

--- a/ingress-controller/test/util/kustomize_consts.go
+++ b/ingress-controller/test/util/kustomize_consts.go
@@ -10,28 +10,21 @@ import (
 	"github.com/samber/lo"
 )
 
-const (
-	// ingressControllerModulePath points to Kubernetes configuration for KGO, since KIC part
-	// only needs a subset of it, so a dedicated one is not needed.
-	ingressControllerLocalPath = "./"
-)
-
 var (
 	kongRBACsKustomize = initKongRBACsKustomizePath()
 
-	kubernetesConfigurationModuleVersion = "" // unused; local paths are used instead of remote module refs
-	kongIncubatorCRDsKustomize           = initKongIncubatorCRDsKustomizePath()
-	kongKOCRDsKustomize                  = initKongOperatorConfigurationCRDs()
+	kongIncubatorCRDsKustomize = initKongIncubatorCRDsKustomizePath()
+	kongKOCRDsKustomize        = initKongOperatorConfigurationCRDs()
 )
 
 func initKongIncubatorCRDsKustomizePath() string {
-	dir := filepath.Join(lo.Must(getRepoRoot()), ingressControllerLocalPath+"config/crd/ingress-controller-incubator")
+	dir := filepath.Join(lo.Must(getRepoRoot()), "config/crd/ingress-controller-incubator")
 	ensureDirExists(dir)
 	return dir
 }
 
 func initKongRBACsKustomizePath() string {
-	dir := filepath.Join(lo.Must(getRepoRoot()), ingressControllerLocalPath+"config/rbac/")
+	dir := filepath.Join(lo.Must(getRepoRoot()), "config/rbac/")
 	ensureDirExists(dir)
 	return dir
 }

--- a/pkg/utils/test/setup_helpers.go
+++ b/pkg/utils/test/setup_helpers.go
@@ -221,20 +221,20 @@ func DeployCRDs(ctx context.Context, crdPath string, operatorClient *operatorcli
 		return err
 	}
 
-	if err := InstallKubernetesConfigurationCRDs(ctx, cluster); err != nil {
+	if err := installKongOperatorCRDs(ctx, cluster); err != nil {
 		return err
 	}
 
 	// NOTE: this check is not ideal, because we don't know if CRDs were deployed, it assumes that all for KGO are deployed
 	// and checks it by waiting for a single arbitrary chosen CRDs for each API group.
-	if err := waitForOperatorCRDs(ctx, operatorClient); err != nil {
+	if err := waitForKongOperatorCRDs(ctx, operatorClient); err != nil {
 		return err
 	}
 	return nil
 }
 
-// InstallKubernetesConfigurationCRDs installs the Kong CRDs from the local repository paths.
-func InstallKubernetesConfigurationCRDs(ctx context.Context, cluster clusters.Cluster) error {
+// installKongOperatorCRDs installs the Kong CRDs from the local repository paths.
+func installKongOperatorCRDs(ctx context.Context, cluster clusters.Cluster) error {
 	kubectlFlags := []string{"--server-side", "-v5"}
 
 	localCRDDirs := []string{
@@ -251,7 +251,7 @@ func InstallKubernetesConfigurationCRDs(ctx context.Context, cluster clusters.Cl
 	return nil
 }
 
-func waitForOperatorCRDs(ctx context.Context, operatorClient *operatorclient.Clientset) error {
+func waitForKongOperatorCRDs(ctx context.Context, operatorClient *operatorclient.Clientset) error {
 	ready := false
 	for !ready {
 		select {

--- a/test/envtest/controller.go
+++ b/test/envtest/controller.go
@@ -86,13 +86,11 @@ func StartReconcilers(
 
 	// This wait group makes it so that we wait for manager to exit.
 	// This way we get clean test logs not mixing between tests.
-	wg := sync.WaitGroup{}
-	wg.Add(1)
 	t.Logf("Starting manager for test case %s", t.Name())
-	go func() {
-		defer wg.Done()
+	var wg sync.WaitGroup
+	wg.Go(func() {
 		assert.NoError(t, mgr.Start(ctx))
-	}()
+	})
 	t.Cleanup(func() {
 		wg.Wait()
 		DumpLogsIfTestFailed(t, logs)


### PR DESCRIPTION
**What this PR does / why we need it**:

Some nits spotted that are basically a continuation (overlooked stuff) of 

- https://github.com/Kong/kong-operator/pull/2384

**Which issue this PR fixes**

Part of 

- #2314

