### PR TITLE
test(e2e/chainsaw) Add test cases for httproute header match for Konnect hybrid gateway

### DIFF
--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/01-assert-prerequisites.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/01-assert-prerequisites.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kong
+  name: ($kong_namespace)
 status:
   phase: Active
 ---
@@ -11,18 +11,44 @@ status:
 apiVersion: v1
 kind: Service
 metadata:
-  name: echo
-  namespace: kong
+  name: ($echo_service_name)
+  namespace: ($echo_service_namespace)
 ---
 # Assert Deployment is ready
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: echo
-  namespace: kong
+  name: ($echo_service_name)
+  namespace: ($echo_service_namespace)
 status:
   # Filter conditions array to check for Available condition
   (conditions[?type == 'Available']):
     - status: 'True'
   readyReplicas: 1
   replicas: 1
+---
+# Assert Gateway is ready
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ($gateway_name)
+  namespace: ($kong_namespace)
+status:
+  (conditions[?type == 'Accepted']):
+    - status: 'True'
+      reason: Accepted
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'DataPlaneReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'KonnectGatewayControlPlaneProgrammed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'KonnectExtensionReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'GatewayService']):
+    - status: 'True'
+      reason: Ready

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/01-assert-prerequisites.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/01-assert-prerequisites.yaml
@@ -1,0 +1,28 @@
+---
+# Assert namespaces exist
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kong
+status:
+  phase: Active
+---
+# Assert Service exists
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: kong
+---
+# Assert Deployment is ready
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo
+  namespace: kong
+status:
+  # Filter conditions array to check for Available condition
+  (conditions[?type == 'Available']):
+    - status: 'True'
+  readyReplicas: 1
+  replicas: 1

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/01-prerequisites.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/01-prerequisites.yaml
@@ -1,0 +1,149 @@
+---
+# Namespace for Kong resources
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kong
+---
+# Namespace for default resources
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+---
+kind: KonnectAPIAuthConfiguration
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: konnect-api-auth-dev-1
+  namespace: kong
+spec:
+  type: token
+  token: (env('KONNECT_TOKEN'))
+  serverURL: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+---
+kind: GatewayConfiguration
+apiVersion: gateway-operator.konghq.com/v2beta1
+metadata:
+  name: kong-foo
+  namespace: kong
+spec:
+  konnect:
+    authRef:
+      name: konnect-api-auth-dev-1
+  dataPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        spec:
+          containers:
+          - name: proxy
+            image: kong/kong-gateway:3.12
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: kong-foo
+spec:
+  controllerName: konghq.com/gateway-operator
+  parametersRef:
+    group: gateway-operator.konghq.com
+    kind: GatewayConfiguration
+    name: kong-foo
+    namespace: kong
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: kong-foo
+  namespace: kong
+spec:
+  gatewayClassName: kong-foo
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: echo
+  name: echo
+  namespace: kong
+spec:
+  ports:
+    - port: 1025
+      name: tcp
+      protocol: TCP
+      targetPort: 1025
+    - port: 1026
+      name: udp
+      protocol: TCP
+      targetPort: 1026
+    - port: 1027
+      name: http
+      protocol: TCP
+      targetPort: 1027
+    - port: 1030
+      name: tls
+      protocol: TCP
+      targetPort: 1030
+  selector:
+    app: echo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: echo
+  name: echo
+  namespace: kong
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: echo
+    spec:
+      containers:
+        - image: kong/go-echo:latest
+          name: echo
+          ports:
+            - containerPort: 1025
+            - containerPort: 1026
+            - containerPort: 1027
+            - containerPort: 1030
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 1027
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 210m
+              memory: 256Mi
+---

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/01-prerequisites.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/01-prerequisites.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kong
+  name: ($kong_namespace)
 ---
 # Namespace for default resources
 apiVersion: v1
@@ -15,7 +15,7 @@ kind: KonnectAPIAuthConfiguration
 apiVersion: konnect.konghq.com/v1alpha1
 metadata:
   name: konnect-api-auth-dev-1
-  namespace: kong
+  namespace: ($gateway_namespace)
 spec:
   type: token
   token: (env('KONNECT_TOKEN'))
@@ -24,8 +24,8 @@ spec:
 kind: GatewayConfiguration
 apiVersion: gateway-operator.konghq.com/v2beta1
 metadata:
-  name: kong-foo
-  namespace: kong
+  name: ($gateway_configuration_name)
+  namespace: ($gateway_namespace)
 spec:
   konnect:
     authRef:
@@ -36,27 +36,27 @@ spec:
         spec:
           containers:
           - name: proxy
-            image: kong/kong-gateway:3.12
+            image: ($gateway_proxy_image)
 ---
 kind: GatewayClass
 apiVersion: gateway.networking.k8s.io/v1
 metadata:
-  name: kong-foo
+  name: ($gateway_class_name)
 spec:
   controllerName: konghq.com/gateway-operator
   parametersRef:
     group: gateway-operator.konghq.com
     kind: GatewayConfiguration
-    name: kong-foo
-    namespace: kong
+    name: ($gateway_configuration_name)
+    namespace: ($gateway_namespace)
 ---
 kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1
 metadata:
-  name: kong-foo
-  namespace: kong
+  name: ($gateway_name)
+  namespace: ($gateway_namespace)
 spec:
-  gatewayClassName: kong-foo
+  gatewayClassName: ($gateway_class_name)
   listeners:
   - name: http
     protocol: HTTP
@@ -67,8 +67,8 @@ kind: Service
 metadata:
   labels:
     app: echo
-  name: echo
-  namespace: kong
+  name: ($echo_service_name)
+  namespace: ($echo_service_namespace)
 spec:
   ports:
     - port: 1025
@@ -95,8 +95,8 @@ kind: Deployment
 metadata:
   labels:
     app: echo
-  name: echo
-  namespace: kong
+  name: ($echo_service_name)
+  namespace: ($echo_service_namespace)
 spec:
   replicas: 1
   selector:

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/02-assert-httproute-single-header-match.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/02-assert-httproute-single-header-match.yaml
@@ -1,0 +1,33 @@
+---
+# Assert HTTPRoute is accepted and programmed
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: echo-header-match
+  namespace: kong
+status:
+  parents:
+    - parentRef:
+        name: kong-foo
+        group: gateway.networking.k8s.io
+        kind: Gateway
+      controllerName: konghq.com/gateway-operator
+      # Filter conditions array to check for all required conditions
+      (conditions[?type == 'Accepted']):
+        - status: "True"
+          reason: Accepted
+      (conditions[?type == 'ResolvedRefs']):
+        - status: "True"
+          reason: ResolvedRefs
+      (conditions[?type == 'KongRouteProgrammed']):
+        - status: "True"
+          reason: KongRouteProgrammed
+      (conditions[?type == 'KongServiceProgrammed']):
+        - status: "True"
+          reason: KongServiceProgrammed
+      (conditions[?type == 'KongUpstreamProgrammed']):
+        - status: "True"
+          reason: KongUpstreamProgrammed
+      (conditions[?type == 'KongTargetProgrammed']):
+        - status: "True"
+          reason: KongTargetProgrammed

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/02-assert-httproute-single-header-match.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/02-assert-httproute-single-header-match.yaml
@@ -3,12 +3,12 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: echo-header-match
-  namespace: kong
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
 status:
   parents:
     - parentRef:
-        name: kong-foo
+        name: ($gateway_name)
         group: gateway.networking.k8s.io
         kind: Gateway
       controllerName: konghq.com/gateway-operator

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/02-httproute-single-header-match.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/02-httproute-single-header-match.yaml
@@ -11,7 +11,7 @@ spec:
   rules:
     - matches:
       - headers:
-        - name: h1
+        - name: single-header-1
           type: Exact
           value: v1
       backendRefs:

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/02-httproute-single-header-match.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/02-httproute-single-header-match.yaml
@@ -1,0 +1,19 @@
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: echo-header-match
+  namespace: kong
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: kong-foo
+  rules:
+    - matches:
+      - headers:
+        - name: h1
+          type: Exact
+          value: v1
+      backendRefs:
+        - name: echo
+          port: 1027

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/02-httproute-single-header-match.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/02-httproute-single-header-match.yaml
@@ -1,13 +1,13 @@
 kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1
 metadata:
-  name: echo-header-match
-  namespace: kong
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: kong-foo
+      name: ($gateway_name)
   rules:
     - matches:
       - headers:
@@ -15,5 +15,5 @@ spec:
           type: Exact
           value: v1
       backendRefs:
-        - name: echo
+        - name: ($echo_service_name)
           port: 1027

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/03-assert-update-httproute-multiple-header-match.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/03-assert-update-httproute-multiple-header-match.yaml
@@ -13,10 +13,10 @@ spec:
   rules:
     - matches:
       - headers:
-        - name: h1
+        - name: multiple-header-1
           type: Exact
           value: v1
-        - name: h2
+        - name: multiple-header-2
           type: Exact
           value: v2
       backendRefs:

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/03-assert-update-httproute-multiple-header-match.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/03-assert-update-httproute-multiple-header-match.yaml
@@ -1,0 +1,50 @@
+---
+# Assert HTTPRoute is accepted and programmed
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: echo-header-match
+  namespace: kong
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: kong-foo
+  rules:
+    - matches:
+      - headers:
+        - name: h1
+          type: Exact
+          value: v1
+        - name: h2
+          type: Exact
+          value: v2
+      backendRefs:
+        - name: echo
+          port: 1027
+status:
+  parents:
+    - parentRef:
+        name: kong-foo
+        group: gateway.networking.k8s.io
+        kind: Gateway
+      controllerName: konghq.com/gateway-operator
+      # Filter conditions array to check for all required conditions
+      (conditions[?type == 'Accepted']):
+        - status: "True"
+          reason: Accepted
+      (conditions[?type == 'ResolvedRefs']):
+        - status: "True"
+          reason: ResolvedRefs
+      (conditions[?type == 'KongRouteProgrammed']):
+        - status: "True"
+          reason: KongRouteProgrammed
+      (conditions[?type == 'KongServiceProgrammed']):
+        - status: "True"
+          reason: KongServiceProgrammed
+      (conditions[?type == 'KongUpstreamProgrammed']):
+        - status: "True"
+          reason: KongUpstreamProgrammed
+      (conditions[?type == 'KongTargetProgrammed']):
+        - status: "True"
+          reason: KongTargetProgrammed

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/03-assert-update-httproute-multiple-header-match.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/03-assert-update-httproute-multiple-header-match.yaml
@@ -3,13 +3,13 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: echo-header-match
-  namespace: kong
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: kong-foo
+      name: ($gateway_name)
   rules:
     - matches:
       - headers:
@@ -20,12 +20,12 @@ spec:
           type: Exact
           value: v2
       backendRefs:
-        - name: echo
+        - name: ($echo_service_name)
           port: 1027
 status:
   parents:
     - parentRef:
-        name: kong-foo
+        name: ($gateway_name)
         group: gateway.networking.k8s.io
         kind: Gateway
       controllerName: konghq.com/gateway-operator

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/03-update-httproute-multiple-header-match.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/03-update-httproute-multiple-header-match.yaml
@@ -1,0 +1,22 @@
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: echo-header-match
+  namespace: kong
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: kong-foo
+  rules:
+    - matches:
+      - headers:
+        - name: h1
+          type: Exact
+          value: v1
+        - name: h2
+          type: Exact
+          value: v2
+      backendRefs:
+        - name: echo
+          port: 1027

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/03-update-httproute-multiple-header-match.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/03-update-httproute-multiple-header-match.yaml
@@ -1,13 +1,13 @@
 kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1
 metadata:
-  name: echo-header-match
-  namespace: kong
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: kong-foo
+      name: ($gateway_name)
   rules:
     - matches:
       - headers:
@@ -18,5 +18,5 @@ spec:
           type: Exact
           value: v2
       backendRefs:
-        - name: echo
+        - name: ($echo_service_name)
           port: 1027

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/03-update-httproute-multiple-header-match.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/03-update-httproute-multiple-header-match.yaml
@@ -11,10 +11,10 @@ spec:
   rules:
     - matches:
       - headers:
-        - name: h1
+        - name: multiple-header-1
           type: Exact
           value: v1
-        - name: h2
+        - name: multiple-header-2
           type: Exact
           value: v2
       backendRefs:

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/04-assert-update-httproute-regex-header-match.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/04-assert-update-httproute-regex-header-match.yaml
@@ -11,7 +11,7 @@ spec:
   rules:
     - matches:
       - headers:
-        - name: h1
+        - name: regex-header-1
           type: RegularExpression
           value: "[a-z]+"
       backendRefs:

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/04-assert-update-httproute-regex-header-match.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/04-assert-update-httproute-regex-header-match.yaml
@@ -1,13 +1,13 @@
 kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1
 metadata:
-  name: echo-header-match
-  namespace: kong
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: kong-foo
+      name: ($gateway_name)
   rules:
     - matches:
       - headers:
@@ -15,12 +15,12 @@ spec:
           type: RegularExpression
           value: "[a-z]+"
       backendRefs:
-        - name: echo
+        - name: ($echo_service_name)
           port: 1027
 status:
   parents:
     - parentRef:
-        name: kong-foo
+        name: ($gateway_name)
         group: gateway.networking.k8s.io
         kind: Gateway
       controllerName: konghq.com/gateway-operator

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/04-assert-update-httproute-regex-header-match.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/04-assert-update-httproute-regex-header-match.yaml
@@ -1,0 +1,45 @@
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: echo-header-match
+  namespace: kong
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: kong-foo
+  rules:
+    - matches:
+      - headers:
+        - name: h1
+          type: RegularExpression
+          value: "[a-z]+"
+      backendRefs:
+        - name: echo
+          port: 1027
+status:
+  parents:
+    - parentRef:
+        name: kong-foo
+        group: gateway.networking.k8s.io
+        kind: Gateway
+      controllerName: konghq.com/gateway-operator
+      # Filter conditions array to check for all required conditions
+      (conditions[?type == 'Accepted']):
+        - status: "True"
+          reason: Accepted
+      (conditions[?type == 'ResolvedRefs']):
+        - status: "True"
+          reason: ResolvedRefs
+      (conditions[?type == 'KongRouteProgrammed']):
+        - status: "True"
+          reason: KongRouteProgrammed
+      (conditions[?type == 'KongServiceProgrammed']):
+        - status: "True"
+          reason: KongServiceProgrammed
+      (conditions[?type == 'KongUpstreamProgrammed']):
+        - status: "True"
+          reason: KongUpstreamProgrammed
+      (conditions[?type == 'KongTargetProgrammed']):
+        - status: "True"
+          reason: KongTargetProgrammed

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/04-update-httproute-regex-header-match.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/04-update-httproute-regex-header-match.yaml
@@ -1,13 +1,13 @@
 kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1
 metadata:
-  name: echo-header-match
-  namespace: kong
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: kong-foo
+      name: ($gateway_name)
   rules:
     - matches:
       - headers:
@@ -15,5 +15,5 @@ spec:
           type: RegularExpression
           value: "[a-z]+"
       backendRefs:
-        - name: echo
+        - name: ($echo_service_name)
           port: 1027

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/04-update-httproute-regex-header-match.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/04-update-httproute-regex-header-match.yaml
@@ -11,7 +11,7 @@ spec:
   rules:
     - matches:
       - headers:
-        - name: h1
+        - name: regex-header-1
           type: RegularExpression
           value: "[a-z]+"
       backendRefs:

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/04-update-httproute-regex-header-match.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/04-update-httproute-regex-header-match.yaml
@@ -1,0 +1,19 @@
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: echo-header-match
+  namespace: kong
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: kong-foo
+  rules:
+    - matches:
+      - headers:
+        - name: h1
+          type: RegularExpression
+          value: "[a-z]+"
+      backendRefs:
+        - name: echo
+          port: 1027

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/chainsaw-test.yaml
@@ -1,0 +1,266 @@
+# HTTPRoute header match test scenario
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: httproute-header-match
+spec:
+  description: |
+    This test validates that the hybrid gateway controller correctly
+    processes a basic HTTPRoute with matches on headers and generates
+    routes that direct traffics as expected.
+
+  timeouts:
+    apply: 120s
+    assert: 300s
+    delete: 120s
+
+  steps:
+  # Step 1: Create prerequisite resources
+  - name: create-prerequisites
+    description: Create GatewayClass, Gateway, and backend Service
+    try:
+      - apply:
+          file: 01-prerequisites.yaml # TODO: Move the prerequisites.yaml to common?
+      # Assert common Konnect and Gateway resources.
+      - assert:
+          file: ../common/assertions/konnect-apiauth.yaml
+      - assert:
+          file: ../common/assertions/gatewayclass.yaml
+      - assert:
+          file: ../common/assertions/gatewayconfiguration.yaml
+      - assert:
+          file: ../common/assertions/gateway.yaml
+      - assert:
+          file: ../common/assertions/konnect-gateway-controlplane.yaml
+      - assert:
+          file: ../common/assertions/konnect-extension.yaml
+      # Assert test-specific resources (namespaces, service, deployment)
+      - assert:
+          file: 01-assert-prerequisites.yaml
+    # Catch block: collect diagnostic info when assertions fail
+    catch:
+      - description: Get Gateway resource status
+        get:
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: Gateway
+          namespace: kong
+      - description: Get DataPlane resources
+        get:
+          apiVersion: gateway-operator.konghq.com/v1beta1
+          kind: DataPlane
+          namespace: kong
+      - description: Get ControlPlane resources
+        get:
+          apiVersion: gateway-operator.konghq.com/v1beta1
+          kind: ControlPlane
+          namespace: kong
+      - description: Get Pods in kong namespace
+        get:
+          apiVersion: v1
+          kind: Pod
+          namespace: kong
+      - description: Describe Gateway
+        describe:
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: Gateway
+          namespace: kong
+          showEvents: true
+      - description: Describe DataPlane
+        describe:
+          apiVersion: gateway-operator.konghq.com/v1beta1
+          kind: DataPlane
+          namespace: kong
+          showEvents: true
+      - description: Get events from kong namespace
+        events:
+          namespace: kong
+      - description: Get operator logs
+        podLogs:
+          namespace: kong-system
+          selector: control-plane=controller-manager
+          tail: 100
+      - description: Get all Pod logs in kong namespace
+        script:
+          content: |
+            echo "=== Listing all Pods in kong namespace ==="
+            kubectl get pods -n kong -o wide
+            echo ""
+            echo "=== Pod details and logs ==="
+            for pod in $(kubectl get pods -n kong -o jsonpath='{.items[*].metadata.name}'); do
+              echo "--- Pod: $pod ---"
+              kubectl describe pod $pod -n kong | tail -50
+              echo ""
+              echo "--- Logs for $pod ---"
+              kubectl logs $pod -n kong --all-containers --tail=50 2>/dev/null || echo "No logs available"
+              echo ""
+            done
+  # Step 2: Create an HTTPRoute that matches a single header and verify the routes are correctly configured
+  - name: create-httproute-single-header-match
+    description: Create an HTTPRoute that matches a single header
+    try:
+      - apply:
+          file: 02-httproute-single-header-match.yaml
+      # Assert status of HTTPRoute.
+      - assert:
+          file: 02-assert-httproute-single-header-match.yaml
+      # Collect bindings for connectivity tests
+      - script:
+          content: |
+            kubectl get gateway -n kong -o jsonpath='{.items[0].metadata.name}'
+          outputs:
+            - name: hybrid_gateway_name
+              value: ($stdout)
+      - script:
+          content: |
+            kubectl get gateway -n kong -o jsonpath='{.items[0].metadata.namespace}'
+          outputs:
+            - name: hybrid_gateway_namespace
+              value: ($stdout)
+      - script:
+          env:
+            - name: GATEWAY_NAME
+              value: ($hybrid_gateway_name)
+            - name: GATEWAY_NAMESPACE
+              value: ($hybrid_gateway_namespace)
+          content: |
+            kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
+          outputs:
+            - name: proxy_ip
+              value: ($stdout)
+              # Test from outside the cluster
+      # Try `curl` with expected headers.
+      - description: Accessing with matching headers
+        script:
+          env:
+            - name: PROXY_IP
+              value: ($proxy_ip)
+          content: |
+            curl --fail --retry 10 --retry-delay 5 --retry-all-errors --header "h1:v1" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
+          check:
+            (contains($stdout, '200')): true
+      # Try `curl` without the expected headers.
+      - description: Accessing with no given header
+        script:
+          env:
+            - name: PROXY_IP
+              value: ($proxy_ip)
+          content: |
+            curl -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
+          check:
+            (contains($stdout, '404')): true
+       # Try `curl` without the header having an unmatched value.
+      - description: Accessing with the header having an unmatched value
+        script:
+          env:
+            - name: PROXY_IP
+              value: ($proxy_ip)
+          content: |
+            curl --header "h1:v2" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
+          check:
+            (contains($stdout, '404')): true
+  # Step 3: Update the HTTPRoute to match multiple headers.
+  - name: update-httproute-multiple-header-match
+    description: Update the HTTPRoute to match multilple headers (ANDed)
+    try:
+      - apply:
+          file: 03-update-httproute-multiple-header-match.yaml
+      - assert:
+          file: 03-assert-update-httproute-multiple-header-match.yaml
+ # Collect bindings for connectivity tests
+      - script:
+          content: |
+            kubectl get gateway -n kong -o jsonpath='{.items[0].metadata.name}'
+          outputs:
+            - name: hybrid_gateway_name
+              value: ($stdout)
+      - script:
+          content: |
+            kubectl get gateway -n kong -o jsonpath='{.items[0].metadata.namespace}'
+          outputs:
+            - name: hybrid_gateway_namespace
+              value: ($stdout)
+      - script:
+          env:
+            - name: GATEWAY_NAME
+              value: ($hybrid_gateway_name)
+            - name: GATEWAY_NAMESPACE
+              value: ($hybrid_gateway_namespace)
+          content: |
+            kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
+          outputs:
+            - name: proxy_ip
+              value: ($stdout)
+              # Test from outside the cluster
+      # Try `curl` with both two headers with matching value..
+      - description: Accessing with matching headers
+        script:
+          env:
+            - name: PROXY_IP
+              value: ($proxy_ip)
+          content: |
+            curl --fail --retry 10 --retry-delay 5 --retry-all-errors --header "h1:v1" --header "h2:v2" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
+          check:
+            (contains($stdout, '200')): true
+      # Try `curl` with one header matching the route but the other not matching.
+      - description: Accessing with the one haeder having matched value but the other header having an unmatched value
+        script:
+          env:
+            - name: PROXY_IP
+              value: ($proxy_ip)
+          content: |
+            curl --header "h1:v2" --header "h2:v2" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
+          check:
+            (contains($stdout, '404')): true
+  # Step 4: Update the HTTPRoute to regex header matching
+  - name: update-httproute-regex-header-match
+    description: Update the HTTPRoute to match headers by regular expressions
+    try:
+      - apply:
+          file: 04-update-httproute-regex-header-match.yaml
+      - assert:
+          file: 04-assert-update-httproute-regex-header-match.yaml
+ # Collect bindings for connectivity tests
+      - script:
+          content: |
+            kubectl get gateway -n kong -o jsonpath='{.items[0].metadata.name}'
+          outputs:
+            - name: hybrid_gateway_name
+              value: ($stdout)
+      - script:
+          content: |
+            kubectl get gateway -n kong -o jsonpath='{.items[0].metadata.namespace}'
+          outputs:
+            - name: hybrid_gateway_namespace
+              value: ($stdout)
+      - script:
+          env:
+            - name: GATEWAY_NAME
+              value: ($hybrid_gateway_name)
+            - name: GATEWAY_NAMESPACE
+              value: ($hybrid_gateway_namespace)
+          content: |
+            kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
+          outputs:
+            - name: proxy_ip
+              value: ($stdout)
+              # Test from outside the cluster
+      # Try `curl` with headers matching the regex given in the regex.
+      - description: Accessing with matching headers
+        script:
+          env:
+            - name: PROXY_IP
+              value: ($proxy_ip)
+          content: |
+            curl --fail --retry 10 --retry-delay 5 --retry-all-errors --header "h1:abc" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
+          check:
+            (contains($stdout, '200')): true
+      # Try `curl` with headers not matching the regex given in the regex.
+      - description: Accessing with the one haeder having matched value but the other header having an unmatched value
+        script:
+          env:
+            - name: PROXY_IP
+              value: ($proxy_ip)
+          content: |
+            curl --header "h1:123" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
+          check:
+            (contains($stdout, '404')): true

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/chainsaw-test.yaml
@@ -12,7 +12,35 @@ spec:
   timeouts:
     apply: 120s
     assert: 300s
+    cleanup: 120s
     delete: 120s
+
+  bindings:
+    - name: kong_namespace
+      value: (join('-', ['kong', 'httproute-header-match', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: konnect_api_auth_name
+      value: konnect-api-auth-dev-1
+    - name: gateway_class_name
+      value: (join('-', ['kong', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: gateway_configuration_name
+      value: ($gateway_class_name)
+    - name: gateway_name
+      value: ($gateway_class_name)
+    - name: gateway_namespace
+      value: ($kong_namespace)
+    - name: http_route_name
+      value: echo-header-match
+    - name: http_route_namespace
+      value: ($kong_namespace)
+    - name: echo_service_name
+      value: echo
+    - name: echo_service_namespace
+      value: ($kong_namespace)
+    - name: operator_namespace
+      value: kong-system
+    - name: gateway_proxy_image
+      value: kong/kong-gateway:3.12
+ 
 
   steps:
   # Step 1: Create prerequisite resources
@@ -21,19 +49,6 @@ spec:
     try:
       - apply:
           file: 01-prerequisites.yaml # TODO: Move the prerequisites.yaml to common?
-      # Assert common Konnect and Gateway resources.
-      - assert:
-          file: ../common/assertions/konnect-apiauth.yaml
-      - assert:
-          file: ../common/assertions/gatewayclass.yaml
-      - assert:
-          file: ../common/assertions/gatewayconfiguration.yaml
-      - assert:
-          file: ../common/assertions/gateway.yaml
-      - assert:
-          file: ../common/assertions/konnect-gateway-controlplane.yaml
-      - assert:
-          file: ../common/assertions/konnect-extension.yaml
       # Assert test-specific resources (namespaces, service, deployment)
       - assert:
           file: 01-assert-prerequisites.yaml
@@ -43,57 +58,42 @@ spec:
         get:
           apiVersion: gateway.networking.k8s.io/v1
           kind: Gateway
-          namespace: kong
+          namespace: ($gateway_namespace)
       - description: Get DataPlane resources
         get:
           apiVersion: gateway-operator.konghq.com/v1beta1
           kind: DataPlane
-          namespace: kong
+          namespace: ($gateway_namespace)
       - description: Get ControlPlane resources
         get:
           apiVersion: gateway-operator.konghq.com/v1beta1
           kind: ControlPlane
-          namespace: kong
-      - description: Get Pods in kong namespace
+          namespace: ($gateway_namespace)
+      - description: Get Pods in the namespace of the gateway
         get:
           apiVersion: v1
           kind: Pod
-          namespace: kong
+          namespace: ($gateway_namespace)
       - description: Describe Gateway
         describe:
           apiVersion: gateway.networking.k8s.io/v1
           kind: Gateway
-          namespace: kong
+          namespace: ($gateway_namespace)
           showEvents: true
       - description: Describe DataPlane
         describe:
           apiVersion: gateway-operator.konghq.com/v1beta1
           kind: DataPlane
-          namespace: kong
+          namespace: ($gateway_namespace)
           showEvents: true
       - description: Get events from kong namespace
         events:
-          namespace: kong
+          namespace: ($gateway_namespace)
       - description: Get operator logs
         podLogs:
-          namespace: kong-system
+          namespace: ($operator_namespace)
           selector: control-plane=controller-manager
           tail: 100
-      - description: Get all Pod logs in kong namespace
-        script:
-          content: |
-            echo "=== Listing all Pods in kong namespace ==="
-            kubectl get pods -n kong -o wide
-            echo ""
-            echo "=== Pod details and logs ==="
-            for pod in $(kubectl get pods -n kong -o jsonpath='{.items[*].metadata.name}'); do
-              echo "--- Pod: $pod ---"
-              kubectl describe pod $pod -n kong | tail -50
-              echo ""
-              echo "--- Logs for $pod ---"
-              kubectl logs $pod -n kong --all-containers --tail=50 2>/dev/null || echo "No logs available"
-              echo ""
-            done
   # Step 2: Create an HTTPRoute that matches a single header and verify the routes are correctly configured
   - name: create-httproute-single-header-match
     description: Create an HTTPRoute that matches a single header
@@ -105,23 +105,11 @@ spec:
           file: 02-assert-httproute-single-header-match.yaml
       # Collect bindings for connectivity tests
       - script:
-          content: |
-            kubectl get gateway -n kong -o jsonpath='{.items[0].metadata.name}'
-          outputs:
-            - name: hybrid_gateway_name
-              value: ($stdout)
-      - script:
-          content: |
-            kubectl get gateway -n kong -o jsonpath='{.items[0].metadata.namespace}'
-          outputs:
-            - name: hybrid_gateway_namespace
-              value: ($stdout)
-      - script:
           env:
             - name: GATEWAY_NAME
-              value: ($hybrid_gateway_name)
+              value: ($gateway_name)
             - name: GATEWAY_NAMESPACE
-              value: ($hybrid_gateway_namespace)
+              value: ($gateway_namespace)
           content: |
             kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
           outputs:
@@ -158,37 +146,20 @@ spec:
             curl --header "single-header-1:v2" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
           check:
             (contains($stdout, '404')): true
-    # Dump HTTPRoute status and KongService, KongRoute, KongUpstream and KongTarget for debugging.
+    # Dump HTTPRoute status and KongRoute for debugging.
     catch:
       - description: Get HTTPRoute status
         get:
           apiVersion: gateway.networking.k8s.io/v1
           kind: HTTPRoute
-          namespace: kong
-          format: yaml
-      - description: Get KongService
-        get:
-          apiVersion: configuration.konghq.com/v1alpha1
-          kind: KongService
-          namespace: kong
+          namespace: ($http_route_namespace)
+          name: ($http_route_name)
           format: yaml
       - description: Get KongRoute
         get:
           apiVersion: configuration.konghq.com/v1alpha1
           kind: KongRoute
-          namespace: kong
-          format: yaml
-      - description: Get KongUpstream
-        get:
-          apiVersion: configuration.konghq.com/v1alpha1
-          kind: KongUpstream
-          namespace: kong
-          format: yaml
-      - description: Get KongTarget
-        get:
-          apiVersion: configuration.konghq.com/v1alpha1
-          kind: KongTarget
-          namespace: kong
+          namespace: ($http_route_namespace)
           format: yaml
   # Step 3: Update the HTTPRoute to match multiple headers.
   - name: update-httproute-multiple-header-match
@@ -200,23 +171,11 @@ spec:
           file: 03-assert-update-httproute-multiple-header-match.yaml
  # Collect bindings for connectivity tests
       - script:
-          content: |
-            kubectl get gateway -n kong -o jsonpath='{.items[0].metadata.name}'
-          outputs:
-            - name: hybrid_gateway_name
-              value: ($stdout)
-      - script:
-          content: |
-            kubectl get gateway -n kong -o jsonpath='{.items[0].metadata.namespace}'
-          outputs:
-            - name: hybrid_gateway_namespace
-              value: ($stdout)
-      - script:
           env:
             - name: GATEWAY_NAME
-              value: ($hybrid_gateway_name)
+              value: ($gateway_name)
             - name: GATEWAY_NAMESPACE
-              value: ($hybrid_gateway_namespace)
+              value: ($gateway_namespace)
           content: |
             kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
           outputs:
@@ -252,37 +211,20 @@ spec:
             curl --header "multiple-header-1:v2" --header "multiple-header-2:v2" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
           check:
             (contains($stdout, '404')): true
-    # Dump HTTPRoute status and KongServices, KongRoutes, KongUpstreams, KongTargets for debugging.
+    # Dump HTTPRoute status and KongRoute for debugging.
     catch:
       - description: Get HTTPRoute status
         get:
           apiVersion: gateway.networking.k8s.io/v1
           kind: HTTPRoute
-          namespace: kong
+          namespace: ($http_route_namespace)
+          name: ($http_route_name)
           format: yaml   
-      - description: Get KongService
-        get:
-          apiVersion: configuration.konghq.com/v1alpha1
-          kind: KongService
-          namespace: kong
-          format: yaml
       - description: Get KongRoute
         get:
           apiVersion: configuration.konghq.com/v1alpha1
           kind: KongRoute
-          namespace: kong
-          format: yaml
-      - description: Get KongUpstream
-        get:
-          apiVersion: configuration.konghq.com/v1alpha1
-          kind: KongUpstream
-          namespace: kong
-          format: yaml
-      - description: Get KongTarget
-        get:
-          apiVersion: configuration.konghq.com/v1alpha1
-          kind: KongTarget
-          namespace: kong
+          namespace: ($http_route_namespace)
           format: yaml
 
   # Step 4: Update the HTTPRoute to regex header matching
@@ -295,23 +237,11 @@ spec:
           file: 04-assert-update-httproute-regex-header-match.yaml
  # Collect bindings for connectivity tests
       - script:
-          content: |
-            kubectl get gateway -n kong -o jsonpath='{.items[0].metadata.name}'
-          outputs:
-            - name: hybrid_gateway_name
-              value: ($stdout)
-      - script:
-          content: |
-            kubectl get gateway -n kong -o jsonpath='{.items[0].metadata.namespace}'
-          outputs:
-            - name: hybrid_gateway_namespace
-              value: ($stdout)
-      - script:
           env:
             - name: GATEWAY_NAME
-              value: ($hybrid_gateway_name)
+              value: ($gateway_name)
             - name: GATEWAY_NAMESPACE
-              value: ($hybrid_gateway_namespace)
+              value: ($gateway_namespace)
           content: |
             kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
           outputs:
@@ -338,35 +268,18 @@ spec:
             curl --header "regex-header-1:123" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
           check:
             (contains($stdout, '404')): true
-    # Dump HTTPRoute status and KongServices, KongRoutes, KongUpstreams, KongTargets for debugging.
+    # Dump HTTPRoute status and KongRoute for debugging.
     catch:
       - description: Get HTTPRoute status
         get:
           apiVersion: gateway.networking.k8s.io/v1
           kind: HTTPRoute
-          namespace: kong
-          format: yaml
-      - description: Get KongService
-        get:
-          apiVersion: configuration.konghq.com/v1alpha1
-          kind: KongService
-          namespace: kong
+          namespace: ($http_route_namespace)
+          name: ($http_route_name)
           format: yaml
       - description: Get KongRoute
         get:
           apiVersion: configuration.konghq.com/v1alpha1
           kind: KongRoute
-          namespace: kong
-          format: yaml
-      - description: Get KongUpstream
-        get:
-          apiVersion: configuration.konghq.com/v1alpha1
-          kind: KongUpstream
-          namespace: kong
-          format: yaml
-      - description: Get KongTarget
-        get:
-          apiVersion: configuration.konghq.com/v1alpha1
-          kind: KongTarget
-          namespace: kong
+          namespace: ($http_route_namespace)
           format: yaml

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/chainsaw-test.yaml
@@ -135,7 +135,7 @@ spec:
             - name: PROXY_IP
               value: ($proxy_ip)
           content: |
-            curl --fail --retry 10 --retry-delay 5 --retry-all-errors --header "h1:v1" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
+            curl --fail --retry 10 --retry-delay 5 --retry-all-errors --header "single-header-1:v1" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
           check:
             (contains($stdout, '200')): true
       # Try `curl` without the expected headers.
@@ -155,9 +155,41 @@ spec:
             - name: PROXY_IP
               value: ($proxy_ip)
           content: |
-            curl --header "h1:v2" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
+            curl --header "single-header-1:v2" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
           check:
             (contains($stdout, '404')): true
+    # Dump HTTPRoute status and KongService, KongRoute, KongUpstream and KongTarget for debugging.
+    catch:
+      - description: Get HTTPRoute status
+        get:
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: HTTPRoute
+          namespace: kong
+          format: yaml
+      - description: Get KongService
+        get:
+          apiVersion: configuration.konghq.com/v1alpha1
+          kind: KongService
+          namespace: kong
+          format: yaml
+      - description: Get KongRoute
+        get:
+          apiVersion: configuration.konghq.com/v1alpha1
+          kind: KongRoute
+          namespace: kong
+          format: yaml
+      - description: Get KongUpstream
+        get:
+          apiVersion: configuration.konghq.com/v1alpha1
+          kind: KongUpstream
+          namespace: kong
+          format: yaml
+      - description: Get KongTarget
+        get:
+          apiVersion: configuration.konghq.com/v1alpha1
+          kind: KongTarget
+          namespace: kong
+          format: yaml
   # Step 3: Update the HTTPRoute to match multiple headers.
   - name: update-httproute-multiple-header-match
     description: Update the HTTPRoute to match multilple headers (ANDed)
@@ -191,14 +223,14 @@ spec:
             - name: proxy_ip
               value: ($stdout)
               # Test from outside the cluster
-      # Try `curl` with both two headers with matching value..
+      # Try `curl` with both two headers with matching value.
       - description: Accessing with matching headers
         script:
           env:
             - name: PROXY_IP
               value: ($proxy_ip)
           content: |
-            curl --fail --retry 10 --retry-delay 5 --retry-all-errors --header "h1:v1" --header "h2:v2" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
+            curl --fail --retry 10 --retry-delay 5 --retry-all-errors --header "multiple-header-1:v1" --header "multiple-header-2:v2" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
           check:
             (contains($stdout, '200')): true
       # Try `curl` with one header matching the route but the other not matching.
@@ -208,9 +240,51 @@ spec:
             - name: PROXY_IP
               value: ($proxy_ip)
           content: |
-            curl --header "h1:v2" --header "h2:v2" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
+            curl --header "multiple-header-1:v1" --header "multiple-header-2:v1" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
           check:
             (contains($stdout, '404')): true
+      - description: Accessing with the one haeder having matched value but the other header having an unmatched value
+        script:
+          env:
+            - name: PROXY_IP
+              value: ($proxy_ip)
+          content: |
+            curl --header "multiple-header-1:v2" --header "multiple-header-2:v2" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
+          check:
+            (contains($stdout, '404')): true
+    # Dump HTTPRoute status and KongServices, KongRoutes, KongUpstreams, KongTargets for debugging.
+    catch:
+      - description: Get HTTPRoute status
+        get:
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: HTTPRoute
+          namespace: kong
+          format: yaml   
+      - description: Get KongService
+        get:
+          apiVersion: configuration.konghq.com/v1alpha1
+          kind: KongService
+          namespace: kong
+          format: yaml
+      - description: Get KongRoute
+        get:
+          apiVersion: configuration.konghq.com/v1alpha1
+          kind: KongRoute
+          namespace: kong
+          format: yaml
+      - description: Get KongUpstream
+        get:
+          apiVersion: configuration.konghq.com/v1alpha1
+          kind: KongUpstream
+          namespace: kong
+          format: yaml
+      - description: Get KongTarget
+        get:
+          apiVersion: configuration.konghq.com/v1alpha1
+          kind: KongTarget
+          namespace: kong
+          format: yaml
+
   # Step 4: Update the HTTPRoute to regex header matching
   - name: update-httproute-regex-header-match
     description: Update the HTTPRoute to match headers by regular expressions
@@ -251,7 +325,7 @@ spec:
             - name: PROXY_IP
               value: ($proxy_ip)
           content: |
-            curl --fail --retry 10 --retry-delay 5 --retry-all-errors --header "h1:abc" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
+            curl --fail --retry 10 --retry-delay 5 --retry-all-errors --header "regex-header-1:abc" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
           check:
             (contains($stdout, '200')): true
       # Try `curl` with headers not matching the regex given in the regex.
@@ -261,6 +335,38 @@ spec:
             - name: PROXY_IP
               value: ($proxy_ip)
           content: |
-            curl --header "h1:123" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
+            curl --header "regex-header-1:123" -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/
           check:
             (contains($stdout, '404')): true
+    # Dump HTTPRoute status and KongServices, KongRoutes, KongUpstreams, KongTargets for debugging.
+    catch:
+      - description: Get HTTPRoute status
+        get:
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: HTTPRoute
+          namespace: kong
+          format: yaml
+      - description: Get KongService
+        get:
+          apiVersion: configuration.konghq.com/v1alpha1
+          kind: KongService
+          namespace: kong
+          format: yaml
+      - description: Get KongRoute
+        get:
+          apiVersion: configuration.konghq.com/v1alpha1
+          kind: KongRoute
+          namespace: kong
+          format: yaml
+      - description: Get KongUpstream
+        get:
+          apiVersion: configuration.konghq.com/v1alpha1
+          kind: KongUpstream
+          namespace: kong
+          format: yaml
+      - description: Get KongTarget
+        get:
+          apiVersion: configuration.konghq.com/v1alpha1
+          kind: KongTarget
+          namespace: kong
+          format: yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
Add chainsaw test cases for header match of `HTTPRoute`, including:
- Matching a single header
- Matching multiple headers (ANDed)
- Matching a header by regular expression

**Which issue this PR fixes**

Fixes #2968

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
