### PR TITLE
fix(hybridgateway): preserve boolean false and non-nil pointer-to-zero in prune

### DIFF
--- a/controller/hybridgateway/managedfields/prune.go
+++ b/controller/hybridgateway/managedfields/prune.go
@@ -53,6 +53,19 @@ func pruneEmptyFields(m map[string]any) {
 			}
 		default:
 			rv := reflect.ValueOf(v)
+			// Don't delete boolean fields even if they're false.
+			if rv.Kind() == reflect.Bool {
+				continue
+			}
+			// Don't delete pointer fields that point to zero values (user explicitly set them to zero).
+			// Only delete if the pointer itself is nil.
+			if rv.Kind() == reflect.Ptr {
+				if rv.IsNil() {
+					delete(m, k)
+				}
+				continue
+			}
+			// For non-pointer, non-bool types, delete if zero value.
 			if !rv.IsValid() || rv.IsZero() {
 				delete(m, k)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**
Fix pruneEmptyFields to treat boolean false as a valid value and only remove pointer fields when the pointer is nil. This prevents explicit values like false or *int = 0 from being pruned and losing user intent. Added/updated unit tests in prune_test.go.

**Which issue this PR fixes**

Fixes #2690 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
