### PR TITLE
feat(hybridgateway): generate resources in the parentRef namespace

### DIFF
--- a/controller/hybridgateway/kongroute/route.go
+++ b/controller/hybridgateway/kongroute/route.go
@@ -67,7 +67,7 @@ func RouteForRule(
 
 	routeBuilder := builder.NewKongRoute().
 		WithName(routeName).
-		WithNamespace(httpRoute.Namespace).
+		WithNamespace(metadata.NamespaceFromParentRef(httpRoute, pRef)).
 		WithLabels(httpRoute, pRef).
 		WithAnnotations(httpRoute, pRef).
 		WithSpecName(routeName).

--- a/controller/hybridgateway/metadata/namespace.go
+++ b/controller/hybridgateway/metadata/namespace.go
@@ -1,16 +1,24 @@
 package metadata
 
 import (
-	gwtypes "github.com/kong/kong-operator/internal/types"
+	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	gwtypes "github.com/kong/kong-operator/internal/types"
 )
 
 // NamespaceFromParentRef returns the namespace for a given Route ParentReference.
 // If the ParentReference specifies a namespace, that namespace is returned.
 // Otherwise, the namespace of the provided resource is returned.
 func NamespaceFromParentRef(obj metav1.Object, pRef *gwtypes.ParentReference) string {
-	if pRef.Namespace != nil && *pRef.Namespace != "" {
-		return string(*pRef.Namespace)
+	var ns gatewayv1.Namespace
+
+	if pRef == nil {
+		return obj.GetNamespace()
 	}
-	return obj.GetNamespace()
+	if ns = lo.FromPtr(pRef.Namespace); ns == "" {
+		return obj.GetNamespace()
+	}
+	return string(ns)
 }

--- a/controller/hybridgateway/metadata/namespace.go
+++ b/controller/hybridgateway/metadata/namespace.go
@@ -1,0 +1,16 @@
+package metadata
+
+import (
+	gwtypes "github.com/kong/kong-operator/internal/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NamespaceFromParentRef returns the namespace for a given Route ParentReference.
+// If the ParentReference specifies a namespace, that namespace is returned.
+// Otherwise, the namespace of the provided resource is returned.
+func NamespaceFromParentRef(obj metav1.Object, pRef *gwtypes.ParentReference) string {
+	if pRef.Namespace != nil && *pRef.Namespace != "" {
+		return string(*pRef.Namespace)
+	}
+	return obj.GetNamespace()
+}

--- a/controller/hybridgateway/metadata/namespace_test.go
+++ b/controller/hybridgateway/metadata/namespace_test.go
@@ -1,0 +1,159 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	gwtypes "github.com/kong/kong-operator/internal/types"
+)
+
+func TestNamespaceFromParentRef(t *testing.T) {
+	testNamespace := gwtypes.Namespace("test-namespace")
+	differentNamespace := gwtypes.Namespace("different-namespace")
+	emptyNamespace := gwtypes.Namespace("")
+
+	tests := []struct {
+		name        string
+		obj         metav1.Object
+		parentRef   *gwtypes.ParentReference
+		expected    string
+		description string
+	}{
+		{
+			name: "parentRef with explicit namespace",
+			obj: &metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "test-namespace",
+			},
+			parentRef: &gwtypes.ParentReference{
+				Name:      "test-gateway",
+				Namespace: &differentNamespace,
+			},
+			expected:    "different-namespace",
+			description: "should return the namespace from parentRef when explicitly set",
+		},
+		{
+			name: "parentRef with nil namespace",
+			obj: &metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "test-namespace",
+			},
+			parentRef: &gwtypes.ParentReference{
+				Name:      "test-gateway",
+				Namespace: nil,
+			},
+			expected:    "test-namespace",
+			description: "should return the object's namespace when parentRef.Namespace is nil",
+		},
+		{
+			name: "parentRef with empty namespace string",
+			obj: &metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "test-namespace",
+			},
+			parentRef: &gwtypes.ParentReference{
+				Name:      "test-gateway",
+				Namespace: &emptyNamespace,
+			},
+			expected:    "test-namespace",
+			description: "should return the object's namespace when parentRef.Namespace is empty string",
+		},
+		{
+			name: "object in default namespace with parentRef namespace",
+			obj: &metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+			},
+			parentRef: &gwtypes.ParentReference{
+				Name:      "prod-gateway",
+				Namespace: &testNamespace,
+			},
+			expected:    "test-namespace",
+			description: "should return parentRef namespace even when object is in default namespace",
+		},
+		{
+			name: "object with no namespace and nil parentRef namespace",
+			obj: &metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "",
+			},
+			parentRef: &gwtypes.ParentReference{
+				Name:      "test-gateway",
+				Namespace: nil,
+			},
+			expected:    "",
+			description: "should return empty string when both object and parentRef have no namespace",
+		},
+		{
+			name: "parentRef with same namespace as object",
+			obj: &metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "test-namespace",
+			},
+			parentRef: &gwtypes.ParentReference{
+				Name:      "test-gateway",
+				Namespace: &testNamespace,
+			},
+			expected:    "test-namespace",
+			description: "should return namespace correctly when parentRef and object share the same namespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NamespaceFromParentRef(tt.obj, tt.parentRef)
+			assert.Equal(t, tt.expected, result, tt.description)
+		})
+	}
+}
+
+func TestNamespaceFromParentRefWithHTTPRoute(t *testing.T) {
+	crossNamespace := gwtypes.Namespace("gateway-namespace")
+
+	tests := []struct {
+		name        string
+		httpRoute   *gwtypes.HTTPRoute
+		parentRef   *gwtypes.ParentReference
+		expected    string
+		description string
+	}{
+		{
+			name: "HTTPRoute with cross-namespace gateway reference",
+			httpRoute: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "api-route",
+					Namespace: "app-namespace",
+				},
+			},
+			parentRef: &gwtypes.ParentReference{
+				Name:      "shared-gateway",
+				Namespace: &crossNamespace,
+			},
+			expected:    "gateway-namespace",
+			description: "should support cross-namespace references",
+		},
+		{
+			name: "HTTPRoute with same-namespace gateway reference",
+			httpRoute: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "api-route",
+					Namespace: "app-namespace",
+				},
+			},
+			parentRef: &gwtypes.ParentReference{
+				Name: "local-gateway",
+			},
+			expected:    "app-namespace",
+			description: "should default to HTTPRoute namespace when parentRef namespace is not set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NamespaceFromParentRef(&tt.httpRoute.ObjectMeta, tt.parentRef)
+			assert.Equal(t, tt.expected, result, tt.description)
+		})
+	}
+}

--- a/controller/hybridgateway/plugin/plugin.go
+++ b/controller/hybridgateway/plugin/plugin.go
@@ -52,7 +52,7 @@ func PluginForFilter(
 
 	plugin, err := builder.NewKongPlugin().
 		WithName(pluginName).
-		WithNamespace(httpRoute.Namespace).
+		WithNamespace(metadata.NamespaceFromParentRef(httpRoute, pRef)).
 		WithLabels(httpRoute, pRef).
 		WithAnnotations(httpRoute, pRef).
 		WithFilter(filter).

--- a/controller/hybridgateway/pluginbinding/pluginbinding.go
+++ b/controller/hybridgateway/pluginbinding/pluginbinding.go
@@ -57,7 +57,7 @@ func BindingForPluginAndRoute(
 
 	binding, err := builder.NewKongPluginBinding().
 		WithName(bindingName).
-		WithNamespace(httpRoute.Namespace).
+		WithNamespace(metadata.NamespaceFromParentRef(httpRoute, pRef)).
 		WithLabels(httpRoute, pRef).
 		WithAnnotations(httpRoute, pRef).
 		WithPluginRef(pluginName).

--- a/controller/hybridgateway/service/service.go
+++ b/controller/hybridgateway/service/service.go
@@ -60,7 +60,7 @@ func ServiceForRule(
 
 	service, err := builder.NewKongService().
 		WithName(serviceName).
-		WithNamespace(httpRoute.Namespace).
+		WithNamespace(metadata.NamespaceFromParentRef(httpRoute, pRef)).
 		WithLabels(httpRoute, pRef).
 		WithAnnotations(httpRoute, pRef).
 		WithSpecName(serviceName).

--- a/controller/hybridgateway/target/target.go
+++ b/controller/hybridgateway/target/target.go
@@ -422,7 +422,7 @@ func createTargetsFromValidBackendRefs(ctx context.Context, logger logr.Logger, 
 
 			target, err := builder.NewKongTarget().
 				WithName(targetName).
-				WithNamespace(httpRoute.Namespace).
+				WithNamespace(metadata.NamespaceFromParentRef(httpRoute, pRef)).
 				WithLabels(httpRoute, pRef).
 				WithAnnotations(httpRoute, pRef).
 				WithUpstreamRef(upstreamName).

--- a/controller/hybridgateway/upstream/upstream.go
+++ b/controller/hybridgateway/upstream/upstream.go
@@ -55,7 +55,7 @@ func UpstreamForRule(
 
 	upstream, err := builder.NewKongUpstream().
 		WithName(upstreamName).
-		WithNamespace(httpRoute.Namespace).
+		WithNamespace(metadata.NamespaceFromParentRef(httpRoute, pRef)).
 		WithLabels(httpRoute, pRef).
 		WithAnnotations(httpRoute, pRef).
 		WithSpecName(upstreamName).


### PR DESCRIPTION
**What this PR does / why we need it**:

Till now the resources were created in the source HTTPRoute namespace. This patch will instead use the parentRef namespace in order to share generated resources among HTTPRoutes living in different namespaces but referencing the same gateway (parentRef).

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
