### PR TITLE
ci: renovate config for kube-api-linter

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,29 @@
       ]
     },
     {
+      "description": "Match dependencies in .custom-gcl.yml that are properly annotated with `# renovate: datasource={} depName={}.`",
+      "customType": "regex",
+      "fileMatch": [
+        "\\.custom-gcl\\.yml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\nversion: v(?<currentValue>.*)"
+      ]
+    },
+    {
+      "description": "Match kube-api-linter git commit digests in .custom-gcl.yml",
+      "customType": "regex",
+      "fileMatch": [
+        ".custom-gcl\\.yml$"
+      ],
+      "matchStrings": [
+        "version:\\s*(?<currentValue>)(?<currentDigest>[a-f0-9]{7,40})"
+      ],
+      "currentValueTemplate": "main",
+      "datasourceTemplate": "git-refs",
+      "lookupNameTemplate": "https://github.com/kubernetes-sigs/kube-api-linter"
+    },
+    {
       "description": "Match dependencies in Makefile that are properly annotated with `# renovate: datasource={} depName={}.`",
       "customType": "regex",
       "fileMatch": [


### PR DESCRIPTION
**What this PR does / why we need it**:

Add renovate config for kube-api-linter.

Borrowed from: https://github.com/Kong/kubernetes-configuration/blob/43efc9a38efcfe980d40340fc72e42d0f5283f9b/renovate.json

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

Tested via:

```
mkdir renovate-cache; docker run --rm --env RENOVATE_GITHUB_COM_TOKEN=${GITHUB_API_TOKEN} --env RENOVATE_CONFIG_FILE=./renovate.json --env LOG_LEVEL=debug -v $(pwd):/usr/src/app -v $(pwd)/renovate-cache:/home/ubuntu/cache renovate/renovate --dry-run --platform local --cache-dir /home/ubuntu/cache
```

```
DEBUG: branches info extended (repository=local)
       "branchesInformation": [
         {
           "branchName": "renovate/https-github.com-kubernetes-sigs-kube-api-linter-digest",
           "prNo": null,
           "prTitle": "Update https://github.com/kubernetes-sigs/kube-api-linter digest to c856454",
           "result": "not-scheduled",
           "upgrades": [
             {
               "datasource": "git-refs",
               "depName": "https://github.com/kubernetes-sigs/kube-api-linter",
               "displayPending": "",
               "currentValue": "main",
               "currentDigest": "65a570bd22aac3fe2eb0c3721b1cc4ea6ec41e48",
               "newValue": "main",
               "newDigest": "c856454e0d836fe342713ecd9b1ecdfbd8ef1b24",
               "packageFile": ".custom-gcl.yml",
               "updateType": "digest",
               "packageName": "https://github.com/kubernetes-sigs/kube-api-linter"
             },
             {
               "datasource": "git-refs",
               "depName": "https://github.com/kubernetes-sigs/kube-api-linter",
               "displayPending": "",
               "currentValue": "main",
               "currentDigest": "65a570bd22aac3fe2eb0c3721b1cc4ea6ec41e48",
               "newValue": "main",
               "newDigest": "c856454e0d836fe342713ecd9b1ecdfbd8ef1b24",
               "packageFile": ".custom-gcl.yml",
               "updateType": "digest",
               "packageName": "https://github.com/kubernetes-sigs/kube-api-linter"
             }
           ]
         },
         {
           "branchName": "renovate/golangci-golangci-lint-2.x",
           "prNo": null,
           "prTitle": "Update dependency golangci/golangci-lint to v2.6.1",
           "result": "not-scheduled",
           "upgrades": [
             {
               "datasource": "github-releases",
               "depName": "golangci/golangci-lint",
               "displayPending": "",
               "fixedVersion": "2.4.0",
               "currentVersion": "v2.4.0",
               "currentValue": "2.4.0",
               "newValue": "2.6.1",
               "newVersion": "v2.6.1",
               "packageFile": ".custom-gcl.yml",
               "updateType": "minor",
               "packageName": "golangci/golangci-lint"
             },
             {
               "datasource": "github-releases",
               "depName": "golangci/golangci-lint",
               "displayPending": "",
               "fixedVersion": "2.4.0",
               "currentVersion": "v2.4.0",
               "currentValue": "2.4.0",
               "newValue": "2.6.1",
               "newVersion": "v2.6.1",
               "packageFile": ".custom-gcl.yml",
               "updateType": "minor",
               "packageName": "golangci/golangci-lint"
             }
           ]
         }
       ]
```

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
