### PR TITLE
fix: initialize slice to empty instead of nil in HTTPRoute status functions

### DIFF
--- a/controller/hybridgateway/route/status.go
+++ b/controller/hybridgateway/route/status.go
@@ -125,7 +125,7 @@ func CleanupOrphanedParentStatus(logger logr.Logger, route *gwtypes.HTTPRoute, c
 	}
 
 	// Filter out orphaned ParentStatus entries.
-	var filteredParents []gwtypes.RouteParentStatus
+	filteredParents := []gwtypes.RouteParentStatus{}
 	removed := false
 
 	for _, parentStatus := range route.Status.Parents {
@@ -173,7 +173,7 @@ func RemoveStatusForParentRef(logger logr.Logger, route *gwtypes.HTTPRoute, pRef
 		return false
 	}
 	removed := false
-	var filteredParents []gwtypes.RouteParentStatus
+	filteredParents := []gwtypes.RouteParentStatus{}
 	for _, parentStatus := range route.Status.Parents {
 		if string(parentStatus.ControllerName) == controllerName && isParentRefEqual(parentStatus.ParentRef, pRef) {
 			// Skip this entry (remove it).


### PR DESCRIPTION
**What this PR does / why we need it**:

When all parent statuses are removed, setting route.Status.Parents to a nil slice causes JSON serialization to produce "null", which fails Kubernetes API validation that requires the status.parents field to be either absent or a valid array.

Initializing the slice as empty ensures it serializes to "[]" instead of "null", satisfying the API validation requirement: "status.parents: Required value" and preventing "Invalid value: null" validation errors.

Fixes HTTPRoute status update failures in hybrid gateway controller.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
