### PR TITLE
fix(ingress-controller): Add translation of healthchecks.threshold in upstreams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,9 @@
   [#2427](https://github.com/Kong/kong-operator/pull/2427)
 - Hybrid Gateway: attach KongService generation to BackendRefs and fix filter/plugin conversion.
   [#2456](https://github.com/Kong/kong-operator/pull/2456)
+- Translate `healtchchecks.thershold` in `KongUpstreamPolicy` to the
+  `healthchecks.thershold` field in Kong upstreams.
+  [#2662](https://github.com/Kong/kong-operator/pull/2662)
 
 ## [v2.0.5]
 

--- a/ingress-controller/internal/dataplane/kongstate/kongupstreampolicy.go
+++ b/ingress-controller/internal/dataplane/kongstate/kongupstreampolicy.go
@@ -170,8 +170,9 @@ func translateHealthchecks(healthchecks *configurationv1beta1.KongUpstreamHealth
 		return nil
 	}
 	return &kong.Healthcheck{
-		Active:  translateActiveHealthcheck(healthchecks.Active),
-		Passive: translatePassiveHealthcheck(healthchecks.Passive),
+		Active:    translateActiveHealthcheck(healthchecks.Active),
+		Passive:   translatePassiveHealthcheck(healthchecks.Passive),
+		Threshold: translateThreshold(healthchecks.Threshold),
 	}
 }
 
@@ -201,6 +202,13 @@ func translatePassiveHealthcheck(healthcheck *configurationv1beta1.KongUpstreamP
 		Healthy:   translateHealthy(healthcheck.Healthy),
 		Unhealthy: translateUnhealthy(healthcheck.Unhealthy),
 	}
+}
+
+func translateThreshold(threshold *int) *float64 {
+	if threshold == nil {
+		return nil
+	}
+	return lo.ToPtr(float64(*threshold))
 }
 
 func translateHealthy(healthy *configurationv1beta1.KongUpstreamHealthcheckHealthy) *kong.Healthy {

--- a/ingress-controller/internal/dataplane/kongstate/kongupstreampolicy_test.go
+++ b/ingress-controller/internal/dataplane/kongstate/kongupstreampolicy_test.go
@@ -382,7 +382,7 @@ func TestTranslateKongUpstreamPolicy(t *testing.T) {
 							Timeouts:    lo.ToPtr(120),
 						},
 					},
-					Threshold: lo.ToPtr(140),
+					Threshold: lo.ToPtr(10),
 				},
 			},
 			expectedUpstream: &kong.Upstream{
@@ -417,6 +417,7 @@ func TestTranslateKongUpstreamPolicy(t *testing.T) {
 							Timeouts:    lo.ToPtr(120),
 						},
 					},
+					Threshold: lo.ToPtr(float64(10.0)),
 				},
 			},
 		},

--- a/ingress-controller/test/kongintegration/kongupstreampolicy_test.go
+++ b/ingress-controller/test/kongintegration/kongupstreampolicy_test.go
@@ -174,7 +174,7 @@ func TestKongUpstreamPolicyTranslation(t *testing.T) {
 							Timeouts:     lo.ToPtr(120),
 						},
 					},
-					Threshold: lo.ToPtr(140),
+					Threshold: lo.ToPtr(15),
 				},
 			},
 			expectedUpstream: &kong.Upstream{
@@ -213,7 +213,7 @@ func TestKongUpstreamPolicyTranslation(t *testing.T) {
 							Timeouts:     lo.ToPtr(120),
 						},
 					},
-					Threshold: lo.ToPtr(0.),
+					Threshold: lo.ToPtr(15.0),
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Migration of https://github.com/Kong/kubernetes-ingress-controller/pull/7784 to fix the missing of translating `healthchecks.threshold`.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
