### PR TITLE
tests: fix TestGatewayWithGatewayClassReconciliation

### DIFF
--- a/ingress-controller/internal/controllers/gateway/gateway_controller.go
+++ b/ingress-controller/internal/controllers/gateway/gateway_controller.go
@@ -51,7 +51,6 @@ type GatewayReconciler struct {
 	Scheme          *runtime.Scheme
 	DataplaneClient controllers.DataPlane
 
-	WatchNamespaces  []string
 	CacheSyncTimeout time.Duration
 
 	ReferenceIndexers ctrlref.CacheIndexers

--- a/ingress-controller/internal/manager/controllerdef.go
+++ b/ingress-controller/internal/manager/controllerdef.go
@@ -304,7 +304,6 @@ func setupControllers(
 					PublishServiceUDPRef: c.PublishServiceUDP,
 					AddressOverrides:     c.PublishStatusAddress,
 					AddressOverridesUDP:  c.PublishStatusAddressUDP,
-					WatchNamespaces:      c.WatchNamespaces,
 					CacheSyncTimeout:     c.CacheSyncTimeout,
 					ReferenceIndexers:    referenceIndexers,
 					GatewayNN:            controllers.NewOptionalNamespacedName(c.GatewayToReconcile),

--- a/ingress-controller/test/envtest/gatewayclass_envtest_test.go
+++ b/ingress-controller/test/envtest/gatewayclass_envtest_test.go
@@ -194,7 +194,7 @@ func TestGatewayWithGatewayClassReconciliation(t *testing.T) {
 				asserts.Never(t, func(ctx context.Context) bool {
 					var gateway gatewayapi.Gateway
 					nn := client.ObjectKeyFromObject(&gw)
-if err := cl.Get(ctx, nn, &gateway); err != nil {
+					if err := cl.Get(ctx, nn, &gateway); err != nil {
 						t.Logf("error getting Gateway %s: %v", nn, err)
 						return true
 					}

--- a/ingress-controller/test/envtest/gatewayclass_envtest_test.go
+++ b/ingress-controller/test/envtest/gatewayclass_envtest_test.go
@@ -107,8 +107,7 @@ func TestGatewayWithGatewayClassReconciliation(t *testing.T) {
 				asserts.Never(t, func(ctx context.Context) bool {
 					var gateway gatewayapi.Gateway
 					nn := client.ObjectKeyFromObject(&gw)
-					err := cl.Get(ctx, nn, &gateway)
-					if err != nil {
+					if err := cl.Get(ctx, nn, &gateway); err != nil {
 						t.Logf("error getting Gateway %s: %v", nn, err)
 						return true
 					}
@@ -195,8 +194,7 @@ func TestGatewayWithGatewayClassReconciliation(t *testing.T) {
 				asserts.Never(t, func(ctx context.Context) bool {
 					var gateway gatewayapi.Gateway
 					nn := client.ObjectKeyFromObject(&gw)
-					err := cl.Get(ctx, nn, &gateway)
-					if err != nil {
+if err := cl.Get(ctx, nn, &gateway); err != nil {
 						t.Logf("error getting Gateway %s: %v", nn, err)
 						return true
 					}
@@ -265,8 +263,7 @@ func TestGatewayWithGatewayClassReconciliation(t *testing.T) {
 				asserts.Never(t, func(ctx context.Context) bool {
 					var gateway gatewayapi.Gateway
 					nn := client.ObjectKeyFromObject(&gw)
-					err := cl.Get(ctx, nn, &gateway)
-					if err != nil {
+					if err := cl.Get(ctx, nn, &gateway); err != nil {
 						t.Logf("error getting Gateway %s: %v", nn, err)
 						return true
 					}

--- a/ingress-controller/test/envtest/httproute_controller_test.go
+++ b/ingress-controller/test/envtest/httproute_controller_test.go
@@ -68,7 +68,7 @@ func TestHTTPRouteReconcilerProperlyReactsToReferenceGrant(t *testing.T) {
 		},
 	}
 	require.NoError(t, client.Create(ctx, &svc))
-	StartReconcilers(ctx, t, client.Scheme(), cfg, reconciler)
+	StartReconciler(ctx, t, client.Scheme(), cfg, reconciler)
 
 	gwc := gatewayapi.GatewayClass{
 		Spec: gatewayapi.GatewayClassSpec{
@@ -284,7 +284,7 @@ func TestHTTPRouteReconciler_RemovesOutdatedParentStatuses(t *testing.T) {
 	ns := CreateNamespace(ctx, t, client)
 	nsRoute := CreateNamespace(ctx, t, client)
 
-	StartReconcilers(ctx, t, client.Scheme(), cfg, reconciler)
+	StartReconciler(ctx, t, client.Scheme(), cfg, reconciler)
 
 	gwc := gatewayapi.GatewayClass{
 		Spec: gatewayapi.GatewayClassSpec{

--- a/ingress-controller/test/envtest/konglicense_controller_test.go
+++ b/ingress-controller/test/envtest/konglicense_controller_test.go
@@ -37,7 +37,7 @@ func TestKongLicenseController(t *testing.T) {
 		mo.None[ctrllicense.ValidatorFunc](),
 	)
 
-	StartReconcilers(ctx, t, ctrlClient.Scheme(), cfg, reconciler)
+	StartReconciler(ctx, t, ctrlClient.Scheme(), cfg, reconciler)
 
 	const (
 		fullControllerName  = ctrllicense.LicenseControllerTypeKIC + "/test"
@@ -153,7 +153,7 @@ func TestKongLicenseControllerValidation(t *testing.T) {
 		mo.None[string](),
 		mo.Some(licenseValidator),
 	)
-	StartReconcilers(ctx, t, ctrlClient.Scheme(), cfg, reconciler)
+	StartReconciler(ctx, t, ctrlClient.Scheme(), cfg, reconciler)
 
 	t.Log("Create a KongLicense and verify that it is reconciled")
 	kongLicense1 := &configurationv1alpha1.KongLicense{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR attempts to fix an issue with `TestGatewayWithGatewayClassReconciliation`:

```
    controller.go:62: 2025-12-01T08:18:16Z	error	One of publish services defined in Gateway's "konghq.com/publish-service" annotation didn't match controller manager's configuration	{"GatewayV1Gateway": {"name":"12ca8250-7a2f-4fc4-8565-b1aed85419a1","namespace":"f486658f-4a7d-454f-a00e-f5df37703425"}, "namespace": "f486658f-4a7d-454f-a00e-f5df37703425", "name": "12ca8250-7a2f-4fc4-8565-b1aed85419a1", "service": "a1fbd7bc-9374-4eb7-860d-f331d5f984ee/publish-svc", "error": "publish service reference \"a1fbd7bc-9374-4eb7-860d-f331d5f984ee/publish-svc\" from Gateway's annotations did not match configured controller manager's publish services (\"f486658f-4a7d-454f-a00e-f5df37703425/publish-svc\")"}
    controller.go:62: 2025-12-01T08:18:16Z	error	Reconciler error	{"reconcileID": "698ed8f8-bb24-4664-8974-0c9c17530b88", "error": "publish service reference \"a1fbd7bc-9374-4eb7-860d-f331d5f984ee/publish-svc\" from Gateway's annotations did not match configured controller manager's publish services (\"f486658f-4a7d-454f-a00e-f5df37703425/publish-svc\")"}
```

e.g. https://github.com/Kong/kong-operator/actions/runs/19815580626/job/56766022226#step:8:2220

The fix relies on using watch namespaces so that each controller watches gateways in separate gateway so that they don't overwrite each others publish service annotations on unmanaged gateways.

This test suite [has been running for a couple of days in a loop](https://github.com/Kong/kong-operator/actions/runs/19767195244?pr=2774)

<img width="390" height="506" alt="image" src="https://github.com/user-attachments/assets/407ddc84-3f7f-40d6-b5eb-b0887b0a2421" />

The only failures that occurred are related to https://github.com/Kong/kong-operator/issues/2778.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
