### PR TITLE
chore: use helm installed via mise

### DIFF
--- a/.github/workflows/charts-tests.yaml
+++ b/.github/workflows/charts-tests.yaml
@@ -139,10 +139,6 @@ jobs:
         with:
           install: false
 
-      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
-        with:
-           version: v3.19.2
-
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.13"
@@ -187,11 +183,6 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      - name: setup helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
-        with:
-           version: v3.19.2
 
       - uses: jdx/mise-action@9dc7d5dd454262207dea3ab5a06a3df6afc8ff26 # v3.4.1
         with:

--- a/.tools_versions.yaml
+++ b/.tools_versions.yaml
@@ -49,3 +49,5 @@ telepresence: "2.25.1"
 markdownlint-cli2: "0.18.1"
 # renovate: datasource=github-releases depName=cert-manager/cert-manager
 cert-manager: "1.19.1"
+# renovate: datasource=github-releases depName=helm/helm
+helm: "4.0.0"

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -55399,6 +55399,125 @@ spec:
             fieldRef:
               fieldPath: metadata.labels
 ---
+# Source: kong-operator/templates/validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: kong-operator
+    helm.sh/chart: kong-operator-1.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/version: "2.0"
+    app.kubernetes.io/component: ko
+  name: controlplane-configuration-validations
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - configuration.konghq.com
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kongconsumers
+    - kongconsumergroups
+    - kongplugins
+    - kongclusterplugins
+    - kongingresses
+    - kongvaults
+    scope: '*'
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+    scope: '*'
+  - apiGroups:
+    - gateway.networking.k8s.io
+    apiVersions:
+    - v1alpha2
+    - v1beta1
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gateways
+    - httproutes
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: secrets.validations.kong.konghq.com
+  objectSelector:
+    matchLabels:
+      konghq.com/secret: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: services.validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - services
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -55527,122 +55646,3 @@ metadata:
 spec:
   policyName: "autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
   validationActions: [Warn, Audit]
----
-# Source: kong-operator/templates/validating-webhook.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  labels:
-    app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0"
-    app.kubernetes.io/component: ko
-  name: controlplane-configuration-validations
-webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - configuration.konghq.com
-    apiVersions:
-    - '*'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - kongconsumers
-    - kongconsumergroups
-    - kongplugins
-    - kongclusterplugins
-    - kongingresses
-    - kongvaults
-    scope: '*'
-  - apiGroups:
-    - networking.k8s.io
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - ingresses
-    scope: '*'
-  - apiGroups:
-    - gateway.networking.k8s.io
-    apiVersions:
-    - v1alpha2
-    - v1beta1
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - gateways
-    - httproutes
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: secrets.validations.kong.konghq.com
-  objectSelector:
-    matchLabels:
-      konghq.com/secret: "true"
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - secrets
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: services.validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - services
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -55412,6 +55412,125 @@ spec:
             fieldRef:
               fieldPath: metadata.labels
 ---
+# Source: kong-operator/templates/validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: kong-operator
+    helm.sh/chart: kong-operator-1.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/version: "2.0"
+    app.kubernetes.io/component: ko
+  name: controlplane-configuration-validations
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - configuration.konghq.com
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kongconsumers
+    - kongconsumergroups
+    - kongplugins
+    - kongclusterplugins
+    - kongingresses
+    - kongvaults
+    scope: '*'
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+    scope: '*'
+  - apiGroups:
+    - gateway.networking.k8s.io
+    apiVersions:
+    - v1alpha2
+    - v1beta1
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gateways
+    - httproutes
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: secrets.validations.kong.konghq.com
+  objectSelector:
+    matchLabels:
+      konghq.com/secret: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: services.validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - services
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -55540,122 +55659,3 @@ metadata:
 spec:
   policyName: "autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
   validationActions: [Warn, Audit]
----
-# Source: kong-operator/templates/validating-webhook.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  labels:
-    app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0"
-    app.kubernetes.io/component: ko
-  name: controlplane-configuration-validations
-webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - configuration.konghq.com
-    apiVersions:
-    - '*'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - kongconsumers
-    - kongconsumergroups
-    - kongplugins
-    - kongclusterplugins
-    - kongingresses
-    - kongvaults
-    scope: '*'
-  - apiGroups:
-    - networking.k8s.io
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - ingresses
-    scope: '*'
-  - apiGroups:
-    - gateway.networking.k8s.io
-    apiVersions:
-    - v1alpha2
-    - v1beta1
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - gateways
-    - httproutes
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: secrets.validations.kong.konghq.com
-  objectSelector:
-    matchLabels:
-      konghq.com/secret: "true"
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - secrets
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: services.validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - services
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -55391,6 +55391,125 @@ spec:
             fieldRef:
               fieldPath: metadata.labels
 ---
+# Source: kong-operator/templates/validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: kong-operator
+    helm.sh/chart: kong-operator-1.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/version: "2.0"
+    app.kubernetes.io/component: ko
+  name: controlplane-configuration-validations
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - configuration.konghq.com
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kongconsumers
+    - kongconsumergroups
+    - kongplugins
+    - kongclusterplugins
+    - kongingresses
+    - kongvaults
+    scope: '*'
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+    scope: '*'
+  - apiGroups:
+    - gateway.networking.k8s.io
+    apiVersions:
+    - v1alpha2
+    - v1beta1
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gateways
+    - httproutes
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: secrets.validations.kong.konghq.com
+  objectSelector:
+    matchLabels:
+      konghq.com/secret: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: services.validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - services
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -55519,122 +55638,3 @@ metadata:
 spec:
   policyName: "autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
   validationActions: [Warn, Audit]
----
-# Source: kong-operator/templates/validating-webhook.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  labels:
-    app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0"
-    app.kubernetes.io/component: ko
-  name: controlplane-configuration-validations
-webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - configuration.konghq.com
-    apiVersions:
-    - '*'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - kongconsumers
-    - kongconsumergroups
-    - kongplugins
-    - kongclusterplugins
-    - kongingresses
-    - kongvaults
-    scope: '*'
-  - apiGroups:
-    - networking.k8s.io
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - ingresses
-    scope: '*'
-  - apiGroups:
-    - gateway.networking.k8s.io
-    apiVersions:
-    - v1alpha2
-    - v1beta1
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - gateways
-    - httproutes
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: secrets.validations.kong.konghq.com
-  objectSelector:
-    matchLabels:
-      konghq.com/secret: "true"
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - secrets
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: services.validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - services
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -55393,6 +55393,125 @@ spec:
             fieldRef:
               fieldPath: metadata.labels
 ---
+# Source: kong-operator/templates/validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: kong-operator
+    helm.sh/chart: kong-operator-1.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/version: "2.0"
+    app.kubernetes.io/component: ko
+  name: controlplane-configuration-validations
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - configuration.konghq.com
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kongconsumers
+    - kongconsumergroups
+    - kongplugins
+    - kongclusterplugins
+    - kongingresses
+    - kongvaults
+    scope: '*'
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+    scope: '*'
+  - apiGroups:
+    - gateway.networking.k8s.io
+    apiVersions:
+    - v1alpha2
+    - v1beta1
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gateways
+    - httproutes
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: secrets.validations.kong.konghq.com
+  objectSelector:
+    matchLabels:
+      konghq.com/secret: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: services.validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - services
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -55521,122 +55640,3 @@ metadata:
 spec:
   policyName: "autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
   validationActions: [Warn, Audit]
----
-# Source: kong-operator/templates/validating-webhook.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  labels:
-    app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0"
-    app.kubernetes.io/component: ko
-  name: controlplane-configuration-validations
-webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - configuration.konghq.com
-    apiVersions:
-    - '*'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - kongconsumers
-    - kongconsumergroups
-    - kongplugins
-    - kongclusterplugins
-    - kongingresses
-    - kongvaults
-    scope: '*'
-  - apiGroups:
-    - networking.k8s.io
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - ingresses
-    scope: '*'
-  - apiGroups:
-    - gateway.networking.k8s.io
-    apiVersions:
-    - v1alpha2
-    - v1beta1
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - gateways
-    - httproutes
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: secrets.validations.kong.konghq.com
-  objectSelector:
-    matchLabels:
-      konghq.com/secret: "true"
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - secrets
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: services.validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - services
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -55393,6 +55393,125 @@ spec:
             fieldRef:
               fieldPath: metadata.labels
 ---
+# Source: kong-operator/templates/validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: kong-operator
+    helm.sh/chart: kong-operator-1.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/version: "2.0"
+    app.kubernetes.io/component: ko
+  name: controlplane-configuration-validations
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - configuration.konghq.com
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kongconsumers
+    - kongconsumergroups
+    - kongplugins
+    - kongclusterplugins
+    - kongingresses
+    - kongvaults
+    scope: '*'
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+    scope: '*'
+  - apiGroups:
+    - gateway.networking.k8s.io
+    apiVersions:
+    - v1alpha2
+    - v1beta1
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gateways
+    - httproutes
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: secrets.validations.kong.konghq.com
+  objectSelector:
+    matchLabels:
+      konghq.com/secret: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: services.validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - services
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -55521,122 +55640,3 @@ metadata:
 spec:
   policyName: "autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
   validationActions: [Warn, Audit]
----
-# Source: kong-operator/templates/validating-webhook.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  labels:
-    app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0"
-    app.kubernetes.io/component: ko
-  name: controlplane-configuration-validations
-webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - configuration.konghq.com
-    apiVersions:
-    - '*'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - kongconsumers
-    - kongconsumergroups
-    - kongplugins
-    - kongclusterplugins
-    - kongingresses
-    - kongvaults
-    scope: '*'
-  - apiGroups:
-    - networking.k8s.io
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - ingresses
-    scope: '*'
-  - apiGroups:
-    - gateway.networking.k8s.io
-    apiVersions:
-    - v1alpha2
-    - v1beta1
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - gateways
-    - httproutes
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: secrets.validations.kong.konghq.com
-  objectSelector:
-    matchLabels:
-      konghq.com/secret: "true"
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - secrets
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: services.validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - services
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -55392,6 +55392,126 @@ spec:
             fieldRef:
               fieldPath: metadata.labels
 ---
+# Source: kong-operator/templates/validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: kong-operator
+    helm.sh/chart: kong-operator-1.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/version: "2.0"
+    a: "b"
+    app.kubernetes.io/component: ko
+  name: controlplane-configuration-validations
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - configuration.konghq.com
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kongconsumers
+    - kongconsumergroups
+    - kongplugins
+    - kongclusterplugins
+    - kongingresses
+    - kongvaults
+    scope: '*'
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+    scope: '*'
+  - apiGroups:
+    - gateway.networking.k8s.io
+    apiVersions:
+    - v1alpha2
+    - v1beta1
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gateways
+    - httproutes
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: secrets.validations.kong.konghq.com
+  objectSelector:
+    matchLabels:
+      konghq.com/secret: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: services.validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - services
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -55520,123 +55640,3 @@ metadata:
 spec:
   policyName: "autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
   validationActions: [Warn, Audit]
----
-# Source: kong-operator/templates/validating-webhook.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  labels:
-    app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0"
-    a: "b"
-    app.kubernetes.io/component: ko
-  name: controlplane-configuration-validations
-webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - configuration.konghq.com
-    apiVersions:
-    - '*'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - kongconsumers
-    - kongconsumergroups
-    - kongplugins
-    - kongclusterplugins
-    - kongingresses
-    - kongvaults
-    scope: '*'
-  - apiGroups:
-    - networking.k8s.io
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - ingresses
-    scope: '*'
-  - apiGroups:
-    - gateway.networking.k8s.io
-    apiVersions:
-    - v1alpha2
-    - v1beta1
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - gateways
-    - httproutes
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: secrets.validations.kong.konghq.com
-  objectSelector:
-    matchLabels:
-      konghq.com/secret: "true"
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - secrets
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: services.validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - services
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -55391,6 +55391,125 @@ spec:
             fieldRef:
               fieldPath: metadata.labels
 ---
+# Source: kong-operator/templates/validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: kong-operator
+    helm.sh/chart: kong-operator-1.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/version: "2.0"
+    app.kubernetes.io/component: ko
+  name: controlplane-configuration-validations
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - configuration.konghq.com
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kongconsumers
+    - kongconsumergroups
+    - kongplugins
+    - kongclusterplugins
+    - kongingresses
+    - kongvaults
+    scope: '*'
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+    scope: '*'
+  - apiGroups:
+    - gateway.networking.k8s.io
+    apiVersions:
+    - v1alpha2
+    - v1beta1
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gateways
+    - httproutes
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: secrets.validations.kong.konghq.com
+  objectSelector:
+    matchLabels:
+      konghq.com/secret: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: services.validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - services
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -55519,122 +55638,3 @@ metadata:
 spec:
   policyName: "autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
   validationActions: [Warn, Audit]
----
-# Source: kong-operator/templates/validating-webhook.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  labels:
-    app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0"
-    app.kubernetes.io/component: ko
-  name: controlplane-configuration-validations
-webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - configuration.konghq.com
-    apiVersions:
-    - '*'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - kongconsumers
-    - kongconsumergroups
-    - kongplugins
-    - kongclusterplugins
-    - kongingresses
-    - kongvaults
-    scope: '*'
-  - apiGroups:
-    - networking.k8s.io
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - ingresses
-    scope: '*'
-  - apiGroups:
-    - gateway.networking.k8s.io
-    apiVersions:
-    - v1alpha2
-    - v1beta1
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - gateways
-    - httproutes
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: secrets.validations.kong.konghq.com
-  objectSelector:
-    matchLabels:
-      konghq.com/secret: "true"
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - secrets
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: services.validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - services
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -55389,6 +55389,125 @@ spec:
             fieldRef:
               fieldPath: metadata.labels
 ---
+# Source: kong-operator/templates/validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: kong-operator
+    helm.sh/chart: kong-operator-1.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/version: "2.0"
+    app.kubernetes.io/component: ko
+  name: controlplane-configuration-validations
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - configuration.konghq.com
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kongconsumers
+    - kongconsumergroups
+    - kongplugins
+    - kongclusterplugins
+    - kongingresses
+    - kongvaults
+    scope: '*'
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+    scope: '*'
+  - apiGroups:
+    - gateway.networking.k8s.io
+    apiVersions:
+    - v1alpha2
+    - v1beta1
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gateways
+    - httproutes
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: secrets.validations.kong.konghq.com
+  objectSelector:
+    matchLabels:
+      konghq.com/secret: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: services.validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - services
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -55517,122 +55636,3 @@ metadata:
 spec:
   policyName: "autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
   validationActions: [Warn, Audit]
----
-# Source: kong-operator/templates/validating-webhook.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  labels:
-    app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0"
-    app.kubernetes.io/component: ko
-  name: controlplane-configuration-validations
-webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - configuration.konghq.com
-    apiVersions:
-    - '*'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - kongconsumers
-    - kongconsumergroups
-    - kongplugins
-    - kongclusterplugins
-    - kongingresses
-    - kongvaults
-    scope: '*'
-  - apiGroups:
-    - networking.k8s.io
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - ingresses
-    scope: '*'
-  - apiGroups:
-    - gateway.networking.k8s.io
-    apiVersions:
-    - v1alpha2
-    - v1beta1
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - gateways
-    - httproutes
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: secrets.validations.kong.konghq.com
-  objectSelector:
-    matchLabels:
-      konghq.com/secret: "true"
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - secrets
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: services.validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - services
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -55390,6 +55390,125 @@ spec:
             fieldRef:
               fieldPath: metadata.labels
 ---
+# Source: kong-operator/templates/validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: kong-operator
+    helm.sh/chart: kong-operator-1.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/version: "2.0"
+    app.kubernetes.io/component: ko
+  name: controlplane-configuration-validations
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - configuration.konghq.com
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kongconsumers
+    - kongconsumergroups
+    - kongplugins
+    - kongclusterplugins
+    - kongingresses
+    - kongvaults
+    scope: '*'
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+    scope: '*'
+  - apiGroups:
+    - gateway.networking.k8s.io
+    apiVersions:
+    - v1alpha2
+    - v1beta1
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gateways
+    - httproutes
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: secrets.validations.kong.konghq.com
+  objectSelector:
+    matchLabels:
+      konghq.com/secret: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: services.validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - services
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -55518,122 +55637,3 @@ metadata:
 spec:
   policyName: "autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
   validationActions: [Warn, Audit]
----
-# Source: kong-operator/templates/validating-webhook.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  labels:
-    app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0"
-    app.kubernetes.io/component: ko
-  name: controlplane-configuration-validations
-webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - configuration.konghq.com
-    apiVersions:
-    - '*'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - kongconsumers
-    - kongconsumergroups
-    - kongplugins
-    - kongclusterplugins
-    - kongingresses
-    - kongvaults
-    scope: '*'
-  - apiGroups:
-    - networking.k8s.io
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - ingresses
-    scope: '*'
-  - apiGroups:
-    - gateway.networking.k8s.io
-    apiVersions:
-    - v1alpha2
-    - v1beta1
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - gateways
-    - httproutes
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: secrets.validations.kong.konghq.com
-  objectSelector:
-    matchLabels:
-      konghq.com/secret: "true"
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - secrets
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: services.validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - services
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -55391,6 +55391,125 @@ spec:
             fieldRef:
               fieldPath: metadata.labels
 ---
+# Source: kong-operator/templates/validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: kong-operator
+    helm.sh/chart: kong-operator-1.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/version: "2.0"
+    app.kubernetes.io/component: ko
+  name: controlplane-configuration-validations
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - configuration.konghq.com
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kongconsumers
+    - kongconsumergroups
+    - kongplugins
+    - kongclusterplugins
+    - kongingresses
+    - kongvaults
+    scope: '*'
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+    scope: '*'
+  - apiGroups:
+    - gateway.networking.k8s.io
+    apiVersions:
+    - v1alpha2
+    - v1beta1
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gateways
+    - httproutes
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: secrets.validations.kong.konghq.com
+  objectSelector:
+    matchLabels:
+      konghq.com/secret: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: services.validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - services
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -55519,122 +55638,3 @@ metadata:
 spec:
   policyName: "autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
   validationActions: [Warn, Audit]
----
-# Source: kong-operator/templates/validating-webhook.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  labels:
-    app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0"
-    app.kubernetes.io/component: ko
-  name: controlplane-configuration-validations
-webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - configuration.konghq.com
-    apiVersions:
-    - '*'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - kongconsumers
-    - kongconsumergroups
-    - kongplugins
-    - kongclusterplugins
-    - kongingresses
-    - kongvaults
-    scope: '*'
-  - apiGroups:
-    - networking.k8s.io
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - ingresses
-    scope: '*'
-  - apiGroups:
-    - gateway.networking.k8s.io
-    apiVersions:
-    - v1alpha2
-    - v1beta1
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - gateways
-    - httproutes
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: secrets.validations.kong.konghq.com
-  objectSelector:
-    matchLabels:
-      konghq.com/secret: "true"
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - secrets
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: services.validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - services
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -55393,6 +55393,125 @@ spec:
             fieldRef:
               fieldPath: metadata.labels
 ---
+# Source: kong-operator/templates/validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: kong-operator
+    helm.sh/chart: kong-operator-1.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/version: "2.0"
+    app.kubernetes.io/component: ko
+  name: controlplane-configuration-validations
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - configuration.konghq.com
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kongconsumers
+    - kongconsumergroups
+    - kongplugins
+    - kongclusterplugins
+    - kongingresses
+    - kongvaults
+    scope: '*'
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+    scope: '*'
+  - apiGroups:
+    - gateway.networking.k8s.io
+    apiVersions:
+    - v1alpha2
+    - v1beta1
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gateways
+    - httproutes
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: secrets.validations.kong.konghq.com
+  objectSelector:
+    matchLabels:
+      konghq.com/secret: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: services.validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - services
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -55521,122 +55640,3 @@ metadata:
 spec:
   policyName: "autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
   validationActions: [Warn, Audit]
----
-# Source: kong-operator/templates/validating-webhook.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  labels:
-    app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0"
-    app.kubernetes.io/component: ko
-  name: controlplane-configuration-validations
-webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - configuration.konghq.com
-    apiVersions:
-    - '*'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - kongconsumers
-    - kongconsumergroups
-    - kongplugins
-    - kongclusterplugins
-    - kongingresses
-    - kongvaults
-    scope: '*'
-  - apiGroups:
-    - networking.k8s.io
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - ingresses
-    scope: '*'
-  - apiGroups:
-    - gateway.networking.k8s.io
-    apiVersions:
-    - v1alpha2
-    - v1beta1
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - gateways
-    - httproutes
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: secrets.validations.kong.konghq.com
-  objectSelector:
-    matchLabels:
-      konghq.com/secret: "true"
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - secrets
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: services.validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - services
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -55389,41 +55389,6 @@ spec:
             fieldRef:
               fieldPath: metadata.labels
 ---
-# Source: kong-operator/templates/validation-policy-konnect.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingAdmissionPolicy
-metadata:
-  name: "autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
-spec:
-  failurePolicy: Fail
-  matchConstraints:
-    resourceRules:
-    - apiGroups:
-      - "konnect.konghq.com"
-      apiVersions:
-      - "v1alpha1"
-      operations:
-      - "CREATE"
-      - "UPDATE"
-      resources:
-      - "konnectcloudgatewaydataplanegroupconfigurations"
-      # NOTE: field-level deprecations via Kubebuilder annotations do not generate any warning to the
-      # users when the deprecated field is used.
-      # Until this is not fixed we need a ValidatingAdmissionPolicy to emit the warning.
-      # Upstream issue: https://github.com/kubernetes/kubernetes/issues/131817
-  validations:
-  - expression: object.spec.dataplane_groups.all(d, d.autoscale.type != "static")
-    message: '''Value "static" in spec.dataplane_groups.autoscale.type is deprecated, use "automatic" instead.'''
----
-# Source: kong-operator/templates/validation-policy-konnect.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingAdmissionPolicyBinding
-metadata:
-  name: "biding-autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
-spec:
-  policyName: "autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
-  validationActions: [Warn, Audit]
----
 # Source: kong-operator/templates/validating-webhook.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -55542,3 +55507,38 @@ webhooks:
     scope: '*'
   sideEffects: None
   timeoutSeconds: 10
+---
+# Source: kong-operator/templates/validation-policy-konnect.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - "konnect.konghq.com"
+      apiVersions:
+      - "v1alpha1"
+      operations:
+      - "CREATE"
+      - "UPDATE"
+      resources:
+      - "konnectcloudgatewaydataplanegroupconfigurations"
+      # NOTE: field-level deprecations via Kubebuilder annotations do not generate any warning to the
+      # users when the deprecated field is used.
+      # Until this is not fixed we need a ValidatingAdmissionPolicy to emit the warning.
+      # Upstream issue: https://github.com/kubernetes/kubernetes/issues/131817
+  validations:
+  - expression: object.spec.dataplane_groups.all(d, d.autoscale.type != "static")
+    message: '''Value "static" in spec.dataplane_groups.autoscale.type is deprecated, use "automatic" instead.'''
+---
+# Source: kong-operator/templates/validation-policy-konnect.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "biding-autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
+spec:
+  policyName: "autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
+  validationActions: [Warn, Audit]

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -30187,6 +30187,125 @@ spec:
             fieldRef:
               fieldPath: metadata.labels
 ---
+# Source: kong-operator/templates/validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: kong-operator
+    helm.sh/chart: kong-operator-1.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/version: "2.0"
+    app.kubernetes.io/component: ko
+  name: controlplane-configuration-validations
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - configuration.konghq.com
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kongconsumers
+    - kongconsumergroups
+    - kongplugins
+    - kongclusterplugins
+    - kongingresses
+    - kongvaults
+    scope: '*'
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+    scope: '*'
+  - apiGroups:
+    - gateway.networking.k8s.io
+    apiVersions:
+    - v1alpha2
+    - v1beta1
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gateways
+    - httproutes
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: secrets.validations.kong.konghq.com
+  objectSelector:
+    matchLabels:
+      konghq.com/secret: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: |-
+      ###DYNAMIC_FIELD###
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: services.validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - services
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
 # Source: kong-operator/templates/validation-policy-dataplane.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -30315,122 +30434,3 @@ metadata:
 spec:
   policyName: "autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
   validationActions: [Warn, Audit]
----
-# Source: kong-operator/templates/validating-webhook.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  labels:
-    app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0"
-    app.kubernetes.io/component: ko
-  name: controlplane-configuration-validations
-webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - configuration.konghq.com
-    apiVersions:
-    - '*'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - kongconsumers
-    - kongconsumergroups
-    - kongplugins
-    - kongclusterplugins
-    - kongingresses
-    - kongvaults
-    scope: '*'
-  - apiGroups:
-    - networking.k8s.io
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - ingresses
-    scope: '*'
-  - apiGroups:
-    - gateway.networking.k8s.io
-    apiVersions:
-    - v1alpha2
-    - v1beta1
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - gateways
-    - httproutes
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: secrets.validations.kong.konghq.com
-  objectSelector:
-    matchLabels:
-      konghq.com/secret: "true"
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - secrets
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: |-
-      ###DYNAMIC_FIELD###
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: services.validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - services
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -55339,6 +55339,125 @@ spec:
             fieldRef:
               fieldPath: metadata.labels
 ---
+# Source: kong-operator/templates/validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: default/chartsnap-kong-operator-webhook-validating-serving-cert
+    cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "internal" } }'
+  labels:
+    app.kubernetes.io/name: kong-operator
+    helm.sh/chart: kong-operator-1.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/version: "2.0"
+    app.kubernetes.io/component: ko
+  name: controlplane-configuration-validations
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: '###DYNAMIC_FIELD###'
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - configuration.konghq.com
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kongconsumers
+    - kongconsumergroups
+    - kongplugins
+    - kongclusterplugins
+    - kongingresses
+    - kongvaults
+    scope: '*'
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+    scope: '*'
+  - apiGroups:
+    - gateway.networking.k8s.io
+    apiVersions:
+    - v1alpha2
+    - v1beta1
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gateways
+    - httproutes
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: '###DYNAMIC_FIELD###'
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: secrets.validations.kong.konghq.com
+  objectSelector:
+    matchLabels:
+      konghq.com/secret: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: chartsnap-kong-operator-webhook
+      namespace: default
+      port: 5443
+    caBundle: '###DYNAMIC_FIELD###'
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: services.validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - services
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
 # Source: kong-operator/templates/certs-cert-manager.yaml
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -55524,122 +55643,3 @@ metadata:
 spec:
   policyName: "autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
   validationActions: [Warn, Audit]
----
-# Source: kong-operator/templates/validating-webhook.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: default/chartsnap-kong-operator-webhook-validating-serving-cert
-    cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "internal" } }'
-  labels:
-    app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/version: "2.0"
-    app.kubernetes.io/component: ko
-  name: controlplane-configuration-validations
-webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: '###DYNAMIC_FIELD###'
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - configuration.konghq.com
-    apiVersions:
-    - '*'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - kongconsumers
-    - kongconsumergroups
-    - kongplugins
-    - kongclusterplugins
-    - kongingresses
-    - kongvaults
-    scope: '*'
-  - apiGroups:
-    - networking.k8s.io
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - ingresses
-    scope: '*'
-  - apiGroups:
-    - gateway.networking.k8s.io
-    apiVersions:
-    - v1alpha2
-    - v1beta1
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - gateways
-    - httproutes
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: '###DYNAMIC_FIELD###'
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: secrets.validations.kong.konghq.com
-  objectSelector:
-    matchLabels:
-      konghq.com/secret: "true"
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - secrets
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: chartsnap-kong-operator-webhook
-      namespace: default
-      port: 5443
-    caBundle: '###DYNAMIC_FIELD###'
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: services.validations.kong.konghq.com
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - services
-    scope: '*'
-  sideEffects: None
-  timeoutSeconds: 10

--- a/scripts/install-chartsnap.sh
+++ b/scripts/install-chartsnap.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 if [ -z "${CHARTSNAP_VERSION}" ]; then
   echo "ERROR: CHARTSNAP_VERSION is not set"
   exit 1
 fi
 
-HELM_VERSION_MAJOR=$(helm version --template='{{.Version}}' | sed -E 's/^v([0-9]+)\..*/\1/')
+if [ -z "${HELM}" ]; then
+  echo "ERROR: HELM is not set"
+  exit 1
+fi
+
+HELM_VERSION_MAJOR=$(${HELM} version --template='{{.Version}}' | sed -E 's/^v([0-9]+)\..*/\1/')
 HELM_PLUGIN_INSTALL_OPTS=""
 if [ "${HELM_VERSION_MAJOR}" -eq 4 ]; then
   HELM_PLUGIN_INSTALL_OPTS="--verify=false"
@@ -14,15 +21,15 @@ fi
 echo "INFO: Helm version detected: ${HELM_VERSION_MAJOR}"
 
 # Only install the plugin if it is not already installed or if the version is different.
-if [[ $(helm plugin list | grep chartsnap | grep -Eo '[0-9]{1,}.[0-9]{1,}.[0-9]{1,}') == "${CHARTSNAP_VERSION}" ]]; then
+if [[ $(${HELM} plugin list | grep chartsnap | grep -Eo '[0-9]{1,}.[0-9]{1,}.[0-9]{1,}') == "${CHARTSNAP_VERSION}" ]]; then
   echo "INFO: chartsnap plugin is already installed and up to date"
 else
   echo "INFO: Installing chartsnap plugin"
-  if [ "$(helm plugin list | grep -ic chartsnap)" -eq 1 ]; then
+  if [ "$(${HELM} plugin list | grep -ic chartsnap)" -eq 1 ]; then
     echo "INFO: Uninstalling existing chartsnap plugin - version mismatch"
-    helm plugin uninstall chartsnap
+    ${HELM} plugin uninstall chartsnap
   fi
-  helm plugin install ${HELM_PLUGIN_INSTALL_OPTS} \
+  ${HELM} plugin install ${HELM_PLUGIN_INSTALL_OPTS} \
     https://github.com/jlandowner/helm-chartsnap \
     --version "${CHARTSNAP_VERSION}"
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

To ensure uniform `helm` version across all environments, use `mise` to enforce the same version.

This PR also sets the default helm version used to 4.0.0.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
