### PR TITLE
feat: define Gateway API in hybrid CLI flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,8 @@
   [#2457](https://github.com/Kong/kong-operator/pull/2457)
 - Add support to HTTPRoute RequestRedirect filter
   [#2470](https://github.com/Kong/kong-operator/pull/2470)
+- Add CLI flag `--enable-fqdn-mode` to indicate whether to use FQDN endpoints for service discovery.
+  [#2607](https://github.com/Kong/kong-operator/pull/2607)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,7 +126,10 @@
   [#2457](https://github.com/Kong/kong-operator/pull/2457)
 - Add support to HTTPRoute RequestRedirect filter
   [#2470](https://github.com/Kong/kong-operator/pull/2470)
-- Add CLI flag `--enable-fqdn-mode` to indicate whether to use FQDN endpoints for service discovery.
+- Add CLI flag `--enable-fqdn-mode` to enable Fully Qualified Domain Name (FQDN)
+  mode for service discovery. When enabled, Kong targets are configured to use
+  service FQDNs (e.g., `service.namespace.svc.cluster.local`) instead of
+  individual pod endpoint IPs.
   [#2607](https://github.com/Kong/kong-operator/pull/2607)
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -858,7 +858,6 @@ _run:
 		-enable-controller-kongplugininstallation \
 		-enable-controller-aigateway \
 		-enable-controller-konnect \
-		-enable-controller-konnect-hybrid \
 		-enable-controller-controlplaneextensions \
 		-enable-conversion-webhook=false \
 		-enable-validating-webhook=false \

--- a/config/debug/manager_debug.yaml
+++ b/config/debug/manager_debug.yaml
@@ -33,7 +33,6 @@ spec:
             - -zap-log-level=debug
             - -enable-controller-kongplugininstallation
             - -enable-controller-konnect
-            - -enable-controller-konnect-hybrid
             - -enable-controller-controlplaneextensions
           name: manager
           env:

--- a/config/dev/manager_dev.yaml
+++ b/config/dev/manager_dev.yaml
@@ -24,7 +24,6 @@ spec:
             - -zap-devel=true
             - -enable-controller-kongplugininstallation
             - -enable-controller-konnect
-            - -enable-controller-konnect-hybrid
             - -enable-controller-controlplaneextensions
           name: manager
           env:

--- a/docs/cli-arguments-for-developer-konghq-com.md
+++ b/docs/cli-arguments-for-developer-konghq-com.md
@@ -144,10 +144,6 @@ rows:
     type: '`bool`'
     description: "Enable the Konnect controllers."
     default: '`false`'
-  - flag: '`--enable-controller-konnect-hybrid`'
-    type: '`bool`'
-    description: "Enable the Konnect Hybrid controllers."
-    default: '`false`'
   - flag: '`--enable-controlplane-config-dump`'
     type: '`bool`'
     description: "Enable the server to dump generated Kong configuration from ControlPlanes. Only effective when ControlPlane controller is enabled."
@@ -156,6 +152,10 @@ rows:
     type: '`bool`'
     description: "Enable the conversion webhook."
     default: '`true`'
+  - flag: '`--enable-fqdn-mode`'
+    type: '`bool`'
+    description: "Enable FQDN mode for the operator. FQDNMode indicates whether to use FQDN endpoints for service discovery."
+    default: '`false`'
   - flag: '`--enable-gateway-api-experimental`'
     type: '`bool`'
     description: "Enable the Gateway API experimental features."

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -105,10 +105,6 @@ rows:
     type: '`bool`'
     description: "Enable the Konnect controllers."
     default: '`false`'
-  - flag: '`--enable-controller-konnect-hybrid`'
-    type: '`bool`'
-    description: "Enable the Konnect Hybrid controllers."
-    default: '`false`'
   - flag: '`--enable-controlplane-config-dump`'
     type: '`bool`'
     description: "Enable the server to dump generated Kong configuration from ControlPlanes. Only effective when ControlPlane controller is enabled."
@@ -117,6 +113,10 @@ rows:
     type: '`bool`'
     description: "Enable the conversion webhook."
     default: '`true`'
+  - flag: '`--enable-fqdn-mode`'
+    type: '`bool`'
+    description: "Enable FQDN mode for the operator. FQDNMode indicates whether to use FQDN endpoints for service discovery."
+    default: '`false`'
   - flag: '`--enable-gateway-api-experimental`'
     type: '`bool`'
     description: "Enable the Gateway API experimental features."

--- a/ingress-controller/pkg/manager/config/consts.go
+++ b/ingress-controller/pkg/manager/config/consts.go
@@ -32,4 +32,6 @@ const (
 	DefaultClusterDomain = "cluster.local"
 	// DefaultEmitKubernetesEvents is the default value for emitting Kubernetes events.
 	DefaultEmitKubernetesEvents = true
+	// DefaultFQDNModeEnabled is the default value for enabling FQDN mode.
+	DefaultFQDNModeEnabled = false
 )

--- a/modules/cli/cli.go
+++ b/modules/cli/cli.go
@@ -57,6 +57,7 @@ func New(m metadata.Info) *CLI {
 	flagSet.IntVar(&cfg.ClusterCAKeySize, "cluster-ca-key-size", mgrconfig.DefaultClusterCAKeySize, "Size (in bits) of the key used for the cluster CA certificate. Only used for RSA keys.")
 	flagSet.DurationVar(&cfg.CacheSyncTimeout, "cache-sync-timeout", 0, "Sets the time limit for syncing controller caches. Defaults to the controller-runtime value if set to `0`.")
 	flagSet.StringVar(&cfg.ClusterDomain, "cluster-domain", ingressmgrconfig.DefaultClusterDomain, "The cluster domain. This is used e.g. in generating addresses for upstream services.")
+	flagSet.BoolVar(&cfg.FQDNModeEnabled, "enable-fqdn-mode", ingressmgrconfig.DefaultFQDNModeEnabled, "Enable FQDN mode for the operator. FQDNMode indicates whether to use FQDN endpoints for service discovery.")
 	flagSet.DurationVar(&cfg.CacheSyncPeriod, "cache-sync-period", 0, "Sets the minimum frequency for reconciling watched resources. Defaults to the controller-runtime value if unspecified or set to 0s.")
 	flagSet.BoolVar(&cfg.EmitKubernetesEvents, "emit-kubernetes-events", ingressmgrconfig.DefaultEmitKubernetesEvents, "Emit Kubernetes events for successful configuration applies, translation failures and configuration apply failures on managed objects.")
 	flagSet.Var(newValidatedValue(&cfg.WatchNamespaces, manager.NewWatchNamespaces), "watch-namespaces", "Comma-separated list of namespaces to watch. If empty (default), all namespaces are watched.")
@@ -79,7 +80,6 @@ func New(m metadata.Info) *CLI {
 
 	// controllers for Konnect APIs
 	flagSet.BoolVar(&cfg.KonnectControllersEnabled, "enable-controller-konnect", false, "Enable the Konnect controllers.")
-	flagSet.BoolVar(&cfg.KonnectHybridControllersEnabled, "enable-controller-konnect-hybrid", false, "Enable the Konnect Hybrid controllers.")
 	flagSet.DurationVar(&cfg.KonnectSyncPeriod, "konnect-sync-period", consts.DefaultKonnectSyncPeriod, "Sync period for Konnect entities. After a successful reconciliation of Konnect entities the controller will wait this duration before enforcing configuration on Konnect once again.")
 	flagSet.UintVar(&cfg.KonnectMaxConcurrentReconciles, "konnect-controller-max-concurrent-reconciles", consts.DefaultKonnectMaxConcurrentReconciles, "Maximum number of concurrent reconciles for Konnect entities.")
 

--- a/modules/cli/cli_test.go
+++ b/modules/cli/cli_test.go
@@ -291,5 +291,6 @@ func expectedDefaultCfg() manager.Config {
 		EmitKubernetesEvents:                    true,
 		ConversionWebhookEnabled:                true,
 		ValidatingWebhookEnabled:                true,
+		FQDNModeEnabled:                         false,
 	}
 }

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -627,7 +627,7 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 			newKonnectEntityController[configurationv1alpha1.KongSNI](controllerFactory),
 		)
 
-		if c.KonnectHybridControllersEnabled {
+		if c.KonnectControllersEnabled {
 			var referenceGrantEnabled bool
 
 			logger := mgr.GetLogger().WithValues("component", "gatewayapi-hybrid-controller")
@@ -645,7 +645,7 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 			}
 
 			controllers = append(controllers,
-				newGatewayAPIHybridController[gwtypes.HTTPRoute](mgr, referenceGrantEnabled, false, ""), // TODO: make FQDN mode and cluster domain configurable
+				newGatewayAPIHybridController[gwtypes.HTTPRoute](mgr, referenceGrantEnabled, c.FQDNModeEnabled, c.ClusterDomain),
 				// TODO: Add more Hybrid controllers here
 			)
 		}

--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -83,6 +83,7 @@ type Config struct {
 	LoggerOpts               *zap.Options
 	EnforceConfig            bool
 	ClusterDomain            string
+	FQDNModeEnabled          bool
 	EmitKubernetesEvents     bool
 	// SecretLabelSelector specifies the label which will be used to limit the ingestion of secrets. Only those that have this label set to "true" will be ingested.
 	SecretLabelSelector string
@@ -115,8 +116,7 @@ type Config struct {
 	ControlPlaneExtensionsControllerEnabled bool
 
 	// Controllers for Konnect APIs.
-	KonnectControllersEnabled       bool
-	KonnectHybridControllersEnabled bool
+	KonnectControllersEnabled bool
 
 	// Webhook options.
 	ConversionWebhookEnabled bool

--- a/pkg/utils/test/config.go
+++ b/pkg/utils/test/config.go
@@ -36,7 +36,6 @@ func DefaultControllerConfigForTests(opts ...ControllerConfigOption) manager.Con
 	cfg.AIGatewayControllerEnabled = true
 	cfg.AnonymousReports = false
 	cfg.KonnectControllersEnabled = true
-	cfg.KonnectHybridControllersEnabled = true
 	cfg.ClusterCAKeyType = mgrconfig.ECDSA
 	cfg.GatewayAPIExperimentalEnabled = true
 	cfg.EnforceConfig = true


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR does the following:
- introduces a new flag related to FQDN resolution for service discovery
- remove the flag `--enable-controller-konnect-hybrid`
- use the already existing flag `--enable-controller-konnect` as a replacement for `--enable-controller-konnect-hybrid`

**Which issue this PR fixes**

Fixes #2519 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
