### PR TITLE
tests: bump k8s version in ingress-controller integration tests to 1.34.2

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -548,7 +548,9 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     name: integration-tests
-    needs: [check-docs-only]
+    needs:
+      - check-docs-only
+      - matrix_k8s_node_versions
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     strategy:
       matrix:
@@ -586,6 +588,7 @@ jobs:
         GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
         KONG_TEST_KONNECT_SERVER_URL: us.api.konghq.tech
+        KONG_CLUSTER_VERSION: ${{ needs.matrix_k8s_node_versions.outputs.latest }}
 
     - name: upload diagnostics
       if: always()

--- a/ingress-controller/Makefile
+++ b/ingress-controller/Makefile
@@ -72,7 +72,6 @@ PKG_LIST = ./pkg/...,./internal/...
 INTEGRATION_TEST_TIMEOUT ?= "45m"
 KONG_CONTROLLER_FEATURE_GATES ?= GatewayAlpha=true
 GOTESTSUM_FORMAT ?= standard-verbose
-KONG_CLUSTER_VERSION ?= v1.28.0
 JUNIT_REPORT ?= /dev/null
 
 .PHONY: use-setup-envtest
@@ -116,7 +115,6 @@ TEST_KONG_HELM_CHART_VERSION ?= $(shell $(YQ) -ojson -r '.integration.helm.kong'
 # Related issue: https://github.com/Kong/kubernetes-ingress-controller/issues/3754
 .PHONY: _test.integration
 _test.integration:
-	KONG_CLUSTER_VERSION="$(KONG_CLUSTER_VERSION)" \
 	TEST_KONG_HELM_CHART_VERSION="$(TEST_KONG_HELM_CHART_VERSION)" \
 	TEST_DATABASE_MODE="$(DBMODE)" \
 	GOFLAGS="-tags=$(GOTAGS)" \


### PR DESCRIPTION
**What this PR does / why we need it**:

This aims to avoid the issue where more complex validations are added to CRDs and ingress-controller test suite fails:

https://github.com/Kong/kong-operator/actions/runs/19534314888/job/55924658447?pr=2665#step:7:1549

```
The CustomResourceDefinition "kongupstreams.configuration.konghq.com" is invalid: spec.validation.openAPIV3Schema.properties[spec].properties[healthchecks].x-kubernetes-validations[0].rule: Invalid value: apiextensions.ValidationRule{Rule:"self.threshold >= 0 && self.threshold <= 100", Message:"healthcheck threshold must be between 0 and 100", MessageExpression:"", Reason:(*apiextensions.FieldValueErrorReason)(nil), FieldPath:""}: compilation failed: ERROR: <input>:1:16: found no matching overload for '_>=_' applied to '(double, int)'
 | self.threshold >= 0 && self.threshold <= 100
 | ...............^
ERROR: <input>:1:39: found no matching overload for '_<=_' applied to '(double, int)'
 | self.threshold >= 0 && self.threshold <= 100
 | ......................................^
): exit status 1
FAIL	github.com/kong/kong-operator/ingress-controller/test/integration	97.705s
```

This PR makes the ingress-controller integration tests use the latest version available in https://github.com/Kong/kong-operator/blob/e24a563a89ee77730c4c03ad398810d9c767aada/.github/supported_k8s_node_versions.yaml.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
