### PR TITLE
fix(hybridgateway): do not provision dataplane before `KonnectExtension`

### DIFF
--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -51,6 +51,7 @@ func (r *Reconciler) createDataPlane(
 	ctx context.Context,
 	gateway *gwtypes.Gateway,
 	gatewayConfig *GatewayConfiguration,
+	konnectExtension *konnectv1alpha2.KonnectExtension,
 ) (*operatorv1beta1.DataPlane, error) {
 	dataplane := &operatorv1beta1.DataPlane{
 		ObjectMeta: metav1.ObjectMeta{
@@ -66,7 +67,7 @@ func (r *Reconciler) createDataPlane(
 		return nil, err
 	}
 
-	dataplane.Spec.Extensions = extensions.MergeExtensions(gatewayConfig.Spec.Extensions, dataplane)
+	dataplane.Spec.Extensions = extensions.MergeExtensionsForDataPlane(gatewayConfig.Spec.Extensions, konnectExtension)
 
 	k8sutils.SetOwnerForObject(dataplane, gateway)
 	gatewayutils.LabelObjectAsGatewayManaged(dataplane)

--- a/controller/pkg/extensions/apply.go
+++ b/controller/pkg/extensions/apply.go
@@ -15,6 +15,7 @@ import (
 	operatorv2beta1 "github.com/kong/kong-operator/api/gateway-operator/v2beta1"
 	kcfgkonnect "github.com/kong/kong-operator/api/konnect"
 	extensionserrors "github.com/kong/kong-operator/controller/pkg/extensions/errors"
+	"github.com/kong/kong-operator/controller/pkg/extensions/processor"
 	"github.com/kong/kong-operator/controller/pkg/patch"
 	gwtypes "github.com/kong/kong-operator/internal/types"
 	k8sutils "github.com/kong/kong-operator/pkg/utils/kubernetes"
@@ -47,7 +48,7 @@ type Extendable interface {
 //     of an API server error), the resource should be requeued. For misconfiguration errors, the resource does not
 //     need to be requeued, and feedback is provided via resource status conditions.
 //   - err: an error in case of failure.
-func ApplyExtensions[t ExtendableT](ctx context.Context, cl client.Client, o t, konnectEnabled bool, processor Processor) (stop bool, res ctrl.Result, err error) {
+func ApplyExtensions[t ExtendableT](ctx context.Context, cl client.Client, o t, konnectEnabled bool, processor processor.Processor) (stop bool, res ctrl.Result, err error) {
 	// extensionsCondition can be nil. In that case, no extensions are referenced by the object.
 	extensionsCondition := validateExtensions(o)
 	if extensionsCondition == nil {

--- a/controller/pkg/extensions/konnect/controlplane.go
+++ b/controller/pkg/extensions/konnect/controlplane.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
-	"github.com/kong/kong-operator/controller/pkg/extensions"
+	"github.com/kong/kong-operator/controller/pkg/extensions/processor"
 	managercfg "github.com/kong/kong-operator/ingress-controller/pkg/manager/config"
 	gwtypes "github.com/kong/kong-operator/internal/types"
 )
@@ -29,7 +29,7 @@ type ControlPlaneKonnectExtensionProcessor struct {
 }
 
 // Compile-time check to ensure ControlPlaneKonnectExtensionProcessor implements the extensions.ExtensionProcessor interface.
-var _ extensions.Processor = (*ControlPlaneKonnectExtensionProcessor)(nil)
+var _ processor.Processor = (*ControlPlaneKonnectExtensionProcessor)(nil)
 
 // Process extracts the KonnectExtension from the ControlPlane and generates the KonnectExtensionConfig.
 // It returns true if a KonnectExtension was found and processed, false otherwise.

--- a/controller/pkg/extensions/konnect/dataplane.go
+++ b/controller/pkg/extensions/konnect/dataplane.go
@@ -11,7 +11,7 @@ import (
 
 	operatorv1beta1 "github.com/kong/kong-operator/api/gateway-operator/v1beta1"
 	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
-	"github.com/kong/kong-operator/controller/pkg/extensions"
+	"github.com/kong/kong-operator/controller/pkg/extensions/processor"
 	"github.com/kong/kong-operator/internal/utils/config"
 	"github.com/kong/kong-operator/pkg/consts"
 	k8sutils "github.com/kong/kong-operator/pkg/utils/kubernetes"
@@ -21,8 +21,8 @@ import (
 // DataPlaneKonnectExtensionProcessor processes Konnect extensions for DataPlane resources.
 type DataPlaneKonnectExtensionProcessor struct{}
 
-// Compile-time check to ensure DataPlaneKonnectExtensionProcessor implements the extensions.ExtensionProcessor interface.
-var _ extensions.Processor = (*DataPlaneKonnectExtensionProcessor)(nil)
+// Compile-time check to ensure DataPlaneKonnectExtensionProcessor implements the processor.Processor interface.
+var _ processor.Processor = (*DataPlaneKonnectExtensionProcessor)(nil)
 
 // Process gets the DataPlane as argument, and in case it references a KonnectExtension, it
 // fetches the referenced extension and applies the necessary changes to the DataPlane spec.

--- a/controller/pkg/extensions/konnect/utils.go
+++ b/controller/pkg/extensions/konnect/utils.go
@@ -1,0 +1,23 @@
+package konnect
+
+import (
+	"github.com/samber/lo"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
+)
+
+// KonnectExtensionToExtensionRef converts a KonnectExtension to the corresponding ExtensionRef.
+func KonnectExtensionToExtensionRef(extension *konnectv1alpha2.KonnectExtension) *commonv1alpha1.ExtensionRef {
+	if extension == nil {
+		return nil
+	}
+	return &commonv1alpha1.ExtensionRef{
+		Group: konnectv1alpha2.SchemeGroupVersion.Group,
+		Kind:  konnectv1alpha2.KonnectExtensionKind,
+		NamespacedRef: commonv1alpha1.NamespacedRef{
+			Name:      extension.Name,
+			Namespace: lo.ToPtr(extension.Namespace),
+		},
+	}
+}

--- a/controller/pkg/extensions/konnect/utils_test.go
+++ b/controller/pkg/extensions/konnect/utils_test.go
@@ -1,0 +1,76 @@
+package konnect
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
+)
+
+func TestKonnectExtensionToExtensionRef(t *testing.T) {
+	tests := []struct {
+		name      string
+		extension *konnectv1alpha2.KonnectExtension
+		want      *commonv1alpha1.ExtensionRef
+	}{
+		{
+			name:      "nil extension returns nil",
+			extension: nil,
+			want:      nil,
+		},
+		{
+			name: "converts extension with name and namespace",
+			extension: &konnectv1alpha2.KonnectExtension{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-extension",
+					Namespace: "default",
+				},
+			},
+			want: &commonv1alpha1.ExtensionRef{
+				Group: konnectv1alpha2.SchemeGroupVersion.Group,
+				Kind:  konnectv1alpha2.KonnectExtensionKind,
+				NamespacedRef: commonv1alpha1.NamespacedRef{
+					Name:      "test-extension",
+					Namespace: lo.ToPtr("default"),
+				},
+			},
+		},
+		{
+			name: "converts extension with additional fields (only name and namespace used)",
+			extension: &konnectv1alpha2.KonnectExtension{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "complex-extension",
+					Namespace: "production",
+					Labels: map[string]string{
+						"app": "test",
+					},
+					Annotations: map[string]string{
+						"description": "test extension",
+					},
+				},
+				Spec: konnectv1alpha2.KonnectExtensionSpec{
+					// Fields here should not affect the conversion
+				},
+			},
+			want: &commonv1alpha1.ExtensionRef{
+				Group: konnectv1alpha2.SchemeGroupVersion.Group,
+				Kind:  konnectv1alpha2.KonnectExtensionKind,
+				NamespacedRef: commonv1alpha1.NamespacedRef{
+					Name:      "complex-extension",
+					Namespace: lo.ToPtr("production"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := KonnectExtensionToExtensionRef(tt.extension)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/controller/pkg/extensions/merge_test.go
+++ b/controller/pkg/extensions/merge_test.go
@@ -204,7 +204,7 @@ func TestMergeExtensionsForType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := MergeExtensionsForDataPlane(tt.defaultExtensions, tt.extensions)
+			result := mergeExtensionsForDataPlane(tt.defaultExtensions, tt.extensions)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/controller/pkg/extensions/processor/processor.go
+++ b/controller/pkg/extensions/processor/processor.go
@@ -1,4 +1,4 @@
-package extensions
+package processor
 
 import (
 	"context"


### PR DESCRIPTION
**What this PR does / why we need it**:

We had a bug related to the `DataPlane` being provisioned before the `KonnectGatewayControlPlane` and `Konnectextension` provisioning. This PR fixes that, setting the `KonnectExtension` existence as a prerequisite for the `DataPlane` provisioning.

**Which issue this PR fixes**

Fixes #2609

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
