### PR TITLE
feat(hybridgateway): implement HandleOrphanedResource for Gateway converter

### DIFF
--- a/controller/hybridgateway/converter/gateway.go
+++ b/controller/hybridgateway/converter/gateway.go
@@ -24,9 +24,11 @@ import (
 	"github.com/kong/kong-operator/controller/pkg/secrets"
 	secretref "github.com/kong/kong-operator/controller/pkg/secrets/ref"
 	gwtypes "github.com/kong/kong-operator/internal/types"
+	k8sutils "github.com/kong/kong-operator/pkg/utils/kubernetes"
 )
 
 var _ APIConverter[gwtypes.Gateway] = &gatewayConverter{}
+var _ OrphanedResourceHandler = &gatewayConverter{}
 
 // gatewayConverter is a concrete implementation of the APIConverter interface for Gateway.
 type gatewayConverter struct {
@@ -189,6 +191,39 @@ func (c *gatewayConverter) UpdateRootObjectStatus(ctx context.Context, logger lo
 	// TODO: implement status update logic
 
 	return false, false, nil
+}
+
+// HandleOrphanedResource implements OrphanedResourceHandler.
+//
+// Determines whether an orphaned resource should be deleted or preserved during cleanup.
+// Resources are only deleted if they are owned by this specific Gateway instance.
+// This prevents accidental deletion of resources that may be owned by other Gateways.
+//
+// Parameters:
+//   - ctx: The context for the operation
+//   - logger: Logger for structured logging
+//   - resource: The orphaned resource to evaluate
+//
+// Returns:
+//   - skipDelete: true if the resource should be preserved, false if it should be deleted
+//   - err: any error encountered during evaluation
+func (c *gatewayConverter) HandleOrphanedResource(ctx context.Context, logger logr.Logger, resource *unstructured.Unstructured) (skipDelete bool, err error) {
+	// Check if the resource is owned by this gateway.
+	if k8sutils.IsOwnedByRefUID(resource, c.gateway.UID) {
+		// Resource is owned by this gateway, allow deletion.
+		log.Debug(logger, "Resource is owned by this gateway, allowing deletion",
+			"resource", resource.GetName(),
+			"kind", resource.GetKind(),
+			"gateway", c.gateway.Name)
+		return false, nil
+	}
+
+	// Resource is not owned by this gateway, skip deletion
+	log.Debug(logger, "Resource is not owned by this gateway, skipping deletion",
+		"resource", resource.GetName(),
+		"kind", resource.GetKind(),
+		"gateway", c.gateway.Name)
+	return true, nil
 }
 
 // processListenerCertificate processes a certificate reference from a listener,


### PR DESCRIPTION

**What this PR does / why we need it**:

Implement the HandleOrphanedResource method in the gatewayConverter to properly handle resource cleanup.

The implementation checks if an orphaned resource (KongCertificate or KongSNI) is owned by the current Gateway instance using the k8sutils.IsOwnedByRefUID utility. Resources owned by the Gateway are allowed to be deleted (skipDelete=false), while resources owned by other Gateways are preserved (skipDelete=true).

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
