### PR TITLE
tests: fix flaky TestAgent

### DIFF
--- a/ingress-controller/internal/license/agent_test.go
+++ b/ingress-controller/internal/license/agent_test.go
@@ -181,7 +181,12 @@ func TestAgent(t *testing.T) {
 				listCalls := upstreamClient.GetCalls()
 				lastListCall := listCalls[len(listCalls)-1]
 				lastButOneCall := listCalls[len(listCalls)-2]
-				return lastListCall.Sub(lastButOneCall).Abs() <= allowedDelta
+				// Verify that the agent uses the regular polling period once a
+				// license has been retrieved by checking that the time between the
+				// last two calls is approximately the regular polling period.
+				diff := lastListCall.Sub(lastButOneCall)
+				return diff >= regularPollingPeriod-allowedDelta &&
+					diff <= regularPollingPeriod+allowedDelta
 			}, time.Second, time.Millisecond)
 		})
 

--- a/ingress-controller/test/mocks/ticker.go
+++ b/ingress-controller/test/mocks/ticker.go
@@ -58,13 +58,13 @@ func (t *Ticker) Reset(d time.Duration) {
 	default:
 	}
 
-	now := time.Now()
-
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
-	t.lastTick = now
-	t.time = now
+	// Use the logical time maintained by the ticker instead of time.Now() to
+	// keep the ticker deterministic in tests. This avoids mixing real wall
+	// clock time with the synthetic time advanced via Add().
+	t.lastTick = t.time
 	t.d = d
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Observed a failure in https://github.com/Kong/kong-operator/actions/runs/19531581080/job/55915636990#step:7:11578

```
=== Failed
=== FAIL: ingress-controller/internal/license TestAgent/initial_license_retrieval_fails_and_recovers/regular_polling_period_is_used_after_the_initial_license_is_retrieved (1.00s)
    agent_test.go:87: license not yet available
    agent_test.go:180: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/ingress-controller/internal/license/agent_test.go:180
        	Error:      	Condition never satisfied
        	Test:       	TestAgent/initial_license_retrieval_fails_and_recovers/regular_polling_period_is_used_after_the_initial_license_is_retrieved

=== FAIL: ingress-controller/internal/license TestAgent/initial_license_retrieval_fails_and_recovers (1.01s)

=== FAIL: ingress-controller/internal/license TestAgent (1.01s)
```

Tested with:

```
go test -c -race ./ingress-controller/internal/license && while true; do date && ./license.test -test.count 1000; done
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
