### PR TITLE
[backport release/2.0.x] make Gateway controllers watch changes on Secrets referenced by spec.listeners.tls.certificateRef (#2661)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@
   [#2717](https://github.com/Kong/kong-operator/pull/2717)
 - Reject CA Secrets with multiple PEM certs.
   [#2671](https://github.com/Kong/kong-operator/pull/2671)
+- Gateway controllers now watch changes on Secrets referenced by
+  `spec.listeners.tls.certificateRef`, ensuring Gateway status conditions
+  are updated when referenced certificates change.
+  [#2661](https://github.com/Kong/kong-operator/pull/2661)
 
 ## [v2.0.5]
 

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -129,6 +129,16 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 			),
 		)
 	}
+
+	// Watch Secrets to requeue Gateways that reference them via listeners.tls.certificateRefs.
+	builder.WatchesRawSource(
+		source.Kind(
+			mgr.GetCache(),
+			&corev1.Secret{},
+			handler.TypedEnqueueRequestsFromMapFunc(r.listGatewayReconcileRequestsForSecret),
+		),
+	)
+
 	return builder.Complete(r)
 }
 

--- a/controller/gateway/controller_watch_test.go
+++ b/controller/gateway/controller_watch_test.go
@@ -1,0 +1,295 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	gwtypes "github.com/kong/kong-operator/internal/types"
+	"github.com/kong/kong-operator/internal/utils/index"
+	"github.com/kong/kong-operator/modules/manager/scheme"
+	"github.com/kong/kong-operator/pkg/vars"
+)
+
+func TestReconciler_listGatewayReconcileRequestsForSecret(t *testing.T) {
+	testCases := []struct {
+		name             string
+		secret           *corev1.Secret
+		gatewayClass     *gatewayv1.GatewayClass
+		gateways         []*gwtypes.Gateway
+		expectedRequests []reconcile.Request
+	}{
+		{
+			name: "secret referenced by single gateway returns one request",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cert",
+					Namespace: "default",
+				},
+			},
+			gatewayClass: &gatewayv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gatewayclass",
+				},
+				Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: gatewayv1.GatewayController(vars.ControllerName()),
+				},
+				Status: gatewayv1.GatewayClassStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(gatewayv1.GatewayClassConditionStatusAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(gatewayv1.GatewayClassReasonAccepted),
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			gateways: []*gwtypes.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gw-1",
+						Namespace: "default",
+						UID:       types.UID(uuid.NewString()),
+					},
+					Spec: gatewayv1.GatewaySpec{
+						GatewayClassName: "test-gatewayclass",
+						Listeners: []gatewayv1.Listener{
+							{
+								Name:     "https",
+								Port:     443,
+								Protocol: gatewayv1.HTTPSProtocolType,
+								TLS: &gatewayv1.GatewayTLSConfig{
+									CertificateRefs: []gatewayv1.SecretObjectReference{
+										{Name: "test-cert"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: "default", Name: "gw-1"}},
+			},
+		},
+		{
+			name: "secret referenced by multiple gateways returns multiple requests",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "shared-cert",
+					Namespace: "default",
+				},
+			},
+			gatewayClass: &gatewayv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gatewayclass",
+				},
+				Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: gatewayv1.GatewayController(vars.ControllerName()),
+				},
+				Status: gatewayv1.GatewayClassStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(gatewayv1.GatewayClassConditionStatusAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(gatewayv1.GatewayClassReasonAccepted),
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			gateways: []*gwtypes.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gw-1",
+						Namespace: "default",
+						UID:       types.UID(uuid.NewString()),
+					},
+					Spec: gatewayv1.GatewaySpec{
+						GatewayClassName: "test-gatewayclass",
+						Listeners: []gatewayv1.Listener{
+							{
+								Name:     "https",
+								Port:     443,
+								Protocol: gatewayv1.HTTPSProtocolType,
+								TLS: &gatewayv1.GatewayTLSConfig{
+									CertificateRefs: []gatewayv1.SecretObjectReference{
+										{Name: "shared-cert"},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gw-2",
+						Namespace: "default",
+						UID:       types.UID(uuid.NewString()),
+					},
+					Spec: gatewayv1.GatewaySpec{
+						GatewayClassName: "test-gatewayclass",
+						Listeners: []gatewayv1.Listener{
+							{
+								Name:     "https",
+								Port:     443,
+								Protocol: gatewayv1.HTTPSProtocolType,
+								TLS: &gatewayv1.GatewayTLSConfig{
+									CertificateRefs: []gatewayv1.SecretObjectReference{
+										{Name: "shared-cert"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: "default", Name: "gw-1"}},
+				{NamespacedName: types.NamespacedName{Namespace: "default", Name: "gw-2"}},
+			},
+		},
+		{
+			name: "secret not referenced by any gateway returns empty",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "unused-cert",
+					Namespace: "default",
+				},
+			},
+			gatewayClass: &gatewayv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gatewayclass",
+				},
+				Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: gatewayv1.GatewayController(vars.ControllerName()),
+				},
+				Status: gatewayv1.GatewayClassStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(gatewayv1.GatewayClassConditionStatusAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(gatewayv1.GatewayClassReasonAccepted),
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			gateways: []*gwtypes.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gw-1",
+						Namespace: "default",
+						UID:       types.UID(uuid.NewString()),
+					},
+					Spec: gatewayv1.GatewaySpec{
+						GatewayClassName: "test-gatewayclass",
+						Listeners: []gatewayv1.Listener{
+							{
+								Name:     "https",
+								Port:     443,
+								Protocol: gatewayv1.HTTPSProtocolType,
+								TLS: &gatewayv1.GatewayTLSConfig{
+									CertificateRefs: []gatewayv1.SecretObjectReference{
+										{Name: "other-cert"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRequests: nil,
+		},
+		{
+			name: "gateway with non-matching gatewayclass is filtered out",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cert",
+					Namespace: "default",
+				},
+			},
+			gatewayClass: &gatewayv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "other-gatewayclass",
+				},
+				Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: gatewayv1.GatewayController("other-controller"),
+				},
+				Status: gatewayv1.GatewayClassStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(gatewayv1.GatewayClassConditionStatusAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(gatewayv1.GatewayClassReasonAccepted),
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			gateways: []*gwtypes.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gw-1",
+						Namespace: "default",
+						UID:       types.UID(uuid.NewString()),
+					},
+					Spec: gatewayv1.GatewaySpec{
+						GatewayClassName: "other-gatewayclass",
+						Listeners: []gatewayv1.Listener{
+							{
+								Name:     "https",
+								Port:     443,
+								Protocol: gatewayv1.HTTPSProtocolType,
+								TLS: &gatewayv1.GatewayTLSConfig{
+									CertificateRefs: []gatewayv1.SecretObjectReference{
+										{Name: "test-cert"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRequests: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			// Build client with index and objects.
+			clientBuilder := fakectrlruntimeclient.NewClientBuilder().
+				WithScheme(scheme.Get()).
+				WithObjects(tc.secret, tc.gatewayClass)
+
+			for _, gw := range tc.gateways {
+				clientBuilder.WithObjects(gw)
+			}
+
+			// Register the TLS certificate index.
+			for _, opt := range index.OptionsForGatewayTLSSecret() {
+				clientBuilder.WithIndex(opt.Object, opt.Field, opt.ExtractValueFn)
+			}
+
+			fakeClient := clientBuilder.Build()
+
+			reconciler := &Reconciler{
+				Client: fakeClient,
+			}
+
+			requests := reconciler.listGatewayReconcileRequestsForSecret(ctx, tc.secret)
+
+			require.ElementsMatch(t, tc.expectedRequests, requests)
+		})
+	}
+}

--- a/internal/utils/index/gateway_tls_secret.go
+++ b/internal/utils/index/gateway_tls_secret.go
@@ -1,0 +1,63 @@
+package index
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gwtypes "github.com/kong/kong-operator/internal/types"
+)
+
+const (
+	// TLSCertificateSecretsOnGatewayIndex maps Secret "namespace/name" to Gateway objects that
+	// reference them in listeners.tls.certificateRefs.
+	TLSCertificateSecretsOnGatewayIndex = "TLSCertificateSecretsOnGateway"
+)
+
+// OptionsForGatewayTLSSecret returns index options for Gateways referencing Secrets via TLS certificateRefs.
+func OptionsForGatewayTLSSecret() []Option {
+	return []Option{
+		{
+			Object:         &gwtypes.Gateway{},
+			Field:          TLSCertificateSecretsOnGatewayIndex,
+			ExtractValueFn: tlsCertificateSecretsOnGateway,
+		},
+	}
+}
+
+// tlsCertificateSecretsOnGateway extracts Secret references (namespace/name) from a Gateway's listeners.tls.certificateRefs.
+func tlsCertificateSecretsOnGateway(o client.Object) []string {
+	gw, ok := o.(*gwtypes.Gateway)
+	if !ok {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	for _, l := range gw.Spec.Listeners {
+		if l.TLS == nil {
+			continue
+		}
+		for _, ref := range l.TLS.CertificateRefs {
+			// Only index core/v1 Secret references (or defaulted ones when group/kind are nil).
+			if ref.Group != nil && string(*ref.Group) != corev1.GroupName {
+				continue
+			}
+			if ref.Kind != nil && string(*ref.Kind) != "Secret" {
+				continue
+			}
+			ns := gw.Namespace
+			if ref.Namespace != nil {
+				ns = string(*ref.Namespace)
+			}
+			if ref.Name == "" {
+				continue
+			}
+			seen[ns+"/"+string(ref.Name)] = struct{}{}
+		}
+	}
+
+	out := make([]string, 0, len(seen))
+	for key := range seen {
+		out = append(out, key)
+	}
+	return out
+}

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -97,6 +97,9 @@ func SetupCacheIndexes(ctx context.Context, mgr manager.Manager, cfg Config) err
 
 	if cfg.GatewayControllerEnabled {
 		indexOptions = append(indexOptions, index.OptionsForGatewayClass()...)
+		// Index Gateways by referenced TLS Secrets so the Gateway controller can
+		// efficiently list Gateways for a Secret event.
+		indexOptions = append(indexOptions, index.OptionsForGatewayTLSSecret()...)
 	}
 
 	if cfg.KonnectControllersEnabled {

--- a/test/envtest/gateway_secret_watch_envtest_test.go
+++ b/test/envtest/gateway_secret_watch_envtest_test.go
@@ -1,0 +1,106 @@
+package envtest
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	kogateway "github.com/kong/kong-operator/controller/gateway"
+	certhelper "github.com/kong/kong-operator/ingress-controller/test/helpers/certificate"
+	"github.com/kong/kong-operator/modules/manager/logging"
+	managerscheme "github.com/kong/kong-operator/modules/manager/scheme"
+	testutils "github.com/kong/kong-operator/pkg/utils/test"
+	"github.com/kong/kong-operator/pkg/vars"
+)
+
+func TestGatewaySecretWatch_UpdatesResolvedRefsOnSecretRotation(t *testing.T) {
+	t.Parallel()
+
+	// Prepare scheme, envtest, manager and KO Gateway reconciler.
+	scheme := managerscheme.Get()
+	ctx := t.Context()
+
+	cfg, ns := Setup(t, ctx, scheme)
+	mgr, logs := NewManager(t, ctx, cfg, scheme)
+
+	r := &kogateway.Reconciler{
+		Client:                mgr.GetClient(),
+		Scheme:                scheme,
+		Namespace:             ns.Name,
+		DefaultDataPlaneImage: "kong:latest",
+		LoggingMode:           logging.DevelopmentMode,
+	}
+	StartReconcilers(ctx, t, mgr, logs, r)
+
+	c := mgr.GetClient()
+
+	// Create a GatewayClass accepted by the controller.
+	gc := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "gc-ko"},
+		Spec: gatewayv1.GatewayClassSpec{
+			ControllerName: gatewayv1.GatewayController(vars.ControllerName()),
+		},
+	}
+	require.NoError(t, c.Create(ctx, gc))
+
+	t.Log("patching GatewayClass status to Accepted=True")
+	require.Eventually(t, testutils.GatewayClassAcceptedStatusUpdate(t, ctx, gc.Name, c), waitTime, tickTime)
+
+	// Create an initial INVALID TLS Secret referenced by the Gateway listener.
+	secretName := "test-cert"
+	bad := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns.Name, Name: secretName},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       []byte("not-a-cert"),
+			corev1.TLSPrivateKeyKey: []byte("not-a-key"),
+		},
+	}
+	require.NoError(t, c.Create(ctx, bad))
+
+	// Create a Gateway with a TLS listener referencing the Secret.
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns.Name, Name: "gw"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(gc.Name),
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "https",
+					Port:     443,
+					Protocol: gatewayv1.HTTPSProtocolType,
+					TLS: &gatewayv1.GatewayTLSConfig{
+						Mode: lo.ToPtr(gatewayv1.TLSModeTerminate),
+						CertificateRefs: []gatewayv1.SecretObjectReference{{
+							Name: gatewayv1.ObjectName(secretName),
+						}},
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, c.Create(ctx, gw))
+
+	t.Log("verifying that the invalid Secret results in ResolvedRefs=False (InvalidCertificateRef)")
+	gwNN := types.NamespacedName{Namespace: ns.Name, Name: gw.Name}
+	require.Eventually(t, testutils.GatewayListenerResolvedRefsCondition(t, ctx, gwNN, c, metav1.ConditionFalse), waitTime, tickTime)
+
+	t.Log("rotating the Secret with a valid TLS certificate and key")
+	certPEM, keyPEM := certhelper.MustGenerateCertPEMFormat()
+	require.NoError(t, c.Patch(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns.Name, Name: secretName},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       certPEM,
+			corev1.TLSPrivateKeyKey: keyPEM,
+		},
+	}, client.MergeFrom(bad)))
+
+	t.Log("verifying that after rotation the Secret watch enqueues the Gateway and ResolvedRefs becomes True")
+	require.Eventually(t, testutils.GatewayListenerResolvedRefsCondition(t, ctx, gwNN, c, metav1.ConditionTrue), waitTime, tickTime)
+}


### PR DESCRIPTION

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
