### PR TITLE
ci: deduplicate integrations tests artifacts name

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -603,7 +603,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
       with:
-        name: diagnostics-integration
+        name: diagnostics-integration-${{ matrix.directory }}
         path: /tmp/ktf-diag*
         if-no-files-found: ignore
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR prevents:

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

Which happens because both integration test suites use the same artifact name.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
