### PR TITLE
tests: take ownership of CRDs between ct install tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -744,12 +744,22 @@ test.charts.ct.install:
 # for each release. Without this, some objects like CRDs can still be around
 # when another test helm release is being installed and the above mentioned
 # ownership error will be returned.
+#
+# NOTE: We add the --take-ownership below to ensure that we take ownership of
+# existing CRDs installed by prior test runs. This technically shouldn't be an
+# issue but sometimes on CI the CRDs are left around from prior runs and
+# we get:
+# Error: INSTALLATION FAILED: Unable to continue with install: CustomResourceDefinition
+# "kongkeysets.configuration.konghq.com" in namespace "" exists and cannot be imported into
+# the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-name"
+# must equal "kong-operator-3xhr8uzhvr": current value is "kong-operator-8in3ojpws4"
 
 	ct install --target-branch main \
 		--debug \
 		--helm-extra-set-args "--set=ko-crds.keep=false" \
 		--helm-extra-args "--wait" \
 		--helm-extra-args "--timeout=3m" \
+		--helm-extra-args "--take-ownership" \
 		--charts charts/$(CHART_NAME) \
 		--namespace kong-test
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Try to avoid issues like: https://github.com/Kong/kong-operator/actions/runs/19730968341/job/56531759802?pr=2739#step:11:413

```
>>> helm install kong-operator-3xhr8uzhvr charts/kong-operator --namespace kong-test --wait --values charts/kong-operator/ci/disable-gateway-controller-values.yaml --timeout=3m --set=ko-crds.keep=false
...
Error: INSTALLATION FAILED: Unable to continue with install: CustomResourceDefinition "kongkeysets.configuration.konghq.com" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-name" must equal "kong-operator-3xhr8uzhvr": current value is "kong-operator-8in3ojpws4"
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
