### PR TITLE
ci: prevent GitHub API rate limiting in chart linter tests

### DIFF
--- a/.github/workflows/charts-tests.yaml
+++ b/.github/workflows/charts-tests.yaml
@@ -101,6 +101,8 @@ jobs:
 
       - name: Run linters
         run: make lint.charts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   matrix_k8s_node_versions:
     runs-on: ubuntu-latest
@@ -169,8 +171,12 @@ jobs:
       
       - name: Install cert-manager
         run: make install.helm.cert-manager
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run chart-testing (install)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           kubectl create ns kong-test
           make install.helm.cert-manager
@@ -196,6 +202,8 @@ jobs:
 
       - name: run golden tests
         run: make test.charts.golden
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Workaround to allow checking the matrix tests as required tests without adding the individual cases
   # Ref: https://github.com/orgs/community/discussions/26822#discussioncomment-3305794


### PR DESCRIPTION
**What this PR does / why we need it**:

After https://github.com/Kong/kong-operator/pull/2928 got merged, rate limiting is still happening in other jobs, e.g.: https://github.com/Kong/kong-operator/actions/runs/20368435335/job/58529011012#step:10:67

```
   0: Failed to install github:mikefarah/yq@4.50.1: GitHub attestations verification error for github:mikefarah/yq@4.50.1: API error: GitHub API returned 403 Forbidden: {"message":"API rate limit exceeded for 64.236.142.145. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
```

so add `GITHUB_TOKEN` where necessary.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
