### PR TITLE
chore(ci): increase timeout for conformance tests

### DIFF
--- a/.github/workflows/conformance_tests_report.yaml
+++ b/.github/workflows/conformance_tests_report.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   conformance-tests:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Continuation of 

- https://github.com/Kong/kong-operator/pull/2555

increase timeout (from the default 10 minutes), because [it's not enough](https://github.com/Kong/kong-operator/actions/runs/19131461356)