### PR TITLE
[Backport release/2.0.x] fix(ingress-controller): Add translation of healthchecks.threshold in upstreams (#2662)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
 
+## Unreleased
+
+### Fixes
+
+- Translate `healtchchecks.thershold` in `KongUpstreamPolicy` to the
+  `healthchecks.thershold` field in Kong upstreams.
+  [#2662](https://github.com/Kong/kong-operator/pull/2662)
+
 ## [v2.0.5]
 
 > Release date: 2025-10-17

--- a/ingress-controller/internal/dataplane/kongstate/kongupstreampolicy.go
+++ b/ingress-controller/internal/dataplane/kongstate/kongupstreampolicy.go
@@ -171,8 +171,9 @@ func translateHealthchecks(healthchecks *configurationv1beta1.KongUpstreamHealth
 		return nil
 	}
 	return &kong.Healthcheck{
-		Active:  translateActiveHealthcheck(healthchecks.Active),
-		Passive: translatePassiveHealthcheck(healthchecks.Passive),
+		Active:    translateActiveHealthcheck(healthchecks.Active),
+		Passive:   translatePassiveHealthcheck(healthchecks.Passive),
+		Threshold: translateThreshold(healthchecks.Threshold),
 	}
 }
 
@@ -202,6 +203,13 @@ func translatePassiveHealthcheck(healthcheck *configurationv1beta1.KongUpstreamP
 		Healthy:   translateHealthy(healthcheck.Healthy),
 		Unhealthy: translateUnhealthy(healthcheck.Unhealthy),
 	}
+}
+
+func translateThreshold(threshold *int) *float64 {
+	if threshold == nil {
+		return nil
+	}
+	return lo.ToPtr(float64(*threshold))
 }
 
 func translateHealthy(healthy *configurationv1beta1.KongUpstreamHealthcheckHealthy) *kong.Healthy {

--- a/ingress-controller/internal/dataplane/kongstate/kongupstreampolicy_test.go
+++ b/ingress-controller/internal/dataplane/kongstate/kongupstreampolicy_test.go
@@ -383,7 +383,7 @@ func TestTranslateKongUpstreamPolicy(t *testing.T) {
 							Timeouts:    lo.ToPtr(120),
 						},
 					},
-					Threshold: lo.ToPtr(140),
+					Threshold: lo.ToPtr(10),
 				},
 			},
 			expectedUpstream: &kong.Upstream{
@@ -418,6 +418,7 @@ func TestTranslateKongUpstreamPolicy(t *testing.T) {
 							Timeouts:    lo.ToPtr(120),
 						},
 					},
+					Threshold: lo.ToPtr(float64(10.0)),
 				},
 			},
 		},

--- a/ingress-controller/test/kongintegration/kongupstreampolicy_test.go
+++ b/ingress-controller/test/kongintegration/kongupstreampolicy_test.go
@@ -175,7 +175,7 @@ func TestKongUpstreamPolicyTranslation(t *testing.T) {
 							Timeouts:     lo.ToPtr(120),
 						},
 					},
-					Threshold: lo.ToPtr(140),
+					Threshold: lo.ToPtr(15),
 				},
 			},
 			expectedUpstream: &kong.Upstream{
@@ -214,7 +214,7 @@ func TestKongUpstreamPolicyTranslation(t *testing.T) {
 							Timeouts:     lo.ToPtr(120),
 						},
 					},
-					Threshold: lo.ToPtr(0.),
+					Threshold: lo.ToPtr(15.0),
 				},
 			},
 		},


### PR DESCRIPTION


(cherry picked from commit bea7233ac1e32326fefbc70cf9286c5aa432ae74)

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
