### PR TITLE
tests: add init sync to TestStickySessionsNotSupportedEventGeneration

### DIFF
--- a/ingress-controller/test/envtest/configerrorevent_envtest_test.go
+++ b/ingress-controller/test/envtest/configerrorevent_envtest_test.go
@@ -277,6 +277,7 @@ func TestStickySessionsNotSupportedEventGeneration(t *testing.T) {
 		WithPublishService(ns.Name),
 		WithIngressClass(ingressClassName),
 		WithKongServiceFacadeFeatureEnabled(),
+		WithInitCacheSyncDuration(2*time.Second),
 		WithProxySyncInterval(100*time.Millisecond),
 		WithKongAdminURLs(kongContainer.AdminURL(ctx, t)),
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:

This test has been running for a while in a loop in CI https://github.com/Kong/kong-operator/actions/runs/19822170910/job/56884151162?pr=2763

<img width="350" height="414" alt="image" src="https://github.com/user-attachments/assets/8e7935d3-8558-4faa-90cc-43261aff1efd" />

There's been only 1 unrelated failure: https://github.com/Kong/kong-operator/actions/runs/19822170910/job/56881426985?pr=2763


```
    conditions.go:56: condition Type:ResolvedRefs, Status:False, Reason:RefNotPermitted missing from route:65f955e2-66e0-4a13-9ac8-1aa980578b86/e6959ebd-b57a-43b3-960e-13a48c201813 status
    conditions.go:56: condition Type:ResolvedRefs, Status:False, Reason:RefNotPermitted missing from route:65f955e2-66e0-4a13-9ac8-1aa980578b86/e6959ebd-b57a-43b3-960e-13a48c201813 status
    conditions.go:56: condition Type:ResolvedRefs, Status:False, Reason:RefNotPermitted missing from route:65f955e2-66e0-4a13-9ac8-1aa980578b86/e6959ebd-b57a-43b3-960e-13a48c201813 status
    conditions.go:56: condition Type:ResolvedRefs, Status:False, Reason:RefNotPermitted missing from route:65f955e2-66e0-4a13-9ac8-1aa980578b86/e6959ebd-b57a-43b3-960e-13a48c201813 status
    conditions.go:56: condition Type:ResolvedRefs, Status:False, Reason:RefNotPermitted missing from route:65f955e2-66e0-4a13-9ac8-1aa980578b86/e6959ebd-b57a-43b3-960e-13a48c201813 status
    httproute_controller_test.go:254: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/ingress-controller/test/envtest/httproute_controller_test.go:254
        	Error:      	Condition never satisfied
        	Test:       	TestHTTPRouteReconcilerProperlyReactsToReferenceGrant
    httproute_controller_test.go:264: HTTPRoute 65f955e2-66e0-4a13-9ac8-1aa980578b86/e6959ebd-b57a-43b3-960e-13a48c201813 has the following Parents in Status:
        Parent 221e4865-c7ef-4805-be8a-44fcdd2f6c2d/23a061aa-e684-4dfd-94de-82a9796fa27f: 
        	condition: Type:Accepted, Status:True, Reason:Accepted, ObservedGeneration:1
        	condition: Type:ResolvedRefs, Status:True, Reason:ResolvedRefs, ObservedGeneration:1
        	condition: Type:Programmed, Status:Unknown, Reason:Unknown, ObservedGeneration:1
        
    controller.go:67: Test TestHTTPRouteReconcilerProperlyReactsToReferenceGrant failed: dumping controller logs
    controller.go:67: 2025-12-02T08:40:36Z	info	Starting EventSource	{"source": "kind source: *v1beta1.ReferenceGrant"}
    controller.go:67: 2025-12-02T08:40:36Z	info	Starting EventSource	{"source": "kind source: *v1.HTTPRoute"}
    controller.go:67: 2025-12-02T08:40:36Z	info	Starting EventSource	{"source": "kind source: *v1.Gateway"}
    controller.go:67: 2025-12-02T08:40:36Z	info	Starting EventSource	{"source": "kind source: *v1.GatewayClass"}
    controller.go:67: 2025-12-02T08:40:36Z	info	Starting Controller
    controller.go:67: 2025-12-02T08:40:36Z	info	Starting workers	{"worker count": 1}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Processing httproute	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Checking deletion timestamp	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Retrieving GatewayClass and Gateway for route	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Checking if the httproute's gateways are ready	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Ensuring status contains Gateway associations	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Processing httproute	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Checking deletion timestamp	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Retrieving GatewayClass and Gateway for route	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Checking if the httproute's gateways are ready	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Ensuring status contains Gateway associations	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Processing httproute	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Checking deletion timestamp	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Retrieving GatewayClass and Gateway for route	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Checking if the httproute's gateways are ready	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Ensuring status contains Gateway associations	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Ensuring status contains Programmed condition	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	info	HTTPRoute has been configured on the data-plane	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Processing httproute	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Checking deletion timestamp	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Retrieving GatewayClass and Gateway for route	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Checking if the httproute's gateways are ready	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Ensuring status contains Gateway associations	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	debug	Ensuring status contains Programmed condition	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:36Z	info	HTTPRoute has been configured on the data-plane	{"GatewayV1HTTPRoute": {"name":"e6959ebd-b57a-43b3-960e-13a48c201813","namespace":"65f955e2-66e0-4a13-9ac8-1aa980578b86"}, "namespace": "65f955e2-66e0-4a13-9ac8-1aa980578b86", "name": "e6959ebd-b57a-43b3-960e-13a48c201813"}
    controller.go:67: 2025-12-02T08:40:41Z	info	Stopping and waiting for non leader election runnables
    controller.go:67: 2025-12-02T08:40:41Z	info	Stopping and waiting for leader election runnables
    controller.go:67: 2025-12-02T08:40:41Z	info	Stopping and waiting for warmup runnables
    controller.go:67: 2025-12-02T08:40:41Z	info	Shutdown signal received, waiting for all workers to finish
    controller.go:67: 2025-12-02T08:40:41Z	info	All workers finished
    controller.go:67: 2025-12-02T08:40:41Z	info	Stopping and waiting for caches
    controller.go:67: 2025-12-02T08:40:41Z	info	Stopping and waiting for webhooks
    controller.go:67: 2025-12-02T08:40:41Z	info	Stopping and waiting for HTTP servers
    controller.go:67: 2025-12-02T08:40:41Z	info	Wait completed, proceeding to shutdown the manager
```

**Which issue this PR fixes**

Fixes https://github.com/Kong/kong-operator/issues/2082

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
