### PR TITLE
tests: fix data race in integration tests framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -656,14 +656,6 @@ test.integration:
 		COVERPROFILE="coverage.integration.out" \
 		GOTESTPATH=./test/integration/
 
-.PHONY: test.integration_bluegreen
-test.integration_bluegreen:
-	@$(MAKE) _test.integration \
-		KONG_OPERATOR_BLUEGREEN_CONTROLLER="true" \
-		GOTESTFLAGS="-run='BlueGreen|TestDataPlane' $(GOTESTFLAGS)" \
-		COVERPROFILE="coverage.integration-bluegreen.out" \
-		GOTESTPATH=./test/integration/
-
 # Prevent the following data race by not running via gotestsum:
 # WARNING: DATA RACE
 # Read at 0x00000bcabcb0 by goroutine 1080:
@@ -709,6 +701,21 @@ test.integration_bluegreen:
 #       /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/manager/runnable_group.go:244 +0x23c
 #   sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).Start.func1.gowrap2()
 #       /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/manager/runnable_group.go:173 +0x33
+
+.PHONY: test.integration_bluegreen
+test.integration_bluegreen: download.telepresence
+	KUBECONFIG=$(KUBECONFIG) \
+	TELEPRESENCE_BIN=$(TELEPRESENCE) \
+	GOFLAGS=$(GOFLAGS) \
+	KONG_OPERATOR_BLUEGREEN_CONTROLLER="true" \
+	go test \
+	-run='BlueGreen|TestDataPlane' $(GOTESTFLAGS) \
+	-timeout $(INTEGRATION_TEST_TIMEOUT) \
+	-ldflags "$(LDFLAGS_COMMON) $(LDFLAGS) $(LDFLAGS_METADATA)" \
+	-race -v \
+	-coverprofile="coverage.integration-bluegreen.out" \
+	./test/integration/
+
 .PHONY: test.integration_validatingwebhook
 test.integration_validatingwebhook: download.telepresence
 	KUBECONFIG=$(KUBECONFIG) \


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the following data race: 

```
==================
WARNING: DATA RACE
Write at 0x00000bf2f030 by main goroutine:
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.25.5/x64/src/testing/testing.go:2285 +0x294
  github.com/kong/kong-operator/test/integration.TestMain()
      /home/runner/work/kong-operator/kong-operator/test/integration/suite_test.go:158 +0xf97
  main.main()
      _testmain.go:153 +0x171

Previous read at 0x00000bf2f030 by goroutine 1173:
  k8s.io/klog/v2.(*loggingT).output()
      /home/runner/go/pkg/mod/k8s.io/klog/v2@v2.130.1/klog.go:888 +0x81a
  k8s.io/klog/v2.(*loggingT).printWithInfos()
      /home/runner/go/pkg/mod/k8s.io/klog/v2@v2.130.1/klog.go:733 +0x319
  k8s.io/klog/v2.(*loggingT).printDepth()
      /home/runner/go/pkg/mod/k8s.io/klog/v2@v2.130.1/klog.go:715 +0xe9
  k8s.io/klog/v2.(*loggingT).printS()
      /home/runner/go/pkg/mod/k8s.io/klog/v2@v2.130.1/klog.go:822 +0x285
  k8s.io/klog/v2.(*loggingT).infoS()
      /home/runner/go/pkg/mod/k8s.io/klog/v2@v2.130.1/klog.go:806 +0x176
  k8s.io/klog/v2.Verbose.InfoSDepth()
      /home/runner/go/pkg/mod/k8s.io/klog/v2@v2.130.1/klog.go:1467 +0x175
  k8s.io/klog/v2.(*klogger).Info()
      /home/runner/go/pkg/mod/k8s.io/klog/v2@v2.130.1/klogr.go:58 +0xb4
  github.com/go-logr/logr.Logger.Info()
      /home/runner/go/pkg/mod/github.com/go-logr/logr@v1.4.3/logr.go:280 +0x107
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).Start.func1()
      /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:286 +0x214
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).Start()
      /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:303 +0x188
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[sigs.k8s.io/controller-runtime/pkg/reconcile.Request]).Start()
      /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:259 +0x4a
  sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1()
      /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/manager/runnable_group.go:260 +0x1e1
  sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.gowrap1()
      /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/manager/runnable_group.go:283 +0x41

Goroutine 1173 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile()
      /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/manager/runnable_group.go:244 +0x23c
  sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).Start.func1.gowrap2()
      /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/manager/runnable_group.go:173 +0x33
==================
```

by not using `gotestsum`.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
