### PR TITLE
feat(konnectextension): use managed KongDataPlaneClientCertificate in KonnectExtension reconciler

### DIFF
--- a/api/gateway-operator/v2beta1/zz_generated_list_funcs.go
+++ b/api/gateway-operator/v2beta1/zz_generated_list_funcs.go
@@ -6,3 +6,8 @@ package v2beta1
 func (obj GatewayConfigurationList) GetItems() []GatewayConfiguration {
 	return obj.Items
 }
+
+// GetItems returns the list of ControlPlane items.
+func (obj ControlPlaneList) GetItems() []ControlPlane {
+	return obj.Items
+}

--- a/api/konnect/v1alpha1/konnect_conditions.go
+++ b/api/konnect/v1alpha1/konnect_conditions.go
@@ -181,6 +181,10 @@ const (
 	// used with the DataPlaneCertificateProvisioned condition type indicating that the
 	// the DataPlane client certificate creation in Konnect has failed.
 	DataPlaneCertificateProvisionedReasonKonnectAPIOpFailed = "KonnectAPIOpFailed"
+	// DataPlaneCertificateProvisionedReasonProvisioning is the reason
+	// used with the DataPlaneCertificateProvisioned condition type indicating that the
+	// the DataPlane client certificate creation in Konnect is in progress.
+	DataPlaneCertificateProvisionedReasonProvisioning = "Provisioning"
 )
 
 const (

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -56792,7 +56792,7 @@ rules:
   - kongcertificates
   - kongconsumergroups
   - kongconsumers
-  - kongdataplaneclientcertificates
+  - kongdataplaneclientcertificates/status
   - kongkeys
   - kongkeysets
   - kongsnis
@@ -56823,7 +56823,6 @@ rules:
   - kongcredentialjwts/finalizers
   - kongcredentialjwts/status
   - kongdataplaneclientcertificates/finalizers
-  - kongdataplaneclientcertificates/status
   - kongkeys/finalizers
   - kongkeys/status
   - kongkeysets/finalizers
@@ -56866,6 +56865,7 @@ rules:
   - kongcredentialbasicauths
   - kongcredentialhmacs
   - kongcredentialjwts
+  - kongdataplaneclientcertificates
   - kongpluginbindings
   - kongplugins
   - kongroutes

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -56792,7 +56792,7 @@ rules:
   - kongcertificates
   - kongconsumergroups
   - kongconsumers
-  - kongdataplaneclientcertificates
+  - kongdataplaneclientcertificates/status
   - kongkeys
   - kongkeysets
   - kongsnis
@@ -56823,7 +56823,6 @@ rules:
   - kongcredentialjwts/finalizers
   - kongcredentialjwts/status
   - kongdataplaneclientcertificates/finalizers
-  - kongdataplaneclientcertificates/status
   - kongkeys/finalizers
   - kongkeys/status
   - kongkeysets/finalizers
@@ -56866,6 +56865,7 @@ rules:
   - kongcredentialbasicauths
   - kongcredentialhmacs
   - kongcredentialjwts
+  - kongdataplaneclientcertificates
   - kongpluginbindings
   - kongplugins
   - kongroutes

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -56792,7 +56792,7 @@ rules:
   - kongcertificates
   - kongconsumergroups
   - kongconsumers
-  - kongdataplaneclientcertificates
+  - kongdataplaneclientcertificates/status
   - kongkeys
   - kongkeysets
   - kongsnis
@@ -56823,7 +56823,6 @@ rules:
   - kongcredentialjwts/finalizers
   - kongcredentialjwts/status
   - kongdataplaneclientcertificates/finalizers
-  - kongdataplaneclientcertificates/status
   - kongkeys/finalizers
   - kongkeys/status
   - kongkeysets/finalizers
@@ -56866,6 +56865,7 @@ rules:
   - kongcredentialbasicauths
   - kongcredentialhmacs
   - kongcredentialjwts
+  - kongdataplaneclientcertificates
   - kongpluginbindings
   - kongplugins
   - kongroutes

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -56792,7 +56792,7 @@ rules:
   - kongcertificates
   - kongconsumergroups
   - kongconsumers
-  - kongdataplaneclientcertificates
+  - kongdataplaneclientcertificates/status
   - kongkeys
   - kongkeysets
   - kongsnis
@@ -56823,7 +56823,6 @@ rules:
   - kongcredentialjwts/finalizers
   - kongcredentialjwts/status
   - kongdataplaneclientcertificates/finalizers
-  - kongdataplaneclientcertificates/status
   - kongkeys/finalizers
   - kongkeys/status
   - kongkeysets/finalizers
@@ -56866,6 +56865,7 @@ rules:
   - kongcredentialbasicauths
   - kongcredentialhmacs
   - kongcredentialjwts
+  - kongdataplaneclientcertificates
   - kongpluginbindings
   - kongplugins
   - kongroutes

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -56792,7 +56792,7 @@ rules:
   - kongcertificates
   - kongconsumergroups
   - kongconsumers
-  - kongdataplaneclientcertificates
+  - kongdataplaneclientcertificates/status
   - kongkeys
   - kongkeysets
   - kongsnis
@@ -56823,7 +56823,6 @@ rules:
   - kongcredentialjwts/finalizers
   - kongcredentialjwts/status
   - kongdataplaneclientcertificates/finalizers
-  - kongdataplaneclientcertificates/status
   - kongkeys/finalizers
   - kongkeys/status
   - kongkeysets/finalizers
@@ -56866,6 +56865,7 @@ rules:
   - kongcredentialbasicauths
   - kongcredentialhmacs
   - kongcredentialjwts
+  - kongdataplaneclientcertificates
   - kongpluginbindings
   - kongplugins
   - kongroutes

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -56793,7 +56793,7 @@ rules:
   - kongcertificates
   - kongconsumergroups
   - kongconsumers
-  - kongdataplaneclientcertificates
+  - kongdataplaneclientcertificates/status
   - kongkeys
   - kongkeysets
   - kongsnis
@@ -56824,7 +56824,6 @@ rules:
   - kongcredentialjwts/finalizers
   - kongcredentialjwts/status
   - kongdataplaneclientcertificates/finalizers
-  - kongdataplaneclientcertificates/status
   - kongkeys/finalizers
   - kongkeys/status
   - kongkeysets/finalizers
@@ -56867,6 +56866,7 @@ rules:
   - kongcredentialbasicauths
   - kongcredentialhmacs
   - kongcredentialjwts
+  - kongdataplaneclientcertificates
   - kongpluginbindings
   - kongplugins
   - kongroutes

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -56792,7 +56792,7 @@ rules:
   - kongcertificates
   - kongconsumergroups
   - kongconsumers
-  - kongdataplaneclientcertificates
+  - kongdataplaneclientcertificates/status
   - kongkeys
   - kongkeysets
   - kongsnis
@@ -56823,7 +56823,6 @@ rules:
   - kongcredentialjwts/finalizers
   - kongcredentialjwts/status
   - kongdataplaneclientcertificates/finalizers
-  - kongdataplaneclientcertificates/status
   - kongkeys/finalizers
   - kongkeys/status
   - kongkeysets/finalizers
@@ -56866,6 +56865,7 @@ rules:
   - kongcredentialbasicauths
   - kongcredentialhmacs
   - kongcredentialjwts
+  - kongdataplaneclientcertificates
   - kongpluginbindings
   - kongplugins
   - kongroutes

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -56792,7 +56792,7 @@ rules:
   - kongcertificates
   - kongconsumergroups
   - kongconsumers
-  - kongdataplaneclientcertificates
+  - kongdataplaneclientcertificates/status
   - kongkeys
   - kongkeysets
   - kongsnis
@@ -56823,7 +56823,6 @@ rules:
   - kongcredentialjwts/finalizers
   - kongcredentialjwts/status
   - kongdataplaneclientcertificates/finalizers
-  - kongdataplaneclientcertificates/status
   - kongkeys/finalizers
   - kongkeys/status
   - kongkeysets/finalizers
@@ -56866,6 +56865,7 @@ rules:
   - kongcredentialbasicauths
   - kongcredentialhmacs
   - kongcredentialjwts
+  - kongdataplaneclientcertificates
   - kongpluginbindings
   - kongplugins
   - kongroutes

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -56792,7 +56792,7 @@ rules:
   - kongcertificates
   - kongconsumergroups
   - kongconsumers
-  - kongdataplaneclientcertificates
+  - kongdataplaneclientcertificates/status
   - kongkeys
   - kongkeysets
   - kongsnis
@@ -56823,7 +56823,6 @@ rules:
   - kongcredentialjwts/finalizers
   - kongcredentialjwts/status
   - kongdataplaneclientcertificates/finalizers
-  - kongdataplaneclientcertificates/status
   - kongkeys/finalizers
   - kongkeys/status
   - kongkeysets/finalizers
@@ -56866,6 +56865,7 @@ rules:
   - kongcredentialbasicauths
   - kongcredentialhmacs
   - kongcredentialjwts
+  - kongdataplaneclientcertificates
   - kongpluginbindings
   - kongplugins
   - kongroutes

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -56792,7 +56792,7 @@ rules:
   - kongcertificates
   - kongconsumergroups
   - kongconsumers
-  - kongdataplaneclientcertificates
+  - kongdataplaneclientcertificates/status
   - kongkeys
   - kongkeysets
   - kongsnis
@@ -56823,7 +56823,6 @@ rules:
   - kongcredentialjwts/finalizers
   - kongcredentialjwts/status
   - kongdataplaneclientcertificates/finalizers
-  - kongdataplaneclientcertificates/status
   - kongkeys/finalizers
   - kongkeys/status
   - kongkeysets/finalizers
@@ -56866,6 +56865,7 @@ rules:
   - kongcredentialbasicauths
   - kongcredentialhmacs
   - kongcredentialjwts
+  - kongdataplaneclientcertificates
   - kongpluginbindings
   - kongplugins
   - kongroutes

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -56792,7 +56792,7 @@ rules:
   - kongcertificates
   - kongconsumergroups
   - kongconsumers
-  - kongdataplaneclientcertificates
+  - kongdataplaneclientcertificates/status
   - kongkeys
   - kongkeysets
   - kongsnis
@@ -56823,7 +56823,6 @@ rules:
   - kongcredentialjwts/finalizers
   - kongcredentialjwts/status
   - kongdataplaneclientcertificates/finalizers
-  - kongdataplaneclientcertificates/status
   - kongkeys/finalizers
   - kongkeys/status
   - kongkeysets/finalizers
@@ -56866,6 +56865,7 @@ rules:
   - kongcredentialbasicauths
   - kongcredentialhmacs
   - kongcredentialjwts
+  - kongdataplaneclientcertificates
   - kongpluginbindings
   - kongplugins
   - kongroutes

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -56792,7 +56792,7 @@ rules:
   - kongcertificates
   - kongconsumergroups
   - kongconsumers
-  - kongdataplaneclientcertificates
+  - kongdataplaneclientcertificates/status
   - kongkeys
   - kongkeysets
   - kongsnis
@@ -56823,7 +56823,6 @@ rules:
   - kongcredentialjwts/finalizers
   - kongcredentialjwts/status
   - kongdataplaneclientcertificates/finalizers
-  - kongdataplaneclientcertificates/status
   - kongkeys/finalizers
   - kongkeys/status
   - kongkeysets/finalizers
@@ -56866,6 +56865,7 @@ rules:
   - kongcredentialbasicauths
   - kongcredentialhmacs
   - kongcredentialjwts
+  - kongdataplaneclientcertificates
   - kongpluginbindings
   - kongplugins
   - kongroutes

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -30450,7 +30450,7 @@ rules:
   - kongcertificates
   - kongconsumergroups
   - kongconsumers
-  - kongdataplaneclientcertificates
+  - kongdataplaneclientcertificates/status
   - kongkeys
   - kongkeysets
   - kongsnis
@@ -30481,7 +30481,6 @@ rules:
   - kongcredentialjwts/finalizers
   - kongcredentialjwts/status
   - kongdataplaneclientcertificates/finalizers
-  - kongdataplaneclientcertificates/status
   - kongkeys/finalizers
   - kongkeys/status
   - kongkeysets/finalizers
@@ -30524,6 +30523,7 @@ rules:
   - kongcredentialbasicauths
   - kongcredentialhmacs
   - kongcredentialjwts
+  - kongdataplaneclientcertificates
   - kongpluginbindings
   - kongplugins
   - kongroutes

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -56742,7 +56742,7 @@ rules:
   - kongcertificates
   - kongconsumergroups
   - kongconsumers
-  - kongdataplaneclientcertificates
+  - kongdataplaneclientcertificates/status
   - kongkeys
   - kongkeysets
   - kongsnis
@@ -56773,7 +56773,6 @@ rules:
   - kongcredentialjwts/finalizers
   - kongcredentialjwts/status
   - kongdataplaneclientcertificates/finalizers
-  - kongdataplaneclientcertificates/status
   - kongkeys/finalizers
   - kongkeys/status
   - kongkeysets/finalizers
@@ -56816,6 +56815,7 @@ rules:
   - kongcredentialbasicauths
   - kongcredentialhmacs
   - kongcredentialjwts
+  - kongdataplaneclientcertificates
   - kongpluginbindings
   - kongplugins
   - kongroutes

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -30425,7 +30425,7 @@ rules:
   - kongcertificates
   - kongconsumergroups
   - kongconsumers
-  - kongdataplaneclientcertificates
+  - kongdataplaneclientcertificates/status
   - kongkeys
   - kongkeysets
   - kongsnis
@@ -30456,7 +30456,6 @@ rules:
   - kongcredentialjwts/finalizers
   - kongcredentialjwts/status
   - kongdataplaneclientcertificates/finalizers
-  - kongdataplaneclientcertificates/status
   - kongkeys/finalizers
   - kongkeys/status
   - kongkeysets/finalizers
@@ -30499,6 +30498,7 @@ rules:
   - kongcredentialbasicauths
   - kongcredentialhmacs
   - kongcredentialjwts
+  - kongdataplaneclientcertificates
   - kongpluginbindings
   - kongplugins
   - kongroutes

--- a/charts/kong-operator/templates/cluster-role.yaml
+++ b/charts/kong-operator/templates/cluster-role.yaml
@@ -156,7 +156,7 @@ rules:
       - kongcertificates
       - kongconsumergroups
       - kongconsumers
-      - kongdataplaneclientcertificates
+      - kongdataplaneclientcertificates/status
       - kongkeys
       - kongkeysets
       - kongsnis
@@ -187,7 +187,6 @@ rules:
       - kongcredentialjwts/finalizers
       - kongcredentialjwts/status
       - kongdataplaneclientcertificates/finalizers
-      - kongdataplaneclientcertificates/status
       - kongkeys/finalizers
       - kongkeys/status
       - kongkeysets/finalizers
@@ -230,6 +229,7 @@ rules:
       - kongcredentialbasicauths
       - kongcredentialhmacs
       - kongcredentialjwts
+      - kongdataplaneclientcertificates
       - kongpluginbindings
       - kongplugins
       - kongroutes

--- a/config/rbac/role/role.yaml
+++ b/config/rbac/role/role.yaml
@@ -156,7 +156,7 @@ rules:
   - kongcertificates
   - kongconsumergroups
   - kongconsumers
-  - kongdataplaneclientcertificates
+  - kongdataplaneclientcertificates/status
   - kongkeys
   - kongkeysets
   - kongsnis
@@ -187,7 +187,6 @@ rules:
   - kongcredentialjwts/finalizers
   - kongcredentialjwts/status
   - kongdataplaneclientcertificates/finalizers
-  - kongdataplaneclientcertificates/status
   - kongkeys/finalizers
   - kongkeys/status
   - kongkeysets/finalizers
@@ -230,6 +229,7 @@ rules:
   - kongcredentialbasicauths
   - kongcredentialhmacs
   - kongcredentialjwts
+  - kongdataplaneclientcertificates
   - kongpluginbindings
   - kongplugins
   - kongroutes

--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -864,13 +864,13 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 }
 
 // SecretInUseEnforceT is an enum type for enforcing or removing the secret-in-use finalizer.
-type SecretInUseEnforceT byte
+type SecretInUseEnforceT string
 
 const (
 	// SecretInUseEnforceAdd enforces the secret-in-use finalizer.
-	SecretInUseEnforceAdd SecretInUseEnforceT = 1
+	SecretInUseEnforceAdd SecretInUseEnforceT = "add"
 	// SecretInUseEnforceRemove removes the secret-in-use finalizer.
-	SecretInUseEnforceRemove SecretInUseEnforceT = 0
+	SecretInUseEnforceRemove SecretInUseEnforceT = "remove"
 )
 
 // enforceSecretInUseFinalizer adds or removes the secret-in-use finalizer on the given secret.
@@ -904,6 +904,7 @@ func enforceSecretInUseFinalizer(
 	log.Debug(logger,
 		finalizer+" finalizer enforced on Secret",
 		"secret", client.ObjectKeyFromObject(certificateSecret),
+		"operation", enforce,
 	)
 	return true, ctrl.Result{}, nil
 }

--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/go-logr/logr"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -23,10 +24,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
 	operatorv1beta1 "github.com/kong/kong-operator/api/gateway-operator/v1beta1"
 	konnectv1alpha1 "github.com/kong/kong-operator/api/konnect/v1alpha1"
 	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
+	ctrlconsts "github.com/kong/kong-operator/controller/consts"
 	"github.com/kong/kong-operator/controller/konnect/ops"
 	sdkops "github.com/kong/kong-operator/controller/konnect/ops/sdk"
 	"github.com/kong/kong-operator/controller/konnect/server"
@@ -110,6 +113,10 @@ func (r *KonnectExtensionReconciler) SetupWithManager(ctx context.Context, mgr c
 				enqueueKonnectExtensionsForKonnectGatewayControlPlane(mgr.GetClient()),
 			),
 		).
+		Watches(
+			&configurationv1alpha1.KongDataPlaneClientCertificate{},
+			handler.EnqueueRequestForOwner(r.Scheme(), mgr.GetRESTMapper(), &konnectv1alpha2.KonnectExtension{}),
+		).
 		Complete(r)
 }
 
@@ -151,21 +158,17 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	logger := log.GetLogger(ctx, konnectv1alpha2.KonnectExtensionKind, r.LoggingMode).WithValues("konnectExtension", req.NamespacedName)
 
-	var (
-		dataPlaneList    operatorv1beta1.DataPlaneList
-		controlPlaneList gwtypes.ControlPlaneList
-	)
 	ctx = ctrllog.IntoContext(ctx, logger)
 	log.Debug(logger, "reconciling")
 
-	if err := r.List(ctx, &dataPlaneList, client.MatchingFields{
-		index.KonnectExtensionIndex: client.ObjectKeyFromObject(&ext).String(),
-	}); err != nil {
+	nn := client.ObjectKeyFromObject(&ext)
+
+	dataplanes, err := listKonnectExtensionReferrers[operatorv1beta1.DataPlaneList](ctx, r.Client, nn)
+	if err != nil {
 		return ctrl.Result{}, err
 	}
-	if err := r.List(ctx, &controlPlaneList, client.MatchingFields{
-		index.KonnectExtensionIndex: client.ObjectKeyFromObject(&ext).String(),
-	}); err != nil {
+	controlplanes, err := listKonnectExtensionReferrers[gwtypes.ControlPlaneList](ctx, r.Client, nn)
+	if err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -174,12 +177,12 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// If the extension is marked for deletion and no object is using it, we can proceed with the cleanup.
 	if !ext.DeletionTimestamp.IsZero() &&
 		ext.DeletionTimestamp.Before(lo.ToPtr(metav1.Now())) &&
-		len(dataPlaneList.Items)+len(controlPlaneList.Items) == 0 {
+		len(dataplanes)+len(controlplanes) == 0 {
 		cleanup = true
 	}
 
 	switch {
-	case len(dataPlaneList.Items)+len(controlPlaneList.Items) == 0:
+	case len(dataplanes)+len(controlplanes) == 0:
 		updated = controllerutil.RemoveFinalizer(&ext, consts.ExtensionInUseFinalizer)
 	default:
 		updated = controllerutil.AddFinalizer(&ext, consts.ExtensionInUseFinalizer)
@@ -216,16 +219,8 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		// if the certificate exists and the cleanup in Konnect has been performed, we can remove the secret-in-use finalizer from the secret.
 		if certExists && !controllerutil.ContainsFinalizer(certificateSecret, KonnectCleanupFinalizer) {
 			// remove the secret-in-use finalizer from the secret.
-			updated = controllerutil.RemoveFinalizer(certificateSecret, consts.KonnectExtensionSecretInUseFinalizer)
-			if updated {
-				if err := r.Update(ctx, certificateSecret); err != nil {
-					if k8serrors.IsConflict(err) {
-						return ctrl.Result{Requeue: true}, nil
-					}
-					return ctrl.Result{}, err
-				}
-				log.Debug(logger, "Secret-in-use finalizer removed from Secret")
-				return ctrl.Result{}, nil
+			if op, res, err := enforceSecretInUseFinalizer(ctx, r.Client, certificateSecret, logger, SecretInUseEnforceRemove); err != nil || !res.IsZero() || op {
+				return res, err
 			}
 		}
 
@@ -268,6 +263,58 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 
+	certProvisionedCond := metav1.Condition{
+		Type:    konnectv1alpha1.DataPlaneCertificateProvisionedConditionType,
+		Status:  metav1.ConditionFalse,
+		Reason:  konnectv1alpha1.DataPlaneCertificateProvisionedReasonProvisioning,
+		Message: "DataPlane client certificate is provisioning",
+	}
+	// get the Kubernetes secret holding the certificate.
+	opRes, certificateSecret, err := r.getCertificateSecret(ctx, ext, false)
+	if client.IgnoreNotFound(err) != nil {
+		return ctrl.Result{}, err
+	}
+	if opRes != op.Noop {
+		return ctrl.Result{}, nil
+	}
+	if err != nil {
+		certProvisionedCond.Status = metav1.ConditionFalse
+		certProvisionedCond.Reason = konnectv1alpha1.DataPlaneCertificateProvisionedReasonRefNotFound
+		certProvisionedCond.Message = err.Error()
+		if res, updated, err := patch.StatusWithConditions(
+			ctx,
+			r.Client,
+			&ext,
+			readyCondition,
+			certProvisionedCond,
+		); err != nil || updated || !res.IsZero() {
+			return res, err
+		}
+		log.Debug(logger, "certificate secret retrieval failed")
+		return ctrl.Result{}, err
+	}
+
+	// check if the secret contains a valid tls certificate
+	certData, ok := certificateSecret.Data[consts.TLSCRT]
+	if !ok {
+		certProvisionedCond.Status = metav1.ConditionFalse
+		certProvisionedCond.Reason = konnectv1alpha1.DataPlaneCertificateProvisionedReasonInvalidSecret
+		certProvisionedCond.Message = "the secret does not contain a valid tls secret"
+		if res, updated, err := patch.StatusWithConditions(
+			ctx,
+			r.Client,
+			&ext,
+			readyCondition,
+			certProvisionedCond,
+		); err != nil || updated || !res.IsZero() {
+			return res, err
+		}
+		log.Debug(logger, "referenced secret malformed")
+		return ctrl.Result{}, nil
+	}
+
+	log.Debug(logger, "DataPlane certificate validity checked")
+
 	// Get the GatewayKonnectControlPlane and set conditions accordingly, also
 	// obtain valid ControlPlane ID or requeue. When KonnectExtension is during deletion,
 	// we proceed with the cleanup even if the ControlPlane is not found.
@@ -277,8 +324,41 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		switch {
 		case !k8serrors.IsNotFound(err) && !errors.Is(err, extensionserrors.ErrKonnectGatewayControlPlaneNotProgrammed):
 			return res, err
-		case k8serrors.IsNotFound(err) && cleanup:
-			log.Debug(logger, "ControlPlane not found, for KonnectExtension during deletion, proceeding with cleanup")
+		case k8serrors.IsNotFound(err):
+			if cleanup {
+				log.Debug(logger, "ControlPlane not found, for KonnectExtension during deletion, proceeding with cleanup")
+			}
+
+			// When the referenced ControlPlane is not found, we need to cleanup
+			// all the KongDataPlaneClientCertificates referencing it as they don't exist
+			// in Konnect anymore.
+			var dpCerts configurationv1alpha1.KongDataPlaneClientCertificateList
+			err = r.List(ctx, &dpCerts,
+				client.InNamespace(ext.Namespace),
+				client.MatchingFields{
+					index.IndexFieldKongDataPlaneClientCertificateOnKonnectExtensionOwner: ext.Name,
+				},
+			)
+			if err != nil {
+				log.Debug(logger, "Couldn't delete all KongDataPlaneClientCertificates referencing not existing ControlPlane", "error", err)
+				// Continue with cleanup.
+			} else {
+				for _, dp := range dpCerts.Items {
+					if err := r.Delete(ctx, &dp); client.IgnoreNotFound(err) != nil {
+						log.Debug(logger,
+							"Couldn't delete KongDataPlaneClientCertificate during ControlPlane not found cleanup",
+							"dataPlaneClientCertificate", client.ObjectKeyFromObject(&dp),
+							"error", err)
+					}
+				}
+			}
+
+			// Removed the secret in use finalizer from Secret as the ControlPlane so any
+			// certificate using this Secret has been already removed from Konnect along with the ControlPlane.
+			if op, res, err := enforceSecretInUseFinalizer(ctx, r.Client, certificateSecret, logger, SecretInUseEnforceRemove); err != nil || !res.IsZero() || op {
+				return res, err
+			}
+
 		default:
 			log.Debug(logger, "ControlPlane not ready yet")
 			return res, nil
@@ -286,6 +366,10 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	} else {
 		// Update the controlPlane ID to the value presented in the status by ControlPlane itself.
 		cpID = cp.Status.ID
+
+		if op, res, err := enforceSecretInUseFinalizer(ctx, r.Client, certificateSecret, logger, SecretInUseEnforceAdd); err != nil || !res.IsZero() || op {
+			return res, err
+		}
 	}
 
 	log.Debug(logger, "controlPlane reference validity checked")
@@ -345,80 +429,21 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// NOTE: We need to create a new SDK instance for each reconciliation
 	// because the token is retrieved in runtime through KonnectAPIAuthConfiguration.
+	// TODO: remove SDK usage in https://github.com/Kong/kong-operator/issues/2630
 	server, err := server.NewServer[*konnectv1alpha2.KonnectExtension](apiAuth.Spec.ServerURL)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to parse server URL: %w", err)
 	}
 	sdk := r.SdkFactory.NewKonnectSDK(server, sdkops.SDKToken(token))
 
-	certProvisionedCond := metav1.Condition{
-		Type:    konnectv1alpha1.DataPlaneCertificateProvisionedConditionType,
-		Status:  metav1.ConditionTrue,
-		Reason:  konnectv1alpha1.DataPlaneCertificateProvisionedReasonProvisioned,
-		Message: "DataPlane client certificate is provisioned",
-	}
-
-	// get the Kubernetes secret holding the certificate.
-	opRes, certificateSecret, err := r.getCertificateSecret(ctx, ext, false)
-	if client.IgnoreNotFound(err) != nil {
-		return ctrl.Result{}, err
-	}
-	if opRes != op.Noop {
-		return ctrl.Result{}, nil
-	}
-	if err != nil {
-		certProvisionedCond.Status = metav1.ConditionFalse
-		certProvisionedCond.Reason = konnectv1alpha1.DataPlaneCertificateProvisionedReasonRefNotFound
-		certProvisionedCond.Message = err.Error()
-		if res, updated, err := patch.StatusWithConditions(
-			ctx,
-			r.Client,
-			&ext,
-			readyCondition,
-			certProvisionedCond,
-		); err != nil || updated || !res.IsZero() {
-			return res, err
-		}
-		log.Debug(logger, "certificate secret retrieval failed")
-		return ctrl.Result{}, err
-	}
-
-	// check if the secret contains a valid tls certificate
-	certData, ok := certificateSecret.Data[consts.TLSCRT]
-	if !ok {
-		certProvisionedCond.Status = metav1.ConditionFalse
-		certProvisionedCond.Reason = konnectv1alpha1.DataPlaneCertificateProvisionedReasonInvalidSecret
-		certProvisionedCond.Message = "the secret does not contain a valid tls secret"
-		if res, updated, err := patch.StatusWithConditions(
-			ctx,
-			r.Client,
-			&ext,
-			readyCondition,
-			certProvisionedCond,
-		); err != nil || updated || !res.IsZero() {
-			return res, err
-		}
-		log.Debug(logger, "referenced secret malformed")
-		return ctrl.Result{}, nil
-	}
-
-	// Enforce a finalizer on the secret to prevent it from being deleted while in use.
-	if controllerutil.AddFinalizer(certificateSecret, consts.KonnectExtensionSecretInUseFinalizer) {
-		if err := r.Update(ctx, certificateSecret); err != nil {
-			if k8serrors.IsConflict(err) {
-				return ctrl.Result{Requeue: true}, nil
-			}
-			return ctrl.Result{}, err
-		}
-
-		log.Info(logger, "finalizer on the referenced secret updated")
-		return ctrl.Result{}, nil
-	}
-
-	log.Debug(logger, "DataPlane certificate validity checked")
-
-	// Get the list of DataPlane client certificates in Konnect.
-	dpCertificates, err := ops.ListKongDataPlaneClientCertificates(ctx, sdk.GetDataPlaneCertificatesSDK(), cpID)
+	// Get the list of in cluster DataPlane client certificates.
+	var dpCertificates configurationv1alpha1.KongDataPlaneClientCertificateList
+	err = r.List(ctx, &dpCertificates,
+		client.InNamespace(ext.Namespace),
+		client.MatchingFields{
+			index.IndexFieldKongDataPlaneClientCertificateOnKonnectExtensionOwner: ext.Name,
+		},
+	)
 	if err != nil && !ops.ErrIsNotFound(err) {
 		certProvisionedCond.Status = metav1.ConditionFalse
 		certProvisionedCond.Reason = konnectv1alpha1.DataPlaneCertificateProvisionedReasonKonnectAPIOpFailed
@@ -433,25 +458,23 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return res, err
 		}
 
-		log.Debug(logger, "DataPlane client certificate list retrieval failed in Konnect")
-		// Setting "Requeue: true" along with RequeueAfter makes the controller bulletproof, as
-		// if the syncPeriod is set to zero, the controller won't requeue.
-		return ctrl.Result{Requeue: true, RequeueAfter: r.SyncPeriod}, err
+		log.Debug(logger, "DataPlane client certificate list retrieval failed in Konnect", "error", err.Error())
+		return ctrl.Result{RequeueAfter: r.SyncPeriod}, err
 	}
 
 	var (
-		cert      sdkkonnectcomp.DataPlaneClientCertificate
-		certFound bool
+		cert        configurationv1alpha1.KongDataPlaneClientCertificate
+		certFound   bool
+		certDataStr = sanitizeCert(string(certData))
 	)
 	// retrieve all the konnect certificates bound to this secret
-	mappedIDs := lo.FilterMap(dpCertificates, func(c sdkkonnectcomp.DataPlaneClientCertificate, _ int) (k string, include bool) {
-		if c.Cert != nil && c.ID != nil {
-			certStr := sanitizeCert(*c.Cert)
-			certDataStr := sanitizeCert(string(certData))
+	mappedIDs := lo.FilterMap(dpCertificates.Items, func(c configurationv1alpha1.KongDataPlaneClientCertificate, _ int) (k string, include bool) {
+		if c.Spec.Cert != "" && c.GetKonnectID() != "" {
+			certStr := sanitizeCert(c.Spec.Cert)
 			if certStr == certDataStr {
 				cert = c
 				certFound = true
-				return *c.ID, true
+				return c.GetKonnectID(), true
 			}
 		}
 		return "", false
@@ -470,16 +493,68 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
-	secretCleanup := certificateSecret.DeletionTimestamp != nil && certificateSecret.DeletionTimestamp.Before(&metav1.Time{Time: time.Now()})
+	var (
+		certSDK      sdkkonnectcomp.DataPlaneClientCertificate
+		certSDKFound bool
+	)
+
+	// If there are no mapped IDs from KongDataPlaneClientCertificates in cluster,
+	// then let's use the SDK to query Konnect directly to find any existing certificates.
+	// This is just to make sure that users migrating from older versions of the operator
+	// where the dataplane client certificates were not managed using
+	// KongDataPlaneClientCertificate CRs don't end up creating duplicate
+	// certificates in Konnect.
+	// TODO: https://github.com/Kong/kong-operator/issues/2630
+	// remove this block in future major release after several operator releases.
+	if len(mappedIDs) == 0 {
+		// Get the list of DataPlane client certificates in Konnect.
+		dpCertificates, err := ops.ListKongDataPlaneClientCertificates(ctx, sdk.GetDataPlaneCertificatesSDK(), cpID)
+		if err != nil && !ops.ErrIsNotFound(err) {
+			certProvisionedCond.Status = metav1.ConditionFalse
+			certProvisionedCond.Reason = konnectv1alpha1.DataPlaneCertificateProvisionedReasonKonnectAPIOpFailed
+			certProvisionedCond.Message = err.Error()
+			if res, updated, err := patch.StatusWithConditions(
+				ctx,
+				r.Client,
+				&ext,
+				readyCondition,
+				certProvisionedCond,
+			); err != nil || updated || !res.IsZero() {
+				return res, err
+			}
+
+			log.Debug(logger, "DataPlane client certificate list retrieval failed in Konnect")
+			return ctrl.Result{RequeueAfter: r.SyncPeriod}, nil
+		}
+
+		// retrieve all the konnect certificates bound to this secret
+		mappedIDs = lo.FilterMap(dpCertificates, func(c sdkkonnectcomp.DataPlaneClientCertificate, _ int) (k string, include bool) {
+			if c.Cert != nil && c.ID != nil {
+				certStr := sanitizeCert(*c.Cert)
+				certDataStr := sanitizeCert(string(certData))
+				if certStr == certDataStr {
+					certSDK = c
+					certSDKFound = true
+					return *c.ID, true
+				}
+			}
+			return "", false
+		})
+	}
+
+	secretCleanup := certificateSecret.DeletionTimestamp != nil &&
+		certificateSecret.DeletionTimestamp.Before(&metav1.Time{Time: time.Now()})
 	switch {
 	case !cleanup && !secretCleanup:
-		if !certFound {
-			log.Debug(logger, "DataPlane client certificate enforced in Konnect")
+
+		if !certFound && !certSDKFound {
+			log.Debug(logger, "Creating KongDataPlaneClientCertificate custom resource")
 			dpCert := konnectresource.GenerateKongDataPlaneClientCertificate(
 				certificateSecret.Name,
 				certificateSecret.Namespace,
 				&ext.Spec.Konnect.ControlPlane.Ref,
 				string(certificateSecret.Data[consts.TLSCRT]),
+				&ext,
 				func(dpCert *configurationv1alpha1.KongDataPlaneClientCertificate) {
 					dpCert.Status.Konnect = &konnectv1alpha2.KonnectEntityStatusWithControlPlaneRef{
 						// setting the controlPlane ID in the status as a workaround for the GetControlPlaneID method,
@@ -488,53 +563,134 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 					}
 				},
 			)
-			if err := ops.CreateKongDataPlaneClientCertificate(ctx, sdk.GetDataPlaneCertificatesSDK(), &dpCert); err != nil {
-				certProvisionedCond.Status = metav1.ConditionFalse
-				certProvisionedCond.Reason = konnectv1alpha1.DataPlaneCertificateProvisionedReasonKonnectAPIOpFailed
-				certProvisionedCond.Message = err.Error()
-				if res, updated, err := patch.StatusWithConditions(
-					ctx,
-					r.Client,
-					&ext,
-					readyCondition,
-					certProvisionedCond,
-				); err != nil || updated || !res.IsZero() {
-					return res, err
-				}
-				// Setting "Requeue: true" along with RequeueAfter makes the controller bulletproof, as
-				// if the syncPeriod is set to zero, the controller won't requeue.
-				return ctrl.Result{Requeue: true, RequeueAfter: r.SyncPeriod}, err
+
+			err := controllerutil.SetOwnerReference(&ext, &dpCert, r.Scheme(), controllerutil.WithBlockOwnerDeletion(true))
+			if err != nil {
+				return ctrl.Result{}, err
 			}
-			updated, res, err := patch.WithFinalizer(ctx, r.Client, client.Object(certificateSecret), KonnectCleanupFinalizer)
+
+			if err := r.Create(ctx, &dpCert); err != nil {
+				if errS := (&k8serrors.StatusError{}); errors.As(err, &errS) {
+					if errS.ErrStatus.Reason == metav1.StatusReasonAlreadyExists {
+						log.Debug(logger, "DataPlane client certificate already exists", "name", dpCert.Name, "namespace", dpCert.Namespace)
+					}
+				} else {
+					certProvisionedCond.Status = metav1.ConditionFalse
+					certProvisionedCond.Reason = konnectv1alpha1.DataPlaneCertificateProvisionedReasonKonnectAPIOpFailed
+					certProvisionedCond.Message = err.Error()
+					if res, updated, err := patch.StatusWithConditions(
+						ctx,
+						r.Client,
+						&ext,
+						readyCondition,
+						certProvisionedCond,
+					); err != nil || updated || !res.IsZero() {
+						return res, err
+					}
+					// In case of an error when creating the object in Konnect, we requeue "immediately"
+					// so that the operation is retried without waiting for the resync period.
+					return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
+				}
+			}
+			updated, res, err := patch.WithFinalizer(ctx, r.Client, certificateSecret, KonnectCleanupFinalizer)
 			if err != nil || !res.IsZero() {
 				return res, err
 			}
 			if updated {
 				log.Info(logger, "konnect-cleanup finalizer on the referenced secret updated")
-				// Setting "Requeue: true" along with RequeueAfter makes the controller bulletproof, as
-				// if the syncPeriod is set to zero, the controller won't requeue.
-				return ctrl.Result{Requeue: true, RequeueAfter: r.SyncPeriod}, err
+				return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
+			}
+		} else if certSDKFound && !certFound {
+			// In case the certificate exists in Konnect but not in cluster,
+			// we create the KongDataPlaneClientCertificate resource in cluster
+			// to adopt the existing certificate in Konnect.
+			dpCert := konnectresource.GenerateKongDataPlaneClientCertificate(
+				certificateSecret.Name,
+				certificateSecret.Namespace,
+				&ext.Spec.Konnect.ControlPlane.Ref,
+				string(certificateSecret.Data[consts.TLSCRT]),
+				&ext,
+				func(dpCert *configurationv1alpha1.KongDataPlaneClientCertificate) {
+					dpCert.Status.Konnect = &konnectv1alpha2.KonnectEntityStatusWithControlPlaneRef{
+						// setting the controlPlane ID in the status as a workaround for the GetControlPlaneID method,
+						// that expects the ControlPlaneID to be set in the status.
+						ControlPlaneID: cpID,
+					}
+					dpCert.Spec.Adopt = &commonv1alpha1.AdoptOptions{
+						From: commonv1alpha1.AdoptSourceKonnect,
+						Mode: commonv1alpha1.AdoptModeMatch,
+						Konnect: &commonv1alpha1.AdoptKonnectOptions{
+							ID: lo.FromPtr(certSDK.ID),
+						},
+					}
+				},
+			)
+			err := controllerutil.SetOwnerReference(&ext, &dpCert, r.Scheme(), controllerutil.WithBlockOwnerDeletion(true))
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+
+			if err := r.Create(ctx, &dpCert); err != nil {
+				if errS := (&k8serrors.StatusError{}); errors.As(err, &errS) {
+					if errS.ErrStatus.Reason == metav1.StatusReasonAlreadyExists {
+						log.Debug(logger, "DataPlane client certificate already exists", "name", dpCert.Name, "namespace", dpCert.Namespace)
+					}
+				} else {
+					certProvisionedCond.Status = metav1.ConditionFalse
+					certProvisionedCond.Reason = konnectv1alpha1.DataPlaneCertificateProvisionedReasonKonnectAPIOpFailed
+					certProvisionedCond.Message = err.Error()
+					if res, updated, err := patch.StatusWithConditions(
+						ctx,
+						r.Client,
+						&ext,
+						readyCondition,
+						certProvisionedCond,
+					); err != nil || updated || !res.IsZero() {
+						return res, err
+					}
+					// In case of an error when creating the object in Konnect, we requeue "immediately"
+					// so that the operation is retried without waiting for the resync period.
+					return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
+				}
+			}
+			updated, res, err := patch.WithFinalizer(ctx, r.Client, certificateSecret, KonnectCleanupFinalizer)
+			if err != nil || !res.IsZero() {
+				return res, err
+			}
+			if updated {
+				log.Info(logger, "konnect-cleanup finalizer on the referenced secret updated")
+				return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
 			}
 		}
+
 		updated, res, err := patch.WithFinalizer(ctx, r.Client, &ext, KonnectCleanupFinalizer)
 		if err != nil || !res.IsZero() {
 			return res, err
 		}
 		if updated {
 			log.Info(logger, "KonnectExtension finalizer added", "finalizer", KonnectCleanupFinalizer)
-			return ctrl.Result{}, nil
+			return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
 		}
 	case cleanup || secretCleanup:
-		if certFound {
-			// This should never happen, but checking to make the dereference below bullet-proof
-			if cert.ID == nil {
-				return ctrl.Result{}, errors.New("cannot cleanup certificate in Konnect without ID")
+		// If there are no mapped IDs from KongDataPlaneClientCertificates in cluster,
+		// then let's use the SDK to query Konnect directly to find any existing certificates.
+		// This is just to make sure that users migrating from older versions of the operator
+		// where the dataplane client certificates were not managed using
+		// KongDataPlaneClientCertificate CRs don't end up creating duplicate
+		// certificates in Konnect.
+		// TODO: https://github.com/Kong/kong-operator/issues/2630
+		// remove this block in future major release after several operator releases.
+		if certSDKFound {
+			if certSDK.ID == nil {
+				return ctrl.Result{}, errors.New("cannot cleanup DataPlane certificate in Konnect without ID")
 			}
+
 			dpCert := konnectresource.GenerateKongDataPlaneClientCertificate(
 				certificateSecret.Name,
 				certificateSecret.Namespace,
 				&ext.Spec.Konnect.ControlPlane.Ref,
 				string(certificateSecret.Data[consts.TLSCRT]),
+				&ext,
 				func(dpCert *configurationv1alpha1.KongDataPlaneClientCertificate) {
 					dpCert.Status.Konnect = &konnectv1alpha2.KonnectEntityStatusWithControlPlaneRef{
 						// setting the controlPlane ID in the status as a workaround for the GetControlPlaneID method,
@@ -543,7 +699,7 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 						// setting the ID in the status as a workaround for the DeleteKongDataPlaneClientCertificate method,
 						// that expects the ID to be set in the status.
 						KonnectEntityStatus: konnectv1alpha2.KonnectEntityStatus{
-							ID: *cert.ID,
+							ID: *certSDK.ID,
 						},
 					}
 				},
@@ -561,10 +717,32 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 				); err != nil || updated || !res.IsZero() {
 					return res, err
 				}
-				// In case of an error in the Konnect ops, the resync period will take care of a new creation attempt.
-				// Setting "Requeue: true" along with RequeueAfter makes the controller bulletproof, as
-				// if the syncPeriod is set to zero, the controller won't requeue.
-				return ctrl.Result{Requeue: true, RequeueAfter: r.SyncPeriod}, err
+				return ctrl.Result{RequeueAfter: r.SyncPeriod}, err
+			}
+
+		}
+
+		if certFound {
+			// This should never happen, but checking to make the dereference below bullet-proof
+			if cert.GetKonnectID() == "" {
+				return ctrl.Result{}, errors.New("cannot cleanup DataPlane certificate in Konnect without ID")
+			}
+			if err := r.Delete(ctx, &cert); err != nil {
+				certProvisionedCond.Status = metav1.ConditionFalse
+				certProvisionedCond.Reason = konnectv1alpha1.DataPlaneCertificateProvisionedReasonKonnectAPIOpFailed
+				certProvisionedCond.Message = err.Error()
+				if res, updated, err := patch.StatusWithConditions(
+					ctx,
+					r.Client,
+					&ext,
+					readyCondition,
+					certProvisionedCond,
+				); err != nil || updated || !res.IsZero() {
+					return res, err
+				}
+				// In case of an error in the Konnect ops, we requeue so that
+				// the operation is retried after the resync period.
+				return ctrl.Result{RequeueAfter: r.SyncPeriod}, err
 			}
 			return ctrl.Result{Requeue: true}, err
 		}
@@ -585,6 +763,49 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return ctrl.Result{Requeue: true}, nil
 		}
 	}
+
+	// If the KongDataPlaneClientCertificate exists in cluster, check if it's programmed in Konnect
+	// and proceed only after it is programmed.
+	if certFound {
+		var (
+			dpCert   configurationv1alpha1.KongDataPlaneClientCertificate
+			dpCertNN = types.NamespacedName{
+				Name:      certificateSecret.Name,
+				Namespace: certificateSecret.Namespace,
+			}
+		)
+		if err = r.Get(ctx, dpCertNN, &dpCert); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				log.Debug(logger, "DataPlane client certificate retrieval failed in cluster",
+					"namespace", dpCertNN.Namespace,
+					"name", dpCertNN.Name,
+				)
+				return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
+			}
+			return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
+		}
+		if !k8sutils.IsProgrammed(&dpCert) {
+			log.Debug(logger, "DataPlane client certificate not yet programmed in Konnect",
+				"namespace", dpCertNN.Namespace,
+				"name", dpCertNN.Name,
+			)
+			// set the certificateProvisioned condition to true
+			if res, updated, err := patch.StatusWithConditions(
+				ctx,
+				r.Client,
+				&ext,
+				certProvisionedCond,
+			); err != nil || updated || !res.IsZero() {
+				return res, err
+			}
+			return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
+		}
+	}
+
+	certProvisionedCond.Status = metav1.ConditionTrue
+	certProvisionedCond.Reason = konnectv1alpha1.DataPlaneCertificateProvisionedReasonProvisioned
+	certProvisionedCond.Message = "DataPlane client certificate provisioned successfully"
+
 	// set the certificateProvisioned condition to true
 	if res, updated, err := patch.StatusWithConditions(
 		ctx,
@@ -605,7 +826,7 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			// in case the err is of type conflict, don't return it and instead trigger
 			// another reconciliation.
 			// This is just to prevent spamming of conflict errors.
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
 		}
 		return ctrl.Result{}, err
 	}
@@ -626,7 +847,7 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return res, err
 	}
 
-	if res, err := r.ensureExtendablesReferencesInStatus(ctx, &ext, dataPlaneList, controlPlaneList); err != nil || !res.IsZero() {
+	if res, err := r.ensureExtendablesReferencesInStatus(ctx, &ext, dataplanes, controlplanes); err != nil || !res.IsZero() {
 		return res, err
 	}
 
@@ -640,4 +861,93 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		Requeue:      true,
 		RequeueAfter: r.SyncPeriod,
 	}, nil
+}
+
+// SecretInUseEnforceT is an enum type for enforcing or removing the secret-in-use finalizer.
+type SecretInUseEnforceT byte
+
+const (
+	// SecretInUseEnforceAdd enforces the secret-in-use finalizer.
+	SecretInUseEnforceAdd SecretInUseEnforceT = 1
+	// SecretInUseEnforceRemove removes the secret-in-use finalizer.
+	SecretInUseEnforceRemove SecretInUseEnforceT = 0
+)
+
+// enforceSecretInUseFinalizer adds or removes the secret-in-use finalizer on the given secret.
+// Returns true if the reconciliation should return.
+func enforceSecretInUseFinalizer(
+	ctx context.Context,
+	cl client.Client,
+	certificateSecret *corev1.Secret,
+	logger logr.Logger,
+	enforce SecretInUseEnforceT,
+) (bool, ctrl.Result, error) {
+	var updated bool
+	const finalizer = consts.KonnectExtensionSecretInUseFinalizer
+
+	switch enforce {
+	case SecretInUseEnforceAdd:
+		updated = controllerutil.AddFinalizer(certificateSecret, finalizer)
+	case SecretInUseEnforceRemove:
+		updated = controllerutil.RemoveFinalizer(certificateSecret, finalizer)
+	}
+
+	if !updated {
+		return false, ctrl.Result{}, nil
+	}
+	if err := cl.Update(ctx, certificateSecret); err != nil {
+		if k8serrors.IsConflict(err) {
+			return true, ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
+		}
+		return true, ctrl.Result{}, err
+	}
+	log.Debug(logger,
+		finalizer+" finalizer enforced on Secret",
+		"secret", client.ObjectKeyFromObject(certificateSecret),
+	)
+	return true, ctrl.Result{}, nil
+}
+
+// listKonnectExtensionReferrers lists all objects that reference the given KonnectExtension.
+// It uses the KonnectExtensionIndex index for listing the objects which needs to
+// be set for the queried typed.
+func listKonnectExtensionReferrers[
+	TList interface {
+		operatorv1beta1.DataPlaneList | gwtypes.ControlPlaneList
+		GetItems() []T
+	},
+	TListPtr interface {
+		*TList
+		client.ObjectList
+		GetItems() []T
+	},
+	TT clientObject[T],
+	T any,
+](
+	ctx context.Context,
+	cl client.Client,
+	referencedKonnectExtension client.ObjectKey,
+) ([]T, error) {
+	listOpts := []client.ListOption{
+		client.MatchingFields{
+			index.KonnectExtensionIndex: referencedKonnectExtension.String(),
+		},
+	}
+
+	var (
+		list    TList
+		listPtr TListPtr = &list
+	)
+	if err := cl.List(ctx, listPtr, listOpts...); err != nil {
+		return nil, err
+	}
+	return list.GetItems(), nil
+}
+
+type clientObjectT[T any] interface {
+	*T
+}
+
+type clientObject[T any] interface {
+	clientObjectT[T]
 }

--- a/controller/konnect/konnectextension_controller_rbac.go
+++ b/controller/konnect/konnectextension_controller_rbac.go
@@ -16,3 +16,5 @@ package konnect
 // +kubebuilder:rbac:groups="konnect.konghq.com",resources="konnectapiauthconfigurations",verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;patch;update
 // +kubebuilder:rbac:groups="",resources=secrets/finalizers,verbs=patch;update
+// +kubebuilder:rbac:groups=configuration.konghq.com,resources=kongdataplaneclientcertificates,verbs=create;get;list;delete;update;patch;watch
+// +kubebuilder:rbac:groups=configuration.konghq.com,resources=kongdataplaneclientcertificates/status,verbs=get;list;watch

--- a/internal/utils/index/kongdataplanecertificate.go
+++ b/internal/utils/index/kongdataplanecertificate.go
@@ -1,14 +1,20 @@
 package index
 
 import (
+	"strings"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
 )
 
 const (
 	// IndexFieldKongDataPlaneClientCertificateOnKonnectGatewayControlPlane is the index field for KongDataPlaneCertificate -> KonnectGatewayControlPlane.
 	IndexFieldKongDataPlaneClientCertificateOnKonnectGatewayControlPlane = "dataPlaneCertificateKonnectGatewayControlPlaneRef"
+
+	// IndexFieldKongDataPlaneClientCertificateOnKonnectExtensionOwner is the index field for KongDataPlaneCertificate -> KonnectExtension via the ownership.
+	IndexFieldKongDataPlaneClientCertificateOnKonnectExtensionOwner = "dataPlaneCertificateKonnectExtensionOwner"
 )
 
 // OptionsForKongDataPlaneCertificate returns required Index options for KongConsumer reconciler.
@@ -19,5 +25,31 @@ func OptionsForKongDataPlaneCertificate(cl client.Client) []Option {
 			Field:          IndexFieldKongDataPlaneClientCertificateOnKonnectGatewayControlPlane,
 			ExtractValueFn: indexKonnectGatewayControlPlaneRef[configurationv1alpha1.KongDataPlaneClientCertificate](cl),
 		},
+		{
+			Object:         &configurationv1alpha1.KongDataPlaneClientCertificate{},
+			Field:          IndexFieldKongDataPlaneClientCertificateOnKonnectExtensionOwner,
+			ExtractValueFn: kongDataPlaneCertificateOnKonnectExtensionOwner,
+		},
 	}
+}
+
+func kongDataPlaneCertificateOnKonnectExtensionOwner(object client.Object) []string {
+	dpCert, ok := object.(*configurationv1alpha1.KongDataPlaneClientCertificate)
+
+	if !ok {
+		return nil
+	}
+
+	owners := dpCert.GetOwnerReferences()
+	var ownerNames []string
+	for _, owner := range owners {
+		if owner.Kind != "KonnectExtension" {
+			continue
+		}
+		if !strings.HasPrefix(owner.APIVersion, konnectv1alpha2.GroupVersion.Group) {
+			continue
+		}
+		ownerNames = append(ownerNames, owner.Name)
+	}
+	return ownerNames
 }

--- a/pkg/utils/konnect/resources/kongdataplaneclientcertificate.go
+++ b/pkg/utils/konnect/resources/kongdataplaneclientcertificate.go
@@ -2,19 +2,31 @@ package resources
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/pkg/consts"
 )
 
 // GenerateKongDataPlaneClientCertificate generates a KongDataPlaneClientCertificate object setting
-// the provided controlPlaneRef as the certificate controlPlaneRef. The cert parameter is the actual certificate
-// pushed into Konnect.
-func GenerateKongDataPlaneClientCertificate(name, namespace string, controlPlaneRef *commonv1alpha1.KonnectExtensionControlPlaneRef, cert string, opts ...func(dpCert *configurationv1alpha1.KongDataPlaneClientCertificate)) configurationv1alpha1.KongDataPlaneClientCertificate {
+// the provided controlPlaneRef as the certificate controlPlaneRef.
+// The cert parameter is the actual certificate pushed into Konnect.
+func GenerateKongDataPlaneClientCertificate(
+	name, namespace string,
+	controlPlaneRef *commonv1alpha1.KonnectExtensionControlPlaneRef,
+	cert string,
+	owner client.Object,
+	opts ...func(dpCert *configurationv1alpha1.KongDataPlaneClientCertificate),
+) configurationv1alpha1.KongDataPlaneClientCertificate {
 	dpCert := configurationv1alpha1.KongDataPlaneClientCertificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels: map[string]string{
+				consts.GatewayOperatorManagedByLabel:     "KonnectExtension",
+				consts.GatewayOperatorManagedByNameLabel: owner.GetName(),
+			},
 		},
 		Spec: configurationv1alpha1.KongDataPlaneClientCertificateSpec{
 			KongDataPlaneClientCertificateAPISpec: configurationv1alpha1.KongDataPlaneClientCertificateAPISpec{

--- a/scripts/apitypes-funcs/supportedtypes.go
+++ b/scripts/apitypes-funcs/supportedtypes.go
@@ -261,6 +261,9 @@ var supportedGatewayOperatorTypes = []supportedTypesT{
 			{
 				Type: "GatewayConfiguration",
 			},
+			{
+				Type: "ControlPlane",
+			},
 		},
 	},
 }

--- a/test/envtest/setup.go
+++ b/test/envtest/setup.go
@@ -131,5 +131,10 @@ func NameFromT(t *testing.T) string {
 	name = strings.ReplaceAll(name, "_", "-")
 	name = strings.ReplaceAll(name, "/", "-")
 
+	// This is used as k8s label so we need to truncate it to 63.
+	if len(name) > 63 {
+		return name[:63]
+	}
+
 	return name
 }

--- a/test/integration/konnect_extension_test.go
+++ b/test/integration/konnect_extension_test.go
@@ -113,7 +113,7 @@ func TestKonnectExtensionControlPlaneRotation(t *testing.T) {
 			konnectv1alpha1.DataPlaneCertificateProvisionedConditionType,
 			konnectv1alpha2.KonnectExtensionReadyConditionType)
 		assert.Truef(t, ok, "condition check failed: %s, conditions: %+v", msg, konnectExtension.Status.Conditions)
-	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
+	}, testutils.ObjectUpdateTimeout*30, testutils.ObjectUpdateTick)
 
 	t.Logf("waiting for status.konnect and status.dataPlaneClientAuth to be set for KonnectExtension %s/%s", konnectExtension.Namespace, konnectExtension.Name)
 	require.EventuallyWithT(t,
@@ -468,6 +468,10 @@ func konnectExtensionTestBody(t *testing.T, p KonnectExtensionTestBodyParams) {
 								Name:  "KONG_LOG_LEVEL",
 								Value: "debug",
 							},
+						},
+						ReadinessProbe: &corev1.Probe{
+							InitialDelaySeconds: 1,
+							PeriodSeconds:       1,
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

Leverage `KongDataPlaneClientCertificate` in `KonnectExtension` reconciler.

In order not to break users, this PR makes the `KonnectExtension` reconciler check if matching dataplane client certificates are present in Konnect using an SDK. If that's the case no `KongDataPlaneClientCertificate` is created.

~NOTE: We can potentially use adoption for that but `KongDataPlaneClientCertificate` doesn't have the adoption implemented yet.~

This PR uses the adoption for the `KongDataPlaneClientCertificate` as it has already been implemented.

**Which issue this PR fixes**

Fixes #1294

**Special notes for your reviewer**:

The logic using SDK should be removed in a later release as part of https://github.com/Kong/kong-operator/issues/2630.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
