### PR TITLE
chore(ci): Ignore CVEs GO-2025-4134 and GO-2025-4135

### DIFF
--- a/hack/govulncheck-with-excludes.sh
+++ b/hack/govulncheck-with-excludes.sh
@@ -20,7 +20,17 @@ excludeVulns="$(jq -nc '[
   # Moby firewalld reload removes bridge network isolation in github.com/docker/docker
   # https://pkg.go.dev/vuln/GO-2025-3829
   # (aka CVE-2025-54410, GHSA-4vq8-7jfc-9cvp)
-  "GO-2025-3829"
+  "GO-2025-3829",
+
+  # SSH servers parsing GSSAPI authentication requests do not validate the number of mechanisms specified in the request, allowing an attacker to cause unbounded memory consumption.
+  # It was fixed in golang.org/x/crypto 0.45.0 but the govulncheck workflow still fails: https://github.com/Kong/kong-operator/pull/2658.
+  # https://pkg.go.dev/vuln/GO-2025-4134
+  "GO-2025-4134",
+
+  # SSH Agent servers do not validate the size of messages when processing new identity requests, which may cause the program to panic if the message is malformed due to an out of bounds read.
+  # It was fixed in golang.org/x/crypto 0.45.0 but the govulncheck workflow still fails: https://github.com/Kong/kong-operator/pull/2658.
+  # https://pkg.go.dev/vuln/GO-2025-4135
+  "GO-2025-4135" 
 
 ]')"
 export excludeVulns


### PR DESCRIPTION
**What this PR does / why we need it**:

Since #2658 fixed the CVEs but still failed the govulncheck due to the CVEs GO-2025-4134 and GO-2025-4135, we ignore it temporarily.
Also the `golang.org/x/crypto/ssh` is only imported by `github.com/testcontainers/testcontainers-go` which runs additional containers for envtest tests for KIC functions, it is not relevant to us.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
