### PR TITLE
crds(dataplane): allow up to 64 ingress ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@
   This improves performance of config syncs for large configurations.
   [#2759](https://github.com/Kong/kong-operator/pull/2759)
 
+### Changed
+
+- `DataPlane`'s `spec.network.services.ingress.ports` now allows up to 64 ports
+  to be specified. This aligns `DataPlane` with Gateway APIs' `Gateway`.
+  [#2722](https://github.com/Kong/kong-operator/pull/2722)
+
 ## [v2.1.0-alpha.0]
 
 ### Added

--- a/api/gateway-operator/v1beta1/dataplane_types.go
+++ b/api/gateway-operator/v1beta1/dataplane_types.go
@@ -212,7 +212,7 @@ type DataPlaneServiceOptions struct {
 	// the underlying service ports, while the protocol is defaulted to TCP,
 	// as it is the only protocol currently supported.
 	//
-	// +kubebuilder:validation:MaxItems=4
+	// +kubebuilder:validation:MaxItems=64
 	Ports []DataPlaneServicePort `json:"ports,omitempty"`
 
 	// ServiceOptions is the struct containing service options shared with

--- a/charts/kong-operator/charts/ko-crds/templates/ko-crds.yaml
+++ b/charts/kong-operator/charts/ko-crds/templates/ko-crds.yaml
@@ -19589,7 +19589,7 @@ spec:
                               required:
                               - port
                               type: object
-                            maxItems: 4
+                            maxItems: 64
                             type: array
                           type:
                             default: LoadBalancer

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -18574,7 +18574,7 @@ spec:
                               required:
                               - port
                               type: object
-                            maxItems: 4
+                            maxItems: 64
                             type: array
                           type:
                             default: LoadBalancer

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -18574,7 +18574,7 @@ spec:
                               required:
                               - port
                               type: object
-                            maxItems: 4
+                            maxItems: 64
                             type: array
                           type:
                             default: LoadBalancer

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -18574,7 +18574,7 @@ spec:
                               required:
                               - port
                               type: object
-                            maxItems: 4
+                            maxItems: 64
                             type: array
                           type:
                             default: LoadBalancer

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -18574,7 +18574,7 @@ spec:
                               required:
                               - port
                               type: object
-                            maxItems: 4
+                            maxItems: 64
                             type: array
                           type:
                             default: LoadBalancer

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -18574,7 +18574,7 @@ spec:
                               required:
                               - port
                               type: object
-                            maxItems: 4
+                            maxItems: 64
                             type: array
                           type:
                             default: LoadBalancer

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -18575,7 +18575,7 @@ spec:
                               required:
                               - port
                               type: object
-                            maxItems: 4
+                            maxItems: 64
                             type: array
                           type:
                             default: LoadBalancer

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -18574,7 +18574,7 @@ spec:
                               required:
                               - port
                               type: object
-                            maxItems: 4
+                            maxItems: 64
                             type: array
                           type:
                             default: LoadBalancer

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -18574,7 +18574,7 @@ spec:
                               required:
                               - port
                               type: object
-                            maxItems: 4
+                            maxItems: 64
                             type: array
                           type:
                             default: LoadBalancer

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -18574,7 +18574,7 @@ spec:
                               required:
                               - port
                               type: object
-                            maxItems: 4
+                            maxItems: 64
                             type: array
                           type:
                             default: LoadBalancer

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -18574,7 +18574,7 @@ spec:
                               required:
                               - port
                               type: object
-                            maxItems: 4
+                            maxItems: 64
                             type: array
                           type:
                             default: LoadBalancer

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -18574,7 +18574,7 @@ spec:
                               required:
                               - port
                               type: object
-                            maxItems: 4
+                            maxItems: 64
                             type: array
                           type:
                             default: LoadBalancer

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -18574,7 +18574,7 @@ spec:
                               required:
                               - port
                               type: object
-                            maxItems: 4
+                            maxItems: 64
                             type: array
                           type:
                             default: LoadBalancer

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -10251,7 +10251,7 @@ spec:
                               required:
                               - port
                               type: object
-                            maxItems: 4
+                            maxItems: 64
                             type: array
                           type:
                             default: LoadBalancer

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -18524,7 +18524,7 @@ spec:
                               required:
                               - port
                               type: object
-                            maxItems: 4
+                            maxItems: 64
                             type: array
                           type:
                             default: LoadBalancer

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -10226,7 +10226,7 @@ spec:
                               required:
                               - port
                               type: object
-                            maxItems: 4
+                            maxItems: 64
                             type: array
                           type:
                             default: LoadBalancer

--- a/config/crd/kong-operator/gateway-operator.konghq.com_dataplanes.yaml
+++ b/config/crd/kong-operator/gateway-operator.konghq.com_dataplanes.yaml
@@ -9484,7 +9484,7 @@ spec:
                               required:
                               - port
                               type: object
-                            maxItems: 4
+                            maxItems: 64
                             type: array
                           type:
                             default: LoadBalancer


### PR DESCRIPTION
**What this PR does / why we need it**:

This aligns the `DataPlane` spec with [`Gateway` which allows up to 64 listeners](https://github.com/kubernetes-sigs/gateway-api/blob/v1.3.0/apis/v1/gateway_types.go#L233).

**Which issue this PR fixes**



**Special notes for your reviewer**:

x-ref: https://kongstrong.slack.com/archives/CA42V003B/p1761652973643779

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
