### PR TITLE
chore: for finalizer removals ignore `NotFound` errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@
 - `DataPlane`'s `spec.network.services.ingress.ports` now allows up to 64 ports
   to be specified. This aligns `DataPlane` with Gateway APIs' `Gateway`.
   [#2722](https://github.com/Kong/kong-operator/pull/2722)
+- In Konnect controllers, ignore `NotFound` errors when removing the finalizer
+  from the resource.
+  [#2911](https://github.com/Kong/kong-operator/pull/2911)
 
 ### Fixed
 

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -160,6 +160,10 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 					if k8serrors.IsConflict(err) {
 						return ctrl.Result{Requeue: true}, nil
 					}
+					// in case the finalizer removal fails because the resource does not exist, ignore the error.
+					if k8serrors.IsNotFound(err) {
+						return ctrl.Result{}, nil
+					}
 					return ctrl.Result{}, fmt.Errorf("failed to remove finalizer %s: %w", KonnectCleanupFinalizer, err)
 				}
 			}
@@ -183,6 +187,10 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 				if err := r.Client.Update(ctx, ent); err != nil {
 					if k8serrors.IsConflict(err) {
 						return ctrl.Result{RequeueAfter: time.Second}, nil
+					}
+					// in case the finalizer removal fails because the resource does not exist, ignore the error.
+					if k8serrors.IsNotFound(err) {
+						return ctrl.Result{}, nil
 					}
 					return ctrl.Result{}, fmt.Errorf("failed to remove finalizer %s: %w", KonnectCleanupFinalizer, err)
 				}
@@ -217,6 +225,10 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 				if err := r.Client.Update(ctx, ent); err != nil {
 					if k8serrors.IsConflict(err) {
 						return ctrl.Result{Requeue: true}, nil
+					}
+					// in case the finalizer removal fails because the resource does not exist, ignore the error.
+					if k8serrors.IsNotFound(err) {
+						return ctrl.Result{}, nil
 					}
 					return ctrl.Result{}, fmt.Errorf("failed to remove finalizer %s: %w", KonnectCleanupFinalizer, err)
 				}
@@ -290,6 +302,10 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 				if err := r.Client.Update(ctx, ent); err != nil {
 					if k8serrors.IsConflict(err) {
 						return ctrl.Result{Requeue: true}, nil
+					}
+					// in case the finalizer removal fails because the resource does not exist, ignore the error.
+					if k8serrors.IsNotFound(err) {
+						return ctrl.Result{}, nil
 					}
 					return ctrl.Result{}, fmt.Errorf("failed to remove finalizer %s: %w", KonnectCleanupFinalizer, err)
 				}
@@ -418,6 +434,10 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 			if err := r.Client.Update(ctx, ent); err != nil {
 				if k8serrors.IsConflict(err) {
 					return ctrl.Result{Requeue: true}, nil
+				}
+				// in case the finalizer removal fails because the resource does not exist, ignore the error.
+				if k8serrors.IsNotFound(err) {
+					return ctrl.Result{}, nil
 				}
 				return ctrl.Result{}, fmt.Errorf("failed to remove finalizer %s: %w", KonnectCleanupFinalizer, err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

When the konnect controllers remove the finalizers from resources, ignore NotFound errors, as they are related to out-of sync caches.

**Which issue this PR fixes**

Fixes #2716 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
