### PR TITLE
chore(tests): enable validating_admission_policy for integration and conformance suites

### DIFF
--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -91,6 +91,7 @@ func TestMain(m *testing.M) {
 	exitOnErr(clusters.CreateNamespace(ctx, env.Cluster(), "kong-system"))
 	exitOnErr(clusters.KustomizeDeployForCluster(ctx, env.Cluster(), path.Join(configPath, "/rbac/base")))
 	exitOnErr(clusters.KustomizeDeployForCluster(ctx, env.Cluster(), path.Join(configPath, "/rbac/role")))
+	exitOnErr(clusters.KustomizeDeployForCluster(ctx, env.Cluster(), path.Join(configPath, "/default/validating_policies")))
 
 	// Normally this is obtained from the downward API. The tests fake it.
 	err = os.Setenv("POD_NAMESPACE", "kong-system")

--- a/test/integration/dataplane_ports_validating_admission_policy_test.go
+++ b/test/integration/dataplane_ports_validating_admission_policy_test.go
@@ -1,0 +1,170 @@
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	operatorv1beta1 "github.com/kong/kong-operator/api/gateway-operator/v1beta1"
+	"github.com/kong/kong-operator/pkg/consts"
+	"github.com/kong/kong-operator/test/helpers"
+)
+
+// TestDataPlanePortsValidatingAdmissionPolicy tests if the validating admission policy
+// is indeed configured for integration tests suite. More specific tests for actual
+// logic are in test/crdsvalidation/dataplane_validatingadmissionpolicy_test.go.
+func TestDataPlanePortsValidatingAdmissionPolicy(t *testing.T) {
+	t.Parallel()
+
+	namespace, cleaner := helpers.SetupTestEnv(t, GetCtx(), GetEnv())
+	testCases := []struct {
+		name            string
+		dataPlane       *operatorv1beta1.DataPlane
+		updateDataPlane func(*operatorv1beta1.DataPlane)
+		errorContains   string
+	}{
+		{
+			name: "DataPlane creation - KONG_PORT_MAPS missing port from ingress",
+			dataPlane: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    namespace.Name,
+					GenerateName: "dataplane-invalid-creation-test-",
+				},
+				Spec: operatorv1beta1.DataPlaneSpec{
+					DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+						Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+							DeploymentOptions: operatorv1beta1.DeploymentOptions{
+								PodTemplateSpec: &corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										Containers: []corev1.Container{
+											{
+												Name:  consts.DataPlaneProxyContainerName,
+												Image: helpers.GetDefaultDataPlaneImage(),
+												Env: []corev1.EnvVar{
+													{
+														Name:  "KONG_PORT_MAPS",
+														Value: "80:8000",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						Network: operatorv1beta1.DataPlaneNetworkOptions{
+							Services: &operatorv1beta1.DataPlaneServices{
+								Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+									Ports: []operatorv1beta1.DataPlaneServicePort{
+										{
+											Name:       "http",
+											Port:       80,
+											TargetPort: intstr.FromInt(8000),
+										},
+										{
+											Name:       "https",
+											Port:       443,
+											TargetPort: intstr.FromInt(8443),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			errorContains: "denied request: Each port from spec.network.services.ingress.ports has to have an accompanying port in KONG_PORT_MAPS env",
+		},
+		{
+			name: "DataPlane update - adding mismatched port should fail",
+			dataPlane: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    namespace.Name,
+					GenerateName: "dataplane-invalid-update-test-",
+				},
+				Spec: operatorv1beta1.DataPlaneSpec{
+					DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+						Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+							DeploymentOptions: operatorv1beta1.DeploymentOptions{
+								PodTemplateSpec: &corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										Containers: []corev1.Container{
+											{
+												Name:  consts.DataPlaneProxyContainerName,
+												Image: helpers.GetDefaultDataPlaneImage(),
+												Env: []corev1.EnvVar{
+													{
+														Name:  "KONG_PORT_MAPS",
+														Value: "80:8000",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						Network: operatorv1beta1.DataPlaneNetworkOptions{
+							Services: &operatorv1beta1.DataPlaneServices{
+								Ingress: &operatorv1beta1.DataPlaneServiceOptions{
+									Ports: []operatorv1beta1.DataPlaneServicePort{
+										{
+											Name:       "http",
+											Port:       80,
+											TargetPort: intstr.FromInt(8000),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			// Add a mismatched port without updating KONG_PORT_MAPS.
+			updateDataPlane: func(dp *operatorv1beta1.DataPlane) {
+				dp.Spec.Network.Services.Ingress.Ports = append(
+					dp.Spec.Network.Services.Ingress.Ports,
+					operatorv1beta1.DataPlaneServicePort{
+						Name:       "https",
+						Port:       443,
+						TargetPort: intstr.FromInt(8443),
+					},
+				)
+			},
+			errorContains: "denied request: Each port from spec.network.services.ingress.ports has to have an accompanying port in KONG_PORT_MAPS env",
+		},
+	}
+
+	dataplaneClient := GetClients().OperatorClient.GatewayOperatorV1beta1().DataPlanes(namespace.Name)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var err error
+			if tc.updateDataPlane != nil {
+				var dpToUpdate *operatorv1beta1.DataPlane
+				dpToUpdate, err = dataplaneClient.Create(GetCtx(), tc.dataPlane, metav1.CreateOptions{})
+				require.NoError(t, err, "failed to create initial DataPlane")
+				cleaner.Add(dpToUpdate)
+
+				require.Eventually(t, func() bool {
+					dpToUpdate, err = dataplaneClient.Get(GetCtx(), dpToUpdate.Name, metav1.GetOptions{})
+					tc.updateDataPlane(dpToUpdate)
+					_, err = dataplaneClient.Update(GetCtx(), dpToUpdate, metav1.UpdateOptions{})
+					return !k8serrors.IsConflict(err)
+				}, 10*time.Second, 100*time.Millisecond)
+
+			} else {
+				_, err = dataplaneClient.Create(GetCtx(), tc.dataPlane, metav1.CreateOptions{})
+			}
+			require.Error(t, err, "expected error when submitting DataPlane")
+			require.True(t, k8serrors.IsInvalid(err), "error should be of type Invalid, got: %v", err)
+			require.Contains(t, err.Error(), tc.errorContains, "error message should contain expected substring")
+		})
+	}
+}

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -114,8 +114,7 @@ func TestMain(m *testing.M) {
 
 	exitOnErr(clusters.KustomizeDeployForCluster(GetCtx(), GetEnv().Cluster(), path.Join(configPath, "/rbac/base")))
 	exitOnErr(clusters.KustomizeDeployForCluster(GetCtx(), GetEnv().Cluster(), path.Join(configPath, "/rbac/role")))
-	fmt.Println(`WARN: skipping applying "/default/validating_policies" until https://github.com/Kong/kong-operator/issues/2176 is resolved`)
-	// exitOnErr(clusters.KustomizeDeployForCluster(GetCtx(), GetEnv().Cluster(), path.Join(configPath, "/default/validating_policies")))
+	exitOnErr(clusters.KustomizeDeployForCluster(GetCtx(), GetEnv().Cluster(), path.Join(configPath, "/default/validating_policies")))
 
 	// normally this is obtained from the downward API. the tests fake it.
 	err = os.Setenv("POD_NAMESPACE", "kong-system")


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable validating_admission_policy for integration and conformance suites to ensure that all valid configurations are allowed with this policy configured. Furthermore, add a simple test to ensure that this policy is indeed enabled for the integration suite. 

**Which issue this PR fixes**

Part of 
- https://github.com/Kong/kong-operator/issues/2176

**Special notes for your reviewer**:

Having a single helper for applying CRDs and policies is out of scope for this PR it will be handled separately. 
