### PR TITLE
ci: specify cluster version for envtest suite in Makefiles

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -189,6 +189,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      latest: ${{ steps.set-latest.outputs.latest }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - id: set-matrix
@@ -196,6 +197,13 @@ jobs:
           (
             echo 'matrix<<EOF'
             yq eval -o=json '.' .github/supported_k8s_node_versions.yaml
+            echo 'EOF'
+          ) >> "${GITHUB_OUTPUT}"
+      - id: set-latest
+        run: |
+          (
+            echo 'latest<<EOF'
+            yq eval -r -o=json '. | sort | reverse | .[0]' .github/supported_k8s_node_versions.yaml
             echo 'EOF'
           ) >> "${GITHUB_OUTPUT}"
 
@@ -424,7 +432,9 @@ jobs:
 
   envtest-tests:
     runs-on: ubuntu-latest
-    needs: [check-docs-only]
+    needs:
+    - check-docs-only
+    - matrix_k8s_node_versions
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     strategy:
       matrix:
@@ -452,14 +462,20 @@ jobs:
       id: license
       with:
         op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-        
 
     - name: run envtest tests
       working-directory: ${{ matrix.directory }}
-      run: make test.envtest
       env:
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         GOTESTSUM_JUNITFILE: "${{ matrix.directory }}/envtest-tests.xml"
+      run: |
+        VERSION="${{ needs.matrix_k8s_node_versions.outputs.latest }}"
+        # Remove leading 'v'
+        VERSION="${VERSION#v}"
+        # Remove patch number as envtest releases are not provided for every patch version
+        VERSION="${VERSION%.*}"
+        echo "Cluster version: $VERSION"
+        make test.envtest CLUSTER_VERSION=${VERSION}
 
     - name: collect test coverage
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/ingress-controller/Makefile
+++ b/ingress-controller/Makefile
@@ -77,14 +77,16 @@ JUNIT_REPORT ?= /dev/null
 
 .PHONY: use-setup-envtest
 use-setup-envtest:
-	$(SETUP_ENVTEST) use
+	$(SETUP_ENVTEST) use -v info $(CLUSTER_VERSION)
 
 ENVTEST_TIMEOUT ?= 8m
 
 .PHONY: _test.envtest
 .ONESHELL: _test.envtest
-_test.envtest: gotestsum setup-envtest use-setup-envtest
-	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use -p path)" \
+_test.envtest: gotestsum setup-envtest
+	$(MAKE) use-setup-envtest CLUSTER_VERSION=$(CLUSTER_VERSION)
+	KUBECONFIG=$(KUBECONFIG) \
+	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use $(CLUSTER_VERSION) -p path)" \
 		GOTESTSUM_FORMAT=$(GOTESTSUM_FORMAT) \
 		$(GOTESTSUM) \
 		--hide-summary output \


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the same approach as in https://github.com/Kong/kong-operator/pull/2523 but for envtest suite.

This time, the issue is with `ingress-controller` envtest:

```
make[2]: Leaving directory '/home/runner/work/kong-operator/kong-operator/ingress-controller'
/home/runner/work/kong-operator/kong-operator/ingress-controller/bin/installs/setup-envtest/0.21.0/bin/setup-envtest use
Version: 1.23.5
OS/Arch: linux/amd64
sha512: 9c9ef4082877558c28cc0b8f5bef7f20dbb62749865ae5397135df5c185d15d59cbb13b070813e2761e9de45b296909678856770148af5ee55a45d413246c44e
Path: /home/runner/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64
KUBEBUILDER_ASSETS="/home/runner/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64" \
	GOTESTSUM_FORMAT=standard-verbose \
	/home/runner/work/kong-operator/kong-operator/ingress-controller/bin/installs/gotestsum/1.13.0/bin/gotestsum \
	--hide-summary output \
	-- \
	-race \
	-ldflags="" \
	 \
	-tags envtest \
	-covermode=atomic \
	-timeout 8m \
	-coverpkg=./pkg/...,./internal/... \
	-coverprofile=coverage.envtest.out \
	./test/envtest/...
```

Mark the 1.23 version which is being used (being it's already available on the runner).

With this PR we run envtest suites against the latest version defined in `.github/supported_k8s_node_versions.yaml`

```
make use-setup-envtest CLUSTER_VERSION=1.34
KUBECONFIG= \
KUBEBUILDER_ASSETS="/home/runner/.local/share/kubebuilder-envtest/k8s/1.34.0-linux-amd64" \
	GOTESTSUM_FORMAT=standard-verbose \
	/home/runner/work/kong-operator/kong-operator/ingress-controller/bin/installs/gotestsum/1.13.0/bin/gotestsum \
	--hide-summary output \
	-- \
	-race \
	-ldflags="" \
	 \
	-tags envtest \
	-covermode=atomic \
	-timeout 8m \
	-coverpkg=./pkg/...,./internal/... \
	-coverprofile=coverage.envtest.out \
	./test/envtest/...
make[2]: Entering directory '/home/runner/work/kong-operator/kong-operator/ingress-controller'
/home/runner/work/kong-operator/kong-operator/ingress-controller/bin/installs/setup-envtest/0.21.0/bin/setup-envtest use -v info 1.34
2025-10-31T09:12:53.668Z	INFO	env/env.go:187	applicable version found on disk	{"version": "1.34.0"}
Version: 1.34.0
OS/Arch: linux/amd64
Path: /home/runner/.local/share/kubebuilder-envtest/k8s/1.34.0-linux-amd64
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
