### PR TITLE
chore(ci): fix helm plugin verification

### DIFF
--- a/.github/workflows/charts-tests.yaml
+++ b/.github/workflows/charts-tests.yaml
@@ -140,6 +140,8 @@ jobs:
           install: false
 
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        with:
+           version: v3.19.2
 
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
@@ -188,6 +190,8 @@ jobs:
 
       - name: setup helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        with:
+           version: v3.19.2
 
       - uses: jdx/mise-action@be3be2260bc02bc3fbf94c5e2fed8b7964baf074 # v3.4.0
         with:

--- a/go.mod
+++ b/go.mod
@@ -323,7 +323,7 @@ require (
 replace (
 	k8s.io/api => k8s.io/api v0.33.4
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.33.4
-	k8s.io/apimachinery => k8s.io/apimachinery v0.33.5
+	k8s.io/apimachinery => k8s.io/apimachinery v0.33.6
 	k8s.io/apiserver => k8s.io/apiserver v0.33.4
 	k8s.io/cli-runtime => k8s.io/cli-runtime v0.33.4
 	k8s.io/client-go => k8s.io/client-go v0.33.4
@@ -333,12 +333,12 @@ replace (
 	k8s.io/component-base => k8s.io/component-base v0.33.4
 	k8s.io/component-helpers => k8s.io/component-helpers v0.33.4
 	k8s.io/controller-manager => k8s.io/controller-manager v0.33.4
-	k8s.io/cri-api => k8s.io/cri-api v0.33.5
+	k8s.io/cri-api => k8s.io/cri-api v0.33.6
 	k8s.io/cri-client => k8s.io/cri-client v0.33.4
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.33.4
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.33.4
 	k8s.io/endpointslice => k8s.io/endpointslice v0.33.4
-	k8s.io/externaljwt => k8s.io/externaljwt v0.33.5
+	k8s.io/externaljwt => k8s.io/externaljwt v0.33.6
 	k8s.io/kms => k8s.io/kms v0.33.4
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.33.4
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.33.4
@@ -348,7 +348,7 @@ replace (
 	k8s.io/kubelet => k8s.io/kubelet v0.33.4
 	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.30.3
 	k8s.io/metrics => k8s.io/metrics v0.33.4
-	k8s.io/mount-utils => k8s.io/mount-utils v0.33.5
+	k8s.io/mount-utils => k8s.io/mount-utils v0.33.6
 	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.33.4
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.33.4
 	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.33.4

--- a/go.sum
+++ b/go.sum
@@ -798,6 +798,8 @@ k8s.io/apiextensions-apiserver v0.33.4 h1:rtq5SeXiDbXmSwxsF0MLe2Mtv3SwprA6wp+5qh
 k8s.io/apiextensions-apiserver v0.33.4/go.mod h1:mWXcZQkQV1GQyxeIjYApuqsn/081hhXPZwZ2URuJeSs=
 k8s.io/apimachinery v0.33.5 h1:NiT64hln4TQXeYR18/ES39OrNsjGz8NguxsBgp+6QIo=
 k8s.io/apimachinery v0.33.5/go.mod h1:BHW0YOu7n22fFv/JkYOEfkUYNRN0fj0BlvMFWA7b+SM=
+k8s.io/apimachinery v0.33.6 h1:Pq+px1i1t7lNgE58dIeBwJh7OWId6pfGD1dYBm/U5HI=
+k8s.io/apimachinery v0.33.6/go.mod h1:BHW0YOu7n22fFv/JkYOEfkUYNRN0fj0BlvMFWA7b+SM=
 k8s.io/apiserver v0.33.4 h1:6N0TEVA6kASUS3owYDIFJjUH6lgN8ogQmzZvaFFj1/Y=
 k8s.io/apiserver v0.33.4/go.mod h1:8ODgXMnOoSPLMUg1aAzMFx+7wTJM+URil+INjbTZCok=
 k8s.io/cli-runtime v0.33.4 h1:V8NSxGfh24XzZVhXmIGzsApdBpGq0RQS2u/Fz1GvJwk=

--- a/scripts/install-chartsnap.sh
+++ b/scripts/install-chartsnap.sh
@@ -5,6 +5,14 @@ if [ -z "${CHARTSNAP_VERSION}" ]; then
   exit 1
 fi
 
+HELM_VERSION_MAJOR=$(helm version --template='{{.Version}}' | sed -E 's/^v([0-9]+)\..*/\1/')
+HELM_PLUGIN_INSTALL_OPTS=""
+if [ "${HELM_VERSION_MAJOR}" -eq 4 ]; then
+  HELM_PLUGIN_INSTALL_OPTS="--verify=false"
+fi
+
+echo "INFO: Helm version detected: ${HELM_VERSION_MAJOR}"
+
 # Only install the plugin if it is not already installed or if the version is different.
 if [[ $(helm plugin list | grep chartsnap | grep -Eo '[0-9]{1,}.[0-9]{1,}.[0-9]{1,}') == "${CHARTSNAP_VERSION}" ]]; then
   echo "INFO: chartsnap plugin is already installed and up to date"
@@ -14,5 +22,7 @@ else
     echo "INFO: Uninstalling existing chartsnap plugin - version mismatch"
     helm plugin uninstall chartsnap
   fi
-  helm plugin install https://github.com/jlandowner/helm-chartsnap --version "${CHARTSNAP_VERSION}"
+  helm plugin install ${HELM_PLUGIN_INSTALL_OPTS} \
+    https://github.com/jlandowner/helm-chartsnap \
+    --version "${CHARTSNAP_VERSION}"
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes the `scripts/install-chartsnap.sh` script agnostic to helm version.

After helm 4 has been released, the CI started using it (via the `azure/setup-helm` action) and that started causing:

```
Error: plugin source does not support verification. Use --verify=false to skip verification
```

This PR fixes it.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

Helm 4 changed template rendering behavior ever so slightly. This means that we can only support one of Helm 3 or 4 at a time.

For now, this PR makes sure that we keep using Helm 3 (by hardcoding the version use by the `azure/setup-helm` action).

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
