### PR TITLE
ci: prevent GitHub API rate limiting in chart tests

### DIFF
--- a/.github/workflows/charts-tests.yaml
+++ b/.github/workflows/charts-tests.yaml
@@ -23,6 +23,10 @@ on:
       - '*'
   workflow_dispatch: {}
 
+# NOTE: Some jobs require GITHUB_TOKEN env which is used by mise itself to access
+# GitHub's API authenticated and thus not get rate-limited (which causes failures).
+# Ref: https://mise.jdx.dev/getting-started.html#github-api-rate-limiting.
+
 permissions:
   contents: read
 
@@ -73,6 +77,8 @@ jobs:
 
       - name: Run manifests.charts
         run: make manifests.charts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check generated files for diff
         run: make verify.diff

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,11 +31,11 @@ on:
 # GitHub's API authenticated and thus not get rate-limited (which causes failures).
 # Ref: https://mise.jdx.dev/getting-started.html#github-api-rate-limiting.
 
-env:
-  MISE_VERBOSE: 1
-
 permissions:
   contents: read
+
+env:
+  MISE_VERBOSE: 1
 
 jobs:
   check-docs-only:


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent GitHub API rate limiting in chart tests: 

```
DEBUG pooling idle connection for ("https", api.github.com)
Error: 
   0: Failed to install github:kubernetes-sigs/controller-tools@0.19.0: GitHub attestations verification error for github:kubernetes-sigs/controller-tools@0.19.0: API error: GitHub API returned 403 Forbidden: {"message":"API rate limit exceeded for 135.119.236.50. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
      

Location:
   src/toolset/toolset_install.rs:129

Version:
   2025.12.12 linux-x64 (2025-12-18)
```

https://github.com/Kong/kong-operator/actions/runs/20366130096/job/58521555713?pr=2924#step:7:357

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
