### PR TITLE
requeue the resource after Konnect 429

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,9 @@
 - Fixed an issue where users could set the secret of configmap label selectors
   to empty when the other one was left non-empty.
   [#2810](https://github.com/Kong/kong-operator/pull/2810)
+- Handle Konnect API 429 rate limit responses by requeuing resources with
+  the appropriate retry-after duration from the response header.
+  [#2856](https://github.com/Kong/kong-operator/pull/2856)
 
 ## [v2.1.0-alpha.0]
 

--- a/controller/konnect/ops/errors.go
+++ b/controller/konnect/ops/errors.go
@@ -2,6 +2,7 @@ package ops
 
 import (
 	"fmt"
+	"time"
 
 	kcfgconsts "github.com/kong/kong-operator/api/common/consts"
 	"github.com/kong/kong-operator/controller/konnect/constraints"
@@ -107,4 +108,22 @@ type KonnectEntityAdoptionNotMatchError struct {
 // Error implements the error interface.
 func (e KonnectEntityAdoptionNotMatchError) Error() string {
 	return fmt.Sprintf("Konnect entity (ID: %s) does not match the spec of the object when adopting in match mode", e.KonnectID)
+}
+
+// RateLimitError is an error type returned when a Konnect API operation
+// fails due to rate limiting (HTTP 429 Too Many Requests).
+// It includes the retry-after duration to indicate when the operation can be retried.
+type RateLimitError struct {
+	Err        error
+	RetryAfter time.Duration
+}
+
+// Error implements the error interface.
+func (e RateLimitError) Error() string {
+	return fmt.Sprintf("rate limited by Konnect API, retry after %s: %v", e.RetryAfter, e.Err)
+}
+
+// Unwrap returns the underlying error.
+func (e RateLimitError) Unwrap() error {
+	return e.Err
 }

--- a/controller/konnect/ops/ops_errors.go
+++ b/controller/konnect/ops/ops_errors.go
@@ -190,7 +190,6 @@ func ErrorIsRateLimited(err error) bool {
 const (
 	// DefaultRateLimitRetryAfter is the default retry-after duration when the
 	// Retry-After header is not present in the rate limit response.
-	// TODO: for reviewer, maybe we need a discussion about this value
 	DefaultRateLimitRetryAfter = 15 * time.Second
 )
 

--- a/controller/konnect/ops/ops_errors.go
+++ b/controller/konnect/ops/ops_errors.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
@@ -167,6 +169,60 @@ func ErrorIsSDKError400(err error) bool {
 	}
 
 	return errSDK.StatusCode == 400
+}
+
+// ErrorIsRateLimited returns true if the provided error is a 429 Too Many Requests error.
+// This can happen when the Konnect API rate limit is exhausted.
+func ErrorIsRateLimited(err error) bool {
+	var errRateLimited *sdkkonnecterrs.RateLimited
+	if errors.As(err, &errRateLimited) {
+		return true
+	}
+
+	var errSDK *sdkkonnecterrs.SDKError
+	if errors.As(err, &errSDK) {
+		return errSDK.StatusCode == http.StatusTooManyRequests
+	}
+
+	return false
+}
+
+const (
+	// DefaultRateLimitRetryAfter is the default retry-after duration when the
+	// Retry-After header is not present in the rate limit response.
+	// TODO: for reviewer, maybe we need a discussion about this value
+	DefaultRateLimitRetryAfter = 15 * time.Second
+)
+
+// GetRetryAfterFromRateLimitError extracts the Retry-After duration from a rate limit error.
+// It checks for the Retry-After header in the HTTP response.
+// If the header is not present or cannot be parsed, it returns the default retry-after duration.
+// If the error is not a rate limit error, it returns 0 and false.
+func GetRetryAfterFromRateLimitError(err error) (time.Duration, bool) {
+	if !ErrorIsRateLimited(err) {
+		return 0, false
+	}
+
+	var errSDK *sdkkonnecterrs.SDKError
+	if errors.As(err, &errSDK) && errSDK.RawResponse != nil {
+		if retryAfter := errSDK.RawResponse.Header.Get("Retry-After"); retryAfter != "" {
+			// Try parsing as seconds (integer)
+			if seconds, parseErr := strconv.ParseInt(retryAfter, 10, 64); parseErr == nil && seconds > 0 {
+				return time.Duration(seconds) * time.Second, true
+			}
+
+			// Try parsing as HTTP-date
+			if t, parseErr := http.ParseTime(retryAfter); parseErr == nil {
+				duration := time.Until(t)
+				if duration > 0 {
+					return duration, true
+				}
+			}
+		}
+	}
+
+	// Return default retry-after duration if we couldn't extract a value
+	return DefaultRateLimitRetryAfter, true
 }
 
 // ErrorIsConflictError returns true if the provided error is a 409 ConflictError.
@@ -341,7 +397,7 @@ func handleDeleteError[
 }
 
 // IgnoreUnrecoverableAPIErr ignores unrecoverable errors that would cause the
-// reconciler to endlessly requeue.
+// reconciler to endlessly requeue, and wraps rate limit errors with retry-after duration.
 func IgnoreUnrecoverableAPIErr(err error, logger logr.Logger) error {
 	// If the error is a type field error or bad request error, then don't propagate
 	// it to the caller.
@@ -353,6 +409,16 @@ func IgnoreUnrecoverableAPIErr(err error, logger logr.Logger) error {
 		ErrorIsConflictError(err) {
 		log.Debug(logger, "ignoring unrecoverable API error, consult object's status for details", "err", err)
 		return nil
+	}
+
+	// If the error is a rate limit error, wrap it with the retry-after duration
+	// so the reconciler can use it to set RequeueAfter.
+	if retryAfter, isRateLimited := GetRetryAfterFromRateLimitError(err); isRateLimited {
+		logger.Info("rate limited by Konnect API", "retry_after", retryAfter.String())
+		return RateLimitError{
+			Err:        err,
+			RetryAfter: retryAfter,
+		}
 	}
 
 	return err

--- a/controller/konnect/ops/ops_errors_test.go
+++ b/controller/konnect/ops/ops_errors_test.go
@@ -8,6 +8,7 @@ import (
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 )
 
@@ -487,7 +488,7 @@ func TestErrorIsRateLimited(t *testing.T) {
 	}{
 		{
 			name: "error is RateLimited",
-			err:  &sdkkonnecterrs.RateLimited{Status: toPtr(int64(429)), Title: toPtr("Too Many Requests")},
+			err:  &sdkkonnecterrs.RateLimited{Status: lo.ToPtr(int64(429)), Title: lo.ToPtr("Too Many Requests")},
 			want: true,
 		},
 		{
@@ -618,7 +619,7 @@ func TestGetRetryAfterFromRateLimitError(t *testing.T) {
 		},
 		{
 			name:              "RateLimited error returns default (no RawResponse)",
-			err:               &sdkkonnecterrs.RateLimited{Status: toPtr(int64(429)), Title: toPtr("Too Many Requests")},
+			err:               &sdkkonnecterrs.RateLimited{Status: lo.ToPtr(int64(429)), Title: lo.ToPtr("Too Many Requests")},
 			wantDuration:      DefaultRateLimitRetryAfter,
 			wantIsRateLimited: true,
 		},
@@ -633,8 +634,4 @@ func TestGetRetryAfterFromRateLimitError(t *testing.T) {
 			}
 		})
 	}
-}
-
-func toPtr[T any](v T) *T {
-	return &v
 }

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -418,6 +418,12 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 
 		if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 			if err := ops.Delete(ctx, sdk, r.Client, r.MetricRecorder, ent); err != nil {
+				// If the error is a rate limit error, requeue after the retry-after duration
+				// instead of returning an error.
+				if retryAfter, isRateLimited := ops.GetRetryAfterFromRateLimitError(err); isRateLimited {
+					logger.Info("rate limited by Konnect API during delete, requeueing", "retry_after", retryAfter.String())
+					return ctrl.Result{RequeueAfter: retryAfter}, nil
+				}
 				if res, errStatus := patch.StatusWithCondition(
 					ctx, r.Client, ent,
 					konnectv1alpha1.KonnectEntityProgrammedConditionType,
@@ -502,6 +508,12 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		}
 
 		if err != nil {
+			// If the error is a rate limit error, requeue after the retry-after duration
+			// instead of returning an error.
+			var rateLimitErr ops.RateLimitError
+			if errors.As(err, &rateLimitErr) {
+				return ctrl.Result{RequeueAfter: rateLimitErr.RetryAfter}, nil
+			}
 			return ctrl.Result{}, ops.FailedKonnectOpError[T]{
 				Op:  ops.CreateOp,
 				Err: err,
@@ -523,6 +535,12 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		return ctrl.Result{}, fmt.Errorf("failed to update in cluster resource after Konnect update: %w %w", errUpd, err)
 	}
 	if err != nil {
+		// If the error is a rate limit error, requeue after the retry-after duration
+		// instead of returning an error.
+		var rateLimitErr ops.RateLimitError
+		if errors.As(err, &rateLimitErr) {
+			return ctrl.Result{RequeueAfter: rateLimitErr.RetryAfter}, nil
+		}
 		logger.Error(err, "failed to update")
 	} else if !res.IsZero() {
 		return res, nil
@@ -597,6 +615,12 @@ func (r *KonnectEntityReconciler[T, TEnt]) adoptFromExistingEntity(
 	}
 
 	if retErr != nil {
+		// If the error is a rate limit error, requeue after the retry-after duration
+		// instead of returning an error.
+		var rateLimitErr ops.RateLimitError
+		if errors.As(retErr, &rateLimitErr) {
+			return ctrl.Result{RequeueAfter: rateLimitErr.RetryAfter}, nil
+		}
 		return ctrl.Result{}, ops.FailedKonnectOpError[T]{
 			Op:  ops.AdoptOp,
 			Err: retErr,


### PR DESCRIPTION
**What this PR does / why we need it**:

The response header like this

```json
{
  "response": {
    "headers": {
      "connection": "close",
      "content-length": "37",
      "content-type": "application/json; charset=utf-8",
      "ratelimit-limit": "3000",
      "ratelimit-remaining": "0",
      "ratelimit-reset": "48",
      "retry-after": "77",
      "vary": "Origin",
      "via": "kong-enterprise-edition",
      "x-kong-response-latency": "1",
      "x-ratelimit-limit-minute": "3000",
      "x-ratelimit-remaining-minute": "0"
    },
    "size": 400,
    "status": 429
  }
}
```

**Which issue this PR fixes**

Fixes https://github.com/Kong/kong-operator/issues/809

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
