### PR TITLE
chore: fix odd number of parameters error when logging

### DIFF
--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -174,10 +174,10 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// In case the referenced KongService is being deleted, disregard the error
 		// and continue.
 		case errors.As(err, &ReferencedKongServiceIsBeingDeleted{}):
-			log.Info(logger, "referenced KongService is being deleted, proceeding with reconciliation", err.Error())
+			log.Info(logger, "referenced KongService is being deleted, proceeding with reconciliation", "error", err.Error())
 		case errors.As(err, &ReferencedObjectDoesNotExist{}):
 			if ent.GetDeletionTimestamp().IsZero() {
-				log.Info(logger, "referenced KongService does not exist, proceeding with reconciliation", err.Error())
+				log.Info(logger, "referenced KongService does not exist, proceeding with reconciliation", "error", err.Error())
 			}
 			if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 				if err := r.Client.Update(ctx, ent); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix:

```
{
	"level": "error",
	"ts": "2025-12-02T14:50:13.572+0100",
	"logger": "KongRoute",
	"msg": "referenced KongService is being deleted, proceeding with reconciliation",
	"controller": "KongRoute",
	"controllerGroup": "configuration.konghq.com",
	"controllerKind": "KongRoute",
	"KongRoute": {
		"name": "route-1",
		"namespace": "default"
	},
	"namespace": "default",
	"name": "route-1",
	"reconcileID": "66a5c725-371d-4f4c-a1f7-2ce6f6e07118",
	"error": "log message has odd number of arguments",
	"stacktrace": "github.com/kong/kong-operator/controller/pkg/log.oddKeyValues\n\t/Users/USER/code_/gateway-operator/controller/pkg/log/log.go:47\ngithub.com/kong/kong-operator/controller/pkg/log._log\n\t/Users/USER/code_/gateway-operator/controller/pkg/log/log.go:37\ngithub.com/kong/kong-operator/controller/pkg/log.Info\n\t/Users/USER/code_/gateway-operator/controller/pkg/log/log.go:15\ngithub.com/kong/kong-operator/controller/konnect.(*KonnectEntityReconciler[...]).Reconcile\n\t/Users/USER/code_/gateway-operator/controller/konnect/reconciler_generic.go:177\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/Users/USER/.gvm/pkgsets/go1.25.3/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:216\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/USER/.gvm/pkgsets/go1.25.3/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:461\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/USER/.gvm/pkgsets/go1.25.3/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:421\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/Users/USER/.gvm/pkgsets/go1.25.3/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:296"
}
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
