### PR TITLE
tests: skip flaky test TestStickySessionsNotSupportedEventGeneration

### DIFF
--- a/ingress-controller/test/envtest/configerrorevent_envtest_test.go
+++ b/ingress-controller/test/envtest/configerrorevent_envtest_test.go
@@ -207,6 +207,8 @@ func TestConfigErrorEventGenerationDBMode(t *testing.T) {
 }
 
 func TestStickySessionsNotSupportedEventGeneration(t *testing.T) {
+	t.Skip("skipping flaky test, TODO: https://github.com/Kong/kong-operator/issues/2082")
+
 	// Can't be run in parallel because we're using t.Setenv() below which doesn't allow it.
 
 	ctx, cancel := context.WithCancel(t.Context())


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Related: https://github.com/Kong/kong-operator/issues/2082

**Special notes for your reviewer**:

https://github.com/Kong/kong-operator/pull/2763 attempts at solving the flakiness by adding init cache sync timeout but before that solution is verified, let's skip the test to prevent failures in CI.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
