### PR TITLE
tests: fix TestDiagnosticsServer_Diffs flakiness

### DIFF
--- a/ingress-controller/internal/diagnostics/server_test.go
+++ b/ingress-controller/internal/diagnostics/server_test.go
@@ -93,8 +93,26 @@ func TestDiagnosticsServer_Diffs(t *testing.T) {
 		last = diff.Hash
 	}
 
-	// request the diff report
+	// Wait for all diffs to be processed by the collector before making HTTP requests.
+	// This prevents race conditions where the HTTP handler might return data before all
+	// diffs have been stored in the collector's diff map.
 	httpClient := &http.Client{}
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		resp, err := httpClient.Get(fmt.Sprintf("http://localhost:%d/debug/config/diff-report", port))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		b := new(bytes.Buffer)
+		_, err = b.ReadFrom(resp.Body)
+		require.NoError(t, err)
+		got := DiffResponse{}
+		require.NoError(t, json.Unmarshal(b.Bytes(), &got))
+
+		// Check that all sent diffs have been processed
+		require.Len(t, got.Available, configDumpsToWrite, "expected all %d diffs to be available", configDumpsToWrite)
+	}, time.Second*5, time.Millisecond*10, "all diffs should be processed")
+
+	// request the diff report
 	resp, err := httpClient.Get(fmt.Sprintf("http://localhost:%d/debug/config/diff-report", port))
 	require.NoError(t, err)
 	defer resp.Body.Close()
@@ -124,6 +142,14 @@ func TestDiagnosticsServer_Diffs(t *testing.T) {
 	extra := testConfigDiff()
 	configDiffs[extra.Hash] = extra
 	diffCh <- extra
+
+	// Wait for the extra diff to be processed before checking the results
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		resp, err := httpClient.Get(fmt.Sprintf("http://localhost:%d/debug/config/diff-report?hash=%s", port, extra.Hash))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode, "extra diff should be available")
+	}, time.Second*5, time.Millisecond*10, "extra diff should be processed")
 
 	second, err := httpClient.Get(fmt.Sprintf("http://localhost:%d/debug/config/diff-report", port))
 	require.NoError(t, err)
@@ -193,13 +219,12 @@ func setupTestServer(ctx context.Context, t *testing.T) (Client, int) {
 	t.Log("Started diagnostics collector")
 
 	// Wait for the server to be ready
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))
-		if err != nil {
-			return false
+		if !assert.NoError(c, err) {
+			return
 		}
-		conn.Close()
-		return true
+		conn.Close() //nolint:errcheck
 	}, 5*time.Second, 100*time.Millisecond, "Server should be ready")
 
 	return client, port

--- a/ingress-controller/internal/diagnostics/server_test.go
+++ b/ingress-controller/internal/diagnostics/server_test.go
@@ -221,7 +221,7 @@ func setupTestServer(ctx context.Context, t *testing.T) (Client, int) {
 		if !assert.NoError(c, err) {
 			return
 		}
-		conn.Close() //nolint:errcheck
+		conn.Close()
 	}, 5*time.Second, 100*time.Millisecond, "Server should be ready")
 
 	return client, port

--- a/ingress-controller/internal/diagnostics/server_test.go
+++ b/ingress-controller/internal/diagnostics/server_test.go
@@ -102,17 +102,14 @@ func TestDiagnosticsServer_Diffs(t *testing.T) {
 		require.NoError(t, err)
 		defer resp.Body.Close()
 
-		b := new(bytes.Buffer)
-		_, err = b.ReadFrom(resp.Body)
-		require.NoError(t, err)
 		got := DiffResponse{}
-		require.NoError(t, json.Unmarshal(b.Bytes(), &got))
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
 
-		// Check that all sent diffs have been processed
+		// Check that all sent diffs have been processed.
 		require.Len(t, got.Available, configDumpsToWrite, "expected all %d diffs to be available", configDumpsToWrite)
 	}, time.Second*5, time.Millisecond*10, "all diffs should be processed")
 
-	// request the diff report
+	// Request the diff report.
 	resp, err := httpClient.Get(fmt.Sprintf("http://localhost:%d/debug/config/diff-report", port))
 	require.NoError(t, err)
 	defer resp.Body.Close()
@@ -143,7 +140,7 @@ func TestDiagnosticsServer_Diffs(t *testing.T) {
 	configDiffs[extra.Hash] = extra
 	diffCh <- extra
 
-	// Wait for the extra diff to be processed before checking the results
+	// Wait for the extra diff to be processed before checking the results.
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		resp, err := httpClient.Get(fmt.Sprintf("http://localhost:%d/debug/config/diff-report?hash=%s", port, extra.Hash))
 		require.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

The test had a race condition where it sent diffs to a buffered channel and immediately made HTTP requests without waiting for the asynchronous Collector goroutine to process them. This caused the test to sometimes compare different UUIDs—one stored in the test's local map versus a different one returned from the HTTP endpoint that hadn't been processed yet.

Adding require.Eventually to fix the flakiness.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
