### PR TITLE
chore: install helm globally with mise, outside of bin/

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,7 +1,3 @@
-[env]
-
-MISE_DATA_DIR='bin/'
-
 # NOTE: The reason for tool version being set here and not in .tools-versions.toml
 # is that mise requires the version to be specified when using version_prefix
 # and we need to set the latter for kustomize because its tags on GitHub are prefixed


### PR DESCRIPTION
**What this PR does / why we need it**:

To prevent the following error when running `helm` in KO's dir:

```
mise ERROR Failed to install http:helm[platforms={ linux-arm64 = { url = "https://get.helm.sh/helm-v{version}-linux-arm64.tar.gz" }, linux-x64 = { url = "https://get.helm.sh/helm-v{version}-linux-amd64.tar.gz" }, macos-arm64 = { url = "https://get.helm.sh/helm-v{version}-darwin-arm64.tar.gz" } }]@4.0.2:
   0: Http backend requires 'url' option

Location:
   src/backend/http.rs:561
```

This PR installs `helm` with `mise` globally on the system, so that it can be used without setting the `MISE_DATA_DIR` to `$(PROJECT_DIR)/bin/`.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
