### PR TITLE
fix: support mirror `KonnectGatewayControlPlane`s

### DIFF
--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -802,8 +802,8 @@ func (r *Reconciler) provisionKonnectGatewayControlPlane(
 	// If we continue, there is only one konnect gateway controlplane.
 	konnectControlPlane := konnectControlPlanes[0].DeepCopy()
 
-	// For now, we don't update the KonnectGatewayControlPlane spec as it's managed by Konnect.
-	// In the future, we might want to support updating certain fields.
+	// TODO: https://github.com/Kong/kong-operator/issues/2639
+	// enforce KonnectGatewayControlPlane spec
 
 	log.Trace(logger, "Waiting for KonnectGatewayControlPlane readiness")
 	if !k8sutils.IsProgrammed(konnectControlPlane) {

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -1906,7 +1906,7 @@ func TestIsGatewayHybrid(t *testing.T) {
 					Name: "test-auth",
 				},
 			},
-			expectHybrid: false,
+			expectHybrid: true,
 		},
 		{
 			name: "konnect with default source (Origin) and auth ref",


### PR DESCRIPTION
This commit fixes a bug that prevented a `GatewayConfiguration` to be configured with a mirror `KonnectGatewayControlPlane`.

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #2606 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
