### PR TITLE
fix: random errors during validation of `HTTPRoute`s for `Gateway`s in different namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,10 @@
 - Fix the default values of `combinedServicesFromDifferentHTTPRoutes` and
   `drainSupport` in `ControlPlaneTranslationOptions` not being set correctly.
   [#2589](https://github.com/Kong/kong-operator/pull/2589)
+- Fix random, unexpected and invalid validation error during validation of `HTTPRoute`s
+  for `Gateway`s configured in different namespaces with `GatewayConfiguration` that
+  has field `spec.controlPlaneOptions.watchNamespaces.type` set to `own`.
+  [#2717](https://github.com/Kong/kong-operator/pull/2717)
 
 ## [v2.0.5]
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes random, unexpected and invalid validation error during validation of `HTTPRoute`s for `Gateway`s configured in different namespaces with `GatewayConfiguration` that has field `spec.controlPlaneOptions.watchNamespaces.type` set to `own`. It manifests like that during kubectl apply

```
Error from server (InternalError): error when applying patch:
{"spec":{"rules":[{"backendRefs":[{"name":"echo","port":1027}],"matches":[{"path":{"type":"PathPrefix","value":"/echo"}}]}]}}
to:
Resource: "gateway.networking.k8s.io/v1, Resource=httproutes", GroupVersionKind: "gateway.networking.k8s.io/v1, Kind=HTTPRoute"
Name: "echo", Namespace: "app-bu1"
for: "wips.test/reproduction/1-gateway-api-bu1/6-echo-svc-HTTPRoute.yaml": error when patching "wips.test/reproduction/1-gateway-api-bu1/6-echo-svc-HTTPRoute.yaml": Internal error occurred: failed calling webhook "validations.kong.konghq.com": failed to call webhook: an error on the server ("failed to determine whether HTTPRoute is managed by \"konghq.com/gateway-operator\" controller: failed to get Gateway: unable to get: app-bu1/kong-gwapi-bu1 because of unknown namespace for the cache") has prevented the request from succeeding
```

☝️ `failed to get Gateway: unable to get: app-bu1/kong-gwapi-bu1 because of unknown namespace for the cache")` comes from 
https://github.com/Kong/kong-operator/blob/6e128140ad1605e20e090e06dff62cf6c4371a88/ingress-controller/internal/admission/validation/gateway/httproute.go#L100-L111


The bug was originally reported in [this Slack thread](https://kongstrong.slack.com/archives/CA42V003B/p1763992809536219) by @jeromeguillaume (thank you).

*Steps to reproduce*

Two configurations

- `1.yml`
    ```yml
    kind: Namespace
    apiVersion: v1
    metadata:
      name: kong-bu1
    ---
    kind: GatewayConfiguration
    apiVersion: gateway-operator.konghq.com/v2beta1
    metadata:
      name: config-bu1
      namespace: kong-bu1
    spec:
      controlPlaneOptions:
        watchNamespaces:
          type: own
    ---
    kind: GatewayClass
    apiVersion: gateway.networking.k8s.io/v1
    metadata:
      name: kong-bu1
    spec:
      controllerName: konghq.com/gateway-operator
      parametersRef:
        group: gateway-operator.konghq.com
        kind: GatewayConfiguration
        name: config-bu1
        namespace: kong-bu1
    ---
    apiVersion: gateway.networking.k8s.io/v1
    kind: Gateway
    metadata:
      name: kong-bu1
      namespace: kong-bu1
    spec:
      gatewayClassName: kong-bu1
      listeners:
      - name: http
        protocol: HTTP
        port: 80
    ---
    kind: HTTPRoute
    apiVersion: gateway.networking.k8s.io/v1
    metadata:
      name: echo
      namespace: kong-bu1
    spec:
      parentRefs:
        - group: gateway.networking.k8s.io
          kind: Gateway
          name: kong-bu1
      rules:
        - matches:
            - path:
                type: PathPrefix
                value: /echo
          backendRefs:
            - name: echo
              port: 1027
    ```
- `2.yml`
    ```yml
    kind: Namespace
    apiVersion: v1
    metadata:
      name: kong-bu2
    ---
    kind: GatewayConfiguration
    apiVersion: gateway-operator.konghq.com/v2beta1
    metadata:
      name: config-bu2
      namespace: kong-bu2
    spec:
      controlPlaneOptions:
        watchNamespaces:
          type: own
    ---
    kind: GatewayClass
    apiVersion: gateway.networking.k8s.io/v1
    metadata:
      name: kong-bu2
    spec:
      controllerName: konghq.com/gateway-operator
      parametersRef:
        group: gateway-operator.konghq.com
        kind: GatewayConfiguration
        name: config-bu2
        namespace: kong-bu2
    ---
    apiVersion: gateway.networking.k8s.io/v1
    kind: Gateway
    metadata:
      name: kong-bu2
      namespace: kong-bu2
    spec:
      gatewayClassName: kong-bu2
      listeners:
      - name: http
        protocol: HTTP
        port: 8080
    ---
    kind: HTTPRoute
    apiVersion: gateway.networking.k8s.io/v1
    metadata:
      name: echo
      namespace: kong-bu2
    spec:
      parentRefs:
        - group: gateway.networking.k8s.io
          kind: Gateway
          name: kong-bu2
      rules:
        - matches:
            - path:
                type: PathPrefix
                value: /echo
          backendRefs:
            - name: echo
              port: 1027
    ```
Firstly 

```sh
kubectl apply -f 1.yml
```

next

```sh
kubectl apply -f 2.yml
```

Do it a couple of times in circa half cases error will appear. It doesn't matter whether it is the creation of `HTTPRoute` or an update, so just keep applying.

**Special notes for your reviewer**:

The root cause is the architecture of this validation webhook, which is directly taken from KIC, for each `Gateway` KIC instance is run, which involves appropriate caches. For watching its own namespace, it has only access to its cache, and it can't be decided during dispatch to which instance to pass some particular object, e.g. `HTTPRoute`. See the comments in PR. Since in Go the order of iteration for map is random, and in reproduction steps there are two `Gateway`s it happens for `~50%` of `kupectl apply`. The fix proposes the creation of a client that has access to all namespaces, and it's used only for validation. 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
