### PR TITLE
fix: fix empty `KonnectAPIAuthConfiguration` reference in condition

### DIFF
--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -309,14 +309,7 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	var apiAuth konnectv1alpha1.KonnectAPIAuthConfiguration
 	err = r.Get(ctx, apiAuthRef, &apiAuth)
-	if requeue, res, retErr := handleAPIAuthStatusCondition(
-		ctx,
-		r.Client,
-		&ext,
-		apiAuth,
-		err,
-		readyCondition,
-	); requeue {
+	if requeue, res, retErr := handleAPIAuthStatusCondition(ctx, r.Client, &ext, apiAuth, apiAuthRef, err, readyCondition); requeue {
 		return res, retErr
 	}
 

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -352,7 +352,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 
 	var apiAuth konnectv1alpha1.KonnectAPIAuthConfiguration
 	err = r.Client.Get(ctx, apiAuthRef, &apiAuth)
-	if requeue, res, retErr := handleAPIAuthStatusCondition(ctx, r.Client, ent, apiAuth, err); requeue {
+	if requeue, res, retErr := handleAPIAuthStatusCondition(ctx, r.Client, ent, apiAuth, apiAuthRef, err); requeue {
 		return res, retErr
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When controller fails to get the `KonnectAPIAuthConfiguration`, it will end up trying to the the namespaced name from the empty object.

This PR fixes it.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
