### PR TITLE
fix the report path

### DIFF
--- a/.github/workflows/conformance_tests_report.yaml
+++ b/.github/workflows/conformance_tests_report.yaml
@@ -61,4 +61,4 @@ jobs:
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: conformance-report-${{ matrix.router-flavor }}
-          path: experimental*.yaml
+          path: "*report.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:

In 2.0.6 the conformance report file name was

https://github.com/Kong/kong-operator/blob/a445e24e48e086f015c6a85a8c4129bdce6d3fa4/test/conformance/conformance_test.go#L91

It's different from main branch

https://github.com/Kong/kong-operator/blob/fd2f4367ff4ed9e2dbdda8685e2c2e4fe59168af/test/conformance/conformance_test.go#L100-L101

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
