### PR TITLE
hybridgateway: add converter interface for custom orphaned resource handling

### DIFF
--- a/controller/hybridgateway/converter/converter.go
+++ b/controller/hybridgateway/converter/converter.go
@@ -26,6 +26,8 @@ type APIConverter[t RootObject] interface {
 	GetOutputStore(ctx context.Context, logger logr.Logger) ([]unstructured.Unstructured, error)
 	// UpdateRootObjectStatus updates the status for the root object.
 	UpdateRootObjectStatus(ctx context.Context, logger logr.Logger) (updated bool, stop bool, err error)
+	// HandleOrphanedResource is called before deleting orphaned resources to allow the converter to perform custom cleanup logic and skip the deletion.
+	HandleOrphanedResource(ctx context.Context, logger logr.Logger, resource *unstructured.Unstructured) (skipDelete bool, err error)
 }
 
 // RootObject is an interface that represents all resource types that can be loaded

--- a/controller/hybridgateway/converter/converter.go
+++ b/controller/hybridgateway/converter/converter.go
@@ -26,7 +26,6 @@ type APIConverter[t RootObject] interface {
 	GetOutputStore(ctx context.Context, logger logr.Logger) ([]unstructured.Unstructured, error)
 	// UpdateRootObjectStatus updates the status for the root object.
 	UpdateRootObjectStatus(ctx context.Context, logger logr.Logger) (updated bool, stop bool, err error)
-	// HandleOrphanedResource is called before deleting orphaned resources to allow the converter to perform custom cleanup logic and skip the deletion.
 }
 
 // OrphanedResourceHandler is an optional interface that converters can implement

--- a/controller/hybridgateway/converter/converter.go
+++ b/controller/hybridgateway/converter/converter.go
@@ -27,6 +27,18 @@ type APIConverter[t RootObject] interface {
 	// UpdateRootObjectStatus updates the status for the root object.
 	UpdateRootObjectStatus(ctx context.Context, logger logr.Logger) (updated bool, stop bool, err error)
 	// HandleOrphanedResource is called before deleting orphaned resources to allow the converter to perform custom cleanup logic and skip the deletion.
+}
+
+// OrphanedResourceHandler is an optional interface that converters can implement
+// to provide custom cleanup logic for orphaned resources. If a converter implements
+// this interface, the HandleOrphanedResource method will be called before deleting
+// orphaned resources, allowing the converter to perform custom logic such as
+// updating the resource or deciding whether to skip deletion.
+type OrphanedResourceHandler interface {
+	// HandleOrphanedResource is called before deleting orphaned resources.
+	// Returns:
+	//   - skipDelete: true if the resource should not be deleted, false to proceed with deletion
+	//   - err: any error that occurred during processing
 	HandleOrphanedResource(ctx context.Context, logger logr.Logger, resource *unstructured.Unstructured) (skipDelete bool, err error)
 }
 

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -286,22 +286,20 @@ func (c *httpRouteConverter) UpdateRootObjectStatus(ctx context.Context, logger 
 	return updated, stop, nil
 }
 
-// HandleOrphanedResource implements APIConverter.
+// HandleOrphanedResource implements OrphanedResourceHandler.
 //
 // Processes orphaned resources by checking and updating hybrid-routes annotations.
-// This method is called during cleanup when a resource is no longer in the desired state.
-// For HTTPRoute, it removes the route reference from the hybrid-routes annotation and
-// determines whether the resource should be deleted or just updated.
+// This method is called during cleanup to check if the resource passed as argument was part of the set of translated resources
+// derived from the source HTTPRoute. If so, it removes the route reference from the hybrid-routes annotation and determines whether
+// to update the resource and if it should be skipped from deletion.
 //
 // Parameters:
 //   - ctx: The context for API calls and cancellation
-//   - cl: The Kubernetes client for CRUD operations
 //   - logger: Logger for debugging information
 //   - resource: The orphaned resource to process
 //
 // Returns:
-//   - delete: true if the resource should be deleted, false if it should be skipped
-//   - updated: true if the resource was updated (annotation modified and patched)
+//   - skipDelete: true if the resource should NOT be deleted (skip deletion), false if it should be deleted
 //   - err: any error that occurred during processing
 func (c *httpRouteConverter) HandleOrphanedResource(ctx context.Context, logger logr.Logger, resource *unstructured.Unstructured) (skipDelete bool, err error) {
 	am := metadata.NewAnnotationManager(logger)
@@ -324,7 +322,7 @@ func (c *httpRouteConverter) HandleOrphanedResource(ctx context.Context, logger 
 		return true, nil
 	}
 
-	// No other routes in the annotation, the resource is orphaned.
+	// No other routes in the annotation, don't skip deletion.
 	return false, nil
 }
 

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -17,6 +18,7 @@ import (
 	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
 	hybridgatewayerrors "github.com/kong/kong-operator/controller/hybridgateway/errors"
 	"github.com/kong/kong-operator/controller/hybridgateway/kongroute"
+	"github.com/kong/kong-operator/controller/hybridgateway/metadata"
 	"github.com/kong/kong-operator/controller/hybridgateway/plugin"
 	"github.com/kong/kong-operator/controller/hybridgateway/pluginbinding"
 	"github.com/kong/kong-operator/controller/hybridgateway/refs"
@@ -282,6 +284,48 @@ func (c *httpRouteConverter) UpdateRootObjectStatus(ctx context.Context, logger 
 
 	log.Debug(logger, "Finished UpdateRootObjectStatus", "updated", updated)
 	return updated, stop, nil
+}
+
+// HandleOrphanedResource implements APIConverter.
+//
+// Processes orphaned resources by checking and updating hybrid-routes annotations.
+// This method is called during cleanup when a resource is no longer in the desired state.
+// For HTTPRoute, it removes the route reference from the hybrid-routes annotation and
+// determines whether the resource should be deleted or just updated.
+//
+// Parameters:
+//   - ctx: The context for API calls and cancellation
+//   - cl: The Kubernetes client for CRUD operations
+//   - logger: Logger for debugging information
+//   - resource: The orphaned resource to process
+//
+// Returns:
+//   - delete: true if the resource should be deleted, false if it should be skipped
+//   - updated: true if the resource was updated (annotation modified and patched)
+//   - err: any error that occurred during processing
+func (c *httpRouteConverter) HandleOrphanedResource(ctx context.Context, logger logr.Logger, resource *unstructured.Unstructured) (skipDelete bool, err error) {
+	am := metadata.NewAnnotationManager(logger)
+
+	// If the route is not present in the the hybrid-routes annotation of the Kong resource, don't touch it.
+	if !am.ContainsRoute(resource, c.route) {
+		log.Trace(logger, "Route annotation not found, skipping resource", "kind", resource.GetKind(), "obj", client.ObjectKeyFromObject(resource))
+		return true, nil
+	}
+
+	oldResource := resource.DeepCopy()
+	am.RemoveRouteFromAnnotation(resource, c.route)
+
+	// If other Routes are still present in the annotation, we just need to update the resource.
+	if len(am.GetRoutes(resource)) > 0 {
+		log.Debug(logger, "Updating hybrid-routes annotation", "kind", resource.GetKind(), "obj", client.ObjectKeyFromObject(resource))
+		if err := c.Patch(ctx, resource, client.MergeFrom(oldResource)); err != nil && !k8serrors.IsNotFound(err) {
+			return true, fmt.Errorf("failed to update resource: %w", err)
+		}
+		return true, nil
+	}
+
+	// No other routes in the annotation, the resource is orphaned.
+	return false, nil
 }
 
 // translate converts the HTTPRoute to Kong resources and stores them in outputStore.


### PR DESCRIPTION
**What this PR does / why we need it**:
The current orphaned resource deletion function assumes all converters will generate resources with the hybrid-routes annotation. This is not always true, so the assumption of the present of the annotation prevents proper clean-up of not *Routes root kind.

This PR introduces a new optional interface that when implemented enables custom logic execution during the orphan deletion phase.

**Which issue this PR fixes**

Fixes #2898 

**Special notes for your reviewer**:
This PR is made up of two commits: the first one introduces a new signature in the APIConverter interface. This would require anyway that ANY APIConverter implementation defines a HandleOrphanedResource() method even when no special management of the orphan resources is needed.
The second commit moves the function to a dedicated interface, allowing to execute the custom function only for those types implementing the new interface.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
