### PR TITLE
fix(hybridgateway): return explicit errors for unsupported ParentRef kind/group

### DIFF
--- a/controller/hybridgateway/errors/errors.go
+++ b/controller/hybridgateway/errors/errors.go
@@ -14,6 +14,12 @@ var (
 	// ErrNoGatewayController is returned when a GatewayClass exists but is not managed by this controller.
 	ErrNoGatewayController = fmt.Errorf("gatewayClass is not managed by this controller")
 
+	// ErrUnsupportedKind is returned when a ParentRef references an unsupported resource kind.
+	ErrUnsupportedKind = fmt.Errorf("unsupported ParentRef kind, only Gateway is supported")
+
+	// ErrUnsupportedGroup is returned when a ParentRef references an unsupported API group.
+	ErrUnsupportedGroup = fmt.Errorf("unsupported ParentRef group, only gateway.networking.k8s.io is supported")
+
 	// ErrKonnectExtensionCrossNamespaceReference is returned when a KonnectExtension references a ControlPlane in a different namespace.
 	ErrKonnectExtensionCrossNamespaceReference = fmt.Errorf("cross-namespace references between KonnectExtension and ControlPlane are not supported")
 )

--- a/controller/hybridgateway/refs/by.go
+++ b/controller/hybridgateway/refs/by.go
@@ -44,11 +44,6 @@ func GetControlPlaneRefByParentRef(ctx context.Context, logger logr.Logger, cl c
 		return nil, err
 	}
 
-	// If the gateway is nil, it means the ParentRef is not supported (wrong group/kind).
-	if gw == nil {
-		return nil, nil
-	}
-
 	konnectNamespacedRef, err := byGateway(ctx, cl, *gw)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get ControlPlaneRef for ParentRef %+v in route %q: %w", pRef, client.ObjectKeyFromObject(route), err)

--- a/controller/hybridgateway/refs/by_test.go
+++ b/controller/hybridgateway/refs/by_test.go
@@ -108,8 +108,8 @@ func TestGetControlPlaneRefByParentRef(t *testing.T) {
 				}
 			},
 			expected:    nil,
-			wantErr:     false,
-			description: "should return nil for invalid group",
+			wantErr:     true,
+			description: "should return error for invalid group",
 		},
 		{
 			name: "invalid kind",
@@ -128,8 +128,8 @@ func TestGetControlPlaneRefByParentRef(t *testing.T) {
 				}
 			},
 			expected:    nil,
-			wantErr:     false,
-			description: "should return nil for invalid kind",
+			wantErr:     true,
+			description: "should return error for invalid kind",
 		},
 		{
 			name: "gateway not found",

--- a/controller/hybridgateway/refs/get.go
+++ b/controller/hybridgateway/refs/get.go
@@ -64,22 +64,23 @@ func GetGatewaysByHTTPRoute(ctx context.Context, cl client.Client, r gwtypes.HTT
 //   - error: Specific error indicating why the ParentRef is not supported, or nil if validation passes.
 //
 // The function returns specific errors to help callers understand why a ParentRef is not supported:
+// - hybridgatewayerrors.ErrUnsupportedKind: The ParentRef references a non-Gateway resource kind.
+// - hybridgatewayerrors.ErrUnsupportedGroup: The ParentRef references an unsupported API group.
 // - hybridgatewayerrors.ErrNoGatewayFound: The referenced Gateway doesn't exist.
 // - hybridgatewayerrors.ErrNoGatewayClassFound: The Gateway's GatewayClass doesn't exist.
 // - hybridgatewayerrors.ErrNoGatewayController: The GatewayClass is not controlled by this controller.
-// - nil error with nil Gateway: The ParentRef is valid but not supported (wrong kind/group).
 func GetSupportedGatewayForParentRef(ctx context.Context, logger logr.Logger, cl client.Client, pRef gwtypes.ParentReference,
 	routeNamespace string) (*gwtypes.Gateway, error) {
 	// Only support Gateway kind.
 	if pRef.Kind != nil && *pRef.Kind != "Gateway" {
 		log.Debug(logger, "Ignoring ParentRef, unsupported kind", "pRef", pRef, "kind", *pRef.Kind)
-		return nil, nil
+		return nil, hybridgatewayerrors.ErrUnsupportedKind
 	}
 
 	// Only support gateway.networking.k8s.io group (or empty group which defaults to this).
 	if pRef.Group != nil && *pRef.Group != gwtypes.GroupName {
 		log.Debug(logger, "Ignoring ParentRef, unsupported group", "pRef", pRef, "group", *pRef.Group)
-		return nil, nil
+		return nil, hybridgatewayerrors.ErrUnsupportedGroup
 	}
 
 	// Determine the namespace - use route's namespace if not specified.


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, GetSupportedGatewayForParentRef returned (nil, nil) when encountering unsupported ParentRef kinds or API groups, making it ambiguous whether validation passed or failed. This forced callers to guess about the validation outcome.

Changes:
- Add ErrUnsupportedKind and ErrUnsupportedGroup sentinel errors
- Return specific errors instead of (nil, nil) for invalid ParentRefs
- Update error handling in HTTPRoute converter to use switch statement
- Add new error types to all error handling paths
- Update tests to verify new error behavior

This improves error clarity and allows callers to distinguish between:
- Wrong kind/group (not supported by controller)
- Gateway not found (resource doesn't exist)
- GatewayClass not found
- Wrong controller (managed by different controller)

All error checks now use errors.Is() for proper sentinel error handling.

**Which issue this PR fixes**

Fixes #2920 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
