### PR TITLE
chore(ci): bump chart testing to 3.14.0

### DIFF
--- a/.github/workflows/charts-tests.yaml
+++ b/.github/workflows/charts-tests.yaml
@@ -149,7 +149,10 @@ jobs:
         with:
           # Specify version to get https://github.com/helm/chart-testing/pull/721
           # --wait flag to helm uninstall
-          version: "3.13.0"
+          # Can be removed when action is updated to use chart-testing >= 3.13.0
+          #
+          # renovate: datasource=github-releases depName=helm/chart-testing
+          version: "3.14.0"
 
       - name: Run chart-testing (lint)
         run: ct lint --target-branch main --check-version-increment=false


### PR DESCRIPTION
**What this PR does / why we need it**:

Also add renovate config, tested locally via:

```
mkdir renovate-cache; docker run --rm --env RENOVATE_GITHUB_COM_TOKEN=${GITHUB_API_TOKEN} --env RENOVATE_CONFIG_FILE=./renovate.json --env LOG_LEVEL=debug -v $(pwd):/usr/src/app -v $(pwd)/renovate-cache:/home/ubuntu/cache renovate/renovate --dry-run --platform local --cache-dir /home/ubuntu/cache
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
