### PR TITLE
feat: hybrid `Gateway` reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,9 @@
   - Improved event mapping and indexing logic for efficient reconciliation.
   - Added unit tests for new watch and index logic.
   [#2419](https://github.com/Kong/kong-operator/pull/2419)
+- Provision hybrid Gateway: implement support for provisioning hybrid Gateways with
+  gateway api `Gateway` and `GatewayConfiguration` resources.
+  [#2457](https://github.com/Kong/kong-operator/pull/2457)
 
 ### Changed
 

--- a/api/gateway-operator/gateway/conditions.go
+++ b/api/gateway-operator/gateway/conditions.go
@@ -15,6 +15,12 @@ const (
 
 	// DataPlaneReadyType the DataPlane is deployed and Ready
 	DataPlaneReadyType consts.ConditionType = "DataPlaneReady"
+
+	// KonnectExtensionReadyType the KonnectExtension is deployed and Ready
+	KonnectExtensionReadyType consts.ConditionType = "KonnectExtensionReady"
+
+	// KonnectGatewayControlPlaneProgrammedType the ControlPlane is programmed in Konnect
+	KonnectGatewayControlPlaneProgrammedType consts.ConditionType = "KonnectGatewayControlPlaneProgrammed"
 )
 
 // -----------------------------------------------------------------------------

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -54953,8 +54953,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -54979,6 +54977,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -54953,8 +54953,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -54979,6 +54977,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -54953,8 +54953,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -54979,6 +54977,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -54953,8 +54953,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -54979,6 +54977,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -54953,8 +54953,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -54979,6 +54977,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -54954,8 +54954,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -54980,6 +54978,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -54953,8 +54953,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -54979,6 +54977,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -54953,8 +54953,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -54979,6 +54977,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -54953,8 +54953,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -54979,6 +54977,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -54953,8 +54953,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -54979,6 +54977,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -54953,8 +54953,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -54979,6 +54977,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -54953,8 +54953,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -54979,6 +54977,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -29765,8 +29765,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -29791,6 +29789,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -54903,8 +54903,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -54929,6 +54927,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -29740,8 +29740,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -29766,6 +29764,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/kong-operator/templates/cluster-role.yaml
+++ b/charts/kong-operator/templates/cluster-role.yaml
@@ -415,8 +415,6 @@ rules:
       - konnectcloudgatewaydataplanegroupconfigurations
       - konnectcloudgatewaynetworks
       - konnectcloudgatewaytransitgateways
-      - konnectextensions
-      - konnectgatewaycontrolplanes
     verbs:
       - get
       - list
@@ -441,6 +439,19 @@ rules:
     verbs:
       - patch
       - update
+  - apiGroups:
+      - konnect.konghq.com
+    resources:
+      - konnectextensions
+      - konnectgatewaycontrolplanes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:

--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -415,8 +415,6 @@ rules:
   - konnectcloudgatewaydataplanegroupconfigurations
   - konnectcloudgatewaynetworks
   - konnectcloudgatewaytransitgateways
-  - konnectextensions
-  - konnectgatewaycontrolplanes
   verbs:
   - get
   - list
@@ -441,6 +439,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectextensions
+  - konnectgatewaycontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/controller/gateway/controller_rbac.go
+++ b/controller/gateway/controller_rbac.go
@@ -13,3 +13,5 @@ package gateway
 //+kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=controlplanes,verbs=create;get;list;watch;update;patch;delete
 //+kubebuilder:rbac:groups=gateway-operator.konghq.com,resources=gatewayconfigurations,verbs=get;list;watch
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;get;update;patch;list;watch;delete
+//+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectgatewaycontrolplanes,verbs=create;get;list;watch;update;patch;delete
+//+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectextensions,verbs=create;get;list;watch;update;patch;delete

--- a/controller/hybridgateway/refs/by_test.go
+++ b/controller/hybridgateway/refs/by_test.go
@@ -246,46 +246,6 @@ func TestGetListenersByParentRef(t *testing.T) {
 	}
 }
 
-func TestByGatewayConfiguration(t *testing.T) {
-	tests := []struct {
-		name        string
-		setup       func() (client.Client, gwtypes.GatewayConfiguration)
-		expected    *commonv1alpha1.KonnectNamespacedRef
-		wantErr     bool
-		description string
-	}{
-		{
-			name: "GatewayConfiguration without KonnectExtension",
-			setup: func() (client.Client, gwtypes.GatewayConfiguration) {
-				cl := fake.NewClientBuilder().Build()
-				gwConfig := gwtypes.GatewayConfiguration{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-gateway-config",
-					},
-				}
-				return cl, gwConfig
-			},
-			expected:    nil,
-			wantErr:     false,
-			description: "should return nil when KonnectExtension not found",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cl, gwConfig := tt.setup()
-			result, err := byGatewayConfiguration(context.Background(), cl, gwConfig)
-
-			if tt.wantErr {
-				assert.Error(t, err, tt.description)
-			} else {
-				assert.NoError(t, err, tt.description)
-				assert.Equal(t, tt.expected, result, tt.description)
-			}
-		})
-	}
-}
-
 func TestByKonnectExtension(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/controller/hybridgateway/refs/get.go
+++ b/controller/hybridgateway/refs/get.go
@@ -3,11 +3,8 @@ package refs
 import (
 	"context"
 
-	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
-	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
 	gwtypes "github.com/kong/kong-operator/internal/types"
 )
 
@@ -71,28 +68,4 @@ func getGatewayConfigurationByGatewayClass(ctx context.Context, cl client.Client
 	}
 
 	return &gwConf
-}
-
-// getKonnectExtensionByGatewayConfiguration returns the KonnectExtension referenced by the given GatewayConfiguration, or nil if not found.
-func getKonnectExtensionByGatewayConfiguration(ctx context.Context, cl client.Client, gwConf gwtypes.GatewayConfiguration) (*konnectv1alpha2.KonnectExtension, error) {
-	extRef, found := lo.Find(gwConf.Spec.Extensions, func(extRef commonv1alpha1.ExtensionRef) bool {
-		if extRef.Group != konnectv1alpha2.SchemeGroupVersion.Group ||
-			extRef.Kind != konnectv1alpha2.KonnectExtensionKind {
-			return false
-		}
-		return true
-	})
-	if !found {
-		return nil, nil
-	}
-	ke := &konnectv1alpha2.KonnectExtension{}
-	err := cl.Get(ctx, client.ObjectKey{
-		Namespace: gwConf.Namespace,
-		Name:      extRef.Name,
-	}, ke)
-	if err != nil {
-		return nil, err
-	}
-
-	return ke, nil
 }

--- a/modules/manager/controller_setup_test.go
+++ b/modules/manager/controller_setup_test.go
@@ -23,7 +23,7 @@ func TestSetupControllers(t *testing.T) {
 	controllerDefs, err := manager.SetupControllers(mgr, &cfg, nil)
 	require.NoError(t, err)
 
-	const expectedControllerCount = 42
+	const expectedControllerCount = 43
 	require.Len(t, controllerDefs, expectedControllerCount)
 
 	seenControllerTypes := make(map[string]int, expectedControllerCount)

--- a/pkg/utils/kubernetes/reduce/reduce.go
+++ b/pkg/utils/kubernetes/reduce/reduce.go
@@ -15,6 +15,7 @@ import (
 
 	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
 	operatorv1beta1 "github.com/kong/kong-operator/api/gateway-operator/v1beta1"
+	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
 	"github.com/kong/kong-operator/controller/konnect/constraints"
 	"github.com/kong/kong-operator/pkg/clientops"
 )
@@ -164,4 +165,20 @@ func ReduceKongCredentials[
 ](ctx context.Context, k8sClient client.Client, kongCredentials []T) error {
 	filtered := filterKongCredentials[T, TPtr](kongCredentials)
 	return clientops.DeleteAll[T, TPtr](ctx, k8sClient, filtered)
+}
+
+// +kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectgatewaycontrolplanes,verbs=delete
+
+// ReduceKonnectGatewayControlPlane detects the best KonnectGatewayControlPlane in the set and deletes all the others.
+func ReduceKonnectGatewayControlPlane(ctx context.Context, k8sClient client.Client, cps []konnectv1alpha2.KonnectGatewayControlPlane) error {
+	filteredCPs := filterKonnectGatewayControlPlanes(cps)
+	return clientops.DeleteAll(ctx, k8sClient, filteredCPs)
+}
+
+// +kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectextensions,verbs=delete
+
+// ReduceKonnectExtension detects the best KonnectExtension in the set and deletes all the others.
+func ReduceKonnectExtension(ctx context.Context, k8sClient client.Client, exts []konnectv1alpha2.KonnectExtension) error {
+	filteredExts := filterKonnectExtensions(exts)
+	return clientops.DeleteAll(ctx, k8sClient, filteredExts)
 }

--- a/pkg/utils/test/asserts.go
+++ b/pkg/utils/test/asserts.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1beta1 "github.com/kong/kong-operator/api/gateway-operator/v1beta1"
+	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
 	gwtypes "github.com/kong/kong-operator/internal/types"
 	"github.com/kong/kong-operator/pkg/consts"
 	gatewayutils "github.com/kong/kong-operator/pkg/utils/gateway"
@@ -28,6 +29,14 @@ func MustListControlPlanesForGateway(t *testing.T, ctx context.Context, gateway 
 	controlPlanes, err := gatewayutils.ListControlPlanesForGateway(ctx, clients.MgrClient, gateway)
 	require.NoError(t, err)
 	return controlPlanes
+}
+
+// MustListKonnectGatewayControlPlanesForGateway is a helper function for tests that
+// conveniently lists all KonnectGatewayControlPlanes managed by a given Gateway.
+func MustListKonnectGatewayControlPlanesForGateway(t *testing.T, ctx context.Context, gateway *gwtypes.Gateway, clients K8sClients) []konnectv1alpha2.KonnectGatewayControlPlane {
+	konnectGatewayControlPlanes, err := gatewayutils.ListKonnectGatewayControlPlanesForGateway(ctx, clients.MgrClient, gateway)
+	require.NoError(t, err)
+	return konnectGatewayControlPlanes
 }
 
 // MustListNetworkPoliciesForGateway is a helper function for tests that

--- a/pkg/utils/test/config.go
+++ b/pkg/utils/test/config.go
@@ -36,6 +36,7 @@ func DefaultControllerConfigForTests(opts ...ControllerConfigOption) manager.Con
 	cfg.AIGatewayControllerEnabled = true
 	cfg.AnonymousReports = false
 	cfg.KonnectControllersEnabled = true
+	cfg.KonnectHybridControllersEnabled = true
 	cfg.ClusterCAKeyType = mgrconfig.ECDSA
 	cfg.GatewayAPIExperimentalEnabled = true
 	cfg.EnforceConfig = true


### PR DESCRIPTION
**What this PR does / why we need it**:

End-to-end, robust support for hybrid `Gateway` reconciliation.


Such a scenario is supported

```yaml
kind: KonnectAPIAuthConfiguration
apiVersion: konnect.konghq.com/v1alpha1
metadata:
  name: konnect-api-auth
  namespace: default
spec:
  type: token
  token: XYZ
  serverURL: us.api.konghq.tech
```

after

```yml
kind: GatewayConfiguration
apiVersion: gateway-operator.konghq.com/v2beta1
metadata:
  name: jw-gwc
  namespace: default
spec:
  konnect:
    authRef:
      name: konnect-api-auth
  dataPlaneOptions:
    deployment:
      podTemplateSpec:
        spec:
          containers:
          - name: proxy
            image: kong/kong-gateway:3.12
---
kind: GatewayClass
apiVersion: gateway.networking.k8s.io/v1
metadata:
  name: kong-v2beta1
spec:
  controllerName: konghq.com/gateway-operator
  parametersRef:
    group: gateway-operator.konghq.com
    kind: GatewayConfiguration
    name: jw-gwc
    namespace: default
---
kind: Gateway
apiVersion: gateway.networking.k8s.io/v1
metadata:
  name: jw-gw
  namespace: default
spec:
  gatewayClassName: kong-v2beta1
  listeners:
  - name: http
    protocol: HTTP
    port: 80
```

It can be observed in Konnect and the statuses of respective objects in the K8s cluster

```log
kubectl get gateways
kubectl get konnectgatewaycontrolplanes
kubectl get dataplanes
```

next

```yml
apiVersion: v1
kind: Service
metadata:
  name: echo
spec:
  ports:
    - protocol: TCP
      name: http
      port: 80
      targetPort: http
  selector:
    app: echo
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: echo
  name: echo
spec:
  replicas: 1
  selector:
    matchLabels:
      app: echo
  template:
    metadata:
      labels:
        app: echo
    spec:
      containers:
        - name: echo
          image: registry.k8s.io/e2e-test-images/agnhost:2.40
          command:
            - /agnhost
            - netexec
            - --http-port=8080
          ports:
            - containerPort: 8080
              name: http
          env:
            - name: NODE_NAME
              valueFrom:
                fieldRef:
                  fieldPath: spec.nodeName
            - name: POD_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
            - name: NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
            - name: POD_IP
              valueFrom:
                fieldRef:
                  fieldPath: status.podIP
          resources:
            requests:
              cpu: 10m
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: httproute-echo
  namespace: default
spec:
  parentRefs:
  - name: jw-gw
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /echo
    backendRefs:
    - name: echo
      kind: Service
      port: 80
```

And traffic after a couple of seconds is routed and respective `KonnectGatewayControlPlane` with `KongRoute`s can be found in Konnect.


**Which issue this PR fixes**

Part of 
- #2377

The missing piece to handle in a separate PR is the docs. 

**Special notes for your reviewer**:

The comprehensive test `TestGatewayHybridFull` is added, which also checks `HTTPRoute` with one caveat (marked with `TODO` comment - spin-off issue https://github.com/Kong/kong-operator/issues/2468). It ensures that it works. In terms of testing, we should have a broader discussion about the approach for testing Konnect controlplane, but it's out of scope for this PR.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
