### PR TITLE
ci: add cooldown to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
   - /hack/generators/
   schedule:
     interval: daily
+  cooldown:
+    semver-major-days: 5
+    semver-minor-days: 2
+    semver-patch-days: 2
+    exclude:
+    - "github.com/Kong/*"
+    - "github.com/kong/*"
   labels:
   - dependencies
   # Create a group of dependencies to be updated together in one pull request
@@ -32,6 +39,10 @@ updates:
     interval: daily
   labels:
   - github_actions
+  cooldown:
+    semver-major-days: 5
+    semver-minor-days: 2
+    semver-patch-days: 2
 - package-ecosystem: docker
   directory: /
   schedule:


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding [cooldown](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-) to dependabot config.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
