### PR TITLE
feat(hybridgateway): add ReferenceGrant watch support for HTTPRoute

### DIFF
--- a/controller/hybridgateway/controller.go
+++ b/controller/hybridgateway/controller.go
@@ -103,7 +103,7 @@ func (r *HybridGatewayReconciler[t, tPtr]) SetupWithManager(ctx context.Context,
 	}
 
 	// Add watches for other resources.
-	for _, w := range watch.Watches(obj, r.Client) {
+	for _, w := range watch.Watches(obj, r.Client, r.referenceGrantEnabled) {
 		builder = builder.Watches(w.Object, handler.EnqueueRequestsFromMapFunc(w.MapFunc))
 	}
 

--- a/controller/hybridgateway/watch/mapfuncs.go
+++ b/controller/hybridgateway/watch/mapfuncs.go
@@ -191,12 +191,8 @@ func MapHTTPRouteForReferenceGrant(cl client.Client) handler.MapFunc {
 				hasCrossNamespaceRef := false
 				for _, rule := range httpRoute.Spec.Rules {
 					for _, backendRef := range rule.BackendRefs {
-						ns := httpRoute.Namespace
-						if backendRef.Namespace != nil {
-							ns = string(*backendRef.Namespace)
-						}
 						// The backend must be in the ReferenceGrant's namespace (target namespace).
-						if ns == rg.Namespace && ns != httpRoute.Namespace {
+						if backendRef.Namespace != nil && string(*backendRef.Namespace) == rg.Namespace && httpRoute.Namespace != rg.Namespace {
 							hasCrossNamespaceRef = true
 							break
 						}

--- a/controller/hybridgateway/watch/watch.go
+++ b/controller/hybridgateway/watch/watch.go
@@ -18,10 +18,10 @@ type Watcher struct {
 }
 
 // Watches returns a list of Watcher objects for the given resource type.
-func Watches(obj client.Object, cl client.Client) []Watcher {
+func Watches(obj client.Object, cl client.Client, referenceGrantEnabled bool) []Watcher {
 	switch obj.(type) {
 	case *gwtypes.HTTPRoute:
-		return []Watcher{
+		watcher := []Watcher{
 			{
 				&gwtypes.Gateway{},
 				MapHTTPRouteForGateway(cl),
@@ -39,6 +39,14 @@ func Watches(obj client.Object, cl client.Client) []Watcher {
 				MapHTTPRouteForEndpointSlice(cl),
 			},
 		}
+
+		if referenceGrantEnabled {
+			watcher = append(watcher, Watcher{
+				&gwtypes.ReferenceGrant{},
+				MapHTTPRouteForReferenceGrant(cl),
+			})
+		}
+		return watcher
 	default:
 		return nil
 	}

--- a/internal/types/gatewaytypes.go
+++ b/internal/types/gatewaytypes.go
@@ -36,6 +36,7 @@ type (
 	ParametersReference    = gatewayv1.ParametersReference
 	ParentReference        = gatewayv1.ParentReference
 	PortNumber             = gatewayv1.PortNumber
+	ReferenceGrant         = gatewayv1beta1.ReferenceGrant
 	ReferenceGrantList     = gatewayv1beta1.ReferenceGrantList
 	ReferenceGrantSpec     = gatewayv1beta1.ReferenceGrantSpec
 	RouteGroupKind         = gatewayv1.RouteGroupKind


### PR DESCRIPTION
**What this PR does / why we need it**:

Add conditional ReferenceGrant watching for HTTPRoute controller to trigger reconciliation when ReferenceGrants that permit cross-namespace backend references change.

This enables the controller to react to ReferenceGrant changes that affect cross-namespace backend reference permissions.

**Which issue this PR fixes**

Fixes #2582 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
