### PR TITLE
rename the channel annotation from "gateway-operator" to "kong-operator" for CRDs.

### DIFF
--- a/api/common/v1alpha1/objectref_types.go
+++ b/api/common/v1alpha1/objectref_types.go
@@ -26,7 +26,7 @@ const (
 // +kubebuilder:validation:XValidation:rule="self.type == 'konnectID' ? has(self.konnectID) : true", message="when type is konnectID, konnectID must be set"
 // +kubebuilder:validation:XValidation:rule="self.type == 'konnectID' ? !has(self.namespacedRef) : true", message="when type is konnectID, namespacedRef must not be set"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type ObjectRef struct {
 	// Type defines type of the object which is referenced. It can be one of:
 	//

--- a/api/configuration/v1/kongconsumer_types.go
+++ b/api/configuration/v1/kongconsumer_types.go
@@ -39,7 +39,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="(!has(self.spec) || !has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef)) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!has(self.spec) || !has(self.spec.controlPlaneRef)) ? true : (!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongConsumer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1/kongplugin_types.go
+++ b/api/configuration/v1/kongplugin_types.go
@@ -39,7 +39,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!(has(self.configFrom) && has(self.configPatches))", message="Using both configFrom and configPatches fields is not allowed."
 // +kubebuilder:validation:XValidation:rule="self.plugin == oldSelf.plugin", message="The plugin field is immutable"
 // +apireference:kic:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongPlugin struct {
 	metav1.TypeMeta `json:",inline"`
 	// Setting a `global` label to `true` will apply the plugin to every request proxied by the Kong.

--- a/api/configuration/v1alpha1/keysetref.go
+++ b/api/configuration/v1alpha1/keysetref.go
@@ -23,7 +23,7 @@ const (
 // +kubebuilder:validation:XValidation:rule="self.type == 'namespacedRef' ? has(self.namespacedRef) : true", message="when type is namespacedRef, namespacedRef must be set"
 // +kubebuilder:validation:XValidation:rule="self.type == 'konnectID' ? has(self.konnectID) : true", message="when type is konnectID, konnectID must be set"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KeySetRef struct {
 	// Type defines type of the KeySet object reference. It can be one of:
 	// - konnectID

--- a/api/configuration/v1alpha1/kongcaertificate_types.go
+++ b/api/configuration/v1alpha1/kongcaertificate_types.go
@@ -21,7 +21,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="(!has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef)) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongCACertificate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongcertificate_types.go
+++ b/api/configuration/v1alpha1/kongcertificate_types.go
@@ -21,7 +21,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="(!has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef)) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongCertificate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongcredentialacl_types.go
+++ b/api/configuration/v1alpha1/kongcredentialacl_types.go
@@ -36,7 +36,7 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef",message="spec.consumerRef is immutable when an entity is already Programmed"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongCredentialACL struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongcredentialapikey_types.go
+++ b/api/configuration/v1alpha1/kongcredentialapikey_types.go
@@ -36,7 +36,7 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef",message="spec.consumerRef is immutable when an entity is already Programmed"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongCredentialAPIKey struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongcredentialbasicauth_types.go
+++ b/api/configuration/v1alpha1/kongcredentialbasicauth_types.go
@@ -36,7 +36,7 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef",message="spec.consumerRef is immutable when an entity is already Programmed"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongCredentialBasicAuth struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongcredentialhmac_types.go
+++ b/api/configuration/v1alpha1/kongcredentialhmac_types.go
@@ -36,7 +36,7 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef",message="spec.consumerRef is immutable when an entity is already Programmed"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongCredentialHMAC struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongcredentialjwt_types.go
+++ b/api/configuration/v1alpha1/kongcredentialjwt_types.go
@@ -37,7 +37,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef",message="spec.consumerRef is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="self.spec.algorithm in [ 'RS256','RS384','RS512','ES256','ES384','ES512','PS256','PS384','PS512','EdDSA', ] ? has(self.spec.rsa_public_key) : true",message="spec.rsa_public_key is required when algorithm is RS*, ES*, PS* or EdDSA*"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongCredentialJWT struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongdataplaneclientcertificate_types.go
+++ b/api/configuration/v1alpha1/kongdataplaneclientcertificate_types.go
@@ -38,7 +38,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.cert == self.spec.cert", message="spec.cert is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="(!has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef)) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongDataPlaneClientCertificate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongkey_types.go
+++ b/api/configuration/v1alpha1/kongkey_types.go
@@ -37,7 +37,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="(!has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef)) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongKey struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongkeyset_types.go
+++ b/api/configuration/v1alpha1/kongkeyset_types.go
@@ -36,7 +36,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="(!has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef)) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongKeySet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/konglicense_types.go
+++ b/api/configuration/v1alpha1/konglicense_types.go
@@ -18,7 +18,7 @@ import (
 // +apireference:kic:include
 // +apireference:kgo:include
 // +apireference:kic:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongLicense struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongpluginbinding_types.go
+++ b/api/configuration/v1alpha1/kongpluginbinding_types.go
@@ -55,7 +55,7 @@ const (
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="(!has(self.spec) || !has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef)) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongPluginBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongroute_types.go
+++ b/api/configuration/v1alpha1/kongroute_types.go
@@ -40,7 +40,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="(!has(self.spec) || !has(self.spec.controlPlaneRef)) ? true : (!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongRoute struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongservice_types.go
+++ b/api/configuration/v1alpha1/kongservice_types.go
@@ -40,7 +40,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="(!has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef)) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!has(self.spec.controlPlaneRef)) ? true : (!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongService struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongsni_types.go
+++ b/api/configuration/v1alpha1/kongsni_types.go
@@ -35,7 +35,7 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.certificateRef == self.spec.certificateRef", message="spec.certificateRef is immutable when programmed"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongSNI struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongtarget_types.go
+++ b/api/configuration/v1alpha1/kongtarget_types.go
@@ -35,7 +35,7 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="oldSelf.spec.upstreamRef == self.spec.upstreamRef", message="spec.upstreamRef is immutable"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongTarget struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongupstream_types.go
+++ b/api/configuration/v1alpha1/kongupstream_types.go
@@ -38,7 +38,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="(!has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef)) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongUpstream struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongvault_types.go
+++ b/api/configuration/v1alpha1/kongvault_types.go
@@ -49,7 +49,7 @@ const (
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True') || !has(self.spec.controlPlaneRef)) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongVault struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1beta1/kongconsumergroup_types.go
+++ b/api/configuration/v1beta1/kongconsumergroup_types.go
@@ -37,7 +37,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="(!has(self.spec) || !has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef)) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!has(oldSelf.spec) || !has(oldSelf.spec.controlPlaneRef)) ? true : (!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongConsumerGroup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1beta1/kongupstreampolicy_types.go
+++ b/api/configuration/v1beta1/kongupstreampolicy_types.go
@@ -53,7 +53,7 @@ func init() {
 // +kubebuilder:validation:XValidation:rule="has(self.spec.stickySessions) ? (has(self.spec.hashOn) && has(self.spec.hashOn.input) && self.spec.hashOn.input == 'none' && !has(self.spec.hashOn.cookie) && !has(self.spec.hashOn.cookiePath) && !has(self.spec.hashOn.header) && !has(self.spec.hashOn.uriCapture) && !has(self.spec.hashOn.queryArg)) : true", message="When spec.stickySessions is set, spec.hashOn.input must be set to 'none' (no other hash_on fields allowed)."
 // +kubebuilder:validation:XValidation:rule="has(self.spec.stickySessions) ? has(self.spec.stickySessions.cookie) : true", message="spec.stickySessions.cookie is required when spec.stickySessions is set."
 // +kubebuilder:validation:XValidation:rule="has(self.spec.stickySessions) ? (has(self.spec.algorithm) && self.spec.algorithm == \"sticky-sessions\") : true", message="spec.algorithm must be set to 'sticky-sessions' when spec.stickySessions is set."
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongUpstreamPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/gateway-operator/v1alpha1/aigateway_types.go
+++ b/api/gateway-operator/v1alpha1/aigateway_types.go
@@ -53,7 +53,7 @@ import (
 // +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".status.endpoint",description="The URL endpoint for the AIGateway"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type AIGateway struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/gateway-operator/v1alpha1/dataplane_metrics_extension_types.go
+++ b/api/gateway-operator/v1alpha1/dataplane_metrics_extension_types.go
@@ -45,7 +45,7 @@ const (
 // enriched with metadata required for in-cluster Kubernetes autoscaling.
 //
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type DataPlaneMetricsExtension struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/gateway-operator/v1alpha1/kongplugin_installation_types.go
+++ b/api/gateway-operator/v1alpha1/kongplugin_installation_types.go
@@ -37,7 +37,7 @@ func init() {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Accepted",description="The Resource is accepted",type=string,JSONPath=`.status.conditions[?(@.type=='Accepted')].status`
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KongPluginInstallation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/gateway-operator/v1alpha1/watchnamespacegrant_types.go
+++ b/api/gateway-operator/v1alpha1/watchnamespacegrant_types.go
@@ -15,7 +15,7 @@ func init() {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type WatchNamespaceGrant struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/gateway-operator/v1beta1/controlplane_types.go
+++ b/api/gateway-operator/v1beta1/controlplane_types.go
@@ -40,7 +40,7 @@ func init() {
 // +kubebuilder:printcolumn:name="Provisioned",description="The Resource is provisioned",type=string,JSONPath=`.status.conditions[?(@.type=='Provisioned')].status`
 // +kubebuilder:validation:XValidation:message="ControlPlane requires an image to be set on controller container",rule="has(self.spec.deployment.podTemplateSpec) && has(self.spec.deployment.podTemplateSpec.spec.containers) && self.spec.deployment.podTemplateSpec.spec.containers.exists(c, c.name == 'controller' && has(c.image))"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type ControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/gateway-operator/v1beta1/dataplane_types.go
+++ b/api/gateway-operator/v1beta1/dataplane_types.go
@@ -34,7 +34,7 @@ func init() {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.deployment.replicas,statuspath=.status.replicas,selectorpath=.status.selector

--- a/api/gateway-operator/v1beta1/gatewayconfiguration_types.go
+++ b/api/gateway-operator/v1beta1/gatewayconfiguration_types.go
@@ -31,7 +31,7 @@ func init() {
 //
 // +genclient
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 // +kubebuilder:deprecatedversion:warning="GatewayConfiguration v1beta1 has been deprecated in favor of v2beta1 and it will be removed in future."
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status

--- a/api/gateway-operator/v2beta1/controlplane_types.go
+++ b/api/gateway-operator/v2beta1/controlplane_types.go
@@ -39,7 +39,7 @@ func init() {
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +kubebuilder:printcolumn:name="Ready",description="The Resource is ready",type=string,JSONPath=`.status.conditions[?(@.type=='Ready')].status`
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type ControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/gateway-operator/v2beta1/gatewayconfiguration_types.go
+++ b/api/gateway-operator/v2beta1/gatewayconfiguration_types.go
@@ -37,7 +37,7 @@ func init() {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:storageversion
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=kogc,categories=kong

--- a/api/konnect/v1alpha1/konnect_apiauthconfiguration_types.go
+++ b/api/konnect/v1alpha1/konnect_apiauthconfiguration_types.go
@@ -24,7 +24,7 @@ func init() {
 // +kubebuilder:validation:XValidation:rule="self.spec.type != 'token' || (self.spec.token.startsWith('spat_') || self.spec.token.startsWith('kpat_'))", message="Konnect tokens have to start with spat_ or kpat_"
 // +kubebuilder:validation:XValidation:rule="self.spec.type != 'token' || (!has(oldSelf.spec.token) || has(self.spec.token))", message="Token is required once set"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KonnectAPIAuthConfiguration struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/konnect/v1alpha1/konnect_cloudgateway_dataplane_configuration_types.go
+++ b/api/konnect/v1alpha1/konnect_cloudgateway_dataplane_configuration_types.go
@@ -26,7 +26,7 @@ func init() {
 // +kubebuilder:printcolumn:name="OrgID",description="Konnect Organization ID this resource belongs to.",type=string,JSONPath=`.status.organizationID`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KonnectCloudGatewayDataPlaneGroupConfiguration struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/konnect/v1alpha1/konnect_cloudgateway_network_types.go
+++ b/api/konnect/v1alpha1/konnect_cloudgateway_network_types.go
@@ -31,7 +31,7 @@ func init() {
 // +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.cidr_block == self.spec.cidr_block",message="spec.cidr_block is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : (!has(self.spec.state) && !has(oldSelf.spec.state)) || self.spec.state == oldSelf.spec.state",message="spec.state is immutable when an entity is already Programmed"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KonnectCloudGatewayNetwork struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/konnect/v1alpha1/konnect_cloudgateway_transitgateway_types.go
+++ b/api/konnect/v1alpha1/konnect_cloudgateway_transitgateway_types.go
@@ -29,7 +29,7 @@ func init() {
 // +kubebuilder:printcolumn:name="OrgID",description="Konnect Organization ID this resource belongs to.",type=string,JSONPath=`.status.organizationID`
 // +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : (!has(self.spec.awsTransitGateway) ? true : oldSelf.spec.awsTransitGateway.name == self.spec.awsTransitGateway.name)",message="spec.awsTransitGateway.name is immutable when transit gateway is already Programmed"
 // +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : (!has(self.spec.azureTransitGateway) ? true : oldSelf.spec.azureTransitGateway.name == self.spec.azureTransitGateway.name)",message="spec.azureTransitGateway.name is immutable when transit gateway is already Programmed"
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KonnectCloudGatewayTransitGateway struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/konnect/v1alpha1/konnect_extension_types.go
+++ b/api/konnect/v1alpha1/konnect_extension_types.go
@@ -47,7 +47,7 @@ const (
 // +kubebuilder:validation:XValidation:rule="self.spec.konnect.controlPlane.ref.type == 'konnectID' ? has(self.spec.konnect.configuration) : true",message="konnect must be set when ControlPlaneRef is set to KonnectID."
 // +kubebuilder:validation:XValidation:rule="self.spec.konnect.controlPlane.ref.type == 'konnectNamespacedRef' ? !has(self.spec.konnect.configuration) : true",message="konnect must be unset when ControlPlaneRef is set to konnectNamespacedRef."
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KonnectExtension struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
+++ b/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
@@ -28,7 +28,7 @@ func init() {
 // +kubebuilder:validation:XValidation:message="spec.konnect.authRef is immutable when an entity is already Programmed", rule="!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef"
 // +kubebuilder:validation:XValidation:message="spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration", rule="!self.status.conditions.exists(c, c.type == 'APIAuthValid' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KonnectGatewayControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/konnect/v1alpha2/konnect_extension_types.go
+++ b/api/konnect/v1alpha2/konnect_extension_types.go
@@ -44,7 +44,7 @@ const (
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +kubebuilder:validation:XValidation:rule="oldSelf.spec.konnect.controlPlane.ref == self.spec.konnect.controlPlane.ref", message="spec.konnect.controlPlane.ref is immutable."
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KonnectExtension struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/konnect/v1alpha2/konnect_gateway_controlplane_types.go
+++ b/api/konnect/v1alpha2/konnect_gateway_controlplane_types.go
@@ -28,7 +28,7 @@ func init() {
 // +kubebuilder:validation:XValidation:message="spec.konnect.authRef is immutable when an entity is already Programmed", rule="!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef"
 // +kubebuilder:validation:XValidation:message="spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration", rule="!self.status.conditions.exists(c, c.type == 'APIAuthValid' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef"
 // +apireference:kgo:include
-// +kong:channels=gateway-operator
+// +kong:channels=kong-operator
 type KonnectGatewayControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/charts/kong-operator/charts/ko-crds/templates/ko-crds.yaml
+++ b/charts/kong-operator/charts/ko-crds/templates/ko-crds.yaml
@@ -50,7 +50,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: aigateways.gateway-operator.konghq.com
 spec:
@@ -593,7 +593,7 @@ metadata:
     cert-manager.io/inject-ca-from: {{ template "kong.namespace" . }}/{{ template "kong.webhookServiceName" . }}-serving-cert
 {{ end }}
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: controlplanes.gateway-operator.konghq.com
 spec:
@@ -9955,7 +9955,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:
@@ -10108,7 +10108,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanes.gateway-operator.konghq.com
 spec:
@@ -20052,7 +20052,7 @@ metadata:
     cert-manager.io/inject-ca-from: {{ template "kong.namespace" . }}/{{ template "kong.webhookServiceName" . }}-serving-cert
 {{ end }}
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:
@@ -48786,7 +48786,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcacertificates.configuration.konghq.com
 spec:
@@ -49111,7 +49111,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcertificates.configuration.konghq.com
 spec:
@@ -49764,7 +49764,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -50091,7 +50091,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -50445,7 +50445,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialacls.configuration.konghq.com
 spec:
@@ -50703,7 +50703,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
@@ -50961,7 +50961,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
@@ -51223,7 +51223,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
@@ -51487,7 +51487,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialjwts.configuration.konghq.com
 spec:
@@ -51970,7 +51970,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
@@ -52289,7 +52289,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeys.configuration.konghq.com
 spec:
@@ -52690,7 +52690,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeysets.configuration.konghq.com
 spec:
@@ -53014,7 +53014,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konglicenses.configuration.konghq.com
 spec:
@@ -53217,7 +53217,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongpluginbindings.configuration.konghq.com
 spec:
@@ -53701,7 +53701,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:
@@ -53886,7 +53886,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugins.configuration.konghq.com
 spec:
@@ -54191,7 +54191,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongroutes.configuration.konghq.com
 spec:
@@ -54681,7 +54681,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongservices.configuration.konghq.com
 spec:
@@ -55067,7 +55067,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongsnis.configuration.konghq.com
 spec:
@@ -55324,7 +55324,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongtargets.configuration.konghq.com
 spec:
@@ -55587,7 +55587,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   labels:
     gateway.networking.k8s.io/policy: direct
@@ -56346,7 +56346,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongupstreams.configuration.konghq.com
 spec:
@@ -56899,7 +56899,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongvaults.configuration.konghq.com
 spec:
@@ -57265,7 +57265,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
@@ -57475,7 +57475,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:
@@ -58018,7 +58018,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:
@@ -58327,7 +58327,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaytransitgateways.konnect.konghq.com
 spec:
@@ -58792,7 +58792,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectextensions.konnect.konghq.com
 spec:
@@ -59610,7 +59610,7 @@ metadata:
     cert-manager.io/inject-ca-from: {{ template "kong.namespace" . }}/{{ template "kong.webhookServiceName" . }}-serving-cert
 {{ end }}
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
@@ -60341,7 +60341,7 @@ metadata:
 {{ if .Values.keep }}
     helm.sh/resource-policy: keep
 {{ end }}
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: watchnamespacegrants.gateway-operator.konghq.com
 spec:

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -63,7 +63,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: aigateways.gateway-operator.konghq.com
 spec:
@@ -595,7 +595,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: controlplanes.gateway-operator.konghq.com
 spec:
@@ -9456,7 +9456,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:
@@ -9606,7 +9606,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanes.gateway-operator.konghq.com
 spec:
@@ -19000,7 +19000,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:
@@ -45883,7 +45883,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcacertificates.configuration.konghq.com
 spec:
@@ -46184,7 +46184,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcertificates.configuration.konghq.com
 spec:
@@ -46805,7 +46805,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -47109,7 +47109,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -47440,7 +47440,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialacls.configuration.konghq.com
 spec:
@@ -47686,7 +47686,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
@@ -47932,7 +47932,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
@@ -48182,7 +48182,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
@@ -48434,7 +48434,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialjwts.configuration.konghq.com
 spec:
@@ -48897,7 +48897,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
@@ -49190,7 +49190,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeys.configuration.konghq.com
 spec:
@@ -49564,7 +49564,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeysets.configuration.konghq.com
 spec:
@@ -49864,7 +49864,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konglicenses.configuration.konghq.com
 spec:
@@ -50060,7 +50060,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongpluginbindings.configuration.konghq.com
 spec:
@@ -50504,7 +50504,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:
@@ -50684,7 +50684,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugins.configuration.konghq.com
 spec:
@@ -50979,7 +50979,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongroutes.configuration.konghq.com
 spec:
@@ -51397,7 +51397,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongservices.configuration.konghq.com
 spec:
@@ -51748,7 +51748,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongsnis.configuration.konghq.com
 spec:
@@ -51992,7 +51992,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongtargets.configuration.konghq.com
 spec:
@@ -52242,7 +52242,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   labels:
     gateway.networking.k8s.io/policy: direct
@@ -52933,7 +52933,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongupstreams.configuration.konghq.com
 spec:
@@ -53427,7 +53427,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongvaults.configuration.konghq.com
 spec:
@@ -53769,7 +53769,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
@@ -53966,7 +53966,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:
@@ -54463,7 +54463,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:
@@ -54746,7 +54746,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaytransitgateways.konnect.konghq.com
 spec:
@@ -55177,7 +55177,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectextensions.konnect.konghq.com
 spec:
@@ -55922,7 +55922,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
@@ -56566,7 +56566,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: watchnamespacegrants.gateway-operator.konghq.com
 spec:

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -63,7 +63,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: aigateways.gateway-operator.konghq.com
 spec:
@@ -595,7 +595,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: controlplanes.gateway-operator.konghq.com
 spec:
@@ -9456,7 +9456,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:
@@ -9606,7 +9606,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanes.gateway-operator.konghq.com
 spec:
@@ -19000,7 +19000,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:
@@ -45883,7 +45883,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcacertificates.configuration.konghq.com
 spec:
@@ -46184,7 +46184,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcertificates.configuration.konghq.com
 spec:
@@ -46805,7 +46805,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -47109,7 +47109,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -47440,7 +47440,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialacls.configuration.konghq.com
 spec:
@@ -47686,7 +47686,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
@@ -47932,7 +47932,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
@@ -48182,7 +48182,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
@@ -48434,7 +48434,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialjwts.configuration.konghq.com
 spec:
@@ -48897,7 +48897,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
@@ -49190,7 +49190,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeys.configuration.konghq.com
 spec:
@@ -49564,7 +49564,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeysets.configuration.konghq.com
 spec:
@@ -49864,7 +49864,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konglicenses.configuration.konghq.com
 spec:
@@ -50060,7 +50060,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongpluginbindings.configuration.konghq.com
 spec:
@@ -50504,7 +50504,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:
@@ -50684,7 +50684,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugins.configuration.konghq.com
 spec:
@@ -50979,7 +50979,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongroutes.configuration.konghq.com
 spec:
@@ -51397,7 +51397,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongservices.configuration.konghq.com
 spec:
@@ -51748,7 +51748,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongsnis.configuration.konghq.com
 spec:
@@ -51992,7 +51992,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongtargets.configuration.konghq.com
 spec:
@@ -52242,7 +52242,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   labels:
     gateway.networking.k8s.io/policy: direct
@@ -52933,7 +52933,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongupstreams.configuration.konghq.com
 spec:
@@ -53427,7 +53427,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongvaults.configuration.konghq.com
 spec:
@@ -53769,7 +53769,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
@@ -53966,7 +53966,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:
@@ -54463,7 +54463,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:
@@ -54746,7 +54746,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaytransitgateways.konnect.konghq.com
 spec:
@@ -55177,7 +55177,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectextensions.konnect.konghq.com
 spec:
@@ -55922,7 +55922,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
@@ -56566,7 +56566,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: watchnamespacegrants.gateway-operator.konghq.com
 spec:

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -63,7 +63,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: aigateways.gateway-operator.konghq.com
 spec:
@@ -595,7 +595,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: controlplanes.gateway-operator.konghq.com
 spec:
@@ -9456,7 +9456,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:
@@ -9606,7 +9606,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanes.gateway-operator.konghq.com
 spec:
@@ -19000,7 +19000,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:
@@ -45883,7 +45883,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcacertificates.configuration.konghq.com
 spec:
@@ -46184,7 +46184,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcertificates.configuration.konghq.com
 spec:
@@ -46805,7 +46805,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -47109,7 +47109,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -47440,7 +47440,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialacls.configuration.konghq.com
 spec:
@@ -47686,7 +47686,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
@@ -47932,7 +47932,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
@@ -48182,7 +48182,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
@@ -48434,7 +48434,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialjwts.configuration.konghq.com
 spec:
@@ -48897,7 +48897,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
@@ -49190,7 +49190,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeys.configuration.konghq.com
 spec:
@@ -49564,7 +49564,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeysets.configuration.konghq.com
 spec:
@@ -49864,7 +49864,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konglicenses.configuration.konghq.com
 spec:
@@ -50060,7 +50060,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongpluginbindings.configuration.konghq.com
 spec:
@@ -50504,7 +50504,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:
@@ -50684,7 +50684,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugins.configuration.konghq.com
 spec:
@@ -50979,7 +50979,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongroutes.configuration.konghq.com
 spec:
@@ -51397,7 +51397,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongservices.configuration.konghq.com
 spec:
@@ -51748,7 +51748,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongsnis.configuration.konghq.com
 spec:
@@ -51992,7 +51992,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongtargets.configuration.konghq.com
 spec:
@@ -52242,7 +52242,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   labels:
     gateway.networking.k8s.io/policy: direct
@@ -52933,7 +52933,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongupstreams.configuration.konghq.com
 spec:
@@ -53427,7 +53427,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongvaults.configuration.konghq.com
 spec:
@@ -53769,7 +53769,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
@@ -53966,7 +53966,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:
@@ -54463,7 +54463,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:
@@ -54746,7 +54746,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaytransitgateways.konnect.konghq.com
 spec:
@@ -55177,7 +55177,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectextensions.konnect.konghq.com
 spec:
@@ -55922,7 +55922,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
@@ -56566,7 +56566,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: watchnamespacegrants.gateway-operator.konghq.com
 spec:

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -63,7 +63,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: aigateways.gateway-operator.konghq.com
 spec:
@@ -595,7 +595,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: controlplanes.gateway-operator.konghq.com
 spec:
@@ -9456,7 +9456,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:
@@ -9606,7 +9606,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanes.gateway-operator.konghq.com
 spec:
@@ -19000,7 +19000,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:
@@ -45883,7 +45883,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcacertificates.configuration.konghq.com
 spec:
@@ -46184,7 +46184,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcertificates.configuration.konghq.com
 spec:
@@ -46805,7 +46805,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -47109,7 +47109,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -47440,7 +47440,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialacls.configuration.konghq.com
 spec:
@@ -47686,7 +47686,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
@@ -47932,7 +47932,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
@@ -48182,7 +48182,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
@@ -48434,7 +48434,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialjwts.configuration.konghq.com
 spec:
@@ -48897,7 +48897,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
@@ -49190,7 +49190,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeys.configuration.konghq.com
 spec:
@@ -49564,7 +49564,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeysets.configuration.konghq.com
 spec:
@@ -49864,7 +49864,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konglicenses.configuration.konghq.com
 spec:
@@ -50060,7 +50060,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongpluginbindings.configuration.konghq.com
 spec:
@@ -50504,7 +50504,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:
@@ -50684,7 +50684,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugins.configuration.konghq.com
 spec:
@@ -50979,7 +50979,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongroutes.configuration.konghq.com
 spec:
@@ -51397,7 +51397,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongservices.configuration.konghq.com
 spec:
@@ -51748,7 +51748,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongsnis.configuration.konghq.com
 spec:
@@ -51992,7 +51992,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongtargets.configuration.konghq.com
 spec:
@@ -52242,7 +52242,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   labels:
     gateway.networking.k8s.io/policy: direct
@@ -52933,7 +52933,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongupstreams.configuration.konghq.com
 spec:
@@ -53427,7 +53427,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongvaults.configuration.konghq.com
 spec:
@@ -53769,7 +53769,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
@@ -53966,7 +53966,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:
@@ -54463,7 +54463,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:
@@ -54746,7 +54746,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaytransitgateways.konnect.konghq.com
 spec:
@@ -55177,7 +55177,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectextensions.konnect.konghq.com
 spec:
@@ -55922,7 +55922,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
@@ -56566,7 +56566,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: watchnamespacegrants.gateway-operator.konghq.com
 spec:

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -63,7 +63,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: aigateways.gateway-operator.konghq.com
 spec:
@@ -595,7 +595,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: controlplanes.gateway-operator.konghq.com
 spec:
@@ -9456,7 +9456,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:
@@ -9606,7 +9606,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanes.gateway-operator.konghq.com
 spec:
@@ -19000,7 +19000,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:
@@ -45883,7 +45883,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcacertificates.configuration.konghq.com
 spec:
@@ -46184,7 +46184,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcertificates.configuration.konghq.com
 spec:
@@ -46805,7 +46805,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -47109,7 +47109,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -47440,7 +47440,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialacls.configuration.konghq.com
 spec:
@@ -47686,7 +47686,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
@@ -47932,7 +47932,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
@@ -48182,7 +48182,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
@@ -48434,7 +48434,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialjwts.configuration.konghq.com
 spec:
@@ -48897,7 +48897,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
@@ -49190,7 +49190,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeys.configuration.konghq.com
 spec:
@@ -49564,7 +49564,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeysets.configuration.konghq.com
 spec:
@@ -49864,7 +49864,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konglicenses.configuration.konghq.com
 spec:
@@ -50060,7 +50060,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongpluginbindings.configuration.konghq.com
 spec:
@@ -50504,7 +50504,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:
@@ -50684,7 +50684,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugins.configuration.konghq.com
 spec:
@@ -50979,7 +50979,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongroutes.configuration.konghq.com
 spec:
@@ -51397,7 +51397,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongservices.configuration.konghq.com
 spec:
@@ -51748,7 +51748,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongsnis.configuration.konghq.com
 spec:
@@ -51992,7 +51992,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongtargets.configuration.konghq.com
 spec:
@@ -52242,7 +52242,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   labels:
     gateway.networking.k8s.io/policy: direct
@@ -52933,7 +52933,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongupstreams.configuration.konghq.com
 spec:
@@ -53427,7 +53427,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongvaults.configuration.konghq.com
 spec:
@@ -53769,7 +53769,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
@@ -53966,7 +53966,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:
@@ -54463,7 +54463,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:
@@ -54746,7 +54746,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaytransitgateways.konnect.konghq.com
 spec:
@@ -55177,7 +55177,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectextensions.konnect.konghq.com
 spec:
@@ -55922,7 +55922,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
@@ -56566,7 +56566,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: watchnamespacegrants.gateway-operator.konghq.com
 spec:

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -64,7 +64,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: aigateways.gateway-operator.konghq.com
 spec:
@@ -596,7 +596,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: controlplanes.gateway-operator.konghq.com
 spec:
@@ -9457,7 +9457,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:
@@ -9607,7 +9607,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanes.gateway-operator.konghq.com
 spec:
@@ -19001,7 +19001,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:
@@ -45884,7 +45884,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcacertificates.configuration.konghq.com
 spec:
@@ -46185,7 +46185,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcertificates.configuration.konghq.com
 spec:
@@ -46806,7 +46806,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -47110,7 +47110,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -47441,7 +47441,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialacls.configuration.konghq.com
 spec:
@@ -47687,7 +47687,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
@@ -47933,7 +47933,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
@@ -48183,7 +48183,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
@@ -48435,7 +48435,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialjwts.configuration.konghq.com
 spec:
@@ -48898,7 +48898,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
@@ -49191,7 +49191,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeys.configuration.konghq.com
 spec:
@@ -49565,7 +49565,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeysets.configuration.konghq.com
 spec:
@@ -49865,7 +49865,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konglicenses.configuration.konghq.com
 spec:
@@ -50061,7 +50061,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongpluginbindings.configuration.konghq.com
 spec:
@@ -50505,7 +50505,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:
@@ -50685,7 +50685,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugins.configuration.konghq.com
 spec:
@@ -50980,7 +50980,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongroutes.configuration.konghq.com
 spec:
@@ -51398,7 +51398,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongservices.configuration.konghq.com
 spec:
@@ -51749,7 +51749,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongsnis.configuration.konghq.com
 spec:
@@ -51993,7 +51993,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongtargets.configuration.konghq.com
 spec:
@@ -52243,7 +52243,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   labels:
     gateway.networking.k8s.io/policy: direct
@@ -52934,7 +52934,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongupstreams.configuration.konghq.com
 spec:
@@ -53428,7 +53428,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongvaults.configuration.konghq.com
 spec:
@@ -53770,7 +53770,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
@@ -53967,7 +53967,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:
@@ -54464,7 +54464,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:
@@ -54747,7 +54747,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaytransitgateways.konnect.konghq.com
 spec:
@@ -55178,7 +55178,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectextensions.konnect.konghq.com
 spec:
@@ -55923,7 +55923,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
@@ -56567,7 +56567,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: watchnamespacegrants.gateway-operator.konghq.com
 spec:

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -63,7 +63,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: aigateways.gateway-operator.konghq.com
 spec:
@@ -595,7 +595,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: controlplanes.gateway-operator.konghq.com
 spec:
@@ -9456,7 +9456,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:
@@ -9606,7 +9606,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanes.gateway-operator.konghq.com
 spec:
@@ -19000,7 +19000,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:
@@ -45883,7 +45883,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcacertificates.configuration.konghq.com
 spec:
@@ -46184,7 +46184,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcertificates.configuration.konghq.com
 spec:
@@ -46805,7 +46805,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -47109,7 +47109,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -47440,7 +47440,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialacls.configuration.konghq.com
 spec:
@@ -47686,7 +47686,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
@@ -47932,7 +47932,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
@@ -48182,7 +48182,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
@@ -48434,7 +48434,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialjwts.configuration.konghq.com
 spec:
@@ -48897,7 +48897,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
@@ -49190,7 +49190,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeys.configuration.konghq.com
 spec:
@@ -49564,7 +49564,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeysets.configuration.konghq.com
 spec:
@@ -49864,7 +49864,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konglicenses.configuration.konghq.com
 spec:
@@ -50060,7 +50060,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongpluginbindings.configuration.konghq.com
 spec:
@@ -50504,7 +50504,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:
@@ -50684,7 +50684,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugins.configuration.konghq.com
 spec:
@@ -50979,7 +50979,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongroutes.configuration.konghq.com
 spec:
@@ -51397,7 +51397,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongservices.configuration.konghq.com
 spec:
@@ -51748,7 +51748,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongsnis.configuration.konghq.com
 spec:
@@ -51992,7 +51992,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongtargets.configuration.konghq.com
 spec:
@@ -52242,7 +52242,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   labels:
     gateway.networking.k8s.io/policy: direct
@@ -52933,7 +52933,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongupstreams.configuration.konghq.com
 spec:
@@ -53427,7 +53427,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongvaults.configuration.konghq.com
 spec:
@@ -53769,7 +53769,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
@@ -53966,7 +53966,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:
@@ -54463,7 +54463,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:
@@ -54746,7 +54746,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaytransitgateways.konnect.konghq.com
 spec:
@@ -55177,7 +55177,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectextensions.konnect.konghq.com
 spec:
@@ -55922,7 +55922,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
@@ -56566,7 +56566,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: watchnamespacegrants.gateway-operator.konghq.com
 spec:

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -63,7 +63,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: aigateways.gateway-operator.konghq.com
 spec:
@@ -595,7 +595,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: controlplanes.gateway-operator.konghq.com
 spec:
@@ -9456,7 +9456,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:
@@ -9606,7 +9606,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanes.gateway-operator.konghq.com
 spec:
@@ -19000,7 +19000,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:
@@ -45883,7 +45883,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcacertificates.configuration.konghq.com
 spec:
@@ -46184,7 +46184,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcertificates.configuration.konghq.com
 spec:
@@ -46805,7 +46805,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -47109,7 +47109,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -47440,7 +47440,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialacls.configuration.konghq.com
 spec:
@@ -47686,7 +47686,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
@@ -47932,7 +47932,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
@@ -48182,7 +48182,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
@@ -48434,7 +48434,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialjwts.configuration.konghq.com
 spec:
@@ -48897,7 +48897,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
@@ -49190,7 +49190,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeys.configuration.konghq.com
 spec:
@@ -49564,7 +49564,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeysets.configuration.konghq.com
 spec:
@@ -49864,7 +49864,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konglicenses.configuration.konghq.com
 spec:
@@ -50060,7 +50060,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongpluginbindings.configuration.konghq.com
 spec:
@@ -50504,7 +50504,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:
@@ -50684,7 +50684,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugins.configuration.konghq.com
 spec:
@@ -50979,7 +50979,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongroutes.configuration.konghq.com
 spec:
@@ -51397,7 +51397,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongservices.configuration.konghq.com
 spec:
@@ -51748,7 +51748,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongsnis.configuration.konghq.com
 spec:
@@ -51992,7 +51992,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongtargets.configuration.konghq.com
 spec:
@@ -52242,7 +52242,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   labels:
     gateway.networking.k8s.io/policy: direct
@@ -52933,7 +52933,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongupstreams.configuration.konghq.com
 spec:
@@ -53427,7 +53427,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongvaults.configuration.konghq.com
 spec:
@@ -53769,7 +53769,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
@@ -53966,7 +53966,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:
@@ -54463,7 +54463,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:
@@ -54746,7 +54746,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaytransitgateways.konnect.konghq.com
 spec:
@@ -55177,7 +55177,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectextensions.konnect.konghq.com
 spec:
@@ -55922,7 +55922,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
@@ -56566,7 +56566,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: watchnamespacegrants.gateway-operator.konghq.com
 spec:

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -63,7 +63,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: aigateways.gateway-operator.konghq.com
 spec:
@@ -595,7 +595,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: controlplanes.gateway-operator.konghq.com
 spec:
@@ -9456,7 +9456,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:
@@ -9606,7 +9606,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanes.gateway-operator.konghq.com
 spec:
@@ -19000,7 +19000,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:
@@ -45883,7 +45883,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcacertificates.configuration.konghq.com
 spec:
@@ -46184,7 +46184,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcertificates.configuration.konghq.com
 spec:
@@ -46805,7 +46805,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -47109,7 +47109,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -47440,7 +47440,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialacls.configuration.konghq.com
 spec:
@@ -47686,7 +47686,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
@@ -47932,7 +47932,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
@@ -48182,7 +48182,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
@@ -48434,7 +48434,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialjwts.configuration.konghq.com
 spec:
@@ -48897,7 +48897,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
@@ -49190,7 +49190,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeys.configuration.konghq.com
 spec:
@@ -49564,7 +49564,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeysets.configuration.konghq.com
 spec:
@@ -49864,7 +49864,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konglicenses.configuration.konghq.com
 spec:
@@ -50060,7 +50060,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongpluginbindings.configuration.konghq.com
 spec:
@@ -50504,7 +50504,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:
@@ -50684,7 +50684,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugins.configuration.konghq.com
 spec:
@@ -50979,7 +50979,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongroutes.configuration.konghq.com
 spec:
@@ -51397,7 +51397,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongservices.configuration.konghq.com
 spec:
@@ -51748,7 +51748,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongsnis.configuration.konghq.com
 spec:
@@ -51992,7 +51992,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongtargets.configuration.konghq.com
 spec:
@@ -52242,7 +52242,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   labels:
     gateway.networking.k8s.io/policy: direct
@@ -52933,7 +52933,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongupstreams.configuration.konghq.com
 spec:
@@ -53427,7 +53427,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongvaults.configuration.konghq.com
 spec:
@@ -53769,7 +53769,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
@@ -53966,7 +53966,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:
@@ -54463,7 +54463,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:
@@ -54746,7 +54746,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaytransitgateways.konnect.konghq.com
 spec:
@@ -55177,7 +55177,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectextensions.konnect.konghq.com
 spec:
@@ -55922,7 +55922,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
@@ -56566,7 +56566,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: watchnamespacegrants.gateway-operator.konghq.com
 spec:

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -63,7 +63,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: aigateways.gateway-operator.konghq.com
 spec:
@@ -595,7 +595,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: controlplanes.gateway-operator.konghq.com
 spec:
@@ -9456,7 +9456,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:
@@ -9606,7 +9606,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanes.gateway-operator.konghq.com
 spec:
@@ -19000,7 +19000,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:
@@ -45883,7 +45883,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcacertificates.configuration.konghq.com
 spec:
@@ -46184,7 +46184,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcertificates.configuration.konghq.com
 spec:
@@ -46805,7 +46805,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -47109,7 +47109,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -47440,7 +47440,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialacls.configuration.konghq.com
 spec:
@@ -47686,7 +47686,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
@@ -47932,7 +47932,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
@@ -48182,7 +48182,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
@@ -48434,7 +48434,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialjwts.configuration.konghq.com
 spec:
@@ -48897,7 +48897,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
@@ -49190,7 +49190,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeys.configuration.konghq.com
 spec:
@@ -49564,7 +49564,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeysets.configuration.konghq.com
 spec:
@@ -49864,7 +49864,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konglicenses.configuration.konghq.com
 spec:
@@ -50060,7 +50060,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongpluginbindings.configuration.konghq.com
 spec:
@@ -50504,7 +50504,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:
@@ -50684,7 +50684,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugins.configuration.konghq.com
 spec:
@@ -50979,7 +50979,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongroutes.configuration.konghq.com
 spec:
@@ -51397,7 +51397,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongservices.configuration.konghq.com
 spec:
@@ -51748,7 +51748,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongsnis.configuration.konghq.com
 spec:
@@ -51992,7 +51992,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongtargets.configuration.konghq.com
 spec:
@@ -52242,7 +52242,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   labels:
     gateway.networking.k8s.io/policy: direct
@@ -52933,7 +52933,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongupstreams.configuration.konghq.com
 spec:
@@ -53427,7 +53427,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongvaults.configuration.konghq.com
 spec:
@@ -53769,7 +53769,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
@@ -53966,7 +53966,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:
@@ -54463,7 +54463,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:
@@ -54746,7 +54746,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaytransitgateways.konnect.konghq.com
 spec:
@@ -55177,7 +55177,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectextensions.konnect.konghq.com
 spec:
@@ -55922,7 +55922,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
@@ -56566,7 +56566,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: watchnamespacegrants.gateway-operator.konghq.com
 spec:

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -63,7 +63,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: aigateways.gateway-operator.konghq.com
 spec:
@@ -595,7 +595,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: controlplanes.gateway-operator.konghq.com
 spec:
@@ -9456,7 +9456,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:
@@ -9606,7 +9606,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanes.gateway-operator.konghq.com
 spec:
@@ -19000,7 +19000,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:
@@ -45883,7 +45883,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcacertificates.configuration.konghq.com
 spec:
@@ -46184,7 +46184,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcertificates.configuration.konghq.com
 spec:
@@ -46805,7 +46805,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -47109,7 +47109,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -47440,7 +47440,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialacls.configuration.konghq.com
 spec:
@@ -47686,7 +47686,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
@@ -47932,7 +47932,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
@@ -48182,7 +48182,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
@@ -48434,7 +48434,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialjwts.configuration.konghq.com
 spec:
@@ -48897,7 +48897,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
@@ -49190,7 +49190,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeys.configuration.konghq.com
 spec:
@@ -49564,7 +49564,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeysets.configuration.konghq.com
 spec:
@@ -49864,7 +49864,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konglicenses.configuration.konghq.com
 spec:
@@ -50060,7 +50060,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongpluginbindings.configuration.konghq.com
 spec:
@@ -50504,7 +50504,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:
@@ -50684,7 +50684,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugins.configuration.konghq.com
 spec:
@@ -50979,7 +50979,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongroutes.configuration.konghq.com
 spec:
@@ -51397,7 +51397,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongservices.configuration.konghq.com
 spec:
@@ -51748,7 +51748,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongsnis.configuration.konghq.com
 spec:
@@ -51992,7 +51992,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongtargets.configuration.konghq.com
 spec:
@@ -52242,7 +52242,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   labels:
     gateway.networking.k8s.io/policy: direct
@@ -52933,7 +52933,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongupstreams.configuration.konghq.com
 spec:
@@ -53427,7 +53427,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongvaults.configuration.konghq.com
 spec:
@@ -53769,7 +53769,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
@@ -53966,7 +53966,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:
@@ -54463,7 +54463,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:
@@ -54746,7 +54746,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaytransitgateways.konnect.konghq.com
 spec:
@@ -55177,7 +55177,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectextensions.konnect.konghq.com
 spec:
@@ -55922,7 +55922,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
@@ -56566,7 +56566,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: watchnamespacegrants.gateway-operator.konghq.com
 spec:

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -63,7 +63,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: aigateways.gateway-operator.konghq.com
 spec:
@@ -595,7 +595,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: controlplanes.gateway-operator.konghq.com
 spec:
@@ -9456,7 +9456,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:
@@ -9606,7 +9606,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanes.gateway-operator.konghq.com
 spec:
@@ -19000,7 +19000,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:
@@ -45883,7 +45883,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcacertificates.configuration.konghq.com
 spec:
@@ -46184,7 +46184,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcertificates.configuration.konghq.com
 spec:
@@ -46805,7 +46805,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -47109,7 +47109,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -47440,7 +47440,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialacls.configuration.konghq.com
 spec:
@@ -47686,7 +47686,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
@@ -47932,7 +47932,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
@@ -48182,7 +48182,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
@@ -48434,7 +48434,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialjwts.configuration.konghq.com
 spec:
@@ -48897,7 +48897,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
@@ -49190,7 +49190,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeys.configuration.konghq.com
 spec:
@@ -49564,7 +49564,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeysets.configuration.konghq.com
 spec:
@@ -49864,7 +49864,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konglicenses.configuration.konghq.com
 spec:
@@ -50060,7 +50060,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongpluginbindings.configuration.konghq.com
 spec:
@@ -50504,7 +50504,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:
@@ -50684,7 +50684,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugins.configuration.konghq.com
 spec:
@@ -50979,7 +50979,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongroutes.configuration.konghq.com
 spec:
@@ -51397,7 +51397,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongservices.configuration.konghq.com
 spec:
@@ -51748,7 +51748,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongsnis.configuration.konghq.com
 spec:
@@ -51992,7 +51992,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongtargets.configuration.konghq.com
 spec:
@@ -52242,7 +52242,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   labels:
     gateway.networking.k8s.io/policy: direct
@@ -52933,7 +52933,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongupstreams.configuration.konghq.com
 spec:
@@ -53427,7 +53427,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongvaults.configuration.konghq.com
 spec:
@@ -53769,7 +53769,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
@@ -53966,7 +53966,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:
@@ -54463,7 +54463,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:
@@ -54746,7 +54746,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaytransitgateways.konnect.konghq.com
 spec:
@@ -55177,7 +55177,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectextensions.konnect.konghq.com
 spec:
@@ -55922,7 +55922,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
@@ -56566,7 +56566,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: watchnamespacegrants.gateway-operator.konghq.com
 spec:

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -38,7 +38,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: aigateways.gateway-operator.konghq.com
 spec:
@@ -570,7 +570,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: controlplanes.gateway-operator.konghq.com
 spec:
@@ -1133,7 +1133,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:
@@ -1283,7 +1283,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanes.gateway-operator.konghq.com
 spec:
@@ -10677,7 +10677,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:
@@ -20227,7 +20227,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcacertificates.configuration.konghq.com
 spec:
@@ -20528,7 +20528,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcertificates.configuration.konghq.com
 spec:
@@ -21149,7 +21149,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -21453,7 +21453,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -21784,7 +21784,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialacls.configuration.konghq.com
 spec:
@@ -22030,7 +22030,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
@@ -22276,7 +22276,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
@@ -22526,7 +22526,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
@@ -22778,7 +22778,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialjwts.configuration.konghq.com
 spec:
@@ -23241,7 +23241,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
@@ -23534,7 +23534,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeys.configuration.konghq.com
 spec:
@@ -23908,7 +23908,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeysets.configuration.konghq.com
 spec:
@@ -24208,7 +24208,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konglicenses.configuration.konghq.com
 spec:
@@ -24404,7 +24404,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongpluginbindings.configuration.konghq.com
 spec:
@@ -24848,7 +24848,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:
@@ -25028,7 +25028,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugins.configuration.konghq.com
 spec:
@@ -25323,7 +25323,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongroutes.configuration.konghq.com
 spec:
@@ -25741,7 +25741,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongservices.configuration.konghq.com
 spec:
@@ -26092,7 +26092,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongsnis.configuration.konghq.com
 spec:
@@ -26336,7 +26336,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongtargets.configuration.konghq.com
 spec:
@@ -26586,7 +26586,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   labels:
     gateway.networking.k8s.io/policy: direct
@@ -27277,7 +27277,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongupstreams.configuration.konghq.com
 spec:
@@ -27771,7 +27771,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongvaults.configuration.konghq.com
 spec:
@@ -28113,7 +28113,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
@@ -28310,7 +28310,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:
@@ -28807,7 +28807,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:
@@ -29090,7 +29090,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaytransitgateways.konnect.konghq.com
 spec:
@@ -29521,7 +29521,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectextensions.konnect.konghq.com
 spec:
@@ -29885,7 +29885,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
@@ -30224,7 +30224,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: watchnamespacegrants.gateway-operator.konghq.com
 spec:

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -13,7 +13,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: aigateways.gateway-operator.konghq.com
 spec:
@@ -546,7 +546,7 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
     cert-manager.io/inject-ca-from: default/chartsnap-kong-operator-webhook-serving-cert
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: controlplanes.gateway-operator.konghq.com
 spec:
@@ -9406,7 +9406,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:
@@ -9556,7 +9556,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanes.gateway-operator.konghq.com
 spec:
@@ -18951,7 +18951,7 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
     cert-manager.io/inject-ca-from: default/chartsnap-kong-operator-webhook-serving-cert
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:
@@ -45833,7 +45833,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcacertificates.configuration.konghq.com
 spec:
@@ -46134,7 +46134,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcertificates.configuration.konghq.com
 spec:
@@ -46755,7 +46755,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -47059,7 +47059,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -47390,7 +47390,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialacls.configuration.konghq.com
 spec:
@@ -47636,7 +47636,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
@@ -47882,7 +47882,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
@@ -48132,7 +48132,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
@@ -48384,7 +48384,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialjwts.configuration.konghq.com
 spec:
@@ -48847,7 +48847,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
@@ -49140,7 +49140,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeys.configuration.konghq.com
 spec:
@@ -49514,7 +49514,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeysets.configuration.konghq.com
 spec:
@@ -49814,7 +49814,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konglicenses.configuration.konghq.com
 spec:
@@ -50010,7 +50010,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongpluginbindings.configuration.konghq.com
 spec:
@@ -50454,7 +50454,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:
@@ -50634,7 +50634,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugins.configuration.konghq.com
 spec:
@@ -50929,7 +50929,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongroutes.configuration.konghq.com
 spec:
@@ -51347,7 +51347,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongservices.configuration.konghq.com
 spec:
@@ -51698,7 +51698,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongsnis.configuration.konghq.com
 spec:
@@ -51942,7 +51942,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongtargets.configuration.konghq.com
 spec:
@@ -52192,7 +52192,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   labels:
     gateway.networking.k8s.io/policy: direct
@@ -52883,7 +52883,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongupstreams.configuration.konghq.com
 spec:
@@ -53377,7 +53377,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongvaults.configuration.konghq.com
 spec:
@@ -53719,7 +53719,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
@@ -53916,7 +53916,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:
@@ -54413,7 +54413,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:
@@ -54696,7 +54696,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaytransitgateways.konnect.konghq.com
 spec:
@@ -55127,7 +55127,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectextensions.konnect.konghq.com
 spec:
@@ -55873,7 +55873,7 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
     cert-manager.io/inject-ca-from: default/chartsnap-kong-operator-webhook-serving-cert
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
@@ -56516,7 +56516,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: watchnamespacegrants.gateway-operator.konghq.com
 spec:

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -13,7 +13,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: aigateways.gateway-operator.konghq.com
 spec:
@@ -545,7 +545,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: controlplanes.gateway-operator.konghq.com
 spec:
@@ -1108,7 +1108,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:
@@ -1258,7 +1258,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanes.gateway-operator.konghq.com
 spec:
@@ -10652,7 +10652,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:
@@ -20202,7 +20202,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcacertificates.configuration.konghq.com
 spec:
@@ -20503,7 +20503,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcertificates.configuration.konghq.com
 spec:
@@ -21124,7 +21124,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -21428,7 +21428,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -21759,7 +21759,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialacls.configuration.konghq.com
 spec:
@@ -22005,7 +22005,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
@@ -22251,7 +22251,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
@@ -22501,7 +22501,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
@@ -22753,7 +22753,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialjwts.configuration.konghq.com
 spec:
@@ -23216,7 +23216,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
@@ -23509,7 +23509,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeys.configuration.konghq.com
 spec:
@@ -23883,7 +23883,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeysets.configuration.konghq.com
 spec:
@@ -24183,7 +24183,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konglicenses.configuration.konghq.com
 spec:
@@ -24379,7 +24379,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongpluginbindings.configuration.konghq.com
 spec:
@@ -24823,7 +24823,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:
@@ -25003,7 +25003,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugins.configuration.konghq.com
 spec:
@@ -25298,7 +25298,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongroutes.configuration.konghq.com
 spec:
@@ -25716,7 +25716,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongservices.configuration.konghq.com
 spec:
@@ -26067,7 +26067,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongsnis.configuration.konghq.com
 spec:
@@ -26311,7 +26311,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongtargets.configuration.konghq.com
 spec:
@@ -26561,7 +26561,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   labels:
     gateway.networking.k8s.io/policy: direct
@@ -27252,7 +27252,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongupstreams.configuration.konghq.com
 spec:
@@ -27746,7 +27746,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongvaults.configuration.konghq.com
 spec:
@@ -28088,7 +28088,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
@@ -28285,7 +28285,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:
@@ -28782,7 +28782,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:
@@ -29065,7 +29065,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaytransitgateways.konnect.konghq.com
 spec:
@@ -29496,7 +29496,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectextensions.konnect.konghq.com
 spec:
@@ -29860,7 +29860,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
@@ -30199,7 +30199,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: watchnamespacegrants.gateway-operator.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongcacertificates.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcacertificates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcacertificates.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongcertificates.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcertificates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcertificates.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongconsumergroups.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongconsumergroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumergroups.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongconsumers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongconsumers.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongcredentialacls.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcredentialacls.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialacls.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongcredentialapikeys.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcredentialapikeys.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialapikeys.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongcredentialbasicauths.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcredentialbasicauths.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongcredentialhmacs.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcredentialhmacs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialhmacs.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongcredentialjwts.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongcredentialjwts.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongcredentialjwts.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongdataplaneclientcertificates.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongdataplaneclientcertificates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongkeys.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongkeys.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeys.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongkeysets.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongkeysets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongkeysets.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_konglicenses.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_konglicenses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konglicenses.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongpluginbindings.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongpluginbindings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongpluginbindings.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongplugins.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongplugins.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugins.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongroutes.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongroutes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongroutes.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongservices.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongservices.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongservices.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongsnis.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongsnis.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongsnis.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongtargets.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongtargets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongtargets.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongupstreampolicies.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongupstreampolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   labels:
     gateway.networking.k8s.io/policy: direct

--- a/config/crd/kong-operator/configuration.konghq.com_kongupstreams.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongupstreams.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongupstreams.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/configuration.konghq.com_kongvaults.yaml
+++ b/config/crd/kong-operator/configuration.konghq.com_kongvaults.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongvaults.configuration.konghq.com
 spec:

--- a/config/crd/kong-operator/gateway-operator.konghq.com_aigateways.yaml
+++ b/config/crd/kong-operator/gateway-operator.konghq.com_aigateways.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: aigateways.gateway-operator.konghq.com
 spec:

--- a/config/crd/kong-operator/gateway-operator.konghq.com_controlplanes.yaml
+++ b/config/crd/kong-operator/gateway-operator.konghq.com_controlplanes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: controlplanes.gateway-operator.konghq.com
 spec:

--- a/config/crd/kong-operator/gateway-operator.konghq.com_dataplanemetricsextensions.yaml
+++ b/config/crd/kong-operator/gateway-operator.konghq.com_dataplanemetricsextensions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:

--- a/config/crd/kong-operator/gateway-operator.konghq.com_dataplanes.yaml
+++ b/config/crd/kong-operator/gateway-operator.konghq.com_dataplanes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: dataplanes.gateway-operator.konghq.com
 spec:

--- a/config/crd/kong-operator/gateway-operator.konghq.com_gatewayconfigurations.yaml
+++ b/config/crd/kong-operator/gateway-operator.konghq.com_gatewayconfigurations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:

--- a/config/crd/kong-operator/gateway-operator.konghq.com_kongplugininstallations.yaml
+++ b/config/crd/kong-operator/gateway-operator.konghq.com_kongplugininstallations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:

--- a/config/crd/kong-operator/gateway-operator.konghq.com_watchnamespacegrants.yaml
+++ b/config/crd/kong-operator/gateway-operator.konghq.com_watchnamespacegrants.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: watchnamespacegrants.gateway-operator.konghq.com
 spec:

--- a/config/crd/kong-operator/konnect.konghq.com_konnectapiauthconfigurations.yaml
+++ b/config/crd/kong-operator/konnect.konghq.com_konnectapiauthconfigurations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:

--- a/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaydataplanegroupconfigurations.yaml
+++ b/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaydataplanegroupconfigurations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:

--- a/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaynetworks.yaml
+++ b/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaynetworks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:

--- a/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaytransitgateways.yaml
+++ b/config/crd/kong-operator/konnect.konghq.com_konnectcloudgatewaytransitgateways.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectcloudgatewaytransitgateways.konnect.konghq.com
 spec:

--- a/config/crd/kong-operator/konnect.konghq.com_konnectextensions.yaml
+++ b/config/crd/kong-operator/konnect.konghq.com_konnectextensions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectextensions.konnect.konghq.com
 spec:

--- a/config/crd/kong-operator/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
+++ b/config/crd/kong-operator/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/channels: kong-operator
     kubernetes-configuration.konghq.com/version: v2.1.0-alpha.0
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:

--- a/ingress-controller/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/ingress-controller/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -375,7 +375,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -627,7 +627,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -1098,7 +1098,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: konglicenses.configuration.konghq.com
 spec:
@@ -1298,7 +1298,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongplugins.configuration.konghq.com
 spec:
@@ -2476,7 +2476,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongvaults.configuration.konghq.com
 spec:

--- a/ingress-controller/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/ingress-controller/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -375,7 +375,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -627,7 +627,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -1098,7 +1098,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: konglicenses.configuration.konghq.com
 spec:
@@ -1298,7 +1298,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongplugins.configuration.konghq.com
 spec:
@@ -2476,7 +2476,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongvaults.configuration.konghq.com
 spec:

--- a/ingress-controller/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/ingress-controller/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -375,7 +375,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -627,7 +627,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -1098,7 +1098,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: konglicenses.configuration.konghq.com
 spec:
@@ -1298,7 +1298,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongplugins.configuration.konghq.com
 spec:
@@ -2476,7 +2476,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongvaults.configuration.konghq.com
 spec:

--- a/ingress-controller/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/ingress-controller/test/e2e/manifests/all-in-one-dbless.yaml
@@ -375,7 +375,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -627,7 +627,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -1098,7 +1098,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: konglicenses.configuration.konghq.com
 spec:
@@ -1298,7 +1298,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongplugins.configuration.konghq.com
 spec:
@@ -2476,7 +2476,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongvaults.configuration.konghq.com
 spec:

--- a/ingress-controller/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/ingress-controller/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -375,7 +375,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -627,7 +627,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -1098,7 +1098,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: konglicenses.configuration.konghq.com
 spec:
@@ -1298,7 +1298,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongplugins.configuration.konghq.com
 spec:
@@ -2476,7 +2476,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongvaults.configuration.konghq.com
 spec:

--- a/ingress-controller/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/ingress-controller/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -375,7 +375,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -627,7 +627,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -1098,7 +1098,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: konglicenses.configuration.konghq.com
 spec:
@@ -1298,7 +1298,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongplugins.configuration.konghq.com
 spec:
@@ -2476,7 +2476,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongvaults.configuration.konghq.com
 spec:

--- a/ingress-controller/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/ingress-controller/test/e2e/manifests/all-in-one-postgres.yaml
@@ -375,7 +375,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongconsumergroups.configuration.konghq.com
 spec:
@@ -627,7 +627,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongconsumers.configuration.konghq.com
 spec:
@@ -1098,7 +1098,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: konglicenses.configuration.konghq.com
 spec:
@@ -1298,7 +1298,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongplugins.configuration.konghq.com
 spec:
@@ -2476,7 +2476,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/channels: ingress-controller,kong-operator
     kubernetes-configuration.konghq.com/version: v1.5.2
   name: kongvaults.configuration.konghq.com
 spec:

--- a/scripts/crds-generator/main.go
+++ b/scripts/crds-generator/main.go
@@ -205,7 +205,7 @@ func channelsFromAnnotations(crd apiext.CustomResourceDefinition) []ChannelType 
 		switch ChannelType(strings.TrimSpace(s)) {
 		case IngressControllerIncubatorChannelType:
 			return ChannelType(strings.TrimSpace(s))
-		case IngressControllerChannelType, GatewayOperatorChannelType:
+		case IngressControllerChannelType, GatewayOperatorChannelType, KongOperatorChannelType:
 			return KongOperatorChannelType
 		default:
 			log.Fatalf("unknown channel: %s", s)


### PR DESCRIPTION
**What this PR does / why we need it**:

Since we have migrate from kong gateway operator to kong operator, we don't need gateway-operator annotation anymore.

**Which issue this PR fixes**

Fixes https://github.com/Kong/kong-operator/issues/2296

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
