### PR TITLE
chore: bump ingress-controller envtest suite timeout to 10m

### DIFF
--- a/ingress-controller/Makefile
+++ b/ingress-controller/Makefile
@@ -79,7 +79,7 @@ JUNIT_REPORT ?= /dev/null
 use-setup-envtest:
 	$(SETUP_ENVTEST) use -v info $(CLUSTER_VERSION)
 
-ENVTEST_TIMEOUT ?= 8m
+ENVTEST_TIMEOUT ?= 10m
 
 .PHONY: _test.envtest
 .ONESHELL: _test.envtest


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent failures like: https://github.com/Kong/kong-operator/actions/runs/19534839833/job/55926399517?pr=2666

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
