### PR TITLE
ci: increase retry timeout for verify.generators in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -180,8 +180,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        timeout_minutes: 3
-        max_attempts: 6
+        timeout_minutes: 5
+        max_attempts: 5
         retry_wait_seconds: 20
         command: make verify.generators
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent:

```
  Warning: Attempt 1 failed. Reason: Timeout of 180000ms hit
```

https://github.com/Kong/kong-operator/actions/runs/18968702145/job/54171086606?pr=2180#step:8:460

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
