### PR TITLE
feat(hybridgateway): update naming for autogenerated resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,8 @@
 - For Hybrid `Gateway`s the operator does not run the `ControlPlane` anymore, as
   the `DataPlane` is configured to use `Koko` as Konnect control plane.
   [#2253](https://github.com/Kong/kong-operator/pull/2253)
+- HybridGateway auto-generated resource names has been revised.
+  [#2566](https://github.com/Kong/kong-operator/pull/2566)
 
 ### Fixes
 

--- a/controller/hybridgateway/namegen/name.go
+++ b/controller/hybridgateway/namegen/name.go
@@ -1,7 +1,6 @@
 package namegen
 
 import (
-	"fmt"
 	"strings"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -11,115 +10,69 @@ import (
 	gwtypes "github.com/kong/kong-operator/internal/types"
 )
 
-// Name represents a structured naming scheme for Kong entities to be identified by the HTTPRoute, ParentReference,
-// and HTTPRoute section from which the resource is derived.
-type Name struct {
-	httpRouteID    string
-	controlPlaneID string
-	sectionID      string
-}
-
 const (
-	defaultHTTPRoutePrefix = "http"
-	defaultCPPrefix        = "cp"
-	defaultResPrefix       = "res"
+	defaultCPPrefix = "cp"
+	namegenPrefix   = "ngn"
+	maxLen          = 253
 )
 
-// String returns the full name as a dot-separated string.
-func (h *Name) String() string {
-	const maxLen = 253 - len("faf385ae") - 1 // reserve space for one extra hash (+ 1 dot) for child resources (e.g., KongTargets)
-
-	parts := []string{}
-	if h.httpRouteID != "" {
-		parts = append(parts, h.httpRouteID)
-	}
-	if h.controlPlaneID != "" {
-		parts = append(parts, h.controlPlaneID)
-	}
-	if h.sectionID != "" {
-		parts = append(parts, h.sectionID)
-	}
-	fullName := strings.Join(parts, ".")
-
-	if len(fullName) <= maxLen {
-		return fullName
+// newName generates a name by concatenating the given components if the length is within the limit of
+// Kubernetes resource names, otherwise it returns a hashed version of the concatenated elements.
+func newName(elements ...string) string {
+	if name := strings.Join(elements, "."); len(name) <= maxLen {
+		return name
 	}
 
-	// If the full name exceeds the max length, we fallback to a hashed version of each component
-	const maxCompLen = (maxLen - 2) / 3
-
-	httpRouteID := h.httpRouteID
-	parentRefID := h.controlPlaneID
-	sectionID := h.sectionID
-
-	if len(httpRouteID) > maxCompLen {
-		httpRouteID = defaultHTTPRoutePrefix + utils.Hash32(httpRouteID)
-	}
-	if len(parentRefID) > maxCompLen {
-		parentRefID = defaultCPPrefix + utils.Hash32(parentRefID)
-	}
-	if len(sectionID) > maxCompLen {
-		sectionID = defaultResPrefix + utils.Hash32(sectionID)
-	}
-
-	parts = []string{httpRouteID, parentRefID}
-	if sectionID != "" {
-		parts = append(parts, sectionID)
-	}
-	fullName = strings.Join(parts, ".")
-
-	return fullName
+	// If the name exceeds the max length, return a hashed version of the concatenated elements
+	return namegenPrefix + utils.Hash64(elements)
 }
 
-// newName creates a new Name instance with the given components.
-func newName(httpRouteID, controlPlaneID, sectionID string) *Name {
-	return &Name{
-		httpRouteID:    httpRouteID,
-		controlPlaneID: controlPlaneID,
-		sectionID:      sectionID,
-	}
-}
-
-// NewKongUpstreamName generates a KongUpstream name based on the ControlPlaneRef and HTTPRouteRule.
+// NewKongUpstreamName generates a KongUpstream name based on the ControlPlaneRef and HTTPRouteRule passed as arguments.
 func NewKongUpstreamName(cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTPRouteRule) string {
 	return newName(
-		"",
 		defaultCPPrefix+utils.Hash32(cp),
 		utils.Hash32(rule.BackendRefs),
-	).String()
+	)
 }
 
-// NewKongServiceName generates a KongService name based on the ControlPlaneRef and HTTPRouteRule.
+// NewKongServiceName generates a KongService name based on the ControlPlaneRef and HTTPRouteRule passed as arguments.
 func NewKongServiceName(cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTPRouteRule) string {
 	return newName(
-		"",
 		defaultCPPrefix+utils.Hash32(cp),
 		utils.Hash32(rule.BackendRefs),
-	).String()
+	)
 }
 
-// NewKongRouteName generates a KongRoute name based on the HTTPRoute, ControlPlaneRef, and HTTPRouteRule.
+// NewKongRouteName generates a KongRoute name based on the HTTPRoute, ControlPlaneRef, and HTTPRouteRule passed as arguments.
 func NewKongRouteName(route *gwtypes.HTTPRoute, cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTPRouteRule) string {
 	return newName(
 		route.Namespace+"-"+route.Name,
 		defaultCPPrefix+utils.Hash32(cp),
 		utils.Hash32(rule.Matches),
-	).String()
+	)
 }
 
-// NewKongPluginName generates a KongPlugin name based on the HTTPRouteFilter.
+// NewKongPluginName generates a KongPlugin name based on the HTTPRouteFilter passed as argument.
 func NewKongPluginName(filter gatewayv1.HTTPRouteFilter) string {
-	return newName("", "", "pl"+utils.Hash32(filter)).String()
+	return newName("pl" + utils.Hash32(filter))
 }
 
-// NewKongPluginBindingName generates a KongPlugin name based on the HTTPRoute, ControlPlaneRef and HTTPRouteFilter.
+// NewKongPluginBindingName generates a KongPlugin name based on the KongRoute and the KongPlugin names.
 func NewKongPluginBindingName(routeID, pluginId string) string {
-	return newName(routeID, "", pluginId).String()
+	return newName(routeID, pluginId)
 }
 
 // NewKongTargetName generates a KongTarget name based on the KongUpstream name, the Service Endpoint ip,
 // the service port and the HTTPBackendRef.
 func NewKongTargetName(upstreamID, endpointID string, port int, br *gwtypes.HTTPBackendRef) string {
-	return newName(upstreamID, "",
-		utils.Hash32(utils.Hash32(br)+fmt.Sprintf("%s:%d", endpointID, port))).String()
+	obj := struct {
+		endpointID string
+		port       int
+		backend    *gwtypes.HTTPBackendRef
+	}{
+		endpointID: endpointID,
+		port:       port,
+		backend:    br,
+	}
+	return newName(upstreamID, utils.Hash32(obj))
 }

--- a/controller/hybridgateway/namegen/name.go
+++ b/controller/hybridgateway/namegen/name.go
@@ -19,9 +19,11 @@ type Name struct {
 	sectionID      string
 }
 
-const defaultHTTPRoutePrefix = "http"
-const defaultCPPrefix = "cp"
-const defaultResPrefix = "res"
+const (
+  defaultHTTPRoutePrefix = "http"
+  defaultCPPrefix = "cp"
+  defaultResPrefix = "res"
+)
 
 // String returns the full name as a dot-separated string.
 func (h *Name) String() string {

--- a/controller/hybridgateway/namegen/name.go
+++ b/controller/hybridgateway/namegen/name.go
@@ -11,9 +11,10 @@ import (
 )
 
 const (
-	defaultCPPrefix = "cp"
-	namegenPrefix   = "ngn"
-	maxLen          = 253
+	httpProcolPrefix = "http"
+	defaultCPPrefix  = "cp"
+	namegenPrefix    = "ngn"
+	maxLen           = 253
 )
 
 // newName generates a name by concatenating the given components if the length is within the limit of
@@ -38,6 +39,7 @@ func NewKongUpstreamName(cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTP
 // NewKongServiceName generates a KongService name based on the ControlPlaneRef and HTTPRouteRule passed as arguments.
 func NewKongServiceName(cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTPRouteRule) string {
 	return newName(
+		httpProcolPrefix,
 		defaultCPPrefix+utils.Hash32(cp),
 		utils.Hash32(rule.BackendRefs),
 	)
@@ -46,6 +48,7 @@ func NewKongServiceName(cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTPR
 // NewKongRouteName generates a KongRoute name based on the HTTPRoute, ControlPlaneRef, and HTTPRouteRule passed as arguments.
 func NewKongRouteName(route *gwtypes.HTTPRoute, cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTPRouteRule) string {
 	return newName(
+		httpProcolPrefix,
 		route.Namespace+"-"+route.Name,
 		defaultCPPrefix+utils.Hash32(cp),
 		utils.Hash32(rule.Matches),

--- a/controller/hybridgateway/namegen/name.go
+++ b/controller/hybridgateway/namegen/name.go
@@ -20,9 +20,9 @@ type Name struct {
 }
 
 const (
-  defaultHTTPRoutePrefix = "http"
-  defaultCPPrefix = "cp"
-  defaultResPrefix = "res"
+	defaultHTTPRoutePrefix = "http"
+	defaultCPPrefix        = "cp"
+	defaultResPrefix       = "res"
 )
 
 // String returns the full name as a dot-separated string.
@@ -71,8 +71,8 @@ func (h *Name) String() string {
 	return fullName
 }
 
-// NewName creates a new Name instance with the given components.
-func NewName(httpRouteID, controlPlaneID, sectionID string) *Name {
+// newName creates a new Name instance with the given components.
+func newName(httpRouteID, controlPlaneID, sectionID string) *Name {
 	return &Name{
 		httpRouteID:    httpRouteID,
 		controlPlaneID: controlPlaneID,
@@ -82,7 +82,7 @@ func NewName(httpRouteID, controlPlaneID, sectionID string) *Name {
 
 // NewKongUpstreamName generates a KongUpstream name based on the ControlPlaneRef and HTTPRouteRule.
 func NewKongUpstreamName(cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTPRouteRule) string {
-	return NewName(
+	return newName(
 		"",
 		defaultCPPrefix+utils.Hash32(cp),
 		utils.Hash32(rule.BackendRefs),
@@ -91,7 +91,7 @@ func NewKongUpstreamName(cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTP
 
 // NewKongServiceName generates a KongService name based on the ControlPlaneRef and HTTPRouteRule.
 func NewKongServiceName(cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTPRouteRule) string {
-	return NewName(
+	return newName(
 		"",
 		defaultCPPrefix+utils.Hash32(cp),
 		utils.Hash32(rule.BackendRefs),
@@ -100,7 +100,7 @@ func NewKongServiceName(cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTPR
 
 // NewKongRouteName generates a KongRoute name based on the HTTPRoute, ControlPlaneRef, and HTTPRouteRule.
 func NewKongRouteName(route *gwtypes.HTTPRoute, cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTPRouteRule) string {
-	return NewName(
+	return newName(
 		route.Namespace+"-"+route.Name,
 		defaultCPPrefix+utils.Hash32(cp),
 		utils.Hash32(rule.Matches),
@@ -109,17 +109,17 @@ func NewKongRouteName(route *gwtypes.HTTPRoute, cp *commonv1alpha1.ControlPlaneR
 
 // NewKongPluginName generates a KongPlugin name based on the HTTPRouteFilter.
 func NewKongPluginName(filter gatewayv1.HTTPRouteFilter) string {
-	return NewName("", "", "pl"+utils.Hash32(filter)).String()
+	return newName("", "", "pl"+utils.Hash32(filter)).String()
 }
 
 // NewKongPluginBindingName generates a KongPlugin name based on the HTTPRoute, ControlPlaneRef and HTTPRouteFilter.
 func NewKongPluginBindingName(routeID, pluginId string) string {
-	return NewName(routeID, "", pluginId).String()
+	return newName(routeID, "", pluginId).String()
 }
 
 // NewKongTargetName generates a KongTarget name based on the KongUpstream name, the Service Endpoint ip,
 // the service port and the HTTPBackendRef.
 func NewKongTargetName(upstreamID, endpointID string, port int, br *gwtypes.HTTPBackendRef) string {
-	return NewName(upstreamID, "",
+	return newName(upstreamID, "",
 		utils.Hash32(utils.Hash32(br)+fmt.Sprintf("%s:%d", endpointID, port))).String()
 }

--- a/controller/hybridgateway/namegen/name.go
+++ b/controller/hybridgateway/namegen/name.go
@@ -1,18 +1,27 @@
 package namegen
 
 import (
+	"fmt"
 	"strings"
 
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
 	"github.com/kong/kong-operator/controller/hybridgateway/utils"
+	gwtypes "github.com/kong/kong-operator/internal/types"
 )
 
 // Name represents a structured naming scheme for Kong entities to be identified by the HTTPRoute, ParentReference,
 // and HTTPRoute section from which the resource is derived.
 type Name struct {
-	httpRouteID string
-	parentRefID string
-	sectionID   string
+	httpRouteID    string
+	controlPlaneID string
+	sectionID      string
 }
+
+const defaultHTTPRoutePrefix = "http"
+const defaultCPPrefix = "cp"
+const defaultResPrefix = "res"
 
 // String returns the full name as a dot-separated string.
 func (h *Name) String() string {
@@ -22,8 +31,8 @@ func (h *Name) String() string {
 	if h.httpRouteID != "" {
 		parts = append(parts, h.httpRouteID)
 	}
-	if h.parentRefID != "" {
-		parts = append(parts, h.parentRefID)
+	if h.controlPlaneID != "" {
+		parts = append(parts, h.controlPlaneID)
 	}
 	if h.sectionID != "" {
 		parts = append(parts, h.sectionID)
@@ -35,23 +44,20 @@ func (h *Name) String() string {
 	}
 
 	// If the full name exceeds the max length, we fallback to a hashed version of each component
-	const DefaultHTTPRoutePrefix = "http"
-	const DefaultParentRefPrefix = "cp"
-	const DefaultSectPrefix = "res"
 	const maxCompLen = (maxLen - 2) / 3
 
 	httpRouteID := h.httpRouteID
-	parentRefID := h.parentRefID
+	parentRefID := h.controlPlaneID
 	sectionID := h.sectionID
 
 	if len(httpRouteID) > maxCompLen {
-		httpRouteID = DefaultHTTPRoutePrefix + utils.Hash32(httpRouteID)
+		httpRouteID = defaultHTTPRoutePrefix + utils.Hash32(httpRouteID)
 	}
 	if len(parentRefID) > maxCompLen {
-		parentRefID = DefaultParentRefPrefix + utils.Hash32(parentRefID)
+		parentRefID = defaultCPPrefix + utils.Hash32(parentRefID)
 	}
 	if len(sectionID) > maxCompLen {
-		sectionID = DefaultSectPrefix + utils.Hash32(sectionID)
+		sectionID = defaultResPrefix + utils.Hash32(sectionID)
 	}
 
 	parts = []string{httpRouteID, parentRefID}
@@ -64,10 +70,54 @@ func (h *Name) String() string {
 }
 
 // NewName creates a new Name instance with the given components.
-func NewName(httpRouteID, parentRefID, sectionID string) *Name {
+func NewName(httpRouteID, controlPlaneID, sectionID string) *Name {
 	return &Name{
-		httpRouteID: httpRouteID,
-		parentRefID: parentRefID,
-		sectionID:   sectionID,
+		httpRouteID:    httpRouteID,
+		controlPlaneID: controlPlaneID,
+		sectionID:      sectionID,
 	}
+}
+
+// NewKongUpstreamName generates a KongUpstream name based on the ControlPlaneRef and HTTPRouteRule.
+func NewKongUpstreamName(cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTPRouteRule) string {
+	return NewName(
+		"",
+		defaultCPPrefix+utils.Hash32(cp),
+		utils.Hash32(rule.BackendRefs),
+	).String()
+}
+
+// NewKongServiceName generates a KongService name based on the ControlPlaneRef and HTTPRouteRule.
+func NewKongServiceName(cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTPRouteRule) string {
+	return NewName(
+		"",
+		defaultCPPrefix+utils.Hash32(cp),
+		utils.Hash32(rule.BackendRefs),
+	).String()
+}
+
+// NewKongRouteName generates a KongRoute name based on the HTTPRoute, ControlPlaneRef, and HTTPRouteRule.
+func NewKongRouteName(route *gwtypes.HTTPRoute, cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTPRouteRule) string {
+	return NewName(
+		route.Namespace+"-"+route.Name,
+		defaultCPPrefix+utils.Hash32(cp),
+		utils.Hash32(rule.Matches),
+	).String()
+}
+
+// NewKongPluginName generates a KongPlugin name based on the HTTPRouteFilter.
+func NewKongPluginName(filter gatewayv1.HTTPRouteFilter) string {
+	return NewName("", "", "pl"+utils.Hash32(filter)).String()
+}
+
+// NewKongPluginBindingName generates a KongPlugin name based on the HTTPRoute, ControlPlaneRef and HTTPRouteFilter.
+func NewKongPluginBindingName(routeID, pluginId string) string {
+	return NewName(routeID, "", pluginId).String()
+}
+
+// NewKongTargetName generates a KongTarget name based on the KongUpstream name, the Service Endpoint ip,
+// the service port and the HTTPBackendRef.
+func NewKongTargetName(upstreamID, endpointID string, port int, br *gwtypes.HTTPBackendRef) string {
+	return NewName(upstreamID, "",
+		utils.Hash32(utils.Hash32(br)+fmt.Sprintf("%s:%d", endpointID, port))).String()
 }

--- a/controller/hybridgateway/namegen/name_test.go
+++ b/controller/hybridgateway/namegen/name_test.go
@@ -6,6 +6,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	gwtypes "github.com/kong/kong-operator/internal/types"
 )
 
 func TestNewName(t *testing.T) {
@@ -235,4 +240,459 @@ func TestName_String_Consistency(t *testing.T) {
 			assert.Equal(t, result1, result2, "same inputs should produce same outputs")
 		})
 	}
+}
+
+func TestNewKongUpstreamName(t *testing.T) {
+	tests := []struct {
+		name string
+		cp   *commonv1alpha1.ControlPlaneRef
+		rule gatewayv1.HTTPRouteRule
+	}{
+		{
+			name: "basic upstream name generation",
+			cp: &commonv1alpha1.ControlPlaneRef{
+				Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+				KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+					Name: "test-cp",
+				},
+			},
+			rule: gatewayv1.HTTPRouteRule{
+				BackendRefs: []gatewayv1.HTTPBackendRef{
+					{
+						BackendRef: gatewayv1.BackendRef{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Name: "service1",
+								Port: func() *gatewayv1.PortNumber { p := gatewayv1.PortNumber(8080); return &p }(),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple backend refs",
+			cp: &commonv1alpha1.ControlPlaneRef{
+				Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+				KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+					Name: "multi-cp",
+				},
+			},
+			rule: gatewayv1.HTTPRouteRule{
+				BackendRefs: []gatewayv1.HTTPBackendRef{
+					{
+						BackendRef: gatewayv1.BackendRef{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Name: "service1",
+								Port: func() *gatewayv1.PortNumber { p := gatewayv1.PortNumber(8080); return &p }(),
+							},
+						},
+					},
+					{
+						BackendRef: gatewayv1.BackendRef{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Name: "service2",
+								Port: func() *gatewayv1.PortNumber { p := gatewayv1.PortNumber(9090); return &p }(),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NewKongUpstreamName(tt.cp, tt.rule)
+			assert.NotEmpty(t, result)
+			parts := strings.Split(result, ".")
+			assert.GreaterOrEqual(t, len(parts), 2)
+			assert.True(t, strings.HasPrefix(parts[0], "cp"))
+		})
+	}
+}
+
+func TestNewKongServiceName(t *testing.T) {
+	tests := []struct {
+		name string
+		cp   *commonv1alpha1.ControlPlaneRef
+		rule gatewayv1.HTTPRouteRule
+	}{
+		{
+			name: "basic service name generation",
+			cp: &commonv1alpha1.ControlPlaneRef{
+				Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+				KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+					Name: "test-cp",
+				},
+			},
+			rule: gatewayv1.HTTPRouteRule{
+				BackendRefs: []gatewayv1.HTTPBackendRef{
+					{
+						BackendRef: gatewayv1.BackendRef{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Name: "service1",
+								Port: func() *gatewayv1.PortNumber { p := gatewayv1.PortNumber(8080); return &p }(),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "service with namespace",
+			cp: &commonv1alpha1.ControlPlaneRef{
+				Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+				KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+					Name:      "namespaced-cp",
+					Namespace: "konnect-system",
+				},
+			},
+			rule: gatewayv1.HTTPRouteRule{
+				BackendRefs: []gatewayv1.HTTPBackendRef{
+					{
+						BackendRef: gatewayv1.BackendRef{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Name:      "backend-service",
+								Namespace: func() *gatewayv1.Namespace { ns := gatewayv1.Namespace("backend-ns"); return &ns }(),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NewKongServiceName(tt.cp, tt.rule)
+			assert.NotEmpty(t, result)
+			parts := strings.Split(result, ".")
+			assert.GreaterOrEqual(t, len(parts), 2)
+			assert.True(t, strings.HasPrefix(parts[0], "cp"))
+		})
+	}
+}
+
+func TestNewKongRouteName(t *testing.T) {
+	tests := []struct {
+		name  string
+		route *gwtypes.HTTPRoute
+		cp    *commonv1alpha1.ControlPlaneRef
+		rule  gatewayv1.HTTPRouteRule
+	}{
+		{
+			name: "basic route name generation",
+			route: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+			},
+			cp: &commonv1alpha1.ControlPlaneRef{
+				Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+				KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+					Name: "test-cp",
+				},
+			},
+			rule: gatewayv1.HTTPRouteRule{
+				Matches: []gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  func() *gatewayv1.PathMatchType { t := gatewayv1.PathMatchPathPrefix; return &t }(),
+							Value: func() *string { s := "/api"; return &s }(),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "route with multiple matches",
+			route: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "complex-route",
+					Namespace: "test-ns",
+				},
+			},
+			cp: &commonv1alpha1.ControlPlaneRef{
+				Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+				KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+					Name: "complex-cp",
+				},
+			},
+			rule: gatewayv1.HTTPRouteRule{
+				Matches: []gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  func() *gatewayv1.PathMatchType { t := gatewayv1.PathMatchPathPrefix; return &t }(),
+							Value: func() *string { s := "/api/v1"; return &s }(),
+						},
+						Headers: []gatewayv1.HTTPHeaderMatch{
+							{
+								Name:  "X-API-Version",
+								Value: "v1",
+							},
+						},
+					},
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  func() *gatewayv1.PathMatchType { t := gatewayv1.PathMatchExact; return &t }(),
+							Value: func() *string { s := "/health"; return &s }(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NewKongRouteName(tt.route, tt.cp, tt.rule)
+			assert.NotEmpty(t, result)
+			parts := strings.Split(result, ".")
+			assert.GreaterOrEqual(t, len(parts), 2)
+			assert.Equal(t, tt.route.Namespace+"-"+tt.route.Name, parts[0])
+		})
+	}
+}
+
+func TestNewKongPluginName(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter gatewayv1.HTTPRouteFilter
+	}{
+		{
+			name: "request header modifier filter",
+			filter: gatewayv1.HTTPRouteFilter{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Set: []gatewayv1.HTTPHeader{
+						{Name: "X-Test", Value: "test-value"},
+					},
+				},
+			},
+		},
+		{
+			name: "response header modifier filter",
+			filter: gatewayv1.HTTPRouteFilter{
+				Type: gatewayv1.HTTPRouteFilterResponseHeaderModifier,
+				ResponseHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Add: []gatewayv1.HTTPHeader{
+						{Name: "X-Response", Value: "response-value"},
+					},
+				},
+			},
+		},
+		{
+			name: "request redirect filter",
+			filter: gatewayv1.HTTPRouteFilter{
+				Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+				RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+					StatusCode: func() *int { s := 301; return &s }(),
+					Hostname:   func() *gatewayv1.PreciseHostname { h := gatewayv1.PreciseHostname("example.com"); return &h }(),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NewKongPluginName(tt.filter)
+			assert.NotEmpty(t, result)
+			assert.True(t, strings.HasPrefix(result, "pl"))
+		})
+	}
+}
+
+func TestNewKongPluginBindingName(t *testing.T) {
+	tests := []struct {
+		name     string
+		routeID  string
+		pluginId string
+		expected string
+	}{
+		{
+			name:     "basic plugin binding name",
+			routeID:  "default-test-route.cp12345678.ab123456",
+			pluginId: "pl87654321",
+			expected: "default-test-route.cp12345678.ab123456..pl87654321",
+		},
+		{
+			name:     "empty route ID",
+			routeID:  "",
+			pluginId: "pl99887766",
+			expected: "pl99887766",
+		},
+		{
+			name:     "long route ID",
+			routeID:  "very-long-namespace-name-very-long-route-name.cp12345678.ab123456",
+			pluginId: "pl11223344",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NewKongPluginBindingName(tt.routeID, tt.pluginId)
+			assert.NotEmpty(t, result)
+			assert.Contains(t, result, tt.pluginId)
+			if tt.routeID != "" {
+				assert.Contains(t, result, tt.routeID)
+			}
+		})
+	}
+}
+
+func TestNewKongTargetName(t *testing.T) {
+	tests := []struct {
+		name       string
+		upstreamID string
+		endpointID string
+		port       int
+		br         *gwtypes.HTTPBackendRef
+	}{
+		{
+			name:       "basic target name",
+			upstreamID: "cp12345678.ab123456",
+			endpointID: "192.168.1.100",
+			port:       8080,
+			br: &gwtypes.HTTPBackendRef{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name: "backend-service",
+						Port: func() *gatewayv1.PortNumber { p := gatewayv1.PortNumber(8080); return &p }(),
+					},
+				},
+			},
+		},
+		{
+			name:       "target with different port",
+			upstreamID: "cp87654321.cd987654",
+			endpointID: "10.0.0.50",
+			port:       9090,
+			br: &gwtypes.HTTPBackendRef{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name:      "api-service",
+						Namespace: func() *gatewayv1.Namespace { ns := gatewayv1.Namespace("api-ns"); return &ns }(),
+						Port:      func() *gatewayv1.PortNumber { p := gatewayv1.PortNumber(9090); return &p }(),
+					},
+					Weight: func() *int32 { w := int32(100); return &w }(),
+				},
+			},
+		},
+		{
+			name:       "target with IPv6 endpoint",
+			upstreamID: "cp11223344.ef556677",
+			endpointID: "2001:db8::1",
+			port:       443,
+			br: &gwtypes.HTTPBackendRef{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name: "secure-service",
+						Port: func() *gatewayv1.PortNumber { p := gatewayv1.PortNumber(443); return &p }(),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NewKongTargetName(tt.upstreamID, tt.endpointID, tt.port, tt.br)
+			assert.NotEmpty(t, result)
+			parts := strings.Split(result, ".")
+			assert.GreaterOrEqual(t, len(parts), 2)
+			assert.Equal(t, tt.upstreamID, strings.Join(parts[0:2], "."))
+		})
+	}
+}
+
+func TestNameGenerationConsistency(t *testing.T) {
+	// Test that the same inputs always produce the same outputs
+	cp := &commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: "consistent-cp",
+		},
+	}
+
+	rule := gatewayv1.HTTPRouteRule{
+		BackendRefs: []gatewayv1.HTTPBackendRef{
+			{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name: "consistent-service",
+						Port: func() *gatewayv1.PortNumber { p := gatewayv1.PortNumber(8080); return &p }(),
+					},
+				},
+			},
+		},
+	}
+
+	route := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "consistent-route",
+			Namespace: "default",
+		},
+	}
+
+	filter := gatewayv1.HTTPRouteFilter{
+		Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+		RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+			Set: []gatewayv1.HTTPHeader{
+				{Name: "X-Consistent", Value: "test"},
+			},
+		},
+	}
+
+	br := &gwtypes.HTTPBackendRef{
+		BackendRef: gatewayv1.BackendRef{
+			BackendObjectReference: gatewayv1.BackendObjectReference{
+				Name: "consistent-backend",
+				Port: func() *gatewayv1.PortNumber { p := gatewayv1.PortNumber(8080); return &p }(),
+			},
+		},
+	}
+
+	t.Run("upstream name consistency", func(t *testing.T) {
+		result1 := NewKongUpstreamName(cp, rule)
+		result2 := NewKongUpstreamName(cp, rule)
+		assert.Equal(t, result1, result2)
+	})
+
+	t.Run("service name consistency", func(t *testing.T) {
+		result1 := NewKongServiceName(cp, rule)
+		result2 := NewKongServiceName(cp, rule)
+		assert.Equal(t, result1, result2)
+	})
+
+	t.Run("route name consistency", func(t *testing.T) {
+		ruleWithMatches := gatewayv1.HTTPRouteRule{
+			Matches: []gatewayv1.HTTPRouteMatch{
+				{
+					Path: &gatewayv1.HTTPPathMatch{
+						Type:  func() *gatewayv1.PathMatchType { t := gatewayv1.PathMatchPathPrefix; return &t }(),
+						Value: func() *string { s := "/api"; return &s }(),
+					},
+				},
+			},
+		}
+		result1 := NewKongRouteName(route, cp, ruleWithMatches)
+		result2 := NewKongRouteName(route, cp, ruleWithMatches)
+		assert.Equal(t, result1, result2)
+	})
+
+	t.Run("plugin name consistency", func(t *testing.T) {
+		result1 := NewKongPluginName(filter)
+		result2 := NewKongPluginName(filter)
+		assert.Equal(t, result1, result2)
+	})
+
+	t.Run("target name consistency", func(t *testing.T) {
+		upstreamID := "test-upstream"
+		endpointID := "192.168.1.1"
+		port := 8080
+		result1 := NewKongTargetName(upstreamID, endpointID, port, br)
+		result2 := NewKongTargetName(upstreamID, endpointID, port, br)
+		assert.Equal(t, result1, result2)
+	})
 }

--- a/controller/hybridgateway/namegen/name_test.go
+++ b/controller/hybridgateway/namegen/name_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -15,229 +14,48 @@ import (
 
 func TestNewName(t *testing.T) {
 	tests := []struct {
-		name        string
-		httpRouteID string
-		parentRefID string
-		sectionID   string
-		expected    *Name
+		name           string
+		elements       []string
+		expected       string
+		expectedPrefix string
 	}{
 		{
-			name:        "all parameters provided",
-			httpRouteID: "test-ns-test-route",
-			parentRefID: "cp123456",
-			sectionID:   "res789",
-			expected: &Name{
-				httpRouteID:    "test-ns-test-route",
-				controlPlaneID: "cp123456",
-				sectionID:      "res789",
-			},
+			name:     "short name - no hashing needed",
+			elements: []string{"test-route", "cp123456", "match123456"},
+			expected: "test-route.cp123456.match123456",
 		},
 		{
-			name:        "empty section ID",
-			httpRouteID: "test-ns-test-route",
-			parentRefID: "cp123456",
-			sectionID:   "",
-			expected: &Name{
-				httpRouteID:    "test-ns-test-route",
-				controlPlaneID: "cp123456",
-				sectionID:      "",
-			},
+			name:     "single element",
+			elements: []string{"test"},
+			expected: "test",
 		},
 		{
-			name:        "all empty strings",
-			httpRouteID: "",
-			parentRefID: "",
-			sectionID:   "",
-			expected: &Name{
-				httpRouteID:    "",
-				controlPlaneID: "",
-				sectionID:      "",
+			name: "very long name - should hash",
+			elements: []string{
+				"very-long-element-that-exceeds-limits",
+				"very-long-second-elemental-that-also-exceeds-normal-limits",
+				"very-long-controlplane-hash-that-makes-everything-too-long",
+				"and-even-more-content-to-ensure-we-exceed-the-max-length-limit-of-253-characters-for-kubernetes-resource-names-which-is-quite-a-lot-but-we-need-to-test-the-hashing-behavior-properly",
 			},
+			expectedPrefix: namegenPrefix,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := newName(tt.httpRouteID, tt.parentRefID, tt.sectionID)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
+			result := newName(tt.elements...)
 
-func TestName_String(t *testing.T) {
-	tests := []struct {
-		name        string
-		nameObj     *Name
-		expected    string
-		description string
-	}{
-		{
-			name: "short name with section",
-			nameObj: &Name{
-				httpRouteID:    "test-ns-route",
-				controlPlaneID: "cp123",
-				sectionID:      "res456",
-			},
-			expected:    "test-ns-route.cp123.res456",
-			description: "should join all parts with dots when length is acceptable",
-		},
-		{
-			name: "short name without http route",
-			nameObj: &Name{
-				httpRouteID:    "",
-				controlPlaneID: "cp123",
-				sectionID:      "res456",
-			},
-			expected:    "cp123.res456",
-			description: "should join only non-empty parts with dots",
-		},
-		{
-			name: "short name without parent reference",
-			nameObj: &Name{
-				httpRouteID:    "test-ns-route",
-				controlPlaneID: "",
-				sectionID:      "res456",
-			},
-			expected:    "test-ns-route.res456",
-			description: "should join only non-empty parts with dots",
-		},
-		{
-			name: "short name without section",
-			nameObj: &Name{
-				httpRouteID:    "test-ns-route",
-				controlPlaneID: "cp123",
-				sectionID:      "",
-			},
-			expected:    "test-ns-route.cp123",
-			description: "should join only non-empty parts with dots",
-		},
-		{
-			name: "short name with just httproute",
-			nameObj: &Name{
-				httpRouteID:    "test-ns-route",
-				controlPlaneID: "",
-				sectionID:      "",
-			},
-			expected:    "test-ns-route",
-			description: "should join only non-empty parts with dots",
-		},
-		{
-			name: "short name with just parentref",
-			nameObj: &Name{
-				httpRouteID:    "",
-				controlPlaneID: "cp123",
-				sectionID:      "",
-			},
-			expected:    "cp123",
-			description: "should join only non-empty parts with dots",
-		},
-		{
-			name: "short name with just section",
-			nameObj: &Name{
-				httpRouteID:    "",
-				controlPlaneID: "",
-				sectionID:      "res456",
-			},
-			expected:    "res456",
-			description: "should join only non-empty parts with dots",
-		},
-		{
-			name: "empty name",
-			nameObj: &Name{
-				httpRouteID:    "",
-				controlPlaneID: "",
-				sectionID:      "",
-			},
-			expected:    "",
-			description: "should handle empty strings gracefully",
-		},
-		{
-			name: "very long names that need hashing",
-			nameObj: &Name{
-				httpRouteID:    strings.Repeat("a", 100),
-				controlPlaneID: strings.Repeat("b", 100),
-				sectionID:      strings.Repeat("c", 100),
-			},
-			expected:    "", // Will be set dynamically in test
-			description: "should hash long components and stay within length limits",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := tt.nameObj.String()
-
-			if tt.name == "very long names that need hashing" {
-				// For long names, verify the result is within limits and has expected prefixes
-				assert.LessOrEqual(t, len(result), 253-len("faf385ae")-1, "result should be within max length")
-				parts := strings.Split(result, ".")
-				require.Len(t, parts, 3, "should have 3 parts after hashing")
-				assert.True(t, strings.HasPrefix(parts[0], "http"), "first part should have 'http' prefix")
-				assert.True(t, strings.HasPrefix(parts[1], "cp"), "second part should have 'cp' prefix")
-				assert.True(t, strings.HasPrefix(parts[2], "res"), "third part should have 'res' prefix")
+			if tt.expected != "" {
+				assert.Equal(t, tt.expected, result)
 			} else {
-				assert.Equal(t, tt.expected, result, tt.description)
+				// For very long names, verify it's hashed
+				joined := strings.Join(tt.elements, ".")
+				if len(joined) > maxLen {
+					assert.True(t, strings.HasPrefix(result, namegenPrefix), "should start with prefix when hashed")
+					assert.LessOrEqual(t, len(result), maxLen, "result should not exceed max length")
+					assert.True(t, strings.HasPrefix(result, tt.expectedPrefix), "result should have the expected prefix")
+				}
 			}
-		})
-	}
-}
-
-func TestName_String_Hashing(t *testing.T) {
-	// Create names that will definitely trigger hashing
-	longHTTPRoute := strings.Repeat("httproute", 50)
-	longParentRef := strings.Repeat("parentref", 50)
-	longSection := strings.Repeat("section", 50)
-
-	nameObj := newName(longHTTPRoute, longParentRef, longSection)
-	result := nameObj.String()
-
-	// Should be hashed and within limits
-	maxLen := 253 - len("faf385ae") - 1
-	assert.LessOrEqual(t, len(result), maxLen)
-
-	// Should contain the expected prefixes for hashed components
-	parts := strings.Split(result, ".")
-	assert.Len(t, parts, 3)
-	assert.True(t, strings.HasPrefix(parts[0], "http"))
-	assert.True(t, strings.HasPrefix(parts[1], "cp"))
-	assert.True(t, strings.HasPrefix(parts[2], "res"))
-
-	// Each hashed part should be reasonably short
-	for _, part := range parts {
-		assert.LessOrEqual(t, len(part), 50, "hashed parts should be reasonably short")
-	}
-}
-
-func TestName_String_Consistency(t *testing.T) {
-	tests := []struct {
-		name        string
-		httpRouteID string
-		parentRefID string
-		sectionID   string
-	}{
-		{
-			name:        "normal components",
-			httpRouteID: "test-route",
-			parentRefID: "cp123",
-			sectionID:   "res456",
-		},
-		{
-			name:        "long components (trigger hashing)",
-			httpRouteID: strings.Repeat("httproute", 50),
-			parentRefID: strings.Repeat("parentref", 50),
-			sectionID:   strings.Repeat("section", 50),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			nameObj1 := newName(tt.httpRouteID, tt.parentRefID, tt.sectionID)
-			nameObj2 := newName(tt.httpRouteID, tt.parentRefID, tt.sectionID)
-
-			result1 := nameObj1.String()
-			result2 := nameObj2.String()
-
-			assert.Equal(t, result1, result2, "same inputs should produce same outputs")
 		})
 	}
 }
@@ -448,9 +266,14 @@ func TestNewKongRouteName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := NewKongRouteName(tt.route, tt.cp, tt.rule)
 			assert.NotEmpty(t, result)
+			// Result should contain namespace and name as separate dot-separated parts
+			assert.Contains(t, result, tt.route.Namespace)
+			assert.Contains(t, result, tt.route.Name)
+			// Result should have multiple parts (namespace.name.cp<hash>.<matches_hash>)
 			parts := strings.Split(result, ".")
-			assert.GreaterOrEqual(t, len(parts), 2)
-			assert.Equal(t, tt.route.Namespace+"-"+tt.route.Name, parts[0])
+			assert.GreaterOrEqual(t, len(parts), 3, "should have at least 4 parts: namespace + name, cp hash, and matches hash")
+			assert.Equal(t, tt.route.Namespace+"-"+tt.route.Name, parts[0], "name prefix should be route namespace-name")
+			assert.True(t, strings.HasPrefix(parts[1], "cp"), "second part should be the control plane hash")
 		})
 	}
 }

--- a/controller/hybridgateway/namegen/name_test.go
+++ b/controller/hybridgateway/namegen/name_test.go
@@ -22,9 +22,9 @@ func TestNewName(t *testing.T) {
 			parentRefID: "cp123456",
 			sectionID:   "res789",
 			expected: &Name{
-				httpRouteID: "test-ns-test-route",
-				parentRefID: "cp123456",
-				sectionID:   "res789",
+				httpRouteID:    "test-ns-test-route",
+				controlPlaneID: "cp123456",
+				sectionID:      "res789",
 			},
 		},
 		{
@@ -33,9 +33,9 @@ func TestNewName(t *testing.T) {
 			parentRefID: "cp123456",
 			sectionID:   "",
 			expected: &Name{
-				httpRouteID: "test-ns-test-route",
-				parentRefID: "cp123456",
-				sectionID:   "",
+				httpRouteID:    "test-ns-test-route",
+				controlPlaneID: "cp123456",
+				sectionID:      "",
 			},
 		},
 		{
@@ -44,9 +44,9 @@ func TestNewName(t *testing.T) {
 			parentRefID: "",
 			sectionID:   "",
 			expected: &Name{
-				httpRouteID: "",
-				parentRefID: "",
-				sectionID:   "",
+				httpRouteID:    "",
+				controlPlaneID: "",
+				sectionID:      "",
 			},
 		},
 	}
@@ -69,9 +69,9 @@ func TestName_String(t *testing.T) {
 		{
 			name: "short name with section",
 			nameObj: &Name{
-				httpRouteID: "test-ns-route",
-				parentRefID: "cp123",
-				sectionID:   "res456",
+				httpRouteID:    "test-ns-route",
+				controlPlaneID: "cp123",
+				sectionID:      "res456",
 			},
 			expected:    "test-ns-route.cp123.res456",
 			description: "should join all parts with dots when length is acceptable",
@@ -79,9 +79,9 @@ func TestName_String(t *testing.T) {
 		{
 			name: "short name without http route",
 			nameObj: &Name{
-				httpRouteID: "",
-				parentRefID: "cp123",
-				sectionID:   "res456",
+				httpRouteID:    "",
+				controlPlaneID: "cp123",
+				sectionID:      "res456",
 			},
 			expected:    "cp123.res456",
 			description: "should join only non-empty parts with dots",
@@ -89,9 +89,9 @@ func TestName_String(t *testing.T) {
 		{
 			name: "short name without parent reference",
 			nameObj: &Name{
-				httpRouteID: "test-ns-route",
-				parentRefID: "",
-				sectionID:   "res456",
+				httpRouteID:    "test-ns-route",
+				controlPlaneID: "",
+				sectionID:      "res456",
 			},
 			expected:    "test-ns-route.res456",
 			description: "should join only non-empty parts with dots",
@@ -99,9 +99,9 @@ func TestName_String(t *testing.T) {
 		{
 			name: "short name without section",
 			nameObj: &Name{
-				httpRouteID: "test-ns-route",
-				parentRefID: "cp123",
-				sectionID:   "",
+				httpRouteID:    "test-ns-route",
+				controlPlaneID: "cp123",
+				sectionID:      "",
 			},
 			expected:    "test-ns-route.cp123",
 			description: "should join only non-empty parts with dots",
@@ -109,9 +109,9 @@ func TestName_String(t *testing.T) {
 		{
 			name: "short name with just httproute",
 			nameObj: &Name{
-				httpRouteID: "test-ns-route",
-				parentRefID: "",
-				sectionID:   "",
+				httpRouteID:    "test-ns-route",
+				controlPlaneID: "",
+				sectionID:      "",
 			},
 			expected:    "test-ns-route",
 			description: "should join only non-empty parts with dots",
@@ -119,9 +119,9 @@ func TestName_String(t *testing.T) {
 		{
 			name: "short name with just parentref",
 			nameObj: &Name{
-				httpRouteID: "",
-				parentRefID: "cp123",
-				sectionID:   "",
+				httpRouteID:    "",
+				controlPlaneID: "cp123",
+				sectionID:      "",
 			},
 			expected:    "cp123",
 			description: "should join only non-empty parts with dots",
@@ -129,9 +129,9 @@ func TestName_String(t *testing.T) {
 		{
 			name: "short name with just section",
 			nameObj: &Name{
-				httpRouteID: "",
-				parentRefID: "",
-				sectionID:   "res456",
+				httpRouteID:    "",
+				controlPlaneID: "",
+				sectionID:      "res456",
 			},
 			expected:    "res456",
 			description: "should join only non-empty parts with dots",
@@ -139,9 +139,9 @@ func TestName_String(t *testing.T) {
 		{
 			name: "empty name",
 			nameObj: &Name{
-				httpRouteID: "",
-				parentRefID: "",
-				sectionID:   "",
+				httpRouteID:    "",
+				controlPlaneID: "",
+				sectionID:      "",
 			},
 			expected:    "",
 			description: "should handle empty strings gracefully",
@@ -149,9 +149,9 @@ func TestName_String(t *testing.T) {
 		{
 			name: "very long names that need hashing",
 			nameObj: &Name{
-				httpRouteID: strings.Repeat("a", 100),
-				parentRefID: strings.Repeat("b", 100),
-				sectionID:   strings.Repeat("c", 100),
+				httpRouteID:    strings.Repeat("a", 100),
+				controlPlaneID: strings.Repeat("b", 100),
+				sectionID:      strings.Repeat("c", 100),
 			},
 			expected:    "", // Will be set dynamically in test
 			description: "should hash long components and stay within length limits",

--- a/controller/hybridgateway/namegen/name_test.go
+++ b/controller/hybridgateway/namegen/name_test.go
@@ -58,7 +58,7 @@ func TestNewName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := NewName(tt.httpRouteID, tt.parentRefID, tt.sectionID)
+			result := newName(tt.httpRouteID, tt.parentRefID, tt.sectionID)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -188,7 +188,7 @@ func TestName_String_Hashing(t *testing.T) {
 	longParentRef := strings.Repeat("parentref", 50)
 	longSection := strings.Repeat("section", 50)
 
-	nameObj := NewName(longHTTPRoute, longParentRef, longSection)
+	nameObj := newName(longHTTPRoute, longParentRef, longSection)
 	result := nameObj.String()
 
 	// Should be hashed and within limits
@@ -231,8 +231,8 @@ func TestName_String_Consistency(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			nameObj1 := NewName(tt.httpRouteID, tt.parentRefID, tt.sectionID)
-			nameObj2 := NewName(tt.httpRouteID, tt.parentRefID, tt.sectionID)
+			nameObj1 := newName(tt.httpRouteID, tt.parentRefID, tt.sectionID)
+			nameObj2 := newName(tt.httpRouteID, tt.parentRefID, tt.sectionID)
 
 			result1 := nameObj1.String()
 			result2 := nameObj2.String()

--- a/controller/hybridgateway/namegen/name_test.go
+++ b/controller/hybridgateway/namegen/name_test.go
@@ -1,6 +1,7 @@
 package namegen
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -185,8 +186,9 @@ func TestNewKongServiceName(t *testing.T) {
 			result := NewKongServiceName(tt.cp, tt.rule)
 			assert.NotEmpty(t, result)
 			parts := strings.Split(result, ".")
-			assert.GreaterOrEqual(t, len(parts), 2)
-			assert.True(t, strings.HasPrefix(parts[0], "cp"))
+			assert.GreaterOrEqual(t, len(parts), 3, fmt.Sprintf("should have at least 3 parts: %q, cp hash, and backend refs hash", httpProcolPrefix))
+			assert.Equal(t, httpProcolPrefix, parts[0], fmt.Sprintf("first part should be %q", httpProcolPrefix))
+			assert.True(t, strings.HasPrefix(parts[1], defaultCPPrefix), fmt.Sprintf("second part should start with %q", defaultCPPrefix))
 		})
 	}
 }
@@ -266,14 +268,15 @@ func TestNewKongRouteName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := NewKongRouteName(tt.route, tt.cp, tt.rule)
 			assert.NotEmpty(t, result)
-			// Result should contain namespace and name as separate dot-separated parts
+			// Result should be: http.<namespace>-<name>.cp<hash>.<matches_hash>
 			assert.Contains(t, result, tt.route.Namespace)
 			assert.Contains(t, result, tt.route.Name)
 			// Result should have multiple parts (namespace.name.cp<hash>.<matches_hash>)
 			parts := strings.Split(result, ".")
-			assert.GreaterOrEqual(t, len(parts), 3, "should have at least 4 parts: namespace + name, cp hash, and matches hash")
-			assert.Equal(t, tt.route.Namespace+"-"+tt.route.Name, parts[0], "name prefix should be route namespace-name")
-			assert.True(t, strings.HasPrefix(parts[1], "cp"), "second part should be the control plane hash")
+			assert.GreaterOrEqual(t, len(parts), 4, fmt.Sprintf("should have at least 4 parts: %q, namespace-name, cp hash, and matches hash", httpProcolPrefix))
+			assert.Equal(t, httpProcolPrefix, parts[0], fmt.Sprintf("first part should be %q", httpProcolPrefix))
+			assert.Equal(t, tt.route.Namespace+"-"+tt.route.Name, parts[1], "second part should be route <namespace>-<name>")
+			assert.True(t, strings.HasPrefix(parts[2], defaultCPPrefix), fmt.Sprintf("third part should start with %q", defaultCPPrefix))
 		})
 	}
 }

--- a/controller/hybridgateway/target/target.go
+++ b/controller/hybridgateway/target/target.go
@@ -14,8 +14,8 @@ import (
 
 	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
 	"github.com/kong/kong-operator/controller/hybridgateway/builder"
+	"github.com/kong/kong-operator/controller/hybridgateway/namegen"
 	"github.com/kong/kong-operator/controller/hybridgateway/route"
-	"github.com/kong/kong-operator/controller/hybridgateway/utils"
 	"github.com/kong/kong-operator/controller/pkg/log"
 	gwtypes "github.com/kong/kong-operator/internal/types"
 )
@@ -392,7 +392,7 @@ func createTargetsFromValidBackendRefs(httpRoute *gwtypes.HTTPRoute, pRef *gwtyp
 
 			// Create target with explicit endpoint address (works for all cases: real endpoints, FQDN, external names).
 			target, err := builder.NewKongTarget().
-				WithName(fmt.Sprintf("%s.%s", upstreamName, utils.Hash32(utils.Hash32(vbRef.backendRef)+endpoint))).
+				WithName(namegen.NewKongTargetName(upstreamName, endpoint, port, vbRef.backendRef)).
 				WithNamespace(httpRoute.Namespace).
 				WithLabels(httpRoute, pRef).
 				WithAnnotations(httpRoute, pRef).

--- a/docs/internal/hybridgateway/autogen-resource-naming.md
+++ b/docs/internal/hybridgateway/autogen-resource-naming.md
@@ -7,12 +7,12 @@ A KongRoute is created for each HTTPRoute rule. It is uniquely identified by HTT
 
 Auto-generated name (HR stands for HTTPRoute):
 
-`<HR namespace>-<HR name>.cp<HASH(<Control Plane>).HASH(HR.spec.rule[x].matches)>`
+`http.<HR namespace>-<HR name>.cp<HASH(<Control Plane>).HASH(HR.spec.rule[x].matches)>`
 
 example (HTTPRoute name: default/httproute-echo):
 
 ```
-default-httproute-echo.cp431ef96.1b69eced
+<GatewayAPI protocol>.default-httproute-echo.cp431ef96.1b69eced
 ```
 
 ## KongService
@@ -22,11 +22,11 @@ A KongService is uniquely identified from a set of BackendRefs of an HTTPRoute. 
 
 Auto-generated name:
 
-`cp<HASH(<Conrol Plane>).HASH(HR.spec.rule[x].backendRefs)>`
+`<GatewayAPI protocol>.cp<HASH(<Conrol Plane>).HASH(HR.spec.rule[x].backendRefs)>`
 
 example:
 ```
-cp431ef96.5a7cc34c
+http.cp431ef96.5a7cc34c
 ```
 
 ## KongUpstream
@@ -88,5 +88,5 @@ Auto-generated name:
 
 example:
 ```
-default-httproute-echo.cp431ef96.1b69eced.pl72ae1b9a
+http.default-httproute-echo.cp431ef96.1b69eced.pl72ae1b9a
 ```

--- a/docs/internal/hybridgateway/autogen-resource-naming.md
+++ b/docs/internal/hybridgateway/autogen-resource-naming.md
@@ -1,0 +1,92 @@
+# Hybrid Controller auto-generated Kong resources names
+
+## KongRoutes
+Are identified by the paths and the serviceRef field (which references a KongService, which gives an indirect reference to the Control Plane).
+
+A KongRoute is created for each HTTPRoute rule. It is uniquely identified by HTTPRoute matches.
+
+Auto-generated name (HR stands for HTTPRoute):
+
+`<HR namespace>-<HR name>.cp<HASH(<Control Plane>).HASH(HR.spec.rule[x].matches)>`
+
+example (HTTPRoute name: default/httproute-echo):
+
+```
+default-httproute-echo.cp431ef96.1b69eced
+```
+
+## KongService
+Are identified by the Control Plane (controlPlaneRef) and the host fields (which will be filled with a KongUpstream name).
+
+A KongService is uniquely identified from a set of BackendRefs of an HTTPRoute. If the same set of BackendRefs appears in different rules of even different HTTPRoutes, only one KongService should be created referenced by multiple KongRoutes.
+
+Auto-generated name:
+
+`cp<HASH(<Conrol Plane>).HASH(HR.spec.rule[x].backendRefs)>`
+
+example:
+```
+cp431ef96.5a7cc34c
+```
+
+## KongUpstream
+Same as KongService above.
+
+There is a 1:1 mapping between auto-generated KongServices and KongUpstreams.
+
+Each pair of generated KongService and KongUpstream have an identical name.
+
+Auto-generated name:
+
+`cp<HASH(<Conrol Plane>).HASH(HR.spec.rule[x].backendRefs)>`
+
+example:
+```
+cp431ef96.5a7cc34c
+```
+
+## KongTargets
+They can reference one and only one parent KongUpstream.
+
+They are strictly coupled with the KongUpstream.
+
+Each KongTarget is derived by a single Endpoint of a Service referenced by an HTTPRoute BackendRef.
+
+Auto-generated name:
+
+`<KongUpstream.name>.<HASH(HR.spec.rule[x].BackendRef[y],endpoint ip, endpoint port)>`
+
+example:
+```
+cp431ef96.5a7cc34c.46cb9d28
+```
+
+## KongPlugins
+They are identified only by their config.
+
+They can be referenced by multiple KongPluginBindings.
+
+They don't need to be coupled with the parentRef (control plane).
+
+Auto-generated name:
+
+`pl<HASH(HR.spec.rule[x].filter[z])>`
+
+example:
+```
+pl72ae1b9a
+```
+
+## KongPluginBindings
+They bind a KongRoute with a KongPlugin.
+
+Their natural name is the concatenation of the names of the bound KongRoute and KongPlugin.
+
+Auto-generated name:
+
+`<KongRoute.name>.<KongPlugin.name>`
+
+example:
+```
+default-httproute-echo.cp431ef96.1b69eced.pl72ae1b9a
+```


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently Kong CRDs names are derived from the HTTPRoute resource name and an hash based on the relevant part of the HTTPRoute spec.
This result in creating different KongService / Upstream resources mapping the same backend Services (BackendRefs) if they are referenced in different HTTPRoute resources.
HTTPRoute name from the generated names of KongService and KongUpstreams should be dropped.

While there, move all the name generation logic to the namegen package.

**Which issue this PR fixes**

Fixes #2542 

**Special notes for your reviewer**:
This PR introduces an issue with the ownership of the created resources: till now the Owner was the source HTTPRoute, but at this point different HTTPRoutes may share the same KongService/KongUpstream/KongPlugin/KongTargets.
This issue is going to be addressed while working on #2520.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
