### PR TITLE
chore: add more linters to kube API linter config

### DIFF
--- a/.golangci-kube-api.yaml
+++ b/.golangci-kube-api.yaml
@@ -13,21 +13,39 @@ linters:
             disable:
               - "*"
             enable:
-              - jsontags
-              - duplicatemarkers
+              - arrayofstruct
               - conditions
-              - maxlength
+              - defaultorrequired
+              - duplicatemarkers
               - integers
+              - jsontags
+              - maxlength
               - nobools
+              - nodurations
               - nofloats
               - nomaps
+              - nonullable
               - nophase
+              - notimestamp
               - optionalorrequired
+              - preferredmarkers
               - requiredfields
               - statusoptional
               - statussubresource
               - uniquemarkers
           lintersConfig:
+            # https://github.com/kubernetes-sigs/kube-api-linter/issues/195
+            # requiredfields:
+            #   omitempty:
+            #     policy: Ignore
+            preferredmarkers:
+              markers:
+                - preferredIdentifier: "k8s:optional"
+                  equivalentIdentifiers:
+                    - identifier: "kubebuilder:validation:Optional"
+                - preferredIdentifier: "k8s:required"
+                  equivalentIdentifiers:
+                    - identifier: "kubebuilder:validation:Required"
             conditions:
               isFirstField: Warn
               useProtobuf: Warn
@@ -42,14 +60,6 @@ linters:
               preferredRequiredMarker: required
   exclusions:
     rules:
-      - linters:
-          - kubeapilinter
-        path: .*
-        text: "(optionalorrequired: embedded field  must be marked as optional or required)"
-      - linters:
-          - kubeapilinter
-        path: .*
-        text: "(optionalorrequired: field Spec must be marked as optional or required)"
       - linters:
           - kubeapilinter
         path: .*
@@ -75,6 +85,11 @@ linters:
           - kubeapilinter
         path: api/konnect/v1alpha1/.*
         text: "conditions: Conditions field must be the first field in the struct"
+      # NOTE: We've already released v2beta1 with Duration fields in ControlPlane spec.
+      - linters:
+          - kubeapilinter
+        path: api/gateway-operator/v2beta1/controlplane_types.go
+        text: 'nodurations: field ControlPlane.* pointer should not use a Duration'
 
       # TODO: remove this.
       - linters:
@@ -109,5 +124,5 @@ linters:
       # TODO: remove this.
       - linters:
           - kubeapilinter
-        path: api/(konnect|gateway-operator)/.*
+        path: api/(konnect/v1alpha(1|2)|gateway-operator/v2beta1)/.*
         text: 'maxlength: .*'

--- a/api/gateway-operator/v2beta1/controlplane_types.go
+++ b/api/gateway-operator/v2beta1/controlplane_types.go
@@ -353,7 +353,7 @@ const (
 type ControlPlaneConfigDump struct {
 	// When State is enabled, Operator will dump the translated Kong configuration by it from a diagnostics server.
 	//
-	// +required
+	// +optional
 	// +kubebuilder:validation:Enum=enabled;disabled
 	// +kubebuilder:default="disabled"
 	State ConfigDumpState `json:"state"`
@@ -361,7 +361,7 @@ type ControlPlaneConfigDump struct {
 	// When DumpSensitive is enabled, the configuration will be dumped unchanged, including sensitive parts like private keys and credentials.
 	// When DumpSensitive is disabled, the sensitive configuration parts like private keys and credentials are redacted.
 	//
-	// +required
+	// +optional
 	// +kubebuilder:validation:Enum=enabled;disabled
 	// +kubebuilder:default="disabled"
 	DumpSensitive ConfigDumpState `json:"dumpSensitive"`

--- a/api/konnect/v1alpha1/konnect_cloudgateway_transitgateway_types.go
+++ b/api/konnect/v1alpha1/konnect_cloudgateway_transitgateway_types.go
@@ -146,12 +146,12 @@ type AzureTransitGateway struct {
 type TransitGatewayDNSConfig struct {
 	// RemoteDNSServerIPAddresses is the list of remote DNS server IP Addresses to connect to for resolving internal DNS via a transit gateway.
 	//
-	// +optional
+	// +required
 	RemoteDNSServerIPAddresses []string `json:"remote_dns_server_ip_addresses,omitempty"`
 	// DomainProxyList is the list of internal domain names to proxy for DNS resolution from the listed remote DNS server IP addresses,
 	// for a transit gateway.
 	//
-	// +optional
+	// +required
 	DomainProxyList []string `json:"domain_proxy_list,omitempty"`
 }
 
@@ -159,7 +159,7 @@ type TransitGatewayDNSConfig struct {
 type AwsTransitGatewayAttachmentConfig struct {
 	// TransitGatewayID is the AWS transit gateway ID to create attachment to.
 	//
-	// +required
+	// +optional
 	// +kubebuilder:validation:MinLength=1
 	TransitGatewayID string `json:"transit_gateway_id"`
 	// RAMShareArn is the resource share ARN to verify request to create transit gateway attachment.

--- a/charts/kong-operator/charts/ko-crds/templates/ko-crds.yaml
+++ b/charts/kong-operator/charts/ko-crds/templates/ko-crds.yaml
@@ -9062,9 +9062,6 @@ spec:
                     - enabled
                     - disabled
                     type: string
-                required:
-                - dumpSensitive
-                - state
                 type: object
                 x-kubernetes-validations:
                 - message: Cannot enable dumpSensitive when state is disabled
@@ -37146,9 +37143,6 @@ spec:
                         - enabled
                         - disabled
                         type: string
-                    required:
-                    - dumpSensitive
-                    - state
                     type: object
                     x-kubernetes-validations:
                     - message: Cannot enable dumpSensitive when state is disabled
@@ -56542,7 +56536,6 @@ spec:
                         type: string
                     required:
                     - ram_share_arn
-                    - transit_gateway_id
                     type: object
                   cidr_blocks:
                     description: |-
@@ -56573,6 +56566,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:
@@ -56641,6 +56637,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -8597,9 +8597,6 @@ spec:
                     - enabled
                     - disabled
                     type: string
-                required:
-                - dumpSensitive
-                - state
                 type: object
                 x-kubernetes-validations:
                 - message: Cannot enable dumpSensitive when state is disabled
@@ -34907,9 +34904,6 @@ spec:
                         - enabled
                         - disabled
                         type: string
-                    required:
-                    - dumpSensitive
-                    - state
                     type: object
                     x-kubernetes-validations:
                     - message: Cannot enable dumpSensitive when state is disabled
@@ -52967,7 +52961,6 @@ spec:
                         type: string
                     required:
                     - ram_share_arn
-                    - transit_gateway_id
                     type: object
                   cidr_blocks:
                     description: |-
@@ -52995,6 +52988,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:
@@ -53056,6 +53052,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -8597,9 +8597,6 @@ spec:
                     - enabled
                     - disabled
                     type: string
-                required:
-                - dumpSensitive
-                - state
                 type: object
                 x-kubernetes-validations:
                 - message: Cannot enable dumpSensitive when state is disabled
@@ -34907,9 +34904,6 @@ spec:
                         - enabled
                         - disabled
                         type: string
-                    required:
-                    - dumpSensitive
-                    - state
                     type: object
                     x-kubernetes-validations:
                     - message: Cannot enable dumpSensitive when state is disabled
@@ -52967,7 +52961,6 @@ spec:
                         type: string
                     required:
                     - ram_share_arn
-                    - transit_gateway_id
                     type: object
                   cidr_blocks:
                     description: |-
@@ -52995,6 +52988,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:
@@ -53056,6 +53052,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -8597,9 +8597,6 @@ spec:
                     - enabled
                     - disabled
                     type: string
-                required:
-                - dumpSensitive
-                - state
                 type: object
                 x-kubernetes-validations:
                 - message: Cannot enable dumpSensitive when state is disabled
@@ -34907,9 +34904,6 @@ spec:
                         - enabled
                         - disabled
                         type: string
-                    required:
-                    - dumpSensitive
-                    - state
                     type: object
                     x-kubernetes-validations:
                     - message: Cannot enable dumpSensitive when state is disabled
@@ -52967,7 +52961,6 @@ spec:
                         type: string
                     required:
                     - ram_share_arn
-                    - transit_gateway_id
                     type: object
                   cidr_blocks:
                     description: |-
@@ -52995,6 +52988,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:
@@ -53056,6 +53052,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -8597,9 +8597,6 @@ spec:
                     - enabled
                     - disabled
                     type: string
-                required:
-                - dumpSensitive
-                - state
                 type: object
                 x-kubernetes-validations:
                 - message: Cannot enable dumpSensitive when state is disabled
@@ -34907,9 +34904,6 @@ spec:
                         - enabled
                         - disabled
                         type: string
-                    required:
-                    - dumpSensitive
-                    - state
                     type: object
                     x-kubernetes-validations:
                     - message: Cannot enable dumpSensitive when state is disabled
@@ -52967,7 +52961,6 @@ spec:
                         type: string
                     required:
                     - ram_share_arn
-                    - transit_gateway_id
                     type: object
                   cidr_blocks:
                     description: |-
@@ -52995,6 +52988,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:
@@ -53056,6 +53052,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -8597,9 +8597,6 @@ spec:
                     - enabled
                     - disabled
                     type: string
-                required:
-                - dumpSensitive
-                - state
                 type: object
                 x-kubernetes-validations:
                 - message: Cannot enable dumpSensitive when state is disabled
@@ -34907,9 +34904,6 @@ spec:
                         - enabled
                         - disabled
                         type: string
-                    required:
-                    - dumpSensitive
-                    - state
                     type: object
                     x-kubernetes-validations:
                     - message: Cannot enable dumpSensitive when state is disabled
@@ -52967,7 +52961,6 @@ spec:
                         type: string
                     required:
                     - ram_share_arn
-                    - transit_gateway_id
                     type: object
                   cidr_blocks:
                     description: |-
@@ -52995,6 +52988,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:
@@ -53056,6 +53052,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -8598,9 +8598,6 @@ spec:
                     - enabled
                     - disabled
                     type: string
-                required:
-                - dumpSensitive
-                - state
                 type: object
                 x-kubernetes-validations:
                 - message: Cannot enable dumpSensitive when state is disabled
@@ -34908,9 +34905,6 @@ spec:
                         - enabled
                         - disabled
                         type: string
-                    required:
-                    - dumpSensitive
-                    - state
                     type: object
                     x-kubernetes-validations:
                     - message: Cannot enable dumpSensitive when state is disabled
@@ -52968,7 +52962,6 @@ spec:
                         type: string
                     required:
                     - ram_share_arn
-                    - transit_gateway_id
                     type: object
                   cidr_blocks:
                     description: |-
@@ -52996,6 +52989,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:
@@ -53057,6 +53053,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -8597,9 +8597,6 @@ spec:
                     - enabled
                     - disabled
                     type: string
-                required:
-                - dumpSensitive
-                - state
                 type: object
                 x-kubernetes-validations:
                 - message: Cannot enable dumpSensitive when state is disabled
@@ -34907,9 +34904,6 @@ spec:
                         - enabled
                         - disabled
                         type: string
-                    required:
-                    - dumpSensitive
-                    - state
                     type: object
                     x-kubernetes-validations:
                     - message: Cannot enable dumpSensitive when state is disabled
@@ -52967,7 +52961,6 @@ spec:
                         type: string
                     required:
                     - ram_share_arn
-                    - transit_gateway_id
                     type: object
                   cidr_blocks:
                     description: |-
@@ -52995,6 +52988,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:
@@ -53056,6 +53052,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -8597,9 +8597,6 @@ spec:
                     - enabled
                     - disabled
                     type: string
-                required:
-                - dumpSensitive
-                - state
                 type: object
                 x-kubernetes-validations:
                 - message: Cannot enable dumpSensitive when state is disabled
@@ -34907,9 +34904,6 @@ spec:
                         - enabled
                         - disabled
                         type: string
-                    required:
-                    - dumpSensitive
-                    - state
                     type: object
                     x-kubernetes-validations:
                     - message: Cannot enable dumpSensitive when state is disabled
@@ -52967,7 +52961,6 @@ spec:
                         type: string
                     required:
                     - ram_share_arn
-                    - transit_gateway_id
                     type: object
                   cidr_blocks:
                     description: |-
@@ -52995,6 +52988,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:
@@ -53056,6 +53052,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -8597,9 +8597,6 @@ spec:
                     - enabled
                     - disabled
                     type: string
-                required:
-                - dumpSensitive
-                - state
                 type: object
                 x-kubernetes-validations:
                 - message: Cannot enable dumpSensitive when state is disabled
@@ -34907,9 +34904,6 @@ spec:
                         - enabled
                         - disabled
                         type: string
-                    required:
-                    - dumpSensitive
-                    - state
                     type: object
                     x-kubernetes-validations:
                     - message: Cannot enable dumpSensitive when state is disabled
@@ -52967,7 +52961,6 @@ spec:
                         type: string
                     required:
                     - ram_share_arn
-                    - transit_gateway_id
                     type: object
                   cidr_blocks:
                     description: |-
@@ -52995,6 +52988,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:
@@ -53056,6 +53052,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -8597,9 +8597,6 @@ spec:
                     - enabled
                     - disabled
                     type: string
-                required:
-                - dumpSensitive
-                - state
                 type: object
                 x-kubernetes-validations:
                 - message: Cannot enable dumpSensitive when state is disabled
@@ -34907,9 +34904,6 @@ spec:
                         - enabled
                         - disabled
                         type: string
-                    required:
-                    - dumpSensitive
-                    - state
                     type: object
                     x-kubernetes-validations:
                     - message: Cannot enable dumpSensitive when state is disabled
@@ -52967,7 +52961,6 @@ spec:
                         type: string
                     required:
                     - ram_share_arn
-                    - transit_gateway_id
                     type: object
                   cidr_blocks:
                     description: |-
@@ -52995,6 +52988,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:
@@ -53056,6 +53052,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -8597,9 +8597,6 @@ spec:
                     - enabled
                     - disabled
                     type: string
-                required:
-                - dumpSensitive
-                - state
                 type: object
                 x-kubernetes-validations:
                 - message: Cannot enable dumpSensitive when state is disabled
@@ -34907,9 +34904,6 @@ spec:
                         - enabled
                         - disabled
                         type: string
-                    required:
-                    - dumpSensitive
-                    - state
                     type: object
                     x-kubernetes-validations:
                     - message: Cannot enable dumpSensitive when state is disabled
@@ -52967,7 +52961,6 @@ spec:
                         type: string
                     required:
                     - ram_share_arn
-                    - transit_gateway_id
                     type: object
                   cidr_blocks:
                     description: |-
@@ -52995,6 +52988,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:
@@ -53056,6 +53052,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -8597,9 +8597,6 @@ spec:
                     - enabled
                     - disabled
                     type: string
-                required:
-                - dumpSensitive
-                - state
                 type: object
                 x-kubernetes-validations:
                 - message: Cannot enable dumpSensitive when state is disabled
@@ -34907,9 +34904,6 @@ spec:
                         - enabled
                         - disabled
                         type: string
-                    required:
-                    - dumpSensitive
-                    - state
                     type: object
                     x-kubernetes-validations:
                     - message: Cannot enable dumpSensitive when state is disabled
@@ -52967,7 +52961,6 @@ spec:
                         type: string
                     required:
                     - ram_share_arn
-                    - transit_gateway_id
                     type: object
                   cidr_blocks:
                     description: |-
@@ -52995,6 +52988,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:
@@ -53056,6 +53052,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -648,9 +648,6 @@ spec:
                     - enabled
                     - disabled
                     type: string
-                required:
-                - dumpSensitive
-                - state
                 type: object
                 x-kubernetes-validations:
                 - message: Cannot enable dumpSensitive when state is disabled
@@ -10381,9 +10378,6 @@ spec:
                         - enabled
                         - disabled
                         type: string
-                    required:
-                    - dumpSensitive
-                    - state
                     type: object
                     x-kubernetes-validations:
                     - message: Cannot enable dumpSensitive when state is disabled
@@ -28445,7 +28439,6 @@ spec:
                         type: string
                     required:
                     - ram_share_arn
-                    - transit_gateway_id
                     type: object
                   cidr_blocks:
                     description: |-
@@ -28473,6 +28466,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:
@@ -28534,6 +28530,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -8547,9 +8547,6 @@ spec:
                     - enabled
                     - disabled
                     type: string
-                required:
-                - dumpSensitive
-                - state
                 type: object
                 x-kubernetes-validations:
                 - message: Cannot enable dumpSensitive when state is disabled
@@ -34857,9 +34854,6 @@ spec:
                         - enabled
                         - disabled
                         type: string
-                    required:
-                    - dumpSensitive
-                    - state
                     type: object
                     x-kubernetes-validations:
                     - message: Cannot enable dumpSensitive when state is disabled
@@ -52917,7 +52911,6 @@ spec:
                         type: string
                     required:
                     - ram_share_arn
-                    - transit_gateway_id
                     type: object
                   cidr_blocks:
                     description: |-
@@ -52945,6 +52938,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:
@@ -53006,6 +53002,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -623,9 +623,6 @@ spec:
                     - enabled
                     - disabled
                     type: string
-                required:
-                - dumpSensitive
-                - state
                 type: object
                 x-kubernetes-validations:
                 - message: Cannot enable dumpSensitive when state is disabled
@@ -10356,9 +10353,6 @@ spec:
                         - enabled
                         - disabled
                         type: string
-                    required:
-                    - dumpSensitive
-                    - state
                     type: object
                     x-kubernetes-validations:
                     - message: Cannot enable dumpSensitive when state is disabled
@@ -28420,7 +28414,6 @@ spec:
                         type: string
                     required:
                     - ram_share_arn
-                    - transit_gateway_id
                     type: object
                   cidr_blocks:
                     description: |-
@@ -28448,6 +28441,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:
@@ -28509,6 +28505,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:

--- a/config/crd/kong-operator/gateway-operator.konghq.com_controlplanes.yaml
+++ b/config/crd/kong-operator/gateway-operator.konghq.com_controlplanes.yaml
@@ -8454,9 +8454,6 @@ spec:
                     - enabled
                     - disabled
                     type: string
-                required:
-                - dumpSensitive
-                - state
                 type: object
                 x-kubernetes-validations:
                 - message: Cannot enable dumpSensitive when state is disabled

--- a/config/crd/kong-operator/gateway-operator.konghq.com_gatewayconfigurations.yaml
+++ b/config/crd/kong-operator/gateway-operator.konghq.com_gatewayconfigurations.yaml
@@ -17836,9 +17836,6 @@ spec:
                         - enabled
                         - disabled
                         type: string
-                    required:
-                    - dumpSensitive
-                    - state
                     type: object
                     x-kubernetes-validations:
                     - message: Cannot enable dumpSensitive when state is disabled

--- a/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaytransitgateways.yaml
+++ b/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaytransitgateways.yaml
@@ -147,7 +147,6 @@ spec:
                         type: string
                     required:
                     - ram_share_arn
-                    - transit_gateway_id
                     type: object
                   cidr_blocks:
                     description: |-
@@ -178,6 +177,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:
@@ -246,6 +248,9 @@ spec:
                           items:
                             type: string
                           type: array
+                      required:
+                      - domain_proxy_list
+                      - remote_dns_server_ip_addresses
                       type: object
                     type: array
                   name:


### PR DESCRIPTION
**What this PR does / why we need it**:

Some of these changes might look like breaking changes but they align us with the API, e.g. `TransitGatewayDNSConfig` changes make its fields required as it's stated in https://developer.konghq.com/api/konnect/cloud-gateways/v2/#/operations/create-transit-gateway

<img width="953" height="541" alt="image" src="https://github.com/user-attachments/assets/b72432a1-b8a3-48ea-ab44-6d6de17b61e0" />

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
