### PR TITLE
fix(konnect): handle missing CP in `KongRoute`s and `KongTarget`s

### DIFF
--- a/controller/konnect/reconciler_serviceref.go
+++ b/controller/konnect/reconciler_serviceref.go
@@ -17,6 +17,7 @@ import (
 	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
 	"github.com/kong/kong-operator/controller/konnect/constraints"
 	"github.com/kong/kong-operator/controller/pkg/controlplane"
+	"github.com/kong/kong-operator/controller/pkg/op"
 	"github.com/kong/kong-operator/controller/pkg/patch"
 	k8sutils "github.com/kong/kong-operator/pkg/utils/kubernetes"
 )
@@ -130,15 +131,16 @@ func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constra
 			fmt.Sprintf("Referenced KongService %s is not programmed yet", nn),
 		)
 
-		_, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
+		res, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
 		if err != nil {
 			if k8serrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{}, err
 		}
-
-		return ctrl.Result{Requeue: true}, nil
+		if res == op.Updated {
+			return ctrl.Result{}, nil
+		}
 	}
 
 	// TODO(pmalek): make this generic.

--- a/controller/konnect/reconciler_serviceref_test.go
+++ b/controller/konnect/reconciler_serviceref_test.go
@@ -200,7 +200,7 @@ func TestHandleServiceRef(t *testing.T) {
 				testControlPlaneOK,
 			},
 			expectResult: ctrl.Result{
-				Requeue: true,
+				Requeue: false,
 			},
 			expectError: false,
 			updatedEntAssertions: []func(*configurationv1alpha1.KongRoute) (bool, string){

--- a/controller/konnect/reconciler_upstreamref_test.go
+++ b/controller/konnect/reconciler_upstreamref_test.go
@@ -281,7 +281,7 @@ func TestHandleUpstreamRef(t *testing.T) {
 			},
 			objects:      []client.Object{testKongUpstreamNotProgrammed},
 			expectError:  false,
-			expectResult: ctrl.Result{Requeue: true},
+			expectResult: ctrl.Result{Requeue: false},
 			updatedEntAssertions: []func(*configurationv1alpha1.KongTarget) (bool, string){
 				func(kt *configurationv1alpha1.KongTarget) (bool, string) {
 					return lo.ContainsBy(kt.Status.Conditions, func(c metav1.Condition) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:

When a `KongTarget` references a `KongService` which references a non-existing ControlPlane, we need to remove the finalizer from the `KongTarget` to ensure proper cleanup can be done. The same for `KongRoute`s.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
