### PR TITLE
Support `HTTPRoute`->`Gateway` cross-namespace reference

### DIFF
--- a/controller/hybridgateway/converter/converter.go
+++ b/controller/hybridgateway/converter/converter.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,8 +30,7 @@ type APIConverter[t RootObject] interface {
 // RootObject is an interface that represents all resource types that can be loaded
 // as root by the APIConverter.
 type RootObject interface {
-	corev1.Service |
-		gwtypes.HTTPRoute
+	gwtypes.HTTPRoute
 }
 
 // RootObjectPtr is a generic interface that represents a pointer to a type T,

--- a/controller/hybridgateway/kongroute/route.go
+++ b/controller/hybridgateway/kongroute/route.go
@@ -73,8 +73,7 @@ func RouteForRule(
 		WithSpecName(routeName).
 		WithHosts(hostnames).
 		WithStripPath(metadata.ExtractStripPath(httpRoute.Annotations)).
-		WithKongService(serviceName).
-		WithOwner(httpRoute)
+		WithKongService(serviceName)
 
 	// Add HTTPRoute matches
 	for _, match := range rule.Matches {

--- a/controller/hybridgateway/reconciler_utils.go
+++ b/controller/hybridgateway/reconciler_utils.go
@@ -263,11 +263,8 @@ func cleanOrphanedResources[t converter.RootObject, tPtr converter.RootObjectPtr
 		list.SetGroupVersionKind(gvk)
 		selector := metadata.LabelSelectorForOwnedResources(rootObjPtr, nil)
 
-		// List all resources of this GVK owned by the root object in the same namespace.
-		ns := rootObjPtr.GetNamespace()
-
-		if err := cl.List(ctx, list, selector, client.InNamespace(ns)); err != nil {
-			return false, fmt.Errorf("unable to list objects with gvk %s in namespace %s: %w", gvk.String(), ns, err)
+		if err := cl.List(ctx, list, selector); err != nil {
+			return false, fmt.Errorf("unable to list objects with gvk %s: %w", gvk.String(), err)
 		}
 
 		log.Debug(logger, "Found existing resources for GVK", "gvk", gvk.String(), "resourceCount", len(list.Items))

--- a/controller/hybridgateway/reconciler_utils_test.go
+++ b/controller/hybridgateway/reconciler_utils_test.go
@@ -139,13 +139,6 @@ func TestCleanOrphanedResources(t *testing.T) {
 			wantNames:    map[schema.GroupVersionKind][]string{gvks[0]: {"route1", "route2"}},
 		},
 		{
-			name:         "Orphans in different namespace are not deleted",
-			gvks:         []schema.GroupVersionKind{gvks[0]},
-			desiredNames: map[schema.GroupVersionKind][]string{gvks[0]: {"route1"}},
-			orphanNames:  map[schema.GroupVersionKind][]string{gvks[0]: {"route2"}},
-			wantNames:    map[schema.GroupVersionKind][]string{gvks[0]: {"route1", "route2"}}, // route2 is in a different namespace, should not be deleted
-		},
-		{
 			name:         "Orphan with label mismatch is not deleted",
 			gvks:         []schema.GroupVersionKind{gvks[0]},
 			desiredNames: map[schema.GroupVersionKind][]string{gvks[0]: {"route1"}},


### PR DESCRIPTION
**What this PR does / why we need it**:

In the hybrid controller, when cleaning up resources, consider cross-namespace entities as well.

Support `HTTPRoute`->`Gateway` cross-namespace reference.

**Which issue this PR fixes**

Fixes #2378 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
