### PR TITLE
Fix(hybrid gateway): Add regex prefix to RegularExpression header matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@
 - HybridGateway: Fixed the logic of translating `HTTPRoute` path matches to
   paths in the generated `KongRoute`.
   [#2996](https://github.com/Kong/kong-operator/pull/2996)
+- HybridGateway: Add the `~*` prefix to mark the header should be matched by
+  regular expression in the translated `KongRoute` when the `HTTPRoute`'s header
+  match has the `RegularExpression` type.
+  [#2995](https://github.com/Kong/kong-operator/pull/2995)
 
 ## [v2.1.0-beta.0]
 

--- a/controller/hybridgateway/builder/kongroute.go
+++ b/controller/hybridgateway/builder/kongroute.go
@@ -19,6 +19,9 @@ import (
 const (
 	// KongPathRegexPrefix is the reserved prefix string that instructs Kong 3.0+ to interpret a path as a regex.
 	KongPathRegexPrefix = "~"
+	// KongHeaderRegexPrefix is a reserved prefix string that Kong uses to determine if it should parse a header value
+	// as a regex.
+	KongHeaderRegexPrefix = "~*"
 )
 
 // KongRouteBuilder is a builder for configurationv1alpha1.KongRoute resources.
@@ -59,7 +62,11 @@ func (b *KongRouteBuilder) WithHTTPRouteMatch(match gwtypes.HTTPRouteMatch) *Kon
 			b.route.Spec.Headers = make(map[string][]string)
 		}
 		for _, hdr := range match.Headers {
-			b.route.Spec.Headers[string(hdr.Name)] = append(b.route.Spec.Headers[string(hdr.Name)], hdr.Value)
+			value := hdr.Value
+			if hdr.Type != nil && *hdr.Type == gatewayv1.HeaderMatchRegularExpression {
+				value = KongHeaderRegexPrefix + value
+			}
+			b.route.Spec.Headers[string(hdr.Name)] = append(b.route.Spec.Headers[string(hdr.Name)], value)
 		}
 	}
 	// Note: QueryParams are not natively supported by KongRoute

--- a/controller/hybridgateway/builder/kongroute_test.go
+++ b/controller/hybridgateway/builder/kongroute_test.go
@@ -141,14 +141,19 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 			match: gwtypes.HTTPRouteMatch{
 				Headers: []gatewayv1.HTTPHeaderMatch{
 					{
-						Type:  &[]gatewayv1.HeaderMatchType{gatewayv1.HeaderMatchExact}[0],
+						Type:  lo.ToPtr(gatewayv1.HeaderMatchExact),
 						Name:  "Authorization",
 						Value: "Bearer token",
 					},
 					{
-						Type:  &[]gatewayv1.HeaderMatchType{gatewayv1.HeaderMatchExact}[0],
+						Type:  nil,
 						Name:  "Content-Type",
 						Value: "application/json",
+					},
+					{
+						Type:  lo.ToPtr(gatewayv1.HeaderMatchRegularExpression),
+						Name:  "Foo",
+						Value: "(bar|baz)",
 					},
 				},
 			},
@@ -158,6 +163,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 				require.NotNil(t, route.Spec.Headers)
 				assert.Equal(t, []string{"Bearer token"}, route.Spec.Headers["Authorization"])
 				assert.Equal(t, []string{"application/json"}, route.Spec.Headers["Content-Type"])
+				assert.Equal(t, []string{"~*(bar|baz)"}, route.Spec.Headers["Foo"])
 			},
 		},
 		{
@@ -165,12 +171,12 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 			match: gwtypes.HTTPRouteMatch{
 				Headers: []gatewayv1.HTTPHeaderMatch{
 					{
-						Type:  &[]gatewayv1.HeaderMatchType{gatewayv1.HeaderMatchExact}[0],
+						Type:  lo.ToPtr(gatewayv1.HeaderMatchExact),
 						Name:  "Accept",
 						Value: "application/json",
 					},
 					{
-						Type:  &[]gatewayv1.HeaderMatchType{gatewayv1.HeaderMatchExact}[0],
+						Type:  lo.ToPtr(gatewayv1.HeaderMatchExact),
 						Name:  "Accept",
 						Value: "text/plain",
 					},
@@ -191,7 +197,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 				Method: &method,
 				Headers: []gatewayv1.HTTPHeaderMatch{
 					{
-						Type:  &[]gatewayv1.HeaderMatchType{gatewayv1.HeaderMatchExact}[0],
+						Type:  lo.ToPtr(gatewayv1.HeaderMatchExact),
 						Name:  "Authorization",
 						Value: "Bearer token",
 					},


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the required `~*` prefix to note that the header should be matched by regex if the HTTPRoute match has `RegularExpression` type in header match.

**Which issue this PR fixes**

Fixes #2994

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
