### PR TITLE
fix(hybrid-gateway): reconciler only konnect-related objects

### DIFF
--- a/controller/hybridgateway/converter/gateway.go
+++ b/controller/hybridgateway/converter/gateway.go
@@ -88,12 +88,12 @@ func (c *gatewayConverter) Translate(ctx context.Context, logger logr.Logger) (i
 	// It could happen when the GatewayClass is changed to an unsupported one.
 	// This check prevents the translation from proceeding in such cases and allows
 	// the reconciler to clean up any previously created resources.
-	supported, err := refs.IsGatewaySupported(ctx, c.Client, c.gateway)
+	isInKonnect, err := refs.IsGatewayInKonnect(ctx, c.Client, c.gateway)
 	if err != nil {
 		return 0, fmt.Errorf("failed to check if Gateway is supported: %w", err)
 	}
 
-	if !supported {
+	if !isInKonnect {
 		log.Debug(logger, "Gateway is not supported by this controller, skipping translation", "gateway", client.ObjectKeyFromObject(c.gateway))
 		return 0, nil
 	}

--- a/controller/hybridgateway/converter/gateway_test.go
+++ b/controller/hybridgateway/converter/gateway_test.go
@@ -1126,9 +1126,8 @@ func TestTranslate(t *testing.T) {
 
 				// No KonnectExtension created, gateway doesn't reference control plane.
 			},
-			expectError:   true,
+			expectError:   false, // Changed: unsupported gateways are silently skipped
 			expectedCount: 0,
-			errorContains: "does not reference a ControlPlane",
 		},
 		{
 			name: "skips missing secrets without error",

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -216,7 +216,7 @@ func (c *httpRouteConverter) UpdateRootObjectStatus(ctx context.Context, logger 
 	for _, pRef := range c.route.Spec.ParentRefs {
 		log.Debug(logger, "Processing ParentReference", "parentRef", pRef)
 		// Check if the parentRef belongs to a Gateway managed by us.
-		gateway, err := refs.GetSupportedGatewayForParentRef(ctx, logger, c.Client, pRef, c.route.Namespace)
+		gateway, found, err := refs.GetSupportedGatewayForParentRef(ctx, logger, c.Client, pRef, c.route.Namespace)
 		if err != nil {
 			switch {
 			case errors.Is(err, hybridgatewayerrors.ErrNoGatewayClassFound),
@@ -237,6 +237,9 @@ func (c *httpRouteConverter) UpdateRootObjectStatus(ctx context.Context, logger 
 				log.Error(logger, err, "Failed to get supported gateway for ParentReference", "parentRef", pRef)
 				return false, stop, fmt.Errorf("failed to get supported gateway for parentRef %s: %w", pRef.Name, err)
 			}
+		}
+		if !found {
+			continue
 		}
 
 		log.Debug(logger, "Building Accepted condition", "parentRef", pRef, "gateway", gateway.Name)

--- a/controller/hybridgateway/reconciler_utils.go
+++ b/controller/hybridgateway/reconciler_utils.go
@@ -473,13 +473,13 @@ func referencesSupportedGateway(ctx context.Context, cl client.Client, obj clien
 	case *gwtypes.HTTPRoute:
 		// Check if any of the ParentRefs reference a supported Gateway.
 		for _, pRef := range o.Spec.ParentRefs {
-			gw, err := refs.GetSupportedGatewayForParentRef(ctx, logger, cl, pRef, o.Namespace)
+			gw, found, err := refs.GetSupportedGatewayForParentRef(ctx, logger, cl, pRef, o.Namespace)
 			if err != nil {
 				// Log the error but continue checking other ParentRefs.
 				log.Trace(logger, "Error checking ParentRef", "parentRef", pRef, "error", err)
 				continue
 			}
-			if gw != nil {
+			if found {
 				// Found at least one supported Gateway reference.
 				log.Trace(logger, "Found supported Gateway reference", "gateway", client.ObjectKeyFromObject(gw))
 				return true
@@ -489,7 +489,7 @@ func referencesSupportedGateway(ctx context.Context, cl client.Client, obj clien
 
 	case *gwtypes.Gateway:
 		// For Gateway objects, check if they are supported by checking their GatewayClass.
-		supported, err := refs.IsGatewaySupported(ctx, cl, o)
+		supported, err := refs.IsGatewayInKonnect(ctx, cl, o)
 		if err != nil {
 			log.Debug(logger, "Error checking if Gateway is supported", "error", err)
 			return false

--- a/controller/hybridgateway/refs/by.go
+++ b/controller/hybridgateway/refs/by.go
@@ -47,7 +47,7 @@ func GetControlPlaneRefByParentRef(ctx context.Context, logger logr.Logger, cl c
 		return nil, nil
 	}
 
-	konnectNamespacedRef, found, err := byGateway(ctx, cl, *gw)
+	konnectNamespacedRef, _, err := byGateway(ctx, cl, *gw)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get ControlPlaneRef for ParentRef %+v in route %q: %w", pRef, client.ObjectKeyFromObject(route), err)
 	}

--- a/controller/hybridgateway/refs/get_test.go
+++ b/controller/hybridgateway/refs/get_test.go
@@ -15,6 +15,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
 	hybridgatewayerrors "github.com/kong/kong-operator/controller/hybridgateway/errors"
 	gwtypes "github.com/kong/kong-operator/internal/types"
 	"github.com/kong/kong-operator/modules/manager/scheme"
@@ -31,9 +33,14 @@ func Test_GetSupportedGatewayForParentRef(t *testing.T) {
 	s := scheme.Get()
 
 	gateway := &gwtypes.Gateway{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "gateway.networking.k8s.io/v1",
+			Kind:       "Gateway",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "my-gateway",
+			UID:       "gateway-uid",
 		},
 		Spec: gwtypes.GatewaySpec{
 			GatewayClassName: "my-class",
@@ -44,19 +51,51 @@ func Test_GetSupportedGatewayForParentRef(t *testing.T) {
 		Version: "v1",
 		Kind:    "Gateway",
 	})
-	gatewayClass := &gwtypes.GatewayClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "my-class",
+
+	konnectExtension := &konnectv1alpha2.KonnectExtension{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "konnect.konghq.com/v1alpha2",
+			Kind:       "KonnectExtension",
 		},
-		Spec: gwtypes.GatewayClassSpec{
-			ControllerName: gwtypes.GatewayController(controllerName),
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "my-gateway",
+			Labels: map[string]string{
+				"gateway-operator.konghq.com/managed-by": "gateway",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "gateway.networking.k8s.io/v1",
+					Kind:       "Gateway",
+					Name:       "my-gateway",
+					UID:        "gateway-uid",
+				},
+			},
+		},
+		Spec: konnectv1alpha2.KonnectExtensionSpec{
+			Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+				ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+					Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+						Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+						KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+							Name: "test-cp",
+						},
+					},
+				},
+			},
 		},
 	}
-	gatewayClass.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   gwtypes.GroupName,
-		Version: "v1",
-		Kind:    "GatewayClass",
-	})
+
+	konnectGatewayControlPlane := &konnectv1alpha2.KonnectGatewayControlPlane{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "konnect.konghq.com/v1alpha2",
+			Kind:       "KonnectGatewayControlPlane",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-cp",
+		},
+	}
 
 	tests := []struct {
 		name            string
@@ -66,68 +105,92 @@ func Test_GetSupportedGatewayForParentRef(t *testing.T) {
 		controllerVal   string
 		interceptorFunc interceptor.Funcs
 		wantErr         error
-		wantNil         bool
+		wantFound       bool
 	}{
 		{
-			name:    "unsupported kind",
-			pRef:    gwtypes.ParentReference{Kind: kindPtr("OtherKind"), Name: "my-gateway"},
-			routeNS: "default",
-			objs:    []client.Object{gateway, gatewayClass},
-			wantErr: hybridgatewayerrors.ErrUnsupportedKind,
+			name:      "unsupported kind",
+			pRef:      gwtypes.ParentReference{Kind: kindPtr("OtherKind"), Name: "my-gateway"},
+			routeNS:   "default",
+			objs:      []client.Object{gateway, konnectExtension, konnectGatewayControlPlane},
+			wantErr:   hybridgatewayerrors.ErrUnsupportedKind,
+			wantFound: false,
 		},
 		{
-			name:    "unsupported group",
-			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr("other.group"), Name: "my-gateway"},
-			routeNS: "default",
-			objs:    []client.Object{gateway, gatewayClass},
-			wantErr: hybridgatewayerrors.ErrUnsupportedGroup,
+			name:      "unsupported group",
+			pRef:      gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr("other.group"), Name: "my-gateway"},
+			routeNS:   "default",
+			objs:      []client.Object{gateway, konnectExtension, konnectGatewayControlPlane},
+			wantErr:   hybridgatewayerrors.ErrUnsupportedGroup,
+			wantFound: false,
 		},
 		{
-			name:    "gateway not found",
-			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "notfound"},
-			routeNS: "default",
-			objs:    []client.Object{},
-			wantErr: hybridgatewayerrors.ErrNoGatewayFound,
+			name:      "gateway not found",
+			pRef:      gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "notfound"},
+			routeNS:   "default",
+			objs:      []client.Object{},
+			wantErr:   hybridgatewayerrors.ErrNoGatewayFound,
+			wantFound: false,
 		},
 		{
-			name:    "gateway class not found",
+			name:      "gateway without konnect extension",
+			pRef:      gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "my-gateway"},
+			routeNS:   "default",
+			objs:      []client.Object{gateway},
+			wantErr:   nil,
+			wantFound: false,
+		},
+		{
+			name:    "gateway with konnect extension but no control plane",
 			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "my-gateway"},
 			routeNS: "default",
-			objs:    []client.Object{gateway},
-			wantErr: hybridgatewayerrors.ErrNoGatewayClassFound,
-		},
-		{
-			name:    "gateway class wrong controller",
-			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "my-gateway"},
-			routeNS: "default",
-			objs: []client.Object{gateway, &gwtypes.GatewayClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "my-class"},
-				Spec:       gwtypes.GatewayClassSpec{ControllerName: "wrong-controller"},
+			objs: []client.Object{gateway, &konnectv1alpha2.KonnectExtension{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "konnect.konghq.com/v1alpha2",
+					Kind:       "KonnectExtension",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "my-gateway",
+					Labels: map[string]string{
+						"gateway-operator.konghq.com/managed-by": "gateway",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "gateway.networking.k8s.io/v1",
+							Kind:       "Gateway",
+							Name:       "my-gateway",
+							UID:        "gateway-uid",
+						},
+					},
+				},
+				Spec: konnectv1alpha2.KonnectExtensionSpec{
+					Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+						ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+							Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+								Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+								KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+									Name: "non-existent-cp",
+								},
+							},
+						},
+					},
+				},
 			}},
-			wantErr: hybridgatewayerrors.ErrNoGatewayController,
+			wantErr:   nil,
+			wantFound: false,
 		},
 		{
-			name:    "gateway class empty controller",
-			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "my-gateway"},
-			routeNS: "default",
-			objs: []client.Object{gateway, &gwtypes.GatewayClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "my-class"},
-				Spec:       gwtypes.GatewayClassSpec{ControllerName: ""},
-			}},
-			wantErr: hybridgatewayerrors.ErrNoGatewayController,
-		},
-		{
-			name:    "supported parent ref",
-			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "my-gateway"},
-			routeNS: "default",
-			objs:    []client.Object{gateway, gatewayClass},
-			wantNil: false,
+			name:      "supported parent ref",
+			pRef:      gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "my-gateway"},
+			routeNS:   "default",
+			objs:      []client.Object{gateway, konnectExtension, konnectGatewayControlPlane},
+			wantFound: true,
 		},
 		{
 			name:    "gateway get generic error",
 			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "my-gateway"},
 			routeNS: "default",
-			objs:    []client.Object{gateway, gatewayClass},
+			objs:    []client.Object{gateway, konnectExtension, konnectGatewayControlPlane},
 			interceptorFunc: interceptor.Funcs{
 				Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 					if key.Name == "my-gateway" && key.Namespace == "default" {
@@ -136,22 +199,21 @@ func Test_GetSupportedGatewayForParentRef(t *testing.T) {
 					return client.Get(ctx, key, obj, opts...)
 				},
 			},
-			wantErr: fmt.Errorf("failed to get gateway for ParentRef"),
+			wantErr:   fmt.Errorf("failed to get gateway for ParentRef"),
+			wantFound: false,
 		},
 		{
-			name:    "gatewayclass get generic error",
+			name:    "konnect extension listing error",
 			pRef:    gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "my-gateway"},
 			routeNS: "default",
-			objs:    []client.Object{gateway, gatewayClass},
+			objs:    []client.Object{gateway, konnectExtension, konnectGatewayControlPlane},
 			interceptorFunc: interceptor.Funcs{
-				Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-					if key.Name == "my-class" && key.Namespace == "" {
-						return fmt.Errorf("generic gatewayclass error")
-					}
-					return client.Get(ctx, key, obj, opts...)
+				List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					return fmt.Errorf("generic list error")
 				},
 			},
-			wantErr: fmt.Errorf("failed to get gatewayClass for ParentRef"),
+			wantErr:   fmt.Errorf("failed to determine if Gateway"),
+			wantFound: false,
 		},
 		{
 			name:    "parentRef with custom namespace",
@@ -159,38 +221,78 @@ func Test_GetSupportedGatewayForParentRef(t *testing.T) {
 			routeNS: "default",
 			objs: []client.Object{
 				&gwtypes.Gateway{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "gateway.networking.k8s.io/v1",
+						Kind:       "Gateway",
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "custom-ns",
 						Name:      "my-gateway",
+						UID:       "custom-gateway-uid",
 					},
 					Spec: gwtypes.GatewaySpec{
 						GatewayClassName: "my-class",
 					},
 				},
-				&gwtypes.GatewayClass{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "my-class",
+				&konnectv1alpha2.KonnectExtension{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "konnect.konghq.com/v1alpha2",
+						Kind:       "KonnectExtension",
 					},
-					Spec: gwtypes.GatewayClassSpec{
-						ControllerName: gwtypes.GatewayController(vars.DefaultControllerName),
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "custom-ns",
+						Name:      "my-gateway",
+						Labels: map[string]string{
+							"gateway-operator.konghq.com/managed-by": "gateway",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "gateway.networking.k8s.io/v1",
+								Kind:       "Gateway",
+								Name:       "my-gateway",
+								UID:        "custom-gateway-uid",
+							},
+						},
+					},
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-cp",
+									},
+								},
+							},
+						},
+					},
+				},
+				&konnectv1alpha2.KonnectGatewayControlPlane{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "konnect.konghq.com/v1alpha2",
+						Kind:       "KonnectGatewayControlPlane",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "custom-ns",
+						Name:      "test-cp",
 					},
 				},
 			},
-			wantNil: false,
+			wantFound: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			clientBuilder := fake.NewClientBuilder().WithScheme(s).WithObjects(tt.objs...)
-			if tt.interceptorFunc.Get != nil {
+			if tt.interceptorFunc.Get != nil || tt.interceptorFunc.List != nil {
 				clientBuilder = clientBuilder.WithInterceptorFuncs(tt.interceptorFunc)
 			}
 			cl := clientBuilder.Build()
-			gw, _, err := GetSupportedGatewayForParentRef(ctx, logger, cl, tt.pRef, tt.routeNS)
+			gw, found, err := GetSupportedGatewayForParentRef(ctx, logger, cl, tt.pRef, tt.routeNS)
 			if tt.wantErr != nil {
 				require.Error(t, err)
-				if errors.Is(err, hybridgatewayerrors.ErrNoGatewayFound) || errors.Is(err, hybridgatewayerrors.ErrNoGatewayClassFound) || errors.Is(err, hybridgatewayerrors.ErrNoGatewayController) || errors.Is(err, hybridgatewayerrors.ErrUnsupportedKind) || errors.Is(err, hybridgatewayerrors.ErrUnsupportedGroup) {
+				if errors.Is(err, hybridgatewayerrors.ErrNoGatewayFound) || errors.Is(err, hybridgatewayerrors.ErrUnsupportedKind) || errors.Is(err, hybridgatewayerrors.ErrUnsupportedGroup) {
 					// Specific error type matches
 					require.ErrorIs(t, err, tt.wantErr)
 					return
@@ -198,9 +300,9 @@ func Test_GetSupportedGatewayForParentRef(t *testing.T) {
 				require.Contains(t, err.Error(), tt.wantErr.Error())
 				return
 			}
-			if tt.wantNil {
-				require.Nil(t, gw)
-			} else {
+			require.NoError(t, err)
+			require.Equal(t, tt.wantFound, found)
+			if tt.wantFound {
 				require.NotNil(t, gw)
 			}
 		})
@@ -214,116 +316,174 @@ func nsPtr(s string) *gatewayv1.Namespace { n := gatewayv1.Namespace(s); return 
 func TestIsGatewayInKonnect(t *testing.T) {
 	ctx := context.Background()
 
-	controllerName := vars.DefaultControllerName
-	vars.SetControllerName(controllerName)
-
 	s := scheme.Get()
 
 	tests := []struct {
 		name           string
 		gateway        *gwtypes.Gateway
-		existingObjs   []client.Object
+		setupObjs      func(*gwtypes.Gateway) []client.Object
 		expectedResult bool
 		expectError    bool
 		errorContains  string
 	}{
 		{
-			name: "supported gateway with matching controller",
+			name: "gateway with konnect extension and control plane",
 			gateway: &gwtypes.Gateway{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "gateway.networking.k8s.io/v1",
+					Kind:       "Gateway",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-gateway",
 					Namespace: "default",
-				},
-				Spec: gwtypes.GatewaySpec{
-					GatewayClassName: "supported-class",
+					UID:       "test-gateway-uid",
 				},
 			},
-			existingObjs: []client.Object{
-				&gwtypes.GatewayClass{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "supported-class",
+			setupObjs: func(gw *gwtypes.Gateway) []client.Object {
+				return []client.Object{
+					&konnectv1alpha2.KonnectExtension{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "konnect.konghq.com/v1alpha2",
+							Kind:       "KonnectExtension",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-gateway",
+							Namespace: "default",
+							Labels: map[string]string{
+								"gateway-operator.konghq.com/managed-by": "gateway",
+							},
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: "gateway.networking.k8s.io/v1",
+									Kind:       "Gateway",
+									Name:       gw.Name,
+									UID:        gw.UID,
+								},
+							},
+						},
+						Spec: konnectv1alpha2.KonnectExtensionSpec{
+							Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+								ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+									Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+										Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+										KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+											Name: "test-cp",
+										},
+									},
+								},
+							},
+						},
 					},
-					Spec: gwtypes.GatewayClassSpec{
-						ControllerName: gwtypes.GatewayController(controllerName),
+					&konnectv1alpha2.KonnectGatewayControlPlane{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "konnect.konghq.com/v1alpha2",
+							Kind:       "KonnectGatewayControlPlane",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-cp",
+							Namespace: "default",
+						},
 					},
-				},
+				}
 			},
 			expectedResult: true,
 			expectError:    false,
 		},
 		{
-			name: "unsupported gateway with different controller",
+			name: "gateway without konnect extension",
 			gateway: &gwtypes.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-gateway",
 					Namespace: "default",
-				},
-				Spec: gwtypes.GatewaySpec{
-					GatewayClassName: "other-class",
+					UID:       "test-gateway-uid",
 				},
 			},
-			existingObjs: []client.Object{
-				&gwtypes.GatewayClass{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "other-class",
-					},
-					Spec: gwtypes.GatewayClassSpec{
-						ControllerName: "some.other/controller",
-					},
-				},
+			setupObjs: func(gw *gwtypes.Gateway) []client.Object {
+				return []client.Object{}
 			},
 			expectedResult: false,
 			expectError:    false,
 		},
 		{
-			name: "gateway with non-existent gatewayclass",
+			name: "gateway with konnect extension but no control plane",
 			gateway: &gwtypes.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-gateway",
 					Namespace: "default",
-				},
-				Spec: gwtypes.GatewaySpec{
-					GatewayClassName: "non-existent-class",
+					UID:       "test-gateway-uid",
 				},
 			},
-			existingObjs:   []client.Object{},
+			setupObjs: func(gw *gwtypes.Gateway) []client.Object {
+				return []client.Object{
+					&konnectv1alpha2.KonnectExtension{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-gateway",
+							Namespace: "default",
+							Labels: map[string]string{
+								"gateway-operator.konghq.com/managed-by": "gateway",
+							},
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: "gateway.networking.k8s.io/v1",
+									Kind:       "Gateway",
+									Name:       gw.Name,
+									UID:        gw.UID,
+								},
+							},
+						},
+						Spec: konnectv1alpha2.KonnectExtensionSpec{
+							Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+								ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+									Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+										Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+										KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+											Name: "non-existent-cp",
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			},
 			expectedResult: false,
 			expectError:    false,
 		},
 		{
-			name: "error getting gatewayclass",
+			name: "error listing konnect extensions",
 			gateway: &gwtypes.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-gateway",
 					Namespace: "default",
-				},
-				Spec: gwtypes.GatewaySpec{
-					GatewayClassName: "error-class",
+					UID:       "test-gateway-uid",
 				},
 			},
-			existingObjs:   []client.Object{},
+			setupObjs: func(gw *gwtypes.Gateway) []client.Object {
+				return []client.Object{}
+			},
 			expectedResult: false,
 			expectError:    true,
-			errorContains:  "failed to get gatewayClass",
+			errorContains:  "failed to determine if Gateway",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			existingObjs := tt.setupObjs(tt.gateway)
+			// Add the gateway itself to the objects
+			existingObjs = append(existingObjs, tt.gateway)
+
 			clientBuilder := fake.NewClientBuilder().WithScheme(s)
 
-			if len(tt.existingObjs) > 0 {
-				clientBuilder = clientBuilder.WithObjects(tt.existingObjs...)
+			if len(existingObjs) > 0 {
+				clientBuilder = clientBuilder.WithObjects(existingObjs...)
 			}
 
 			// For the error test case, add an interceptor to simulate API errors
 			if tt.expectError && tt.errorContains != "" {
 				clientBuilder = clientBuilder.WithInterceptorFuncs(interceptor.Funcs{
-					Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-						if key.Name == "error-class" {
-							return fmt.Errorf("simulated API error")
-						}
-						return client.Get(ctx, key, obj, opts...)
+					List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+						return fmt.Errorf("simulated API error")
 					},
 				})
 			}

--- a/controller/hybridgateway/refs/get_test.go
+++ b/controller/hybridgateway/refs/get_test.go
@@ -187,7 +187,7 @@ func Test_GetSupportedGatewayForParentRef(t *testing.T) {
 				clientBuilder = clientBuilder.WithInterceptorFuncs(tt.interceptorFunc)
 			}
 			cl := clientBuilder.Build()
-			gw, err := GetSupportedGatewayForParentRef(ctx, logger, cl, tt.pRef, tt.routeNS)
+			gw, _, err := GetSupportedGatewayForParentRef(ctx, logger, cl, tt.pRef, tt.routeNS)
 			if tt.wantErr != nil {
 				require.Error(t, err)
 				if errors.Is(err, hybridgatewayerrors.ErrNoGatewayFound) || errors.Is(err, hybridgatewayerrors.ErrNoGatewayClassFound) || errors.Is(err, hybridgatewayerrors.ErrNoGatewayController) || errors.Is(err, hybridgatewayerrors.ErrUnsupportedKind) || errors.Is(err, hybridgatewayerrors.ErrUnsupportedGroup) {
@@ -211,7 +211,7 @@ func groupPtr(s string) *gatewayv1.Group  { g := gatewayv1.Group(s); return &g }
 func kindPtr(s string) *gatewayv1.Kind    { k := gatewayv1.Kind(s); return &k }
 func nsPtr(s string) *gatewayv1.Namespace { n := gatewayv1.Namespace(s); return &n }
 
-func TestIsGatewaySupported(t *testing.T) {
+func TestIsGatewayInKonnect(t *testing.T) {
 	ctx := context.Background()
 
 	controllerName := vars.DefaultControllerName
@@ -330,7 +330,7 @@ func TestIsGatewaySupported(t *testing.T) {
 
 			cl := clientBuilder.Build()
 
-			result, err := IsGatewaySupported(ctx, cl, tt.gateway)
+			result, err := IsGatewayInKonnect(ctx, cl, tt.gateway)
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/controller/hybridgateway/watch/filter.go
+++ b/controller/hybridgateway/watch/filter.go
@@ -81,7 +81,7 @@ func filterByGateway(ctx context.Context, cl client.Client) *predicate.Funcs {
 		}
 
 		// Check if the Gateway is supported (i.e., controlled by us).
-		supported, err := refs.IsGatewaySupported(ctx, cl, gateway)
+		supported, err := refs.IsGatewayInKonnect(ctx, cl, gateway)
 		if err != nil {
 			// For other errors (e.g., temporary API server issues), enqueue the event
 			// so the reconciler can handle it and log it if the error persists.

--- a/controller/hybridgateway/watch/filter_test.go
+++ b/controller/hybridgateway/watch/filter_test.go
@@ -587,18 +587,46 @@ func TestFilterByGateway(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-gateway",
 					Namespace: "default",
+					UID:       "test-gateway-uid",
 				},
 				Spec: gwtypes.GatewaySpec{
 					GatewayClassName: "kong",
 				},
 			},
 			existingObjs: []client.Object{
-				&gwtypes.GatewayClass{
+				&konnectv1alpha2.KonnectExtension{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "kong",
+						Name:      "test-gateway",
+						Namespace: "default",
+						Labels: map[string]string{
+							"gateway-operator.konghq.com/managed-by": "gateway",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "gateway.networking.k8s.io/v1",
+								Kind:       "Gateway",
+								Name:       "test-gateway",
+								UID:        "test-gateway-uid",
+							},
+						},
 					},
-					Spec: gwtypes.GatewayClassSpec{
-						ControllerName: "konghq.com/gateway-operator",
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-cp",
+									},
+								},
+							},
+						},
+					},
+				},
+				&konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cp",
+						Namespace: "default",
 					},
 				},
 			},
@@ -611,23 +639,51 @@ func TestFilterByGateway(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-gateway",
 					Namespace: "default",
+					UID:       "test-gateway-uid",
 				},
 				Spec: gwtypes.GatewaySpec{
 					GatewayClassName: "kong",
 				},
 			},
 			existingObjs: []client.Object{
-				&gwtypes.GatewayClass{
+				&konnectv1alpha2.KonnectExtension{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "kong",
+						Name:      "test-gateway",
+						Namespace: "default",
+						Labels: map[string]string{
+							"gateway-operator.konghq.com/managed-by": "gateway",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "gateway.networking.k8s.io/v1",
+								Kind:       "Gateway",
+								Name:       "test-gateway",
+								UID:        "test-gateway-uid",
+							},
+						},
 					},
-					Spec: gwtypes.GatewayClassSpec{
-						ControllerName: "konghq.com/gateway-operator",
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-cp",
+									},
+								},
+							},
+						},
+					},
+				},
+				&konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cp",
+						Namespace: "default",
 					},
 				},
 			},
 			interceptorFuncs: &interceptor.Funcs{
-				Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
 					return errors.New("simulated API error")
 				},
 			},
@@ -680,6 +736,7 @@ func TestFilterByGateway(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-gateway",
 					Namespace: "default",
+					UID:       "test-gateway-uid",
 				},
 				Spec: gwtypes.GatewaySpec{
 					GatewayClassName: "kong",
@@ -689,18 +746,46 @@ func TestFilterByGateway(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-gateway",
 					Namespace: "default",
+					UID:       "test-gateway-uid",
 				},
 				Spec: gwtypes.GatewaySpec{
 					GatewayClassName: "non-existent",
 				},
 			},
 			existingObjs: []client.Object{
-				&gwtypes.GatewayClass{
+				&konnectv1alpha2.KonnectExtension{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "kong",
+						Name:      "test-gateway",
+						Namespace: "default",
+						Labels: map[string]string{
+							"gateway-operator.konghq.com/managed-by": "gateway",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "gateway.networking.k8s.io/v1",
+								Kind:       "Gateway",
+								Name:       "test-gateway",
+								UID:        "test-gateway-uid",
+							},
+						},
 					},
-					Spec: gwtypes.GatewayClassSpec{
-						ControllerName: "konghq.com/gateway-operator",
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-cp",
+									},
+								},
+							},
+						},
+					},
+				},
+				&konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cp",
+						Namespace: "default",
 					},
 				},
 			},
@@ -713,6 +798,7 @@ func TestFilterByGateway(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-gateway",
 					Namespace: "default",
+					UID:       "test-gateway-uid",
 				},
 				Spec: gwtypes.GatewaySpec{
 					GatewayClassName: "non-existent",
@@ -722,18 +808,46 @@ func TestFilterByGateway(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-gateway",
 					Namespace: "default",
+					UID:       "test-gateway-uid",
 				},
 				Spec: gwtypes.GatewaySpec{
 					GatewayClassName: "kong",
 				},
 			},
 			existingObjs: []client.Object{
-				&gwtypes.GatewayClass{
+				&konnectv1alpha2.KonnectExtension{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "kong",
+						Name:      "test-gateway",
+						Namespace: "default",
+						Labels: map[string]string{
+							"gateway-operator.konghq.com/managed-by": "gateway",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "gateway.networking.k8s.io/v1",
+								Kind:       "Gateway",
+								Name:       "test-gateway",
+								UID:        "test-gateway-uid",
+							},
+						},
 					},
-					Spec: gwtypes.GatewayClassSpec{
-						ControllerName: "konghq.com/gateway-operator",
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-cp",
+									},
+								},
+							},
+						},
+					},
+				},
+				&konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cp",
+						Namespace: "default",
 					},
 				},
 			},
@@ -771,18 +885,46 @@ func TestFilterByGateway(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-gateway",
 					Namespace: "default",
+					UID:       "test-gateway-uid",
 				},
 				Spec: gwtypes.GatewaySpec{
 					GatewayClassName: "kong",
 				},
 			},
 			existingObjs: []client.Object{
-				&gwtypes.GatewayClass{
+				&konnectv1alpha2.KonnectExtension{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "kong",
+						Name:      "test-gateway",
+						Namespace: "default",
+						Labels: map[string]string{
+							"gateway-operator.konghq.com/managed-by": "gateway",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "gateway.networking.k8s.io/v1",
+								Kind:       "Gateway",
+								Name:       "test-gateway",
+								UID:        "test-gateway-uid",
+							},
+						},
 					},
-					Spec: gwtypes.GatewayClassSpec{
-						ControllerName: "konghq.com/gateway-operator",
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-cp",
+									},
+								},
+							},
+						},
+					},
+				},
+				&konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cp",
+						Namespace: "default",
 					},
 				},
 			},
@@ -820,18 +962,46 @@ func TestFilterByGateway(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-gateway",
 					Namespace: "default",
+					UID:       "test-gateway-uid",
 				},
 				Spec: gwtypes.GatewaySpec{
 					GatewayClassName: "kong",
 				},
 			},
 			existingObjs: []client.Object{
-				&gwtypes.GatewayClass{
+				&konnectv1alpha2.KonnectExtension{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "kong",
+						Name:      "test-gateway",
+						Namespace: "default",
+						Labels: map[string]string{
+							"gateway-operator.konghq.com/managed-by": "gateway",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "gateway.networking.k8s.io/v1",
+								Kind:       "Gateway",
+								Name:       "test-gateway",
+								UID:        "test-gateway-uid",
+							},
+						},
 					},
-					Spec: gwtypes.GatewayClassSpec{
-						ControllerName: "konghq.com/gateway-operator",
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-cp",
+									},
+								},
+							},
+						},
+					},
+				},
+				&konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cp",
+						Namespace: "default",
 					},
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

In the Hybrid `Gateway` and `HTTPRoute` reconcilers, filter out the objects that are unrelated to Konnect.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
