### PR TITLE
fix(actions): Add global contents:read permission to falco analyzed e2es

### DIFF
--- a/.github/workflows/falco-analyzed-e2e.yaml
+++ b/.github/workflows/falco-analyzed-e2e.yaml
@@ -3,6 +3,9 @@ name: falco-analyzed-e2e
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   MISE_VERBOSE: 1
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add global permission annotation `contents: read` to the `falco-analyzed-e2e` action.
**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
