### PR TITLE
tests: more verbose logging in envtest suite

### DIFF
--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -156,7 +156,7 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	logger := log.GetLogger(ctx, konnectv1alpha2.KonnectExtensionKind, r.LoggingMode).WithValues("konnectExtension", req.NamespacedName)
+	logger := log.GetLogger(ctx, konnectv1alpha2.KonnectExtensionKind, r.LoggingMode)
 
 	ctx = ctrllog.IntoContext(ctx, logger)
 	log.Debug(logger, "reconciling")

--- a/test/envtest/gateway_secret_watch_envtest_test.go
+++ b/test/envtest/gateway_secret_watch_envtest_test.go
@@ -13,7 +13,6 @@ import (
 
 	kogateway "github.com/kong/kong-operator/controller/gateway"
 	certhelper "github.com/kong/kong-operator/ingress-controller/test/helpers/certificate"
-	"github.com/kong/kong-operator/modules/manager/logging"
 	managerscheme "github.com/kong/kong-operator/modules/manager/scheme"
 	testutils "github.com/kong/kong-operator/pkg/utils/test"
 	"github.com/kong/kong-operator/pkg/vars"
@@ -34,7 +33,6 @@ func TestGatewaySecretWatch_UpdatesResolvedRefsOnSecretRotation(t *testing.T) {
 		Scheme:                scheme,
 		Namespace:             ns.Name,
 		DefaultDataPlaneImage: "kong:latest",
-		LoggingMode:           logging.DevelopmentMode,
 	}
 	StartReconcilers(ctx, t, mgr, logs, r)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Using development logger doesn't use the configured config and thus does not include debug level logs in tests output. This PR fixes it by not using development log mode in tests.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
