### PR TITLE
ci: do not use GITHUB_TOKEN, allow workflows to read attestations

### DIFF
--- a/.github/workflows/charts-tests.yaml
+++ b/.github/workflows/charts-tests.yaml
@@ -26,9 +26,13 @@ on:
 # NOTE: Some jobs require GITHUB_TOKEN env which is used by mise itself to access
 # GitHub's API authenticated and thus not get rate-limited (which causes failures).
 # Ref: https://mise.jdx.dev/getting-started.html#github-api-rate-limiting.
+#
+# Recent versions of mise started to also accept MISE_GITHUB_TOKEN as an alternative to
+# GITHUB_TOKEN. That env var is set by the mise-action automatically.
 
 permissions:
   contents: read
+  attestations: read
 
 env:
   MISE_VERBOSE: 1
@@ -77,8 +81,6 @@ jobs:
 
       - name: Run manifests.charts
         run: make manifests.charts
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check generated files for diff
         run: make verify.diff
@@ -101,8 +103,6 @@ jobs:
 
       - name: Run linters
         run: make lint.charts
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   matrix_k8s_node_versions:
     runs-on: ubuntu-latest
@@ -171,12 +171,8 @@ jobs:
       
       - name: Install cert-manager
         run: make install.helm.cert-manager
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run chart-testing (install)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           kubectl create ns kong-test
           make install.helm.cert-manager
@@ -202,8 +198,6 @@ jobs:
 
       - name: run golden tests
         run: make test.charts.golden
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Workaround to allow checking the matrix tests as required tests without adding the individual cases
   # Ref: https://github.com/orgs/community/discussions/26822#discussioncomment-3305794

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,9 +30,13 @@ on:
 # NOTE: Some jobs require GITHUB_TOKEN env which is used by mise itself to access
 # GitHub's API authenticated and thus not get rate-limited (which causes failures).
 # Ref: https://mise.jdx.dev/getting-started.html#github-api-rate-limiting.
+#
+# Recent versions of mise started to also accept MISE_GITHUB_TOKEN as an alternative to
+# GITHUB_TOKEN. That env var is set by the mise-action automatically.
 
 permissions:
   contents: read
+  attestations: read
 
 env:
   MISE_VERBOSE: 1
@@ -104,19 +108,13 @@ jobs:
       env:
         # Our .golangci.yaml has fix: true, but we don't want that in CI therefore the below override.
         GOLANGCI_LINT_FLAGS: "--fix=false"
-        GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: make lint
 
     - name: run lint.api
       run: make lint.api
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: run lint.actions
       run: make lint.actions
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   lint-markdownlint:
     runs-on: ubuntu-latest
@@ -137,8 +135,6 @@ jobs:
 
     - name: run lint.markdownlint
       run: make lint.markdownlint
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   govulncheck:
     runs-on: ubuntu-latest
@@ -159,8 +155,6 @@ jobs:
       with:
         install: false
     - run: make govulncheck
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   verify:
     runs-on: ubuntu-latest
@@ -185,13 +179,9 @@ jobs:
 
     - name: Verify manifests consistency
       run: make verify.manifests
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Verify generators consistency
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         timeout_minutes: 8
         max_attempts: 3
@@ -255,13 +245,9 @@ jobs:
     # in base kustomization (e.g. currently AIGateway) but which have samples defined.
     - name: Verify installing CRDs via kustomize works
       run: make install.all
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install and delete each sample one by one
       run: make test.samples
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Verify that uninstalling operator CRDs via kustomize works
       run: make ignore-not-found=true uninstall.all
@@ -307,8 +293,6 @@ jobs:
 
     - name: Verify installing CRDs via kustomize works
       run: make install
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Load image to kind cluster
       run: kind load docker-image kong-operator:e2e-${{ github.sha }} --name $CLUSTER_NAME
@@ -317,7 +301,6 @@ jobs:
       env:
         IMG: kong-operator
         VERSION: e2e-${{ github.sha }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: make deploy
 
     - name: Verify that undeploying operator via kustomize works
@@ -373,7 +356,6 @@ jobs:
       env:
         KONG_PLUGIN_IMAGE_REGISTRY_CREDENTIALS: ${{ secrets.KONG_PLUGIN_IMAGE_REGISTRY_CREDENTIALS }}
         GOTESTSUM_JUNITFILE: "unit-tests.xml"
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: collect test coverage
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -413,8 +395,6 @@ jobs:
         install: false
 
     - name: Run the crds validation tests
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         VERSION="${{ matrix.kubernetes-node-version }}"
         # Remove leading 'v'
@@ -425,8 +405,6 @@ jobs:
         make test.crds-validation CLUSTER_VERSION=${VERSION}
 
     - name: Run the API tests
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: make test.api
 
   envtest-tests:
@@ -466,7 +444,6 @@ jobs:
       env:
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         GOTESTSUM_JUNITFILE: "${{ matrix.directory }}/envtest-tests.xml"
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         VERSION="${{ needs.matrix_k8s_node_versions.outputs.latest }}"
         # Remove leading 'v'
@@ -530,8 +507,6 @@ jobs:
       env:
         GOTESTSUM_JUNITFILE: conformance-tests-${{ matrix.router-flavor }}.xml
         TEST_KONG_ROUTER_FLAVOR: ${{ matrix.router-flavor }}
-        GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: upload diagnostics
       if: ${{ always() }}
@@ -598,8 +573,6 @@ jobs:
         KONG_PLUGIN_IMAGE_REGISTRY_CREDENTIALS: ${{ secrets.KONG_PLUGIN_IMAGE_REGISTRY_CREDENTIALS }}
         KONG_CONTROLLER_OUT: stdout
         GOTESTSUM_JUNITFILE: "${{ matrix.directory }}/integration-tests.xml"
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
         KONG_TEST_KONNECT_SERVER_URL: us.api.konghq.tech
         KONG_CLUSTER_VERSION: ${{ needs.matrix_k8s_node_versions.outputs.latest }}
@@ -653,8 +626,6 @@ jobs:
       env:
         KONG_CONTROLLER_OUT: stdout
         GOTESTSUM_JUNITFILE: integration-tests.xml
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KONG_CLUSTER_VERSION: ${{ needs.matrix_k8s_node_versions.outputs.latest }}
 
     - name: upload diagnostics
@@ -705,7 +676,6 @@ jobs:
       env:
         KONG_CONTROLLER_OUT: stdout
         GOTESTSUM_JUNITFILE: integration-tests-bluegreen.xml
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
         KONG_TEST_KONNECT_SERVER_URL: us.api.konghq.tech
 
@@ -764,7 +734,6 @@ jobs:
       env:
         KONG_TEST_KONG_OPERATOR_IMAGE_LOAD: kong-operator:e2e-${{ github.sha }}
         GOTESTSUM_JUNITFILE: "e2e-tests.xml"
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: upload diagnostics
       if: always()
@@ -834,7 +803,6 @@ jobs:
       env:
         KONNECT_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
         KONNECT_SERVER_URL: us.api.konghq.tech
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   buildpulse-report:
     needs:

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,6 @@
+[settings.github]
+github_attestations = false
+
 # NOTE: The reason for tool version being set here and not in .tools-versions.toml
 # is that mise requires the version to be specified when using version_prefix
 # and we need to set the latter for kustomize because its tags on GitHub are prefixed


### PR DESCRIPTION
**What this PR does / why we need it**:

Apart from using `MISE_GITHUB_TOKEN` (which is set by default by `jsx/mise-action`) this also disables github attestations (https://mise.jdx.dev/configuration/settings.html#github_attestations) to prevent errors like:

```
   0: Failed to install github:mikefarah/yq@4.50.1: GitHub attestations verification error for github:mikefarah/yq@4.50.1: API error: GitHub API returned 403 Forbidden: {"message":"API rate limit exceeded for 52.190.140.131. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
```

This should be fixed by https://github.com/jdx/mise/pull/7446 but it's not merged yet in jdx.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
