### PR TITLE
fix: kongRoute orphans handling

### DIFF
--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -178,8 +178,8 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 	res, err = handleKongServiceRef(ctx, r.Client, ent)
 	if err != nil {
 		switch {
-		// in case the referenced KongService is being deleted, disregard the error
-		// and continue
+		// In case the referenced KongService is being deleted, disregard the error
+		// and continue.
 		case errors.As(err, &ReferencedKongServiceIsBeingDeleted{}):
 			log.Info(logger, "referenced KongService is being deleted, proceeding with reconciliation", err.Error())
 		case errors.As(err, &ReferencedObjectDoesNotExist{}):
@@ -189,7 +189,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 			if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 				if err := r.Client.Update(ctx, ent); err != nil {
 					if k8serrors.IsConflict(err) {
-						return ctrl.Result{Requeue: true}, nil
+						return ctrl.Result{RequeueAfter: time.Second}, nil
 					}
 					return ctrl.Result{}, fmt.Errorf("failed to remove finalizer %s: %w", KonnectCleanupFinalizer, err)
 				}

--- a/controller/konnect/watch_kongroute.go
+++ b/controller/konnect/watch_kongroute.go
@@ -93,7 +93,7 @@ func kongRouteRefersToKonnectGatewayControlPlane(cl client.Client) func(obj clie
 			Name:      scvRef.NamespacedRef.Name,
 		}
 		kongSvc := configurationv1alpha1.KongService{}
-		if err := cl.Get(context.Background(), nn, &kongSvc); client.IgnoreNotFound(err) != nil {
+		if err := cl.Get(context.Background(), nn, &kongSvc); err != nil {
 			return true
 		}
 		return objHasControlPlaneRef(&kongSvc)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR handles the case when `KongRoute`s attached to a non-existent `KongService` (yet, configured in Konnect) get deleted. The added logic removes the finalizer from the routes in case they are marked for deletion and the service they refer to does not exist.

**Which issue this PR fixes**

Fixes #2468 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
