### PR TITLE
test(envtest): Add envtest for adopting routes, upstreams and targets

### DIFF
--- a/test/envtest/konnect_entities_kongroute_test.go
+++ b/test/envtest/konnect_entities_kongroute_test.go
@@ -278,7 +278,7 @@ func TestKongRoute(t *testing.T) {
 
 		w := setupWatch[configurationv1alpha1.KongRouteList](t, ctx, cl, client.InNamespace(ns.Name))
 
-		t.Log("Setting up SDK expectations for gettingroutes")
+		t.Log("Setting up SDK expectations for getting routes")
 		sdk.RoutesSDK.EXPECT().GetRoute(
 			mock.Anything,
 			routeID,

--- a/test/envtest/konnect_entities_kongroute_test.go
+++ b/test/envtest/konnect_entities_kongroute_test.go
@@ -185,22 +185,10 @@ func TestKongRoute(t *testing.T) {
 		t.Logf("Creating a KongRoute to adopt the existing route (ID: %s)", routeID)
 		createdRoute := deploy.KongRoute(t, ctx, clientNamespaced,
 			deploy.WithNamespacedKongServiceRef(svc),
-			func(obj client.Object) {
-				r, ok := obj.(*configurationv1alpha1.KongRoute)
-				require.True(t, ok)
-				r.Spec.Adopt = &commonv1alpha1.AdoptOptions{
-					From: commonv1alpha1.AdoptSourceKonnect,
-					Mode: commonv1alpha1.AdoptModeOverride,
-					Konnect: &commonv1alpha1.AdoptKonnectOptions{
-						ID: routeID,
-					},
-				}
-				r.Spec.Name = &routeName
-				r.Spec.Paths = []string{"/path-2"}
-			},
+			deploy.WithKonnectAdoptOptions[*configurationv1alpha1.KongRoute](commonv1alpha1.AdoptModeOverride, routeID),
 		)
 
-		t.Log("Waiting for the KongRoute to get KonnectID and marked as programmed")
+		t.Logf("Waiting for the KongRoute %s/%s to get KonnectID and marked as programmed", ns.Name, createdRoute.Name)
 		watchFor(t, ctx, w, apiwatch.Modified, func(r *configurationv1alpha1.KongRoute) bool {
 			return r.Name == createdRoute.Name && r.GetKonnectID() == routeID && k8sutils.IsProgrammed(r)
 		},
@@ -210,7 +198,7 @@ func TestKongRoute(t *testing.T) {
 		t.Log("Setting up SDK expectations for route deletion")
 		sdk.RoutesSDK.EXPECT().DeleteRoute(mock.Anything, cp.GetKonnectID(), routeID).Return(nil, nil)
 
-		t.Log("Deleting KongRoute")
+		t.Logf("Deleting KongRoute %s/%s", ns.Name, createdRoute.Name)
 		require.NoError(t, clientNamespaced.Delete(ctx, createdRoute))
 
 		eventually.WaitForObjectToNotExist(t, ctx, cl, createdRoute, waitTime, tickTime)
@@ -249,22 +237,10 @@ func TestKongRoute(t *testing.T) {
 		t.Logf("Creating a KongRoute to adopt the existing route (ID: %s)", routeID)
 		createdRoute := deploy.KongRoute(t, ctx, clientNamespaced,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
-			func(obj client.Object) {
-				r, ok := obj.(*configurationv1alpha1.KongRoute)
-				require.True(t, ok)
-				r.Spec.Adopt = &commonv1alpha1.AdoptOptions{
-					From: commonv1alpha1.AdoptSourceKonnect,
-					Mode: commonv1alpha1.AdoptModeOverride,
-					Konnect: &commonv1alpha1.AdoptKonnectOptions{
-						ID: routeID,
-					},
-				}
-				r.Spec.Name = &routeName
-				r.Spec.Paths = []string{"/path-2"}
-			},
+			deploy.WithKonnectAdoptOptions[*configurationv1alpha1.KongRoute](commonv1alpha1.AdoptModeOverride, routeID),
 		)
 
-		t.Log("Waiting for the KongRoute to get KonnectID and marked as programmed")
+		t.Logf("Waiting for the KongRoute %s/%s to get KonnectID and marked as programmed", ns.Name, createdRoute.Name)
 		watchFor(t, ctx, w, apiwatch.Modified, func(r *configurationv1alpha1.KongRoute) bool {
 			return r.Name == createdRoute.Name && r.GetKonnectID() == routeID && k8sutils.IsProgrammed(r)
 		},
@@ -300,22 +276,10 @@ func TestKongRoute(t *testing.T) {
 		t.Logf("Creating a KongRoute to adopt the existing route (ID: %s)", routeID)
 		createdRoute := deploy.KongRoute(t, ctx, clientNamespaced,
 			deploy.WithNamespacedKongServiceRef(svc),
-			func(obj client.Object) {
-				r, ok := obj.(*configurationv1alpha1.KongRoute)
-				require.True(t, ok)
-				r.Spec.Adopt = &commonv1alpha1.AdoptOptions{
-					From: commonv1alpha1.AdoptSourceKonnect,
-					Mode: commonv1alpha1.AdoptModeOverride,
-					Konnect: &commonv1alpha1.AdoptKonnectOptions{
-						ID: routeID,
-					},
-				}
-				r.Spec.Name = &routeName
-				r.Spec.Paths = []string{"/path-2"}
-			},
+			deploy.WithKonnectAdoptOptions[*configurationv1alpha1.KongRoute](commonv1alpha1.AdoptModeOverride, routeID),
 		)
 
-		t.Log("Waiting for the KongRoute to be marked as not programmed and not adopted")
+		t.Logf("Waiting for the KongRoute %s/%s to be marked as not programmed and not adopted", ns.Name, createdRoute.Name)
 		watchFor(t, ctx, w, apiwatch.Modified, func(r *configurationv1alpha1.KongRoute) bool {
 			return r.Name == createdRoute.Name &&
 				conditionsContainProgrammedFalse(r.GetConditions()) &&

--- a/test/envtest/konnect_entities_kongservice_test.go
+++ b/test/envtest/konnect_entities_kongservice_test.go
@@ -447,20 +447,10 @@ func TestKongService(t *testing.T) {
 
 		t.Log("Creating a KongService to adopt the existing service")
 		createdService := deploy.KongService(t, t.Context(), clientNamespaced, deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
-			func(obj client.Object) {
-				ks, ok := obj.(*configurationv1alpha1.KongService)
-				require.True(t, ok)
-				ks.Spec.URL = lo.ToPtr("https://example.com/example")
-				ks.Spec.Adopt = &commonv1alpha1.AdoptOptions{
-					From: commonv1alpha1.AdoptSourceKonnect,
-					Mode: commonv1alpha1.AdoptModeOverride,
-					Konnect: &commonv1alpha1.AdoptKonnectOptions{
-						ID: serviceKonnectID,
-					},
-				}
-			})
+			deploy.WithKonnectAdoptOptions[*configurationv1alpha1.KongService](commonv1alpha1.AdoptModeOverride, serviceKonnectID),
+		)
 
-		t.Log("Waiting for the service to be programmed and get Konnect ID")
+		t.Logf("Waiting for the KongService %s/%s to be programmed and get Konnect ID", ns.Name, createdService.Name)
 		watchFor(t, t.Context(), w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
 			return ks.Name == createdService.Name &&
 				ks.GetKonnectID() == serviceKonnectID && k8sutils.IsProgrammed(ks)
@@ -475,7 +465,7 @@ func TestKongService(t *testing.T) {
 			serviceKonnectID,
 		).Return(&sdkkonnectops.DeleteServiceResponse{}, nil)
 
-		t.Log("Deleting the KongService")
+		t.Logf("Deleting the KongService %s/%s", ns.Name, createdService.Name)
 		require.NoError(t, clientNamespaced.Delete(t.Context(), createdService))
 
 		t.Log("Waiting for the SDK's DeleteService to be called")
@@ -502,20 +492,10 @@ func TestKongService(t *testing.T) {
 
 		t.Log("Creating a KongService to adopt the existing service")
 		createdService := deploy.KongService(t, t.Context(), clientNamespaced, deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
-			func(obj client.Object) {
-				ks, ok := obj.(*configurationv1alpha1.KongService)
-				require.True(t, ok)
-				ks.Spec.URL = lo.ToPtr("https://example.com/example")
-				ks.Spec.Adopt = &commonv1alpha1.AdoptOptions{
-					From: commonv1alpha1.AdoptSourceKonnect,
-					Mode: commonv1alpha1.AdoptModeOverride,
-					Konnect: &commonv1alpha1.AdoptKonnectOptions{
-						ID: serviceKonnectID,
-					},
-				}
-			})
+			deploy.WithKonnectAdoptOptions[*configurationv1alpha1.KongService](commonv1alpha1.AdoptModeOverride, serviceKonnectID),
+		)
 
-		t.Log("Waiting for the KongService to be marked as not programmed")
+		t.Logf("Waiting for the KongService %s/%s to be marked as not programmed", ns.Name, createdService.Name)
 		watchFor(t, t.Context(), w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
 			return ks.Name == createdService.Name &&
 				conditionsContainProgrammedFalse(ks.GetConditions()) &&
@@ -555,20 +535,10 @@ func TestKongService(t *testing.T) {
 
 		t.Log("Creating a KongService to adopt the existing service")
 		createdService := deploy.KongService(t, t.Context(), clientNamespaced, deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
-			func(obj client.Object) {
-				ks, ok := obj.(*configurationv1alpha1.KongService)
-				require.True(t, ok)
-				ks.Spec.URL = lo.ToPtr("https://example.com/example")
-				ks.Spec.Adopt = &commonv1alpha1.AdoptOptions{
-					From: commonv1alpha1.AdoptSourceKonnect,
-					Mode: commonv1alpha1.AdoptModeOverride,
-					Konnect: &commonv1alpha1.AdoptKonnectOptions{
-						ID: serviceKonnectID,
-					},
-				}
-			})
+			deploy.WithKonnectAdoptOptions[*configurationv1alpha1.KongService](commonv1alpha1.AdoptModeOverride, serviceKonnectID),
+		)
 
-		t.Log("Waiting for the KongService to be marked as not programmed")
+		t.Logf("Waiting for the KongService %s/%s to be marked as not programmed", ns.Name, createdService.Name)
 		watchFor(t, t.Context(), w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
 			return ks.Name == createdService.Name &&
 				conditionsContainProgrammedFalse(ks.GetConditions()) &&

--- a/test/envtest/konnect_entities_kongtarget_test.go
+++ b/test/envtest/konnect_entities_kongtarget_test.go
@@ -163,19 +163,10 @@ func TestKongTarget(t *testing.T) {
 
 		t.Logf("Creating a KongTarget to adopt the existing target (ID:%s)", targetID)
 		createdTarget := deploy.KongTargetAttachedToUpstream(t, ctx, clientNamespaced, upstream,
-			func(obj client.Object) {
-				kt, ok := obj.(*configurationv1alpha1.KongTarget)
-				require.True(t, ok)
-				kt.Spec.Adopt = &commonv1alpha1.AdoptOptions{
-					From: commonv1alpha1.AdoptSourceKonnect,
-					Mode: commonv1alpha1.AdoptModeOverride,
-					Konnect: &commonv1alpha1.AdoptKonnectOptions{
-						ID: targetID,
-					},
-				}
-			})
+			deploy.WithKonnectAdoptOptions[*configurationv1alpha1.KongTarget](commonv1alpha1.AdoptModeOverride, targetID),
+		)
 
-		t.Log("Waiting for KongTarget to set Konnect ID and programmed condition")
+		t.Logf("Waiting for KongTarget %s/%s to set Konnect ID and programmed condition", ns.Name, createdTarget.Name)
 		watchFor(t, ctx, w, apiwatch.Modified, func(kt *configurationv1alpha1.KongTarget) bool {
 			return createdTarget.Name == kt.Name &&
 				kt.GetKonnectID() == targetID && k8sutils.IsProgrammed(kt)

--- a/test/helpers/deploy/deploy_resources.go
+++ b/test/helpers/deploy/deploy_resources.go
@@ -1243,25 +1243,26 @@ func WithKonnectConfiguration[T ObjectSupportingKonnectConfiguration](
 	}
 }
 
-// AdoptOptionsOverrideModeWithID returns the adopt option with the override mode and the given ID.
-func AdoptOptionsOverrideModeWithID(id string) *commonv1alpha1.AdoptOptions {
-	return &commonv1alpha1.AdoptOptions{
-		From: commonv1alpha1.AdoptSourceKonnect,
-		Mode: commonv1alpha1.AdoptModeOverride,
-		Konnect: &commonv1alpha1.AdoptKonnectOptions{
-			ID: id,
-		},
-	}
+// ObjectSupportingAdoption defines the interface of types supporting adoption.
+type ObjectSupportingAdoption interface {
+	client.Object
+	SetAdoptOptions(*commonv1alpha1.AdoptOptions)
 }
 
-// AdoptOptionsMatchModeWithID returns the adopt option with the match mode and the given ID.
-func AdoptOptionsMatchModeWithID(id string) *commonv1alpha1.AdoptOptions {
-	return &commonv1alpha1.AdoptOptions{
-		From: commonv1alpha1.AdoptSourceKonnect,
-		Mode: commonv1alpha1.AdoptModeMatch,
-		Konnect: &commonv1alpha1.AdoptKonnectOptions{
-			ID: id,
-		},
+// WithKonnectAdoptOptions returns an option function that sets the adopt options to adopt from Konnect.
+func WithKonnectAdoptOptions[T ObjectSupportingAdoption](mode commonv1alpha1.AdoptMode, id string) ObjOption {
+	return func(obj client.Object) {
+		ent, ok := obj.(T)
+		if ok {
+			opts := &commonv1alpha1.AdoptOptions{
+				From: commonv1alpha1.AdoptSourceKonnect,
+				Mode: mode,
+				Konnect: &commonv1alpha1.AdoptKonnectOptions{
+					ID: id,
+				},
+			}
+			ent.SetAdoptOptions(opts)
+		}
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add envtest cases for adopting routes, upstreams and targets
**Which issue this PR fixes**

Part of #2545 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
