### PR TITLE
ci: use .mise.toml for kube-api-linter version

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,7 +1,0 @@
-# renovate: datasource=github-releases depName=golangci/golangci-lint
-version: v2.6.2
-name: golangci-kube-api-linter
-destination: ./bin
-plugins:
-- module: 'sigs.k8s.io/kube-api-linter'
-  version: 8e86c463aeb87cce6056eb639df56ec0f06d0ec4

--- a/.mise.toml
+++ b/.mise.toml
@@ -33,3 +33,7 @@ version = "4.0.1"
 linux-x64 = { url = "https://get.helm.sh/helm-v{version}-linux-amd64.tar.gz" }
 linux-arm64 = { url = "https://get.helm.sh/helm-v{version}-linux-arm64.tar.gz" }
 macos-arm64 = { url = "https://get.helm.sh/helm-v{version}-darwin-arm64.tar.gz" }
+
+[tools."go:sigs.k8s.io/kube-api-linter/cmd/golangci-lint-kube-api-linter"]
+# renovate: datasource=git-refs packageName=https://github.com/kubernetes-sigs/kube-api-linter.git
+version = "8e86c463aeb87cce6056eb639df56ec0f06d0ec4"

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,6 @@ endif
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 
 TOOLS_VERSIONS_FILE = $(PROJECT_DIR)/.tools_versions.yaml
-CUSTOM_GOLANGCI_LINT_FILE = $(PROJECT_DIR)/.custom-gcl.yml
 
 .PHONY: tools
 tools: controller-gen kustomize client-gen golangci-lint gotestsum skaffold yq crd-ref-docs
@@ -190,7 +189,7 @@ HELM = $(PROJECT_DIR)/bin/installs/http-helm/$(HELM_VERSION)/helm
 download.helm: mise yq ## Download helm locally if necessary.
 	$(MAKE) mise-install DEP_VER=http:helm
 
-KUBE_API_LINTER_VERSION = $(shell $(YQ) -r '.plugins[0].version' < $(CUSTOM_GOLANGCI_LINT_FILE))
+KUBE_API_LINTER_VERSION = $(shell $(YQ) -p toml -o yaml '.tools["go:sigs.k8s.io/kube-api-linter/cmd/golangci-lint-kube-api-linter"].version' < $(MISE_FILE))
 KUBE_API_LINTER = $(PROJECT_DIR)/bin/installs/go-sigs-k8s-io-kube-api-linter-cmd-golangci-lint-kube-api-linter/$(KUBE_API_LINTER_VERSION)/bin/golangci-lint-kube-api-linter
 .PHONY: download.kube-api-linter
 download.kube-api-linter: mise yq ## Download kube-api-linter locally if necessary.

--- a/renovate.json
+++ b/renovate.json
@@ -46,27 +46,14 @@
       ]
     },
     {
-      "description": "Match dependencies in .custom-gcl.yml that are properly annotated with `# renovate: datasource={} depName={}.`",
+      "description": "Match dependencies (specifying SHAs) in .mise.toml that are properly annotated with `# renovate: datasource={} depName={}.`",
       "customType": "regex",
       "fileMatch": [
-        "\\.custom-gcl\\.yml$"
+        "\\.mise\\.toml$"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\nversion: v(?<currentValue>.*)"
+        "# renovate: datasource=(?<datasource>.*?) packageName=(?<packageName>.*?)\\nversion\\s*=\\s*\"(?<currentValue>)(?<currentDigest>[a-f0-9]{7,40})\""
       ]
-    },
-    {
-      "description": "Match kube-api-linter git commit digests in .custom-gcl.yml",
-      "customType": "regex",
-      "fileMatch": [
-        ".custom-gcl\\.yml$"
-      ],
-      "matchStrings": [
-        "version:\\s*(?<currentValue>)(?<currentDigest>[a-f0-9]{7,40})"
-      ],
-      "currentValueTemplate": "main",
-      "datasourceTemplate": "git-refs",
-      "lookupNameTemplate": "https://github.com/kubernetes-sigs/kube-api-linter"
     },
     {
       "description": "Match dependencies in Makefile that are properly annotated with `# renovate: datasource={} depName={}.`",


### PR DESCRIPTION
**What this PR does / why we need it**:

Renovate config tested locally:

```
...
DEBUG: Branch summary (repository=local)
       "cacheModified": undefined,
       "baseBranches": [{"branchName": "", "sha": null}],
       "branches": [],
       "defaultBranch": "",
       "inactiveBranches": ["renovate/https-github.com-kubernetes-sigs-kube-api-linter.git-digest"]
DEBUG: branches info extended (repository=local)
       "branchesInformation": [
         {
           "branchName": "renovate/https-github.com-kubernetes-sigs-kube-api-linter.git-digest",
           "prNo": null,
           "prTitle": "Update https://github.com/kubernetes-sigs/kube-api-linter.git digest to 8e86c46",
           "result": "not-scheduled",
           "upgrades": [
             {
               "datasource": "git-refs",
               "depName": "https://github.com/kubernetes-sigs/kube-api-linter.git",
               "displayPending": "",
               "currentDigest": "cd3fb27832ba2972f76f9cffc379518f51e182fe",
               "newDigest": "8e86c463aeb87cce6056eb639df56ec0f06d0ec4",
               "packageFile": ".mise.toml",
               "updateType": "digest",
               "packageName": "https://github.com/kubernetes-sigs/kube-api-linter.git"
             },
             {
               "datasource": "git-refs",
               "depName": "https://github.com/kubernetes-sigs/kube-api-linter.git",
               "displayPending": "",
               "currentDigest": "cd3fb27832ba2972f76f9cffc379518f51e182fe",
               "newDigest": "8e86c463aeb87cce6056eb639df56ec0f06d0ec4",
               "packageFile": ".mise.toml",
               "updateType": "digest",
               "packageName": "https://github.com/kubernetes-sigs/kube-api-linter.git"
             }
           ]
         }
       ]
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
