### PR TITLE
feat(konnect): Add SetAdoptOptions methods for CRDs supporting adoption

### DIFF
--- a/api/configuration/v1/zz_generated_adopt_funcs.go
+++ b/api/configuration/v1/zz_generated_adopt_funcs.go
@@ -10,3 +10,8 @@ import (
 func (obj *KongConsumer) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
 }
+
+// Set the options to adopt the resource from an existing resource.
+func (obj *KongConsumer) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
+}

--- a/api/configuration/v1alpha1/zz_generated_adopt_funcs.go
+++ b/api/configuration/v1alpha1/zz_generated_adopt_funcs.go
@@ -11,9 +11,19 @@ func (obj *KongKey) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
 }
 
+// Set the options to adopt the resource from an existing resource.
+func (obj *KongKey) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
+}
+
 // Get the options to adopt the resource from an existing resource.
 func (obj *KongKeySet) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
+}
+
+// Set the options to adopt the resource from an existing resource.
+func (obj *KongKeySet) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
 }
 
 // Get the options to adopt the resource from an existing resource.
@@ -21,9 +31,19 @@ func (obj *KongCredentialBasicAuth) GetAdoptOptions() *commonv1alpha1.AdoptOptio
 	return obj.Spec.Adopt
 }
 
+// Set the options to adopt the resource from an existing resource.
+func (obj *KongCredentialBasicAuth) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
+}
+
 // Get the options to adopt the resource from an existing resource.
 func (obj *KongCredentialAPIKey) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
+}
+
+// Set the options to adopt the resource from an existing resource.
+func (obj *KongCredentialAPIKey) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
 }
 
 // Get the options to adopt the resource from an existing resource.
@@ -31,9 +51,19 @@ func (obj *KongCredentialJWT) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
 }
 
+// Set the options to adopt the resource from an existing resource.
+func (obj *KongCredentialJWT) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
+}
+
 // Get the options to adopt the resource from an existing resource.
 func (obj *KongCredentialACL) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
+}
+
+// Set the options to adopt the resource from an existing resource.
+func (obj *KongCredentialACL) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
 }
 
 // Get the options to adopt the resource from an existing resource.
@@ -41,9 +71,19 @@ func (obj *KongCredentialHMAC) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
 }
 
+// Set the options to adopt the resource from an existing resource.
+func (obj *KongCredentialHMAC) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
+}
+
 // Get the options to adopt the resource from an existing resource.
 func (obj *KongCACertificate) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
+}
+
+// Set the options to adopt the resource from an existing resource.
+func (obj *KongCACertificate) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
 }
 
 // Get the options to adopt the resource from an existing resource.
@@ -51,9 +91,19 @@ func (obj *KongCertificate) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
 }
 
+// Set the options to adopt the resource from an existing resource.
+func (obj *KongCertificate) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
+}
+
 // Get the options to adopt the resource from an existing resource.
 func (obj *KongPluginBinding) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
+}
+
+// Set the options to adopt the resource from an existing resource.
+func (obj *KongPluginBinding) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
 }
 
 // Get the options to adopt the resource from an existing resource.
@@ -61,9 +111,19 @@ func (obj *KongService) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
 }
 
+// Set the options to adopt the resource from an existing resource.
+func (obj *KongService) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
+}
+
 // Get the options to adopt the resource from an existing resource.
 func (obj *KongRoute) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
+}
+
+// Set the options to adopt the resource from an existing resource.
+func (obj *KongRoute) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
 }
 
 // Get the options to adopt the resource from an existing resource.
@@ -71,9 +131,19 @@ func (obj *KongUpstream) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
 }
 
+// Set the options to adopt the resource from an existing resource.
+func (obj *KongUpstream) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
+}
+
 // Get the options to adopt the resource from an existing resource.
 func (obj *KongTarget) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
+}
+
+// Set the options to adopt the resource from an existing resource.
+func (obj *KongTarget) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
 }
 
 // Get the options to adopt the resource from an existing resource.
@@ -81,7 +151,17 @@ func (obj *KongVault) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
 }
 
+// Set the options to adopt the resource from an existing resource.
+func (obj *KongVault) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
+}
+
 // Get the options to adopt the resource from an existing resource.
 func (obj *KongSNI) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
+}
+
+// Set the options to adopt the resource from an existing resource.
+func (obj *KongSNI) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
 }

--- a/api/configuration/v1beta1/zz_generated_adopt_funcs.go
+++ b/api/configuration/v1beta1/zz_generated_adopt_funcs.go
@@ -10,3 +10,8 @@ import (
 func (obj *KongConsumerGroup) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
 }
+
+// Set the options to adopt the resource from an existing resource.
+func (obj *KongConsumerGroup) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
+}

--- a/api/konnect/v1alpha1/zz_generated_adopt_funcs.go
+++ b/api/konnect/v1alpha1/zz_generated_adopt_funcs.go
@@ -11,12 +11,27 @@ func (obj *KonnectCloudGatewayNetwork) GetAdoptOptions() *commonv1alpha1.AdoptOp
 	return obj.Spec.Adopt
 }
 
+// Set the options to adopt the resource from an existing resource.
+func (obj *KonnectCloudGatewayNetwork) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
+}
+
 // Get the options to adopt the resource from an existing resource.
 func (obj *KonnectCloudGatewayTransitGateway) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
 }
 
+// Set the options to adopt the resource from an existing resource.
+func (obj *KonnectCloudGatewayTransitGateway) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
+}
+
 // Get the options to adopt the resource from an existing resource.
 func (obj *KonnectCloudGatewayDataPlaneGroupConfiguration) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
+}
+
+// Set the options to adopt the resource from an existing resource.
+func (obj *KonnectCloudGatewayDataPlaneGroupConfiguration) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
 }

--- a/controller/konnect/constraints/constraints.go
+++ b/controller/konnect/constraints/constraints.go
@@ -68,6 +68,7 @@ type SupportedKonnectEntityType interface {
 type KonnectEntityTypeSupportingAdoption interface {
 	GetTypeName() string
 	GetAdoptOptions() *commonv1alpha1.AdoptOptions
+	SetAdoptOptions(*commonv1alpha1.AdoptOptions)
 }
 
 // EntityTypeObject is an interface that allows non Konnect types to be used

--- a/scripts/apitypes-funcs/templates.go
+++ b/scripts/apitypes-funcs/templates.go
@@ -312,5 +312,10 @@ func (obj *{{.Type}}) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 	return obj.Spec.Adopt
 }
 
+// Set the options to adopt the resource from an existing resource.
+func (obj *{{.Type}}) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
+}
+
 {{- end }}`
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `SetAdoptOption` to configure adopt options for CRDs to simplify the places to set the options (for example, tests).

**Which issue this PR fixes**

Fixes #2660 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
