### PR TITLE
fix: correct Azure DNSConfig mapping and rename typo

### DIFF
--- a/controller/konnect/ops/ops_konnecttransitgateway.go
+++ b/controller/konnect/ops/ops_konnecttransitgateway.go
@@ -142,7 +142,7 @@ func getKonnectTransitGatewayMatchingSpecName(
 	return getMatchingEntryFromListResponseData(listTransitGatewayResponseDataToEntityWithIDSlice(resp.ListTransitGatewaysResponse.Data), tg)
 }
 
-var trasitGatewayTypeToSDKTransitGatewayType = map[konnectv1alpha1.TransitGatewayType]sdkkonnectcomp.CreateTransitGatewayRequestType{
+var transitGatewayTypeToSDKTransitGatewayType = map[konnectv1alpha1.TransitGatewayType]sdkkonnectcomp.CreateTransitGatewayRequestType{
 	konnectv1alpha1.TransitGatewayTypeAWSTransitGateway:   sdkkonnectcomp.CreateTransitGatewayRequestTypeAWSTransitGateway,
 	konnectv1alpha1.TransitGatewayTypeAzureTransitGateway: sdkkonnectcomp.CreateTransitGatewayRequestTypeAzureTransitGateway,
 }
@@ -150,7 +150,7 @@ var trasitGatewayTypeToSDKTransitGatewayType = map[konnectv1alpha1.TransitGatewa
 func transitGatewaySpecToTransitGatewayInput(
 	spec konnectv1alpha1.KonnectTransitGatewayAPISpec,
 ) sdkkonnectcomp.CreateTransitGatewayRequest {
-	typ := trasitGatewayTypeToSDKTransitGatewayType[spec.Type]
+	typ := transitGatewayTypeToSDKTransitGatewayType[spec.Type]
 
 	req := sdkkonnectcomp.CreateTransitGatewayRequest{
 		Type: typ,
@@ -176,7 +176,7 @@ func transitGatewaySpecToTransitGatewayInput(
 	case konnectv1alpha1.TransitGatewayTypeAzureTransitGateway:
 		req.AzureTransitGateway = &sdkkonnectcomp.AzureTransitGateway{
 			Name: spec.AzureTransitGateway.Name,
-			DNSConfig: lo.Map(spec.AWSTransitGateway.DNSConfig, func(dnsConf konnectv1alpha1.TransitGatewayDNSConfig, _ int) sdkkonnectcomp.TransitGatewayDNSConfig {
+			DNSConfig: lo.Map(spec.AzureTransitGateway.DNSConfig, func(dnsConf konnectv1alpha1.TransitGatewayDNSConfig, _ int) sdkkonnectcomp.TransitGatewayDNSConfig {
 				return sdkkonnectcomp.TransitGatewayDNSConfig{
 					RemoteDNSServerIPAddresses: dnsConf.RemoteDNSServerIPAddresses,
 					DomainProxyList:            dnsConf.DomainProxyList,

--- a/controller/konnect/ops/ops_konnecttransitgateway_test.go
+++ b/controller/konnect/ops/ops_konnecttransitgateway_test.go
@@ -38,7 +38,7 @@ func TestTransitGatewaySpecToInput_AzureDNSConfig(t *testing.T) {
 
 	req := transitGatewaySpecToTransitGatewayInput(spec)
 
-	assert.NotNil(t, req.AzureTransitGateway)
+	require.NotNil(t, req.AzureTransitGateway)
 	az := req.AzureTransitGateway
 	if assert.Len(t, az.DNSConfig, 1) {
 		cfg := az.DNSConfig[0]


### PR DESCRIPTION
**What this PR does / why we need it**:

* Use `AzureTransitGateway.DNSConfig` in Azure branch (was `AWSTransitGateway.DNSConfig`)
* Rename variable to `transitGatewayTypeToSDKTransitGatewayType`
* Add TestTransitGatewaySpecToInput_AzureDNSConfig

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes~
