### PR TITLE
fix: fix setting secret or configmap label selector to empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@
   to be specified. This aligns `DataPlane` with Gateway APIs' `Gateway`.
   [#2722](https://github.com/Kong/kong-operator/pull/2722)
 
+### Fixed
+
+- Fixed an issue where users could set the secret of configmap label selectors
+  to empty when the other one was left non-empty.
+  [#2810](https://github.com/Kong/kong-operator/pull/2810)
+
 ## [v2.1.0-alpha.0]
 
 ### Added

--- a/modules/manager/cache_options.go
+++ b/modules/manager/cache_options.go
@@ -1,0 +1,58 @@
+package manager
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func createCacheOptions(l logr.Logger, cfg Config) (cache.Options, error) {
+	var cacheOptions cache.Options
+	if cfg.CacheSyncPeriod > 0 {
+		l.Info("cache sync period set", "period", cfg.CacheSyncPeriod)
+		cacheOptions.SyncPeriod = &cfg.CacheSyncPeriod
+	}
+
+	// If there are no configured watch namespaces, then we're watching ALL namespaces,
+	// and we don't have to bother individually caching any particular namespaces.
+	// This is the default behavior of the controller-runtime manager.
+	// If there are configured watch namespaces, then we're watching only those namespaces.
+	if len(cfg.WatchNamespaces) > 0 {
+		l.Info("Manager set up with multiple namespaces", "namespaces", cfg.WatchNamespaces)
+		watched := make(map[string]cache.Config)
+		for _, ns := range cfg.WatchNamespaces {
+			watched[ns] = cache.Config{}
+		}
+		cacheOptions.DefaultNamespaces = watched
+	}
+
+	cacheByObject, err := createCacheByObject(cfg)
+	if err != nil {
+		return cacheOptions, fmt.Errorf("failed to create cache options: %w", err)
+	}
+	cacheOptions.ByObject = cacheByObject
+
+	return cacheOptions, nil
+}
+
+func createCacheByObject(cfg Config) (map[client.Object]cache.ByObject, error) {
+	if cfg.ConfigMapLabelSelector == "" && cfg.SecretLabelSelector == "" {
+		return nil, nil
+	}
+	byObject := map[client.Object]cache.ByObject{}
+	if cfg.SecretLabelSelector != "" {
+		if err := setByObjectFor[corev1.Secret](cfg.SecretLabelSelector, byObject); err != nil {
+			return nil, fmt.Errorf("failed to set byObject for Secrets: %w", err)
+		}
+	}
+	if cfg.ConfigMapLabelSelector != "" {
+		if err := setByObjectFor[corev1.ConfigMap](cfg.ConfigMapLabelSelector, byObject); err != nil {
+			return nil, fmt.Errorf("failed to set byObject for ConfigMaps: %w", err)
+		}
+	}
+
+	return byObject, nil
+}

--- a/modules/manager/cache_options_test.go
+++ b/modules/manager/cache_options_test.go
@@ -1,0 +1,112 @@
+package manager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestCreateCacheByObject(t *testing.T) {
+	tests := []struct {
+		name                   string
+		cfg                    Config
+		expectError            bool
+		expectNil              bool
+		expectedConfigMapLabel string
+		expectedSecretLabel    string
+	}{
+		{
+			name: "no label selectors returns nil",
+			cfg: Config{
+				ConfigMapLabelSelector: "",
+				SecretLabelSelector:    "",
+			},
+			expectError: false,
+			expectNil:   true,
+		},
+		{
+			name: "only secret label selector",
+			cfg: Config{
+				SecretLabelSelector: "app",
+			},
+			expectError:         false,
+			expectNil:           false,
+			expectedSecretLabel: "app",
+		},
+		{
+			name: "only configmap label selector",
+			cfg: Config{
+				ConfigMapLabelSelector: "configmap.konghq.com",
+			},
+			expectError:            false,
+			expectNil:              false,
+			expectedConfigMapLabel: "configmap.konghq.com",
+		},
+		{
+			name: "both label selectors",
+			cfg: Config{
+				ConfigMapLabelSelector: "configmap.konghq.com",
+				SecretLabelSelector:    "app",
+			},
+			expectError:            false,
+			expectNil:              false,
+			expectedConfigMapLabel: "configmap.konghq.com",
+			expectedSecretLabel:    "app",
+		},
+		{
+			name: "invalid secret label selector",
+			cfg: Config{
+				SecretLabelSelector: "invalid==label",
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid configmap label selector",
+			cfg: Config{
+				ConfigMapLabelSelector: "invalid==label",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := createCacheByObject(tt.cfg)
+
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tt.expectNil {
+				require.Nil(t, result)
+				return
+			}
+
+			require.NotNil(t, result)
+
+			if tt.expectedSecretLabel != "" {
+				for obj, v := range result {
+					if _, ok := obj.(*corev1.Secret); ok {
+						r, _ := v.Label.Requirements()
+						require.Len(t, r, 1)
+						require.Equal(t, tt.expectedSecretLabel, r[0].Key())
+					}
+				}
+			}
+
+			if tt.expectedConfigMapLabel != "" {
+				for obj, v := range result {
+					if _, ok := obj.(*corev1.ConfigMap); ok {
+						r, _ := v.Label.Requirements()
+						require.Len(t, r, 1)
+						require.Equal(t, tt.expectedConfigMapLabel, r[0].Key())
+					}
+				}
+			}
+		})
+	}
+}

--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -212,33 +212,9 @@ func Run(
 		return err
 	}
 
-	var cacheOptions cache.Options
-	if cfg.CacheSyncPeriod > 0 {
-		setupLog.Info("cache sync period set", "period", cfg.CacheSyncPeriod)
-		cacheOptions.SyncPeriod = &cfg.CacheSyncPeriod
-	}
-
-	// If there are no configured watch namespaces, then we're watching ALL namespaces,
-	// and we don't have to bother individually caching any particular namespaces.
-	// This is the default behavior of the controller-runtime manager.
-	// If there are configured watch namespaces, then we're watching only those namespaces.
-	if len(cfg.WatchNamespaces) > 0 {
-		setupLog.Info("Manager set up with multiple namespaces", "namespaces", cfg.WatchNamespaces)
-		watched := make(map[string]cache.Config)
-		for _, ns := range cfg.WatchNamespaces {
-			watched[ns] = cache.Config{}
-		}
-		cacheOptions.DefaultNamespaces = watched
-	}
-
-	if cfg.ConfigMapLabelSelector != "" || cfg.SecretLabelSelector != "" {
-		cacheOptions.ByObject = map[client.Object]cache.ByObject{}
-		if err := setByObjectFor[corev1.Secret](cfg.SecretLabelSelector, cacheOptions.ByObject); err != nil {
-			return fmt.Errorf("failed to set byObject for Secrets: %w", err)
-		}
-		if err := setByObjectFor[corev1.ConfigMap](cfg.ConfigMapLabelSelector, cacheOptions.ByObject); err != nil {
-			return fmt.Errorf("failed to set byObject for ConfigMaps: %w", err)
-		}
+	cacheOptions, err := createCacheOptions(setupLog, cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create cache options: %w", err)
 	}
 
 	managerOpts := ctrl.Options{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an issue where users would set either of secret or configmap label selector to empty string but left the other to default non empty value or set it to different non empty value, which would cause:

```
{"level":"error","ts":"2025-12-05T11:30:44.415+0100","msg":"failed to run manager","error":"failed to set byObject for Secrets: failed to make label requirement for secrets: key: Invalid value: \"\": name part must be non-empty; name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')","stacktrace":"main.main\n\t/Users/patryk.malek/code_/gateway-operator/cmd/main.go:42\nruntime.main\n\t/Users/patryk.malek/.gvm/gos/go1.25.5/src/runtime/proc.go:285"}
```

x-ref: https://kongstrong.slack.com/archives/CA42V003B/p1764923952772699

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
