### PR TITLE
tests: use default ExpectedErrorEventuallyConfig which has longer timeout

### DIFF
--- a/test/crdsvalidation/konnect.konghq.com/konnectextension_test.go
+++ b/test/crdsvalidation/konnect.konghq.com/konnectextension_test.go
@@ -2,7 +2,6 @@ package crdsvalidation_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/samber/lo"
 
@@ -51,9 +50,6 @@ func TestKonnectExtension(t *testing.T) {
 			},
 			{
 				Name: "konnect controlplane, manual provisioning, secret",
-				ExpectedErrorEventuallyConfig: common.EventuallyConfig{
-					Timeout: 1 * time.Second,
-				},
 				TestObject: &konnectv1alpha2.KonnectExtension{
 					ObjectMeta: common.CommonObjectMeta(ns.Name),
 					Spec: konnectv1alpha2.KonnectExtensionSpec{
@@ -80,9 +76,6 @@ func TestKonnectExtension(t *testing.T) {
 			},
 			{
 				Name: "konnect controlplane, manual provisioning, no secret",
-				ExpectedErrorEventuallyConfig: common.EventuallyConfig{
-					Timeout: 1 * time.Second,
-				},
 				TestObject: &konnectv1alpha2.KonnectExtension{
 					ObjectMeta: common.CommonObjectMeta(ns.Name),
 					Spec: konnectv1alpha2.KonnectExtensionSpec{
@@ -107,9 +100,6 @@ func TestKonnectExtension(t *testing.T) {
 			},
 			{
 				Name: "konnect controlplane, automatic provisioning, secret",
-				ExpectedErrorEventuallyConfig: common.EventuallyConfig{
-					Timeout: 1 * time.Second,
-				},
 				TestObject: &konnectv1alpha2.KonnectExtension{
 					ObjectMeta: common.CommonObjectMeta(ns.Name),
 					Spec: konnectv1alpha2.KonnectExtensionSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Possibly fix https://github.com/Kong/kong-operator/issues/2586

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
