### PR TITLE
chore: kube-api-linter make maxlength validation more strict

### DIFF
--- a/.golangci-kube-api.yaml
+++ b/.golangci-kube-api.yaml
@@ -125,4 +125,10 @@ linters:
       - linters:
           - kubeapilinter
         path: api/(konnect/v1alpha(1|2)|gateway-operator/v2beta1)/.*
-        text: 'maxlength: .*'
+        text: 'maxlength: field .* must have a maximum items, add kubebuilder:validation:MaxItems marker'
+
+      # TODO: remove this.
+      - linters:
+          - kubeapilinter
+        path: api/(common/v1alpha1|konnect/v1alpha1|konnect/v1alpha2)/.*
+        text: 'maxlength: field .* must have a maximum length, add kubebuilder:validation:(items:)?MaxLength marker'

--- a/api/gateway-operator/v1beta1/controlplane_conversion.go
+++ b/api/gateway-operator/v1beta1/controlplane_conversion.go
@@ -216,7 +216,7 @@ func (c *ControlPlaneOptions) convertTo(dst *operatorv2beta1.ControlPlaneOptions
 			return err
 		}
 
-		storageState, err := parseEnvForToggle[operatorv2beta1.ControlPlaneKonnectLicensingState](envControllerEnableKonnectLicensingStorage, containerEnvVars)
+		storageState, err := parseEnvForToggle[operatorv2beta1.ControlPlaneKonnectLicenseStorageState](envControllerEnableKonnectLicensingStorage, containerEnvVars)
 		if err != nil {
 			return err
 		}

--- a/api/gateway-operator/v2beta1/controlplane_types.go
+++ b/api/gateway-operator/v2beta1/controlplane_types.go
@@ -101,6 +101,7 @@ type ControlPlaneOptions struct {
 	// If omitted, Ingress resources will not be supported by the ControlPlane.
 	//
 	// +optional
+	// +kubebuilder:validation:MaxLength=63
 	IngressClass *string `json:"ingressClass,omitempty"`
 
 	// WatchNamespaces indicates the namespaces to watch for resources.
@@ -253,6 +254,8 @@ type ControlPlaneDataPlaneSync struct {
 }
 
 // ControlPlaneReverseSyncState defines the state of the reverse sync feature.
+//
+// +kubebuilder:validation:Enum=enabled;disabled
 type ControlPlaneReverseSyncState string
 
 const (
@@ -304,6 +307,7 @@ type ControlPlaneDataPlaneTargetRef struct {
 	//
 	// +required
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 }
 
@@ -415,6 +419,7 @@ type ControlPlaneController struct {
 	//
 	// +required
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	// State indicates whether the feature gate is enabled or disabled.
@@ -425,6 +430,8 @@ type ControlPlaneController struct {
 }
 
 // FeatureGateState defines the state of a feature gate.
+//
+// +kubebuilder:validation:Enum=enabled;disabled
 type FeatureGateState string
 
 const (
@@ -443,12 +450,12 @@ type ControlPlaneFeatureGate struct {
 	//
 	// +required
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	// State indicates whether the feature gate is enabled or disabled.
 	//
 	// +required
-	// +kubebuilder:validation:Enum=enabled;disabled
 	State FeatureGateState `json:"state"`
 }
 
@@ -497,6 +504,7 @@ type ControlPlaneDataPlaneStatus struct {
 	//
 	// +required
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 }
 
@@ -523,7 +531,6 @@ type ControlPlaneKonnectOptions struct {
 	//
 	// +optional
 	// +kubebuilder:default=enabled
-	// +kubebuilder:validation:Enum=enabled;disabled
 	ConsumersSync *ControlPlaneKonnectConsumersSyncState `json:"consumersSync,omitempty"`
 
 	// Licensing defines the configuration for Konnect licensing.
@@ -543,6 +550,8 @@ type ControlPlaneKonnectOptions struct {
 }
 
 // ControlPlaneKonnectConsumersSyncState defines the state of consumer synchronization with Konnect.
+//
+// +kubebuilder:validation:Enum=enabled;disabled
 type ControlPlaneKonnectConsumersSyncState string
 
 const (
@@ -563,7 +572,6 @@ type ControlPlaneKonnectLicensing struct {
 	//
 	// +optional
 	// +kubebuilder:default=disabled
-	// +kubebuilder:validation:Enum=enabled;disabled
 	State *ControlPlaneKonnectLicensingState `json:"state,omitempty"`
 
 	// InitialPollingPeriod is the initial polling period for license checks.
@@ -582,11 +590,24 @@ type ControlPlaneKonnectLicensing struct {
 	//
 	// +optional
 	// +kubebuilder:default=enabled
-	// +kubebuilder:validation:Enum=enabled;disabled
-	StorageState *ControlPlaneKonnectLicensingState `json:"storageState,omitempty"`
+	StorageState *ControlPlaneKonnectLicenseStorageState `json:"storageState,omitempty"`
 }
 
+// ControlPlaneKonnectLicenseStorageState defines the state of Konnect licensing.
+//
+// +kubebuilder:validation:Enum=enabled;disabled
+type ControlPlaneKonnectLicenseStorageState string
+
+const (
+	// ControlPlaneKonnectLicenseStorageStateEnabled indicates that Konnect license storage is enabled.
+	ControlPlaneKonnectLicenseStorageStateEnabled ControlPlaneKonnectLicenseStorageState = "enabled"
+	// ControlPlaneKonnectLicenseStorageStateDisabled indicates that Konnect license storage is disabled.
+	ControlPlaneKonnectLicenseStorageStateDisabled ControlPlaneKonnectLicenseStorageState = "disabled"
+)
+
 // ControlPlaneKonnectLicensingState defines the state of Konnect licensing.
+//
+// +kubebuilder:validation:Enum=enabled;disabled
 type ControlPlaneKonnectLicensingState string
 
 const (

--- a/api/gateway-operator/v2beta1/gatewayconfiguration_types.go
+++ b/api/gateway-operator/v2beta1/gatewayconfiguration_types.go
@@ -155,6 +155,7 @@ type GatewayConfigDataPlaneOptions struct {
 	// use this GatewayConfig.
 	//
 	// +optional
+	// +kubebuilder:validation:MaxItems=32
 	PluginsToInstall []NamespacedName `json:"pluginsToInstall,omitempty"`
 }
 

--- a/api/gateway-operator/v2beta1/shared_types.go
+++ b/api/gateway-operator/v2beta1/shared_types.go
@@ -71,8 +71,10 @@ type HorizontalScaling struct {
 	// increased, and vice-versa.  See the individual metric source types for
 	// more information about how each type of metric must respond.
 	// If not set, the default metric will be set to 80% average CPU utilization.
+	//
 	// +listType=atomic
 	// +optional
+	// +kubebuilder:validation:MaxItems=8
 	Metrics []autoscalingv2.MetricSpec `json:"metrics,omitempty" protobuf:"bytes,4,rep,name=metrics"`
 
 	// behavior configures the scaling behavior of the target
@@ -250,11 +252,13 @@ type NamespacedName struct {
 	//
 	// +required
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	// Namespace is the namespace of the resource.
 	//
 	// +optional
+	// +kubebuilder:validation:MaxLength=63
 	Namespace string `json:"namespace"`
 }
 
@@ -288,6 +292,7 @@ type ServiceOptions struct {
 	// If Name is empty, the controller will generate a service name from the owning object.
 	//
 	// +optional
+	// +kubebuilder:validation:MaxLength=63
 	Name *string `json:"name,omitempty"`
 
 	// Annotations is an unstructured key value map stored with a resource that may be

--- a/api/gateway-operator/v2beta1/watch_namespaces_types.go
+++ b/api/gateway-operator/v2beta1/watch_namespaces_types.go
@@ -16,6 +16,8 @@ type WatchNamespaces struct {
 	// Only used when Type is set to List.
 	//
 	// +optional
+	// +kubebuilder:validation:MaxItems=64
+	// +kubebuilder:validation:items:MaxLength=64
 	List []string `json:"list,omitempty"`
 }
 

--- a/api/gateway-operator/v2beta1/zz_generated.deepcopy.go
+++ b/api/gateway-operator/v2beta1/zz_generated.deepcopy.go
@@ -316,7 +316,7 @@ func (in *ControlPlaneKonnectLicensing) DeepCopyInto(out *ControlPlaneKonnectLic
 	}
 	if in.StorageState != nil {
 		in, out := &in.StorageState, &out.StorageState
-		*out = new(ControlPlaneKonnectLicensingState)
+		*out = new(ControlPlaneKonnectLicenseStorageState)
 		**out = **in
 	}
 }

--- a/api/test/conversion/gateway-operator.konghq.com/v1beta1/controlplane_test.go
+++ b/api/test/conversion/gateway-operator.konghq.com/v1beta1/controlplane_test.go
@@ -482,7 +482,7 @@ func TestControlPlane_RoundTrip(t *testing.T) {
 							State:                lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
 							InitialPollingPeriod: &metav1.Duration{Duration: 10 * time.Second},
 							PollingPeriod:        &metav1.Duration{Duration: 60 * time.Second},
-							StorageState:         lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateDisabled),
+							StorageState:         lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicenseStorageStateDisabled),
 						},
 						NodeRefreshPeriod:  &metav1.Duration{Duration: 30 * time.Second},
 						ConfigUploadPeriod: &metav1.Duration{Duration: 10 * time.Second},

--- a/api/test/conversion/gateway-operator.konghq.com/v1beta1/gatewayconfiguration_test.go
+++ b/api/test/conversion/gateway-operator.konghq.com/v1beta1/gatewayconfiguration_test.go
@@ -502,7 +502,7 @@ func TestGatewayConfiguration_RoundTrip(t *testing.T) {
 									State:                lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
 									InitialPollingPeriod: &metav1.Duration{Duration: 10 * time.Second},
 									PollingPeriod:        &metav1.Duration{Duration: 60 * time.Second},
-									StorageState:         lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateDisabled),
+									StorageState:         lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicenseStorageStateDisabled),
 								},
 								NodeRefreshPeriod:  &metav1.Duration{Duration: 30 * time.Second},
 								ConfigUploadPeriod: &metav1.Duration{Duration: 10 * time.Second},

--- a/charts/kong-operator/charts/ko-crds/templates/ko-crds.yaml
+++ b/charts/kong-operator/charts/ko-crds/templates/ko-crds.yaml
@@ -9456,6 +9456,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9487,6 +9488,7 @@ spec:
                     properties:
                       name:
                         description: Ref is the name of the DataPlane to configure.
+                        maxLength: 63
                         minLength: 1
                         type: string
                     required:
@@ -9519,6 +9521,9 @@ spec:
                     description: |-
                       ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                       the configuration checksum has not changed since previous update.
+                    enum:
+                    - enabled
+                    - disabled
                     type: string
                   timeout:
                     description: Timeout is the timeout of a single run of syncing
@@ -9580,6 +9585,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9620,6 +9626,7 @@ spec:
                   which Ingress resources this ControlPlane should be responsible for.
 
                   If omitted, Ingress resources will not be supported by the ControlPlane.
+                maxLength: 63
                 type: string
               konnect:
                 description: Konnect defines the Konnect-related configuration options
@@ -9775,7 +9782,9 @@ spec:
                       List is a list of namespaces to watch for resources.
                       Only used when Type is set to List.
                     items:
+                      maxLength: 64
                       type: string
+                    maxItems: 64
                     type: array
                   type:
                     description: |-
@@ -9881,6 +9890,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9906,6 +9916,7 @@ spec:
                 properties:
                   name:
                     description: Name is the name of the DataPlane.
+                    maxLength: 63
                     minLength: 1
                     type: string
                 required:
@@ -9921,6 +9932,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -38679,6 +38691,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the controller.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -38710,6 +38723,9 @@ spec:
                         description: |-
                           ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                           the configuration checksum has not changed since previous update.
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                       timeout:
                         description: Timeout is the timeout of a single run of syncing
@@ -38726,6 +38742,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the feature gate.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -38766,6 +38783,7 @@ spec:
                       which Ingress resources this ControlPlane should be responsible for.
 
                       If omitted, Ingress resources will not be supported by the ControlPlane.
+                    maxLength: 63
                     type: string
                   konnect:
                     description: Konnect defines the Konnect-related configuration
@@ -38924,7 +38942,9 @@ spec:
                           List is a list of namespaces to watch for resources.
                           Only used when Type is set to List.
                         items:
+                          maxLength: 64
                           type: string
+                        maxItems: 64
                         type: array
                       type:
                         description: |-
@@ -48280,6 +48300,7 @@ spec:
                                   required:
                                   - type
                                   type: object
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-type: atomic
                               minReplicas:
@@ -48353,6 +48374,7 @@ spec:
                                 description: |-
                                   Name defines the name of the service.
                                   If Name is empty, the controller will generate a service name from the owning object.
+                                maxLength: 63
                                 type: string
                               type:
                                 default: LoadBalancer
@@ -48396,14 +48418,17 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the resource.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         namespace:
                           description: Namespace is the namespace of the resource.
+                          maxLength: 63
                           type: string
                       required:
                       - name
                       type: object
+                    maxItems: 32
                     type: array
                   resources:
                     description: |-

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -8988,6 +8988,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9018,6 +9019,7 @@ spec:
                     properties:
                       name:
                         description: Ref is the name of the DataPlane to configure.
+                        maxLength: 63
                         minLength: 1
                         type: string
                     required:
@@ -9048,6 +9050,9 @@ spec:
                     description: |-
                       ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                       the configuration checksum has not changed since previous update.
+                    enum:
+                    - enabled
+                    - disabled
                     type: string
                   timeout:
                     description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -9105,6 +9110,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9143,6 +9149,7 @@ spec:
                   which Ingress resources this ControlPlane should be responsible for.
 
                   If omitted, Ingress resources will not be supported by the ControlPlane.
+                maxLength: 63
                 type: string
               konnect:
                 description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -9283,7 +9290,9 @@ spec:
                       List is a list of namespaces to watch for resources.
                       Only used when Type is set to List.
                     items:
+                      maxLength: 64
                       type: string
+                    maxItems: 64
                     type: array
                   type:
                     description: |-
@@ -9386,6 +9395,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9410,6 +9420,7 @@ spec:
                 properties:
                   name:
                     description: Name is the name of the DataPlane.
+                    maxLength: 63
                     minLength: 1
                     type: string
                 required:
@@ -9424,6 +9435,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -36429,6 +36441,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the controller.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36457,6 +36470,9 @@ spec:
                         description: |-
                           ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                           the configuration checksum has not changed since previous update.
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                       timeout:
                         description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -36471,6 +36487,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the feature gate.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36509,6 +36526,7 @@ spec:
                       which Ingress resources this ControlPlane should be responsible for.
 
                       If omitted, Ingress resources will not be supported by the ControlPlane.
+                    maxLength: 63
                     type: string
                   konnect:
                     description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -36649,7 +36667,9 @@ spec:
                           List is a list of namespaces to watch for resources.
                           Only used when Type is set to List.
                         items:
+                          maxLength: 64
                           type: string
+                        maxItems: 64
                         type: array
                       type:
                         description: |-
@@ -45398,6 +45418,7 @@ spec:
                                   required:
                                   - type
                                   type: object
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-type: atomic
                               minReplicas:
@@ -45470,6 +45491,7 @@ spec:
                                 description: |-
                                   Name defines the name of the service.
                                   If Name is empty, the controller will generate a service name from the owning object.
+                                maxLength: 63
                                 type: string
                               type:
                                 default: LoadBalancer
@@ -45510,14 +45532,17 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the resource.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         namespace:
                           description: Namespace is the namespace of the resource.
+                          maxLength: 63
                           type: string
                       required:
                       - name
                       type: object
+                    maxItems: 32
                     type: array
                   resources:
                     description: |-

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -8988,6 +8988,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9018,6 +9019,7 @@ spec:
                     properties:
                       name:
                         description: Ref is the name of the DataPlane to configure.
+                        maxLength: 63
                         minLength: 1
                         type: string
                     required:
@@ -9048,6 +9050,9 @@ spec:
                     description: |-
                       ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                       the configuration checksum has not changed since previous update.
+                    enum:
+                    - enabled
+                    - disabled
                     type: string
                   timeout:
                     description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -9105,6 +9110,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9143,6 +9149,7 @@ spec:
                   which Ingress resources this ControlPlane should be responsible for.
 
                   If omitted, Ingress resources will not be supported by the ControlPlane.
+                maxLength: 63
                 type: string
               konnect:
                 description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -9283,7 +9290,9 @@ spec:
                       List is a list of namespaces to watch for resources.
                       Only used when Type is set to List.
                     items:
+                      maxLength: 64
                       type: string
+                    maxItems: 64
                     type: array
                   type:
                     description: |-
@@ -9386,6 +9395,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9410,6 +9420,7 @@ spec:
                 properties:
                   name:
                     description: Name is the name of the DataPlane.
+                    maxLength: 63
                     minLength: 1
                     type: string
                 required:
@@ -9424,6 +9435,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -36429,6 +36441,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the controller.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36457,6 +36470,9 @@ spec:
                         description: |-
                           ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                           the configuration checksum has not changed since previous update.
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                       timeout:
                         description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -36471,6 +36487,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the feature gate.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36509,6 +36526,7 @@ spec:
                       which Ingress resources this ControlPlane should be responsible for.
 
                       If omitted, Ingress resources will not be supported by the ControlPlane.
+                    maxLength: 63
                     type: string
                   konnect:
                     description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -36649,7 +36667,9 @@ spec:
                           List is a list of namespaces to watch for resources.
                           Only used when Type is set to List.
                         items:
+                          maxLength: 64
                           type: string
+                        maxItems: 64
                         type: array
                       type:
                         description: |-
@@ -45398,6 +45418,7 @@ spec:
                                   required:
                                   - type
                                   type: object
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-type: atomic
                               minReplicas:
@@ -45470,6 +45491,7 @@ spec:
                                 description: |-
                                   Name defines the name of the service.
                                   If Name is empty, the controller will generate a service name from the owning object.
+                                maxLength: 63
                                 type: string
                               type:
                                 default: LoadBalancer
@@ -45510,14 +45532,17 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the resource.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         namespace:
                           description: Namespace is the namespace of the resource.
+                          maxLength: 63
                           type: string
                       required:
                       - name
                       type: object
+                    maxItems: 32
                     type: array
                   resources:
                     description: |-

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -8988,6 +8988,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9018,6 +9019,7 @@ spec:
                     properties:
                       name:
                         description: Ref is the name of the DataPlane to configure.
+                        maxLength: 63
                         minLength: 1
                         type: string
                     required:
@@ -9048,6 +9050,9 @@ spec:
                     description: |-
                       ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                       the configuration checksum has not changed since previous update.
+                    enum:
+                    - enabled
+                    - disabled
                     type: string
                   timeout:
                     description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -9105,6 +9110,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9143,6 +9149,7 @@ spec:
                   which Ingress resources this ControlPlane should be responsible for.
 
                   If omitted, Ingress resources will not be supported by the ControlPlane.
+                maxLength: 63
                 type: string
               konnect:
                 description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -9283,7 +9290,9 @@ spec:
                       List is a list of namespaces to watch for resources.
                       Only used when Type is set to List.
                     items:
+                      maxLength: 64
                       type: string
+                    maxItems: 64
                     type: array
                   type:
                     description: |-
@@ -9386,6 +9395,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9410,6 +9420,7 @@ spec:
                 properties:
                   name:
                     description: Name is the name of the DataPlane.
+                    maxLength: 63
                     minLength: 1
                     type: string
                 required:
@@ -9424,6 +9435,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -36429,6 +36441,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the controller.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36457,6 +36470,9 @@ spec:
                         description: |-
                           ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                           the configuration checksum has not changed since previous update.
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                       timeout:
                         description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -36471,6 +36487,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the feature gate.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36509,6 +36526,7 @@ spec:
                       which Ingress resources this ControlPlane should be responsible for.
 
                       If omitted, Ingress resources will not be supported by the ControlPlane.
+                    maxLength: 63
                     type: string
                   konnect:
                     description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -36649,7 +36667,9 @@ spec:
                           List is a list of namespaces to watch for resources.
                           Only used when Type is set to List.
                         items:
+                          maxLength: 64
                           type: string
+                        maxItems: 64
                         type: array
                       type:
                         description: |-
@@ -45398,6 +45418,7 @@ spec:
                                   required:
                                   - type
                                   type: object
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-type: atomic
                               minReplicas:
@@ -45470,6 +45491,7 @@ spec:
                                 description: |-
                                   Name defines the name of the service.
                                   If Name is empty, the controller will generate a service name from the owning object.
+                                maxLength: 63
                                 type: string
                               type:
                                 default: LoadBalancer
@@ -45510,14 +45532,17 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the resource.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         namespace:
                           description: Namespace is the namespace of the resource.
+                          maxLength: 63
                           type: string
                       required:
                       - name
                       type: object
+                    maxItems: 32
                     type: array
                   resources:
                     description: |-

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -8988,6 +8988,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9018,6 +9019,7 @@ spec:
                     properties:
                       name:
                         description: Ref is the name of the DataPlane to configure.
+                        maxLength: 63
                         minLength: 1
                         type: string
                     required:
@@ -9048,6 +9050,9 @@ spec:
                     description: |-
                       ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                       the configuration checksum has not changed since previous update.
+                    enum:
+                    - enabled
+                    - disabled
                     type: string
                   timeout:
                     description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -9105,6 +9110,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9143,6 +9149,7 @@ spec:
                   which Ingress resources this ControlPlane should be responsible for.
 
                   If omitted, Ingress resources will not be supported by the ControlPlane.
+                maxLength: 63
                 type: string
               konnect:
                 description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -9283,7 +9290,9 @@ spec:
                       List is a list of namespaces to watch for resources.
                       Only used when Type is set to List.
                     items:
+                      maxLength: 64
                       type: string
+                    maxItems: 64
                     type: array
                   type:
                     description: |-
@@ -9386,6 +9395,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9410,6 +9420,7 @@ spec:
                 properties:
                   name:
                     description: Name is the name of the DataPlane.
+                    maxLength: 63
                     minLength: 1
                     type: string
                 required:
@@ -9424,6 +9435,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -36429,6 +36441,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the controller.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36457,6 +36470,9 @@ spec:
                         description: |-
                           ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                           the configuration checksum has not changed since previous update.
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                       timeout:
                         description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -36471,6 +36487,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the feature gate.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36509,6 +36526,7 @@ spec:
                       which Ingress resources this ControlPlane should be responsible for.
 
                       If omitted, Ingress resources will not be supported by the ControlPlane.
+                    maxLength: 63
                     type: string
                   konnect:
                     description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -36649,7 +36667,9 @@ spec:
                           List is a list of namespaces to watch for resources.
                           Only used when Type is set to List.
                         items:
+                          maxLength: 64
                           type: string
+                        maxItems: 64
                         type: array
                       type:
                         description: |-
@@ -45398,6 +45418,7 @@ spec:
                                   required:
                                   - type
                                   type: object
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-type: atomic
                               minReplicas:
@@ -45470,6 +45491,7 @@ spec:
                                 description: |-
                                   Name defines the name of the service.
                                   If Name is empty, the controller will generate a service name from the owning object.
+                                maxLength: 63
                                 type: string
                               type:
                                 default: LoadBalancer
@@ -45510,14 +45532,17 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the resource.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         namespace:
                           description: Namespace is the namespace of the resource.
+                          maxLength: 63
                           type: string
                       required:
                       - name
                       type: object
+                    maxItems: 32
                     type: array
                   resources:
                     description: |-

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -8988,6 +8988,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9018,6 +9019,7 @@ spec:
                     properties:
                       name:
                         description: Ref is the name of the DataPlane to configure.
+                        maxLength: 63
                         minLength: 1
                         type: string
                     required:
@@ -9048,6 +9050,9 @@ spec:
                     description: |-
                       ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                       the configuration checksum has not changed since previous update.
+                    enum:
+                    - enabled
+                    - disabled
                     type: string
                   timeout:
                     description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -9105,6 +9110,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9143,6 +9149,7 @@ spec:
                   which Ingress resources this ControlPlane should be responsible for.
 
                   If omitted, Ingress resources will not be supported by the ControlPlane.
+                maxLength: 63
                 type: string
               konnect:
                 description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -9283,7 +9290,9 @@ spec:
                       List is a list of namespaces to watch for resources.
                       Only used when Type is set to List.
                     items:
+                      maxLength: 64
                       type: string
+                    maxItems: 64
                     type: array
                   type:
                     description: |-
@@ -9386,6 +9395,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9410,6 +9420,7 @@ spec:
                 properties:
                   name:
                     description: Name is the name of the DataPlane.
+                    maxLength: 63
                     minLength: 1
                     type: string
                 required:
@@ -9424,6 +9435,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -36429,6 +36441,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the controller.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36457,6 +36470,9 @@ spec:
                         description: |-
                           ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                           the configuration checksum has not changed since previous update.
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                       timeout:
                         description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -36471,6 +36487,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the feature gate.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36509,6 +36526,7 @@ spec:
                       which Ingress resources this ControlPlane should be responsible for.
 
                       If omitted, Ingress resources will not be supported by the ControlPlane.
+                    maxLength: 63
                     type: string
                   konnect:
                     description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -36649,7 +36667,9 @@ spec:
                           List is a list of namespaces to watch for resources.
                           Only used when Type is set to List.
                         items:
+                          maxLength: 64
                           type: string
+                        maxItems: 64
                         type: array
                       type:
                         description: |-
@@ -45398,6 +45418,7 @@ spec:
                                   required:
                                   - type
                                   type: object
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-type: atomic
                               minReplicas:
@@ -45470,6 +45491,7 @@ spec:
                                 description: |-
                                   Name defines the name of the service.
                                   If Name is empty, the controller will generate a service name from the owning object.
+                                maxLength: 63
                                 type: string
                               type:
                                 default: LoadBalancer
@@ -45510,14 +45532,17 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the resource.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         namespace:
                           description: Namespace is the namespace of the resource.
+                          maxLength: 63
                           type: string
                       required:
                       - name
                       type: object
+                    maxItems: 32
                     type: array
                   resources:
                     description: |-

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -8989,6 +8989,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9019,6 +9020,7 @@ spec:
                     properties:
                       name:
                         description: Ref is the name of the DataPlane to configure.
+                        maxLength: 63
                         minLength: 1
                         type: string
                     required:
@@ -9049,6 +9051,9 @@ spec:
                     description: |-
                       ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                       the configuration checksum has not changed since previous update.
+                    enum:
+                    - enabled
+                    - disabled
                     type: string
                   timeout:
                     description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -9106,6 +9111,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9144,6 +9150,7 @@ spec:
                   which Ingress resources this ControlPlane should be responsible for.
 
                   If omitted, Ingress resources will not be supported by the ControlPlane.
+                maxLength: 63
                 type: string
               konnect:
                 description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -9284,7 +9291,9 @@ spec:
                       List is a list of namespaces to watch for resources.
                       Only used when Type is set to List.
                     items:
+                      maxLength: 64
                       type: string
+                    maxItems: 64
                     type: array
                   type:
                     description: |-
@@ -9387,6 +9396,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9411,6 +9421,7 @@ spec:
                 properties:
                   name:
                     description: Name is the name of the DataPlane.
+                    maxLength: 63
                     minLength: 1
                     type: string
                 required:
@@ -9425,6 +9436,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -36430,6 +36442,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the controller.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36458,6 +36471,9 @@ spec:
                         description: |-
                           ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                           the configuration checksum has not changed since previous update.
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                       timeout:
                         description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -36472,6 +36488,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the feature gate.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36510,6 +36527,7 @@ spec:
                       which Ingress resources this ControlPlane should be responsible for.
 
                       If omitted, Ingress resources will not be supported by the ControlPlane.
+                    maxLength: 63
                     type: string
                   konnect:
                     description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -36650,7 +36668,9 @@ spec:
                           List is a list of namespaces to watch for resources.
                           Only used when Type is set to List.
                         items:
+                          maxLength: 64
                           type: string
+                        maxItems: 64
                         type: array
                       type:
                         description: |-
@@ -45399,6 +45419,7 @@ spec:
                                   required:
                                   - type
                                   type: object
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-type: atomic
                               minReplicas:
@@ -45471,6 +45492,7 @@ spec:
                                 description: |-
                                   Name defines the name of the service.
                                   If Name is empty, the controller will generate a service name from the owning object.
+                                maxLength: 63
                                 type: string
                               type:
                                 default: LoadBalancer
@@ -45511,14 +45533,17 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the resource.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         namespace:
                           description: Namespace is the namespace of the resource.
+                          maxLength: 63
                           type: string
                       required:
                       - name
                       type: object
+                    maxItems: 32
                     type: array
                   resources:
                     description: |-

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -8988,6 +8988,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9018,6 +9019,7 @@ spec:
                     properties:
                       name:
                         description: Ref is the name of the DataPlane to configure.
+                        maxLength: 63
                         minLength: 1
                         type: string
                     required:
@@ -9048,6 +9050,9 @@ spec:
                     description: |-
                       ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                       the configuration checksum has not changed since previous update.
+                    enum:
+                    - enabled
+                    - disabled
                     type: string
                   timeout:
                     description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -9105,6 +9110,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9143,6 +9149,7 @@ spec:
                   which Ingress resources this ControlPlane should be responsible for.
 
                   If omitted, Ingress resources will not be supported by the ControlPlane.
+                maxLength: 63
                 type: string
               konnect:
                 description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -9283,7 +9290,9 @@ spec:
                       List is a list of namespaces to watch for resources.
                       Only used when Type is set to List.
                     items:
+                      maxLength: 64
                       type: string
+                    maxItems: 64
                     type: array
                   type:
                     description: |-
@@ -9386,6 +9395,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9410,6 +9420,7 @@ spec:
                 properties:
                   name:
                     description: Name is the name of the DataPlane.
+                    maxLength: 63
                     minLength: 1
                     type: string
                 required:
@@ -9424,6 +9435,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -36429,6 +36441,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the controller.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36457,6 +36470,9 @@ spec:
                         description: |-
                           ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                           the configuration checksum has not changed since previous update.
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                       timeout:
                         description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -36471,6 +36487,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the feature gate.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36509,6 +36526,7 @@ spec:
                       which Ingress resources this ControlPlane should be responsible for.
 
                       If omitted, Ingress resources will not be supported by the ControlPlane.
+                    maxLength: 63
                     type: string
                   konnect:
                     description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -36649,7 +36667,9 @@ spec:
                           List is a list of namespaces to watch for resources.
                           Only used when Type is set to List.
                         items:
+                          maxLength: 64
                           type: string
+                        maxItems: 64
                         type: array
                       type:
                         description: |-
@@ -45398,6 +45418,7 @@ spec:
                                   required:
                                   - type
                                   type: object
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-type: atomic
                               minReplicas:
@@ -45470,6 +45491,7 @@ spec:
                                 description: |-
                                   Name defines the name of the service.
                                   If Name is empty, the controller will generate a service name from the owning object.
+                                maxLength: 63
                                 type: string
                               type:
                                 default: LoadBalancer
@@ -45510,14 +45532,17 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the resource.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         namespace:
                           description: Namespace is the namespace of the resource.
+                          maxLength: 63
                           type: string
                       required:
                       - name
                       type: object
+                    maxItems: 32
                     type: array
                   resources:
                     description: |-

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -8988,6 +8988,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9018,6 +9019,7 @@ spec:
                     properties:
                       name:
                         description: Ref is the name of the DataPlane to configure.
+                        maxLength: 63
                         minLength: 1
                         type: string
                     required:
@@ -9048,6 +9050,9 @@ spec:
                     description: |-
                       ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                       the configuration checksum has not changed since previous update.
+                    enum:
+                    - enabled
+                    - disabled
                     type: string
                   timeout:
                     description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -9105,6 +9110,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9143,6 +9149,7 @@ spec:
                   which Ingress resources this ControlPlane should be responsible for.
 
                   If omitted, Ingress resources will not be supported by the ControlPlane.
+                maxLength: 63
                 type: string
               konnect:
                 description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -9283,7 +9290,9 @@ spec:
                       List is a list of namespaces to watch for resources.
                       Only used when Type is set to List.
                     items:
+                      maxLength: 64
                       type: string
+                    maxItems: 64
                     type: array
                   type:
                     description: |-
@@ -9386,6 +9395,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9410,6 +9420,7 @@ spec:
                 properties:
                   name:
                     description: Name is the name of the DataPlane.
+                    maxLength: 63
                     minLength: 1
                     type: string
                 required:
@@ -9424,6 +9435,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -36429,6 +36441,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the controller.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36457,6 +36470,9 @@ spec:
                         description: |-
                           ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                           the configuration checksum has not changed since previous update.
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                       timeout:
                         description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -36471,6 +36487,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the feature gate.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36509,6 +36526,7 @@ spec:
                       which Ingress resources this ControlPlane should be responsible for.
 
                       If omitted, Ingress resources will not be supported by the ControlPlane.
+                    maxLength: 63
                     type: string
                   konnect:
                     description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -36649,7 +36667,9 @@ spec:
                           List is a list of namespaces to watch for resources.
                           Only used when Type is set to List.
                         items:
+                          maxLength: 64
                           type: string
+                        maxItems: 64
                         type: array
                       type:
                         description: |-
@@ -45398,6 +45418,7 @@ spec:
                                   required:
                                   - type
                                   type: object
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-type: atomic
                               minReplicas:
@@ -45470,6 +45491,7 @@ spec:
                                 description: |-
                                   Name defines the name of the service.
                                   If Name is empty, the controller will generate a service name from the owning object.
+                                maxLength: 63
                                 type: string
                               type:
                                 default: LoadBalancer
@@ -45510,14 +45532,17 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the resource.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         namespace:
                           description: Namespace is the namespace of the resource.
+                          maxLength: 63
                           type: string
                       required:
                       - name
                       type: object
+                    maxItems: 32
                     type: array
                   resources:
                     description: |-

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -8988,6 +8988,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9018,6 +9019,7 @@ spec:
                     properties:
                       name:
                         description: Ref is the name of the DataPlane to configure.
+                        maxLength: 63
                         minLength: 1
                         type: string
                     required:
@@ -9048,6 +9050,9 @@ spec:
                     description: |-
                       ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                       the configuration checksum has not changed since previous update.
+                    enum:
+                    - enabled
+                    - disabled
                     type: string
                   timeout:
                     description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -9105,6 +9110,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9143,6 +9149,7 @@ spec:
                   which Ingress resources this ControlPlane should be responsible for.
 
                   If omitted, Ingress resources will not be supported by the ControlPlane.
+                maxLength: 63
                 type: string
               konnect:
                 description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -9283,7 +9290,9 @@ spec:
                       List is a list of namespaces to watch for resources.
                       Only used when Type is set to List.
                     items:
+                      maxLength: 64
                       type: string
+                    maxItems: 64
                     type: array
                   type:
                     description: |-
@@ -9386,6 +9395,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9410,6 +9420,7 @@ spec:
                 properties:
                   name:
                     description: Name is the name of the DataPlane.
+                    maxLength: 63
                     minLength: 1
                     type: string
                 required:
@@ -9424,6 +9435,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -36429,6 +36441,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the controller.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36457,6 +36470,9 @@ spec:
                         description: |-
                           ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                           the configuration checksum has not changed since previous update.
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                       timeout:
                         description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -36471,6 +36487,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the feature gate.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36509,6 +36526,7 @@ spec:
                       which Ingress resources this ControlPlane should be responsible for.
 
                       If omitted, Ingress resources will not be supported by the ControlPlane.
+                    maxLength: 63
                     type: string
                   konnect:
                     description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -36649,7 +36667,9 @@ spec:
                           List is a list of namespaces to watch for resources.
                           Only used when Type is set to List.
                         items:
+                          maxLength: 64
                           type: string
+                        maxItems: 64
                         type: array
                       type:
                         description: |-
@@ -45398,6 +45418,7 @@ spec:
                                   required:
                                   - type
                                   type: object
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-type: atomic
                               minReplicas:
@@ -45470,6 +45491,7 @@ spec:
                                 description: |-
                                   Name defines the name of the service.
                                   If Name is empty, the controller will generate a service name from the owning object.
+                                maxLength: 63
                                 type: string
                               type:
                                 default: LoadBalancer
@@ -45510,14 +45532,17 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the resource.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         namespace:
                           description: Namespace is the namespace of the resource.
+                          maxLength: 63
                           type: string
                       required:
                       - name
                       type: object
+                    maxItems: 32
                     type: array
                   resources:
                     description: |-

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -8988,6 +8988,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9018,6 +9019,7 @@ spec:
                     properties:
                       name:
                         description: Ref is the name of the DataPlane to configure.
+                        maxLength: 63
                         minLength: 1
                         type: string
                     required:
@@ -9048,6 +9050,9 @@ spec:
                     description: |-
                       ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                       the configuration checksum has not changed since previous update.
+                    enum:
+                    - enabled
+                    - disabled
                     type: string
                   timeout:
                     description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -9105,6 +9110,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9143,6 +9149,7 @@ spec:
                   which Ingress resources this ControlPlane should be responsible for.
 
                   If omitted, Ingress resources will not be supported by the ControlPlane.
+                maxLength: 63
                 type: string
               konnect:
                 description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -9283,7 +9290,9 @@ spec:
                       List is a list of namespaces to watch for resources.
                       Only used when Type is set to List.
                     items:
+                      maxLength: 64
                       type: string
+                    maxItems: 64
                     type: array
                   type:
                     description: |-
@@ -9386,6 +9395,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9410,6 +9420,7 @@ spec:
                 properties:
                   name:
                     description: Name is the name of the DataPlane.
+                    maxLength: 63
                     minLength: 1
                     type: string
                 required:
@@ -9424,6 +9435,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -36429,6 +36441,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the controller.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36457,6 +36470,9 @@ spec:
                         description: |-
                           ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                           the configuration checksum has not changed since previous update.
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                       timeout:
                         description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -36471,6 +36487,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the feature gate.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36509,6 +36526,7 @@ spec:
                       which Ingress resources this ControlPlane should be responsible for.
 
                       If omitted, Ingress resources will not be supported by the ControlPlane.
+                    maxLength: 63
                     type: string
                   konnect:
                     description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -36649,7 +36667,9 @@ spec:
                           List is a list of namespaces to watch for resources.
                           Only used when Type is set to List.
                         items:
+                          maxLength: 64
                           type: string
+                        maxItems: 64
                         type: array
                       type:
                         description: |-
@@ -45398,6 +45418,7 @@ spec:
                                   required:
                                   - type
                                   type: object
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-type: atomic
                               minReplicas:
@@ -45470,6 +45491,7 @@ spec:
                                 description: |-
                                   Name defines the name of the service.
                                   If Name is empty, the controller will generate a service name from the owning object.
+                                maxLength: 63
                                 type: string
                               type:
                                 default: LoadBalancer
@@ -45510,14 +45532,17 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the resource.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         namespace:
                           description: Namespace is the namespace of the resource.
+                          maxLength: 63
                           type: string
                       required:
                       - name
                       type: object
+                    maxItems: 32
                     type: array
                   resources:
                     description: |-

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -8988,6 +8988,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9018,6 +9019,7 @@ spec:
                     properties:
                       name:
                         description: Ref is the name of the DataPlane to configure.
+                        maxLength: 63
                         minLength: 1
                         type: string
                     required:
@@ -9048,6 +9050,9 @@ spec:
                     description: |-
                       ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                       the configuration checksum has not changed since previous update.
+                    enum:
+                    - enabled
+                    - disabled
                     type: string
                   timeout:
                     description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -9105,6 +9110,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9143,6 +9149,7 @@ spec:
                   which Ingress resources this ControlPlane should be responsible for.
 
                   If omitted, Ingress resources will not be supported by the ControlPlane.
+                maxLength: 63
                 type: string
               konnect:
                 description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -9283,7 +9290,9 @@ spec:
                       List is a list of namespaces to watch for resources.
                       Only used when Type is set to List.
                     items:
+                      maxLength: 64
                       type: string
+                    maxItems: 64
                     type: array
                   type:
                     description: |-
@@ -9386,6 +9395,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9410,6 +9420,7 @@ spec:
                 properties:
                   name:
                     description: Name is the name of the DataPlane.
+                    maxLength: 63
                     minLength: 1
                     type: string
                 required:
@@ -9424,6 +9435,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -36429,6 +36441,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the controller.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36457,6 +36470,9 @@ spec:
                         description: |-
                           ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                           the configuration checksum has not changed since previous update.
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                       timeout:
                         description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -36471,6 +36487,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the feature gate.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36509,6 +36526,7 @@ spec:
                       which Ingress resources this ControlPlane should be responsible for.
 
                       If omitted, Ingress resources will not be supported by the ControlPlane.
+                    maxLength: 63
                     type: string
                   konnect:
                     description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -36649,7 +36667,9 @@ spec:
                           List is a list of namespaces to watch for resources.
                           Only used when Type is set to List.
                         items:
+                          maxLength: 64
                           type: string
+                        maxItems: 64
                         type: array
                       type:
                         description: |-
@@ -45398,6 +45418,7 @@ spec:
                                   required:
                                   - type
                                   type: object
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-type: atomic
                               minReplicas:
@@ -45470,6 +45491,7 @@ spec:
                                 description: |-
                                   Name defines the name of the service.
                                   If Name is empty, the controller will generate a service name from the owning object.
+                                maxLength: 63
                                 type: string
                               type:
                                 default: LoadBalancer
@@ -45510,14 +45532,17 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the resource.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         namespace:
                           description: Namespace is the namespace of the resource.
+                          maxLength: 63
                           type: string
                       required:
                       - name
                       type: object
+                    maxItems: 32
                     type: array
                   resources:
                     description: |-

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -8988,6 +8988,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9018,6 +9019,7 @@ spec:
                     properties:
                       name:
                         description: Ref is the name of the DataPlane to configure.
+                        maxLength: 63
                         minLength: 1
                         type: string
                     required:
@@ -9048,6 +9050,9 @@ spec:
                     description: |-
                       ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                       the configuration checksum has not changed since previous update.
+                    enum:
+                    - enabled
+                    - disabled
                     type: string
                   timeout:
                     description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -9105,6 +9110,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9143,6 +9149,7 @@ spec:
                   which Ingress resources this ControlPlane should be responsible for.
 
                   If omitted, Ingress resources will not be supported by the ControlPlane.
+                maxLength: 63
                 type: string
               konnect:
                 description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -9283,7 +9290,9 @@ spec:
                       List is a list of namespaces to watch for resources.
                       Only used when Type is set to List.
                     items:
+                      maxLength: 64
                       type: string
+                    maxItems: 64
                     type: array
                   type:
                     description: |-
@@ -9386,6 +9395,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9410,6 +9420,7 @@ spec:
                 properties:
                   name:
                     description: Name is the name of the DataPlane.
+                    maxLength: 63
                     minLength: 1
                     type: string
                 required:
@@ -9424,6 +9435,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -36429,6 +36441,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the controller.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36457,6 +36470,9 @@ spec:
                         description: |-
                           ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                           the configuration checksum has not changed since previous update.
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                       timeout:
                         description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -36471,6 +36487,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the feature gate.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36509,6 +36526,7 @@ spec:
                       which Ingress resources this ControlPlane should be responsible for.
 
                       If omitted, Ingress resources will not be supported by the ControlPlane.
+                    maxLength: 63
                     type: string
                   konnect:
                     description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -36649,7 +36667,9 @@ spec:
                           List is a list of namespaces to watch for resources.
                           Only used when Type is set to List.
                         items:
+                          maxLength: 64
                           type: string
+                        maxItems: 64
                         type: array
                       type:
                         description: |-
@@ -45398,6 +45418,7 @@ spec:
                                   required:
                                   - type
                                   type: object
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-type: atomic
                               minReplicas:
@@ -45470,6 +45491,7 @@ spec:
                                 description: |-
                                   Name defines the name of the service.
                                   If Name is empty, the controller will generate a service name from the owning object.
+                                maxLength: 63
                                 type: string
                               type:
                                 default: LoadBalancer
@@ -45510,14 +45532,17 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the resource.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         namespace:
                           description: Namespace is the namespace of the resource.
+                          maxLength: 63
                           type: string
                       required:
                       - name
                       type: object
+                    maxItems: 32
                     type: array
                   resources:
                     description: |-

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -661,6 +661,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -691,6 +692,7 @@ spec:
                     properties:
                       name:
                         description: Ref is the name of the DataPlane to configure.
+                        maxLength: 63
                         minLength: 1
                         type: string
                     required:
@@ -721,6 +723,9 @@ spec:
                     description: |-
                       ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                       the configuration checksum has not changed since previous update.
+                    enum:
+                    - enabled
+                    - disabled
                     type: string
                   timeout:
                     description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -778,6 +783,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -816,6 +822,7 @@ spec:
                   which Ingress resources this ControlPlane should be responsible for.
 
                   If omitted, Ingress resources will not be supported by the ControlPlane.
+                maxLength: 63
                 type: string
               konnect:
                 description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -956,7 +963,9 @@ spec:
                       List is a list of namespaces to watch for resources.
                       Only used when Type is set to List.
                     items:
+                      maxLength: 64
                       type: string
+                    maxItems: 64
                     type: array
                   type:
                     description: |-
@@ -1059,6 +1068,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -1083,6 +1093,7 @@ spec:
                 properties:
                   name:
                     description: Name is the name of the DataPlane.
+                    maxLength: 63
                     minLength: 1
                     type: string
                 required:
@@ -1097,6 +1108,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -10769,6 +10781,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the controller.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -10797,6 +10810,9 @@ spec:
                         description: |-
                           ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                           the configuration checksum has not changed since previous update.
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                       timeout:
                         description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -10811,6 +10827,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the feature gate.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -10849,6 +10866,7 @@ spec:
                       which Ingress resources this ControlPlane should be responsible for.
 
                       If omitted, Ingress resources will not be supported by the ControlPlane.
+                    maxLength: 63
                     type: string
                   konnect:
                     description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -10989,7 +11007,9 @@ spec:
                           List is a list of namespaces to watch for resources.
                           Only used when Type is set to List.
                         items:
+                          maxLength: 64
                           type: string
+                        maxItems: 64
                         type: array
                       type:
                         description: |-
@@ -19738,6 +19758,7 @@ spec:
                                   required:
                                   - type
                                   type: object
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-type: atomic
                               minReplicas:
@@ -19810,6 +19831,7 @@ spec:
                                 description: |-
                                   Name defines the name of the service.
                                   If Name is empty, the controller will generate a service name from the owning object.
+                                maxLength: 63
                                 type: string
                               type:
                                 default: LoadBalancer
@@ -19850,14 +19872,17 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the resource.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         namespace:
                           description: Namespace is the namespace of the resource.
+                          maxLength: 63
                           type: string
                       required:
                       - name
                       type: object
+                    maxItems: 32
                     type: array
                   resources:
                     description: |-

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -8938,6 +8938,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -8968,6 +8969,7 @@ spec:
                     properties:
                       name:
                         description: Ref is the name of the DataPlane to configure.
+                        maxLength: 63
                         minLength: 1
                         type: string
                     required:
@@ -8998,6 +9000,9 @@ spec:
                     description: |-
                       ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                       the configuration checksum has not changed since previous update.
+                    enum:
+                    - enabled
+                    - disabled
                     type: string
                   timeout:
                     description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -9055,6 +9060,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9093,6 +9099,7 @@ spec:
                   which Ingress resources this ControlPlane should be responsible for.
 
                   If omitted, Ingress resources will not be supported by the ControlPlane.
+                maxLength: 63
                 type: string
               konnect:
                 description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -9233,7 +9240,9 @@ spec:
                       List is a list of namespaces to watch for resources.
                       Only used when Type is set to List.
                     items:
+                      maxLength: 64
                       type: string
+                    maxItems: 64
                     type: array
                   type:
                     description: |-
@@ -9336,6 +9345,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9360,6 +9370,7 @@ spec:
                 properties:
                   name:
                     description: Name is the name of the DataPlane.
+                    maxLength: 63
                     minLength: 1
                     type: string
                 required:
@@ -9374,6 +9385,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -36379,6 +36391,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the controller.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36407,6 +36420,9 @@ spec:
                         description: |-
                           ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                           the configuration checksum has not changed since previous update.
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                       timeout:
                         description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -36421,6 +36437,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the feature gate.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -36459,6 +36476,7 @@ spec:
                       which Ingress resources this ControlPlane should be responsible for.
 
                       If omitted, Ingress resources will not be supported by the ControlPlane.
+                    maxLength: 63
                     type: string
                   konnect:
                     description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -36599,7 +36617,9 @@ spec:
                           List is a list of namespaces to watch for resources.
                           Only used when Type is set to List.
                         items:
+                          maxLength: 64
                           type: string
+                        maxItems: 64
                         type: array
                       type:
                         description: |-
@@ -45348,6 +45368,7 @@ spec:
                                   required:
                                   - type
                                   type: object
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-type: atomic
                               minReplicas:
@@ -45420,6 +45441,7 @@ spec:
                                 description: |-
                                   Name defines the name of the service.
                                   If Name is empty, the controller will generate a service name from the owning object.
+                                maxLength: 63
                                 type: string
                               type:
                                 default: LoadBalancer
@@ -45460,14 +45482,17 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the resource.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         namespace:
                           description: Namespace is the namespace of the resource.
+                          maxLength: 63
                           type: string
                       required:
                       - name
                       type: object
+                    maxItems: 32
                     type: array
                   resources:
                     description: |-

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -636,6 +636,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -666,6 +667,7 @@ spec:
                     properties:
                       name:
                         description: Ref is the name of the DataPlane to configure.
+                        maxLength: 63
                         minLength: 1
                         type: string
                     required:
@@ -696,6 +698,9 @@ spec:
                     description: |-
                       ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                       the configuration checksum has not changed since previous update.
+                    enum:
+                    - enabled
+                    - disabled
                     type: string
                   timeout:
                     description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -753,6 +758,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -791,6 +797,7 @@ spec:
                   which Ingress resources this ControlPlane should be responsible for.
 
                   If omitted, Ingress resources will not be supported by the ControlPlane.
+                maxLength: 63
                 type: string
               konnect:
                 description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -931,7 +938,9 @@ spec:
                       List is a list of namespaces to watch for resources.
                       Only used when Type is set to List.
                     items:
+                      maxLength: 64
                       type: string
+                    maxItems: 64
                     type: array
                   type:
                     description: |-
@@ -1034,6 +1043,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -1058,6 +1068,7 @@ spec:
                 properties:
                   name:
                     description: Name is the name of the DataPlane.
+                    maxLength: 63
                     minLength: 1
                     type: string
                 required:
@@ -1072,6 +1083,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -10744,6 +10756,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the controller.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -10772,6 +10785,9 @@ spec:
                         description: |-
                           ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                           the configuration checksum has not changed since previous update.
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                       timeout:
                         description: Timeout is the timeout of a single run of syncing Kong configuration with dataplanes.
@@ -10786,6 +10802,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the feature gate.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -10824,6 +10841,7 @@ spec:
                       which Ingress resources this ControlPlane should be responsible for.
 
                       If omitted, Ingress resources will not be supported by the ControlPlane.
+                    maxLength: 63
                     type: string
                   konnect:
                     description: Konnect defines the Konnect-related configuration options for the ControlPlane.
@@ -10964,7 +10982,9 @@ spec:
                           List is a list of namespaces to watch for resources.
                           Only used when Type is set to List.
                         items:
+                          maxLength: 64
                           type: string
+                        maxItems: 64
                         type: array
                       type:
                         description: |-
@@ -19713,6 +19733,7 @@ spec:
                                   required:
                                   - type
                                   type: object
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-type: atomic
                               minReplicas:
@@ -19785,6 +19806,7 @@ spec:
                                 description: |-
                                   Name defines the name of the service.
                                   If Name is empty, the controller will generate a service name from the owning object.
+                                maxLength: 63
                                 type: string
                               type:
                                 default: LoadBalancer
@@ -19825,14 +19847,17 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the resource.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         namespace:
                           description: Namespace is the namespace of the resource.
+                          maxLength: 63
                           type: string
                       required:
                       - name
                       type: object
+                    maxItems: 32
                     type: array
                   resources:
                     description: |-

--- a/config/crd/kong-operator/gateway-operator.konghq.com_controlplanes.yaml
+++ b/config/crd/kong-operator/gateway-operator.konghq.com_controlplanes.yaml
@@ -8848,6 +8848,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -8879,6 +8880,7 @@ spec:
                     properties:
                       name:
                         description: Ref is the name of the DataPlane to configure.
+                        maxLength: 63
                         minLength: 1
                         type: string
                     required:
@@ -8911,6 +8913,9 @@ spec:
                     description: |-
                       ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                       the configuration checksum has not changed since previous update.
+                    enum:
+                    - enabled
+                    - disabled
                     type: string
                   timeout:
                     description: Timeout is the timeout of a single run of syncing
@@ -8972,6 +8977,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9012,6 +9018,7 @@ spec:
                   which Ingress resources this ControlPlane should be responsible for.
 
                   If omitted, Ingress resources will not be supported by the ControlPlane.
+                maxLength: 63
                 type: string
               konnect:
                 description: Konnect defines the Konnect-related configuration options
@@ -9167,7 +9174,9 @@ spec:
                       List is a list of namespaces to watch for resources.
                       Only used when Type is set to List.
                     items:
+                      maxLength: 64
                       type: string
+                    maxItems: 64
                     type: array
                   type:
                     description: |-
@@ -9273,6 +9282,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the controller.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:
@@ -9298,6 +9308,7 @@ spec:
                 properties:
                   name:
                     description: Name is the name of the DataPlane.
+                    maxLength: 63
                     minLength: 1
                     type: string
                 required:
@@ -9313,6 +9324,7 @@ spec:
                   properties:
                     name:
                       description: Name is the name of the feature gate.
+                      maxLength: 63
                       minLength: 1
                       type: string
                     state:

--- a/config/crd/kong-operator/gateway-operator.konghq.com_gatewayconfigurations.yaml
+++ b/config/crd/kong-operator/gateway-operator.konghq.com_gatewayconfigurations.yaml
@@ -18612,6 +18612,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the controller.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -18643,6 +18644,9 @@ spec:
                         description: |-
                           ReverseSync sends configuration to DataPlane (Kong Gateway) even if
                           the configuration checksum has not changed since previous update.
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                       timeout:
                         description: Timeout is the timeout of a single run of syncing
@@ -18659,6 +18663,7 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the feature gate.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         state:
@@ -18699,6 +18704,7 @@ spec:
                       which Ingress resources this ControlPlane should be responsible for.
 
                       If omitted, Ingress resources will not be supported by the ControlPlane.
+                    maxLength: 63
                     type: string
                   konnect:
                     description: Konnect defines the Konnect-related configuration
@@ -18857,7 +18863,9 @@ spec:
                           List is a list of namespaces to watch for resources.
                           Only used when Type is set to List.
                         items:
+                          maxLength: 64
                           type: string
+                        maxItems: 64
                         type: array
                       type:
                         description: |-
@@ -28213,6 +28221,7 @@ spec:
                                   required:
                                   - type
                                   type: object
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-type: atomic
                               minReplicas:
@@ -28286,6 +28295,7 @@ spec:
                                 description: |-
                                   Name defines the name of the service.
                                   If Name is empty, the controller will generate a service name from the owning object.
+                                maxLength: 63
                                 type: string
                               type:
                                 default: LoadBalancer
@@ -28329,14 +28339,17 @@ spec:
                       properties:
                         name:
                           description: Name is the name of the resource.
+                          maxLength: 63
                           minLength: 1
                           type: string
                         namespace:
                           description: Namespace is the namespace of the resource.
+                          maxLength: 63
                           type: string
                       required:
                       - name
                       type: object
+                    maxItems: 32
                     type: array
                   resources:
                     description: |-

--- a/controller/controlplane/manager_options.go
+++ b/controller/controlplane/manager_options.go
@@ -588,7 +588,7 @@ func WithKonnectOptions(konnectOptions *operatorv2beta1.ControlPlaneKonnectOptio
 				c.Konnect.LicensePollingPeriod = licensing.PollingPeriod.Duration
 			}
 			if licensing.StorageState != nil {
-				c.Konnect.LicenseStorageEnabled = (*licensing.StorageState == operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled)
+				c.Konnect.LicenseStorageEnabled = (*licensing.StorageState == operatorv2beta1.ControlPlaneKonnectLicenseStorageStateEnabled)
 			}
 		}
 

--- a/controller/controlplane/manager_options_test.go
+++ b/controller/controlplane/manager_options_test.go
@@ -1127,8 +1127,8 @@ func TestWithKonnectOptions(t *testing.T) {
 					}(),
 					InitialPollingPeriod: &metav1.Duration{Duration: 5 * time.Minute},
 					PollingPeriod:        &metav1.Duration{Duration: 10 * time.Minute},
-					StorageState: func() *operatorv2beta1.ControlPlaneKonnectLicensingState {
-						state := operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled
+					StorageState: func() *operatorv2beta1.ControlPlaneKonnectLicenseStorageState {
+						state := operatorv2beta1.ControlPlaneKonnectLicenseStorageStateEnabled
 						return &state
 					}(),
 				},

--- a/docs/all-api-reference.md
+++ b/docs/all-api-reference.md
@@ -4049,6 +4049,26 @@ Allowed values:
 | `enabled` | ControlPlaneKonnectConsumersSyncStateEnabled indicates that consumer synchronization is enabled.<br /> |
 | `disabled` | ControlPlaneKonnectConsumersSyncStateDisabled indicates that consumer synchronization is disabled.<br /> |
 
+#### ControlPlaneKonnectLicenseStorageState
+
+_Underlying type:_ `string`
+
+ControlPlaneKonnectLicenseStorageState defines the state of Konnect licensing.
+
+
+
+
+_Appears in:_
+
+- [ControlPlaneKonnectLicensing](#gateway-operator-konghq-com-v2beta1-types-controlplanekonnectlicensing)
+
+Allowed values:
+
+| Value | Description |
+| --- | --- |
+| `enabled` | ControlPlaneKonnectLicenseStorageStateEnabled indicates that Konnect license storage is enabled.<br /> |
+| `disabled` | ControlPlaneKonnectLicenseStorageStateDisabled indicates that Konnect license storage is disabled.<br /> |
+
 #### ControlPlaneKonnectLicensing
 
 
@@ -4061,7 +4081,7 @@ ControlPlaneKonnectLicensing defines the configuration for Konnect licensing.
 | `state` _[ControlPlaneKonnectLicensingState](#gateway-operator-konghq-com-v2beta1-types-controlplanekonnectlicensingstate)_ | State indicates whether Konnect licensing is enabled. |
 | `initialPollingPeriod` _*k8s.io/apimachinery/pkg/apis/meta/v1.Duration_ | InitialPollingPeriod is the initial polling period for license checks. |
 | `pollingPeriod` _*k8s.io/apimachinery/pkg/apis/meta/v1.Duration_ | PollingPeriod is the polling period for license checks. |
-| `storageState` _[ControlPlaneKonnectLicensingState](#gateway-operator-konghq-com-v2beta1-types-controlplanekonnectlicensingstate)_ | StorageState indicates whether to store licenses fetched from Konnect to Secrets locally to use them later when connection to Konnect is broken. Only effective when State is set to enabled. |
+| `storageState` _[ControlPlaneKonnectLicenseStorageState](#gateway-operator-konghq-com-v2beta1-types-controlplanekonnectlicensestoragestate)_ | StorageState indicates whether to store licenses fetched from Konnect to Secrets locally to use them later when connection to Konnect is broken. Only effective when State is set to enabled. |
 
 _Appears in:_
 

--- a/docs/gateway-operator-api-reference.md
+++ b/docs/gateway-operator-api-reference.md
@@ -1788,6 +1788,26 @@ Allowed values:
 | `enabled` | ControlPlaneKonnectConsumersSyncStateEnabled indicates that consumer synchronization is enabled.<br /> |
 | `disabled` | ControlPlaneKonnectConsumersSyncStateDisabled indicates that consumer synchronization is disabled.<br /> |
 
+#### ControlPlaneKonnectLicenseStorageState
+
+_Underlying type:_ `string`
+
+ControlPlaneKonnectLicenseStorageState defines the state of Konnect licensing.
+
+
+
+
+_Appears in:_
+
+- [ControlPlaneKonnectLicensing](#gateway-operator-konghq-com-v2beta1-types-controlplanekonnectlicensing)
+
+Allowed values:
+
+| Value | Description |
+| --- | --- |
+| `enabled` | ControlPlaneKonnectLicenseStorageStateEnabled indicates that Konnect license storage is enabled.<br /> |
+| `disabled` | ControlPlaneKonnectLicenseStorageStateDisabled indicates that Konnect license storage is disabled.<br /> |
+
 #### ControlPlaneKonnectLicensing
 
 
@@ -1800,7 +1820,7 @@ ControlPlaneKonnectLicensing defines the configuration for Konnect licensing.
 | `state` _[ControlPlaneKonnectLicensingState](#gateway-operator-konghq-com-v2beta1-types-controlplanekonnectlicensingstate)_ | State indicates whether Konnect licensing is enabled. |
 | `initialPollingPeriod` _*k8s.io/apimachinery/pkg/apis/meta/v1.Duration_ | InitialPollingPeriod is the initial polling period for license checks. |
 | `pollingPeriod` _*k8s.io/apimachinery/pkg/apis/meta/v1.Duration_ | PollingPeriod is the polling period for license checks. |
-| `storageState` _[ControlPlaneKonnectLicensingState](#gateway-operator-konghq-com-v2beta1-types-controlplanekonnectlicensingstate)_ | StorageState indicates whether to store licenses fetched from Konnect to Secrets locally to use them later when connection to Konnect is broken. Only effective when State is set to enabled. |
+| `storageState` _[ControlPlaneKonnectLicenseStorageState](#gateway-operator-konghq-com-v2beta1-types-controlplanekonnectlicensestoragestate)_ | StorageState indicates whether to store licenses fetched from Konnect to Secrets locally to use them later when connection to Konnect is broken. Only effective when State is set to enabled. |
 
 _Appears in:_
 

--- a/test/crdsvalidation/gateway-operator.konghq.com/controlplane_v2_test.go
+++ b/test/crdsvalidation/gateway-operator.konghq.com/controlplane_v2_test.go
@@ -824,7 +824,7 @@ func TestControlPlaneV2(t *testing.T) {
 										State:                lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
 										InitialPollingPeriod: lo.ToPtr(metav1.Duration{Duration: 30 * time.Second}),
 										PollingPeriod:        lo.ToPtr(metav1.Duration{Duration: 300 * time.Second}),
-										StorageState:         lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
+										StorageState:         lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicenseStorageStateEnabled),
 									},
 									NodeRefreshPeriod:  lo.ToPtr(metav1.Duration{Duration: 60 * time.Second}),
 									ConfigUploadPeriod: lo.ToPtr(metav1.Duration{Duration: 30 * time.Second}),
@@ -919,7 +919,7 @@ func TestControlPlaneV2(t *testing.T) {
 								Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
 									Licensing: &operatorv2beta1.ControlPlaneKonnectLicensing{
 										State:        lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateDisabled),
-										StorageState: lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateDisabled),
+										StorageState: lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicenseStorageStateDisabled),
 									},
 								},
 							},
@@ -939,7 +939,7 @@ func TestControlPlaneV2(t *testing.T) {
 										State:                lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
 										InitialPollingPeriod: lo.ToPtr(metav1.Duration{Duration: 30 * time.Second}),
 										PollingPeriod:        lo.ToPtr(metav1.Duration{Duration: 300 * time.Second}),
-										StorageState:         lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
+										StorageState:         lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicenseStorageStateEnabled),
 									},
 								},
 							},
@@ -959,7 +959,7 @@ func TestControlPlaneV2(t *testing.T) {
 										State:                lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
 										InitialPollingPeriod: lo.ToPtr(metav1.Duration{Duration: 30 * time.Second}),
 										PollingPeriod:        lo.ToPtr(metav1.Duration{Duration: 300 * time.Second}),
-										StorageState:         lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateDisabled),
+										StorageState:         lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicenseStorageStateDisabled),
 									},
 								},
 							},
@@ -977,7 +977,7 @@ func TestControlPlaneV2(t *testing.T) {
 								Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
 									Licensing: &operatorv2beta1.ControlPlaneKonnectLicensing{
 										State:        lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
-										StorageState: lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingState("invalid")),
+										StorageState: lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicenseStorageState("invalid")),
 									},
 								},
 							},
@@ -996,7 +996,7 @@ func TestControlPlaneV2(t *testing.T) {
 								Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
 									Licensing: &operatorv2beta1.ControlPlaneKonnectLicensing{
 										State:        lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateDisabled),
-										StorageState: lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
+										StorageState: lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicenseStorageStateEnabled),
 									},
 								},
 							},


### PR DESCRIPTION
**What this PR does / why we need it**:

Some of these changes can be considered breaking as for example limiting the max length of names but they are limited to 63 characters which is max label key and value length (and we're using those names as label values in several plances) in k8s https://kubernetes.io/docs/concepts/overview/working-with-objects/names/.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
