### PR TITLE
chore: kustomize download fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,10 +88,11 @@ controller-gen: mise yq ## Download controller-gen locally if necessary.
 	$(MAKE) mise-install DEP_VER=github:kubernetes-sigs/controller-tools@$(CONTROLLER_GEN_VERSION)
 
 KUSTOMIZE_VERSION = $(shell $(YQ) -p toml -o yaml '.tools["github:kubernetes-sigs/kustomize"].version' < $(MISE_FILE))
-KUSTOMIZE = $(PROJECT_DIR)/bin/installs/github-kubernetes-sigs-kustomize/$(KUSTOMIZE_VERSION)/kustomize
+KUSTOMIZE_VERSION_PREFIX = $(shell $(YQ) -p toml -o yaml '.tools["github:kubernetes-sigs/kustomize"].version_prefix' < $(MISE_FILE))
+KUSTOMIZE = $(PROJECT_DIR)/bin/installs/github-kubernetes-sigs-kustomize/kustomize-$(KUSTOMIZE_VERSION)/kustomize
 .PHONY: kustomize
 kustomize: mise yq ## Download kustomize locally if necessary.
-	$(MAKE) mise-install DEP_VER=github:kubernetes-sigs/kustomize
+	$(MAKE) mise-install DEP_VER=github:kubernetes-sigs/kustomize@$(KUSTOMIZE_VERSION_PREFIX)$(KUSTOMIZE_VERSION)
 
 CLIENT_GEN_VERSION = $(shell $(YQ) -r '.code-generator' < $(TOOLS_VERSIONS_FILE))
 CLIENT_GEN = $(PROJECT_DIR)/bin/installs/kube-code-generator/$(CLIENT_GEN_VERSION)/bin/client-gen


### PR DESCRIPTION
**What this PR does / why we need it**:
Local build with "make build" fails as kustomize cannot be downloaded.
The  version and version_prefix set in the .mise.toml config file for some reason seems to not be considered.
```
$> make build
[...]
DEBUG Version: 2025.11.8 linux-x64 (2025-11-26)
DEBUG ARGS: /home/fgiudici/.local/bin/mise install -q github:kubernetes-sigs/kustomize
DEBUG install_some_versions: github:kubernetes-sigs/kustomize@latest
INFO  github:kubernetes-sigs/kustomize@kyaml/v0.21.0 install
DEBUG GET https://api.github.com/repos/kubernetes-sigs/kustomize/releases/tags/vkyaml/v0.21.0
DEBUG starting new connection: https://api.github.com/
DEBUG connecting to 140.82.121.5:443
DEBUG connected to 140.82.121.5:443
DEBUG pooling idle connection for ("https", api.github.com)
DEBUG GET https://api.github.com/repos/kubernetes-sigs/kustomize/releases/tags/vkyaml/v0.21.0 404 Not Found
Error: 
   0: Failed to install github:kubernetes-sigs/kustomize@latest: No suitable asset found for current platform (linux-x64)
      Available assets: 

Location:
   src/toolset/mod.rs:281
[...]
```

This PR use the values in .mise.toml directly in the Makefile.