### PR TITLE
chore: bump golang 1.25.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Builder
 # ------------------------------------------------------------------------------
 
-FROM --platform=$BUILDPLATFORM golang:1.25.2@sha256:1c91b4f4391774a73d6489576878ad3ff3161ebc8c78466ec26e83474855bfcf AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.3@sha256:7d73c4c57127279b23f3f70cbb368bf0fe08f7ab32af5daf5764173d25e78b74 AS builder
 
 WORKDIR /workspace
 ARG GOPATH

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -2,7 +2,7 @@
 # Debug image
 # ------------------------------------------------------------------------------
 
-FROM --platform=$BUILDPLATFORM golang:1.25.2@sha256:1c91b4f4391774a73d6489576878ad3ff3161ebc8c78466ec26e83474855bfcf AS debug
+FROM --platform=$BUILDPLATFORM golang:1.25.3@sha256:7d73c4c57127279b23f3f70cbb368bf0fe08f7ab32af5daf5764173d25e78b74 AS builder
 
 ARG GOPATH
 ARG GOCACHE

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kong-operator
 
-go 1.24.6
+go 1.25.3
 
 require (
 	cloud.google.com/go/container v1.44.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Some envtests failed due to the version of Golang. 




https://github.com/Kong/kong-operator/actions/runs/18471634682/job/52641526775?pr=2427#step:8:178

```
DEBUG $ ~/work/kong-operator/kong-operator/ingress-controller/bin/plugins/setup-envtest/bin/install 
go: downloading sigs.k8s.io/controller-runtime v0.21.0
go: finding module for package sigs.k8s.io/controller-runtime/tools/setup-envtest
go: downloading sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20251013174334-cddb2d9d2eac
go: downloading sigs.k8s.io/controller-runtime v0.22.3
go: toolchain upgrade needed to resolve sigs.k8s.io/controller-runtime/tools/setup-envtest
go: sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20251013174334-cddb2d9d2eac requires go >= 1.25.0 (running go 1.24.6; GOTOOLCHAIN=local)
ERROR ~/work/kong-operator/kong-operator/ingress-controller/bin/plugins/setup-envtest/bin/install failed
Error: 
   0: Failed to install asdf:setup-envtest@0.21.0: 
         0: ~/work/kong-operator/kong-operator/ingress-controller/bin/plugins/setup-envtest/bin/install exited with non-zero status: exit code 1

      Location:
         src/plugins/script_manager.rs:184

      Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
      Run with RUST_BACKTRACE=full to include source snippets.

Location:
   src/toolset/mod.rs:264

Version:
   2025.10.8 linux-x64 (2025-10-13)
```


https://github.com/Kong/kong-operator/actions/runs/18471634682/job/52641526775?pr=2427#step:8:178

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes~
