### PR TITLE
tests: disable chainsaw e2e tests from CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -898,7 +898,9 @@ jobs:
       - integration-tests-bluegreen
       - integration-tests-validating-webhook
       - e2e-tests
-      - e2e-tests-chainsaw
+      # TODO: reenable when chainsaw e2e tests are stable
+      # https://github.com/Kong/kong-operator/issues/2960
+      # - e2e-tests-chainsaw
       - buildpulse-report
     if: always()
     steps:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

Re-enabling these tests as PR required checks will be done in https://github.com/Kong/kong-operator/issues/2960

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
