### PR TITLE
feat(hybridgateway): add conditional event recording

### DIFF
--- a/controller/hybridgateway/const/route/events.go
+++ b/controller/hybridgateway/const/route/events.go
@@ -1,0 +1,27 @@
+package route
+
+// Event reasons for HTTPRoute operations in the hybrid gateway controller.
+// These constants are used when recording Kubernetes events to provide
+// consistent event reasons across the controller.
+
+const (
+	// EventReasonHTTPRouteTranslationSucceeded is used when HTTPRoute translation completes successfully.
+	EventReasonHTTPRouteTranslationSucceeded = "HTTPRouteTranslationSucceeded"
+	// EventReasonHTTPRouteTranslationFailed is used when HTTPRoute translation fails.
+	EventReasonHTTPRouteTranslationFailed = "HTTPRouteTranslationFailed"
+
+	// EventReasonHTTPRouteStatusUpdateSucceeded is used when HTTPRoute status is successfully updated.
+	EventReasonHTTPRouteStatusUpdateSucceeded = "HTTPRouteStatusUpdateSucceeded"
+	// EventReasonHTTPRouteStatusUpdateFailed is used when HTTPRoute status update fails.
+	EventReasonHTTPRouteStatusUpdateFailed = "HTTPRouteStatusUpdateFailed"
+
+	// EventReasonStateEnforcementSucceeded is used when Kong resources are successfully enforced.
+	EventReasonStateEnforcementSucceeded = "StateEnforcementSucceeded"
+	// EventReasonStateEnforcementFailed is used when Kong resource enforcement fails.
+	EventReasonStateEnforcementFailed = "StateEnforcementFailed"
+
+	// EventReasonOrphanCleanupSucceeded is used when orphaned Kong resources are successfully cleaned up.
+	EventReasonOrphanCleanupSucceeded = "OrphanCleanupSucceeded"
+	// EventReasonOrphanCleanupFailed is used when orphaned Kong resource cleanup fails.
+	EventReasonOrphanCleanupFailed = "OrphanCleanupFailed"
+)

--- a/controller/hybridgateway/controller.go
+++ b/controller/hybridgateway/controller.go
@@ -135,7 +135,7 @@ func (r *HybridGatewayReconciler[t, tPtr]) Reconcile(ctx context.Context, req ct
 	}
 
 	// Phase 1: Status Update.
-	statusChanged, err := EnforceStatus(ctx, logger, conv)
+	statusChanged, err := enforceStatus(ctx, logger, conv)
 	if err != nil && !k8serrors.IsConflict(err) {
 		// Record status update failure event.
 		r.eventRecorder.Event(
@@ -162,7 +162,7 @@ func (r *HybridGatewayReconciler[t, tPtr]) Reconcile(ctx context.Context, req ct
 	}
 
 	// Phase 2: Translation.
-	resourceCount, err := Translate(conv, ctx, logger)
+	resourceCount, err := translate(conv, ctx, logger)
 	if err != nil {
 		// Record translation failure event.
 		r.eventRecorder.Event(
@@ -183,7 +183,7 @@ func (r *HybridGatewayReconciler[t, tPtr]) Reconcile(ctx context.Context, req ct
 	)
 
 	// Phase 3: State Enforcement.
-	stateChanged, err := EnforceState(ctx, r.Client, logger, conv)
+	stateChanged, err := enforceState(ctx, r.Client, logger, conv)
 	if err != nil {
 		// Record state enforcement failure event.
 		r.eventRecorder.Event(
@@ -208,7 +208,7 @@ func (r *HybridGatewayReconciler[t, tPtr]) Reconcile(ctx context.Context, req ct
 	}
 
 	// Phase 4: Orphan Cleanup.
-	orphansDeleted, err := CleanOrphanedResources[t, tPtr](ctx, r.Client, logger, conv)
+	orphansDeleted, err := cleanOrphanedResources[t, tPtr](ctx, r.Client, logger, conv)
 	if err != nil {
 		// Record orphan cleanup failure event.
 		r.eventRecorder.Event(

--- a/controller/hybridgateway/controller.go
+++ b/controller/hybridgateway/controller.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -12,9 +14,15 @@ import (
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	routeconst "github.com/kong/kong-operator/controller/hybridgateway/const/route"
 	"github.com/kong/kong-operator/controller/hybridgateway/converter"
 	"github.com/kong/kong-operator/controller/hybridgateway/watch"
 	"github.com/kong/kong-operator/controller/pkg/log"
+)
+
+const (
+	// ControllerName is the name used for logging and event recording in the hybrid gateway controller.
+	ControllerName = "hybridgateway"
 )
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongroutes,verbs=get;list;watch;create;update;patch;delete
@@ -35,6 +43,8 @@ import (
 // RootObjectPtr interfaces, allowing flexible reconciliation logic for different resource types.
 type HybridGatewayReconciler[t converter.RootObject, tPtr converter.RootObjectPtr[t]] struct {
 	client.Client
+	// EventRecorder is used to record Kubernetes events for HTTPRoute operations.
+	eventRecorder record.EventRecorder
 	// ReferenceGrantEnabled indicates whether ReferenceGrants are enabled in the cluster (i.e., the CRD is available)
 	referenceGrantEnabled bool
 	// FQDNMode indicates whether to use FQDN endpoints for service discovery.
@@ -48,6 +58,7 @@ type HybridGatewayReconciler[t converter.RootObject, tPtr converter.RootObjectPt
 func NewHybridGatewayReconciler[t converter.RootObject, tPtr converter.RootObjectPtr[t]](mgr ctrl.Manager, referenceGrantEnabled bool, fqdnMode bool, clusterDomain string) *HybridGatewayReconciler[t, tPtr] {
 	return &HybridGatewayReconciler[t, tPtr]{
 		Client:                mgr.GetClient(),
+		eventRecorder:         mgr.GetEventRecorderFor(ControllerName),
 		referenceGrantEnabled: referenceGrantEnabled,
 		fqdnMode:              fqdnMode,
 		clusterDomain:         clusterDomain,
@@ -103,7 +114,7 @@ func (r *HybridGatewayReconciler[t, tPtr]) SetupWithManager(ctx context.Context,
 func (r *HybridGatewayReconciler[t, tPtr]) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var obj tPtr = new(t)
 
-	logger := ctrllog.FromContext(ctx).WithName("HybridGateway")
+	logger := ctrllog.FromContext(ctx).WithName(ControllerName)
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -122,25 +133,100 @@ func (r *HybridGatewayReconciler[t, tPtr]) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, err
 	}
 
-	if stop, err := EnforceStatus(ctx, logger, conv); err != nil && !k8serrors.IsConflict(err) {
+	// Phase 1: Status Update.
+	statusChanged, err := EnforceStatus(ctx, logger, conv)
+	if err != nil && !k8serrors.IsConflict(err) {
+		// Record status update failure event.
+		r.eventRecorder.Event(
+			obj,
+			corev1.EventTypeWarning,
+			routeconst.EventReasonHTTPRouteStatusUpdateFailed,
+			fmt.Sprintf("Status update failed: %v", err),
+		)
 		return ctrl.Result{}, err
 	} else if k8serrors.IsConflict(err) {
 		return ctrl.Result{Requeue: true}, nil
-	} else if stop {
-		return ctrl.Result{}, nil
 	}
 
-	if err := Translate(conv, ctx, logger); err != nil {
+	// Only emit success event if status was actually changed.
+	if statusChanged {
+		r.eventRecorder.Event(
+			obj,
+			corev1.EventTypeNormal,
+			routeconst.EventReasonHTTPRouteStatusUpdateSucceeded,
+			"HTTPRoute status successfully updated",
+		)
+		log.Trace(logger, "Status updated, requeueing")
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Phase 2: Translation.
+	resourceCount, err := Translate(conv, ctx, logger)
+	if err != nil {
+		// Record translation failure event.
+		r.eventRecorder.Event(
+			obj,
+			corev1.EventTypeWarning,
+			routeconst.EventReasonHTTPRouteTranslationFailed,
+			fmt.Sprintf("Translation failed: %v", err),
+		)
 		return ctrl.Result{}, err
 	}
 
-	requeue, _, err := EnforceState(ctx, r.Client, logger, conv)
-	if err != nil || requeue {
-		return ctrl.Result{Requeue: true}, err
+	// Record translation success event.
+	r.eventRecorder.Event(
+		obj,
+		corev1.EventTypeNormal,
+		routeconst.EventReasonHTTPRouteTranslationSucceeded,
+		fmt.Sprintf("HTTPRoute successfully translated to %d Kong resources", resourceCount),
+	)
+
+	// Phase 3: State Enforcement.
+	stateChanged, err := EnforceState(ctx, r.Client, logger, conv)
+	if err != nil {
+		// Record state enforcement failure event.
+		r.eventRecorder.Event(
+			obj,
+			corev1.EventTypeWarning,
+			routeconst.EventReasonStateEnforcementFailed,
+			fmt.Sprintf("State enforcement failed: %v", err),
+		)
+		return ctrl.Result{}, err
 	}
 
-	if err := CleanOrphanedResources[t, tPtr](ctx, r.Client, logger, conv); err != nil {
+	// Only emit success event if state was actually changed.
+	if stateChanged {
+		r.eventRecorder.Event(
+			obj,
+			corev1.EventTypeNormal,
+			routeconst.EventReasonStateEnforcementSucceeded,
+			fmt.Sprintf("Kong resources successfully enforced: %d total", resourceCount),
+		)
+		log.Trace(logger, "State changed, requeueing")
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Phase 4: Orphan Cleanup.
+	orphansDeleted, err := CleanOrphanedResources[t, tPtr](ctx, r.Client, logger, conv)
+	if err != nil {
+		// Record orphan cleanup failure event.
+		r.eventRecorder.Event(
+			obj,
+			corev1.EventTypeWarning,
+			routeconst.EventReasonOrphanCleanupFailed,
+			fmt.Sprintf("Orphan cleanup failed: %v", err),
+		)
 		return ctrl.Result{}, err
+	}
+
+	// Only emit success event if orphans were actually deleted.
+	if orphansDeleted {
+		r.eventRecorder.Event(
+			obj,
+			corev1.EventTypeNormal,
+			routeconst.EventReasonOrphanCleanupSucceeded,
+			"Orphan cleanup completed successfully",
+		)
 	}
 
 	log.Debug(logger, "Object reconciliation completed", "Group", gvk.Group, "Kind", gvk.Kind)

--- a/controller/hybridgateway/controller.go
+++ b/controller/hybridgateway/controller.go
@@ -28,6 +28,7 @@ const (
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongroutes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongroutes/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongservices,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongservices/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongupstreams,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongupstreams/status,verbs=get;update;patch

--- a/controller/hybridgateway/converter/converter.go
+++ b/controller/hybridgateway/converter/converter.go
@@ -18,8 +18,8 @@ import (
 type APIConverter[t RootObject] interface {
 	// GetExpectedGVKs returns the list of GroupVersionKinds for resources expected to be created by this converter.
 	GetExpectedGVKs() []schema.GroupVersionKind
-	// Translate performs the conversion or translation logic for the root object, returning an error if the process fails.
-	Translate(ctx context.Context, logger logr.Logger) error
+	// Translate performs the conversion or translation logic for the root object, returning the number of Kong resources created and an error if the process fails.
+	Translate(ctx context.Context, logger logr.Logger) (int, error)
 	// GetRootObject returns the current root object of type t.
 	GetRootObject() t
 	// GetOutputStore returns a slice of unstructured.Unstructured objects representing the current state of the store, using the provided context.

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -89,9 +89,13 @@ func (c *httpRouteConverter) GetRootObject() gwtypes.HTTPRoute {
 //   - logger: Logger for structured logging with httproute-translate phase
 //
 // Returns:
+//   - int: Number of Kong resources created during translation
 //   - error: Aggregated translation errors or nil if successful
-func (c *httpRouteConverter) Translate(ctx context.Context, logger logr.Logger) error {
-	return c.translate(ctx, logger)
+func (c *httpRouteConverter) Translate(ctx context.Context, logger logr.Logger) (int, error) {
+	if err := c.translate(ctx, logger); err != nil {
+		return 0, err
+	}
+	return len(c.outputStore), nil
 }
 
 // GetOutputStore implements APIConverter.

--- a/controller/hybridgateway/converter/http_route_test.go
+++ b/controller/hybridgateway/converter/http_route_test.go
@@ -106,7 +106,7 @@ func TestHostnamesIntersection(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
 
 			converter := newHTTPRouteConverter(tt.route, fakeClient, true, false, "")
-			err := converter.Translate(t.Context(), logr.Discard())
+			_, err := converter.Translate(t.Context(), logr.Discard())
 			require.NoError(t, err)
 
 			output, err := converter.GetOutputStore(context.TODO(), logr.Discard())

--- a/controller/hybridgateway/reconciler_utils.go
+++ b/controller/hybridgateway/reconciler_utils.go
@@ -21,13 +21,13 @@ const (
 	FieldManager = "gateway-operator"
 )
 
-// Translate performs the full translation process using the provided APIConverter.
+// translate performs the full translation process using the provided APIConverter.
 // Returns the number of Kong resources created and an error if the translation fails.
-func Translate[t converter.RootObject](conv converter.APIConverter[t], ctx context.Context, logger logr.Logger) (int, error) {
+func translate[t converter.RootObject](conv converter.APIConverter[t], ctx context.Context, logger logr.Logger) (int, error) {
 	return conv.Translate(ctx, logger)
 }
 
-// EnforceState ensures that the desired state of Kubernetes resources, as provided by the APIConverter,
+// enforceState ensures that the desired state of Kubernetes resources, as provided by the APIConverter,
 // is reflected in the cluster. It attempts to create or update resources using server-side apply and
 // structured merge. The function returns a boolean indicating if any changes were made and an error
 // for any unrecoverable or transient issues. Resources marked for deletion are skipped. Conflict errors
@@ -53,7 +53,7 @@ func Translate[t converter.RootObject](conv converter.APIConverter[t], ctx conte
 //
 // The function uses server-side apply with the "gateway-operator" field manager to ensure
 // proper ownership and conflict resolution when multiple controllers manage the same resources.
-func EnforceState[t converter.RootObject](ctx context.Context, cl client.Client, logger logr.Logger, conv converter.APIConverter[t]) (bool, error) {
+func enforceState[t converter.RootObject](ctx context.Context, cl client.Client, logger logr.Logger, conv converter.APIConverter[t]) (bool, error) {
 	logger = logger.WithValues("phase", "state-enforcement")
 	log.Debug(logger, "Starting state enforcement")
 
@@ -175,7 +175,7 @@ func EnforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 	return stateChanged, nil
 }
 
-// EnforceStatus updates the status of the root object managed by the provided APIConverter.
+// enforceStatus updates the status of the root object managed by the provided APIConverter.
 // This function delegates to the converter's UpdateRootObjectStatus method to handle
 // status condition management and cluster updates.
 //
@@ -191,11 +191,11 @@ func EnforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 // This is a generic wrapper function that works with any converter implementing
 // the APIConverter interface, providing a consistent interface for status enforcement
 // across different resource types.
-func EnforceStatus[t converter.RootObject](ctx context.Context, logger logr.Logger, conv converter.APIConverter[t]) (bool, error) {
+func enforceStatus[t converter.RootObject](ctx context.Context, logger logr.Logger, conv converter.APIConverter[t]) (bool, error) {
 	return conv.UpdateRootObjectStatus(ctx, logger)
 }
 
-// CleanOrphanedResources deletes resources previously managed by the converter but no longer present in the desired output.
+// cleanOrphanedResources deletes resources previously managed by the converter but no longer present in the desired output.
 //
 // The function performs the following operations:
 // 1. Retrieves the current desired state from the converter's output store
@@ -219,7 +219,7 @@ func EnforceStatus[t converter.RootObject](ctx context.Context, logger logr.Logg
 //
 // The function uses ownership labels to identify resources managed by the root object
 // and only deletes resources that are no longer present in the converter's desired output.
-func CleanOrphanedResources[t converter.RootObject, tPtr converter.RootObjectPtr[t]](ctx context.Context, cl client.Client, logger logr.Logger, conv converter.APIConverter[t]) (bool, error) {
+func cleanOrphanedResources[t converter.RootObject, tPtr converter.RootObjectPtr[t]](ctx context.Context, cl client.Client, logger logr.Logger, conv converter.APIConverter[t]) (bool, error) {
 	logger = logger.WithValues("phase", "orphan-cleanup")
 	log.Debug(logger, "Starting orphaned resource cleanup")
 
@@ -296,7 +296,7 @@ func CleanOrphanedResources[t converter.RootObject, tPtr converter.RootObjectPtr
 	}
 
 	log.Debug(logger, "Finished orphaned resource cleanup", "totalOrphansDeleted", totalOrphansDeleted)
-	// Return true if any orphans were deleted
+	// Return true if any orphans were deleted.
 	orphansDeleted := totalOrphansDeleted > 0
 	return orphansDeleted, nil
 }

--- a/controller/hybridgateway/reconciler_utils.go
+++ b/controller/hybridgateway/reconciler_utils.go
@@ -22,15 +22,16 @@ const (
 )
 
 // Translate performs the full translation process using the provided APIConverter.
-func Translate[t converter.RootObject](conv converter.APIConverter[t], ctx context.Context, logger logr.Logger) error {
+// Returns the number of Kong resources created and an error if the translation fails.
+func Translate[t converter.RootObject](conv converter.APIConverter[t], ctx context.Context, logger logr.Logger) (int, error) {
 	return conv.Translate(ctx, logger)
 }
 
 // EnforceState ensures that the desired state of Kubernetes resources, as provided by the APIConverter,
 // is reflected in the cluster. It attempts to create or update resources using server-side apply and
-// structured merge. The function returns requeue and stop flags to control reconciliation flow, and an error
+// structured merge. The function returns a boolean indicating if any changes were made and an error
 // for any unrecoverable or transient issues. Resources marked for deletion are skipped. Conflict errors
-// trigger a requeue for optimistic concurrency. All other errors are wrapped with resource kind and name for context.
+// are returned as errors. All other errors are wrapped with resource kind and name for context.
 //
 // The function performs the following operations:
 // 1. Retrieves the desired state from the converter's output store
@@ -38,7 +39,7 @@ func Translate[t converter.RootObject](conv converter.APIConverter[t], ctx conte
 // 3. Creates new resources using server-side apply if they don't exist
 // 4. Skips resources that are marked for deletion
 // 5. Updates existing resources if changes are detected using managed fields comparison
-// 6. Handles conflicts by returning requeue=true for optimistic concurrency
+// 6. Handles conflicts by returning an error for proper error handling
 //
 // Parameters:
 //   - ctx: The context for API calls and cancellation
@@ -47,24 +48,23 @@ func Translate[t converter.RootObject](conv converter.APIConverter[t], ctx conte
 //   - conv: The APIConverter that provides the desired state
 //
 // Returns:
-//   - requeue: true if the reconciliation should be retried due to conflicts
-//   - stop: true if reconciliation should stop (currently always false)
-//   - err: Any error that occurred during state enforcement
+//   - bool: true if any resources were created or updated in the cluster
+//   - error: Any error that occurred during state enforcement
 //
 // The function uses server-side apply with the "gateway-operator" field manager to ensure
 // proper ownership and conflict resolution when multiple controllers manage the same resources.
-func EnforceState[t converter.RootObject](ctx context.Context, cl client.Client, logger logr.Logger, conv converter.APIConverter[t]) (requeue bool, stop bool, err error) {
+func EnforceState[t converter.RootObject](ctx context.Context, cl client.Client, logger logr.Logger, conv converter.APIConverter[t]) (bool, error) {
 	logger = logger.WithValues("phase", "state-enforcement")
 	log.Debug(logger, "Starting state enforcement")
 
 	// Get the desired state from the converter.
 	desiredObjects, err := conv.GetOutputStore(ctx, logger)
 	if err != nil {
-		return false, false, fmt.Errorf("failed to get desired objects from converter: %w", err)
+		return false, fmt.Errorf("failed to get desired objects from converter: %w", err)
 	}
 	if len(desiredObjects) == 0 {
 		log.Debug(logger, "No desired objects to enforce")
-		return false, false, nil
+		return false, nil
 	}
 
 	log.Debug(logger, "Retrieved desired objects for enforcement", "objectCount", len(desiredObjects))
@@ -97,16 +97,16 @@ func EnforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 				// Set field manager for server-side apply
 				if err := cl.Patch(ctx, &desired, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
 					if errors.IsConflict(err) {
-						return true, false, fmt.Errorf("conflict during create of object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
+						return false, fmt.Errorf("conflict during create of object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 					}
-					return true, false, fmt.Errorf("failed to create object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
+					return false, fmt.Errorf("failed to create object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 				}
 				objectsCreated++
 				log.Debug(logger, "Successfully created object", "kind", desired.GetKind(), "obj", namespacedNameDesired)
 				continue
 			} else {
 				// Other error getting the object.
-				return true, false, fmt.Errorf("failed to get object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
+				return false, fmt.Errorf("failed to get object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 			}
 		}
 
@@ -120,16 +120,16 @@ func EnforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 		// Object exists, check if we need to update it.
 		managedFieldsObj, err := managedfields.ExtractAsUnstructured(existing, FieldManager, "")
 		if err != nil {
-			return true, false, fmt.Errorf("failed to extract managed fields for kind %s obj %s: %w", existing.GetKind(), namespacedNameExisting, err)
+			return false, fmt.Errorf("failed to extract managed fields for kind %s obj %s: %w", existing.GetKind(), namespacedNameExisting, err)
 		}
 		if managedFieldsObj == nil {
 			// No managed fields for our field manager, we should update.
 			log.Debug(logger, "No managed fields found for our field manager, will apply desired state", "kind", existing.GetKind(), "obj", namespacedNameExisting)
 			if err := cl.Patch(ctx, &desired, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
 				if errors.IsConflict(err) {
-					return true, false, fmt.Errorf("conflict during create of object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
+					return false, fmt.Errorf("conflict during create of object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 				}
-				return true, false, fmt.Errorf("failed to create object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
+				return false, fmt.Errorf("failed to create object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 			}
 			objectsUpdated++
 			log.Debug(logger, "Successfully applied desired state (no managed fields)", "kind", existing.GetKind(), "obj", namespacedNameExisting)
@@ -139,13 +139,13 @@ func EnforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 		// Convert desired resource to unstructured.
 		desiredU, err := utils.ToUnstructured(&desired, cl.Scheme())
 		if err != nil {
-			return true, false, fmt.Errorf("failed to convert to unstructured desired obj for kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
+			return false, fmt.Errorf("failed to convert to unstructured desired obj for kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 		}
 
 		// Compare the two states.
 		compare, err := managedfields.Compare(managedFieldsObj, pruneDesiredObj(desiredU))
 		if err != nil {
-			return true, false, fmt.Errorf("failed to compare managed fields for kind %s obj %s: %w", existing.GetKind(), namespacedNameExisting, err)
+			return false, fmt.Errorf("failed to compare managed fields for kind %s obj %s: %w", existing.GetKind(), namespacedNameExisting, err)
 		}
 
 		if compare.IsSame() {
@@ -155,9 +155,9 @@ func EnforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 			// Changes detected, apply the desired state using server-side apply.
 			if err := cl.Patch(ctx, &desired, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
 				if errors.IsConflict(err) {
-					return true, false, fmt.Errorf("conflict during create of object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
+					return false, fmt.Errorf("conflict during create of object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 				}
-				return true, false, fmt.Errorf("failed to update object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
+				return false, fmt.Errorf("failed to update object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 			}
 			objectsUpdated++
 			log.Debug(logger, "Successfully applied changes to object", "kind", existing.GetKind(), "obj", namespacedNameExisting)
@@ -170,7 +170,9 @@ func EnforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 		"updated", objectsUpdated,
 		"skipped", objectsSkipped)
 
-	return false, false, nil
+	// Return true if any resources were created or updated
+	stateChanged := (objectsCreated + objectsUpdated) > 0
+	return stateChanged, nil
 }
 
 // EnforceStatus updates the status of the root object managed by the provided APIConverter.
@@ -183,13 +185,13 @@ func EnforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 //   - conv: The APIConverter that manages the root object and its status
 //
 // Returns:
-//   - stop: true if reconciliation should stop, false to continue
-//   - err: Any error that occurred during status processing
+//   - bool: true if the status was actually updated in the cluster
+//   - error: Any error that occurred during status processing
 //
 // This is a generic wrapper function that works with any converter implementing
 // the APIConverter interface, providing a consistent interface for status enforcement
 // across different resource types.
-func EnforceStatus[t converter.RootObject](ctx context.Context, logger logr.Logger, conv converter.APIConverter[t]) (stop bool, err error) {
+func EnforceStatus[t converter.RootObject](ctx context.Context, logger logr.Logger, conv converter.APIConverter[t]) (bool, error) {
 	return conv.UpdateRootObjectStatus(ctx, logger)
 }
 
@@ -212,17 +214,18 @@ func EnforceStatus[t converter.RootObject](ctx context.Context, logger logr.Logg
 //   - conv: The APIConverter that manages the root object and its desired state
 //
 // Returns:
+//   - bool: true if any orphaned resources were deleted from the cluster
 //   - error: Any error that occurred during the cleanup process
 //
 // The function uses ownership labels to identify resources managed by the root object
 // and only deletes resources that are no longer present in the converter's desired output.
-func CleanOrphanedResources[t converter.RootObject, tPtr converter.RootObjectPtr[t]](ctx context.Context, cl client.Client, logger logr.Logger, conv converter.APIConverter[t]) error {
+func CleanOrphanedResources[t converter.RootObject, tPtr converter.RootObjectPtr[t]](ctx context.Context, cl client.Client, logger logr.Logger, conv converter.APIConverter[t]) (bool, error) {
 	logger = logger.WithValues("phase", "orphan-cleanup")
 	log.Debug(logger, "Starting orphaned resource cleanup")
 
 	desiredObjects, err := conv.GetOutputStore(ctx, logger)
 	if err != nil {
-		return fmt.Errorf("failed to get desired objects from converter for cleanup: %w", err)
+		return false, fmt.Errorf("failed to get desired objects from converter for cleanup: %w", err)
 	}
 
 	desiredSet := make(map[string]struct{})
@@ -239,7 +242,7 @@ func CleanOrphanedResources[t converter.RootObject, tPtr converter.RootObjectPtr
 	case tPtr:
 		rootObjPtr = v
 	default:
-		return fmt.Errorf("failed to convert root object to pointer type: got %T, expected %T", &rootObj, rootObjPtr)
+		return false, fmt.Errorf("failed to convert root object to pointer type: got %T, expected %T", &rootObj, rootObjPtr)
 	}
 
 	// Build a set of desired resource keys.
@@ -264,7 +267,7 @@ func CleanOrphanedResources[t converter.RootObject, tPtr converter.RootObjectPtr
 		ns := rootObjPtr.GetNamespace()
 
 		if err := cl.List(ctx, list, selector, client.InNamespace(ns)); err != nil {
-			return fmt.Errorf("unable to list objects with gvk %s in namespace %s: %w", gvk.String(), ns, err)
+			return false, fmt.Errorf("unable to list objects with gvk %s in namespace %s: %w", gvk.String(), ns, err)
 		}
 
 		log.Debug(logger, "Found existing resources for GVK", "gvk", gvk.String(), "resourceCount", len(list.Items))
@@ -276,7 +279,7 @@ func CleanOrphanedResources[t converter.RootObject, tPtr converter.RootObjectPtr
 				// Not in desired output, delete it.
 				log.Info(logger, "Deleting orphaned resource", "kind", item.GetKind(), "obj", client.ObjectKeyFromObject(&item))
 				if err := cl.Delete(ctx, &item); err != nil && !errors.IsNotFound(err) {
-					return fmt.Errorf("failed to delete orphaned resource kind %s obj %s: %w", item.GetKind(), client.ObjectKeyFromObject(&item), err)
+					return false, fmt.Errorf("failed to delete orphaned resource kind %s obj %s: %w", item.GetKind(), client.ObjectKeyFromObject(&item), err)
 				}
 				orphansForGVK++
 				totalOrphansDeleted++
@@ -293,7 +296,9 @@ func CleanOrphanedResources[t converter.RootObject, tPtr converter.RootObjectPtr
 	}
 
 	log.Debug(logger, "Finished orphaned resource cleanup", "totalOrphansDeleted", totalOrphansDeleted)
-	return nil
+	// Return true if any orphans were deleted
+	orphansDeleted := totalOrphansDeleted > 0
+	return orphansDeleted, nil
 }
 
 // pruneDesiredObj removes fields that should not be compared when checking for differences.

--- a/controller/hybridgateway/reconciler_utils_test.go
+++ b/controller/hybridgateway/reconciler_utils_test.go
@@ -229,7 +229,7 @@ func TestCleanOrphanedResources(t *testing.T) {
 				root:    *root,
 			}
 			logger := logr.Discard()
-			_, err := CleanOrphanedResources(context.Background(), cl, logger, fakeConv)
+			_, err := cleanOrphanedResources(context.Background(), cl, logger, fakeConv)
 			assert.NoError(t, err)
 			for _, gvk := range tt.gvks {
 				list := &unstructured.UnstructuredList{}

--- a/controller/hybridgateway/reconciler_utils_test.go
+++ b/controller/hybridgateway/reconciler_utils_test.go
@@ -229,7 +229,7 @@ func TestCleanOrphanedResources(t *testing.T) {
 				root:    *root,
 			}
 			logger := logr.Discard()
-			err := CleanOrphanedResources(context.Background(), cl, logger, fakeConv)
+			_, err := CleanOrphanedResources(context.Background(), cl, logger, fakeConv)
 			assert.NoError(t, err)
 			for _, gvk := range tt.gvks {
 				list := &unstructured.UnstructuredList{}
@@ -271,8 +271,8 @@ func (f *fakeHTTPRouteConverter) GetOutputStore(ctx context.Context, logger logr
 }
 func (f *fakeHTTPRouteConverter) GetExpectedGVKs() []schema.GroupVersionKind { return f.gvks }
 func (f *fakeHTTPRouteConverter) GetRootObject() gwtypes.HTTPRoute           { return f.root }
-func (f *fakeHTTPRouteConverter) Translate(ctx context.Context, logger logr.Logger) error {
-	return nil
+func (f *fakeHTTPRouteConverter) Translate(ctx context.Context, logger logr.Logger) (int, error) {
+	return len(f.desired), nil
 }
 func (f *fakeHTTPRouteConverter) ListExistingObjects(ctx context.Context) ([]unstructured.Unstructured, error) {
 	return nil, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Add event emission that only records Kubernetes events when meaningful changes occur, reducing event noise while maintaining visibility into reconciliation operations.

Key changes:
- Add event reason constants for consistent event classification
- Only emit events when status updates, state enforcement, or orphan cleanup actually modify cluster resources

Events:
```bash
Events:
  Type    Reason                          Age                From           Message
  ----    ------                          ----               ----           -------
  Normal  HTTPRouteTranslationSucceeded   15s                hybridgateway  HTTPRoute successfully translated to 5 Kong resources
  Normal  StateEnforcementSucceeded       15s                hybridgateway  Kong resources successfully enforced: 5 total
  Normal  HTTPRouteStatusUpdateSucceeded  14s (x5 over 15s)  hybridgateway  HTTPRoute status successfully updated
  Normal  HTTPRouteTranslationSucceeded   7s (x6 over 15s)   hybridgateway  HTTPRoute successfully translated to 8 Kong resources
  Normal  StateEnforcementSucceeded       7s (x6 over 15s)   hybridgateway  Kong resources successfully enforced: 8 total

```
**Which issue this PR fixes**

Fixes #2521 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
