### PR TITLE
test(integration/kic): Fix `TestPluginNullInConfig` flakiness by finding target plugin in plugin list

### DIFF
--- a/ingress-controller/test/integration/plugin_test.go
+++ b/ingress-controller/test/integration/plugin_test.go
@@ -821,7 +821,10 @@ func TestPluginNullInConfig(t *testing.T) {
 		}
 
 		configJSON, err := json.Marshal(datadogPlugin.Config)
-		require.NoError(t, err)
+		if err != nil {
+			t.Logf("failed to encode plugin config to JSON: %v", err)
+			return false
+		}
 		t.Logf("Configuration of datadog plugin: %s", string(configJSON))
 
 		configPrefix, ok := datadogPlugin.Config["prefix"]


### PR DESCRIPTION
**What this PR does / why we need it**:

Find the target `datadog` plugin with `null` config inside instead of requiring only one plugin. Since tests are run in parallel, it may be flaky if we require there is only the target plugin.

**Which issue this PR fixes**

Fixes #2508 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
