### PR TITLE
chore: use mise's github backend instead of plugins to obtain tools

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,6 +23,14 @@ on:
       - '*'
   workflow_dispatch: {}
 
+# NOTE: Some jobs add GITHUB_API_TOKEN env so that some mise plugins which
+# download GitHub release assets can access GitHub's API authenticated and thus
+# not get rate-limited (which causes failures).
+
+# NOTE: Some jobs require GITHUB_TOKEN env which is used by mise itself to access
+# GitHub's API authenticated and thus not get rate-limited (which causes failures).
+# Ref: https://mise.jdx.dev/getting-started.html#github-api-rate-limiting.
+
 env:
   MISE_VERBOSE: 1
 
@@ -96,10 +104,8 @@ jobs:
       env:
         # Our .golangci.yaml has fix: true, but we don't want that in CI therefore the below override.
         GOLANGCI_LINT_FLAGS: "--fix=false"
-        # Add GITHUB_TOKEN env so that mise plugins can can access GitHub's API
-        # authenticated and thus not get rate-limited (which causes failures).
-        # Source ref: https://github.com/hypnoglow/asdf-golangci-lint/blob/f02f2ee73bd6d1bc4d69d6aad583cf05879fc9ea/bin/list-all#L10C12-L12
         GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: make lint
 
     - name: run lint.api
@@ -174,9 +180,6 @@ jobs:
 
     - name: Verify generators consistency
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-      # Add GITHUB_TOKEN env so that scripts/generate-crd-kustomize.sh can
-      # access GitHub's API authenticated and thus not get rate-limited (which
-      # causes failures).
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -367,6 +370,7 @@ jobs:
       env:
         KONG_PLUGIN_IMAGE_REGISTRY_CREDENTIALS: ${{ secrets.KONG_PLUGIN_IMAGE_REGISTRY_CREDENTIALS }}
         GOTESTSUM_JUNITFILE: "unit-tests.xml"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: collect test coverage
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
@@ -519,10 +523,8 @@ jobs:
       env:
         GOTESTSUM_JUNITFILE: conformance-tests-${{ matrix.router-flavor }}.xml
         TEST_KONG_ROUTER_FLAVOR: ${{ matrix.router-flavor }}
-        # Add GITHUB_TOKEN env so that mise plugins can can access GitHub's API
-        # authenticated and thus not get rate-limited (which causes failures).
-        # Source ref: https://github.com/pirackr/asdf-telepresence/blob/c9eeab4d28b9851bb904c4c67239a118c8dd384d/bin/list-all#L7-L9
         GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: upload diagnostics
       if: ${{ always() }}
@@ -582,9 +584,6 @@ jobs:
         KONG_CONTROLLER_OUT: stdout
         GOTESTSUM_JUNITFILE: "${{ matrix.directory }}/integration-tests.xml"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Add GITHUB_TOKEN env so that mise plugins can can access GitHub's API
-        # authenticated and thus not get rate-limited (which causes failures).
-        # Source ref: https://github.com/pirackr/asdf-telepresence/blob/c9eeab4d28b9851bb904c4c67239a118c8dd384d/bin/list-all#L7-L9
         GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
         KONG_TEST_KONNECT_SERVER_URL: us.api.konghq.tech

--- a/.mise.toml
+++ b/.mise.toml
@@ -7,16 +7,28 @@ MISE_DATA_DIR='bin/'
 helm = "https://github.com/Antiarchitect/asdf-helm.git#00b6ead39b97536304042241f31242811ca39f74"
 govulncheck = "https://github.com/wizzardich/asdf-govulncheck.git#2e3e9ce0edbc6ec89097d221c9a04217bbe1f51b"
 markdownlint-cli2 = "https://github.com/paulo-ferraz-oliveira/asdf-markdownlint-cli2.git#6d14d9fb2f6f7572e7cbcbb818da9670ba4bef62"
-telepresence = "https://github.com/pirackr/asdf-telepresence.git#c9eeab4d28b9851bb904c4c67239a118c8dd384d"
 kubelinter = "https://github.com/the-cashman/asdf-kube-linter.git#14a55249ef69d5fe98b027b89f111aec2c30ee57"
-shellcheck = "https://github.com/luizm/asdf-shellcheck.git#8b954a95d44b8d8a6c6cd5a5a52ed643b7bb52e3"
-actionlint = "https://github.com/crazy-matt/asdf-actionlint.git#f8df3cfa05a1c875415b015808548bc8bac3b3a4"
-mockery = "https://github.com/cabify/asdf-mockery.git#1cb81d68720263709d8f24eb2dafd303c9097b1d"
-setup-envtest = "https://github.com/pmalek/mise-setup-envtest.git#061f3ab0bb3238d9425417cb6879dfd1f810d371"
-skaffold = "https://github.com/nklmilojevic/asdf-skaffold.git#bf2f9922ddfc4d8613a2d92f3fedc458464e36e6"
-gotestsum = "https://github.com/pmalek/mise-gotestsum.git#66845ffc7d0c1ecb0e344be4c66e9babe256c7b7"
-golangci-lint = "https://github.com/hypnoglow/asdf-golangci-lint.git#f02f2ee73bd6d1bc4d69d6aad583cf05879fc9ea"
 kube-code-generator = "https://github.com/mise-plugins/mise-kube-code-generator.git#e98effe0bda46523b4dee7217767457f7ca13fd4"
-kustomize = "https://github.com/Banno/asdf-kustomize.git#a5ecf778e74cbd7d118455c14c2d479d83be88c8"
-kube-controller-tools = "https://github.com/jimmidyson/asdf-kube-controller-tools.git#37526dcd7c92c60a6984459ba1f5144108e2978e"
-yq = "https://github.com/sudermanjr/asdf-yq.git#772992f66c49fe681b1cd02d14e8166930472bf1"
+
+# NOTE: The reason for tool version being set here and not in .tools-versions.toml
+# is that mise requires the version to be specified when using version_prefix
+# and we need to set the latter for kustomize because its tags on GitHub are prefixed
+# with "kustomize/".
+
+# NOTE renovate's mise manager doesn't want to work with this for some reason
+# so we add renovate comments manually here.
+# Ref: https://docs.renovatebot.com/modules/manager/mise/
+
+[tools."github:kubernetes-sigs/kustomize"]
+# renovate: datasource=github-releases depName=kubernetes-sigs/kustomize
+version = "v5.8.0"
+version_prefix = "kustomize/"
+
+[tools."github:telepresenceio/telepresence"]
+# renovate: datasource=github-releases depName=telepresenceio/telepresence
+version = "2.25.1"
+[tools."github:telepresenceio/telepresence".platforms]
+linux-x64 = { asset_pattern = "telepresence-linux-amd64" }
+linux-arm64 = { asset_pattern = "telepresence-linux-arm64" }
+darwin-arm64 = { asset_pattern = "telepresence-darwin-arm64" }
+macos-arm64 = { asset_pattern = "telepresence-darwin-arm64" }

--- a/.tools_versions.yaml
+++ b/.tools_versions.yaml
@@ -2,8 +2,6 @@
 code-generator: "0.34.2"
 # renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools
 controller-tools: "0.19.0"
-# renovate: datasource=github-releases depName=kubernetes-sigs/kustomize
-kustomize: "5.8.0"
 # renovate: datasource=github-releases depName=golangci/golangci-lint
 golangci-lint: "2.6.2"
 # TODO: Renovate comment is missing. This needs to be added at some point.
@@ -43,8 +41,6 @@ govulncheck: "1.1.4"
 chartsnap: "0.6.0"
 # renovate: datasource=github-releases depName=stackrox/kube-linter
 kube-linter: "0.7.6"
-# renovate: datasource=github-releases depName=telepresenceio/telepresence
-telepresence: "2.25.1"
 # renovate: datasource=github-tags depName=DavidAnson/markdownlint-cli2
 markdownlint-cli2: "0.19.1"
 # renovate: datasource=github-releases depName=cert-manager/cert-manager

--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,16 @@
       ]
     },
     {
+      "description": "Match dependencies in .mise.toml that are properly annotated with `# renovate: datasource={} depName={}.`",
+      "customType": "regex",
+      "fileMatch": [
+        "\\.mise\\.toml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( registryUrl=(?<registryUrl>.*?))?\\n.+\"v(?<currentValue>.*?)\""
+      ]
+    },
+    {
       "description": "Match dependencies in .custom-gcl.yml that are properly annotated with `# renovate: datasource={} depName={}.`",
       "customType": "regex",
       "fileMatch": [


### PR DESCRIPTION
**What this PR does / why we need it**:

This implements the change for a couple of tools that we use to use `mise`'s `github` backend instead of third party plugins. Thanks to this change we do away with relying on third party plugins and possibly building the tools themselves and relying on native support in `mise`.

Related `mise` docs: https://mise.jdx.dev/dev-tools/backends/github.html

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
