### PR TITLE
chore: bump golang to 1.25.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Builder
 # ------------------------------------------------------------------------------
 
-FROM --platform=$BUILDPLATFORM golang:1.25.2@sha256:1c91b4f4391774a73d6489576878ad3ff3161ebc8c78466ec26e83474855bfcf AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.3@sha256:7d73c4c57127279b23f3f70cbb368bf0fe08f7ab32af5daf5764173d25e78b74 AS builder
 
 WORKDIR /workspace
 ARG GOPATH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kong-operator
 
-go 1.24.6
+go 1.25.3
 
 require (
 	cloud.google.com/go/container v1.44.0

--- a/ingress-controller/test/envtest/controller.go
+++ b/ingress-controller/test/envtest/controller.go
@@ -54,11 +54,9 @@ func StartReconcilers(ctx context.Context, t *testing.T, scheme *runtime.Scheme,
 	// This wait group makes it so that we wait for manager to exit.
 	// This way we get clean test logs not mixing between tests.
 	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		assert.NoError(t, mgr.Start(ctx))
-	}()
+	})
 	t.Cleanup(func() {
 		wg.Wait()
 		DumpLogsIfTestFailed(t, logs)

--- a/ingress-controller/test/envtest/run.go
+++ b/ingress-controller/test/envtest/run.go
@@ -268,13 +268,10 @@ func RunManager(
 	// This wait group makes it so that we wait for manager to exit.
 	// This way we get clean test logs not mixing between tests.
 	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
+	wg.Go(func() {
 		mgr := SetupManager(ctx, t, mgrID, envcfg, adminAPIOpts, modifyCfgFns...)
 		require.NoError(t, mgr.Run(ctx))
-	}()
+	})
 	t.Cleanup(func() {
 		wg.Wait()
 		DumpLogsIfTestFailed(t, logs)

--- a/test/e2e/operator_logs_test.go
+++ b/test/e2e/operator_logs_test.go
@@ -109,8 +109,7 @@ func TestOperatorLogs(t *testing.T) {
 	}()
 
 	// start a new go routine that iterates over the log stream and performs some checks on the log lines
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		defer wg.Done()
 		scanner := bufio.NewScanner(readCloser)
 		for scanner.Scan() && !t.Failed() {
@@ -147,7 +146,7 @@ func TestOperatorLogs(t *testing.T) {
 		if !scanner.Scan() {
 			t.Log("log stream closed")
 		}
-	}()
+	})
 
 	t.Log("deploying a GatewayClass resource")
 	gatewayClass := helpers.MustGenerateGatewayClass(t)


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to resolve:

```
go: downloading sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20251014053935-394170840d3f
go: toolchain upgrade needed to resolve sigs.k8s.io/controller-runtime/tools/setup-envtest
go: sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20251014053935-394170840d3f requires go >= 1.25.0 (running go 1.24.6; GOTOOLCHAIN=local)
ERROR ~/work/kong-operator/kong-operator/bin/plugins/setup-envtest/bin/install failed
Error: 
   0: Failed to install asdf:setup-envtest@0.21.0: 
         0: ~/work/kong-operator/kong-operator/bin/plugins/setup-envtest/bin/install exited with non-zero status: exit code 1

      Location:
         src/plugins/script_manager.rs:184

      Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
      Run with RUST_BACKTRACE=full to include source snippets.

Location:
   src/toolset/mod.rs:264

Version:
   2025.10.8 linux-x64 (2025-10-13)
```

bump golang in `go.mod` to 1.25.3.

ref: https://github.com/Kong/kong-operator/actions/runs/18489628926/job/52680055557

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
