### PR TITLE
fix cooldown configuration for gha

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,9 +40,7 @@ updates:
   labels:
   - github_actions
   cooldown:
-    semver-major-days: 5
-    semver-minor-days: 2
-    semver-patch-days: 2
+    default-days: 2
 - package-ecosystem: docker
   directory: /
   schedule:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kong-operator
 
-go 1.25.3
+go 1.25.5
 
 require (
 	cloud.google.com/go/container v1.45.0


### PR DESCRIPTION
**What this PR does / why we need it**:

fix https://github.com/Kong/kong-operator/pull/2625/checks?check_run_id=56917014362

```
The property '#/updates/1/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/1/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/1/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.
```

FYI https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-

The `GitHub Actions` is not `SemVer supported`



**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
