### PR TITLE
test(envtest): Add envtest case for adoption of remaining resources

### DIFF
--- a/test/helpers/deploy/deploy_resources.go
+++ b/test/helpers/deploy/deploy_resources.go
@@ -825,6 +825,36 @@ func KongCertificateAttachedToCP(
 	return cert
 }
 
+// KongCertificateAttachedToCPWithProgrammed deploys a KongCertificate resource attached to CP
+// with the "programmed" condition and the given Konnect ID in the status.
+func KongCertificateAttachedToCPWithProgrammed(
+	t *testing.T,
+	ctx context.Context,
+	cl client.Client,
+	cp *konnectv1alpha2.KonnectGatewayControlPlane,
+	konnectID string,
+	opts ...ObjOption,
+) *configurationv1alpha1.KongCertificate {
+	t.Helper()
+
+	cert := KongCertificateAttachedToCP(t, ctx, cl, cp, opts...)
+
+	if konnectID != "" {
+		cert.SetKonnectID(konnectID)
+	}
+	cert.Status.Conditions = []metav1.Condition{
+		{
+			Type:               konnectv1alpha1.KonnectEntityProgrammedConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             konnectv1alpha1.KonnectEntityProgrammedReasonProgrammed,
+			ObservedGeneration: cert.GetGeneration(),
+			LastTransitionTime: metav1.Now(),
+		},
+	}
+	require.NoError(t, cl.Status().Update(ctx, cert))
+	return cert
+}
+
 // KongUpstream deploys a KongUpstream resource and returns it.
 func KongUpstream(
 	t *testing.T,


### PR DESCRIPTION
**What this PR does / why we need it**:

Add envtest cases for adopting of existing resource with the following kinds:

- `KongConusmerGroup`
- `KongCACertificate`
- `KongCertificate`
- `KongKey`
- `KongKeySet`
- `KongSNI`
- `KongVault`

**Which issue this PR fixes**

Fixes #2545 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
