### PR TITLE
feat(Konnect): Support adopting dataplane certificates from Konnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@
     [#2492](https://github.com/Kong/kong-operator/pull/2492)
   - Implement adoption support for `KongCredentialAPIKey`, `KongCredentialBasicAuth`, `KongCredentialACL`, `KongCredentialJWT`, and `KongCredentialHMAC`
     [#2494](https://github.com/Kong/kong-operator/pull/2494)
+  - Implement adoption support for `KongDataPlaneClientCertificate`.
+    [#2678](https://github.com/Kong/kong-operator/pull/2678)
 - HybridGateway:
   - Added controller-runtime watches for Gateway and GatewayClass resources to the hybridgateway controller.
   - HTTPRoutes are now reconciled when related Gateway or GatewayClass resources change.

--- a/api/configuration/v1alpha1/kongdataplaneclientcertificate_types.go
+++ b/api/configuration/v1alpha1/kongdataplaneclientcertificate_types.go
@@ -58,6 +58,11 @@ type KongDataPlaneClientCertificateSpec struct {
 	// +required
 	ControlPlaneRef *commonv1alpha1.ControlPlaneRef `json:"controlPlaneRef"`
 
+	// Adopt is the options for adopting a key from an existing key in Konnect.
+	// +kubebuilder:validation:XValidation:message="Only 'match' mode adoption is supported", rule="self.mode == 'match'"
+	// +optional
+	Adopt *commonv1alpha1.AdoptOptions `json:"adopt,omitempty"`
+
 	// KongDataPlaneClientCertificateAPISpec are the attributes of the KongDataPlaneClientCertificate itself.
 	KongDataPlaneClientCertificateAPISpec `json:",inline"`
 }

--- a/api/configuration/v1alpha1/zz_generated.deepcopy.go
+++ b/api/configuration/v1alpha1/zz_generated.deepcopy.go
@@ -1304,6 +1304,11 @@ func (in *KongDataPlaneClientCertificateSpec) DeepCopyInto(out *KongDataPlaneCli
 		*out = new(commonv1alpha1.ControlPlaneRef)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Adopt != nil {
+		in, out := &in.Adopt, &out.Adopt
+		*out = new(commonv1alpha1.AdoptOptions)
+		(*in).DeepCopyInto(*out)
+	}
 	out.KongDataPlaneClientCertificateAPISpec = in.KongDataPlaneClientCertificateAPISpec
 }
 

--- a/api/configuration/v1alpha1/zz_generated_adopt_funcs.go
+++ b/api/configuration/v1alpha1/zz_generated_adopt_funcs.go
@@ -165,3 +165,13 @@ func (obj *KongSNI) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
 func (obj *KongSNI) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
 	obj.Spec.Adopt = opts
 }
+
+// Get the options to adopt the resource from an existing resource.
+func (obj *KongDataPlaneClientCertificate) GetAdoptOptions() *commonv1alpha1.AdoptOptions {
+	return obj.Spec.Adopt
+}
+
+// Set the options to adopt the resource from an existing resource.
+func (obj *KongDataPlaneClientCertificate) SetAdoptOptions(opts *commonv1alpha1.AdoptOptions) {
+	obj.Spec.Adopt = opts
+}

--- a/charts/kong-operator/charts/ko-crds/templates/ko-crds.yaml
+++ b/charts/kong-operator/charts/ko-crds/templates/ko-crds.yaml
@@ -50119,6 +50119,69 @@ spec:
             description: KongDataPlaneClientCertificateSpec defines the spec for a
               KongDataPlaneClientCertificate.
             properties:
+              adopt:
+                description: Adopt is the options for adopting a key from an existing
+                  key in Konnect.
+                properties:
+                  from:
+                    description: |-
+                      From is the source of the entity to adopt from.
+                      Now 'konnect' is supported.
+                    enum:
+                    - konnect
+                    type: string
+                  konnect:
+                    description: |-
+                      Konnect is the options for adopting the entity from Konnect.
+                      Required when from == 'konnect'.
+                    properties:
+                      id:
+                        description: ID is the Konnect ID of the entity.
+                        maxLength: 36
+                        minLength: 1
+                        type: string
+                    required:
+                    - id
+                    type: object
+                  mode:
+                    description: |-
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      - "override": the operator overrides the remote entity by the CR's spec.
+                        If the entity with the ID and type exists, and it is not managed
+                        by another CR (matching by the metadata.uid of the CR and the "k8s-uid"
+                        label or tag of the Konnect entity), the operator updates the remote entity
+                        by the CR's spec.
+                    enum:
+                    - match
+                    - override
+                    type: string
+                required:
+                - from
+                type: object
+                x-kubernetes-validations:
+                - message: Only 'match' mode adoption is supported
+                  rule: self.mode == 'match'
+                - message: '''from''(adopt source) is immutable'
+                  rule: self.from == oldSelf.from
+                - message: Must specify Konnect options when from='konnect'
+                  rule: 'self.from == ''konnect'' ? has(self.konnect) : true'
+                - message: konnect.id is immutable
+                  rule: 'has(self.konnect) ? (self.konnect.id == oldSelf.konnect.id)
+                    : true'
               cert:
                 description: Cert is the certificate in PEM format. Once the certificate
                   gets programmed this field becomes immutable.

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -47057,6 +47057,67 @@ spec:
           spec:
             description: KongDataPlaneClientCertificateSpec defines the spec for a KongDataPlaneClientCertificate.
             properties:
+              adopt:
+                description: Adopt is the options for adopting a key from an existing key in Konnect.
+                properties:
+                  from:
+                    description: |-
+                      From is the source of the entity to adopt from.
+                      Now 'konnect' is supported.
+                    enum:
+                    - konnect
+                    type: string
+                  konnect:
+                    description: |-
+                      Konnect is the options for adopting the entity from Konnect.
+                      Required when from == 'konnect'.
+                    properties:
+                      id:
+                        description: ID is the Konnect ID of the entity.
+                        maxLength: 36
+                        minLength: 1
+                        type: string
+                    required:
+                    - id
+                    type: object
+                  mode:
+                    description: |-
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      - "override": the operator overrides the remote entity by the CR's spec.
+                        If the entity with the ID and type exists, and it is not managed
+                        by another CR (matching by the metadata.uid of the CR and the "k8s-uid"
+                        label or tag of the Konnect entity), the operator updates the remote entity
+                        by the CR's spec.
+                    enum:
+                    - match
+                    - override
+                    type: string
+                required:
+                - from
+                type: object
+                x-kubernetes-validations:
+                - message: Only 'match' mode adoption is supported
+                  rule: self.mode == 'match'
+                - message: '''from''(adopt source) is immutable'
+                  rule: self.from == oldSelf.from
+                - message: Must specify Konnect options when from='konnect'
+                  rule: 'self.from == ''konnect'' ? has(self.konnect) : true'
+                - message: konnect.id is immutable
+                  rule: 'has(self.konnect) ? (self.konnect.id == oldSelf.konnect.id) : true'
               cert:
                 description: Cert is the certificate in PEM format. Once the certificate gets programmed this field becomes immutable.
                 minLength: 1

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -47057,6 +47057,67 @@ spec:
           spec:
             description: KongDataPlaneClientCertificateSpec defines the spec for a KongDataPlaneClientCertificate.
             properties:
+              adopt:
+                description: Adopt is the options for adopting a key from an existing key in Konnect.
+                properties:
+                  from:
+                    description: |-
+                      From is the source of the entity to adopt from.
+                      Now 'konnect' is supported.
+                    enum:
+                    - konnect
+                    type: string
+                  konnect:
+                    description: |-
+                      Konnect is the options for adopting the entity from Konnect.
+                      Required when from == 'konnect'.
+                    properties:
+                      id:
+                        description: ID is the Konnect ID of the entity.
+                        maxLength: 36
+                        minLength: 1
+                        type: string
+                    required:
+                    - id
+                    type: object
+                  mode:
+                    description: |-
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      - "override": the operator overrides the remote entity by the CR's spec.
+                        If the entity with the ID and type exists, and it is not managed
+                        by another CR (matching by the metadata.uid of the CR and the "k8s-uid"
+                        label or tag of the Konnect entity), the operator updates the remote entity
+                        by the CR's spec.
+                    enum:
+                    - match
+                    - override
+                    type: string
+                required:
+                - from
+                type: object
+                x-kubernetes-validations:
+                - message: Only 'match' mode adoption is supported
+                  rule: self.mode == 'match'
+                - message: '''from''(adopt source) is immutable'
+                  rule: self.from == oldSelf.from
+                - message: Must specify Konnect options when from='konnect'
+                  rule: 'self.from == ''konnect'' ? has(self.konnect) : true'
+                - message: konnect.id is immutable
+                  rule: 'has(self.konnect) ? (self.konnect.id == oldSelf.konnect.id) : true'
               cert:
                 description: Cert is the certificate in PEM format. Once the certificate gets programmed this field becomes immutable.
                 minLength: 1

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -47057,6 +47057,67 @@ spec:
           spec:
             description: KongDataPlaneClientCertificateSpec defines the spec for a KongDataPlaneClientCertificate.
             properties:
+              adopt:
+                description: Adopt is the options for adopting a key from an existing key in Konnect.
+                properties:
+                  from:
+                    description: |-
+                      From is the source of the entity to adopt from.
+                      Now 'konnect' is supported.
+                    enum:
+                    - konnect
+                    type: string
+                  konnect:
+                    description: |-
+                      Konnect is the options for adopting the entity from Konnect.
+                      Required when from == 'konnect'.
+                    properties:
+                      id:
+                        description: ID is the Konnect ID of the entity.
+                        maxLength: 36
+                        minLength: 1
+                        type: string
+                    required:
+                    - id
+                    type: object
+                  mode:
+                    description: |-
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      - "override": the operator overrides the remote entity by the CR's spec.
+                        If the entity with the ID and type exists, and it is not managed
+                        by another CR (matching by the metadata.uid of the CR and the "k8s-uid"
+                        label or tag of the Konnect entity), the operator updates the remote entity
+                        by the CR's spec.
+                    enum:
+                    - match
+                    - override
+                    type: string
+                required:
+                - from
+                type: object
+                x-kubernetes-validations:
+                - message: Only 'match' mode adoption is supported
+                  rule: self.mode == 'match'
+                - message: '''from''(adopt source) is immutable'
+                  rule: self.from == oldSelf.from
+                - message: Must specify Konnect options when from='konnect'
+                  rule: 'self.from == ''konnect'' ? has(self.konnect) : true'
+                - message: konnect.id is immutable
+                  rule: 'has(self.konnect) ? (self.konnect.id == oldSelf.konnect.id) : true'
               cert:
                 description: Cert is the certificate in PEM format. Once the certificate gets programmed this field becomes immutable.
                 minLength: 1

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -47057,6 +47057,67 @@ spec:
           spec:
             description: KongDataPlaneClientCertificateSpec defines the spec for a KongDataPlaneClientCertificate.
             properties:
+              adopt:
+                description: Adopt is the options for adopting a key from an existing key in Konnect.
+                properties:
+                  from:
+                    description: |-
+                      From is the source of the entity to adopt from.
+                      Now 'konnect' is supported.
+                    enum:
+                    - konnect
+                    type: string
+                  konnect:
+                    description: |-
+                      Konnect is the options for adopting the entity from Konnect.
+                      Required when from == 'konnect'.
+                    properties:
+                      id:
+                        description: ID is the Konnect ID of the entity.
+                        maxLength: 36
+                        minLength: 1
+                        type: string
+                    required:
+                    - id
+                    type: object
+                  mode:
+                    description: |-
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      - "override": the operator overrides the remote entity by the CR's spec.
+                        If the entity with the ID and type exists, and it is not managed
+                        by another CR (matching by the metadata.uid of the CR and the "k8s-uid"
+                        label or tag of the Konnect entity), the operator updates the remote entity
+                        by the CR's spec.
+                    enum:
+                    - match
+                    - override
+                    type: string
+                required:
+                - from
+                type: object
+                x-kubernetes-validations:
+                - message: Only 'match' mode adoption is supported
+                  rule: self.mode == 'match'
+                - message: '''from''(adopt source) is immutable'
+                  rule: self.from == oldSelf.from
+                - message: Must specify Konnect options when from='konnect'
+                  rule: 'self.from == ''konnect'' ? has(self.konnect) : true'
+                - message: konnect.id is immutable
+                  rule: 'has(self.konnect) ? (self.konnect.id == oldSelf.konnect.id) : true'
               cert:
                 description: Cert is the certificate in PEM format. Once the certificate gets programmed this field becomes immutable.
                 minLength: 1

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -47057,6 +47057,67 @@ spec:
           spec:
             description: KongDataPlaneClientCertificateSpec defines the spec for a KongDataPlaneClientCertificate.
             properties:
+              adopt:
+                description: Adopt is the options for adopting a key from an existing key in Konnect.
+                properties:
+                  from:
+                    description: |-
+                      From is the source of the entity to adopt from.
+                      Now 'konnect' is supported.
+                    enum:
+                    - konnect
+                    type: string
+                  konnect:
+                    description: |-
+                      Konnect is the options for adopting the entity from Konnect.
+                      Required when from == 'konnect'.
+                    properties:
+                      id:
+                        description: ID is the Konnect ID of the entity.
+                        maxLength: 36
+                        minLength: 1
+                        type: string
+                    required:
+                    - id
+                    type: object
+                  mode:
+                    description: |-
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      - "override": the operator overrides the remote entity by the CR's spec.
+                        If the entity with the ID and type exists, and it is not managed
+                        by another CR (matching by the metadata.uid of the CR and the "k8s-uid"
+                        label or tag of the Konnect entity), the operator updates the remote entity
+                        by the CR's spec.
+                    enum:
+                    - match
+                    - override
+                    type: string
+                required:
+                - from
+                type: object
+                x-kubernetes-validations:
+                - message: Only 'match' mode adoption is supported
+                  rule: self.mode == 'match'
+                - message: '''from''(adopt source) is immutable'
+                  rule: self.from == oldSelf.from
+                - message: Must specify Konnect options when from='konnect'
+                  rule: 'self.from == ''konnect'' ? has(self.konnect) : true'
+                - message: konnect.id is immutable
+                  rule: 'has(self.konnect) ? (self.konnect.id == oldSelf.konnect.id) : true'
               cert:
                 description: Cert is the certificate in PEM format. Once the certificate gets programmed this field becomes immutable.
                 minLength: 1

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -47058,6 +47058,67 @@ spec:
           spec:
             description: KongDataPlaneClientCertificateSpec defines the spec for a KongDataPlaneClientCertificate.
             properties:
+              adopt:
+                description: Adopt is the options for adopting a key from an existing key in Konnect.
+                properties:
+                  from:
+                    description: |-
+                      From is the source of the entity to adopt from.
+                      Now 'konnect' is supported.
+                    enum:
+                    - konnect
+                    type: string
+                  konnect:
+                    description: |-
+                      Konnect is the options for adopting the entity from Konnect.
+                      Required when from == 'konnect'.
+                    properties:
+                      id:
+                        description: ID is the Konnect ID of the entity.
+                        maxLength: 36
+                        minLength: 1
+                        type: string
+                    required:
+                    - id
+                    type: object
+                  mode:
+                    description: |-
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      - "override": the operator overrides the remote entity by the CR's spec.
+                        If the entity with the ID and type exists, and it is not managed
+                        by another CR (matching by the metadata.uid of the CR and the "k8s-uid"
+                        label or tag of the Konnect entity), the operator updates the remote entity
+                        by the CR's spec.
+                    enum:
+                    - match
+                    - override
+                    type: string
+                required:
+                - from
+                type: object
+                x-kubernetes-validations:
+                - message: Only 'match' mode adoption is supported
+                  rule: self.mode == 'match'
+                - message: '''from''(adopt source) is immutable'
+                  rule: self.from == oldSelf.from
+                - message: Must specify Konnect options when from='konnect'
+                  rule: 'self.from == ''konnect'' ? has(self.konnect) : true'
+                - message: konnect.id is immutable
+                  rule: 'has(self.konnect) ? (self.konnect.id == oldSelf.konnect.id) : true'
               cert:
                 description: Cert is the certificate in PEM format. Once the certificate gets programmed this field becomes immutable.
                 minLength: 1

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -47057,6 +47057,67 @@ spec:
           spec:
             description: KongDataPlaneClientCertificateSpec defines the spec for a KongDataPlaneClientCertificate.
             properties:
+              adopt:
+                description: Adopt is the options for adopting a key from an existing key in Konnect.
+                properties:
+                  from:
+                    description: |-
+                      From is the source of the entity to adopt from.
+                      Now 'konnect' is supported.
+                    enum:
+                    - konnect
+                    type: string
+                  konnect:
+                    description: |-
+                      Konnect is the options for adopting the entity from Konnect.
+                      Required when from == 'konnect'.
+                    properties:
+                      id:
+                        description: ID is the Konnect ID of the entity.
+                        maxLength: 36
+                        minLength: 1
+                        type: string
+                    required:
+                    - id
+                    type: object
+                  mode:
+                    description: |-
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      - "override": the operator overrides the remote entity by the CR's spec.
+                        If the entity with the ID and type exists, and it is not managed
+                        by another CR (matching by the metadata.uid of the CR and the "k8s-uid"
+                        label or tag of the Konnect entity), the operator updates the remote entity
+                        by the CR's spec.
+                    enum:
+                    - match
+                    - override
+                    type: string
+                required:
+                - from
+                type: object
+                x-kubernetes-validations:
+                - message: Only 'match' mode adoption is supported
+                  rule: self.mode == 'match'
+                - message: '''from''(adopt source) is immutable'
+                  rule: self.from == oldSelf.from
+                - message: Must specify Konnect options when from='konnect'
+                  rule: 'self.from == ''konnect'' ? has(self.konnect) : true'
+                - message: konnect.id is immutable
+                  rule: 'has(self.konnect) ? (self.konnect.id == oldSelf.konnect.id) : true'
               cert:
                 description: Cert is the certificate in PEM format. Once the certificate gets programmed this field becomes immutable.
                 minLength: 1

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -47057,6 +47057,67 @@ spec:
           spec:
             description: KongDataPlaneClientCertificateSpec defines the spec for a KongDataPlaneClientCertificate.
             properties:
+              adopt:
+                description: Adopt is the options for adopting a key from an existing key in Konnect.
+                properties:
+                  from:
+                    description: |-
+                      From is the source of the entity to adopt from.
+                      Now 'konnect' is supported.
+                    enum:
+                    - konnect
+                    type: string
+                  konnect:
+                    description: |-
+                      Konnect is the options for adopting the entity from Konnect.
+                      Required when from == 'konnect'.
+                    properties:
+                      id:
+                        description: ID is the Konnect ID of the entity.
+                        maxLength: 36
+                        minLength: 1
+                        type: string
+                    required:
+                    - id
+                    type: object
+                  mode:
+                    description: |-
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      - "override": the operator overrides the remote entity by the CR's spec.
+                        If the entity with the ID and type exists, and it is not managed
+                        by another CR (matching by the metadata.uid of the CR and the "k8s-uid"
+                        label or tag of the Konnect entity), the operator updates the remote entity
+                        by the CR's spec.
+                    enum:
+                    - match
+                    - override
+                    type: string
+                required:
+                - from
+                type: object
+                x-kubernetes-validations:
+                - message: Only 'match' mode adoption is supported
+                  rule: self.mode == 'match'
+                - message: '''from''(adopt source) is immutable'
+                  rule: self.from == oldSelf.from
+                - message: Must specify Konnect options when from='konnect'
+                  rule: 'self.from == ''konnect'' ? has(self.konnect) : true'
+                - message: konnect.id is immutable
+                  rule: 'has(self.konnect) ? (self.konnect.id == oldSelf.konnect.id) : true'
               cert:
                 description: Cert is the certificate in PEM format. Once the certificate gets programmed this field becomes immutable.
                 minLength: 1

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -47057,6 +47057,67 @@ spec:
           spec:
             description: KongDataPlaneClientCertificateSpec defines the spec for a KongDataPlaneClientCertificate.
             properties:
+              adopt:
+                description: Adopt is the options for adopting a key from an existing key in Konnect.
+                properties:
+                  from:
+                    description: |-
+                      From is the source of the entity to adopt from.
+                      Now 'konnect' is supported.
+                    enum:
+                    - konnect
+                    type: string
+                  konnect:
+                    description: |-
+                      Konnect is the options for adopting the entity from Konnect.
+                      Required when from == 'konnect'.
+                    properties:
+                      id:
+                        description: ID is the Konnect ID of the entity.
+                        maxLength: 36
+                        minLength: 1
+                        type: string
+                    required:
+                    - id
+                    type: object
+                  mode:
+                    description: |-
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      - "override": the operator overrides the remote entity by the CR's spec.
+                        If the entity with the ID and type exists, and it is not managed
+                        by another CR (matching by the metadata.uid of the CR and the "k8s-uid"
+                        label or tag of the Konnect entity), the operator updates the remote entity
+                        by the CR's spec.
+                    enum:
+                    - match
+                    - override
+                    type: string
+                required:
+                - from
+                type: object
+                x-kubernetes-validations:
+                - message: Only 'match' mode adoption is supported
+                  rule: self.mode == 'match'
+                - message: '''from''(adopt source) is immutable'
+                  rule: self.from == oldSelf.from
+                - message: Must specify Konnect options when from='konnect'
+                  rule: 'self.from == ''konnect'' ? has(self.konnect) : true'
+                - message: konnect.id is immutable
+                  rule: 'has(self.konnect) ? (self.konnect.id == oldSelf.konnect.id) : true'
               cert:
                 description: Cert is the certificate in PEM format. Once the certificate gets programmed this field becomes immutable.
                 minLength: 1

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -47057,6 +47057,67 @@ spec:
           spec:
             description: KongDataPlaneClientCertificateSpec defines the spec for a KongDataPlaneClientCertificate.
             properties:
+              adopt:
+                description: Adopt is the options for adopting a key from an existing key in Konnect.
+                properties:
+                  from:
+                    description: |-
+                      From is the source of the entity to adopt from.
+                      Now 'konnect' is supported.
+                    enum:
+                    - konnect
+                    type: string
+                  konnect:
+                    description: |-
+                      Konnect is the options for adopting the entity from Konnect.
+                      Required when from == 'konnect'.
+                    properties:
+                      id:
+                        description: ID is the Konnect ID of the entity.
+                        maxLength: 36
+                        minLength: 1
+                        type: string
+                    required:
+                    - id
+                    type: object
+                  mode:
+                    description: |-
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      - "override": the operator overrides the remote entity by the CR's spec.
+                        If the entity with the ID and type exists, and it is not managed
+                        by another CR (matching by the metadata.uid of the CR and the "k8s-uid"
+                        label or tag of the Konnect entity), the operator updates the remote entity
+                        by the CR's spec.
+                    enum:
+                    - match
+                    - override
+                    type: string
+                required:
+                - from
+                type: object
+                x-kubernetes-validations:
+                - message: Only 'match' mode adoption is supported
+                  rule: self.mode == 'match'
+                - message: '''from''(adopt source) is immutable'
+                  rule: self.from == oldSelf.from
+                - message: Must specify Konnect options when from='konnect'
+                  rule: 'self.from == ''konnect'' ? has(self.konnect) : true'
+                - message: konnect.id is immutable
+                  rule: 'has(self.konnect) ? (self.konnect.id == oldSelf.konnect.id) : true'
               cert:
                 description: Cert is the certificate in PEM format. Once the certificate gets programmed this field becomes immutable.
                 minLength: 1

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -47057,6 +47057,67 @@ spec:
           spec:
             description: KongDataPlaneClientCertificateSpec defines the spec for a KongDataPlaneClientCertificate.
             properties:
+              adopt:
+                description: Adopt is the options for adopting a key from an existing key in Konnect.
+                properties:
+                  from:
+                    description: |-
+                      From is the source of the entity to adopt from.
+                      Now 'konnect' is supported.
+                    enum:
+                    - konnect
+                    type: string
+                  konnect:
+                    description: |-
+                      Konnect is the options for adopting the entity from Konnect.
+                      Required when from == 'konnect'.
+                    properties:
+                      id:
+                        description: ID is the Konnect ID of the entity.
+                        maxLength: 36
+                        minLength: 1
+                        type: string
+                    required:
+                    - id
+                    type: object
+                  mode:
+                    description: |-
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      - "override": the operator overrides the remote entity by the CR's spec.
+                        If the entity with the ID and type exists, and it is not managed
+                        by another CR (matching by the metadata.uid of the CR and the "k8s-uid"
+                        label or tag of the Konnect entity), the operator updates the remote entity
+                        by the CR's spec.
+                    enum:
+                    - match
+                    - override
+                    type: string
+                required:
+                - from
+                type: object
+                x-kubernetes-validations:
+                - message: Only 'match' mode adoption is supported
+                  rule: self.mode == 'match'
+                - message: '''from''(adopt source) is immutable'
+                  rule: self.from == oldSelf.from
+                - message: Must specify Konnect options when from='konnect'
+                  rule: 'self.from == ''konnect'' ? has(self.konnect) : true'
+                - message: konnect.id is immutable
+                  rule: 'has(self.konnect) ? (self.konnect.id == oldSelf.konnect.id) : true'
               cert:
                 description: Cert is the certificate in PEM format. Once the certificate gets programmed this field becomes immutable.
                 minLength: 1

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -47057,6 +47057,67 @@ spec:
           spec:
             description: KongDataPlaneClientCertificateSpec defines the spec for a KongDataPlaneClientCertificate.
             properties:
+              adopt:
+                description: Adopt is the options for adopting a key from an existing key in Konnect.
+                properties:
+                  from:
+                    description: |-
+                      From is the source of the entity to adopt from.
+                      Now 'konnect' is supported.
+                    enum:
+                    - konnect
+                    type: string
+                  konnect:
+                    description: |-
+                      Konnect is the options for adopting the entity from Konnect.
+                      Required when from == 'konnect'.
+                    properties:
+                      id:
+                        description: ID is the Konnect ID of the entity.
+                        maxLength: 36
+                        minLength: 1
+                        type: string
+                    required:
+                    - id
+                    type: object
+                  mode:
+                    description: |-
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      - "override": the operator overrides the remote entity by the CR's spec.
+                        If the entity with the ID and type exists, and it is not managed
+                        by another CR (matching by the metadata.uid of the CR and the "k8s-uid"
+                        label or tag of the Konnect entity), the operator updates the remote entity
+                        by the CR's spec.
+                    enum:
+                    - match
+                    - override
+                    type: string
+                required:
+                - from
+                type: object
+                x-kubernetes-validations:
+                - message: Only 'match' mode adoption is supported
+                  rule: self.mode == 'match'
+                - message: '''from''(adopt source) is immutable'
+                  rule: self.from == oldSelf.from
+                - message: Must specify Konnect options when from='konnect'
+                  rule: 'self.from == ''konnect'' ? has(self.konnect) : true'
+                - message: konnect.id is immutable
+                  rule: 'has(self.konnect) ? (self.konnect.id == oldSelf.konnect.id) : true'
               cert:
                 description: Cert is the certificate in PEM format. Once the certificate gets programmed this field becomes immutable.
                 minLength: 1

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -22535,6 +22535,67 @@ spec:
           spec:
             description: KongDataPlaneClientCertificateSpec defines the spec for a KongDataPlaneClientCertificate.
             properties:
+              adopt:
+                description: Adopt is the options for adopting a key from an existing key in Konnect.
+                properties:
+                  from:
+                    description: |-
+                      From is the source of the entity to adopt from.
+                      Now 'konnect' is supported.
+                    enum:
+                    - konnect
+                    type: string
+                  konnect:
+                    description: |-
+                      Konnect is the options for adopting the entity from Konnect.
+                      Required when from == 'konnect'.
+                    properties:
+                      id:
+                        description: ID is the Konnect ID of the entity.
+                        maxLength: 36
+                        minLength: 1
+                        type: string
+                    required:
+                    - id
+                    type: object
+                  mode:
+                    description: |-
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      - "override": the operator overrides the remote entity by the CR's spec.
+                        If the entity with the ID and type exists, and it is not managed
+                        by another CR (matching by the metadata.uid of the CR and the "k8s-uid"
+                        label or tag of the Konnect entity), the operator updates the remote entity
+                        by the CR's spec.
+                    enum:
+                    - match
+                    - override
+                    type: string
+                required:
+                - from
+                type: object
+                x-kubernetes-validations:
+                - message: Only 'match' mode adoption is supported
+                  rule: self.mode == 'match'
+                - message: '''from''(adopt source) is immutable'
+                  rule: self.from == oldSelf.from
+                - message: Must specify Konnect options when from='konnect'
+                  rule: 'self.from == ''konnect'' ? has(self.konnect) : true'
+                - message: konnect.id is immutable
+                  rule: 'has(self.konnect) ? (self.konnect.id == oldSelf.konnect.id) : true'
               cert:
                 description: Cert is the certificate in PEM format. Once the certificate gets programmed this field becomes immutable.
                 minLength: 1

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -47007,6 +47007,67 @@ spec:
           spec:
             description: KongDataPlaneClientCertificateSpec defines the spec for a KongDataPlaneClientCertificate.
             properties:
+              adopt:
+                description: Adopt is the options for adopting a key from an existing key in Konnect.
+                properties:
+                  from:
+                    description: |-
+                      From is the source of the entity to adopt from.
+                      Now 'konnect' is supported.
+                    enum:
+                    - konnect
+                    type: string
+                  konnect:
+                    description: |-
+                      Konnect is the options for adopting the entity from Konnect.
+                      Required when from == 'konnect'.
+                    properties:
+                      id:
+                        description: ID is the Konnect ID of the entity.
+                        maxLength: 36
+                        minLength: 1
+                        type: string
+                    required:
+                    - id
+                    type: object
+                  mode:
+                    description: |-
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      - "override": the operator overrides the remote entity by the CR's spec.
+                        If the entity with the ID and type exists, and it is not managed
+                        by another CR (matching by the metadata.uid of the CR and the "k8s-uid"
+                        label or tag of the Konnect entity), the operator updates the remote entity
+                        by the CR's spec.
+                    enum:
+                    - match
+                    - override
+                    type: string
+                required:
+                - from
+                type: object
+                x-kubernetes-validations:
+                - message: Only 'match' mode adoption is supported
+                  rule: self.mode == 'match'
+                - message: '''from''(adopt source) is immutable'
+                  rule: self.from == oldSelf.from
+                - message: Must specify Konnect options when from='konnect'
+                  rule: 'self.from == ''konnect'' ? has(self.konnect) : true'
+                - message: konnect.id is immutable
+                  rule: 'has(self.konnect) ? (self.konnect.id == oldSelf.konnect.id) : true'
               cert:
                 description: Cert is the certificate in PEM format. Once the certificate gets programmed this field becomes immutable.
                 minLength: 1

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -22510,6 +22510,67 @@ spec:
           spec:
             description: KongDataPlaneClientCertificateSpec defines the spec for a KongDataPlaneClientCertificate.
             properties:
+              adopt:
+                description: Adopt is the options for adopting a key from an existing key in Konnect.
+                properties:
+                  from:
+                    description: |-
+                      From is the source of the entity to adopt from.
+                      Now 'konnect' is supported.
+                    enum:
+                    - konnect
+                    type: string
+                  konnect:
+                    description: |-
+                      Konnect is the options for adopting the entity from Konnect.
+                      Required when from == 'konnect'.
+                    properties:
+                      id:
+                        description: ID is the Konnect ID of the entity.
+                        maxLength: 36
+                        minLength: 1
+                        type: string
+                    required:
+                    - id
+                    type: object
+                  mode:
+                    description: |-
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      - "override": the operator overrides the remote entity by the CR's spec.
+                        If the entity with the ID and type exists, and it is not managed
+                        by another CR (matching by the metadata.uid of the CR and the "k8s-uid"
+                        label or tag of the Konnect entity), the operator updates the remote entity
+                        by the CR's spec.
+                    enum:
+                    - match
+                    - override
+                    type: string
+                required:
+                - from
+                type: object
+                x-kubernetes-validations:
+                - message: Only 'match' mode adoption is supported
+                  rule: self.mode == 'match'
+                - message: '''from''(adopt source) is immutable'
+                  rule: self.from == oldSelf.from
+                - message: Must specify Konnect options when from='konnect'
+                  rule: 'self.from == ''konnect'' ? has(self.konnect) : true'
+                - message: konnect.id is immutable
+                  rule: 'has(self.konnect) ? (self.konnect.id == oldSelf.konnect.id) : true'
               cert:
                 description: Cert is the certificate in PEM format. Once the certificate gets programmed this field becomes immutable.
                 minLength: 1

--- a/config/crd/kong-operator/configuration.konghq.com_kongdataplaneclientcertificates.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongdataplaneclientcertificates.yaml
@@ -49,6 +49,69 @@ spec:
             description: KongDataPlaneClientCertificateSpec defines the spec for a
               KongDataPlaneClientCertificate.
             properties:
+              adopt:
+                description: Adopt is the options for adopting a key from an existing
+                  key in Konnect.
+                properties:
+                  from:
+                    description: |-
+                      From is the source of the entity to adopt from.
+                      Now 'konnect' is supported.
+                    enum:
+                    - konnect
+                    type: string
+                  konnect:
+                    description: |-
+                      Konnect is the options for adopting the entity from Konnect.
+                      Required when from == 'konnect'.
+                    properties:
+                      id:
+                        description: ID is the Konnect ID of the entity.
+                        maxLength: 36
+                        minLength: 1
+                        type: string
+                    required:
+                    - id
+                    type: object
+                  mode:
+                    description: |-
+                      Mode selects how the operator adopts an already-existing entity (for example,
+                      a Konnect resource) instead of creating a new one.
+
+                      Supported values:
+                      - "match": the operator retrieves the remote entity referenced by the
+                        corresponding Adopt* options (for example, adopt.konnect.id) and performs a
+                        field-by-field comparison against this CR's spec (ignoring server-assigned
+                        metadata). If the specification matches the remote state, the operator
+                        adopts the entity: it sets the status identifier and marks the resource as
+                        ready/programmed without issuing any write operation to the remote system.
+                        If the specification does not match the remote state, adoption fails: the
+                        operator does not modify the remote entity and surfaces a failure
+                        condition, allowing the user to align the spec with the existing entity if
+                        adoption is desired.
+
+                      - "override": the operator overrides the remote entity by the CR's spec.
+                        If the entity with the ID and type exists, and it is not managed
+                        by another CR (matching by the metadata.uid of the CR and the "k8s-uid"
+                        label or tag of the Konnect entity), the operator updates the remote entity
+                        by the CR's spec.
+                    enum:
+                    - match
+                    - override
+                    type: string
+                required:
+                - from
+                type: object
+                x-kubernetes-validations:
+                - message: Only 'match' mode adoption is supported
+                  rule: self.mode == 'match'
+                - message: '''from''(adopt source) is immutable'
+                  rule: self.from == oldSelf.from
+                - message: Must specify Konnect options when from='konnect'
+                  rule: 'self.from == ''konnect'' ? has(self.konnect) : true'
+                - message: konnect.id is immutable
+                  rule: 'has(self.konnect) ? (self.konnect.id == oldSelf.konnect.id)
+                    : true'
               cert:
                 description: Cert is the certificate in PEM format. Once the certificate
                   gets programmed this field becomes immutable.

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -590,6 +590,8 @@ func Adopt[
 		err = adoptKongCredentialJWT(ctx, sdk.GetJWTCredentialsSDK(), ent)
 	case *configurationv1alpha1.KongCredentialHMAC:
 		err = adoptKongCredentialHMAC(ctx, sdk.GetHMACCredentialsSDK(), ent)
+	case *configurationv1alpha1.KongDataPlaneClientCertificate:
+		err = adoptKongDataPlaneCertificate(ctx, sdk.GetDataPlaneCertificatesSDK(), ent)
 	// TODO: implement adoption for other types.
 	default:
 		return ctrl.Result{}, fmt.Errorf("unsupported entity type %T", ent)

--- a/controller/konnect/ops/sdk/kongdataplanecertificate.go
+++ b/controller/konnect/ops/sdk/kongdataplanecertificate.go
@@ -12,4 +12,5 @@ type DataPlaneClientCertificatesSDK interface {
 	CreateDataplaneCertificate(ctx context.Context, cpID string, dpReq *sdkkonnectcomp.DataPlaneClientCertificateRequest, opts ...sdkkonnectops.Option) (*sdkkonnectops.CreateDataplaneCertificateResponse, error)
 	DeleteDataplaneCertificate(ctx context.Context, controlPlaneID string, certificateID string, opts ...sdkkonnectops.Option) (*sdkkonnectops.DeleteDataplaneCertificateResponse, error)
 	ListDpClientCertificates(ctx context.Context, controlPlaneID string, opts ...sdkkonnectops.Option) (*sdkkonnectops.ListDpClientCertificatesResponse, error)
+	GetDataplaneCertificate(ctx context.Context, controlPlaneID string, certificateID string, opts ...sdkkonnectops.Option) (*sdkkonnectops.GetDataplaneCertificateResponse, error)
 }

--- a/docs/all-api-reference.md
+++ b/docs/all-api-reference.md
@@ -1166,6 +1166,7 @@ KongDataPlaneClientCertificateSpec defines the spec for a KongDataPlaneClientCer
 | Field | Description |
 | --- | --- |
 | `controlPlaneRef` _[ControlPlaneRef](#controlplaneref)_ | ControlPlaneRef is a reference to a Konnect ControlPlane this KongDataPlaneClientCertificate is associated with. |
+| `adopt` _[AdoptOptions](#adoptoptions)_ | Adopt is the options for adopting a key from an existing key in Konnect. |
 | `cert` _string_ | Cert is the certificate in PEM format. Once the certificate gets programmed this field becomes immutable. |
 
 

--- a/docs/configuration-api-reference.md
+++ b/docs/configuration-api-reference.md
@@ -1160,6 +1160,7 @@ KongDataPlaneClientCertificateSpec defines the spec for a KongDataPlaneClientCer
 | Field | Description |
 | --- | --- |
 | `controlPlaneRef` _[ControlPlaneRef](#controlplaneref)_ | ControlPlaneRef is a reference to a Konnect ControlPlane this KongDataPlaneClientCertificate is associated with. |
+| `adopt` _[AdoptOptions](#adoptoptions)_ | Adopt is the options for adopting a key from an existing key in Konnect. |
 | `cert` _string_ | Cert is the certificate in PEM format. Once the certificate gets programmed this field becomes immutable. |
 
 

--- a/scripts/apitypes-funcs/supportedtypes.go
+++ b/scripts/apitypes-funcs/supportedtypes.go
@@ -359,6 +359,9 @@ var supportedConfigurationPackageTypesWithAdopt = []supportedTypesT{
 			{
 				Type: "KongSNI",
 			},
+			{
+				Type: "KongDataPlaneClientCertificate",
+			},
 		},
 	},
 }

--- a/test/crdsvalidation/configuration.konghq.com/kongdataplaneclientcertificate_test.go
+++ b/test/crdsvalidation/configuration.konghq.com/kongdataplaneclientcertificate_test.go
@@ -130,6 +130,55 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 				},
 				ExpectedUpdateErrorMessage: lo.ToPtr("spec.cert is immutable when an entity is already Programmed"),
 			},
+			{
+				Name: "Can adopt in match mode",
+				TestObject: &configurationv1alpha1.KongDataPlaneClientCertificate{
+					ObjectMeta: common.CommonObjectMeta(ns.Name),
+					Spec: configurationv1alpha1.KongDataPlaneClientCertificateSpec{
+						KongDataPlaneClientCertificateAPISpec: configurationv1alpha1.KongDataPlaneClientCertificateAPISpec{
+							Cert: "cert",
+						},
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						Adopt: &commonv1alpha1.AdoptOptions{
+							From: commonv1alpha1.AdoptSourceKonnect,
+							Mode: commonv1alpha1.AdoptModeMatch,
+							Konnect: &commonv1alpha1.AdoptKonnectOptions{
+								ID: "test-dp-cert",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "Cannot adopt in override mode",
+				TestObject: &configurationv1alpha1.KongDataPlaneClientCertificate{
+					ObjectMeta: common.CommonObjectMeta(ns.Name),
+					Spec: configurationv1alpha1.KongDataPlaneClientCertificateSpec{
+						KongDataPlaneClientCertificateAPISpec: configurationv1alpha1.KongDataPlaneClientCertificateAPISpec{
+							Cert: "cert",
+						},
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+						Adopt: &commonv1alpha1.AdoptOptions{
+							From: commonv1alpha1.AdoptSourceKonnect,
+							Mode: commonv1alpha1.AdoptModeOverride,
+							Konnect: &commonv1alpha1.AdoptKonnectOptions{
+								ID: "test-dp-cert",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Only 'match' mode adoption is supported"),
+			},
 		}.
 			RunWithConfig(t, cfg, scheme)
 	})

--- a/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
+++ b/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
@@ -205,23 +205,13 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 			},
 		}, nil)
 
-		t.Log("Creating a KongDataPlaneCertificate for adopting it")
+		t.Log("Creating a KongDataPlaneClientCertificate for adopting it")
 		createdDPCert := deploy.KongDataPlaneClientCertificateAttachedToCP(t, ctx, clientNamespaced,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
-			func(obj client.Object) {
-				dpCert, ok := obj.(*configurationv1alpha1.KongDataPlaneClientCertificate)
-				require.True(t, ok)
-				dpCert.Spec.Adopt = &commonv1alpha1.AdoptOptions{
-					From: commonv1alpha1.AdoptSourceKonnect,
-					Mode: commonv1alpha1.AdoptModeMatch,
-					Konnect: &commonv1alpha1.AdoptKonnectOptions{
-						ID: dpCertID,
-					},
-				}
-			},
+			deploy.WithKonnectAdoptOptions[*configurationv1alpha1.KongDataPlaneClientCertificate](commonv1alpha1.AdoptModeMatch, dpCertID),
 		)
 
-		t.Log("Waiting for KongDataPlaneCertificate to be programmed and set Konnect ID")
+		t.Logf("Waiting for KongDataPlaneClientCertificate %s/%s to be programmed and set Konnect ID", ns.Name, createdDPCert.Name)
 		watchFor(t, ctx, w, apiwatch.Modified, func(dpCert *configurationv1alpha1.KongDataPlaneClientCertificate) bool {
 			return dpCert.Name == createdDPCert.Name &&
 				k8sutils.IsProgrammed(dpCert) &&

--- a/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
+++ b/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
@@ -6,6 +6,7 @@ import (
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -13,11 +14,13 @@ import (
 	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kong-operator/api/konnect/v1alpha1"
 	"github.com/kong/kong-operator/controller/konnect"
 	"github.com/kong/kong-operator/modules/manager/logging"
 	"github.com/kong/kong-operator/modules/manager/scheme"
+	k8sutils "github.com/kong/kong-operator/pkg/utils/kubernetes"
 	"github.com/kong/kong-operator/test/helpers/deploy"
 	"github.com/kong/kong-operator/test/mocks/metricsmocks"
 	"github.com/kong/kong-operator/test/mocks/sdkmocks"
@@ -181,6 +184,50 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 		watchFor(t, ctx, w, apiwatch.Modified,
 			conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			"KongDataPlaneClientCertificate didn't get Programmed and/or ControlPlaneRefValid status condition set to False",
+		)
+	})
+
+	t.Run("Adopting existing dataplane certificate", func(t *testing.T) {
+		dpCertID := uuid.NewString()
+		w := setupWatch[configurationv1alpha1.KongDataPlaneClientCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
+
+		t.Log("Setting up SDK expectations for getting DataPlane certificates")
+		sdk.DataPlaneCertificatesSDK.EXPECT().GetDataplaneCertificate(
+			mock.Anything,
+			cp.GetKonnectID(),
+			dpCertID,
+		).Return(&sdkkonnectops.GetDataplaneCertificateResponse{
+			DataPlaneClientCertificateResponse: &sdkkonnectcomp.DataPlaneClientCertificateResponse{
+				Item: &sdkkonnectcomp.DataPlaneClientCertificate{
+					ID:   lo.ToPtr(dpCertID),
+					Cert: lo.ToPtr(deploy.TestValidCertPEM),
+				},
+			},
+		}, nil)
+
+		t.Log("Creating a KongDataPlaneCertificate for adopting it")
+		createdDPCert := deploy.KongDataPlaneClientCertificateAttachedToCP(t, ctx, clientNamespaced,
+			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
+			func(obj client.Object) {
+				dpCert, ok := obj.(*configurationv1alpha1.KongDataPlaneClientCertificate)
+				require.True(t, ok)
+				dpCert.Spec.Adopt = &commonv1alpha1.AdoptOptions{
+					From: commonv1alpha1.AdoptSourceKonnect,
+					Mode: commonv1alpha1.AdoptModeMatch,
+					Konnect: &commonv1alpha1.AdoptKonnectOptions{
+						ID: dpCertID,
+					},
+				}
+			},
+		)
+
+		t.Log("Waiting for KongDataPlaneCertificate to be programmed and set Konnect ID")
+		watchFor(t, ctx, w, apiwatch.Modified, func(dpCert *configurationv1alpha1.KongDataPlaneClientCertificate) bool {
+			return dpCert.Name == createdDPCert.Name &&
+				k8sutils.IsProgrammed(dpCert) &&
+				dpCert.GetKonnectID() == dpCertID
+		},
+			fmt.Sprintf("KongDataPlaneCertificate didn't get Programmed status condition or didn't get the correct Konnect ID %s assigned", dpCertID),
 		)
 	})
 }

--- a/test/mocks/sdkmocks/zz_generated.kongdataplanecertificate.go
+++ b/test/mocks/sdkmocks/zz_generated.kongdataplanecertificate.go
@@ -217,6 +217,95 @@ func (_c *MockDataPlaneClientCertificatesSDK_DeleteDataplaneCertificate_Call) Ru
 	return _c
 }
 
+// GetDataplaneCertificate provides a mock function for the type MockDataPlaneClientCertificatesSDK
+func (_mock *MockDataPlaneClientCertificatesSDK) GetDataplaneCertificate(ctx context.Context, controlPlaneID string, certificateID string, opts ...operations.Option) (*operations.GetDataplaneCertificateResponse, error) {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _mock.Called(ctx, controlPlaneID, certificateID, opts)
+	} else {
+		tmpRet = _mock.Called(ctx, controlPlaneID, certificateID)
+	}
+	ret := tmpRet
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDataplaneCertificate")
+	}
+
+	var r0 *operations.GetDataplaneCertificateResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, ...operations.Option) (*operations.GetDataplaneCertificateResponse, error)); ok {
+		return returnFunc(ctx, controlPlaneID, certificateID, opts...)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, ...operations.Option) *operations.GetDataplaneCertificateResponse); ok {
+		r0 = returnFunc(ctx, controlPlaneID, certificateID, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*operations.GetDataplaneCertificateResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, ...operations.Option) error); ok {
+		r1 = returnFunc(ctx, controlPlaneID, certificateID, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDataPlaneClientCertificatesSDK_GetDataplaneCertificate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDataplaneCertificate'
+type MockDataPlaneClientCertificatesSDK_GetDataplaneCertificate_Call struct {
+	*mock.Call
+}
+
+// GetDataplaneCertificate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - controlPlaneID string
+//   - certificateID string
+//   - opts ...operations.Option
+func (_e *MockDataPlaneClientCertificatesSDK_Expecter) GetDataplaneCertificate(ctx interface{}, controlPlaneID interface{}, certificateID interface{}, opts ...interface{}) *MockDataPlaneClientCertificatesSDK_GetDataplaneCertificate_Call {
+	return &MockDataPlaneClientCertificatesSDK_GetDataplaneCertificate_Call{Call: _e.mock.On("GetDataplaneCertificate",
+		append([]interface{}{ctx, controlPlaneID, certificateID}, opts...)...)}
+}
+
+func (_c *MockDataPlaneClientCertificatesSDK_GetDataplaneCertificate_Call) Run(run func(ctx context.Context, controlPlaneID string, certificateID string, opts ...operations.Option)) *MockDataPlaneClientCertificatesSDK_GetDataplaneCertificate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 []operations.Option
+		var variadicArgs []operations.Option
+		if len(args) > 3 {
+			variadicArgs = args[3].([]operations.Option)
+		}
+		arg3 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3...,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDataPlaneClientCertificatesSDK_GetDataplaneCertificate_Call) Return(getDataplaneCertificateResponse *operations.GetDataplaneCertificateResponse, err error) *MockDataPlaneClientCertificatesSDK_GetDataplaneCertificate_Call {
+	_c.Call.Return(getDataplaneCertificateResponse, err)
+	return _c
+}
+
+func (_c *MockDataPlaneClientCertificatesSDK_GetDataplaneCertificate_Call) RunAndReturn(run func(ctx context.Context, controlPlaneID string, certificateID string, opts ...operations.Option) (*operations.GetDataplaneCertificateResponse, error)) *MockDataPlaneClientCertificatesSDK_GetDataplaneCertificate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListDpClientCertificates provides a mock function for the type MockDataPlaneClientCertificatesSDK
 func (_mock *MockDataPlaneClientCertificatesSDK) ListDpClientCertificates(ctx context.Context, controlPlaneID string, opts ...operations.Option) (*operations.ListDpClientCertificatesResponse, error) {
 	var tmpRet mock.Arguments


### PR DESCRIPTION
**What this PR does / why we need it**:

Implement the match mode of adopting dataplane certificates by `KongDataPlaneCertificate` CRD in Konnect.

**Which issue this PR fixes**

Fixes #2632

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
