### PR TITLE
Fix(hybrid gateway): Translate paths from HTTPRoute path match to KongRoute paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
 
+## Unreleased
+
+### Fixes
+
+- HybridGateway: Fixed the logic of translating `HTTPRoute` path matches to
+  paths in the generated `KongRoute`.
+  [#2996](https://github.com/Kong/kong-operator/pull/2996)
+
 ## [v2.1.0-beta.0]
 
 ### Added

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -16,6 +16,7 @@ import (
 
 	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/controller/hybridgateway/builder"
 	gwtypes "github.com/kong/kong-operator/internal/types"
 	"github.com/kong/kong-operator/pkg/consts"
 )
@@ -123,7 +124,7 @@ func TestRouteForRule(t *testing.T) {
 
 			// Verify paths from rule matches
 			if len(rule.Matches) > 0 && rule.Matches[0].Path != nil {
-				assert.Contains(t, result.Spec.Paths, *rule.Matches[0].Path.Value)
+				assert.Subset(t, result.Spec.Paths, builder.GenerateKongRoutePathFromHTTPRouteMatch(rule.Matches[0].Path))
 			}
 		})
 	}

--- a/test/e2e/chainsaw/hybridgateway/common/assertions/kongroute.yaml
+++ b/test/e2e/chainsaw/hybridgateway/common/assertions/kongroute.yaml
@@ -19,7 +19,6 @@ metadata:
   (labels."gateway-operator.konghq.com/managed-by" == 'HTTPRoute'): true
   (annotations."gateway-operator.konghq.com/hybrid-routes" | contains(@, join('/', [($managedby_namespace), ($managedby_name)]))): true
 spec:
-  paths: (parse_json($route_paths_json))
   strip_path: ($strip_path)
   serviceRef:
     namespacedRef:


### PR DESCRIPTION
**What this PR does / why we need it**:

Since the specification and behavior of path matching in KongRoute is not the same as them defined in `HTTPRoute` path match, we cannot directly copy the values from the HTTPRoute match to the `paths` of `KongRoute`. We need to translate tha paths properly.

The `generateKongRoutePathFromHTTPRouteMatch` basically is the same as it defined in the translator of KIC here:
https://github.com/Kong/kong-operator/blob/9f2ee71458ae994c3a3c416b0c7c18e852fddac0/ingress-controller/internal/dataplane/translator/subtranslator/httproute.go#L897

**Which issue this PR fixes**


**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
