### PR TITLE
tests: fix data race in TestSpecificGatewayNN

### DIFF
--- a/ingress-controller/test/envtest/specific_gateway_envtest_test.go
+++ b/ingress-controller/test/envtest/specific_gateway_envtest_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kong-operator/ingress-controller/internal/gatewayapi"
+	"github.com/kong/kong-operator/test/helpers/asserts"
 )
 
 func TestSpecificGatewayNN(t *testing.T) {
@@ -92,7 +93,7 @@ func TestSpecificGatewayNN(t *testing.T) {
 	})
 
 	t.Run("not configured gateway does not gets its listener status filled and HTTPRoute attached to it doesn't get its status parent filled", func(t *testing.T) {
-		require.Never(t, func() bool {
+		asserts.Never(t, func(ctx context.Context) bool {
 			t.Logf("Checking if Gateway %s is ignored (does not get status listeners filled)", nnIgnored)
 			var gwIgnored gatewayapi.Gateway
 			if err := ctrlClient.Get(ctx, nnIgnored, &gwIgnored); err != nil {
@@ -128,7 +129,7 @@ func TestSpecificGatewayNN(t *testing.T) {
 	})
 
 	t.Run("changes to gatewayclass used by not configured gateway do not get gateway's listener status filled", func(t *testing.T) {
-		require.Never(t, func() bool {
+		asserts.Never(t, func(ctx context.Context) bool {
 			gwcOld := gwc.DeepCopy()
 			gwc.Annotations = map[string]string{"foo": strconv.Itoa(time.Now().Nanosecond())}
 			if err := ctrlClient.Patch(ctx, &gwc, client.MergeFrom(gwcOld)); err != nil {
@@ -158,7 +159,7 @@ func TestSpecificGatewayNN(t *testing.T) {
 	})
 
 	t.Run("changes to httproute attached to ignored gateway do not get gateway's listener status filled", func(t *testing.T) {
-		require.Never(t, func() bool {
+		asserts.Never(t, func(ctx context.Context) bool {
 			routeIgnored := ignoredRoutes[0].DeepCopy()
 			routeIgnoredOld := routeIgnored.DeepCopy()
 			routeIgnored.Annotations = map[string]string{"foo": strconv.Itoa(time.Now().Nanosecond())}
@@ -211,7 +212,7 @@ func TestSpecificGatewayNN(t *testing.T) {
 		}
 		require.NoError(t, ctrlClient.Create(ctx, &refGrant))
 
-		require.Never(t, func() bool {
+		asserts.Never(t, func(ctx context.Context) bool {
 			refGrantOld := refGrant.DeepCopy()
 			refGrant.Annotations = map[string]string{"foo": strconv.Itoa(time.Now().Nanosecond())}
 			if err := ctrlClient.Patch(ctx, &refGrant, client.MergeFrom(refGrantOld)); err != nil {

--- a/test/helpers/asserts/never.go
+++ b/test/helpers/asserts/never.go
@@ -1,0 +1,49 @@
+package asserts
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Never asserts that the provided conditionFunc never returns true
+// within the specified waitTime, checking the condition every tickTime.
+// If the conditionFunc returns true at any point, the test fails with
+// the provided message and arguments.
+// The conditionFunc receives a context.Context which is derived from
+// the testing.T context, allowing for cancellation and timeouts.
+// The conditionFunc is run immediately upon entering the function,
+// in the same goroutine as the caller, thus it's a blocking call.
+func Never(
+	t *testing.T,
+	conditionFunc func(ctx context.Context) bool,
+	waitTime,
+	tickTime time.Duration,
+	msgAndArgs ...any,
+) {
+	t.Helper()
+	timer := time.NewTimer(waitTime)
+	defer timer.Stop()
+	if len(msgAndArgs) == 0 {
+		msgAndArgs = []any{""}
+	}
+
+	for {
+		tickTimer := time.NewTimer(tickTime)
+		defer tickTimer.Stop()
+
+		if conditionFunc(t.Context()) {
+			require.Fail(t, "Condition met unexpectedly: "+msgAndArgs[0].(string), msgAndArgs[1:]...)
+		}
+
+		select {
+		case <-tickTimer.C:
+		case <-t.Context().Done():
+			return
+		case <-timer.C:
+			return
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Attempt at solving: https://github.com/Kong/kong-operator/issues/2737

**Special notes for your reviewer**:

This has been running in a loop in CI and after a random unrelated flake it didn't fail: https://github.com/Kong/kong-operator/actions/runs/19732356576/job/56563232788?pr=2746.

<img width="333" height="1075" alt="image" src="https://github.com/user-attachments/assets/57ec35fa-ff81-4f4d-83a2-2fed35601a93" />

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
