### PR TITLE
refactor: use apierrors.IsNotFound instead of strings.Contains

### DIFF
--- a/ingress-controller/internal/admission/validator.go
+++ b/ingress-controller/internal/admission/validator.go
@@ -3,7 +3,6 @@ package admission
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/kong/go-kong/kong"
@@ -438,7 +437,7 @@ func (validator KongHTTPValidator) ValidateGateway(
 	// validate the gatewayclass reference
 	gwc := gatewayapi.GatewayClass{}
 	if err := validator.ManagerClient.Get(ctx, client.ObjectKey{Name: string(gateway.Spec.GatewayClassName)}, &gwc); err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if apierrors.IsNotFound(err) {
 			return true, "", nil // not managed by this controller
 		}
 		return false, ErrTextCantRetrieveGatewayClass, err


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

xref https://github.com/Kong/kong-operator/pull/2799

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
