### PR TITLE
feat(testing): Bootstrap hybrid gateway e2e tests with chainsaw

### DIFF
--- a/test/e2e/chainsaw/hybridgateway/README.md
+++ b/test/e2e/chainsaw/hybridgateway/README.md
@@ -1,0 +1,35 @@
+# Chainsaw HybridGateway Test Guide
+
+This README provides instructions for running Chainsaw tests in the `hybridgateway` directory.
+
+## 1. Install Chainsaw
+
+Follow the official Chainsaw installation guide:
+- [Chainsaw Documentation](https://kyverno.github.io/chainsaw/latest/quick-start/install/)
+
+## 2. Required Environment Variables
+
+
+Before running the tests, export the following environment variables:
+
+```
+export KUBECONFIG=/path/to/your/kubeconfig
+export KONNECT_TOKEN=your-konnect-api-token
+export KONNECT_SERVER_URL=eu.api.konghq.tech
+```
+
+Adjust the values as needed for your environment. The `KONNECT_TOKEN` and `KONNECT_SERVER_URL` are required for Konnect API authentication and are referenced in the test manifests.
+
+## 3. Run the Tests
+
+Use the following command to execute the Chainsaw tests:
+
+
+```
+chainsaw test --test-dir test/e2e/chainsaw/hybridgateway/basic-httproute
+```
+
+- `--test-dir`: Path to the test directory
+- `--skip-delete`: Prevents deletion of resources after tests
+
+For more options, see the [Chainsaw CLI documentation](https://kyverno.github.io/chainsaw/latest/).

--- a/test/e2e/chainsaw/hybridgateway/basic-httproute/00-assert-httpbin.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-httproute/00-assert-httpbin.yaml
@@ -1,0 +1,20 @@
+---
+# Assert httpbin Service exists
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  namespace: kong
+---
+# Assert httpbin Deployment is ready
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+  namespace: kong
+status:
+  # Filter conditions array to check for Available condition
+  (conditions[?type == 'Available']):
+    - status: 'True'
+  readyReplicas: 1
+  replicas: 1

--- a/test/e2e/chainsaw/hybridgateway/basic-httproute/00-httpbin.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-httproute/00-httpbin.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+  namespace: kong
+  labels:
+    app: httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+  template:
+    metadata:
+      labels:
+        app: httpbin
+    spec:
+      containers:
+        - name: httpbin
+          image: ghcr.io/mccutchen/go-httpbin:2.19
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /status/200
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /status/200
+              port: http
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            runAsNonRoot: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  namespace: kong
+  labels:
+    app: httpbin
+spec:
+  selector:
+    app: httpbin
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+      appProtocol: http

--- a/test/e2e/chainsaw/hybridgateway/basic-httproute/01-assert-prerequisites.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-httproute/01-assert-prerequisites.yaml
@@ -1,0 +1,28 @@
+---
+# Assert namespaces exist
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kong
+status:
+  phase: Active
+---
+# Assert Service exists
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: kong
+---
+# Assert Deployment is ready
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo
+  namespace: kong
+status:
+  # Filter conditions array to check for Available condition
+  (conditions[?type == 'Available']):
+    - status: 'True'
+  readyReplicas: 1
+  replicas: 1

--- a/test/e2e/chainsaw/hybridgateway/basic-httproute/01-prerequisites.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-httproute/01-prerequisites.yaml
@@ -1,0 +1,149 @@
+---
+# Namespace for Kong resources
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kong
+---
+# Namespace for default resources
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+---
+kind: KonnectAPIAuthConfiguration
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: konnect-api-auth-dev-1
+  namespace: kong
+spec:
+  type: token
+  token: (env('KONNECT_TOKEN'))
+  serverURL: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+---
+kind: GatewayConfiguration
+apiVersion: gateway-operator.konghq.com/v2beta1
+metadata:
+  name: kong-foo
+  namespace: kong
+spec:
+  konnect:
+    authRef:
+      name: konnect-api-auth-dev-1
+  dataPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        spec:
+          containers:
+          - name: proxy
+            image: kong/kong-gateway:3.12
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: kong-foo
+spec:
+  controllerName: konghq.com/gateway-operator
+  parametersRef:
+    group: gateway-operator.konghq.com
+    kind: GatewayConfiguration
+    name: kong-foo
+    namespace: kong
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: kong-foo
+  namespace: kong
+spec:
+  gatewayClassName: kong-foo
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: echo
+  name: echo
+  namespace: kong
+spec:
+  ports:
+    - port: 1025
+      name: tcp
+      protocol: TCP
+      targetPort: 1025
+    - port: 1026
+      name: udp
+      protocol: TCP
+      targetPort: 1026
+    - port: 1027
+      name: http
+      protocol: TCP
+      targetPort: 1027
+    - port: 1030
+      name: tls
+      protocol: TCP
+      targetPort: 1030
+  selector:
+    app: echo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: echo
+  name: echo
+  namespace: kong
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: echo
+    spec:
+      containers:
+        - image: kong/go-echo:latest
+          name: echo
+          ports:
+            - containerPort: 1025
+            - containerPort: 1026
+            - containerPort: 1027
+            - containerPort: 1030
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 1027
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 210m
+              memory: 256Mi
+---

--- a/test/e2e/chainsaw/hybridgateway/basic-httproute/02-assert-httproute.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-httproute/02-assert-httproute.yaml
@@ -1,0 +1,33 @@
+---
+# Assert HTTPRoute is accepted and programmed
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: echo
+  namespace: kong
+status:
+  parents:
+    - parentRef:
+        name: kong-foo
+        group: gateway.networking.k8s.io
+        kind: Gateway
+      controllerName: konghq.com/gateway-operator
+      # Filter conditions array to check for all required conditions
+      (conditions[?type == 'Accepted']):
+        - status: "True"
+          reason: Accepted
+      (conditions[?type == 'ResolvedRefs']):
+        - status: "True"
+          reason: ResolvedRefs
+      (conditions[?type == 'KongRouteProgrammed']):
+        - status: "True"
+          reason: KongRouteProgrammed
+      (conditions[?type == 'KongServiceProgrammed']):
+        - status: "True"
+          reason: KongServiceProgrammed
+      (conditions[?type == 'KongUpstreamProgrammed']):
+        - status: "True"
+          reason: KongUpstreamProgrammed
+      (conditions[?type == 'KongTargetProgrammed']):
+        - status: "True"
+          reason: KongTargetProgrammed

--- a/test/e2e/chainsaw/hybridgateway/basic-httproute/02-httproute.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-httproute/02-httproute.yaml
@@ -1,0 +1,19 @@
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: echo
+  namespace: kong
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: kong-foo
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /echo
+      backendRefs:
+        - name: echo
+          port: 1027

--- a/test/e2e/chainsaw/hybridgateway/basic-httproute/04-assert-updated-resources.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-httproute/04-assert-updated-resources.yaml
@@ -1,0 +1,54 @@
+---
+# Assert updated HTTPRoute with multiple method-based matches in a single rule
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: echo
+  namespace: kong
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: kong-foo
+  rules:
+    - backendRefs:
+        - name: httpbin
+          port: 80
+      matches:
+        - path:
+            type: Exact
+            value: /get
+          method: GET
+        - path:
+            type: Exact
+            value: /post
+          method: POST
+        - path:
+            type: Exact
+            value: /put
+          method: PUT
+        - path:
+            type: Exact
+            value: /patch
+          method: PATCH
+        - path:
+            type: Exact
+            value: /delete
+          method: DELETE
+        - path:
+            type: PathPrefix
+            value: /status
+status:
+  parents:
+    - parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: kong-foo
+      (conditions[?type == 'Accepted']):
+        - status: 'True'
+      (conditions[?type == 'ResolvedRefs']):
+        - status: 'True'
+      (conditions[?type == 'KongRouteProgrammed']):
+        - status: 'True'
+
+

--- a/test/e2e/chainsaw/hybridgateway/basic-httproute/04-update-httproute.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-httproute/04-update-httproute.yaml
@@ -1,0 +1,44 @@
+---
+# Updated HTTPRoute with multiple HTTP method rules pointing to httpbin
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: echo
+  namespace: kong
+  annotations:
+    konghq.com/strip-path: "false"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: kong-foo
+  rules:
+    # All standard HTTP methods to their respective endpoints
+    - matches:
+        - path:
+            type: Exact
+            value: /get
+          method: GET
+        - path:
+            type: Exact
+            value: /post
+          method: POST
+        - path:
+            type: Exact
+            value: /put
+          method: PUT
+        - path:
+            type: Exact
+            value: /patch
+          method: PATCH
+        - path:
+            type: Exact
+            value: /delete
+          method: DELETE
+        - path:
+            type: PathPrefix
+            value: /status
+      backendRefs:
+        - name: httpbin
+          port: 80
+

--- a/test/e2e/chainsaw/hybridgateway/basic-httproute/README.md
+++ b/test/e2e/chainsaw/hybridgateway/basic-httproute/README.md
@@ -1,0 +1,53 @@
+# Basic HTTPRoute Test
+
+This test validates the complete lifecycle of an `HTTPRoute` managed by the Hybrid Gateway controller. It ensures that creating, updating, and routing traffic works as expected.
+
+The test is divided into the following steps:
+
+**Step 1: Create Prerequisite Resources**
+
+- **Goal:** Set up the initial Kubernetes and Kong environment.
+- **Actions:**
+    - Creates `kong` and `default` namespaces.
+    - Deploys two backend applications: `httpbin` and `echo`.
+    - Sets up the core Gateway API resources: `GatewayClass`, `GatewayConfiguration`, and a `Gateway` named `kong-foo`.
+    - Configures Konnect integration using `KonnectAPIAuthConfiguration`.
+- **Verification:** Asserts that all deployments are ready and all gateway-related resources have a `True` status condition, indicating they are correctly programmed and initialized.
+
+**Step 2: Create HTTPRoute**
+
+- **Goal:** Test the creation of a simple `HTTPRoute`.
+- **Actions:**
+    - Applies an `HTTPRoute` that routes traffic from the `/echo` path to the `echo` service.
+- **Verification:** Asserts that the `HTTPRoute` status becomes `Accepted` and all `Programmed` conditions are `True`, confirming that the controller has processed the route.
+
+**Step 3: Verify Generated Kong Resources**
+
+- **Goal:** Ensure the controller translates the `HTTPRoute` into the correct Kong-specific CRDs.
+- **Actions:**
+    - This step inspects the resources created by the controller in response to the `HTTPRoute`.
+- **Verification:**
+    - Asserts that a `KongRoute`, `KongService`, `KongUpstream`, and `KongTarget` have been created.
+    - Verifies that these resources have the correct labels, annotations, and specifications (e.g., paths, service references) derived from the `HTTPRoute`.
+    - Checks that their `status` is `Programmed` and they are correctly linked to the Konnect control plane.
+
+**Step 4: Verify Data Plane Traffic**
+
+- **Goal:** Confirm that the data plane (Kong Gateway proxy) can route traffic according to the `HTTPRoute`.
+- **Actions:**
+    - Retrieves the external IP address of the gateway's proxy service.
+    - Sends HTTP requests to the `/echo` path.
+- **Verification:** Asserts that requests sent from both inside and outside the cluster receive a `200 OK` response, confirming end-to-end connectivity.
+
+**Step 5: Update HTTPRoute and Verify Changes**
+
+- **Goal:** Test the controller's ability to handle updates to an existing `HTTPRoute`.
+- **Actions:**
+    - Applies an updated `HTTPRoute` manifest. The changes include:
+        - Switching the backend service from `echo` to `httpbin`.
+        - Adding multiple path and HTTP method matches (e.g., `GET /get`, `POST /post`).
+        - Disabling `strip_path`.
+- **Verification:**
+    - Asserts that the old Kong resources associated with the previous `HTTPRoute` version are deleted.
+    - Asserts that new Kong resources are created that reflect the updated rules.
+    - Performs end-to-end traffic tests for the new endpoints (`/get`, `/post`, etc.) to confirm the data plane configuration was successfully updated.

--- a/test/e2e/chainsaw/hybridgateway/basic-httproute/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-httproute/chainsaw-test.yaml
@@ -1,0 +1,489 @@
+# Basic HTTPRoute test scenario
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: basic-httproute
+spec:
+  description: |
+    This test validates that the hybrid gateway controller correctly
+    processes a basic HTTPRoute with a single service backend.
+  
+  timeouts:
+    apply: 120s
+    assert: 120s
+    delete: 120s
+  
+  steps:
+    # Step 1: Create prerequisite resources
+    - name: create-prerequisites
+      description: Create GatewayClass, Gateway, and backend Service
+      try:
+        - apply:
+            file: 01-prerequisites.yaml
+        - apply:
+            file: 00-httpbin.yaml
+        # Assert common Konnect and Gateway resources.
+        - assert:
+            file: ../common/assertions/konnect-apiauth.yaml
+        - assert:
+            file: ../common/assertions/gatewayclass.yaml
+        - assert:
+            file: ../common/assertions/gatewayconfiguration.yaml
+        - assert:
+            file: ../common/assertions/gateway.yaml
+        - assert:
+            file: ../common/assertions/konnect-gateway-controlplane.yaml
+        - assert:
+            file: ../common/assertions/konnect-extension.yaml
+        # Assert test-specific resources (namespaces, service, deployment)
+        - assert:
+            file: 00-assert-httpbin.yaml
+        - assert:
+            file: 01-assert-prerequisites.yaml
+    
+    # Step 2: Create HTTPRoute
+    - name: create-httproute
+      description: Create HTTPRoute that references the Gateway
+      try:
+        - apply:
+            file: 02-httproute.yaml
+        - assert:
+            file: 02-assert-httproute.yaml
+    
+    # Step 3: Verify generated Kong resources
+    - name: verify-kong-resources
+      description: Verify KongRoute, KongService, KongUpstream, and KongTarget are created
+      try:
+        # Collect bindings needed for Kong resource assertions
+        - script:
+            content: |
+              kubectl get gateway -n kong -o jsonpath='{.items[0].metadata.name}'
+            outputs:
+              - name: hybrid_gateway_name
+                value: ($stdout)
+        - script:
+            content: |
+              kubectl get gateway -n kong -o jsonpath='{.items[0].metadata.namespace}'
+            outputs:
+              - name: hybrid_gateway_namespace
+                value: ($stdout)
+        - script:
+            content: |
+              kubectl get httproute -n kong -o jsonpath='{.items[0].metadata.name}'
+            outputs:
+              - name: managedby_name
+                value: ($stdout)
+        - script:
+            content: |
+              kubectl get httproute -n kong -o jsonpath='{.items[0].metadata.namespace}'
+            outputs:
+              - name: managedby_namespace
+                value: ($stdout)
+        - script:
+            content: |
+              kubectl get httproute -n kong echo -o jsonpath='{.spec.rules[*].matches[*].path.value}' | jq -Rsc 'split(" ")'
+            outputs:
+              - name: route_paths_json
+                value: ($stdout)
+        - script:
+            content: |
+              OUTPUT=$(kubectl get httproute -n kong echo -o jsonpath='{.spec.rules[*].matches[*].method}')
+              if [ -z "$OUTPUT" ]; then
+                echo '[]'
+              else
+                echo "$OUTPUT" | tr -d '\n' | jq -Rsc 'split(" ")'
+              fi
+            outputs:
+              - name: route_methods_json
+                value: ($stdout)
+        - script:
+            content: |
+              kubectl get konnectgatewaycontrolplane -n kong -l gateway-operator.konghq.com/managed-by=gateway -o jsonpath='{.items[0].metadata.name}'
+            outputs:
+              - name: konnectgatewaycontrolplane_name
+                value: ($stdout)
+        - script:
+            content: |
+              kubectl get kongservice -n kong -l gateway-operator.konghq.com/managed-by=HTTPRoute -o jsonpath='{.items[0].metadata.name}'
+            outputs:
+              - name: kongservice_name
+                value: ($stdout)
+        - script:
+            content: |
+              kubectl get kongupstream -n kong -l gateway-operator.konghq.com/managed-by=HTTPRoute -o jsonpath='{.items[0].metadata.name}'
+            outputs:
+              - name: kongupstream_name
+                value: ($stdout)
+        - script:
+            content: echo "kong"
+            outputs:
+              - name: namespace
+                value: kong
+              - name: strip_path
+                value: true
+              - name: weight
+                value: 1
+        # Assert Kong resources using common templates
+        - assert:
+            file: ../common/assertions/kongroute.yaml
+        - assert:
+            file: ../common/assertions/kongservice.yaml
+        - assert:
+            file: ../common/assertions/kongupstream.yaml
+        - assert:
+            file: ../common/assertions/kongtarget.yaml
+    
+    # Step 4: Verify data plane is configured and traffic flows
+    - name: verify-data-plane
+      description: Verify that the Kong data plane is properly configured and can route traffic
+      try:
+        # Collect bindings for connectivity tests
+        - script:
+            content: |
+              kubectl get gateway -n kong -o jsonpath='{.items[0].metadata.name}'
+            outputs:
+              - name: hybrid_gateway_name
+                value: ($stdout)
+        - script:
+            content: |
+              kubectl get gateway -n kong -o jsonpath='{.items[0].metadata.namespace}'
+            outputs:
+              - name: hybrid_gateway_namespace
+                value: ($stdout)
+        - script:
+            content: |
+              kubectl get httproute -n kong -o jsonpath='{.items[0].spec.rules[0].matches[0].path.value}'
+            outputs:
+              - name: route_path
+                value: ($stdout)
+        # Get the Gateway proxy IP
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($hybrid_gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($hybrid_gateway_namespace)
+            content: |
+              kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
+            outputs:
+              - name: proxy_ip
+                value: ($stdout)
+        # Test from within the cluster
+        - description: Test connectivity from within the cluster
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path)
+            content: |
+              POD_NAME="curl-test-$(date +%s)-$$"
+              kubectl run ${POD_NAME} --image=curlimages/curl:latest --rm -i --restart=Never -- \
+                curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -o /dev/null -w '%{http_code}' http://${PROXY_IP}${ROUTE_PATH}
+            check:
+              (contains($stdout, '200')): true
+        # Test from outside the cluster
+        - description: Test connectivity from outside the cluster
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path)
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}${ROUTE_PATH}
+            check:
+              (contains($stdout, '200')): true
+    
+    # Step 5: Update HTTPRoute
+    - name: update-httproute
+      description: Update HTTPRoute and verify changes propagate
+      try:
+        # Collect old Kong resource names before update
+        - script:
+            content: |
+              kubectl get kongroute -n kong -l gateway-operator.konghq.com/managed-by=HTTPRoute -o jsonpath='{.items[*].metadata.name}'
+            outputs:
+              - name: old_kongroute_names
+                value: ($stdout)
+        - script:
+            content: |
+              kubectl get kongservice -n kong -l gateway-operator.konghq.com/managed-by=HTTPRoute -o jsonpath='{.items[*].metadata.name}'
+            outputs:
+              - name: old_kongservice_names
+                value: ($stdout)
+        - script:
+            content: |
+              kubectl get kongupstream -n kong -l gateway-operator.konghq.com/managed-by=HTTPRoute -o jsonpath='{.items[*].metadata.name}'
+            outputs:
+              - name: old_kongupstream_names
+                value: ($stdout)
+        - script:
+            content: |
+              kubectl get kongtarget -n kong -l gateway-operator.konghq.com/managed-by=HTTPRoute -o jsonpath='{.items[*].metadata.name}'
+            outputs:
+              - name: old_kongtarget_names
+                value: ($stdout)
+        # Apply the update
+        - apply:
+            file: 04-update-httproute.yaml
+        - assert:
+            file: 04-assert-updated-resources.yaml
+        # Wait for old resources to be deleted
+        - script:
+            env:
+              - name: OLD_NAMES
+                value: ($old_kongroute_names)
+            content: |
+              if [ -n "$OLD_NAMES" ]; then
+                for name in $OLD_NAMES; do
+                  echo "Waiting for old KongRoute $name to be deleted..."
+                  kubectl wait --for=delete kongroute/$name -n kong --timeout=60s || true
+                done
+              fi
+        - script:
+            env:
+              - name: OLD_NAMES
+                value: ($old_kongservice_names)
+            content: |
+              if [ -n "$OLD_NAMES" ]; then
+                for name in $OLD_NAMES; do
+                  echo "Waiting for old KongService $name to be deleted..."
+                  kubectl wait --for=delete kongservice/$name -n kong --timeout=60s || true
+                done
+              fi
+        - script:
+            env:
+              - name: OLD_NAMES
+                value: ($old_kongupstream_names)
+            content: |
+              if [ -n "$OLD_NAMES" ]; then
+                for name in $OLD_NAMES; do
+                  echo "Waiting for old KongUpstream $name to be deleted..."
+                  kubectl wait --for=delete kongupstream/$name -n kong --timeout=60s || true
+                done
+              fi
+        - script:
+            env:
+              - name: OLD_NAMES
+                value: ($old_kongtarget_names)
+            content: |
+              if [ -n "$OLD_NAMES" ]; then
+                for name in $OLD_NAMES; do
+                  echo "Waiting for old KongTarget $name to be deleted..."
+                  kubectl wait --for=delete kongtarget/$name -n kong --timeout=60s || true
+                done
+              fi
+        # Wait for new KongRoute to be programmed
+        - script:
+            content: |
+              kubectl wait --for=condition=Programmed --timeout=60s kongroute -n kong -l gateway-operator.konghq.com/managed-by=HTTPRoute
+        # Collect bindings for Kong resource assertions
+        - script:
+            content: |
+              kubectl get gateway -n kong -o jsonpath='{.items[0].metadata.name}'
+            outputs:
+              - name: hybrid_gateway_name
+                value: ($stdout)
+        - script:
+            content: |
+              kubectl get gateway -n kong -o jsonpath='{.items[0].metadata.namespace}'
+            outputs:
+              - name: hybrid_gateway_namespace
+                value: ($stdout)
+        - script:
+            content: |
+              kubectl get httproute -n kong -o jsonpath='{.items[0].metadata.name}'
+            outputs:
+              - name: managedby_name
+                value: ($stdout)
+        - script:
+            content: |
+              kubectl get httproute -n kong -o jsonpath='{.items[0].metadata.namespace}'
+            outputs:
+              - name: managedby_namespace
+                value: ($stdout)
+        - script:
+            content: |
+              kubectl get httproute -n kong echo -o jsonpath='{.spec.rules[*].matches[*].path.value}' | jq -Rsc 'split(" ")'
+            outputs:
+              - name: route_paths_json
+                value: ($stdout)
+        - script:
+            content: |
+              OUTPUT=$(kubectl get httproute -n kong echo -o jsonpath='{.spec.rules[*].matches[*].method}')
+              if [ -z "$OUTPUT" ]; then
+                echo '[]'
+              else
+                echo "$OUTPUT" | tr -d '\n' | jq -Rsc 'split(" ")'
+              fi
+            outputs:
+              - name: route_methods_json
+                value: ($stdout)
+        - script:
+            content: echo "kong"
+            outputs:
+              - name: namespace
+                value: kong
+              - name: strip_path
+                value: false
+              - name: weight
+                value: 1
+        # Collect Kong resource names after reconciliation
+        - script:
+            content: |
+              kubectl get konnectgatewaycontrolplane -n kong -l gateway-operator.konghq.com/managed-by=gateway -o jsonpath='{.items[0].metadata.name}'
+            outputs:
+              - name: konnectgatewaycontrolplane_name
+                value: ($stdout)
+        - script:
+            content: |
+              kubectl get kongservice -n kong -l gateway-operator.konghq.com/managed-by=HTTPRoute -o jsonpath='{.items[0].metadata.name}'
+            outputs:
+              - name: kongservice_name
+                value: ($stdout)
+        - script:
+            content: |
+              kubectl get kongupstream -n kong -l gateway-operator.konghq.com/managed-by=HTTPRoute -o jsonpath='{.items[0].metadata.name}'
+            outputs:
+              - name: kongupstream_name
+                value: ($stdout)
+        # Verify Kong resources are updated
+        - assert:
+            file: ../common/assertions/kongroute.yaml
+        - assert:
+            file: ../common/assertions/kongservice.yaml
+        - assert:
+            file: ../common/assertions/kongupstream.yaml
+        - assert:
+            file: ../common/assertions/kongtarget.yaml
+        # Additional assertion for methods field (specific to this step)
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongRoute
+              metadata:
+                namespace: kong
+              spec:
+                methods: (parse_json($route_methods_json))
+        # Test the updated routes
+        - script:
+            content: |
+              kubectl get gateway -n kong -o jsonpath='{.items[0].status.addresses[0].value}'
+            outputs:
+              - name: proxy_ip
+                value: ($stdout)
+        
+        # Create a test pod for in-cluster tests
+        - script:
+            content: |
+              kubectl run curl-test-pod --image=curlimages/curl:latest --restart=Never -- sleep 3600
+              kubectl wait --for=condition=Ready pod/curl-test-pod --timeout=60s
+        
+        # Test from within the cluster
+        - description: Test GET /get endpoint from within cluster
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+            content: |
+              kubectl exec curl-test-pod -- curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -w '%{http_code}' -o /dev/null http://${PROXY_IP}/get
+            check:
+              (contains($stdout, '200')): true
+        
+        - description: Test POST /post endpoint from within cluster
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+            content: |
+              kubectl exec curl-test-pod -- curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -w '%{http_code}' -o /dev/null -X POST http://${PROXY_IP}/post
+            check:
+              (contains($stdout, '200')): true
+        
+        - description: Test PUT /put endpoint from within cluster
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+            content: |
+              kubectl exec curl-test-pod -- curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -w '%{http_code}' -o /dev/null -X PUT http://${PROXY_IP}/put
+            check:
+              (contains($stdout, '200')): true
+        
+        - description: Test PATCH /patch endpoint from within cluster
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+            content: |
+              kubectl exec curl-test-pod -- curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -w '%{http_code}' -o /dev/null -X PATCH http://${PROXY_IP}/patch
+            check:
+              (contains($stdout, '200')): true
+        
+        - description: Test DELETE /delete endpoint from within cluster
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+            content: |
+              kubectl exec curl-test-pod -- curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -w '%{http_code}' -o /dev/null -X DELETE http://${PROXY_IP}/delete
+            check:
+              (contains($stdout, '200')): true
+        
+        # Delete the test pod
+        - script:
+            content: |
+              kubectl delete pod curl-test-pod --ignore-not-found=true --wait=false
+        
+        # Test from outside the cluster
+        - description: Test GET /get endpoint from host
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/get
+            check:
+              (contains($stdout, '200')): true
+        
+        - description: Test POST /post endpoint from host
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -o /dev/null -w "%{http_code}" -X POST http://${PROXY_IP}/post
+            check:
+              (contains($stdout, '200')): true
+        
+        - description: Test PUT /put endpoint from host
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -o /dev/null -w "%{http_code}" -X PUT http://${PROXY_IP}/put
+            check:
+              (contains($stdout, '200')): true
+        
+        - description: Test PATCH /patch endpoint from host
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -o /dev/null -w "%{http_code}" -X PATCH http://${PROXY_IP}/patch
+            check:
+              (contains($stdout, '200')): true
+        
+        - description: Test DELETE /delete endpoint from host
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -o /dev/null -w "%{http_code}" -X DELETE http://${PROXY_IP}/delete
+            check:
+              (contains($stdout, '200')): true
+    

--- a/test/e2e/chainsaw/hybridgateway/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/chainsaw-test.yaml
@@ -1,0 +1,28 @@
+# Chainsaw test configuration for Hybrid Gateway Controller
+#
+# Required Environment Variables:
+#   KONNECT_TOKEN - Konnect API authentication token (e.g., kpat_...)
+#   KONNECT_SERVER_URL - (Optional) Konnect server URL, defaults to eu.api.konghq.tech
+#
+# Example:
+#   export KONNECT_TOKEN="kpat_your_token_here"
+#   export KONNECT_SERVER_URL="us.api.konghq.tech"  # Optional
+#   chainsaw test
+#
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Configuration
+metadata:
+  name: hybridgateway-tests
+spec:
+  # Timeout for the whole test suite
+  timeout: 15m
+  # Skip deletion of resources after tests (useful for debugging)
+  skipDelete: true
+  # Fail fast on first error
+  failFast: false
+  # Number of parallel tests
+  parallel: 1
+  # Exclude test directories
+  exclude: []
+  # Full name to pass to the underlying test
+  fullName: false

--- a/test/e2e/chainsaw/hybridgateway/common/assertions/gateway.yaml
+++ b/test/e2e/chainsaw/hybridgateway/common/assertions/gateway.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: kong-foo
+  namespace: kong
+status:
+  (conditions[?type == 'Accepted']):
+    - status: 'True'
+      reason: Accepted
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'DataPlaneReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'KonnectGatewayControlPlaneProgrammed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'KonnectExtensionReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'GatewayService']):
+    - status: 'True'
+      reason: Ready

--- a/test/e2e/chainsaw/hybridgateway/common/assertions/gatewayclass.yaml
+++ b/test/e2e/chainsaw/hybridgateway/common/assertions/gatewayclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: kong-foo
+status:
+  conditions:
+    - type: Accepted
+      status: "True"

--- a/test/e2e/chainsaw/hybridgateway/common/assertions/gatewayconfiguration.yaml
+++ b/test/e2e/chainsaw/hybridgateway/common/assertions/gatewayconfiguration.yaml
@@ -1,0 +1,5 @@
+apiVersion: gateway-operator.konghq.com/v2beta1
+kind: GatewayConfiguration
+metadata:
+  name: kong-foo
+  namespace: kong

--- a/test/e2e/chainsaw/hybridgateway/common/assertions/kongroute.yaml
+++ b/test/e2e/chainsaw/hybridgateway/common/assertions/kongroute.yaml
@@ -1,0 +1,44 @@
+---
+# Template for asserting KongRoute resources
+# 
+# Required bindings:
+#   - namespace: Resource namespace (e.g., "kong")
+#   - managedby_name: HTTPRoute name (e.g., "echo")
+#   - managedby_namespace: HTTPRoute namespace (e.g., "kong")
+#   - hybrid_gateway_name: Gateway name (e.g., "kong-foo")
+#   - hybrid_gateway_namespace: Gateway namespace (e.g., "kong")
+#   - strip_path: Strip path boolean (e.g., true)
+#   - kongservice_name: Name of the KongService this route references
+#   - route_paths_json: JSON string array of paths (e.g., "["/echo"]" or "["/get","/post"]")
+apiVersion: configuration.konghq.com/v1alpha1
+kind: KongRoute
+metadata:
+  namespace: ($namespace)
+  (labels."gateway-operator.konghq.com/hybrid-gateways-name" == ($hybrid_gateway_name)): true
+  (labels."gateway-operator.konghq.com/hybrid-gateways-namespace" == ($hybrid_gateway_namespace)): true
+  (labels."gateway-operator.konghq.com/managed-by" == 'HTTPRoute'): true
+  (annotations."gateway-operator.konghq.com/hybrid-routes" | contains(@, join('/', [($managedby_namespace), ($managedby_name)]))): true
+spec:
+  paths: (parse_json($route_paths_json))
+  strip_path: ($strip_path)
+  serviceRef:
+    namespacedRef:
+      name: ($kongservice_name)
+status:
+  # Filter conditions to check for required status
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'KongServiceRefValid']):
+    - status: 'True'
+      reason: Valid
+  (conditions[?type == 'APIAuthResolvedRef']):
+    - status: 'True'
+      reason: ResolvedRef
+  (conditions[?type == 'APIAuthValid']):
+    - status: 'True'
+      reason: Valid
+  # Assert Konnect integration fields are populated
+  (konnect.controlPlaneID != null): true
+  (konnect.id != null): true
+  (konnect.serviceID != null): true

--- a/test/e2e/chainsaw/hybridgateway/common/assertions/kongservice.yaml
+++ b/test/e2e/chainsaw/hybridgateway/common/assertions/kongservice.yaml
@@ -1,0 +1,40 @@
+---
+# Template for asserting KongService resources
+#
+# Required bindings:
+#   - namespace: Resource namespace (e.g., "kong")
+#   - managedby_name: HTTPRoute name (e.g., "echo")
+#   - managedby_namespace: HTTPRoute namespace (e.g., "kong")
+#   - hybrid_gateway_name: Gateway name (e.g., "kong-foo")
+#   - hybrid_gateway_namespace: Gateway namespace (e.g., "kong")
+#   - konnectgatewaycontrolplane_name: Name of the KonnectGatewayControlPlane
+apiVersion: configuration.konghq.com/v1alpha1
+kind: KongService
+metadata:
+  namespace: ($namespace)
+  (labels."gateway-operator.konghq.com/hybrid-gateways-name" == ($hybrid_gateway_name)): true
+  (labels."gateway-operator.konghq.com/hybrid-gateways-namespace" == ($hybrid_gateway_namespace)): true
+  (labels."gateway-operator.konghq.com/managed-by" == 'HTTPRoute'): true
+  (annotations."gateway-operator.konghq.com/hybrid-routes" | contains(@, join('/', [($managedby_namespace), ($managedby_name)]))): true
+spec:
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: ($konnectgatewaycontrolplane_name)
+status:
+  # Filter conditions to check for required status
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'ControlPlaneRefValid']):
+    - status: 'True'
+      reason: Valid
+  (conditions[?type == 'APIAuthResolvedRef']):
+    - status: 'True'
+      reason: ResolvedRef
+  (conditions[?type == 'APIAuthValid']):
+    - status: 'True'
+      reason: Valid
+  # Assert Konnect integration fields are populated
+  (konnect.controlPlaneID != null): true
+  (konnect.id != null): true

--- a/test/e2e/chainsaw/hybridgateway/common/assertions/kongtarget.yaml
+++ b/test/e2e/chainsaw/hybridgateway/common/assertions/kongtarget.yaml
@@ -1,0 +1,46 @@
+---
+# Template for asserting KongTarget resources
+#
+# Required bindings:
+#   - namespace: Resource namespace (e.g., "kong")
+#   - managedby_name: HTTPRoute name (e.g., "echo")
+#   - managedby_namespace: HTTPRoute namespace (e.g., "kong")
+#   - hybrid_gateway_name: Gateway name (e.g., "kong-foo")
+#   - hybrid_gateway_namespace: Gateway namespace (e.g., "kong")
+#   - weight: Target weight (e.g., 1)
+#   - kongupstream_name: Name of the KongUpstream this target references
+apiVersion: configuration.konghq.com/v1alpha1
+kind: KongTarget
+metadata:
+  namespace: ($namespace)
+  (labels."gateway-operator.konghq.com/hybrid-gateways-name" == ($hybrid_gateway_name)): true
+  (labels."gateway-operator.konghq.com/hybrid-gateways-namespace" == ($hybrid_gateway_namespace)): true
+  (labels."gateway-operator.konghq.com/managed-by" == 'HTTPRoute'): true
+  (annotations."gateway-operator.konghq.com/hybrid-routes" | contains(@, join('/', [($managedby_namespace), ($managedby_name)]))): true
+spec:
+  weight: ($weight)
+  upstreamRef:
+    name: ($kongupstream_name)
+  # Assert target field is populated with IP:port
+  (target != null): true
+status:
+  # Filter conditions to check for required status
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'KongUpstreamRefValid']):
+    - status: 'True'
+      reason: Valid
+  (conditions[?type == 'ControlPlaneRefValid']):
+    - status: 'True'
+      reason: Valid
+  (conditions[?type == 'APIAuthResolvedRef']):
+    - status: 'True'
+      reason: ResolvedRef
+  (conditions[?type == 'APIAuthValid']):
+    - status: 'True'
+      reason: Valid
+  # Assert Konnect integration fields are populated
+  (konnect.controlPlaneID != null): true
+  (konnect.id != null): true
+  (konnect.upstreamID != null): true

--- a/test/e2e/chainsaw/hybridgateway/common/assertions/kongupstream.yaml
+++ b/test/e2e/chainsaw/hybridgateway/common/assertions/kongupstream.yaml
@@ -1,0 +1,40 @@
+---
+# Template for asserting KongUpstream resources
+#
+# Required bindings:
+#   - namespace: Resource namespace (e.g., "kong")
+#   - managedby_name: HTTPRoute name (e.g., "echo")
+#   - managedby_namespace: HTTPRoute namespace (e.g., "kong")
+#   - hybrid_gateway_name: Gateway name (e.g., "kong-foo")
+#   - hybrid_gateway_namespace: Gateway namespace (e.g., "kong")
+#   - konnectgatewaycontrolplane_name: Name of the KonnectGatewayControlPlane
+apiVersion: configuration.konghq.com/v1alpha1
+kind: KongUpstream
+metadata:
+  namespace: ($namespace)
+  (labels."gateway-operator.konghq.com/hybrid-gateways-name" == ($hybrid_gateway_name)): true
+  (labels."gateway-operator.konghq.com/hybrid-gateways-namespace" == ($hybrid_gateway_namespace)): true
+  (labels."gateway-operator.konghq.com/managed-by" == 'HTTPRoute'): true
+  (annotations."gateway-operator.konghq.com/hybrid-routes" | contains(@, join('/', [($managedby_namespace), ($managedby_name)]))): true
+spec:
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: ($konnectgatewaycontrolplane_name)
+status:
+  # Filter conditions to check for required status
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'ControlPlaneRefValid']):
+    - status: 'True'
+      reason: Valid
+  (conditions[?type == 'APIAuthResolvedRef']):
+    - status: 'True'
+      reason: ResolvedRef
+  (conditions[?type == 'APIAuthValid']):
+    - status: 'True'
+      reason: Valid
+  # Assert Konnect integration fields are populated
+  (konnect.controlPlaneID != null): true
+  (konnect.id != null): true

--- a/test/e2e/chainsaw/hybridgateway/common/assertions/konnect-apiauth.yaml
+++ b/test/e2e/chainsaw/hybridgateway/common/assertions/konnect-apiauth.yaml
@@ -1,0 +1,9 @@
+apiVersion: konnect.konghq.com/v1alpha1
+kind: KonnectAPIAuthConfiguration
+metadata:
+  name: konnect-api-auth-dev-1
+  namespace: kong
+status:
+  conditions:
+    - type: APIAuthValid
+      status: "True"

--- a/test/e2e/chainsaw/hybridgateway/common/assertions/konnect-extension.yaml
+++ b/test/e2e/chainsaw/hybridgateway/common/assertions/konnect-extension.yaml
@@ -1,0 +1,22 @@
+apiVersion: konnect.konghq.com/v1alpha2
+kind: KonnectExtension
+metadata:
+  namespace: kong
+  labels:
+    gateway-operator.konghq.com/managed-by: gateway
+status:
+  (conditions[?type == 'Ready']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'APIAuthResolvedRef']):
+    - status: 'True'
+      reason: ResolvedRef
+  (conditions[?type == 'APIAuthValid']):
+    - status: 'True'
+      reason: Valid
+  (conditions[?type == 'ControlPlaneRefValid']):
+    - status: 'True'
+      reason: Valid
+  (conditions[?type == 'DataPlaneCertificateProvisioned']):
+    - status: 'True'
+      reason: Provisioned

--- a/test/e2e/chainsaw/hybridgateway/common/assertions/konnect-gateway-controlplane.yaml
+++ b/test/e2e/chainsaw/hybridgateway/common/assertions/konnect-gateway-controlplane.yaml
@@ -1,0 +1,18 @@
+apiVersion: konnect.konghq.com/v1alpha2
+kind: KonnectGatewayControlPlane
+metadata:
+  namespace: kong
+  labels:
+    gateway-operator.konghq.com/managed-by: gateway
+status:
+  clusterType: CLUSTER_TYPE_CONTROL_PLANE
+  (conditions[?type == 'APIAuthResolvedRef']):
+    - status: 'True'
+      reason: ResolvedRef
+  (conditions[?type == 'APIAuthValid']):
+    - status: 'True'
+      reason: Valid
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (id != null): true


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces the `chainsaw` testing framework for end-to-end (e2e) tests of the hybrid gateway controller. It serves as a pilot for future e2e tests using this framework. A basic `HTTPRoute` test scenario is included to validate the initial setup. This test covers the full lifecycle of the `HTTPRoute` resource, including creation, updates, and deletion, while also verifying data plane connectivity.

**Which issue this PR fixes**

Fixes #2522

**Special notes for your reviewer**:

The CI integration for these `chainsaw` tests is not yet in place. For now, these tests will be run manually. Subsequent PRs will focus on automating these tests within our CI pipelines.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
