### PR TITLE
feat: implement comprehensive EndpointSlices-based target resolution for HybridGateway

### DIFF
--- a/controller/hybridgateway/controller.go
+++ b/controller/hybridgateway/controller.go
@@ -37,14 +37,20 @@ type HybridGatewayReconciler[t converter.RootObject, tPtr converter.RootObjectPt
 	client.Client
 	// ReferenceGrantEnabled indicates whether ReferenceGrants are enabled in the cluster (i.e., the CRD is available)
 	referenceGrantEnabled bool
+	// FQDNMode indicates whether to use FQDN endpoints for service discovery.
+	fqdnMode bool
+	// ClusterDomain is the cluster domain to use for FQDN (empty uses service.namespace.svc format).
+	clusterDomain string
 }
 
 // NewHybridGatewayReconciler creates a new instance of GatewayAPIHybridReconciler for the specified
 // generic types t and tPtr. It initializes the reconciler with the client from the provided manager.
-func NewHybridGatewayReconciler[t converter.RootObject, tPtr converter.RootObjectPtr[t]](mgr ctrl.Manager, referenceGrantEnabled bool) *HybridGatewayReconciler[t, tPtr] {
+func NewHybridGatewayReconciler[t converter.RootObject, tPtr converter.RootObjectPtr[t]](mgr ctrl.Manager, referenceGrantEnabled bool, fqdnMode bool, clusterDomain string) *HybridGatewayReconciler[t, tPtr] {
 	return &HybridGatewayReconciler[t, tPtr]{
 		Client:                mgr.GetClient(),
 		referenceGrantEnabled: referenceGrantEnabled,
+		fqdnMode:              fqdnMode,
+		clusterDomain:         clusterDomain,
 	}
 }
 
@@ -111,7 +117,7 @@ func (r *HybridGatewayReconciler[t, tPtr]) Reconcile(ctx context.Context, req ct
 	gvk := obj.GetObjectKind().GroupVersionKind()
 	log.Debug(logger, "Reconciling object", "Group", gvk.Group, "Kind", gvk.Kind)
 
-	conv, err := converter.NewConverter(rootObj, r.Client, r.referenceGrantEnabled)
+	conv, err := converter.NewConverter(rootObj, r.Client, r.referenceGrantEnabled, r.fqdnMode, r.clusterDomain)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controller/hybridgateway/converter/converter.go
+++ b/controller/hybridgateway/converter/converter.go
@@ -46,11 +46,11 @@ type RootObjectPtr[T RootObject] interface {
 // NewConverter is a factory function that creates and returns an APIConverter instance
 // based on the type of the provided root object. It supports different types of root objects
 // and returns an error if the type is unsupported.
-func NewConverter[t RootObject](obj t, cl client.Client, referenceGrantEnabled bool) (APIConverter[t], error) {
+func NewConverter[t RootObject](obj t, cl client.Client, referenceGrantEnabled bool, fqdnMode bool, clusterDomain string) (APIConverter[t], error) {
 	switch o := any(obj).(type) {
 	// TODO: add other types here
 	case gwtypes.HTTPRoute:
-		return newHTTPRouteConverter(&o, cl, referenceGrantEnabled).(APIConverter[t]), nil
+		return newHTTPRouteConverter(&o, cl, referenceGrantEnabled, fqdnMode, clusterDomain).(APIConverter[t]), nil
 	default:
 		return nil, fmt.Errorf("unsupported root object type: %T", obj)
 	}

--- a/controller/hybridgateway/converter/http_route_test.go
+++ b/controller/hybridgateway/converter/http_route_test.go
@@ -104,7 +104,7 @@ func TestHostnamesIntersection(t *testing.T) {
 
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
 
-			converter := newHTTPRouteConverter(tt.route, fakeClient, true)
+			converter := newHTTPRouteConverter(tt.route, fakeClient, true, false, "")
 			err := converter.Translate()
 			require.NoError(t, err)
 

--- a/controller/hybridgateway/target/target.go
+++ b/controller/hybridgateway/target/target.go
@@ -1,0 +1,411 @@
+package target
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/controller/hybridgateway/builder"
+	"github.com/kong/kong-operator/controller/hybridgateway/route"
+	"github.com/kong/kong-operator/controller/hybridgateway/utils"
+	gwtypes "github.com/kong/kong-operator/internal/types"
+)
+
+// ValidBackendRef represents a BackendRef that has passed all validation checks.
+type ValidBackendRef struct {
+	BackendRef  *gwtypes.HTTPBackendRef
+	Service     *corev1.Service
+	ServicePort *corev1.ServicePort
+	// ReadyEndpoints contains merged endpoint addresses from all EndpointSlices for this service.
+	ReadyEndpoints []string
+	// TargetPort is the actual port to use in Kong targets (already resolved based on service type).
+	TargetPort int
+	// Weight is the calculated weight per endpoint for this backend (after weight recalculation).
+	Weight int32
+}
+
+// TargetsForBackendRefs creates KongTargets for all BackendRefs in a rule.
+// This function processes all BackendRefs together, enabling better weight distribution and optimization.
+func TargetsForBackendRefs(
+	ctx context.Context,
+	logger logr.Logger,
+	cl client.Client,
+	httpRoute *gwtypes.HTTPRoute,
+	backendRefs []gwtypes.HTTPBackendRef,
+	pRef *gwtypes.ParentReference,
+	upstreamName string,
+	referenceGrantEnabled bool,
+	fqdn bool,
+	clusterDomain string,
+) ([]configurationv1alpha1.KongTarget, error) {
+	// Step 1: Filter and validate all BackendRefs, extracting endpoints.
+	validBackendRefs, err := filterValidBackendRefs(ctx, logger, cl, httpRoute, backendRefs, referenceGrantEnabled, fqdn, clusterDomain)
+	if err != nil {
+		return nil, fmt.Errorf("failed to filter valid BackendRefs: %w", err)
+	}
+
+	if len(validBackendRefs) == 0 {
+		logger.V(1).Info("no valid BackendRefs found for rule")
+		return []configurationv1alpha1.KongTarget{}, nil
+	}
+
+	// Step 2: Recalculate weights across all valid BackendRefs.
+	validBackendRefs = recalculateWeightsAcrossBackendRefs(validBackendRefs)
+
+	// Step 3: Create KongTargets from the processed ValidBackendRef structs.
+	targets, err := createTargetsFromValidBackendRefs(httpRoute, pRef, upstreamName, validBackendRefs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create targets from valid BackendRefs: %w", err)
+	}
+
+	logger.V(1).Info("created targets for BackendRefs",
+		"totalBackendRefs", len(backendRefs),
+		"validBackendRefs", len(validBackendRefs),
+		"createdTargets", len(targets))
+
+	return targets, nil
+}
+
+// findBackendRefPortInService returns the ServicePort from svc that matches the port specified in bRef.
+// If bRef.Port is nil or no matching port is found in svc.Spec.Ports, an error is returned.
+// This function is used to validate and resolve the actual ServicePort for a given BackendRef.
+func findBackendRefPortInService(bRef *gwtypes.HTTPBackendRef, svc *corev1.Service) (*corev1.ServicePort, error) {
+	// Check if the port is specified in the BackendRef. The port is required.
+	if bRef.Port == nil {
+		// If the port is not specified, return an error.
+		return nil, fmt.Errorf("port not specified in BackendRef")
+	}
+
+	// Find the port in the service that matches the port in the BackendRef.
+	svcPort, svcPortFound := lo.Find(svc.Spec.Ports, func(p corev1.ServicePort) bool {
+		return p.Port == int32(*bRef.Port)
+	})
+	if !svcPortFound {
+		// If the port is not found, return an error.
+		return nil, fmt.Errorf("port %v not found in service %s/%s", *bRef.Port, svc.Namespace, svc.Name)
+	}
+
+	return &svcPort, nil
+}
+
+// getEndpointSlicesForService retrieves all EndpointSlices for a given service.
+func getEndpointSlicesForService(ctx context.Context, cl client.Client, svc *corev1.Service) (*discoveryv1.EndpointSliceList, error) {
+	endpointSlices := &discoveryv1.EndpointSliceList{}
+	req, err := labels.NewRequirement(discoveryv1.LabelServiceName, selection.Equals, []string{svc.Name})
+	if err != nil {
+		return nil, err
+	}
+	labelSelector := labels.NewSelector().Add(*req)
+	err = cl.List(ctx, endpointSlices, &client.ListOptions{Namespace: svc.Namespace, LabelSelector: labelSelector})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list endpointslices for service %s/%s: %w", svc.Namespace, svc.Name, err)
+	}
+	return endpointSlices, nil
+}
+
+// extractReadyEndpointAddresses extracts all ready endpoint addresses that match the service port.
+func extractReadyEndpointAddresses(endpointSlices *discoveryv1.EndpointSliceList, svcPort *corev1.ServicePort) []string {
+	var addresses []string
+
+	for _, endpointSlice := range endpointSlices.Items {
+		for _, p := range endpointSlice.Ports {
+			// Skip ports that don't match the service port.
+			if p.Port == nil || *p.Port < 0 || *p.Protocol != svcPort.Protocol || *p.Name != svcPort.Name {
+				continue
+			}
+
+			for _, endpoint := range endpointSlice.Endpoints {
+				// Only include ready endpoints.
+				if endpoint.Conditions.Ready != nil && *endpoint.Conditions.Ready {
+					addresses = append(addresses, endpoint.Addresses...)
+				}
+			}
+		}
+	}
+
+	return addresses
+}
+
+// resolveServiceEndpoints determines the appropriate endpoints for a service based on its type and configuration.
+// Returns (endpoints, shouldSkip, error) where shouldSkip indicates the service should be skipped.
+func resolveServiceEndpoints(
+	ctx context.Context,
+	logger logr.Logger,
+	cl client.Client,
+	svc *corev1.Service,
+	svcPort *corev1.ServicePort,
+	fqdn bool,
+	clusterDomain string,
+) ([]string, bool, error) {
+	switch {
+	case fqdn && svc.Spec.ClusterIP != "None":
+		// For FQDN mode with regular services (non-headless), use the service FQDN as the single "endpoint".
+		return resolveFQDNEndpoints(svc, clusterDomain), false, nil
+
+	case svc.Spec.Type == corev1.ServiceTypeExternalName:
+		// For ExternalName services, use the external name as the endpoint.
+		return resolveExternalNameEndpoints(logger, svc)
+
+	default:
+		// For all other cases (headless services, regular services without FQDN mode).
+		return resolveEndpointSliceEndpoints(ctx, logger, cl, svc, svcPort)
+	}
+}
+
+// resolveFQDNEndpoints creates FQDN-based endpoints for regular services.
+func resolveFQDNEndpoints(svc *corev1.Service, clusterDomain string) []string {
+	var serviceFQDN string
+	if clusterDomain == "" {
+		// Use the shorter DNS form which works across different cluster domain configurations.
+		serviceFQDN = fmt.Sprintf("%s.%s.svc", svc.Name, svc.Namespace)
+	} else {
+		// Use the full FQDN with the configured cluster domain.
+		serviceFQDN = fmt.Sprintf("%s.%s.svc.%s", svc.Name, svc.Namespace, clusterDomain)
+	}
+	return []string{serviceFQDN}
+}
+
+// resolveExternalNameEndpoints handles ExternalName service endpoints.
+func resolveExternalNameEndpoints(logger logr.Logger, svc *corev1.Service) ([]string, bool, error) {
+	if svc.Spec.ExternalName != "" {
+		return []string{svc.Spec.ExternalName}, false, nil
+	}
+	logger.V(1).Info("skipping ExternalName service with empty externalName", "service", fmt.Sprintf("%s/%s", svc.Namespace, svc.Name))
+	return nil, true, nil
+}
+
+// resolveEndpointSliceEndpoints fetches and processes EndpointSlices for a service.
+func resolveEndpointSliceEndpoints(
+	ctx context.Context,
+	logger logr.Logger,
+	cl client.Client,
+	svc *corev1.Service,
+	svcPort *corev1.ServicePort,
+) ([]string, bool, error) {
+	endpointSlices, err := getEndpointSlicesForService(ctx, cl, svc)
+	if err != nil {
+		// If it's a not found error, log and skip (EndpointSlices might not be created yet).
+		// For other errors (network, permissions, etc.), return the error.
+		if client.IgnoreNotFound(err) != nil {
+			return nil, false, fmt.Errorf("error fetching EndpointSlices for service %s/%s: %w", svc.Namespace, svc.Name, err)
+		}
+		logger.V(1).Info("skipping service with no EndpointSlices found", "service", fmt.Sprintf("%s/%s", svc.Namespace, svc.Name))
+		return nil, true, nil
+	}
+
+	// Extract ready endpoint addresses.
+	readyEndpoints := extractReadyEndpointAddresses(endpointSlices, svcPort)
+
+	// Skip services with no ready endpoints.
+	if len(readyEndpoints) == 0 {
+		logger.V(1).Info("skipping service with no ready endpoints", "service", fmt.Sprintf("%s/%s", svc.Namespace, svc.Name))
+		return nil, true, nil
+	}
+
+	return readyEndpoints, false, nil
+}
+
+// resolveTargetPort determines the appropriate target port based on service type and mode.
+func resolveTargetPort(svc *corev1.Service, svcPort *corev1.ServicePort, fqdn bool) int {
+	switch {
+	case fqdn && svc.Spec.ClusterIP != "None":
+		// For FQDN mode with regular services, use service port (Kong will resolve via DNS).
+		return int(svcPort.Port)
+
+	case svc.Spec.Type == corev1.ServiceTypeExternalName:
+		// For ExternalName services, use service port (external service expectation).
+		return int(svcPort.Port)
+
+	default:
+		// For all other cases (headless services, regular services with endpoint discovery).
+		// Use target port since we're connecting directly to pod endpoints.
+		if svcPort.TargetPort.IntVal > 0 {
+			return int(svcPort.TargetPort.IntVal)
+		}
+		// Default to service port if target port is not specified.
+		return int(svcPort.Port)
+	}
+}
+
+// filterValidBackendRefs filters a list of BackendRefs and returns only the valid ones.
+// It performs the following checks for each BackendRef:
+// 1. Check if the BackendRef is supported (currently only Service).
+// 2. Check if the referenced Service exists.
+// 3. Check if the specified port exists in the Service.
+// 4. Check if ReferenceGrant permits cross-namespace access (if needed).
+// 5. Fetch EndpointSlices and extract ready endpoints (for headless services, regular services, or when FQDN is disabled).
+func filterValidBackendRefs(
+	ctx context.Context,
+	logger logr.Logger,
+	cl client.Client,
+	httpRoute *gwtypes.HTTPRoute,
+	backendRefs []gwtypes.HTTPBackendRef,
+	referenceGrantEnabled bool,
+	fqdn bool,
+	clusterDomain string,
+) ([]ValidBackendRef, error) {
+	var validBackendRefs []ValidBackendRef
+
+	for _, bRef := range backendRefs {
+		// Check if the backendRef is supported.
+		if !route.IsBackendRefSupported(bRef.Group, bRef.Kind) {
+			logger.Info("skipping unsupported backendRef", "group", bRef.Group, "kind", bRef.Kind)
+			continue
+		}
+
+		// Determine the namespace for the referenced Service.
+		bRefNamespace := httpRoute.Namespace
+		if bRef.Namespace != nil && *bRef.Namespace != "" {
+			bRefNamespace = string(*bRef.Namespace)
+		}
+
+		// Check if the referenced Service exists.
+		svc := &corev1.Service{}
+		err := cl.Get(ctx, client.ObjectKey{Namespace: bRefNamespace, Name: string(bRef.Name)}, svc)
+		if err != nil {
+			logger.Info("skipping nonexistent Service", "group", bRef.Group, "kind", bRef.Kind, "name", bRef.Name)
+			continue
+		}
+
+		// Find and validate the port in the Service.
+		svcPort, err := findBackendRefPortInService(&bRef, svc)
+		if err != nil {
+			logger.Info("skipping backendRef with invalid port", "group", bRef.Group, "kind", bRef.Kind, "name", bRef.Name, "error", err)
+			continue
+		}
+
+		// Check ReferenceGrant permission for cross-namespace access.
+		if referenceGrantEnabled && bRefNamespace != httpRoute.Namespace {
+			permitted, found, err := route.CheckReferenceGrant(ctx, cl, &bRef, httpRoute.Namespace)
+			if err != nil {
+				return nil, fmt.Errorf("error checking ReferenceGrant for BackendRef %s: %w", bRef.Name, err)
+			}
+			if !permitted {
+				if found {
+					logger.Info("skipping backendRef not permitted by ReferenceGrant", "group", bRef.Group, "kind", bRef.Kind, "name", bRef.Name)
+				} else {
+					logger.Info("skipping backendRef in different namespace without ReferenceGrant", "group", bRef.Group, "kind", bRef.Kind, "name", bRef.Name)
+				}
+				continue
+			}
+		}
+
+		// Resolve endpoints based on service type and mode.
+		readyEndpoints, shouldSkip, err := resolveServiceEndpoints(ctx, logger, cl, svc, svcPort, fqdn, clusterDomain)
+		if err != nil {
+			return nil, err
+		}
+		if shouldSkip {
+			continue
+		}
+
+		// Determine the target port based on service type and mode.
+		targetPort := resolveTargetPort(svc, svcPort, fqdn)
+
+		// If we reach here, the BackendRef is valid and has endpoints.
+		validBackendRefs = append(validBackendRefs, ValidBackendRef{
+			BackendRef:     &bRef,
+			Service:        svc,
+			ServicePort:    svcPort,
+			ReadyEndpoints: readyEndpoints,
+			TargetPort:     targetPort,
+			// Will be calculated in recalculateWeightsAcrossBackendRefs.
+			Weight: 0,
+		})
+	}
+
+	return validBackendRefs, nil
+}
+
+// recalculateWeightsAcrossBackendRefs recalculates weights across all valid BackendRefs in a rule.
+// This uses the weight calculation algorithm from weight.go to ensure mathematically
+// correct proportional distribution based on the original BackendRef weights and endpoint counts.
+func recalculateWeightsAcrossBackendRefs(validBackendRefs []ValidBackendRef) []ValidBackendRef {
+	if len(validBackendRefs) == 0 {
+		return validBackendRefs
+	}
+
+	// Convert ValidBackendRef to BackendRef for weight calculation.
+	backends := make([]BackendRef, len(validBackendRefs))
+	for i, vbRef := range validBackendRefs {
+		// Generate a unique name for this backend (using service name and namespace).
+		backendName := fmt.Sprintf("%s/%s", vbRef.Service.Namespace, vbRef.Service.Name)
+
+		// Get the original weight (default to 1 if not specified).
+		weight := uint32(1)
+		if vbRef.BackendRef.Weight != nil {
+			weight = uint32(*vbRef.BackendRef.Weight)
+		}
+
+		// Number of ready endpoints (could be 1 for FQDN/ExternalName).
+		endpoints := uint32(len(vbRef.ReadyEndpoints))
+
+		backends[i] = BackendRef{
+			Name:      backendName,
+			Weight:    weight,
+			Endpoints: endpoints,
+		}
+	}
+
+	// Calculate the endpoint weights.
+	endpointWeights := CalculateEndpointWeights(backends)
+
+	// Update the weights in our ValidBackendRef structs directly.
+	for i, vbRef := range validBackendRefs {
+		backendName := fmt.Sprintf("%s/%s", vbRef.Service.Namespace, vbRef.Service.Name)
+		endpointWeight := endpointWeights[backendName]
+		validBackendRefs[i].Weight = int32(endpointWeight)
+	}
+
+	return validBackendRefs
+}
+
+// createTargetsFromValidBackendRefs creates KongTargets from ValidBackendRef structs.
+// This function handles all service types (ClusterIP, ExternalName, FQDN) using a unified approach.
+func createTargetsFromValidBackendRefs(httpRoute *gwtypes.HTTPRoute, pRef *gwtypes.ParentReference, upstreamName string,
+	validBackendRefs []ValidBackendRef) ([]configurationv1alpha1.KongTarget, error) {
+	var targets []configurationv1alpha1.KongTarget
+
+	for _, vbRef := range validBackendRefs {
+		// Skip backends with no endpoints (they have weight 0 anyway).
+		// This should not happen, but if it happens then we skip them.
+		if len(vbRef.ReadyEndpoints) == 0 {
+			continue
+		}
+
+		// After recalculateWeightsAcrossBackendRefs, the ValidBackendRef.Weight contains
+		// the calculated weight per endpoint, so we use it directly for all endpoints.
+		weight := vbRef.Weight
+
+		for _, endpoint := range vbRef.ReadyEndpoints {
+			// Use the pre-calculated target port (already resolved based on service type and mode).
+			port := vbRef.TargetPort
+
+			// Create target with explicit endpoint address (works for all cases: real endpoints, FQDN, external names).
+			target, err := builder.NewKongTarget().
+				WithName(fmt.Sprintf("%s.%s", upstreamName, utils.Hash32(utils.Hash32(vbRef.BackendRef)+endpoint))).
+				WithNamespace(httpRoute.Namespace).
+				WithLabels(httpRoute, pRef).
+				WithAnnotations(httpRoute, pRef).
+				WithUpstreamRef(upstreamName).
+				WithTarget(endpoint, port).
+				WithOwner(httpRoute).
+				WithWeight(&weight).
+				Build()
+			if err != nil {
+				return nil, err
+			}
+			targets = append(targets, target)
+		}
+	}
+
+	return targets, nil
+}

--- a/controller/hybridgateway/target/target_test.go
+++ b/controller/hybridgateway/target/target_test.go
@@ -1,0 +1,2805 @@
+package target
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	_ "github.com/kong/kong-operator/controller/hybridgateway/builder" // Used by function under test.
+	_ "github.com/kong/kong-operator/controller/hybridgateway/utils"   // Used by function under test.
+	gwtypes "github.com/kong/kong-operator/internal/types"
+)
+
+// Helper functions for creating test objects.
+func createTestEndpointSliceList(items []discoveryv1.EndpointSlice) *discoveryv1.EndpointSliceList {
+	return &discoveryv1.EndpointSliceList{
+		Items: items,
+	}
+}
+
+func createTestEndpointSlice(name string, ports []discoveryv1.EndpointPort, endpoints []discoveryv1.Endpoint) discoveryv1.EndpointSlice {
+	return discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Ports:     ports,
+		Endpoints: endpoints,
+	}
+}
+
+func createTestEndpointPort(name string, port int32, protocol corev1.Protocol) discoveryv1.EndpointPort {
+	return discoveryv1.EndpointPort{
+		Name:     ptr.To(name),
+		Port:     ptr.To(port),
+		Protocol: ptr.To(protocol),
+	}
+}
+
+func createTestEndpoint(addresses []string, ready bool) discoveryv1.Endpoint {
+	return discoveryv1.Endpoint{
+		Addresses: addresses,
+		Conditions: discoveryv1.EndpointConditions{
+			Ready: ptr.To(ready),
+		},
+	}
+}
+
+func createTestServicePort() *corev1.ServicePort {
+	return &corev1.ServicePort{
+		Name:     "http",
+		Protocol: corev1.ProtocolTCP,
+	}
+}
+
+// Global helper to create HTTPRoute with optional BackendRefs.
+func createGlobalTestHTTPRoute(name, namespace string, backendRefs ...[]gwtypes.HTTPBackendRef) *gwtypes.HTTPRoute {
+	route := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	if len(backendRefs) > 0 && backendRefs[0] != nil {
+		route.Spec = gwtypes.HTTPRouteSpec{
+			Rules: []gwtypes.HTTPRouteRule{
+				{
+					BackendRefs: backendRefs[0],
+				},
+			},
+		}
+	}
+
+	return route
+}
+
+// Global helper to create HTTPBackendRef - comprehensive version.
+func createGlobalTestHTTPBackendRef(name, namespace string, weight, port *int32, group ...*gwtypes.Group) gwtypes.HTTPBackendRef {
+	serviceKind := gwtypes.Kind("Service")
+	ref := gwtypes.HTTPBackendRef{
+		BackendRef: gwtypes.BackendRef{
+			BackendObjectReference: gwtypes.BackendObjectReference{
+				Name: gwtypes.ObjectName(name),
+				Kind: &serviceKind,
+			},
+			Weight: weight,
+		},
+	}
+
+	if namespace != "" {
+		ns := gwtypes.Namespace(namespace)
+		ref.Namespace = &ns
+	}
+
+	if port != nil {
+		portNum := gwtypes.PortNumber(*port)
+		ref.Port = &portNum
+	}
+
+	if len(group) > 0 && group[0] != nil {
+		ref.Group = group[0]
+	}
+
+	return ref
+}
+
+// createTestScheme creates a scheme for testing with all required types registered.
+func createTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
+	_ = gatewayv1beta1.Install(scheme)
+	return scheme
+}
+
+// createTestFakeClient creates a fake client with test scheme and objects.
+func createTestFakeClient(objects ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(createTestScheme()).
+		WithObjects(objects...).
+		Build()
+}
+
+// createTestFakeClientWithInterceptors creates a fake client with test scheme, objects, and interceptors.
+func createTestFakeClientWithInterceptors(interceptors interceptor.Funcs, objects ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(createTestScheme()).
+		WithObjects(objects...).
+		WithInterceptorFuncs(interceptors).
+		Build()
+}
+
+// createTestService creates a test Service with specified parameters.
+func createTestService(name, namespace string, serviceType corev1.ServiceType, clusterIP, externalName string, ports []corev1.ServicePort) *corev1.Service {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  serviceType,
+			Ports: ports,
+		},
+	}
+	if clusterIP != "" {
+		svc.Spec.ClusterIP = clusterIP
+	}
+	if externalName != "" {
+		svc.Spec.ExternalName = externalName
+	}
+	return svc
+}
+
+// createTestValidBackendRef creates a test ValidBackendRef for testing.
+//
+//nolint:unparam // False positive: namespace parameter receives multiple different values (default, frontend, backend, test-namespace)
+func createTestValidBackendRef(serviceName, namespace string, weight *int32, readyEndpoints []string) ValidBackendRef {
+	serviceKind := gwtypes.Kind("Service")
+	actualWeight := int32(100) // Default weight.
+	if weight != nil {
+		actualWeight = *weight
+	}
+	return ValidBackendRef{
+		BackendRef: &gwtypes.HTTPBackendRef{
+			BackendRef: gwtypes.BackendRef{
+				BackendObjectReference: gwtypes.BackendObjectReference{
+					Name: gwtypes.ObjectName(serviceName),
+					Kind: &serviceKind,
+				},
+				Weight: weight,
+			},
+		},
+		Service: &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceName,
+				Namespace: namespace,
+			},
+		},
+		ServicePort: &corev1.ServicePort{
+			Name: "http",
+			Port: 80,
+		},
+		ReadyEndpoints: readyEndpoints,
+		TargetPort:     8080,         // Default target port.
+		Weight:         actualWeight, // Use the provided weight or default.
+	}
+}
+
+// TestFindBackendRefPortInService tests the findBackendRefPortInService function.
+func TestFindBackendRefPortInService(t *testing.T) {
+	// Helper function to create test HTTPBackendRef.
+	createTestHTTPBackendRef := func(port *int32) *gwtypes.HTTPBackendRef {
+		ref := &gwtypes.HTTPBackendRef{}
+		if port != nil {
+			ref.Port = (*gwtypes.PortNumber)(port)
+		}
+		return ref
+	}
+
+	// Helper function to create test Service for this specific test.
+	createSvc := func(name, namespace string, ports []corev1.ServicePort) *corev1.Service {
+		return &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec:       corev1.ServiceSpec{Ports: ports},
+		}
+	}
+
+	tests := []struct {
+		name          string
+		backendRef    *gwtypes.HTTPBackendRef
+		service       *corev1.Service
+		expectedPort  *corev1.ServicePort
+		expectedError string
+	}{
+		{
+			name:       "Valid port found",
+			backendRef: createTestHTTPBackendRef(ptr.To[int32](80)),
+			service: createSvc("test-service", "default", []corev1.ServicePort{
+				{
+					Name:     "http",
+					Port:     80,
+					Protocol: corev1.ProtocolTCP,
+				},
+			}),
+			expectedPort: &corev1.ServicePort{
+				Name:     "http",
+				Port:     80,
+				Protocol: corev1.ProtocolTCP,
+			},
+		},
+		{
+			name:          "Port not specified in BackendRef",
+			backendRef:    createTestHTTPBackendRef(nil),
+			service:       createSvc("test-service", "default", []corev1.ServicePort{}),
+			expectedError: "port not specified in BackendRef",
+		},
+		{
+			name:       "Port not found in service",
+			backendRef: createTestHTTPBackendRef(ptr.To[int32](443)),
+			service: createSvc("test-service", "default", []corev1.ServicePort{
+				{
+					Name:     "http",
+					Port:     80,
+					Protocol: corev1.ProtocolTCP,
+				},
+			}),
+			expectedError: "port 443 not found in service default/test-service",
+		},
+		{
+			name:       "Multiple ports, correct one found",
+			backendRef: createTestHTTPBackendRef(ptr.To[int32](443)),
+			service: createSvc("web-service", "prod", []corev1.ServicePort{
+				{
+					Name:     "http",
+					Port:     80,
+					Protocol: corev1.ProtocolTCP,
+				},
+				{
+					Name:     "https",
+					Port:     443,
+					Protocol: corev1.ProtocolTCP,
+				},
+				{
+					Name:     "metrics",
+					Port:     9090,
+					Protocol: corev1.ProtocolTCP,
+				},
+			}),
+			expectedPort: &corev1.ServicePort{
+				Name:     "https",
+				Port:     443,
+				Protocol: corev1.ProtocolTCP,
+			},
+		},
+		{
+			name:          "Service with no ports",
+			backendRef:    createTestHTTPBackendRef(ptr.To[int32](80)),
+			service:       createSvc("empty-service", "default", []corev1.ServicePort{}),
+			expectedError: "port 80 not found in service default/empty-service",
+		},
+		{
+			name:       "Different port protocols should not matter for matching",
+			backendRef: createTestHTTPBackendRef(ptr.To[int32](53)),
+			service: createSvc("dns-service", "kube-system", []corev1.ServicePort{
+				{
+					Name:     "dns-tcp",
+					Port:     53,
+					Protocol: corev1.ProtocolTCP,
+				},
+				{
+					Name:     "dns-udp",
+					Port:     53,
+					Protocol: corev1.ProtocolUDP,
+				},
+			}),
+			// Should return the first match (TCP one).
+			expectedPort: &corev1.ServicePort{
+				Name:     "dns-tcp",
+				Port:     53,
+				Protocol: corev1.ProtocolTCP,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port, err := findBackendRefPortInService(tt.backendRef, tt.service)
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.Nil(t, port)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, port)
+				assert.Equal(t, tt.expectedPort.Name, port.Name)
+				assert.Equal(t, tt.expectedPort.Port, port.Port)
+				assert.Equal(t, tt.expectedPort.Protocol, port.Protocol)
+			}
+		})
+	}
+}
+
+// TestExtractReadyEndpointAddresses tests the extractReadyEndpointAddresses function.
+func TestExtractReadyEndpointAddresses(t *testing.T) {
+	tests := []struct {
+		name              string
+		endpointSlices    *discoveryv1.EndpointSliceList
+		servicePort       *corev1.ServicePort
+		expectedAddresses []string
+	}{
+		{
+			name: "Extract ready endpoints with matching port",
+			endpointSlices: createTestEndpointSliceList([]discoveryv1.EndpointSlice{
+				createTestEndpointSlice("test-slice-1",
+					[]discoveryv1.EndpointPort{
+						createTestEndpointPort("http", 8080, corev1.ProtocolTCP),
+					},
+					[]discoveryv1.Endpoint{
+						createTestEndpoint([]string{"10.0.1.1", "10.0.1.2"}, true),
+						createTestEndpoint([]string{"10.0.1.3"}, true),
+					},
+				),
+			}),
+			servicePort:       createTestServicePort(),
+			expectedAddresses: []string{"10.0.1.1", "10.0.1.2", "10.0.1.3"},
+		},
+		{
+			name: "Skip not ready endpoints",
+			endpointSlices: createTestEndpointSliceList([]discoveryv1.EndpointSlice{
+				createTestEndpointSlice("test-slice-1",
+					[]discoveryv1.EndpointPort{
+						createTestEndpointPort("http", 8080, corev1.ProtocolTCP),
+					},
+					[]discoveryv1.Endpoint{
+						createTestEndpoint([]string{"10.0.1.1"}, true),  // Ready.
+						createTestEndpoint([]string{"10.0.1.2"}, false), // Not ready.
+						createTestEndpoint([]string{"10.0.1.3"}, true),  // Ready.
+					},
+				),
+			}),
+			servicePort:       createTestServicePort(),
+			expectedAddresses: []string{"10.0.1.1", "10.0.1.3"},
+		},
+		{
+			name: "Skip endpoints with nil Ready condition",
+			endpointSlices: createTestEndpointSliceList([]discoveryv1.EndpointSlice{
+				createTestEndpointSlice("test-slice-1",
+					[]discoveryv1.EndpointPort{
+						createTestEndpointPort("http", 8080, corev1.ProtocolTCP),
+					},
+					[]discoveryv1.Endpoint{
+						createTestEndpoint([]string{"10.0.1.1"}, true), // Ready.
+						{
+							Addresses: []string{"10.0.1.2"},
+							Conditions: discoveryv1.EndpointConditions{
+								Ready: nil, // Nil ready condition should be skipped.
+							},
+						},
+					},
+				),
+			}),
+			servicePort:       createTestServicePort(),
+			expectedAddresses: []string{"10.0.1.1"},
+		},
+		{
+			name: "Skip ports with different name",
+			endpointSlices: createTestEndpointSliceList([]discoveryv1.EndpointSlice{
+				createTestEndpointSlice("test-slice-1",
+					[]discoveryv1.EndpointPort{
+						createTestEndpointPort("https", 8443, corev1.ProtocolTCP), // Different name.
+					},
+					[]discoveryv1.Endpoint{
+						createTestEndpoint([]string{"10.0.1.1"}, true),
+					},
+				),
+			}),
+			servicePort:       createTestServicePort(),
+			expectedAddresses: nil,
+		},
+		{
+			name: "Skip ports with different protocol",
+			endpointSlices: createTestEndpointSliceList([]discoveryv1.EndpointSlice{
+				createTestEndpointSlice("test-slice-1",
+					[]discoveryv1.EndpointPort{
+						createTestEndpointPort("http", 8080, corev1.ProtocolUDP), // Different protocol.
+					},
+					[]discoveryv1.Endpoint{
+						createTestEndpoint([]string{"10.0.1.1"}, true),
+					},
+				),
+			}),
+			servicePort:       createTestServicePort(),
+			expectedAddresses: nil,
+		},
+		{
+			name: "Skip ports with nil port",
+			endpointSlices: createTestEndpointSliceList([]discoveryv1.EndpointSlice{
+				createTestEndpointSlice("test-slice-1",
+					[]discoveryv1.EndpointPort{
+						{
+							Name:     ptr.To("http"),
+							Port:     nil, // Nil port should be skipped.
+							Protocol: ptr.To(corev1.ProtocolTCP),
+						},
+					},
+					[]discoveryv1.Endpoint{
+						createTestEndpoint([]string{"10.0.1.1"}, true),
+					},
+				),
+			}),
+			servicePort:       createTestServicePort(),
+			expectedAddresses: nil,
+		},
+		{
+			name: "Skip ports with negative port number",
+			endpointSlices: createTestEndpointSliceList([]discoveryv1.EndpointSlice{
+				createTestEndpointSlice("test-slice-1",
+					[]discoveryv1.EndpointPort{
+						createTestEndpointPort("http", -1, corev1.ProtocolTCP), // Negative port.
+					},
+					[]discoveryv1.Endpoint{
+						createTestEndpoint([]string{"10.0.1.1"}, true),
+					},
+				),
+			}),
+			servicePort:       createTestServicePort(),
+			expectedAddresses: nil,
+		},
+		{
+			name: "Multiple endpoint slices with matching ports",
+			endpointSlices: createTestEndpointSliceList([]discoveryv1.EndpointSlice{
+				createTestEndpointSlice("test-slice-1",
+					[]discoveryv1.EndpointPort{
+						createTestEndpointPort("http", 8080, corev1.ProtocolTCP),
+					},
+					[]discoveryv1.Endpoint{
+						createTestEndpoint([]string{"10.0.1.1"}, true),
+					},
+				),
+				createTestEndpointSlice("test-slice-2",
+					[]discoveryv1.EndpointPort{
+						createTestEndpointPort("http", 8080, corev1.ProtocolTCP),
+					},
+					[]discoveryv1.Endpoint{
+						createTestEndpoint([]string{"10.0.1.2", "10.0.1.3"}, true),
+					},
+				),
+			}),
+			servicePort:       createTestServicePort(),
+			expectedAddresses: []string{"10.0.1.1", "10.0.1.2", "10.0.1.3"},
+		},
+		{
+			name:              "Empty endpoint slices",
+			endpointSlices:    createTestEndpointSliceList([]discoveryv1.EndpointSlice{}),
+			servicePort:       createTestServicePort(),
+			expectedAddresses: nil,
+		},
+		{
+			name: "Endpoint slice with no endpoints",
+			endpointSlices: createTestEndpointSliceList([]discoveryv1.EndpointSlice{
+				createTestEndpointSlice("test-slice-1",
+					[]discoveryv1.EndpointPort{
+						createTestEndpointPort("http", 8080, corev1.ProtocolTCP),
+					},
+					[]discoveryv1.Endpoint{}, // No endpoints.
+				),
+			}),
+			servicePort:       createTestServicePort(),
+			expectedAddresses: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addresses := extractReadyEndpointAddresses(tt.endpointSlices, tt.servicePort)
+			assert.Equal(t, tt.expectedAddresses, addresses)
+		})
+	}
+}
+
+// TestResolveFQDNEndpoints tests the resolveFQDNEndpoints function.
+func TestResolveFQDNEndpoints(t *testing.T) {
+	tests := []struct {
+		name          string
+		service       *corev1.Service
+		clusterDomain string
+		expected      []string
+	}{
+		{
+			name: "Default cluster domain (empty) uses short form",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-service",
+					Namespace: "default",
+				},
+			},
+			clusterDomain: "",
+			expected:      []string{"my-service.default.svc"},
+		},
+		{
+			name: "Custom cluster domain uses full FQDN",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-service",
+					Namespace: "default",
+				},
+			},
+			clusterDomain: "cluster.local",
+			expected:      []string{"my-service.default.svc.cluster.local"},
+		},
+		{
+			name: "Service with different namespace and custom domain",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "api-service",
+					Namespace: "backend",
+				},
+			},
+			clusterDomain: "my-cluster.local",
+			expected:      []string{"api-service.backend.svc.my-cluster.local"},
+		},
+		{
+			name: "Service with hyphenated names and empty domain",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "web-frontend-service",
+					Namespace: "production-ns",
+				},
+			},
+			clusterDomain: "",
+			expected:      []string{"web-frontend-service.production-ns.svc"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolveFQDNEndpoints(tt.service, tt.clusterDomain)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestResolveExternalNameEndpoints tests the resolveExternalNameEndpoints function.
+func TestResolveExternalNameEndpoints(t *testing.T) {
+	logger := ctrllog.Log.WithName("test")
+
+	tests := []struct {
+		name               string
+		service            *corev1.Service
+		expectedEndpoints  []string
+		expectedShouldSkip bool
+		expectedError      error
+	}{
+		{
+			name: "ExternalName service with valid external name",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "external-service",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					Type:         corev1.ServiceTypeExternalName,
+					ExternalName: "external.example.com",
+				},
+			},
+			expectedEndpoints:  []string{"external.example.com"},
+			expectedShouldSkip: false,
+			expectedError:      nil,
+		},
+		{
+			name: "ExternalName service with empty external name should be skipped",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "external-service-empty",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					Type:         corev1.ServiceTypeExternalName,
+					ExternalName: "",
+				},
+			},
+			expectedEndpoints:  nil,
+			expectedShouldSkip: true,
+			expectedError:      nil,
+		},
+		{
+			name: "ExternalName service with FQDN external name",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "database-service",
+					Namespace: "production",
+				},
+				Spec: corev1.ServiceSpec{
+					Type:         corev1.ServiceTypeExternalName,
+					ExternalName: "database.prod.example.com",
+				},
+			},
+			expectedEndpoints:  []string{"database.prod.example.com"},
+			expectedShouldSkip: false,
+			expectedError:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoints, shouldSkip, err := resolveExternalNameEndpoints(logger, tt.service)
+
+			assert.Equal(t, tt.expectedEndpoints, endpoints)
+			assert.Equal(t, tt.expectedShouldSkip, shouldSkip)
+			assert.Equal(t, tt.expectedError, err)
+		})
+	}
+}
+
+// TestResolveTargetPort tests the resolveTargetPort function.
+func TestResolveTargetPort(t *testing.T) {
+	tests := []struct {
+		name         string
+		service      *corev1.Service
+		servicePort  *corev1.ServicePort
+		fqdn         bool
+		expectedPort int
+	}{
+		{
+			name: "FQDN mode with regular service should use service port",
+			service: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.0.0.1", // Non-headless
+				},
+			},
+			servicePort: &corev1.ServicePort{
+				Port: 80,
+				TargetPort: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 8080,
+				},
+			},
+			fqdn:         true,
+			expectedPort: 80,
+		},
+		{
+			name: "FQDN mode with headless service should use target port",
+			service: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None", // Headless
+				},
+			},
+			servicePort: &corev1.ServicePort{
+				Port: 80,
+				TargetPort: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 8080,
+				},
+			},
+			fqdn:         true,
+			expectedPort: 8080,
+		},
+		{
+			name: "ExternalName service should use service port",
+			service: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type:         corev1.ServiceTypeExternalName,
+					ExternalName: "external.example.com",
+				},
+			},
+			servicePort: &corev1.ServicePort{
+				Port: 443,
+				TargetPort: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 8443,
+				},
+			},
+			fqdn:         false,
+			expectedPort: 443,
+		},
+		{
+			name: "Regular service without FQDN should use target port",
+			service: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: "10.0.0.1",
+				},
+			},
+			servicePort: &corev1.ServicePort{
+				Port: 80,
+				TargetPort: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 3000,
+				},
+			},
+			fqdn:         false,
+			expectedPort: 3000,
+		},
+		{
+			name: "Service without target port specified should use service port",
+			service: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: "10.0.0.1",
+				},
+			},
+			servicePort: &corev1.ServicePort{
+				Port:       8080,
+				TargetPort: intstr.IntOrString{}, // No target port specified
+			},
+			fqdn:         false,
+			expectedPort: 8080,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolveTargetPort(tt.service, tt.servicePort, tt.fqdn)
+			assert.Equal(t, tt.expectedPort, result)
+		})
+	}
+}
+
+// TestResolveEndpointSliceEndpoints tests the resolveEndpointSliceEndpoints function.
+func TestResolveEndpointSliceEndpoints(t *testing.T) {
+	ctx := context.Background()
+	logger := ctrllog.Log.WithName("test")
+
+	tests := []struct {
+		name               string
+		service            *corev1.Service
+		servicePort        *corev1.ServicePort
+		existingSlices     []discoveryv1.EndpointSlice
+		mockError          error
+		expectedEndpoints  []string
+		expectedShouldSkip bool
+		expectedError      bool
+		expectedErrorMsg   string
+	}{
+		{
+			name: "Service with ready endpoints should return endpoints",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "default",
+				},
+			},
+			servicePort: createTestServicePort(),
+			existingSlices: []discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "slice-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							discoveryv1.LabelServiceName: "test-service",
+						},
+					},
+					Ports: []discoveryv1.EndpointPort{
+						createTestEndpointPort("http", 80, corev1.ProtocolTCP),
+					},
+					Endpoints: []discoveryv1.Endpoint{
+						createTestEndpoint([]string{"10.0.0.1"}, true),
+						createTestEndpoint([]string{"10.0.0.2"}, true),
+					},
+				},
+			},
+			expectedEndpoints:  []string{"10.0.0.1", "10.0.0.2"},
+			expectedShouldSkip: false,
+			expectedError:      false,
+		},
+		{
+			name: "Service with no ready endpoints should be skipped",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "empty-service",
+					Namespace: "default",
+				},
+			},
+			servicePort:        createTestServicePort(),
+			existingSlices:     []discoveryv1.EndpointSlice{},
+			expectedEndpoints:  nil,
+			expectedShouldSkip: true,
+			expectedError:      false,
+		},
+		{
+			name: "EndpointSlices not found should be skipped",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "notfound-service",
+					Namespace: "default",
+				},
+			},
+			servicePort:        createTestServicePort(),
+			mockError:          k8serrors.NewNotFound(discoveryv1.Resource("endpointslices"), "notfound-service"),
+			expectedEndpoints:  nil,
+			expectedShouldSkip: true,
+			expectedError:      false,
+		},
+		{
+			name: "Network error should return error",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "error-service",
+					Namespace: "default",
+				},
+			},
+			servicePort:        createTestServicePort(),
+			mockError:          fmt.Errorf("network timeout"),
+			expectedEndpoints:  nil,
+			expectedShouldSkip: false,
+			expectedError:      true,
+			expectedErrorMsg:   "error fetching EndpointSlices for service default/error-service:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := createTestScheme()
+			var cl client.Client
+
+			if tt.mockError != nil {
+				// Create a client that returns the mock error.
+				cl = fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+							return tt.mockError
+						},
+					}).
+					Build()
+			} else {
+				// Create a normal fake client with existing slices.
+				objects := make([]client.Object, len(tt.existingSlices))
+				for i, slice := range tt.existingSlices {
+					objects[i] = &slice
+				}
+				cl = fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(objects...).
+					Build()
+			}
+
+			endpoints, shouldSkip, err := resolveEndpointSliceEndpoints(ctx, logger, cl, tt.service, tt.servicePort)
+
+			assert.Equal(t, tt.expectedEndpoints, endpoints)
+			assert.Equal(t, tt.expectedShouldSkip, shouldSkip)
+
+			if tt.expectedError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrorMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestResolveServiceEndpoints tests the resolveServiceEndpoints function.
+func TestResolveServiceEndpoints(t *testing.T) {
+	ctx := context.Background()
+	logger := ctrllog.Log.WithName("test")
+
+	tests := []struct {
+		name               string
+		service            *corev1.Service
+		servicePort        *corev1.ServicePort
+		fqdn               bool
+		clusterDomain      string
+		existingSlices     []discoveryv1.EndpointSlice
+		expectedEndpoints  []string
+		expectedShouldSkip bool
+		expectedError      bool
+	}{
+		{
+			name: "FQDN mode with regular service should use FQDN",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "web-service",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.0.0.1", // Non-headless
+				},
+			},
+			servicePort:        createTestServicePort(),
+			fqdn:               true,
+			expectedEndpoints:  []string{"web-service.default.svc"},
+			expectedShouldSkip: false,
+			expectedError:      false,
+		},
+		{
+			name: "ExternalName service should use external name",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "external-db",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					Type:         corev1.ServiceTypeExternalName,
+					ExternalName: "database.example.com",
+				},
+			},
+			servicePort:        createTestServicePort(),
+			fqdn:               false,
+			expectedEndpoints:  []string{"database.example.com"},
+			expectedShouldSkip: false,
+			expectedError:      false,
+		},
+		{
+			name: "ExternalName service with empty external name should be skipped",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "empty-external",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					Type:         corev1.ServiceTypeExternalName,
+					ExternalName: "",
+				},
+			},
+			servicePort:        createTestServicePort(),
+			fqdn:               false,
+			expectedEndpoints:  nil,
+			expectedShouldSkip: true,
+			expectedError:      false,
+		},
+		{
+			name: "Regular service without FQDN should use EndpointSlices",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "backend-service",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.0.0.1",
+				},
+			},
+			servicePort: createTestServicePort(),
+			fqdn:        false,
+			existingSlices: []discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "backend-slice",
+						Namespace: "default",
+						Labels: map[string]string{
+							discoveryv1.LabelServiceName: "backend-service",
+						},
+					},
+					Ports: []discoveryv1.EndpointPort{
+						createTestEndpointPort("http", 80, corev1.ProtocolTCP),
+					},
+					Endpoints: []discoveryv1.Endpoint{
+						createTestEndpoint([]string{"10.1.0.1"}, true),
+						createTestEndpoint([]string{"10.1.0.2"}, true),
+					},
+				},
+			},
+			expectedEndpoints:  []string{"10.1.0.1", "10.1.0.2"},
+			expectedShouldSkip: false,
+			expectedError:      false,
+		},
+		{
+			name: "Headless service with FQDN should still use EndpointSlices",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "headless-service",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None", // Headless
+				},
+			},
+			servicePort: createTestServicePort(),
+			fqdn:        true,
+			existingSlices: []discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "headless-slice",
+						Namespace: "default",
+						Labels: map[string]string{
+							discoveryv1.LabelServiceName: "headless-service",
+						},
+					},
+					Ports: []discoveryv1.EndpointPort{
+						createTestEndpointPort("http", 80, corev1.ProtocolTCP),
+					},
+					Endpoints: []discoveryv1.Endpoint{
+						createTestEndpoint([]string{"10.2.0.1"}, true),
+					},
+				},
+			},
+			expectedEndpoints:  []string{"10.2.0.1"},
+			expectedShouldSkip: false,
+			expectedError:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := createTestScheme()
+
+			// Create objects for the fake client.
+			objects := make([]client.Object, len(tt.existingSlices))
+			for i, slice := range tt.existingSlices {
+				objects[i] = &slice
+			}
+
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				Build()
+
+			endpoints, shouldSkip, err := resolveServiceEndpoints(ctx, logger, cl, tt.service, tt.servicePort, tt.fqdn, tt.clusterDomain)
+
+			assert.Equal(t, tt.expectedEndpoints, endpoints)
+			assert.Equal(t, tt.expectedShouldSkip, shouldSkip)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestGetEndpointSlicesForService tests the getEndpointSlicesForService function.
+func TestGetEndpointSlicesForService(t *testing.T) {
+	tests := []struct {
+		name                string
+		service             *corev1.Service
+		existingSlices      []discoveryv1.EndpointSlice
+		expectError         bool
+		expectedErrorString string
+		expectedSliceNames  []string
+	}{
+		{
+			name: "Service with matching endpoint slices",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "default",
+				},
+			},
+			existingSlices: []discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-service-slice-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							discoveryv1.LabelServiceName: "test-service",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-service-slice-2",
+						Namespace: "default",
+						Labels: map[string]string{
+							discoveryv1.LabelServiceName: "test-service",
+						},
+					},
+				},
+			},
+			expectedSliceNames: []string{"test-service-slice-1", "test-service-slice-2"},
+		},
+		{
+			name: "Service with no endpoint slices",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "empty-service",
+					Namespace: "test-ns",
+				},
+			},
+			existingSlices:     []discoveryv1.EndpointSlice{},
+			expectedSliceNames: []string{},
+		},
+		{
+			name: "Service with slices in different namespace should not match",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cross-ns-service",
+					Namespace: "namespace-a",
+				},
+			},
+			existingSlices: []discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cross-ns-service-slice",
+						Namespace: "namespace-b", // Different namespace.
+						Labels: map[string]string{
+							discoveryv1.LabelServiceName: "cross-ns-service",
+						},
+					},
+				},
+			},
+			expectedSliceNames: []string{},
+		},
+		{
+			name: "Service with slices with different service name should not match",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service-a",
+					Namespace: "default",
+				},
+			},
+			existingSlices: []discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "service-b-slice",
+						Namespace: "default",
+						Labels: map[string]string{
+							discoveryv1.LabelServiceName: "service-b", // Different service name.
+						},
+					},
+				},
+			},
+			expectedSliceNames: []string{},
+		},
+		{
+			name: "Service with mixed matching and non-matching slices",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mixed-service",
+					Namespace: "prod",
+				},
+			},
+			existingSlices: []discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "mixed-service-slice-1",
+						Namespace: "prod",
+						Labels: map[string]string{
+							discoveryv1.LabelServiceName: "mixed-service", // Matches.
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "other-service-slice",
+						Namespace: "prod",
+						Labels: map[string]string{
+							discoveryv1.LabelServiceName: "other-service", // Doesn't match.
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "mixed-service-slice-2",
+						Namespace: "prod",
+						Labels: map[string]string{
+							discoveryv1.LabelServiceName: "mixed-service", // Matches.
+						},
+					},
+				},
+			},
+			expectedSliceNames: []string{"mixed-service-slice-1", "mixed-service-slice-2"},
+		},
+		{
+			name: "Service with slice missing service name label",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "label-test-service",
+					Namespace: "default",
+				},
+			},
+			existingSlices: []discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "label-test-slice-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							discoveryv1.LabelServiceName: "label-test-service", // Has label.
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "label-test-slice-2",
+						Namespace: "default",
+						Labels:    map[string]string{}, // Missing service name label.
+					},
+				},
+			},
+			expectedSliceNames: []string{"label-test-slice-1"},
+		},
+		{
+			name: "Service with empty name",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "",
+					Namespace: "default",
+				},
+			},
+			existingSlices: []discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "empty-name-slice",
+						Namespace: "default",
+						Labels: map[string]string{
+							discoveryv1.LabelServiceName: "", // Empty service name.
+						},
+					},
+				},
+			},
+			expectedSliceNames: []string{"empty-name-slice"},
+		},
+		{
+			name: "Client List operation error should be handled",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "error-test-service",
+					Namespace: "default",
+				},
+			},
+			existingSlices:      []discoveryv1.EndpointSlice{},
+			expectError:         true,
+			expectedErrorString: "failed to list endpointslices for service default/error-test-service",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create objects for the fake client.
+			var objects []client.Object
+			for i := range tt.existingSlices {
+				objects = append(objects, &tt.existingSlices[i])
+			}
+
+			var fakeClient client.Client
+			// Add interceptor for client error test case.
+			if tt.expectedErrorString == "failed to list endpointslices for service default/error-test-service" {
+				fakeClient = createTestFakeClientWithInterceptors(interceptor.Funcs{
+					List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+						return fmt.Errorf("simulated client list error")
+					},
+				}, objects...)
+			} else {
+				fakeClient = createTestFakeClient(objects...)
+			}
+
+			// Call the function.
+			ctx := context.Background()
+			result, err := getEndpointSlicesForService(ctx, fakeClient, tt.service)
+
+			// Verify error expectations.
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.expectedErrorString != "" {
+					assert.Contains(t, err.Error(), tt.expectedErrorString)
+				}
+				return
+			}
+
+			// Verify success case.
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Len(t, result.Items, len(tt.expectedSliceNames))
+
+			// Verify returned slice names.
+			actualNames := make([]string, len(result.Items))
+			for i, slice := range result.Items {
+				actualNames[i] = slice.Name
+			}
+			assert.ElementsMatch(t, tt.expectedSliceNames, actualNames)
+
+			// Verify that all returned slices have the correct service label.
+			for _, slice := range result.Items {
+				assert.Equal(t, tt.service.Name, slice.Labels[discoveryv1.LabelServiceName])
+				assert.Equal(t, tt.service.Namespace, slice.Namespace)
+			}
+		})
+	}
+}
+
+// TestFilterValidBackendRefs tests the filterValidBackendRefs function.
+func TestFilterValidBackendRefs(t *testing.T) {
+	// Create logger for testing.
+	logger := ctrllog.Log.WithName("test")
+
+	// Use global helpers instead of local duplicates.
+	createTestHTTPRoute := createGlobalTestHTTPRoute
+	createTestHTTPBackendRef := func(name string, namespace *string, port *int32) gwtypes.HTTPBackendRef {
+		ns := ""
+		if namespace != nil {
+			ns = *namespace
+		}
+		return createGlobalTestHTTPBackendRef(name, ns, nil, port)
+	}
+
+	tests := []struct {
+		name                   string
+		httpRoute              *gwtypes.HTTPRoute
+		backendRefs            []gwtypes.HTTPBackendRef
+		referenceGrantEnabled  bool
+		fqdn                   bool
+		existingServices       []corev1.Service
+		existingEndpointSlices []discoveryv1.EndpointSlice
+		expectError            bool
+		expectedErrorString    string
+		expectedValidCount     int
+		validateResults        func(t *testing.T, results []ValidBackendRef)
+	}{
+		{
+			name:      "Valid backend ref with regular service",
+			httpRoute: createTestHTTPRoute("test-route", "default"),
+			backendRefs: []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("test-service", nil, ptr.To[int32](80)),
+			},
+			referenceGrantEnabled: false,
+			fqdn:                  false,
+			existingServices: []corev1.Service{
+				*createTestService("test-service", "default", corev1.ServiceTypeClusterIP, "10.0.0.1", "", []corev1.ServicePort{
+					{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8080)},
+				}),
+			},
+			existingEndpointSlices: []discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-service-slice",
+						Namespace: "default",
+						Labels:    map[string]string{discoveryv1.LabelServiceName: "test-service"},
+					},
+					Ports: []discoveryv1.EndpointPort{
+						{Name: ptr.To("http"), Port: ptr.To[int32](8080), Protocol: ptr.To(corev1.ProtocolTCP)},
+					},
+					Endpoints: []discoveryv1.Endpoint{
+						{
+							Addresses:  []string{"10.0.1.1"},
+							Conditions: discoveryv1.EndpointConditions{Ready: ptr.To(true)},
+						},
+					},
+				},
+			},
+			expectedValidCount: 1,
+			validateResults: func(t *testing.T, results []ValidBackendRef) {
+				require.Len(t, results, 1)
+				assert.Equal(t, "test-service", string(results[0].BackendRef.Name))
+				assert.Equal(t, []string{"10.0.1.1"}, results[0].ReadyEndpoints)
+				assert.Equal(t, 8080, results[0].TargetPort) // Should use target port for direct endpoint access.
+			},
+		},
+		{
+			name:      "FQDN mode with regular service",
+			httpRoute: createTestHTTPRoute("test-route", "default"),
+			backendRefs: []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("test-service", nil, ptr.To[int32](80)),
+			},
+			referenceGrantEnabled: false,
+			fqdn:                  true,
+			existingServices: []corev1.Service{
+				*createTestService("test-service", "default", corev1.ServiceTypeClusterIP, "10.0.0.1", "", []corev1.ServicePort{
+					{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP},
+				}),
+			},
+			expectedValidCount: 1,
+			validateResults: func(t *testing.T, results []ValidBackendRef) {
+				require.Len(t, results, 1)
+				assert.Equal(t, []string{"test-service.default.svc.cluster.local"}, results[0].ReadyEndpoints)
+				assert.Equal(t, 80, results[0].TargetPort) // Should use service port for FQDN mode.
+			},
+		},
+		{
+			name:      "ExternalName service",
+			httpRoute: createTestHTTPRoute("test-route", "default"),
+			backendRefs: []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("external-service", nil, ptr.To[int32](443)),
+			},
+			referenceGrantEnabled: false,
+			fqdn:                  false,
+			existingServices: []corev1.Service{
+				*createTestService("external-service", "default", corev1.ServiceTypeExternalName, "", "external.example.com", []corev1.ServicePort{
+					{Name: "https", Port: 443, Protocol: corev1.ProtocolTCP},
+				}),
+			},
+			expectedValidCount: 1,
+			validateResults: func(t *testing.T, results []ValidBackendRef) {
+				require.Len(t, results, 1)
+				assert.Equal(t, []string{"external.example.com"}, results[0].ReadyEndpoints)
+				assert.Equal(t, 443, results[0].TargetPort) // Should use service port for ExternalName.
+			},
+		},
+		{
+			name:      "Headless service",
+			httpRoute: createTestHTTPRoute("test-route", "default"),
+			backendRefs: []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("headless-service", nil, ptr.To[int32](80)),
+			},
+			referenceGrantEnabled: false,
+			fqdn:                  true, // Even with FQDN, headless services should use endpoints.
+			existingServices: []corev1.Service{
+				*createTestService("headless-service", "default", corev1.ServiceTypeClusterIP, "None", "", []corev1.ServicePort{
+					{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8080)},
+				}),
+			},
+			existingEndpointSlices: []discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "headless-service-slice",
+						Namespace: "default",
+						Labels:    map[string]string{discoveryv1.LabelServiceName: "headless-service"},
+					},
+					Ports: []discoveryv1.EndpointPort{
+						{Name: ptr.To("http"), Port: ptr.To[int32](8080), Protocol: ptr.To(corev1.ProtocolTCP)},
+					},
+					Endpoints: []discoveryv1.Endpoint{
+						{
+							Addresses:  []string{"10.0.1.1", "10.0.1.2"},
+							Conditions: discoveryv1.EndpointConditions{Ready: ptr.To(true)},
+						},
+					},
+				},
+			},
+			expectedValidCount: 1,
+			validateResults: func(t *testing.T, results []ValidBackendRef) {
+				require.Len(t, results, 1)
+				assert.Equal(t, []string{"10.0.1.1", "10.0.1.2"}, results[0].ReadyEndpoints)
+				assert.Equal(t, 8080, results[0].TargetPort) // Should use target port for headless service.
+			},
+		},
+		{
+			name:      "Service not found should be skipped",
+			httpRoute: createTestHTTPRoute("test-route", "default"),
+			backendRefs: []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("missing-service", nil, ptr.To[int32](80)),
+			},
+			referenceGrantEnabled: false,
+			fqdn:                  false,
+			existingServices:      []corev1.Service{}, // No services.
+			expectedValidCount:    0,
+		},
+		{
+			name:      "Invalid port should be skipped",
+			httpRoute: createTestHTTPRoute("test-route", "default"),
+			backendRefs: []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("test-service", nil, ptr.To[int32](9999)), // Port not in service.
+			},
+			referenceGrantEnabled: false,
+			fqdn:                  false,
+			existingServices: []corev1.Service{
+				*createTestService("test-service", "default", corev1.ServiceTypeClusterIP, "10.0.0.1", "", []corev1.ServicePort{
+					{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP},
+				}),
+			},
+			expectedValidCount: 0,
+		},
+		{
+			name:      "Service with no ready endpoints should be skipped",
+			httpRoute: createTestHTTPRoute("test-route", "default"),
+			backendRefs: []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("no-endpoints-service", nil, ptr.To[int32](80)),
+			},
+			referenceGrantEnabled: false,
+			fqdn:                  false,
+			existingServices: []corev1.Service{
+				*createTestService("no-endpoints-service", "default", corev1.ServiceTypeClusterIP, "10.0.0.1", "", []corev1.ServicePort{
+					{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP},
+				}),
+			},
+			existingEndpointSlices: []discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "no-endpoints-service-slice",
+						Namespace: "default",
+						Labels:    map[string]string{discoveryv1.LabelServiceName: "no-endpoints-service"},
+					},
+					Ports: []discoveryv1.EndpointPort{
+						{Name: ptr.To("http"), Port: ptr.To[int32](8080), Protocol: ptr.To(corev1.ProtocolTCP)},
+					},
+					Endpoints: []discoveryv1.Endpoint{
+						{
+							Addresses:  []string{"10.0.1.1"},
+							Conditions: discoveryv1.EndpointConditions{Ready: ptr.To(false)}, // Not ready.
+						},
+					},
+				},
+			},
+			expectedValidCount: 0,
+		},
+		{
+			name:      "ExternalName service with empty externalName should be skipped",
+			httpRoute: createTestHTTPRoute("test-route", "default"),
+			backendRefs: []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("empty-external-service", nil, ptr.To[int32](443)),
+			},
+			referenceGrantEnabled: false,
+			fqdn:                  false,
+			existingServices: []corev1.Service{
+				*createTestService("empty-external-service", "default", corev1.ServiceTypeExternalName, "", "", []corev1.ServicePort{
+					{Name: "https", Port: 443, Protocol: corev1.ProtocolTCP},
+				}),
+			},
+			expectedValidCount: 0,
+		},
+		{
+			name:      "Multiple backend refs with mixed validity",
+			httpRoute: createTestHTTPRoute("test-route", "default"),
+			backendRefs: []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("valid-service", nil, ptr.To[int32](80)),
+				createTestHTTPBackendRef("missing-service", nil, ptr.To[int32](80)),
+				createTestHTTPBackendRef("valid-service", nil, ptr.To[int32](443)), // Invalid port.
+			},
+			referenceGrantEnabled: false,
+			fqdn:                  false,
+			existingServices: []corev1.Service{
+				*createTestService("valid-service", "default", corev1.ServiceTypeClusterIP, "10.0.0.1", "", []corev1.ServicePort{
+					{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8080)},
+				}),
+			},
+			existingEndpointSlices: []discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "valid-service-slice",
+						Namespace: "default",
+						Labels:    map[string]string{discoveryv1.LabelServiceName: "valid-service"},
+					},
+					Ports: []discoveryv1.EndpointPort{
+						{Name: ptr.To("http"), Port: ptr.To[int32](8080), Protocol: ptr.To(corev1.ProtocolTCP)},
+					},
+					Endpoints: []discoveryv1.Endpoint{
+						{
+							Addresses:  []string{"10.0.1.1"},
+							Conditions: discoveryv1.EndpointConditions{Ready: ptr.To(true)},
+						},
+					},
+				},
+			},
+			expectedValidCount: 1, // Only the first backend ref should be valid.
+			validateResults: func(t *testing.T, results []ValidBackendRef) {
+				require.Len(t, results, 1)
+				assert.Equal(t, "valid-service", string(results[0].BackendRef.Name))
+			},
+		},
+		{
+			name:      "Backend ref without port should be skipped",
+			httpRoute: createTestHTTPRoute("test-route", "default"),
+			backendRefs: []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("test-service", nil, nil), // No port specified.
+			},
+			referenceGrantEnabled: false,
+			fqdn:                  false,
+			existingServices: []corev1.Service{
+				*createTestService("test-service", "default", corev1.ServiceTypeClusterIP, "10.0.0.1", "", []corev1.ServicePort{
+					{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP},
+				}),
+			},
+			expectedValidCount: 0,
+		},
+		{
+			name:      "Unsupported backend ref kind should be skipped",
+			httpRoute: createTestHTTPRoute("test-route", "default"),
+			backendRefs: []gwtypes.HTTPBackendRef{
+				func() gwtypes.HTTPBackendRef {
+					unsupportedKind := gwtypes.Kind("ConfigMap")
+					ref := createTestHTTPBackendRef("test-configmap", nil, ptr.To[int32](80))
+					ref.Kind = &unsupportedKind
+					return ref
+				}(),
+			},
+			referenceGrantEnabled: false,
+			fqdn:                  false,
+			existingServices:      []corev1.Service{}, // No services needed since it should be skipped.
+			expectedValidCount:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create objects for the fake client.
+			var objects []client.Object
+			for i := range tt.existingServices {
+				objects = append(objects, &tt.existingServices[i])
+			}
+			for i := range tt.existingEndpointSlices {
+				objects = append(objects, &tt.existingEndpointSlices[i])
+			}
+
+			// Create fake client.
+			fakeClient := createTestFakeClient(objects...)
+
+			// Call the function.
+			ctx := context.Background()
+			results, err := filterValidBackendRefs(ctx, logger, fakeClient, tt.httpRoute, tt.backendRefs, tt.referenceGrantEnabled, tt.fqdn, "cluster.local") // Verify error expectations.
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.expectedErrorString != "" {
+					assert.Contains(t, err.Error(), tt.expectedErrorString)
+				}
+				return
+			}
+
+			// Verify success case.
+			require.NoError(t, err)
+			assert.Len(t, results, tt.expectedValidCount)
+
+			// Run custom validation if provided.
+			if tt.validateResults != nil {
+				tt.validateResults(t, results)
+			}
+		})
+	}
+
+	// Additional test for EndpointSlices error handling.
+	t.Run("EndpointSlices fetch error should be returned", func(t *testing.T) {
+		existingServices := []corev1.Service{
+			*createTestService("test-service", "default", corev1.ServiceTypeClusterIP, "10.0.0.1", "", []corev1.ServicePort{
+				{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8080)},
+			}),
+		}
+
+		// Create objects for the fake client.
+		var objects []client.Object
+		for i := range existingServices {
+			objects = append(objects, &existingServices[i])
+		}
+
+		// Create fake client with interceptor that simulates network error.
+		interceptorFunc := interceptor.Funcs{
+			List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*discoveryv1.EndpointSliceList); ok {
+					return fmt.Errorf("simulated network error")
+				}
+				return client.List(ctx, list, opts...)
+			},
+		}
+
+		fakeClient := createTestFakeClientWithInterceptors(interceptorFunc, objects...)
+
+		httpRoute := createTestHTTPRoute("test-route", "default")
+		backendRefs := []gwtypes.HTTPBackendRef{
+			createTestHTTPBackendRef("test-service", nil, ptr.To[int32](80)),
+		}
+
+		// Call the function.
+		ctx := context.Background()
+		_, err := filterValidBackendRefs(ctx, logger, fakeClient, httpRoute, backendRefs, false, false, "cluster.local")
+
+		// Verify that the error is returned.
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "error fetching EndpointSlices for service default/test-service")
+		assert.Contains(t, err.Error(), "simulated network error")
+	})
+
+	// Additional test for cross-namespace backend ref (namespace determination logic).
+	t.Run("Cross-namespace backend ref without ReferenceGrant should be skipped", func(t *testing.T) {
+		existingServices := []corev1.Service{
+			*createTestService("cross-ns-service", "other-namespace", corev1.ServiceTypeClusterIP, "10.0.0.1", "", []corev1.ServicePort{
+				{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8080)},
+			}),
+		}
+
+		// Create objects for the fake client.
+		var objects []client.Object
+		for i := range existingServices {
+			objects = append(objects, &existingServices[i])
+		}
+
+		fakeClient := createTestFakeClient(objects...)
+
+		httpRoute := createTestHTTPRoute("test-route", "default")
+		backendRefs := []gwtypes.HTTPBackendRef{
+			createTestHTTPBackendRef("cross-ns-service", ptr.To("other-namespace"), ptr.To[int32](80)),
+		}
+
+		// Call the function with ReferenceGrant disabled.
+		ctx := context.Background()
+		results, err := filterValidBackendRefs(ctx, logger, fakeClient, httpRoute, backendRefs, false, false, "cluster.local") // Should succeed but return no valid backend refs since ReferenceGrant is disabled.
+		require.NoError(t, err)
+		assert.Len(t, results, 0) // Cross-namespace access blocked without ReferenceGrant.
+	})
+
+	// Test ReferenceGrant scenarios.
+	t.Run("ReferenceGrant enabled scenarios", func(t *testing.T) {
+
+		existingServices := []corev1.Service{
+			*createTestService("cross-ns-service", "other-namespace", corev1.ServiceTypeClusterIP, "10.0.0.1", "", []corev1.ServicePort{
+				{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8080)},
+			}),
+		}
+
+		existingEndpointSlices := []discoveryv1.EndpointSlice{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cross-ns-service-slice",
+					Namespace: "other-namespace",
+					Labels:    map[string]string{discoveryv1.LabelServiceName: "cross-ns-service"},
+				},
+				Ports: []discoveryv1.EndpointPort{
+					{Name: ptr.To("http"), Port: ptr.To[int32](8080), Protocol: ptr.To(corev1.ProtocolTCP)},
+				},
+				Endpoints: []discoveryv1.Endpoint{
+					{
+						Addresses:  []string{"10.0.1.1"},
+						Conditions: discoveryv1.EndpointConditions{Ready: ptr.To(true)},
+					},
+				},
+			},
+		}
+
+		// Test case 1: No ReferenceGrant exists - should be blocked.
+		t.Run("No ReferenceGrant exists", func(t *testing.T) {
+			// Create objects for the fake client (no ReferenceGrant).
+			var objects []client.Object
+			for i := range existingServices {
+				objects = append(objects, &existingServices[i])
+			}
+			for i := range existingEndpointSlices {
+				objects = append(objects, &existingEndpointSlices[i])
+			}
+
+			fakeClient := createTestFakeClient(objects...)
+
+			httpRoute := createTestHTTPRoute("test-route", "default")
+			backendRefs := []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("cross-ns-service", ptr.To("other-namespace"), ptr.To[int32](80)),
+			}
+
+			// Call the function with ReferenceGrant enabled.
+			ctx := context.Background()
+			results, err := filterValidBackendRefs(ctx, logger, fakeClient, httpRoute, backendRefs, true, false, "cluster.local")
+
+			// Should succeed but return no valid backend refs since no ReferenceGrant exists.
+			require.NoError(t, err)
+			assert.Len(t, results, 0) // Cross-namespace access blocked without ReferenceGrant.
+		})
+
+		// Test case 2: ReferenceGrant exists but doesn't permit - should be blocked.
+		t.Run("ReferenceGrant exists but doesn't permit", func(t *testing.T) {
+			// Create a ReferenceGrant that doesn't permit the reference.
+			nonPermittingGrant := &gatewayv1beta1.ReferenceGrant{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "non-permitting-grant",
+					Namespace: "other-namespace",
+				},
+				Spec: gatewayv1beta1.ReferenceGrantSpec{
+					From: []gatewayv1beta1.ReferenceGrantFrom{
+						{
+							Group:     "gateway.networking.k8s.io",
+							Kind:      "HTTPRoute",
+							Namespace: "wrong-namespace", // Wrong source namespace.
+						},
+					},
+					To: []gatewayv1beta1.ReferenceGrantTo{
+						{
+							Group: "",
+							Kind:  "Service",
+						},
+					},
+				},
+			}
+
+			// Create objects for the fake client.
+			var objects []client.Object
+			for i := range existingServices {
+				objects = append(objects, &existingServices[i])
+			}
+			for i := range existingEndpointSlices {
+				objects = append(objects, &existingEndpointSlices[i])
+			}
+			objects = append(objects, nonPermittingGrant)
+
+			fakeClient := createTestFakeClient(objects...)
+
+			httpRoute := createTestHTTPRoute("test-route", "default")
+			backendRefs := []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("cross-ns-service", ptr.To("other-namespace"), ptr.To[int32](80)),
+			}
+
+			// Call the function with ReferenceGrant enabled.
+			ctx := context.Background()
+			results, err := filterValidBackendRefs(ctx, logger, fakeClient, httpRoute, backendRefs, true, false, "cluster.local")
+
+			// Should succeed but return no valid backend refs since ReferenceGrant doesn't permit.
+			require.NoError(t, err)
+			assert.Len(t, results, 0) // Cross-namespace access blocked by non-permitting ReferenceGrant.
+		})
+
+		// Test case 3: Error in CheckReferenceGrant - should return error.
+		t.Run("Error in CheckReferenceGrant", func(t *testing.T) {
+			// Create fake client with interceptor that simulates ReferenceGrant list error.
+			interceptorFunc := interceptor.Funcs{
+				List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					if _, ok := list.(*gatewayv1beta1.ReferenceGrantList); ok {
+						return fmt.Errorf("simulated ReferenceGrant list error")
+					}
+					return client.List(ctx, list, opts...)
+				},
+			}
+
+			// Create objects for the fake client.
+			var objects []client.Object
+			for i := range existingServices {
+				objects = append(objects, &existingServices[i])
+			}
+
+			fakeClient := createTestFakeClientWithInterceptors(interceptorFunc, objects...)
+
+			httpRoute := createTestHTTPRoute("test-route", "default")
+			backendRefs := []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("cross-ns-service", ptr.To("other-namespace"), ptr.To[int32](80)),
+			}
+
+			// Call the function with ReferenceGrant enabled.
+			ctx := context.Background()
+			_, err := filterValidBackendRefs(ctx, logger, fakeClient, httpRoute, backendRefs, true, false, "cluster.local")
+
+			// Should return an error.
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "error checking ReferenceGrant for BackendRef cross-ns-service")
+			assert.Contains(t, err.Error(), "simulated ReferenceGrant list error")
+		})
+	})
+
+	// Additional test for EndpointSlices NotFound scenario.
+	t.Run("Service with EndpointSlices NotFound should be skipped", func(t *testing.T) {
+		existingServices := []corev1.Service{
+			*createTestService("no-endpointslices-service", "default", corev1.ServiceTypeClusterIP, "10.0.0.1", "", []corev1.ServicePort{
+				{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8080)},
+			}),
+		}
+
+		// Create objects for the fake client (no EndpointSlices).
+		var objects []client.Object
+		for i := range existingServices {
+			objects = append(objects, &existingServices[i])
+		}
+
+		// Create fake client with interceptor that simulates NotFound error for EndpointSlices.
+		interceptorFunc := interceptor.Funcs{
+			List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*discoveryv1.EndpointSliceList); ok {
+					// Return a NotFound error for EndpointSlices.
+					return &k8serrors.StatusError{
+						ErrStatus: metav1.Status{
+							Status:  metav1.StatusFailure,
+							Code:    404,
+							Reason:  metav1.StatusReasonNotFound,
+							Message: "endpointslices.discovery.k8s.io not found",
+						},
+					}
+				}
+				return client.List(ctx, list, opts...)
+			},
+		}
+
+		fakeClient := createTestFakeClientWithInterceptors(interceptorFunc, objects...)
+
+		httpRoute := createTestHTTPRoute("test-route", "default")
+		backendRefs := []gwtypes.HTTPBackendRef{
+			createTestHTTPBackendRef("no-endpointslices-service", nil, ptr.To[int32](80)),
+		}
+
+		// Call the function.
+		ctx := context.Background()
+		results, err := filterValidBackendRefs(ctx, logger, fakeClient, httpRoute, backendRefs, false, false, "cluster.local")
+
+		// Should succeed but return no valid backend refs since no EndpointSlices found.
+		require.NoError(t, err)
+		assert.Len(t, results, 0) // Service skipped due to no EndpointSlices.
+	})
+}
+
+// TestRecalculateWeightsAcrossBackendRefs tests the recalculateWeightsAcrossBackendRefs function.
+func TestRecalculateWeightsAcrossBackendRefs(t *testing.T) {
+	// Helper function to create test ValidBackendRef.
+	createTestValidBackendRef := func(serviceName, namespace string, weight *int32, readyEndpoints []string) ValidBackendRef {
+		serviceKind := gwtypes.Kind("Service")
+		return ValidBackendRef{
+			BackendRef: &gwtypes.HTTPBackendRef{
+				BackendRef: gwtypes.BackendRef{
+					BackendObjectReference: gwtypes.BackendObjectReference{
+						Name: gwtypes.ObjectName(serviceName),
+						Kind: &serviceKind,
+					},
+					Weight: weight,
+				},
+			},
+			Service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceName,
+					Namespace: namespace,
+				},
+			},
+			ServicePort: &corev1.ServicePort{
+				Name: "http",
+				Port: 80,
+			},
+			ReadyEndpoints: readyEndpoints,
+			TargetPort:     8080,
+			Weight:         0, // This will be calculated by the function.
+		}
+	}
+
+	tests := []struct {
+		name           string
+		input          []ValidBackendRef
+		validateResult func(t *testing.T, result []ValidBackendRef)
+	}{
+		{
+			name:  "Empty input should return empty output",
+			input: []ValidBackendRef{},
+			validateResult: func(t *testing.T, result []ValidBackendRef) {
+				assert.Len(t, result, 0)
+			},
+		},
+		{
+			name: "Single backend ref should get calculated weight",
+			input: []ValidBackendRef{
+				createTestValidBackendRef("service1", "default", ptr.To[int32](100), []string{"10.0.1.1", "10.0.1.2"}),
+			},
+			validateResult: func(t *testing.T, result []ValidBackendRef) {
+				require.Len(t, result, 1)
+				// With single backend, weight should be simplified ratio.
+				// 100 weight / 2 endpoints = 50/1 = 50, but simplified to 1.
+				assert.Equal(t, int32(1), result[0].Weight)
+			},
+		},
+		{
+			name: "Multiple backend refs with equal weights",
+			input: []ValidBackendRef{
+				createTestValidBackendRef("service1", "default", ptr.To[int32](50), []string{"10.0.1.1"}),
+				createTestValidBackendRef("service2", "default", ptr.To[int32](50), []string{"10.0.2.1"}),
+			},
+			validateResult: func(t *testing.T, result []ValidBackendRef) {
+				require.Len(t, result, 2)
+				// Both services have equal weight/endpoint ratios (50/1), so they get equal weight.
+				assert.Equal(t, int32(1), result[0].Weight)
+				assert.Equal(t, int32(1), result[1].Weight)
+			},
+		},
+		{
+			name: "Multiple backend refs with different weights",
+			input: []ValidBackendRef{
+				createTestValidBackendRef("service1", "default", ptr.To[int32](80), []string{"10.0.1.1"}),
+				createTestValidBackendRef("service2", "default", ptr.To[int32](20), []string{"10.0.2.1"}),
+			},
+			validateResult: func(t *testing.T, result []ValidBackendRef) {
+				require.Len(t, result, 2)
+				// service1: 80/1 = 80, service2: 20/1 = 20. Ratio 80:20 = 4:1.
+				assert.Equal(t, int32(4), result[0].Weight)
+				assert.Equal(t, int32(1), result[1].Weight)
+			},
+		},
+		{
+			name: "Backend refs with different endpoint counts",
+			input: []ValidBackendRef{
+				createTestValidBackendRef("service1", "default", ptr.To[int32](50), []string{"10.0.1.1", "10.0.1.2"}), // 2 endpoints.
+				createTestValidBackendRef("service2", "default", ptr.To[int32](50), []string{"10.0.2.1"}),             // 1 endpoint.
+			},
+			validateResult: func(t *testing.T, result []ValidBackendRef) {
+				require.Len(t, result, 2)
+				// service1: 50/2 = 25, service2: 50/1 = 50. Ratio 25:50 = 1:2.
+				assert.Equal(t, int32(1), result[0].Weight)
+				assert.Equal(t, int32(2), result[1].Weight)
+			},
+		},
+		{
+			name: "Backend refs with nil weights should default to 1",
+			input: []ValidBackendRef{
+				createTestValidBackendRef("service1", "default", nil, []string{"10.0.1.1"}),              // No weight (defaults to 1).
+				createTestValidBackendRef("service2", "default", ptr.To[int32](3), []string{"10.0.2.1"}), // Weight 3.
+			},
+			validateResult: func(t *testing.T, result []ValidBackendRef) {
+				require.Len(t, result, 2)
+				// service1: 1/1 = 1, service2: 3/1 = 3. Ratio 1:3.
+				assert.Equal(t, int32(1), result[0].Weight)
+				assert.Equal(t, int32(3), result[1].Weight)
+			},
+		},
+		{
+			name: "Backend refs with no ready endpoints should get zero weight",
+			input: []ValidBackendRef{
+				createTestValidBackendRef("service-with-endpoints", "default", ptr.To[int32](50), []string{"10.0.1.1"}),
+				createTestValidBackendRef("service-no-endpoints", "default", ptr.To[int32](50), []string{}), // No endpoints.
+			},
+			validateResult: func(t *testing.T, result []ValidBackendRef) {
+				require.Len(t, result, 2)
+				// Service with endpoints should get positive weight.
+				assert.True(t, result[0].Weight > 0, "service with endpoints should have positive weight")
+				// Service with no endpoints should get zero weight.
+				assert.Equal(t, int32(0), result[1].Weight, "service with no endpoints should have zero weight")
+			},
+		},
+		{
+			name: "Backend ref with zero weight should get zero weight regardless of endpoints",
+			input: []ValidBackendRef{
+				createTestValidBackendRef("service-normal", "default", ptr.To[int32](50), []string{"10.0.1.1"}),
+				createTestValidBackendRef("service-zero-weight", "default", ptr.To[int32](0), []string{"10.0.2.1"}), // Zero weight.
+			},
+			validateResult: func(t *testing.T, result []ValidBackendRef) {
+				require.Len(t, result, 2)
+				// Normal service should get positive weight.
+				assert.True(t, result[0].Weight > 0, "normal service should have positive weight")
+				// Zero weight service should get zero weight.
+				assert.Equal(t, int32(0), result[1].Weight, "zero weight service should have zero weight")
+			},
+		},
+		{
+			name: "Complex scenario with multiple services and varying endpoints",
+			input: []ValidBackendRef{
+				createTestValidBackendRef("web", "frontend", ptr.To[int32](60), []string{"10.0.1.1", "10.0.1.2", "10.0.1.3"}), // 3 endpoints.
+				createTestValidBackendRef("api", "backend", ptr.To[int32](30), []string{"10.0.2.1", "10.0.2.2"}),              // 2 endpoints.
+				createTestValidBackendRef("cache", "backend", ptr.To[int32](10), []string{"10.0.3.1"}),                        // 1 endpoint.
+			},
+			validateResult: func(t *testing.T, result []ValidBackendRef) {
+				require.Len(t, result, 3)
+				// Complex weight calculation based on CalculateEndpointWeights logic.
+				// The exact values depend on the weight distribution algorithm.
+				assert.True(t, result[0].Weight > 0, "web service should have positive weight")
+				assert.True(t, result[1].Weight > 0, "api service should have positive weight")
+				assert.True(t, result[2].Weight > 0, "cache service should have positive weight")
+				// Total weight should be reasonable.
+				totalWeight := result[0].Weight + result[1].Weight + result[2].Weight
+				assert.True(t, totalWeight > 0 && totalWeight <= 200, "total weight should be reasonable")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Call the function.
+			result := recalculateWeightsAcrossBackendRefs(tt.input)
+
+			// Check basic expectations.
+			assert.Len(t, result, len(tt.input))
+
+			// Run custom validation if provided.
+			if tt.validateResult != nil {
+				tt.validateResult(t, result)
+			}
+
+			// Verify that input structs are modified (weights updated).
+			for i, vbRef := range result {
+				// Weight should be >= 0 (can be 0 for backends with no endpoints or zero weight).
+				assert.True(t, vbRef.Weight >= 0, "weight should be non-negative for backend %d", i)
+				// Verify that other fields are preserved.
+				assert.Equal(t, tt.input[i].BackendRef, vbRef.BackendRef, "BackendRef should be preserved")
+				assert.Equal(t, tt.input[i].Service, vbRef.Service, "Service should be preserved")
+				assert.Equal(t, tt.input[i].ReadyEndpoints, vbRef.ReadyEndpoints, "ReadyEndpoints should be preserved")
+			}
+		})
+	}
+}
+
+func TestCreateTargetsFromValidBackendRefs(t *testing.T) {
+	// Use global helper.
+	createTestHTTPRoute := func(name, namespace string, backendRefs []gwtypes.HTTPBackendRef) *gwtypes.HTTPRoute {
+		return createGlobalTestHTTPRoute(name, namespace, backendRefs)
+	}
+
+	// Use global helper.
+	createTestHTTPBackendRef := func(name string, namespace string, group *gwtypes.Group, port *int32) gwtypes.HTTPBackendRef {
+		return createGlobalTestHTTPBackendRef(name, namespace, nil, port, group)
+	}
+
+	tests := []struct {
+		name             string
+		httpRoute        *gwtypes.HTTPRoute
+		pRef             *gwtypes.ParentReference
+		upstreamName     string
+		validBackendRefs []ValidBackendRef
+		expectedTargets  int
+		expectedError    bool
+		validateResult   func(t *testing.T, targets []configurationv1alpha1.KongTarget)
+	}{
+		{
+			name: "Empty valid backend refs should return empty targets",
+			httpRoute: createTestHTTPRoute("test-route", "test-namespace", []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("service1", "test-namespace", nil, ptr.To[int32](80)),
+			}),
+			pRef:             &gwtypes.ParentReference{Name: "test-gateway"},
+			upstreamName:     "test-upstream",
+			validBackendRefs: []ValidBackendRef{},
+			expectedTargets:  0,
+			expectedError:    false,
+		},
+		{
+			name: "Backend refs with no endpoints should be skipped",
+			httpRoute: createTestHTTPRoute("test-route", "test-namespace", []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("service1", "test-namespace", nil, ptr.To[int32](80)),
+			}),
+			pRef:         &gwtypes.ParentReference{Name: "test-gateway"},
+			upstreamName: "test-upstream",
+			validBackendRefs: []ValidBackendRef{
+				createTestValidBackendRef("service1", "test-namespace", ptr.To[int32](50), []string{}), // No endpoints.
+			},
+			expectedTargets: 0,
+			expectedError:   false,
+		},
+		{
+			name: "Single backend ref with single endpoint should create one target",
+			httpRoute: createTestHTTPRoute("test-route", "test-namespace", []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("service1", "test-namespace", nil, ptr.To[int32](80)),
+			}),
+			pRef:         &gwtypes.ParentReference{Name: "test-gateway"},
+			upstreamName: "test-upstream",
+			validBackendRefs: []ValidBackendRef{
+				createTestValidBackendRef("service1", "test-namespace", ptr.To[int32](100), []string{"10.0.0.1"}),
+			},
+			expectedTargets: 1,
+			expectedError:   false,
+			validateResult: func(t *testing.T, targets []configurationv1alpha1.KongTarget) {
+				require.Len(t, targets, 1)
+				target := targets[0]
+
+				// Verify target fields.
+				assert.Contains(t, target.Name, "test-upstream.")
+				assert.Equal(t, "test-namespace", target.Namespace)
+				assert.Equal(t, "test-upstream", target.Spec.UpstreamRef.Name)
+				assert.Equal(t, "10.0.0.1:8080", target.Spec.Target) // Default port 8080 from createTestValidBackendRef.
+				assert.Equal(t, 100, target.Spec.Weight)
+
+				// Verify labels and annotations exist.
+				assert.NotEmpty(t, target.Labels)
+				assert.NotEmpty(t, target.Annotations)
+
+				// Verify owner reference is set.
+				assert.Len(t, target.OwnerReferences, 1)
+				assert.Equal(t, "test-route", target.OwnerReferences[0].Name)
+			},
+		},
+		{
+			name: "Single backend ref with multiple endpoints should create multiple targets",
+			httpRoute: createTestHTTPRoute("test-route", "test-namespace", []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("service1", "test-namespace", nil, ptr.To[int32](80)),
+			}),
+			pRef:         &gwtypes.ParentReference{Name: "test-gateway"},
+			upstreamName: "test-upstream",
+			validBackendRefs: []ValidBackendRef{
+				createTestValidBackendRef("service1", "test-namespace", ptr.To[int32](50), []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}),
+			},
+			expectedTargets: 3,
+			expectedError:   false,
+			validateResult: func(t *testing.T, targets []configurationv1alpha1.KongTarget) {
+				require.Len(t, targets, 3)
+
+				expectedAddresses := []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}
+				actualAddresses := make([]string, len(targets))
+
+				for i, target := range targets {
+					// All should have same weight and upstream.
+					assert.Equal(t, 50, target.Spec.Weight)
+					assert.Equal(t, "test-upstream", target.Spec.UpstreamRef.Name)
+					assert.Equal(t, "test-namespace", target.Namespace)
+
+					// Extract the IP address from target spec (format: "IP:PORT").
+					assert.Contains(t, target.Spec.Target, ":8080")
+					actualAddresses[i] = target.Spec.Target[:len(target.Spec.Target)-5] // Remove ":8080".
+				}
+
+				// Verify all expected addresses are present.
+				for _, expected := range expectedAddresses {
+					assert.Contains(t, actualAddresses, expected)
+				}
+			},
+		},
+		{
+			name: "Multiple backend refs with different endpoints and weights",
+			httpRoute: createTestHTTPRoute("test-route", "test-namespace", []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("service1", "test-namespace", nil, ptr.To[int32](80)),
+				createTestHTTPBackendRef("service2", "test-namespace", nil, ptr.To[int32](90)),
+			}),
+			pRef:         &gwtypes.ParentReference{Name: "test-gateway"},
+			upstreamName: "test-upstream",
+			validBackendRefs: []ValidBackendRef{
+				createTestValidBackendRef("service1", "test-namespace", ptr.To[int32](30), []string{"10.0.1.1", "10.0.1.2"}),
+				createTestValidBackendRef("service2", "test-namespace", ptr.To[int32](70), []string{"10.0.2.1"}),
+			},
+			expectedTargets: 3, // 2 from service1 + 1 from service2.
+			expectedError:   false,
+			validateResult: func(t *testing.T, targets []configurationv1alpha1.KongTarget) {
+				require.Len(t, targets, 3)
+
+				service1Targets := 0
+				service2Targets := 0
+
+				for _, target := range targets {
+					switch target.Spec.Target {
+					case "10.0.1.1:8080", "10.0.1.2:8080":
+						service1Targets++
+						assert.Equal(t, 30, target.Spec.Weight)
+					case "10.0.2.1:8080":
+						service2Targets++
+						assert.Equal(t, 70, target.Spec.Weight)
+					default:
+						t.Errorf("Unexpected target: %s", target.Spec.Target)
+					}
+
+					// Common validations.
+					assert.Equal(t, "test-upstream", target.Spec.UpstreamRef.Name)
+					assert.Contains(t, target.Name, "test-upstream.")
+				}
+
+				assert.Equal(t, 2, service1Targets, "Should have 2 targets from service1")
+				assert.Equal(t, 1, service2Targets, "Should have 1 target from service2")
+			},
+		},
+		{
+			name: "Mixed scenario with some backends having no endpoints",
+			httpRoute: createTestHTTPRoute("test-route", "test-namespace", []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("service1", "test-namespace", nil, ptr.To[int32](80)),
+				createTestHTTPBackendRef("service2", "test-namespace", nil, ptr.To[int32](90)),
+				createTestHTTPBackendRef("service3", "test-namespace", nil, ptr.To[int32](85)),
+			}),
+			pRef:         &gwtypes.ParentReference{Name: "test-gateway"},
+			upstreamName: "test-upstream",
+			validBackendRefs: []ValidBackendRef{
+				createTestValidBackendRef("service1", "test-namespace", ptr.To[int32](0), []string{}),                        // No endpoints, should be skipped.
+				createTestValidBackendRef("service2", "test-namespace", ptr.To[int32](60), []string{"10.0.2.1"}),             // 1 endpoint.
+				createTestValidBackendRef("service3", "test-namespace", ptr.To[int32](40), []string{"10.0.3.1", "10.0.3.2"}), // 2 endpoints.
+			},
+			expectedTargets: 3, // 0 from service1 + 1 from service2 + 2 from service3.
+			expectedError:   false,
+			validateResult: func(t *testing.T, targets []configurationv1alpha1.KongTarget) {
+				require.Len(t, targets, 3)
+
+				// Should only have targets from service2 and service3.
+				targetAddresses := make([]string, len(targets))
+				for i, target := range targets {
+					targetAddresses[i] = target.Spec.Target
+				}
+
+				assert.Contains(t, targetAddresses, "10.0.2.1:8080")
+				assert.Contains(t, targetAddresses, "10.0.3.1:8080")
+				assert.Contains(t, targetAddresses, "10.0.3.2:8080")
+
+				// Verify no service1 targets exist.
+				for _, addr := range targetAddresses {
+					assert.NotContains(t, addr, "10.0.1.")
+				}
+			},
+		},
+		{
+			name: "Backend ref with custom port should use correct target port",
+			httpRoute: createTestHTTPRoute("test-route", "test-namespace", []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("service1", "test-namespace", nil, ptr.To[int32](8080)),
+			}),
+			pRef:         &gwtypes.ParentReference{Name: "test-gateway"},
+			upstreamName: "test-upstream",
+			validBackendRefs: []ValidBackendRef{
+				{
+					BackendRef: &gwtypes.HTTPBackendRef{
+						BackendRef: gwtypes.BackendRef{
+							BackendObjectReference: gwtypes.BackendObjectReference{
+								Name: "service1",
+								Kind: ptr.To(gwtypes.Kind("Service")),
+							},
+						},
+					},
+					Service: &corev1.Service{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "service1",
+							Namespace: "test-namespace",
+						},
+					},
+					ServicePort: &corev1.ServicePort{
+						Name: "http",
+						Port: 8080,
+					},
+					ReadyEndpoints: []string{"10.0.0.1"},
+					TargetPort:     9090, // Custom target port.
+					Weight:         100,
+				},
+			},
+			expectedTargets: 1,
+			expectedError:   false,
+			validateResult: func(t *testing.T, targets []configurationv1alpha1.KongTarget) {
+				require.Len(t, targets, 1)
+				target := targets[0]
+
+				// Should use the custom target port.
+				assert.Equal(t, "10.0.0.1:9090", target.Spec.Target)
+				assert.Equal(t, 100, target.Spec.Weight)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Call the function.
+			targets, err := createTargetsFromValidBackendRefs(tt.httpRoute, tt.pRef, tt.upstreamName, tt.validBackendRefs)
+
+			// Check error expectation.
+			if tt.expectedError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Check number of targets.
+			assert.Len(t, targets, tt.expectedTargets)
+
+			// Run custom validation if provided.
+			if tt.validateResult != nil {
+				tt.validateResult(t, targets)
+			}
+
+			// General validations for all targets.
+			for _, target := range targets {
+				// All targets should have the correct upstream reference.
+				assert.Equal(t, tt.upstreamName, target.Spec.UpstreamRef.Name)
+
+				// All targets should be in the same namespace as the HTTPRoute.
+				assert.Equal(t, tt.httpRoute.Namespace, target.Namespace)
+
+				// All target names should contain the upstream name.
+				assert.Contains(t, target.Name, tt.upstreamName+".")
+
+				// Weight should be set.
+				assert.NotZero(t, target.Spec.Weight)
+
+				// Target should have an address:port format.
+				assert.Contains(t, target.Spec.Target, ":")
+
+				// Should have owner reference to the HTTPRoute.
+				require.Len(t, target.OwnerReferences, 1)
+				assert.Equal(t, tt.httpRoute.Name, target.OwnerReferences[0].Name)
+			}
+		})
+	}
+}
+
+func TestTargetsForBackendRefs(t *testing.T) {
+	// Helper function to create test context.
+	createTestContext := context.Background
+
+	// Helper function to create test logger.
+	createTestLogger := func() logr.Logger {
+		return ctrllog.Log.WithName("test")
+	}
+
+	// Use global helper.
+	createTestHTTPRoute := func(name, namespace string, backendRefs []gwtypes.HTTPBackendRef) *gwtypes.HTTPRoute {
+		return createGlobalTestHTTPRoute(name, namespace, backendRefs)
+	}
+
+	// Use global helper.
+	createTestHTTPBackendRef := func(name string, namespace string, weight *int32, port *int32) gwtypes.HTTPBackendRef {
+		return createGlobalTestHTTPBackendRef(name, namespace, weight, port)
+	}
+
+	tests := []struct {
+		name                  string
+		httpRoute             *gwtypes.HTTPRoute
+		backendRefs           []gwtypes.HTTPBackendRef
+		pRef                  *gwtypes.ParentReference
+		upstreamName          string
+		referenceGrantEnabled bool
+		fqdn                  bool
+		services              []corev1.Service
+		endpointSlices        []discoveryv1.EndpointSlice
+		referenceGrants       []gatewayv1beta1.ReferenceGrant
+		expectedTargets       int
+		expectedError         bool
+		clientErrors          map[string]error
+		validateResult        func(t *testing.T, targets []configurationv1alpha1.KongTarget)
+	}{
+		{
+			name: "Error from filterValidBackendRefs should be propagated",
+			httpRoute: createTestHTTPRoute("test-route", "test-namespace", []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("test-service", "other-namespace", nil, ptr.To[int32](80)),
+			}),
+			backendRefs: []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("test-service", "other-namespace", nil, ptr.To[int32](80)),
+			},
+			pRef:                  &gwtypes.ParentReference{Name: "test-gateway"},
+			upstreamName:          "test-upstream",
+			referenceGrantEnabled: true, // This will cause ReferenceGrant check.
+			fqdn:                  false,
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-service", Namespace: "other-namespace"},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP}},
+					},
+				},
+			},
+			endpointSlices:  []discoveryv1.EndpointSlice{},
+			referenceGrants: []gatewayv1beta1.ReferenceGrant{},
+			clientErrors: map[string]error{
+				"list-referencegrant": fmt.Errorf("simulated ReferenceGrant list error"),
+			},
+			expectedError: true,
+		},
+
+		{
+			name: "Error from getEndpointSlicesForService should be propagated",
+			httpRoute: createTestHTTPRoute("test-route", "test-namespace", []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("test-service", "", nil, ptr.To[int32](80)),
+			}),
+			backendRefs: []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("test-service", "", nil, ptr.To[int32](80)),
+			},
+			pRef:                  &gwtypes.ParentReference{Name: "test-gateway"},
+			upstreamName:          "test-upstream",
+			referenceGrantEnabled: false,
+			fqdn:                  false,
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-service", Namespace: "test-namespace"},
+					Spec: corev1.ServiceSpec{
+						Ports:     []corev1.ServicePort{{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP}},
+						ClusterIP: "10.0.0.1", // Regular service, not headless.
+					},
+				},
+			},
+			endpointSlices:  []discoveryv1.EndpointSlice{},
+			referenceGrants: []gatewayv1beta1.ReferenceGrant{},
+			clientErrors: map[string]error{
+				"list-endpointslice": fmt.Errorf("simulated EndpointSlice list error"),
+			},
+			expectedError: true,
+		},
+
+		{
+			name:                  "Empty backend refs should return empty targets",
+			httpRoute:             createTestHTTPRoute("test-route", "test-namespace", []gwtypes.HTTPBackendRef{}),
+			backendRefs:           []gwtypes.HTTPBackendRef{},
+			pRef:                  &gwtypes.ParentReference{Name: "test-gateway"},
+			upstreamName:          "test-upstream",
+			referenceGrantEnabled: false,
+			fqdn:                  false,
+			services:              []corev1.Service{},
+			endpointSlices:        []discoveryv1.EndpointSlice{},
+			referenceGrants:       []gatewayv1beta1.ReferenceGrant{},
+			expectedTargets:       0,
+			expectedError:         false,
+		},
+		{
+			name: "Single valid backend ref should create targets",
+			httpRoute: createTestHTTPRoute("test-route", "test-namespace", []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("test-service", "", nil, ptr.To[int32](80)),
+			}),
+			backendRefs: []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("test-service", "", nil, ptr.To[int32](80)),
+			},
+			pRef:                  &gwtypes.ParentReference{Name: "test-gateway"},
+			upstreamName:          "test-upstream",
+			referenceGrantEnabled: false,
+			fqdn:                  false,
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-service",
+						Namespace: "test-namespace",
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8080)},
+						},
+						Type: corev1.ServiceTypeClusterIP,
+					},
+				},
+			},
+			endpointSlices: []discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-service-slice",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							"kubernetes.io/service-name": "test-service",
+						},
+					},
+					Ports:     []discoveryv1.EndpointPort{createTestEndpointPort("http", 8080, corev1.ProtocolTCP)},
+					Endpoints: []discoveryv1.Endpoint{createTestEndpoint([]string{"10.0.0.1", "10.0.0.2"}, true)},
+				},
+			},
+			referenceGrants: []gatewayv1beta1.ReferenceGrant{},
+			expectedTargets: 2, // 2 endpoints.
+			expectedError:   false,
+			validateResult: func(t *testing.T, targets []configurationv1alpha1.KongTarget) {
+				require.Len(t, targets, 2)
+
+				// Verify both targets have correct upstream and namespace.
+				for _, target := range targets {
+					assert.Equal(t, "test-upstream", target.Spec.UpstreamRef.Name)
+					assert.Equal(t, "test-namespace", target.Namespace)
+					assert.Contains(t, []string{"10.0.0.1:8080", "10.0.0.2:8080"}, target.Spec.Target)
+				}
+			},
+		},
+		{
+			name: "Multiple backend refs with different weights should distribute correctly",
+			httpRoute: createTestHTTPRoute("test-route", "test-namespace", []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("service1", "", ptr.To[int32](70), ptr.To[int32](80)),
+				createTestHTTPBackendRef("service2", "", ptr.To[int32](30), ptr.To[int32](80)),
+			}),
+			backendRefs: []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("service1", "", ptr.To[int32](70), ptr.To[int32](80)),
+				createTestHTTPBackendRef("service2", "", ptr.To[int32](30), ptr.To[int32](80)),
+			},
+			pRef:                  &gwtypes.ParentReference{Name: "test-gateway"},
+			upstreamName:          "test-upstream",
+			referenceGrantEnabled: false,
+			fqdn:                  false,
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "service1", Namespace: "test-namespace"},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8080)}},
+						Type:  corev1.ServiceTypeClusterIP,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "service2", Namespace: "test-namespace"},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8080)}},
+						Type:  corev1.ServiceTypeClusterIP,
+					},
+				},
+			},
+			endpointSlices: []discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "service1-slice",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							"kubernetes.io/service-name": "service1",
+						},
+					},
+					Ports:     []discoveryv1.EndpointPort{createTestEndpointPort("http", 8080, corev1.ProtocolTCP)},
+					Endpoints: []discoveryv1.Endpoint{createTestEndpoint([]string{"10.0.1.1"}, true)},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "service2-slice",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							"kubernetes.io/service-name": "service2",
+						},
+					},
+					Ports:     []discoveryv1.EndpointPort{createTestEndpointPort("http", 8080, corev1.ProtocolTCP)},
+					Endpoints: []discoveryv1.Endpoint{createTestEndpoint([]string{"10.0.2.1"}, true)},
+				},
+			},
+			referenceGrants: []gatewayv1beta1.ReferenceGrant{},
+			expectedTargets: 2,
+			expectedError:   false,
+			validateResult: func(t *testing.T, targets []configurationv1alpha1.KongTarget) {
+				require.Len(t, targets, 2)
+
+				// Verify weight distribution (exact values depend on the algorithm).
+				service1Target := findTargetByAddress(targets, "10.0.1.1:8080")
+				service2Target := findTargetByAddress(targets, "10.0.2.1:8080")
+
+				require.NotNil(t, service1Target, "service1 target should exist")
+				require.NotNil(t, service2Target, "service2 target should exist")
+
+				// Service1 should have higher weight than service2 (70 vs 30).
+				assert.True(t, service1Target.Spec.Weight > service2Target.Spec.Weight,
+					"service1 weight (%d) should be higher than service2 weight (%d)",
+					service1Target.Spec.Weight, service2Target.Spec.Weight)
+			},
+		},
+		{
+			name: "Cross-namespace backend refs with ReferenceGrant should work",
+			httpRoute: createTestHTTPRoute("test-route", "frontend-ns", []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("backend-service", "backend-ns", nil, ptr.To[int32](80)),
+			}),
+			backendRefs: []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("backend-service", "backend-ns", nil, ptr.To[int32](80)),
+			},
+			pRef:                  &gwtypes.ParentReference{Name: "test-gateway"},
+			upstreamName:          "test-upstream",
+			referenceGrantEnabled: true,
+			fqdn:                  false,
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "backend-service", Namespace: "backend-ns"},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8080)}},
+						Type:  corev1.ServiceTypeClusterIP,
+					},
+				},
+			},
+			endpointSlices: []discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "backend-service-slice",
+						Namespace: "backend-ns",
+						Labels: map[string]string{
+							"kubernetes.io/service-name": "backend-service",
+						},
+					},
+					Ports:     []discoveryv1.EndpointPort{createTestEndpointPort("http", 8080, corev1.ProtocolTCP)},
+					Endpoints: []discoveryv1.Endpoint{createTestEndpoint([]string{"10.0.3.1"}, true)},
+				},
+			},
+			referenceGrants: []gatewayv1beta1.ReferenceGrant{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "allow-frontend-to-backend", Namespace: "backend-ns"},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{
+							{Group: "gateway.networking.k8s.io", Kind: "HTTPRoute", Namespace: "frontend-ns"},
+						},
+						To: []gatewayv1beta1.ReferenceGrantTo{
+							{Group: "", Kind: "Service"},
+						},
+					},
+				},
+			},
+			expectedTargets: 1,
+			expectedError:   false,
+		},
+		{
+			name: "Cross-namespace backend refs without ReferenceGrant should fail",
+			httpRoute: createTestHTTPRoute("test-route", "frontend-ns", []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("backend-service", "backend-ns", nil, ptr.To[int32](80)),
+			}),
+			backendRefs: []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("backend-service", "backend-ns", nil, ptr.To[int32](80)),
+			},
+			pRef:                  &gwtypes.ParentReference{Name: "test-gateway"},
+			upstreamName:          "test-upstream",
+			referenceGrantEnabled: true,
+			fqdn:                  false,
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "backend-service", Namespace: "backend-ns"},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8080)}},
+						Type:  corev1.ServiceTypeClusterIP,
+					},
+				},
+			},
+			endpointSlices:  []discoveryv1.EndpointSlice{},
+			referenceGrants: []gatewayv1beta1.ReferenceGrant{}, // No ReferenceGrant.
+			expectedTargets: 0,                                 // Should have no valid targets due to missing ReferenceGrant.
+			expectedError:   false,                             // Should not error, just no targets.
+		},
+
+		{
+			name: "FQDN mode should work correctly",
+			httpRoute: createTestHTTPRoute("test-route", "test-namespace", []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("external-service", "", nil, ptr.To[int32](80)),
+			}),
+			backendRefs: []gwtypes.HTTPBackendRef{
+				createTestHTTPBackendRef("external-service", "", nil, ptr.To[int32](80)),
+			},
+			pRef:                  &gwtypes.ParentReference{Name: "test-gateway"},
+			upstreamName:          "test-upstream",
+			referenceGrantEnabled: false,
+			fqdn:                  true, // FQDN mode.
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "external-service", Namespace: "test-namespace"},
+					Spec: corev1.ServiceSpec{
+						Ports:        []corev1.ServicePort{{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP}},
+						Type:         corev1.ServiceTypeExternalName,
+						ExternalName: "api.example.com",
+					},
+				},
+			},
+			endpointSlices:  []discoveryv1.EndpointSlice{}, // ExternalName services don't use EndpointSlices.
+			referenceGrants: []gatewayv1beta1.ReferenceGrant{},
+			expectedTargets: 1,
+			expectedError:   false,
+			validateResult: func(t *testing.T, targets []configurationv1alpha1.KongTarget) {
+				require.Len(t, targets, 1)
+				target := targets[0]
+
+				// In FQDN mode, it should use the FQDN format for the service name.
+				// The actual behavior might be using cluster DNS format instead of ExternalName.
+				assert.Contains(t, target.Spec.Target, "external-service")
+				assert.Contains(t, target.Spec.Target, ":80")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fake client with test objects.
+			objects := []client.Object{}
+			for i := range tt.services {
+				objects = append(objects, &tt.services[i])
+			}
+			for i := range tt.endpointSlices {
+				objects = append(objects, &tt.endpointSlices[i])
+			}
+			for i := range tt.referenceGrants {
+				objects = append(objects, &tt.referenceGrants[i])
+			}
+
+			var cl client.Client
+			// Add client error interceptors if specified.
+			if tt.clientErrors != nil {
+				cl = createTestFakeClientWithInterceptors(interceptor.Funcs{
+					Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if errorKey, exists := tt.clientErrors["get-service"]; exists {
+							if _, ok := obj.(*corev1.Service); ok && key.Name == "test-service" {
+								return errorKey
+							}
+						}
+						return client.Get(ctx, key, obj, opts...)
+					},
+					List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+						// Handle ReferenceGrant list error.
+						if errorKey, exists := tt.clientErrors["list-referencegrant"]; exists {
+							if _, ok := list.(*gatewayv1beta1.ReferenceGrantList); ok {
+								return errorKey
+							}
+						}
+						// Handle EndpointSlice list error.
+						if errorKey, exists := tt.clientErrors["list-endpointslice"]; exists {
+							if _, ok := list.(*discoveryv1.EndpointSliceList); ok {
+								return errorKey
+							}
+						}
+						return client.List(ctx, list, opts...)
+					},
+				}, objects...)
+			} else {
+				cl = createTestFakeClient(objects...)
+			}
+
+			// Call the function.
+			targets, err := TargetsForBackendRefs(
+				createTestContext(),
+				createTestLogger(),
+				cl,
+				tt.httpRoute,
+				tt.backendRefs,
+				tt.pRef,
+				tt.upstreamName,
+				tt.referenceGrantEnabled,
+				tt.fqdn,
+				"cluster.local",
+			) // Check error expectation.
+			if tt.expectedError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Check number of targets.
+			assert.Len(t, targets, tt.expectedTargets)
+
+			// Run custom validation if provided.
+			if tt.validateResult != nil {
+				tt.validateResult(t, targets)
+			}
+
+			// General validations for all targets.
+			for _, target := range targets {
+				// All targets should have the correct upstream reference.
+				assert.Equal(t, tt.upstreamName, target.Spec.UpstreamRef.Name)
+
+				// All targets should be in the same namespace as the HTTPRoute.
+				assert.Equal(t, tt.httpRoute.Namespace, target.Namespace)
+
+				// All target names should contain the upstream name.
+				assert.Contains(t, target.Name, tt.upstreamName+".")
+
+				// Target should have an address:port format.
+				assert.Contains(t, target.Spec.Target, ":")
+
+				// Should have owner reference to the HTTPRoute.
+				require.Len(t, target.OwnerReferences, 1)
+				assert.Equal(t, tt.httpRoute.Name, target.OwnerReferences[0].Name)
+			}
+		})
+	}
+}
+
+// Helper function to find a target by its address.
+func findTargetByAddress(targets []configurationv1alpha1.KongTarget, address string) *configurationv1alpha1.KongTarget {
+	for i := range targets {
+		if targets[i].Spec.Target == address {
+			return &targets[i]
+		}
+	}
+	return nil
+}

--- a/controller/hybridgateway/target/weight.go
+++ b/controller/hybridgateway/target/weight.go
@@ -1,0 +1,180 @@
+package target
+
+// BackendRef holds the information for a single backend service.
+// This represents a backendRef in a gateway API route.
+type BackendRef struct {
+	// A unique identifier for the backend (e.g., k8s Service name).
+	Name string
+	// The service-level weight assigned in the route.
+	Weight uint32
+	// The total number of ready endpoints for this service.
+	Endpoints uint32
+}
+
+// gcd computes the greatest common divisor of two numbers using the Euclidean algorithm.
+func gcd(a, b uint32) uint32 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+// lcm computes the least common multiple of two numbers.
+func lcm(a, b uint32) uint32 {
+	if a == 0 || b == 0 {
+		return 0
+	}
+	// To prevent potential overflow, calculate as (a / gcd) * b.
+	return (a / gcd(a, b)) * b
+}
+
+// CalculateEndpointWeights translates a set of service-level weights into the
+// smallest possible integer weights for their individual endpoints. This is a crucial
+// step for data plane components that need a flat list of weighted
+// endpoints to perform traffic splitting.
+//
+// The core logic ensures that the proportion of traffic sent to each service's
+// group of endpoints perfectly matches the original service-level weight distribution.
+//
+// --- Mathematical Logic ---
+//
+//  1. **Calculate Traffic-per-Endpoint Ratio:** For each backend service, the conceptual
+//     share of traffic for a single endpoint is proportional to its (ServiceWeight / NumberOfEndpoints).
+//     For example, a service with weight 80 and 10 endpoints has a per-endpoint "value" of 8,
+//     while a service with weight 100 and 20 endpoints has a per-endpoint "value" of 5.
+//
+//  2. **Convert Ratios to Integers:** Since the dataplane requires integer weights, we must
+//     convert these fractional ratios into a set of whole numbers that maintain the
+//     exact same proportions.
+//     - First, each fraction (W/E) is simplified to its lowest terms by dividing
+//     the numerator and denominator by their Greatest Common Divisor (GCD).
+//     - Then, we find the Least Common Multiple (LCM) of all the denominators from the
+//     simplified fractions. This LCM is the smallest number that can be used as a
+//     common multiplier to turn all the fractions into integers.
+//
+//  3. **Simplify to Smallest Integers:** The resulting integer weights are mathematically
+//     correct but might be unnecessarily large (e.g., 300 and 400). To ensure maximum
+//     efficiency in the data plane, we simplify them.
+//     - We calculate the GCD of this new set of integer weights.
+//     - By dividing each weight by this GCD, we arrive at the smallest possible
+//     set of integers that preserve the original traffic distribution (e.g., 3 and 4).
+//
+// --- Edge Cases Handled ---
+//
+// - A backend with 0 weight or 0 endpoints is correctly assigned an effective endpoint weight of 0.
+// - This gracefully handles the case where a service has weight > 0 but no ready endpoints.
+//
+// --- Example 1: Basic Case ---
+//
+// - Backend A: {Weight: 3, Endpoints: 10} -> Ratio: 3/10
+// - Backend B: {Weight: 8, Endpoints: 20} -> Ratio: 8/20 (simplifies to 2/5)
+//
+// 1. Fractions are 3/10 and 2/5. Denominators are 10 and 5.
+// 2. LCM(10, 5) = 10.
+// 3. Multiply each fraction by the LCM:
+//   - A: (3/10) * 10 = 3
+//   - B: (2/5)  * 10 = 4
+//     4. Unsimplified weights are {3, 4}. GCD(3, 4) = 1.
+//     5. Final weights are {3, 4}. This means each of A's 10 endpoints gets weight 3,
+//     and each of B's 20 endpoints gets weight 4.
+//
+// --- Example 2: Complex Case ---
+//
+// - Backend V1: {Weight: 50, Endpoints: 5} -> Ratio: 50/5 (simplifies to 10/1)
+// - Backend V2: {Weight: 50, Endpoints: 8} -> Ratio: 50/8 (simplifies to 25/4)
+// - Backend V3: {Weight:  1, Endpoints: 1} -> Ratio: 1/1
+//
+// 1. Fractions are 10/1, 25/4, and 1/1. Denominators are 1, 4, 1.
+// 2. LCM(1, 4, 1) = 4.
+// 3. Multiply each fraction by the LCM:
+//   - V1: (10/1) * 4 = 40
+//   - V2: (25/4) * 4 = 25
+//   - V3: (1/1)  * 4 = 4
+//
+// 4. Unsimplified weights are {40, 25, 4}. GCD(40, 25, 4) = 1.
+// 5. Final weights are {40, 25, 4}.
+func CalculateEndpointWeights(backends []BackendRef) map[string]uint32 {
+	if len(backends) == 0 {
+		return make(map[string]uint32)
+	}
+
+	// This struct holds the simplified fraction: Weight / Endpoints.
+	type simplifiedFraction struct {
+		id  string
+		num uint32
+		den uint32
+	}
+
+	fractions := make([]simplifiedFraction, 0, len(backends))
+	var activeDenominators []uint32
+
+	// Step 1: Validate input and create simplified fractions for each backend.
+	for _, be := range backends {
+		// Backends with 0 weight or 0 endpoints will get an effective endpoint weight of 0.
+		// This handles the case where a service has weight > 0 but no ready endpoints gracefully.
+		if be.Weight == 0 || be.Endpoints == 0 {
+			fractions = append(fractions, simplifiedFraction{id: be.Name, num: 0, den: 1})
+			continue
+		}
+
+		// Simplify the fraction W/E by dividing by their GCD.
+		commonDivisor := gcd(be.Weight, be.Endpoints)
+		num := be.Weight / commonDivisor
+		den := be.Endpoints / commonDivisor
+		fractions = append(fractions, simplifiedFraction{id: be.Name, num: num, den: den})
+		activeDenominators = append(activeDenominators, den)
+	}
+
+	if len(activeDenominators) == 0 {
+		// This case handles when all backends have 0 weight.
+		results := make(map[string]uint32)
+		for _, f := range fractions {
+			results[f.id] = 0
+		}
+		return results
+	}
+
+	// Step 2: Find the least common multiple (LCM) of all denominators.
+	// This gives us a common multiplier to turn all fractions into integers.
+	overallLCM := activeDenominators[0]
+	for i := 1; i < len(activeDenominators); i++ {
+		overallLCM = lcm(overallLCM, activeDenominators[i])
+	}
+
+	// Step 3: Calculate the un-simplified, integer-based weights.
+	unsimplifiedWeights := make([]uint32, 0, len(fractions))
+	nonZeroWeights := make([]uint32, 0)
+	for _, f := range fractions {
+		// The weight is the fraction's value multiplied by the LCM.
+		weight := (f.num * overallLCM) / f.den
+		unsimplifiedWeights = append(unsimplifiedWeights, weight)
+		if weight > 0 {
+			nonZeroWeights = append(nonZeroWeights, weight)
+		}
+	}
+
+	if len(nonZeroWeights) == 0 {
+		// Defensive check: handles edge cases where all calculated weights become 0.
+		// This could theoretically occur due to integer overflow in LCM calculations
+		// with extremely large denominators, though it should be rare in practice.
+		results := make(map[string]uint32)
+		for _, f := range fractions {
+			results[f.id] = 0
+		}
+		return results
+	}
+
+	// Step 4: Find the GCD of all the new non-zero weights to simplify them.
+	overallGCD := nonZeroWeights[0]
+	for i := 1; i < len(nonZeroWeights); i++ {
+		overallGCD = gcd(overallGCD, nonZeroWeights[i])
+	}
+
+	// Step 5: Calculate the final, simplified weights and build the result map.
+	results := make(map[string]uint32)
+	for i, f := range fractions {
+		results[f.id] = unsimplifiedWeights[i] / overallGCD
+	}
+
+	return results
+}

--- a/controller/hybridgateway/target/weight_test.go
+++ b/controller/hybridgateway/target/weight_test.go
@@ -1,0 +1,477 @@
+package target
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGcd(t *testing.T) {
+	tests := []struct {
+		name     string
+		a, b     uint32
+		expected uint32
+	}{
+		{
+			name:     "basic case",
+			a:        12,
+			b:        18,
+			expected: 6,
+		},
+		{
+			name:     "one number is zero",
+			a:        5,
+			b:        0,
+			expected: 5,
+		},
+		{
+			name:     "both numbers are zero",
+			a:        0,
+			b:        0,
+			expected: 0,
+		},
+		{
+			name:     "coprime numbers",
+			a:        7,
+			b:        11,
+			expected: 1,
+		},
+		{
+			name:     "same numbers",
+			a:        8,
+			b:        8,
+			expected: 8,
+		},
+		{
+			name:     "large numbers",
+			a:        1071,
+			b:        462,
+			expected: 21,
+		},
+		{
+			name:     "reverse order",
+			a:        18,
+			b:        12,
+			expected: 6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := gcd(tt.a, tt.b)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestLcm(t *testing.T) {
+	tests := []struct {
+		name     string
+		a, b     uint32
+		expected uint32
+	}{
+		{
+			name:     "basic case",
+			a:        4,
+			b:        6,
+			expected: 12,
+		},
+		{
+			name:     "one number is zero",
+			a:        5,
+			b:        0,
+			expected: 0,
+		},
+		{
+			name:     "both numbers are zero",
+			a:        0,
+			b:        0,
+			expected: 0,
+		},
+		{
+			name:     "coprime numbers",
+			a:        3,
+			b:        7,
+			expected: 21,
+		},
+		{
+			name:     "same numbers",
+			a:        8,
+			b:        8,
+			expected: 8,
+		},
+		{
+			name:     "one divides the other",
+			a:        3,
+			b:        9,
+			expected: 9,
+		},
+		{
+			name:     "large numbers",
+			a:        15,
+			b:        20,
+			expected: 60,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := lcm(tt.a, tt.b)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCalculateEndpointWeights(t *testing.T) {
+	tests := []struct {
+		name     string
+		backends []BackendRef
+		expected map[string]uint32
+	}{
+		{
+			name:     "empty backends",
+			backends: []BackendRef{},
+			expected: map[string]uint32{},
+		},
+		{
+			name: "single backend",
+			backends: []BackendRef{
+				{Name: "service-a", Weight: 10, Endpoints: 2},
+			},
+			expected: map[string]uint32{
+				"service-a": 1,
+			},
+		},
+		{
+			name: "basic case from documentation example 1",
+			backends: []BackendRef{
+				{Name: "backend-a", Weight: 3, Endpoints: 10},
+				{Name: "backend-b", Weight: 8, Endpoints: 20},
+			},
+			expected: map[string]uint32{
+				"backend-a": 3,
+				"backend-b": 4,
+			},
+		},
+		{
+			name: "complex case from documentation example 2",
+			backends: []BackendRef{
+				{Name: "v1", Weight: 50, Endpoints: 5},
+				{Name: "v2", Weight: 50, Endpoints: 8},
+				{Name: "v3", Weight: 1, Endpoints: 1},
+			},
+			expected: map[string]uint32{
+				"v1": 40,
+				"v2": 25,
+				"v3": 4,
+			},
+		},
+		{
+			name: "backend with zero weight",
+			backends: []BackendRef{
+				{Name: "service-a", Weight: 0, Endpoints: 5},
+				{Name: "service-b", Weight: 10, Endpoints: 2},
+			},
+			expected: map[string]uint32{
+				"service-a": 0,
+				"service-b": 1,
+			},
+		},
+		{
+			name: "backend with zero endpoints and zero weight",
+			backends: []BackendRef{
+				{Name: "service-a", Weight: 0, Endpoints: 0},
+				{Name: "service-b", Weight: 20, Endpoints: 4},
+			},
+			expected: map[string]uint32{
+				"service-a": 0,
+				"service-b": 1,
+			},
+		},
+		{
+			name: "all backends have zero weight",
+			backends: []BackendRef{
+				{Name: "service-a", Weight: 0, Endpoints: 5},
+				{Name: "service-b", Weight: 0, Endpoints: 3},
+			},
+			expected: map[string]uint32{
+				"service-a": 0,
+				"service-b": 0,
+			},
+		},
+		{
+			name: "all backends have zero endpoints and zero weight",
+			backends: []BackendRef{
+				{Name: "service-a", Weight: 0, Endpoints: 0},
+				{Name: "service-b", Weight: 0, Endpoints: 0},
+			},
+			expected: map[string]uint32{
+				"service-a": 0,
+				"service-b": 0,
+			},
+		},
+		{
+			name: "backend with weight > 0 but endpoints = 0 (gracefully handled)",
+			backends: []BackendRef{
+				{Name: "no-endpoints", Weight: 10, Endpoints: 0},
+				{Name: "valid-service", Weight: 20, Endpoints: 4},
+			},
+			expected: map[string]uint32{
+				"no-endpoints":  0,
+				"valid-service": 1,
+			},
+		},
+		{
+			name: "mixed valid and services with no endpoints",
+			backends: []BackendRef{
+				{Name: "valid-service", Weight: 10, Endpoints: 2},
+				{Name: "no-endpoints", Weight: 5, Endpoints: 0},
+			},
+			expected: map[string]uint32{
+				"valid-service": 1,
+				"no-endpoints":  0,
+			},
+		},
+		{
+			name: "multiple services with no endpoints",
+			backends: []BackendRef{
+				{Name: "no-endpoints-1", Weight: 10, Endpoints: 0},
+				{Name: "no-endpoints-2", Weight: 20, Endpoints: 0},
+				{Name: "valid-service", Weight: 30, Endpoints: 3},
+			},
+			expected: map[string]uint32{
+				"no-endpoints-1": 0,
+				"no-endpoints-2": 0,
+				"valid-service":  1,
+			},
+		},
+		{
+			name: "mixed valid and zero weight backends",
+			backends: []BackendRef{
+				{Name: "service-a", Weight: 0, Endpoints: 0},
+				{Name: "service-b", Weight: 15, Endpoints: 3},
+				{Name: "service-c", Weight: 0, Endpoints: 10},
+			},
+			expected: map[string]uint32{
+				"service-a": 0,
+				"service-b": 1,
+				"service-c": 0,
+			},
+		},
+		{
+			name: "equal weights different endpoints",
+			backends: []BackendRef{
+				{Name: "service-a", Weight: 50, Endpoints: 10},
+				{Name: "service-b", Weight: 50, Endpoints: 5},
+			},
+			expected: map[string]uint32{
+				"service-a": 1,
+				"service-b": 2,
+			},
+		},
+		{
+			name: "weights that need GCD simplification",
+			backends: []BackendRef{
+				// Ratio: 5/1.
+				{Name: "service-a", Weight: 20, Endpoints: 4},
+				// Ratio: 5/1.
+				{Name: "service-b", Weight: 30, Endpoints: 6},
+			},
+			expected: map[string]uint32{
+				"service-a": 1,
+				"service-b": 1,
+			},
+		},
+		{
+			name: "large numbers",
+			backends: []BackendRef{
+				{Name: "service-a", Weight: 1000, Endpoints: 100},
+				{Name: "service-b", Weight: 2000, Endpoints: 400},
+			},
+			expected: map[string]uint32{
+				"service-a": 2,
+				"service-b": 1,
+			},
+		},
+		{
+			name: "single endpoint per service",
+			backends: []BackendRef{
+				{Name: "service-a", Weight: 3, Endpoints: 1},
+				{Name: "service-b", Weight: 7, Endpoints: 1},
+			},
+			expected: map[string]uint32{
+				"service-a": 3,
+				"service-b": 7,
+			},
+		},
+		{
+			name: "prime number weights and endpoints",
+			backends: []BackendRef{
+				{Name: "service-a", Weight: 7, Endpoints: 3},
+				{Name: "service-b", Weight: 11, Endpoints: 5},
+			},
+			expected: map[string]uint32{
+				"service-a": 35,
+				"service-b": 33,
+			},
+		},
+		{
+			name: "three backends with complex ratios",
+			backends: []BackendRef{
+				// Ratio: 3/1.
+				{Name: "service-a", Weight: 12, Endpoints: 4},
+				// Ratio: 5/1.
+				{Name: "service-b", Weight: 15, Endpoints: 3},
+				// Ratio: 4/1.
+				{Name: "service-c", Weight: 8, Endpoints: 2},
+			},
+			expected: map[string]uint32{
+				"service-a": 3,
+				"service-b": 5,
+				"service-c": 4,
+			},
+		},
+		{
+			name: "backends with fractional ratios needing LCM",
+			backends: []BackendRef{
+				// Ratio: 2/3.
+				{Name: "service-a", Weight: 2, Endpoints: 3},
+				// Ratio: 3/4.
+				{Name: "service-b", Weight: 3, Endpoints: 4},
+			},
+			expected: map[string]uint32{
+				"service-a": 8,
+				"service-b": 9,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CalculateEndpointWeights(tt.backends)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCalculateEndpointWeights_TrafficDistribution(t *testing.T) {
+	// This test verifies that the calculated weights maintain the correct traffic distribution.
+	t.Run("traffic distribution validation", func(t *testing.T) {
+		backends := []BackendRef{
+			// Should get 10 per endpoint.
+			{Name: "service-a", Weight: 30, Endpoints: 3},
+			// Should get 10 per endpoint.
+			{Name: "service-b", Weight: 70, Endpoints: 7},
+		}
+
+		result := CalculateEndpointWeights(backends)
+
+		// Both services should have the same per-endpoint weight since they have the same ratio.
+		assert.Equal(t, result["service-a"], result["service-b"])
+
+		// Total traffic for service-a: 3 endpoints * weight = 3 * result["service-a"].
+		// Total traffic for service-b: 7 endpoints * weight = 7 * result["service-b"].
+		// Ratio should be 30:70 = 3:7.
+		totalA := 3 * result["service-a"]
+		totalB := 7 * result["service-b"]
+
+		// Since weights are equal, totalA should be 3 and totalB should be 7.
+		assert.Equal(t, uint32(3), totalA/result["service-a"])
+		assert.Equal(t, uint32(7), totalB/result["service-b"])
+	})
+}
+
+func TestCalculateEndpointWeights_EdgeCaseCombinations(t *testing.T) {
+	t.Run("mix of zero and non-zero backends", func(t *testing.T) {
+		backends := []BackendRef{
+			{Name: "zero-weight", Weight: 0, Endpoints: 5},
+			{Name: "zero-endpoints", Weight: 0, Endpoints: 0},
+			{Name: "valid", Weight: 20, Endpoints: 4},
+		}
+
+		result := CalculateEndpointWeights(backends)
+
+		expected := map[string]uint32{
+			"zero-weight":    0,
+			"zero-endpoints": 0,
+			"valid":          1,
+		}
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("all zero weight and zero endpoints", func(t *testing.T) {
+		backends := []BackendRef{
+			{Name: "service-a", Weight: 0, Endpoints: 0},
+			{Name: "service-b", Weight: 0, Endpoints: 0},
+		}
+
+		result := CalculateEndpointWeights(backends)
+
+		expected := map[string]uint32{
+			"service-a": 0,
+			"service-b": 0,
+		}
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("single backend with weight 1 endpoint 1", func(t *testing.T) {
+		backends := []BackendRef{
+			{Name: "minimal", Weight: 1, Endpoints: 1},
+		}
+
+		result := CalculateEndpointWeights(backends)
+
+		expected := map[string]uint32{
+			"minimal": 1,
+		}
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("graceful handling of services with no endpoints", func(t *testing.T) {
+		backends := []BackendRef{
+			{Name: "service-with-endpoints", Weight: 50, Endpoints: 10},
+			{Name: "service-no-endpoints", Weight: 50, Endpoints: 0},
+		}
+
+		result := CalculateEndpointWeights(backends)
+
+		expected := map[string]uint32{
+			"service-with-endpoints": 1,
+			"service-no-endpoints":   0,
+		}
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("edge case: force LCM overflow to trigger defensive branch", func(t *testing.T) {
+		// Use maximum uint32 values to force overflow.
+		// These two large prime numbers should cause LCM overflow.
+		// Large prime close to max uint32.
+		large1 := uint32(4294967291)
+		// Another large prime.
+		large2 := uint32(4294967279)
+
+		backends := []BackendRef{
+			// Ratio: 1/large1.
+			{Name: "overflow-1", Weight: 1, Endpoints: large1},
+			// Ratio: 1/large2.
+			{Name: "overflow-2", Weight: 1, Endpoints: large2},
+		}
+
+		result := CalculateEndpointWeights(backends)
+
+		// If LCM overflows and becomes 0, the defensive branch should trigger
+		// and all services should get weight 0.
+		assert.NotNil(t, result)
+		assert.Contains(t, result, "overflow-1")
+		assert.Contains(t, result, "overflow-2")
+
+		// Check if we successfully triggered the defensive branch.
+		if result["overflow-1"] == 0 && result["overflow-2"] == 0 {
+			// Success! We triggered the len(nonZeroWeights) == 0 branch.
+			t.Logf("Successfully triggered defensive branch: all weights are 0 due to LCM overflow")
+		} else {
+			// The numbers weren't large enough to cause overflow, but that's ok.
+			t.Logf("LCM overflow did not occur, got weights: %v", result)
+		}
+	})
+}

--- a/controller/hybridgateway/watch/watch.go
+++ b/controller/hybridgateway/watch/watch.go
@@ -1,6 +1,8 @@
 package watch
 
 import (
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 
@@ -27,6 +29,14 @@ func Watches(obj client.Object, cl client.Client) []Watcher {
 			{
 				&gwtypes.GatewayClass{},
 				MapHTTPRouteForGatewayClass(cl),
+			},
+			{
+				&corev1.Service{},
+				MapHTTPRouteForService(cl),
+			},
+			{
+				&discoveryv1.EndpointSlice{},
+				MapHTTPRouteForEndpointSlice(cl),
 			},
 		}
 	default:

--- a/controller/hybridgateway/watch/watch_test.go
+++ b/controller/hybridgateway/watch/watch_test.go
@@ -4,16 +4,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gwtypes "github.com/kong/kong-operator/internal/types"
 )
 
-// fakeClient is a minimal stub for client.Client, not used for actual List calls here.
-type fakeClient struct{ client.Client }
-
 func TestWatches(t *testing.T) {
-	cl := &fakeClient{}
+	cl := fake.NewClientBuilder().Build()
 	tests := []struct {
 		name     string
 		obj      client.Object
@@ -23,15 +23,32 @@ func TestWatches(t *testing.T) {
 		{
 			name:    "HTTPRoute",
 			obj:     &gwtypes.HTTPRoute{},
-			wantLen: 2,
+			wantLen: 4,
 			wantType: []any{
 				&gwtypes.Gateway{},
 				&gwtypes.GatewayClass{},
+				&corev1.Service{},
+				&discoveryv1.EndpointSlice{},
 			},
 		},
 		{
-			name:    "OtherType",
+			name:    "Gateway",
 			obj:     &gwtypes.Gateway{},
+			wantLen: 0,
+		},
+		{
+			name:    "GatewayClass",
+			obj:     &gwtypes.GatewayClass{},
+			wantLen: 0,
+		},
+		{
+			name:    "Service",
+			obj:     &corev1.Service{},
+			wantLen: 0,
+		},
+		{
+			name:    "EndpointSlice",
+			obj:     &discoveryv1.EndpointSlice{},
 			wantLen: 0,
 		},
 	}

--- a/internal/utils/index/httproute.go
+++ b/internal/utils/index/httproute.go
@@ -57,10 +57,6 @@ func backendServicesOnHTTPRoute(o client.Object) []string {
 			if backendRef.Namespace != nil {
 				ns = string(*backendRef.Namespace)
 			}
-			// TODO(mlavacca): support cross-namespace references
-			if ns != httpRoute.Namespace {
-				continue
-			}
 
 			services = append(services, ns+"/"+string(backendRef.Name))
 		}

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -645,7 +645,7 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 			}
 
 			controllers = append(controllers,
-				newGatewayAPIHybridController[gwtypes.HTTPRoute](mgr, referenceGrantEnabled),
+				newGatewayAPIHybridController[gwtypes.HTTPRoute](mgr, referenceGrantEnabled, false, ""), // TODO: make FQDN mode and cluster domain configurable
 				// TODO: Add more Hybrid controllers here
 			)
 		}
@@ -693,9 +693,9 @@ func newKonnectPluginController[
 	}
 }
 
-func newGatewayAPIHybridController[t converter.RootObject, tPtr converter.RootObjectPtr[t]](mgr ctrl.Manager, referenceGrantEnabled bool) ControllerDef {
+func newGatewayAPIHybridController[t converter.RootObject, tPtr converter.RootObjectPtr[t]](mgr ctrl.Manager, referenceGrantEnabled bool, fqdnMode bool, clusterDomain string) ControllerDef {
 	return ControllerDef{
 		Enabled:    true,
-		Controller: hybridgateway.NewHybridGatewayReconciler[t, tPtr](mgr, referenceGrantEnabled),
+		Controller: hybridgateway.NewHybridGatewayReconciler[t, tPtr](mgr, referenceGrantEnabled, fqdnMode, clusterDomain),
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

HybridGateway controllers need a robust mechanism to resolve Kubernetes services into Kong targets that supports all service types and provides accurate traffic distribution.

##### Target Resolution (`target.go`)
- `TargetsForBackendRefs()`: Main entry point that processes HTTPRoute BackendRefs
- `filterValidBackendRefs()`: Validates services, ports, and ReferenceGrants
- `resolveServiceEndpoints()`: Handles different service types:
  - Regular services: Uses EndpointSlices API
  - Headless services: Direct endpoint resolution
  - ExternalName services: External DNS targets
  - FQDN mode: Service DNS names
- `recalculateWeightsAcrossBackendRefs()`: Applies weight algorithm across backends

##### Weight Distribution (`weight.go`)
- `CalculateEndpointWeights()`: Converts service weights to per-endpoint weights
- Uses GCD/LCM math to maintain proportional traffic distribution
- Handles edge cases (zero weights, missing endpoints)

##### Integration
- Updates HTTP route converter to use new target resolution
- Maintains existing resource generation patterns

### Service Type Support

| Service Type | Resolution Method | Target Format |
|--------------|-------------------|---------------|
| ClusterIP | EndpointSlices | `pod-ip:target-port` |
| Headless | EndpointSlices | `pod-ip:target-port` |
| ExternalName | DNS | `external-name:service-port` |
| FQDN Mode | Service DNS | `service.ns.svc.cluster.local:service-port` |

#### Testing

- Unit tests for all resolution paths and edge cases
- Weight calculation validation with mathematical examples
- Error handling for missing services, invalid ports, ReferenceGrant scenarios
- Mock client testing for Kubernetes API interactions

#### Files

- `controller/hybridgateway/target/target.go` - Target resolution logic
- `controller/hybridgateway/target/weight.go` - Weight calculation algorithm  
- `controller/hybridgateway/target/*_test.go` - Test coverage
- `controller/hybridgateway/converter/http_route.go` - Integration point

**Which issue this PR fixes**

This PR adds a target resolution system that uses EndpointSlices to discover service endpoints and generate Kong targets with proper weight distribution.


Fixes #2264 #2266

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
