### PR TITLE
fix(konnect): use uncached API reader for secret lookups

### DIFF
--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -44,6 +44,7 @@ type KonnectEntityReconciler[T constraints.SupportedKonnectEntityType, TEnt cons
 	sdkFactory              sdkops.SDKFactory
 	CacheSyncTimeout        time.Duration
 	Client                  client.Client
+	apiReader               client.Reader
 	LoggingMode             logging.Mode
 	MaxConcurrentReconciles uint
 	SyncPeriod              time.Duration
@@ -111,6 +112,7 @@ func NewKonnectEntityReconciler[
 
 // SetupWithManager sets up the controller with the given manager.
 func (r *KonnectEntityReconciler[T, TEnt]) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	r.apiReader = mgr.GetAPIReader()
 	var (
 		e              T
 		ent            = TEnt(&e)
@@ -356,7 +358,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		return res, retErr
 	}
 
-	token, err := getTokenFromKonnectAPIAuthConfiguration(ctx, r.Client, &apiAuth)
+	token, err := getTokenFromKonnectAPIAuthConfiguration(ctx, r.apiReader, &apiAuth)
 	if err != nil {
 		if res, errStatus := patch.StatusWithCondition(
 			ctx, r.Client, &apiAuth,


### PR DESCRIPTION
## Problem

When using `KonnectAPIAuthConfiguration` with `type: secretRef` to reference secrets managed by External Secrets Operator (ESO), the operator fails with `Secret "konnect-token" not found` errors even though:
- The secret exists in the cluster
- The secret has the correct label (`konghq.com/credential: konnect`)
- RBAC permissions are correct
- Test pods can successfully read the secret

This issue affects both:
- `KonnectAPIAuthConfiguration` resources directly
- `KonnectGatewayControlPlane` and other Konnect entities that reference `KonnectAPIAuthConfiguration`

## Root Cause

The reconcilers use the cached client (`client.Client`) for secret lookups. The cache can become stale when secrets are created/updated by ESO, causing the operator to miss recently created secrets.

## Solution

This PR changes the secret lookup to use the uncached API reader (`mgr.GetAPIReader()`) which directly queries the API server, bypassing the cache and ensuring we always get the latest secret data.

**Note:** We tested the requeue approach suggested during review, but it didn't resolve the cache staleness issue. The controller's cache doesn't properly sync with dynamically created secrets from ESO, even after multiple requeues. Using an uncached client is the only reliable way to access ESO-managed secrets in this scenario.

## Changes

### `KonnectAPIAuthConfigurationReconciler`
- Added `apiReader client.Reader` field to `KonnectAPIAuthConfigurationReconciler`
- Initialize `apiReader` with `mgr.GetAPIReader()` in `SetupWithManager()`
- Use `apiReader` instead of cached `client` for secret lookups in `getTokenFromKonnectAPIAuthConfiguration()`
- Updated function signature to accept `client.Reader` instead of `client.Client`

### `KonnectEntityReconciler` (Generic Reconciler)
- Added `apiReader client.Reader` field to `KonnectEntityReconciler` struct
- Initialize `apiReader` with `mgr.GetAPIReader()` in `SetupWithManager()`
- Use `apiReader` instead of cached `Client` for secret lookups in `getTokenFromKonnectAPIAuthConfiguration()`
- This ensures `KonnectGatewayControlPlane` and other Konnect entities can reliably access ESO-managed secrets

## Testing

✅ Tested in production EKS cluster  
✅ Verified `KonnectAPIAuthConfiguration` status changes from `Invalid` to `Valid` after fix  
✅ Verified `KonnectGatewayControlPlane` can successfully use ESO-managed secrets  
✅ Confirmed secret is successfully read and token validated  
✅ Tested requeue approach - confirmed it doesn't resolve cache staleness with ESO secrets

## Related Issues

This fixes the issue where ESO-managed secrets cannot be used with `KonnectAPIAuthConfiguration` and Konnect entities that depend on it.