### PR TITLE
tests: add diagnostic logs to TestMultiInstanceManager_Profiling

### DIFF
--- a/ingress-controller/test/envtest/multiinstance_manager_diagnostics_test.go
+++ b/ingress-controller/test/envtest/multiinstance_manager_diagnostics_test.go
@@ -114,7 +114,7 @@ func TestMultiInstanceManager_Profiling(t *testing.T) {
 		body := io.TeeReader(profileResp.Body, &buff)
 		p, err := profile.Parse(body)
 		if !assert.NoError(c, err, "failed to parse profile") {
-			profileResp.Body = io.NopCloser(bytes.NewReader(buff.Bytes()))
+			profileResp.Body = io.NopCloser(&buff)
 			respDump, err := httputil.DumpResponse(profileResp, true)
 			require.NoError(c, err, "failed to dump response")
 			t.Logf("Profile response dump:\n%s", respDump)


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoid failures like:

```
    multiinstance_manager_diagnostics_test.go:105: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/ingress-controller/test/envtest/multiinstance_manager_diagnostics_test.go:105
        	Error:      	Received unexpected error:
        	            	parsing profile: unrecognized profile format
        	Test:       	TestMultiInstanceManager_Profiling
        	Messages:   	failed to parse profile
```

https://github.com/Kong/kong-operator/actions/runs/19707591893/job/56459181661#step:8:1107

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
