### PR TITLE
test(integration): Use watch to wait gateway and listeners set to not programmed in `TestGatewayEssentials`

### DIFF
--- a/test/helpers/watch.go
+++ b/test/helpers/watch.go
@@ -28,6 +28,8 @@ func WatchFor[
 ) T {
 	t.Helper()
 
+	require.Greater(t, timeout, time.Duration(0), "Must provide a duration greater than 0 as the timeout")
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 

--- a/test/helpers/watch.go
+++ b/test/helpers/watch.go
@@ -1,0 +1,63 @@
+package helpers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kr/pretty"
+	"github.com/stretchr/testify/require"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// WatchFor watches for an event of type eventType using the provided watch.Interface.
+// It returns when either context is done - and then it marks the test as failed -
+// or when the event has been received and predicate returned true.
+// This is a more generic helper watch function that can watch for both our own CRDs and other resources.
+func WatchFor[
+	T client.Object,
+](
+	t *testing.T,
+	ctx context.Context,
+	w apiwatch.Interface,
+	eventType apiwatch.EventType,
+	timeout time.Duration,
+	predicate func(T) bool,
+	failMsg string,
+) T {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var (
+		obj                   T
+		receivedAtLeastOneObj bool
+	)
+	for found := false; !found; {
+		select {
+		case <-ctx.Done():
+			if receivedAtLeastOneObj {
+				require.Failf(t, failMsg, "Last object received:\n%v", pretty.Sprint(obj))
+			} else {
+				require.Fail(t, failMsg)
+			}
+		case e := <-w.ResultChan():
+			if e.Type != eventType {
+				continue
+			}
+			var ok bool
+			obj, ok = e.Object.(T)
+			if !ok {
+				continue
+			}
+			receivedAtLeastOneObj = true
+			if !predicate(obj) {
+				continue
+			}
+			found = true
+		}
+	}
+	return obj
+}

--- a/test/helpers/watch_test.go
+++ b/test/helpers/watch_test.go
@@ -1,0 +1,39 @@
+package helpers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	configurationv1 "github.com/kong/kong-operator/api/configuration/v1"
+	"github.com/kong/kong-operator/modules/manager/scheme"
+)
+
+func TestWatch(t *testing.T) {
+	var (
+		ctx = t.Context()
+		cl  = fakectrlruntimeclient.NewClientBuilder().
+			WithScheme(scheme.Get()).
+			Build()
+		consumer = &configurationv1.KongConsumer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-consumer",
+			},
+		}
+	)
+
+	wConsumer, err := cl.Watch(ctx, &configurationv1.KongConsumerList{})
+	require.NoError(t, err)
+	require.NoError(t, cl.Create(ctx, consumer))
+	WatchFor(t, ctx, wConsumer, apiwatch.Added,
+		time.Second,
+		func(c *configurationv1.KongConsumer) bool {
+			return c.Name == consumer.Name
+		},
+		"error",
+	)
+}

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -57,6 +57,7 @@ func TestGatewayEssentials(t *testing.T) {
 	require.NoError(t, err, "failed to setup a client for watching gateways")
 	wGateway, err := cl.Watch(GetCtx(), &gatewayv1.GatewayList{}, client.InNamespace(namespace.Name))
 	require.NoError(t, err, "failed to start watching gateways")
+	t.Cleanup(func() { wGateway.Stop() })
 
 	t.Log("deploying Gateway resource")
 	gatewayNN := types.NamespacedName{


### PR DESCRIPTION
**What this PR does / why we need it**:

Use `client.Watch` to watch events of gateways and catch the transient state of gateway and its listeners marked as not programmed.

**Which issue this PR fixes**

Part of #2496

**Special notes for your reviewer**:
Note: In this PR I moved `WatchFor` to `helpers` package to run a more generic watch because the `setupWatch` in `envtest` cannot run on types other than our own CRD. The other types does not have our own methods so we have to use the generic method to run watches for them.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
