### PR TITLE
chore(hybridgateway): replace hardcoded Gateway API group with gwtypes.GroupName constant

### DIFF
--- a/controller/hybridgateway/converter/http_route_test.go
+++ b/controller/hybridgateway/converter/http_route_test.go
@@ -176,7 +176,7 @@ func newHTTPRouteWithHostnames(hostnames ...string) *gwtypes.HTTPRoute {
 					{
 						Name:  "test-gateway",
 						Kind:  lo.ToPtr(gwtypes.Kind("Gateway")),
-						Group: lo.ToPtr(gwtypes.Group("gateway.networking.k8s.io")),
+						Group: lo.ToPtr(gwtypes.Group(gwtypes.GroupName)),
 					},
 				},
 			},

--- a/controller/hybridgateway/reconciler_utils_test.go
+++ b/controller/hybridgateway/reconciler_utils_test.go
@@ -85,7 +85,7 @@ func TestCleanOrphanedResources(t *testing.T) {
 	root := &gwtypes.HTTPRoute{}
 	root.SetName("httproute-owner")
 	root.SetNamespace("ns")
-	root.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "HTTPRoute"})
+	root.SetGroupVersionKind(schema.GroupVersionKind{Group: gwtypes.GroupName, Version: "v1alpha2", Kind: "HTTPRoute"})
 	ownerLabels := metadata.BuildLabels(root, nil)
 
 	tests := []struct {

--- a/controller/hybridgateway/refs/by.go
+++ b/controller/hybridgateway/refs/by.go
@@ -71,7 +71,7 @@ func GetControlPlaneRefByParentRef(ctx context.Context, logger logr.Logger, cl c
 // GetListenersByParentRef retrieves the listeners for a given parent reference.
 func GetListenersByParentRef(ctx context.Context, cl client.Client, route *gwtypes.HTTPRoute, pRef gwtypes.ParentReference) ([]gwtypes.Listener, error) {
 	var namespace string
-	if pRef.Group == nil || *pRef.Group != "gateway.networking.k8s.io" {
+	if pRef.Group == nil || *pRef.Group != gwtypes.GroupName {
 		return nil, nil
 	}
 	if pRef.Kind == nil || *pRef.Kind != "Gateway" {

--- a/controller/hybridgateway/refs/by_test.go
+++ b/controller/hybridgateway/refs/by_test.go
@@ -82,7 +82,7 @@ func TestGetNamespacedRefs(t *testing.T) {
 }
 
 func TestGetControlPlaneRefByParentRef(t *testing.T) {
-	gatewayGroup := gwtypes.Group("gateway.networking.k8s.io")
+	gatewayGroup := gwtypes.Group(gwtypes.GroupName)
 	gatewayKind := gwtypes.Kind("Gateway")
 
 	tests := []struct {
@@ -482,7 +482,7 @@ func TestGetControlPlaneRefByParentRef(t *testing.T) {
 }
 
 func TestGetListenersByParentRef(t *testing.T) {
-	gatewayGroup := gwtypes.Group("gateway.networking.k8s.io")
+	gatewayGroup := gwtypes.Group(gwtypes.GroupName)
 	gatewayKind := gwtypes.Kind("Gateway")
 
 	tests := []struct {

--- a/controller/hybridgateway/refs/get.go
+++ b/controller/hybridgateway/refs/get.go
@@ -19,7 +19,7 @@ func GetGatewaysByHTTPRoute(ctx context.Context, cl client.Client, r gwtypes.HTT
 	gatewayRefs := []gwtypes.Gateway{}
 	for _, ref := range r.Spec.ParentRefs {
 		var namespace string
-		if ref.Group == nil || *ref.Group != "gateway.networking.k8s.io" {
+		if ref.Group == nil || *ref.Group != gwtypes.GroupName {
 			continue
 		}
 		if ref.Kind == nil || *ref.Kind != "Gateway" {
@@ -77,7 +77,7 @@ func GetSupportedGatewayForParentRef(ctx context.Context, logger logr.Logger, cl
 	}
 
 	// Only support gateway.networking.k8s.io group (or empty group which defaults to this).
-	if pRef.Group != nil && *pRef.Group != "gateway.networking.k8s.io" {
+	if pRef.Group != nil && *pRef.Group != gwtypes.GroupName {
 		log.Debug(logger, "Ignoring ParentRef, unsupported group", "pRef", pRef, "group", *pRef.Group)
 		return nil, nil
 	}

--- a/controller/hybridgateway/refs/get_test.go
+++ b/controller/hybridgateway/refs/get_test.go
@@ -41,7 +41,7 @@ func Test_GetSupportedGatewayForParentRef(t *testing.T) {
 		},
 	}
 	gateway.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "gateway.networking.k8s.io",
+		Group:   gwtypes.GroupName,
 		Version: "v1",
 		Kind:    "Gateway",
 	})
@@ -54,7 +54,7 @@ func Test_GetSupportedGatewayForParentRef(t *testing.T) {
 		},
 	}
 	gatewayClass.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "gateway.networking.k8s.io",
+		Group:   gwtypes.GroupName,
 		Version: "v1",
 		Kind:    "GatewayClass",
 	})
@@ -85,21 +85,21 @@ func Test_GetSupportedGatewayForParentRef(t *testing.T) {
 		},
 		{
 			name:    "gateway not found",
-			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr("gateway.networking.k8s.io"), Name: "notfound"},
+			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "notfound"},
 			routeNS: "default",
 			objs:    []client.Object{},
 			wantErr: fmt.Errorf("no supported gateway found"),
 		},
 		{
 			name:    "gateway class not found",
-			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr("gateway.networking.k8s.io"), Name: "my-gateway"},
+			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "my-gateway"},
 			routeNS: "default",
 			objs:    []client.Object{gateway},
 			wantErr: fmt.Errorf("no gatewayClass found for gateway"),
 		},
 		{
 			name:    "gateway class wrong controller",
-			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr("gateway.networking.k8s.io"), Name: "my-gateway"},
+			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "my-gateway"},
 			routeNS: "default",
 			objs: []client.Object{gateway, &gwtypes.GatewayClass{
 				ObjectMeta: metav1.ObjectMeta{Name: "my-class"},
@@ -109,7 +109,7 @@ func Test_GetSupportedGatewayForParentRef(t *testing.T) {
 		},
 		{
 			name:    "gateway class empty controller",
-			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr("gateway.networking.k8s.io"), Name: "my-gateway"},
+			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "my-gateway"},
 			routeNS: "default",
 			objs: []client.Object{gateway, &gwtypes.GatewayClass{
 				ObjectMeta: metav1.ObjectMeta{Name: "my-class"},
@@ -119,14 +119,14 @@ func Test_GetSupportedGatewayForParentRef(t *testing.T) {
 		},
 		{
 			name:    "supported parent ref",
-			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr("gateway.networking.k8s.io"), Name: "my-gateway"},
+			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "my-gateway"},
 			routeNS: "default",
 			objs:    []client.Object{gateway, gatewayClass},
 			wantNil: false,
 		},
 		{
 			name:    "gateway get generic error",
-			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr("gateway.networking.k8s.io"), Name: "my-gateway"},
+			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "my-gateway"},
 			routeNS: "default",
 			objs:    []client.Object{gateway, gatewayClass},
 			interceptorFunc: interceptor.Funcs{
@@ -141,7 +141,7 @@ func Test_GetSupportedGatewayForParentRef(t *testing.T) {
 		},
 		{
 			name:    "gatewayclass get generic error",
-			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr("gateway.networking.k8s.io"), Name: "my-gateway"},
+			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "my-gateway"},
 			routeNS: "default",
 			objs:    []client.Object{gateway, gatewayClass},
 			interceptorFunc: interceptor.Funcs{
@@ -156,7 +156,7 @@ func Test_GetSupportedGatewayForParentRef(t *testing.T) {
 		},
 		{
 			name:    "parentRef with custom namespace",
-			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr("gateway.networking.k8s.io"), Name: "my-gateway", Namespace: nsPtr("custom-ns")},
+			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "my-gateway", Namespace: nsPtr("custom-ns")},
 			routeNS: "default",
 			objs: []client.Object{
 				&gwtypes.Gateway{

--- a/controller/hybridgateway/route/status.go
+++ b/controller/hybridgateway/route/status.go
@@ -808,7 +808,7 @@ func FilterListenersByHostnames(logger logr.Logger, listeners []gwtypes.Listener
 
 // GetRouteGroupKind returns the RouteGroupKind for a given route object, ensuring the group is set to the Gateway API default if empty.
 // This function extracts the GroupVersionKind from the route object and converts it to the Gateway API RouteGroupKind format.
-// If the group is empty, it defaults to "gateway.networking.k8s.io" which is the standard Gateway API group.
+// If the group is empty, it defaults to  gwtypes.GroupName which is the standard Gateway API group.
 //
 // Parameters:
 //   - route: The route object (HTTPRoute, GRPCRoute, etc.) to extract GroupKind information from
@@ -821,7 +821,7 @@ func GetRouteGroupKind(route client.Object) gwtypes.RouteGroupKind {
 	gvk := route.GetObjectKind().GroupVersionKind()
 	group := gvk.Group
 	if group == "" {
-		group = "gateway.networking.k8s.io"
+		group = gwtypes.GroupName
 	}
 	grp := gwtypes.Group(group)
 	return gwtypes.RouteGroupKind{

--- a/controller/hybridgateway/route/status_test.go
+++ b/controller/hybridgateway/route/status_test.go
@@ -375,7 +375,7 @@ func Test_GetRouteGroupKind(t *testing.T) {
 		{
 			name:  "empty group defaults to gateway.networking.k8s.io",
 			gvk:   schema.GroupVersionKind{Group: "", Kind: "HTTPRoute"},
-			wantG: "gateway.networking.k8s.io",
+			wantG: gwtypes.GroupName,
 			wantK: "HTTPRoute",
 		},
 	}
@@ -578,7 +578,7 @@ func Test_BuildAcceptedCondition(t *testing.T) {
 		},
 	}
 
-	pRef := gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr("gateway.networking.k8s.io"), Name: "gw"}
+	pRef := gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "gw"}
 
 	// Fake client with default namespace
 	s := runtime.NewScheme()
@@ -692,7 +692,7 @@ func Test_BuildAcceptedCondition(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Namespace: "nonexistent", Name: "route"},
 				Spec:       gwtypes.HTTPRouteSpec{},
 			},
-			pRef:       gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr("gateway.networking.k8s.io"), Name: "gw", SectionName: sectionPtr("listener1")},
+			pRef:       gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "gw", SectionName: sectionPtr("listener1")},
 			client:     fake.NewClientBuilder().WithScheme(s).Build(), // no namespace object
 			wantType:   "",
 			wantStatus: "",
@@ -733,7 +733,7 @@ func Test_BuildAcceptedCondition(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
 				Spec:       gwtypes.HTTPRouteSpec{},
 			},
-			pRef:       gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr("gateway.networking.k8s.io"), Name: "gw", SectionName: sectionPtr("listener1")},
+			pRef:       gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "gw", SectionName: sectionPtr("listener1")},
 			client:     cl,
 			wantType:   "",
 			wantStatus: "",
@@ -1185,7 +1185,7 @@ func Test_FilterListenersByAllowedRoutes(t *testing.T) {
 	gw := &gwtypes.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"}}
 	pRef := gwtypes.ParentReference{Name: "listener1"}
 	listener := gwtypes.Listener{Name: "listener1", Port: 80, Protocol: gwtypes.HTTPProtocolType}
-	kind := gwtypes.RouteGroupKind{Group: groupPtr("gateway.networking.k8s.io"), Kind: "HTTPRoute"}
+	kind := gwtypes.RouteGroupKind{Group: groupPtr(gwtypes.GroupName), Kind: "HTTPRoute"}
 	routeNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
 
 	selector := &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}
@@ -1195,7 +1195,7 @@ func Test_FilterListenersByAllowedRoutes(t *testing.T) {
 	listenerAll.AllowedRoutes = &gwtypes.AllowedRoutes{}
 
 	listenerKindMatch := listener
-	listenerKindMatch.AllowedRoutes = &gwtypes.AllowedRoutes{Kinds: []gwtypes.RouteGroupKind{{Group: groupPtr("gateway.networking.k8s.io"), Kind: "HTTPRoute"}}}
+	listenerKindMatch.AllowedRoutes = &gwtypes.AllowedRoutes{Kinds: []gwtypes.RouteGroupKind{{Group: groupPtr(gwtypes.GroupName), Kind: "HTTPRoute"}}}
 
 	listenerKindMismatch := listener
 	listenerKindMismatch.AllowedRoutes = &gwtypes.AllowedRoutes{Kinds: []gwtypes.RouteGroupKind{{Group: groupPtr("other"), Kind: "OtherRoute"}}}

--- a/controller/hybridgateway/target/target_test.go
+++ b/controller/hybridgateway/target/target_test.go
@@ -1767,7 +1767,7 @@ func TestFiltervalidBackendRefs(t *testing.T) {
 				Spec: gatewayv1beta1.ReferenceGrantSpec{
 					From: []gatewayv1beta1.ReferenceGrantFrom{
 						{
-							Group:     "gateway.networking.k8s.io",
+							Group:     gwtypes.GroupName,
 							Kind:      "HTTPRoute",
 							Namespace: "wrong-namespace", // Wrong source namespace.
 						},
@@ -2623,7 +2623,7 @@ func TestTargetsForBackendRefs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "allow-frontend-to-backend", Namespace: "backend-ns"},
 					Spec: gatewayv1beta1.ReferenceGrantSpec{
 						From: []gatewayv1beta1.ReferenceGrantFrom{
-							{Group: "gateway.networking.k8s.io", Kind: "HTTPRoute", Namespace: "frontend-ns"},
+							{Group: gwtypes.GroupName, Kind: "HTTPRoute", Namespace: "frontend-ns"},
 						},
 						To: []gatewayv1beta1.ReferenceGrantTo{
 							{Group: "", Kind: "Service"},

--- a/controller/hybridgateway/watch/mapfuncs.go
+++ b/controller/hybridgateway/watch/mapfuncs.go
@@ -176,7 +176,7 @@ func MapHTTPRouteForReferenceGrant(cl client.Client) handler.MapFunc {
 		var requests []reconcile.Request
 		for _, from := range rg.Spec.From {
 			// Check that the from kind is HTTPRoute and group is gateway.networking.k8s.io.
-			if from.Kind != "HTTPRoute" || (from.Group != "" && from.Group != "gateway.networking.k8s.io") {
+			if from.Kind != "HTTPRoute" || (from.Group != "" && from.Group != gwtypes.GroupName) {
 				continue
 			}
 

--- a/controller/hybridgateway/watch/mapfuncs_test.go
+++ b/controller/hybridgateway/watch/mapfuncs_test.go
@@ -660,7 +660,7 @@ func Test_MapHTTPRouteForReferenceGrant(t *testing.T) {
 		},
 		Spec: gwtypes.ReferenceGrantSpec{
 			From: []gatewayv1beta1.ReferenceGrantFrom{{
-				Group:     "gateway.networking.k8s.io",
+				Group:     gwtypes.GroupName,
 				Kind:      "HTTPRoute",
 				Namespace: "source-ns",
 			}},
@@ -703,7 +703,7 @@ func Test_MapHTTPRouteForReferenceGrant(t *testing.T) {
 			},
 			Spec: gwtypes.ReferenceGrantSpec{
 				From: []gatewayv1beta1.ReferenceGrantFrom{{
-					Group: "gateway.networking.k8s.io",
+					Group: gwtypes.GroupName,
 					// Not HTTPRoute.
 					Kind:      "TCPRoute",
 					Namespace: "source-ns",
@@ -823,12 +823,12 @@ func Test_MapHTTPRouteForReferenceGrant(t *testing.T) {
 			Spec: gwtypes.ReferenceGrantSpec{
 				From: []gatewayv1beta1.ReferenceGrantFrom{
 					{
-						Group:     "gateway.networking.k8s.io",
+						Group:     gwtypes.GroupName,
 						Kind:      "HTTPRoute",
 						Namespace: "source-ns",
 					},
 					{
-						Group:     "gateway.networking.k8s.io",
+						Group:     gwtypes.GroupName,
 						Kind:      "HTTPRoute",
 						Namespace: "other-ns",
 					},


### PR DESCRIPTION
**What this PR does / why we need it**:

Replace all hardcoded "gateway.networking.k8s.io" string literals with gwtypes.GroupName constant across hybridgateway controller for improved maintainability and consistency.

**Which issue this PR fixes**

Fixes #2650 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
