### PR TITLE
test(envtest): Add test cases for adopting KongService and KonnectCloudGatewayNetwork

### DIFF
--- a/test/envtest/konnect_entities_kongservice_test.go
+++ b/test/envtest/konnect_entities_kongservice_test.go
@@ -17,6 +17,7 @@ import (
 
 	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/api/konnect/v1alpha1"
 	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
 	"github.com/kong/kong-operator/controller/konnect"
 	"github.com/kong/kong-operator/modules/manager/logging"
@@ -423,10 +424,7 @@ func TestKongService(t *testing.T) {
 
 	t.Run("adopting a service in override mode then deleting it", func(t *testing.T) {
 
-		var (
-			serviceKonnectID = "svc-12345"
-		)
-
+		serviceKonnectID := uuid.NewString()
 		w := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting and updating service")
@@ -448,7 +446,7 @@ func TestKongService(t *testing.T) {
 		).Return(&sdkkonnectops.UpsertServiceResponse{}, nil)
 
 		t.Log("Creating a KongService to adopt the existing service")
-		ks := deploy.KongService(t, t.Context(), clientNamespaced, deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
+		createdService := deploy.KongService(t, t.Context(), clientNamespaced, deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 			func(obj client.Object) {
 				ks, ok := obj.(*configurationv1alpha1.KongService)
 				require.True(t, ok)
@@ -464,8 +462,11 @@ func TestKongService(t *testing.T) {
 
 		t.Log("Waiting for the service to be programmed and get Konnect ID")
 		watchFor(t, t.Context(), w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
-			return ks.GetKonnectID() == serviceKonnectID && k8sutils.IsProgrammed(ks)
-		}, "Did not see KongService programmed")
+			return ks.Name == createdService.Name &&
+				ks.GetKonnectID() == serviceKonnectID && k8sutils.IsProgrammed(ks)
+		},
+			"Did not see KongService marked as Programmed and set Konnect ID",
+		)
 
 		t.Log("Setting up SDK expectations for deleting the service")
 		sdk.ServicesSDK.EXPECT().DeleteService(
@@ -475,12 +476,110 @@ func TestKongService(t *testing.T) {
 		).Return(&sdkkonnectops.DeleteServiceResponse{}, nil)
 
 		t.Log("Deleting the KongService")
-		require.NoError(t, clientNamespaced.Delete(t.Context(), ks))
+		require.NoError(t, clientNamespaced.Delete(t.Context(), createdService))
 
 		t.Log("Waiting for the SDK's DeleteService to be called")
 		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for the KongService to disappear")
-		eventually.WaitForObjectToNotExist(t, ctx, cl, ks, waitTime, tickTime)
+		eventually.WaitForObjectToNotExist(t, ctx, cl, createdService, waitTime, tickTime)
+	})
+
+	t.Run("adopting a service with NotFound error returned from upstream", func(t *testing.T) {
+
+		serviceKonnectID := uuid.NewString()
+		w := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
+
+		t.Log("Setting up SDK expectations for getting service")
+		sdk.ServicesSDK.EXPECT().GetService(
+			mock.Anything, serviceKonnectID, cp.GetKonnectID(),
+		).Return(
+			nil, &sdkkonnecterrs.NotFoundError{
+				Title:  "NotFound",
+				Detail: fmt.Sprintf("Service %s not found", serviceKonnectID),
+			},
+		)
+
+		t.Log("Creating a KongService to adopt the existing service")
+		createdService := deploy.KongService(t, t.Context(), clientNamespaced, deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
+			func(obj client.Object) {
+				ks, ok := obj.(*configurationv1alpha1.KongService)
+				require.True(t, ok)
+				ks.Spec.URL = lo.ToPtr("https://example.com/example")
+				ks.Spec.Adopt = &commonv1alpha1.AdoptOptions{
+					From: commonv1alpha1.AdoptSourceKonnect,
+					Mode: commonv1alpha1.AdoptModeOverride,
+					Konnect: &commonv1alpha1.AdoptKonnectOptions{
+						ID: serviceKonnectID,
+					},
+				}
+			})
+
+		t.Log("Waiting for the KongService to be marked as not programmed")
+		watchFor(t, t.Context(), w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
+			return ks.Name == createdService.Name &&
+				conditionsContainProgrammedFalse(ks.GetConditions()) &&
+				lo.ContainsBy(ks.GetConditions(), func(c metav1.Condition) bool {
+					return c.Type == konnectv1alpha1.KonnectEntityAdoptedConditionType &&
+						c.Status == metav1.ConditionFalse
+				})
+		},
+			"Did not see KongService marked as not Programmed and not Adopted",
+		)
+	})
+
+	t.Run("adopting a service with the k8s-uid tag already exists in the upstream service", func(t *testing.T) {
+		serviceKonnectID := uuid.NewString()
+		w := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
+
+		t.Log("Setting up SDK expectations for getting service")
+		sdk.ServicesSDK.EXPECT().GetService(
+			mock.Anything, serviceKonnectID, cp.GetKonnectID(),
+		).Return(
+			&sdkkonnectops.GetServiceResponse{
+				Service: &sdkkonnectcomp.ServiceOutput{
+					ID:   lo.ToPtr(serviceKonnectID),
+					Host: "example.com",
+					Tags: []string{
+						"k8s-group:configuration.konghq.com",
+						"k8s-version:v1alpha1",
+						"k8s-kind:KongService",
+						"k8s-uid:12345678-9999-0000-1111-abcdeffedcba",
+						"k8s-namespace:" + ns.Name,
+						"k8s-name:another-service",
+						"k8s-generation:1",
+					},
+				},
+			}, nil,
+		)
+
+		t.Log("Creating a KongService to adopt the existing service")
+		createdService := deploy.KongService(t, t.Context(), clientNamespaced, deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
+			func(obj client.Object) {
+				ks, ok := obj.(*configurationv1alpha1.KongService)
+				require.True(t, ok)
+				ks.Spec.URL = lo.ToPtr("https://example.com/example")
+				ks.Spec.Adopt = &commonv1alpha1.AdoptOptions{
+					From: commonv1alpha1.AdoptSourceKonnect,
+					Mode: commonv1alpha1.AdoptModeOverride,
+					Konnect: &commonv1alpha1.AdoptKonnectOptions{
+						ID: serviceKonnectID,
+					},
+				}
+			})
+
+		t.Log("Waiting for the KongService to be marked as not programmed")
+		watchFor(t, t.Context(), w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
+			return ks.Name == createdService.Name &&
+				conditionsContainProgrammedFalse(ks.GetConditions()) &&
+				lo.ContainsBy(ks.GetConditions(), func(c metav1.Condition) bool {
+					return c.Type == konnectv1alpha1.KonnectEntityAdoptedConditionType &&
+						c.Status == metav1.ConditionFalse
+				})
+		},
+			"Did not see KongService marked as not Programmed and not Adopted, conditions:",
+		)
+
+		t.Log(createdService.GetConditions())
 	})
 }

--- a/test/envtest/konnect_entities_kongservice_test.go
+++ b/test/envtest/konnect_entities_kongservice_test.go
@@ -15,6 +15,7 @@ import (
 	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
 	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
 	"github.com/kong/kong-operator/controller/konnect"
@@ -418,5 +419,68 @@ func TestKongService(t *testing.T) {
 			),
 			"Object didn't get Programmed set to True",
 		)
+	})
+
+	t.Run("adopting a service in override mode then deleting it", func(t *testing.T) {
+
+		var (
+			serviceKonnectID = "svc-12345"
+		)
+
+		w := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
+
+		t.Log("Setting up SDK expectations for getting and updating service")
+		sdk.ServicesSDK.EXPECT().GetService(
+			mock.Anything, serviceKonnectID, cp.GetKonnectID(),
+		).Return(
+			&sdkkonnectops.GetServiceResponse{
+				Service: &sdkkonnectcomp.ServiceOutput{
+					ID:   lo.ToPtr(serviceKonnectID),
+					Host: "example.com",
+				},
+			}, nil,
+		)
+		sdk.ServicesSDK.EXPECT().UpsertService(
+			mock.Anything,
+			mock.MatchedBy(func(req sdkkonnectops.UpsertServiceRequest) bool {
+				return req.ServiceID == serviceKonnectID
+			}),
+		).Return(&sdkkonnectops.UpsertServiceResponse{}, nil)
+
+		t.Log("Creating a KongService to adopt the existing service")
+		ks := deploy.KongService(t, t.Context(), clientNamespaced, deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
+			func(obj client.Object) {
+				ks, ok := obj.(*configurationv1alpha1.KongService)
+				require.True(t, ok)
+				ks.Spec.URL = lo.ToPtr("https://example.com/example")
+				ks.Spec.Adopt = &commonv1alpha1.AdoptOptions{
+					From: commonv1alpha1.AdoptSourceKonnect,
+					Mode: commonv1alpha1.AdoptModeOverride,
+					Konnect: &commonv1alpha1.AdoptKonnectOptions{
+						ID: serviceKonnectID,
+					},
+				}
+			})
+
+		t.Log("Waiting for the service to be programmed and get Konnect ID")
+		watchFor(t, t.Context(), w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
+			return ks.GetKonnectID() == serviceKonnectID && k8sutils.IsProgrammed(ks)
+		}, "Did not see KongService programmed")
+
+		t.Log("Setting up SDK expectations for deleting the service")
+		sdk.ServicesSDK.EXPECT().DeleteService(
+			mock.Anything,
+			cp.GetKonnectID(),
+			serviceKonnectID,
+		).Return(&sdkkonnectops.DeleteServiceResponse{}, nil)
+
+		t.Log("Deleting the KongService")
+		require.NoError(t, clientNamespaced.Delete(t.Context(), ks))
+
+		t.Log("Waiting for the SDK's DeleteService to be called")
+		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
+
+		t.Log("Waiting for the KongService to disappear")
+		eventually.WaitForObjectToNotExist(t, ctx, cl, ks, waitTime, tickTime)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Add envtest cases for adopting the following entities from Konnect:
- `KongService`
  - Normal case
  - Cases with errors: service not found & service already managed by another k8s `KongService`
- `KonnectCloudGatewayNetwork`
  - Normal case 
  - Configuration does not match 

**Which issue this PR fixes**

Part of #2545

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
