### PR TITLE
test(e2e/chainsaw): Add HTTPRoute filter tests

### DIFF
--- a/controller/hybridgateway/plugin/converter.go
+++ b/controller/hybridgateway/plugin/converter.go
@@ -138,7 +138,7 @@ func translateRequestModifier(filter gwtypes.HTTPRouteFilter) (transformerData, 
 	// Add for GWAPI equals "append" for Kong Plugins (it will add another instance of the header).
 	if len(filter.RequestHeaderModifier.Add) > 0 {
 		for _, v := range filter.RequestHeaderModifier.Add {
-			plugin.Append.Headers = append(plugin.Append.Headers, string(v.Name)+" :"+v.Value)
+			plugin.Append.Headers = append(plugin.Append.Headers, string(v.Name)+":"+v.Value)
 		}
 	}
 	if len(filter.RequestHeaderModifier.Remove) > 0 {

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/00-assert-httpbin.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/00-assert-httpbin.yaml
@@ -1,0 +1,20 @@
+---
+# Assert httpbin Service exists
+apiVersion: v1
+kind: Service
+metadata:
+  name: ($httpbin_service_name)
+  namespace:  ($httpbin_service_namespace)
+---
+# Assert httpbin Deployment is ready
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ($httpbin_service_name)
+  namespace: ($httpbin_service_namespace)
+status:
+  # Filter conditions array to check for Available condition
+  (conditions[?type == 'Available']):
+    - status: 'True'
+  readyReplicas: 1
+  replicas: 1

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/00-httpbin.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/00-httpbin.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ($httpbin_service_name)
+  namespace: ($httpbin_service_namespace)
+  labels:
+    app: httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+  template:
+    metadata:
+      labels:
+        app: httpbin
+    spec:
+      containers:
+        - name: httpbin
+          image: ghcr.io/mccutchen/go-httpbin:2.19
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /status/200
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /status/200
+              port: http
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            runAsNonRoot: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ($httpbin_service_name)
+  namespace: ($httpbin_service_namespace)
+  labels:
+    app: httpbin
+spec:
+  selector:
+    app: httpbin
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+      appProtocol: http

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/01-assert-prerequisites.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/01-assert-prerequisites.yaml
@@ -1,9 +1,0 @@
----
-# Assert namespaces exist
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kong
-status:
-  phase: Active
----

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/01-assert-prerequisites.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/01-assert-prerequisites.yaml
@@ -1,0 +1,9 @@
+---
+# Assert namespaces exist
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kong
+status:
+  phase: Active
+---

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/01-assert-prerequisites.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/01-assert-prerequisites.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($gateway_namespace)
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: ($gateway_class_name)
+status:
+  (conditions[?type == 'Accepted']):
+    - status: 'True'
+      reason: Accepted
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ($gateway_name)
+  namespace: ($gateway_namespace)
+status:
+  (conditions[?type == 'Accepted']):
+    - status: 'True'
+      reason: Accepted
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'DataPlaneReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'KonnectGatewayControlPlaneProgrammed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'KonnectExtensionReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'GatewayService']):
+    - status: 'True'
+      reason: Ready

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/01-prerequisites.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/01-prerequisites.yaml
@@ -1,0 +1,64 @@
+---
+# Namespace for Kong resources
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($gateway_namespace)
+---
+# Namespace for default resources
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+---
+kind: KonnectAPIAuthConfiguration
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: konnect-api-auth-dev-1
+  namespace: ($gateway_namespace)
+spec:
+  type: token
+  token: (env('KONNECT_TOKEN'))
+  serverURL: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+---
+kind: GatewayConfiguration
+apiVersion: gateway-operator.konghq.com/v2beta1
+metadata:
+  name: ($gateway_name)
+  namespace: ($gateway_namespace)
+spec:
+  konnect:
+    authRef:
+      name: konnect-api-auth-dev-1
+  dataPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        spec:
+          containers:
+          - name: proxy
+            image: ($gateway_dataplane_image)
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: ($gateway_name)
+spec:
+  controllerName: konghq.com/gateway-operator
+  parametersRef:
+    group: gateway-operator.konghq.com
+    kind: GatewayConfiguration
+    name: ($gateway_name)
+    namespace: ($gateway_namespace)
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: ($gateway_name)
+  namespace: ($gateway_namespace)
+spec:
+  gatewayClassName: ($gateway_name)
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/01-prerequisites.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/01-prerequisites.yaml
@@ -24,7 +24,7 @@ spec:
 kind: GatewayConfiguration
 apiVersion: gateway-operator.konghq.com/v2beta1
 metadata:
-  name: ($gateway_name)
+  name: ($gateway_configuration_name)
   namespace: ($gateway_namespace)
 spec:
   konnect:
@@ -41,7 +41,7 @@ spec:
 kind: GatewayClass
 apiVersion: gateway.networking.k8s.io/v1
 metadata:
-  name: ($gateway_name)
+  name: ($gateway_class_name)
 spec:
   controllerName: konghq.com/gateway-operator
   parametersRef:
@@ -56,7 +56,7 @@ metadata:
   name: ($gateway_name)
   namespace: ($gateway_namespace)
 spec:
-  gatewayClassName: ($gateway_name)
+  gatewayClassName: ($gateway_class_name)
   listeners:
   - name: http
     protocol: HTTP

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/02-httproute-filter-request-header-modifier.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/02-httproute-filter-request-header-modifier.yaml
@@ -1,0 +1,30 @@
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: ($route_path)
+      filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+            - name: X-Set
+              value: "foo"
+            add:
+            - name: X-Add
+              value: "bar"
+            remove:
+            - X-Remove
+      backendRefs:
+        - name: ($httpbin_service_name)
+          port: 80

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/03-httproute-filter-response-header-modifier.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/03-httproute-filter-response-header-modifier.yaml
@@ -1,0 +1,30 @@
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /httpbin-response-header-modifier
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+            - name: X-Set
+              value: "foo"
+            add:
+            - name: X-Add
+              value: "bar"
+            remove:
+            - X-Remove
+      backendRefs:
+        - name: ($httpbin_service_name)
+          port: 80

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/04-httproute-request-redirect-filter.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/04-httproute-request-redirect-filter.yaml
@@ -1,0 +1,44 @@
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /httpbin-request-redirect-replace-full-path
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            statusCode: 301
+            hostname: ($redirect_host)
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: "/redirect-target/status/200"
+    # ReplacePrefixMatch request redirect filter is not supported yet: https://github.com/Kong/kong-operator/issues/2466
+    # - matches:
+    #  - path:
+    #      type: PathPrefix
+    #      value: /httpbin-request-redirect-replace-prefix-match
+    #  filters:
+    #    - type: RequestRedirect
+    #      requestRedirect:
+    #        # TODO: the redirect plugin does not support an empty host in the redirect URL which specifies to use the host in the `Host` header in the request. 
+    #        hostname: ($redirect_host)
+    #        path:
+    #         type: ReplacePrefixMatch
+    #          replacePrefixMatch: "/redirect-target"
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /redirect-target
+      backendRefs:
+        - name: ($httpbin_service_name)
+          port: 80

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/05-httproute-url-rewrite-filter.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/05-httproute-url-rewrite-filter.yaml
@@ -1,0 +1,40 @@
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /httpbin-url-rewrite-replace-full-path
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: "/status/200"
+      backendRefs:
+        - name: ($httpbin_service_name)
+          port: 80
+    # ReplacePrefixMatch URL rewrite filter is not supported yet.
+    # - matches:
+    #  - path:
+    #      type: PathPrefix
+    #      value: /httpbin-url-rewrite-replace-prefix-match
+    #  filters:
+    #    - type: requestRedirect
+    #      urlRewrite:
+    #       path:
+    #          type: ReplacePrefixMatch
+    #          ReplacePrefixMatch: "/status"
+    #  backendRefs:
+    #    - name: ($httpbin_service_name)
+    #      port: 80
+

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
@@ -11,16 +11,22 @@ spec:
     and `URLRewrite`.
 
   bindings:
+    - name: kong_namespace
+      value: (join('-', ['kong', 'httproute-filters', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: gateway_class_name
+      value:  (join('-', ['kong', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
     - name: gateway_name
-      value: (join('-', ['kong', env('TEST_ID') || 'local']))
+      value: ($gateway_class_name)
+    - name: gateway_configuration_name
+      value: ($gateway_class_name)
     - name: gateway_namespace
-      value: kong
+      value: ($kong_namespace)
     - name: http_route_namespace
-      value: kong
+      value: ($kong_namespace)
     - name: httpbin_service_name
       value: httpbin
     - name: httpbin_service_namespace
-      value: kong
+      value: ($kong_namespace)
     - name: gateway_dataplane_image
       value: "kong/kong-gateway:3.12"
     
@@ -38,20 +44,6 @@ spec:
             file: 01-prerequisites.yaml
         - apply:
             file: 00-httpbin.yaml
-        # Assert common Konnect and Gateway resources.
-        #- assert:
-        #    file: ../common/assertions/konnect-apiauth.yaml
-        #- assert:
-        #    file: ../common/assertions/gatewayclass.yaml
-        #- assert:
-        #    file: ../common/assertions/gatewayconfiguration.yaml
-        #- assert:
-        #    file: ../common/assertions/gateway.yaml
-        #- assert:
-        #    file: ../common/assertions/konnect-gateway-controlplane.yaml
-        #- assert:
-        #    file: ../common/assertions/konnect-extension.yaml
-        # Assert test-specific resources (namespaces, service, deployment)
         - assert:
             file: 00-assert-httpbin.yaml
         - assert:
@@ -105,6 +97,33 @@ spec:
               (contains($stdout, 'X-Add')): true
               (contains($stdout, 'X-Set')): true
               (contains($stdout, 'X-Remove')): false
+        # Dump HTTPRoute and related KongRoutes, KongPlugins and KongPluginBindings.
+      catch:
+        - description: Dump HTTPRoutes
+          get:
+            apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            namespace: ($http_route_namespace)
+            name: ($http_route_name)
+            format: yaml
+        - description: Dump KongRoutes
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongRoute
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongPlugins
+          get:
+            apiVersion: configuration.konghq.com/v1
+            kind: KongPlugin
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongPluginBindings
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongPluginBinding
+            namespace: ($http_route_namespace)
+            format: yaml
     # Step 3: Create the HTTPRoute for testing response header modifier
     - name: create-httproute-for-response-header-modifier-filter
       description: Create the HTTPRoute for verifying that respomse header modifier filter works
@@ -155,6 +174,32 @@ spec:
               "(contains($stdout, 'X-Add: bar'))": true
               "(contains($stdout, 'X-Set: foo'))": true
               (contains($stdout, 'X-Remove')): false
+      catch:
+        - description: Dump HTTPRoutes
+          get:
+            apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            namespace: ($http_route_namespace)
+            name: ($http_route_name)
+            format: yaml
+        - description: Dump KongRoutes
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongRoute
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongPlugins
+          get:
+            apiVersion: configuration.konghq.com/v1
+            kind: KongPlugin
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongPluginBindings
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongPluginBinding
+            namespace: ($http_route_namespace)
+            format: yaml
     # Step 4: Create the HTTPRoute for testing request redirect filter
     - name: create-httproute-for-request-redirect-filter
       description: Create the HTTPRoute for verifying the request redirect filter
@@ -206,6 +251,32 @@ spec:
             # Should redirect to /redirect-target/status/200 and proxied to /status/200 of httpbin service by Kong DP.
             check:
               (contains($stdout, '200')): true
+      catch:
+        - description: Dump HTTPRoutes
+          get:
+            apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            namespace: ($http_route_namespace)
+            name: ($http_route_name)
+            format: yaml
+        - description: Dump KongRoutes
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongRoute
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongPlugins
+          get:
+            apiVersion: configuration.konghq.com/v1
+            kind: KongPlugin
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongPluginBindings
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongPluginBinding
+            namespace: ($http_route_namespace)
+            format: yaml
     # Step 5: Create the HTTPRoute for testing URL rewrite filter
     - name: create-httproute-for-url-rewrite-filter
       description: Create the HTTPRoute for verifying the request redirect filter
@@ -241,4 +312,29 @@ spec:
               curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}${ROUTE_PATH}
             check:
               (contains($stdout, '200')): true
- 
+      catch:
+        - description: Dump HTTPRoutes
+          get:
+            apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            namespace: ($http_route_namespace)
+            name: ($http_route_name)
+            format: yaml
+        - description: Dump KongRoutes
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongRoute
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongPlugins
+          get:
+            apiVersion: configuration.konghq.com/v1
+            kind: KongPlugin
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongPluginBindings
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongPluginBinding
+            namespace: ($http_route_namespace)
+            format: yaml

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
@@ -29,6 +29,8 @@ spec:
       value: ($kong_namespace)
     - name: gateway_dataplane_image
       value: "kong/kong-gateway:3.12"
+    - name: operator_namespace
+      value: kong-system
     
   timeouts:
     apply: 120s
@@ -46,6 +48,24 @@ spec:
             file: 00-httpbin.yaml
         - assert:
             file: 00-assert-httpbin.yaml
+        - assert:
+            file: 01-assert-prerequisites.yaml
+      catch:
+        - description: Get Gateway resource status
+          get:
+            apiVersion: gateway.networking.k8s.io/v1
+            kind: Gateway
+            namespace: ($gateway_namespace)
+        - description: Get Pods in gateway namespace
+          get:
+            apiVersion: v1
+            kind: Pod
+            namespace: ($gateway_namespace)
+        - description: Get operator logs
+          podLogs:
+            namespace: ($operator_namespace)
+            selector: control-plane=controller-manager
+            tail: 100
     # Step 2: Create the HTTPRoute for testing the request header modifier filter
     - name: create-httproute-for-request-header-modifier-filter
       description: Create the HTTPRoute for testing and verify that request header modifier filter works
@@ -68,16 +88,21 @@ spec:
               kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
             outputs:
               - name: proxy_ip
-                value: ($stdout) 
+                value: ($stdout)
         # Wait until the route works
         - description: Test connectivity from outside the cluster
           script:
             env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
               - name: PROXY_IP
                 value: ($proxy_ip)
               - name: ROUTE_PATH
                 value: ($route_path)
             content: |
+              echo "Accessing gateway ${GATEWAY_NAMESPACE}/${GATEWAY_NAME} at ${PROXY_IP}"
               curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}${ROUTE_PATH}/status/200
             check:
               (contains($stdout, '200')): true

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
@@ -1,0 +1,244 @@
+# HTTPRoute filters test scenario
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: httproute-filters
+spec:
+  description: |
+    This test validates that the hybrid gateway controller correctly
+    processes the currently supported filters in HTTPRoute, including:
+    `RequestHeaderModifier`, `ResponseHeaderModifier`, `RequestRedirect`
+    and `URLRewrite`.
+
+  bindings:
+    - name: gateway_name
+      value: (join('-', ['kong', env('TEST_ID') || 'local']))
+    - name: gateway_namespace
+      value: kong
+    - name: http_route_namespace
+      value: kong
+    - name: httpbin_service_name
+      value: httpbin
+    - name: httpbin_service_namespace
+      value: kong
+    - name: gateway_dataplane_image
+      value: "kong/kong-gateway:3.12"
+    
+  timeouts:
+    apply: 120s
+    assert: 300s
+    delete: 120s
+  
+  steps:
+    # Step 1: Create prerequisite resources
+    - name: create-prerequisites
+      description: Create GatewayClass, Gateway, and backend Service
+      try:
+        - apply:
+            file: 01-prerequisites.yaml
+        - apply:
+            file: 00-httpbin.yaml
+        # Assert common Konnect and Gateway resources.
+        #- assert:
+        #    file: ../common/assertions/konnect-apiauth.yaml
+        #- assert:
+        #    file: ../common/assertions/gatewayclass.yaml
+        #- assert:
+        #    file: ../common/assertions/gatewayconfiguration.yaml
+        #- assert:
+        #    file: ../common/assertions/gateway.yaml
+        #- assert:
+        #    file: ../common/assertions/konnect-gateway-controlplane.yaml
+        #- assert:
+        #    file: ../common/assertions/konnect-extension.yaml
+        # Assert test-specific resources (namespaces, service, deployment)
+        - assert:
+            file: 00-assert-httpbin.yaml
+        - assert:
+            file: 01-assert-prerequisites.yaml
+    # Step 2: Create the HTTPRoute for testing the request header modifier filter
+    - name: create-httproute-for-request-header-modifier-filter
+      description: Create the HTTPRoute for testing and verify that request header modifier filter works
+      bindings:
+        - name: route_path
+          value: "/httpbin-request-header-modifier"
+        - name: http_route_name
+          value:  (join('-', ['httproute-filter-request-header-modifier', env('TEST_ID') || 'local']))
+      try:
+        - apply:
+            file: 02-httproute-filter-request-header-modifier.yaml
+        # Get the Gateway proxy IP
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+            content: |
+              kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
+            outputs:
+              - name: proxy_ip
+                value: ($stdout) 
+        # Wait until the route works
+        - description: Test connectivity from outside the cluster
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path)
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}${ROUTE_PATH}/status/200
+            check:
+              (contains($stdout, '200')): true
+        # Verify the headers 
+        - description: Verify that the request header modifier works by the /headers path
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path)
+            content: |
+              curl -s --header "X-Set:baz" --header "X-Remove:qux" http://${PROXY_IP}${ROUTE_PATH}/headers 
+            check:
+              (contains($stdout, 'X-Add')): true
+              (contains($stdout, 'X-Set')): true
+              (contains($stdout, 'X-Remove')): false
+    # Step 3: Create the HTTPRoute for testing response header modifier
+    - name: create-httproute-for-response-header-modifier-filter
+      description: Create the HTTPRoute for verifying that respomse header modifier filter works
+      bindings:
+        - name: route_path
+          value: "/httpbin-response-header-modifier"
+        - name: http_route_name
+          value:  (join('-', ['httproute-filter-response-header-modifier', env('TEST_ID') || 'local']))
+      try:
+        - apply:
+            file: 03-httproute-filter-response-header-modifier.yaml
+        # Get the Gateway proxy IP
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+            content: |
+              kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
+            outputs:
+              - name: proxy_ip
+                value: ($stdout) 
+        # Wait until the route works
+        - description: Test connectivity from outside the cluster
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path)
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}${ROUTE_PATH}/status/200
+            check:
+              (contains($stdout, '200')): true
+        # Check for the response headers
+        - description: Verify that response header modifier works
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path)
+            content: |
+              curl -sI "http://${PROXY_IP}${ROUTE_PATH}/response-headers?x-remove=qux&x-set=baz"
+            check:
+              "(contains($stdout, '200 OK'))": true
+              "(contains($stdout, 'X-Add: bar'))": true
+              "(contains($stdout, 'X-Set: foo'))": true
+              (contains($stdout, 'X-Remove')): false
+    # Step 4: Create the HTTPRoute for testing request redirect filter
+    - name: create-httproute-for-request-redirect-filter
+      description: Create the HTTPRoute for verifying the request redirect filter
+      bindings:
+        - name: http_route_name
+          value:  (join('-', ['httproute-filter-request-redirect', env('TEST_ID') || 'local']))
+        - name: route_path_replace_full
+          value: "/httpbin-request-redirect-replace-full-path"
+        - name: redirect_host
+          value: "httpbin.test"
+      try:
+        - apply:
+            file: 04-httproute-request-redirect-filter.yaml
+        # Get the Gateway proxy IP
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+            content: |
+              kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
+            outputs:
+              - name: proxy_ip
+                value: ($stdout) 
+        # Verify the status code
+        - description: Verify the status code for the ReplaceFullPath filter
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path_replace_full)
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}${ROUTE_PATH}
+            check:
+              (contains($stdout, '301')): true
+        - description: Verify that the redirection works for the ReplaceFullPath request redirect filter
+          script:
+            env:
+            - name: PROXY_IP
+              value: ($proxy_ip)
+            - name: ROUTE_PATH
+              value: ($route_path_replace_full)
+            - name: TEST_HOST
+              value: ($redirect_host)
+            content: |
+              curl -s -o /dev/null --location --resolve "${TEST_HOST}:80:${PROXY_IP}" -w "%{http_code}"  http://${TEST_HOST}${ROUTE_PATH}
+            # Should redirect to /redirect-target/status/200 and proxied to /status/200 of httpbin service by Kong DP.
+            check:
+              (contains($stdout, '200')): true
+    # Step 5: Create the HTTPRoute for testing URL rewrite filter
+    - name: create-httproute-for-url-rewrite-filter
+      description: Create the HTTPRoute for verifying the request redirect filter
+      bindings:
+        - name: http_route_name
+          value:  (join('-', ['httproute-filter-url-rewrite', env('TEST_ID') || 'local']))
+        - name: route_path_replace_full
+          value: "/httpbin-url-rewrite-replace-full-path"
+      try:
+        - apply:
+            file: 05-httproute-url-rewrite-filter.yaml
+        # Get the Gateway proxy IP
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+            content: |
+              kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
+            outputs:
+              - name: proxy_ip
+                value: ($stdout) 
+        # Verify the status code
+        - description: Verify the status code for the ReplaceFullPath URL rewrite filter
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path_replace_full)
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}${ROUTE_PATH}
+            check:
+              (contains($stdout, '200')): true
+ 

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
@@ -35,6 +35,7 @@ spec:
   timeouts:
     apply: 120s
     assert: 300s
+    cleanup: 120s
     delete: 120s
   
   steps:

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
@@ -46,8 +46,6 @@ spec:
             file: 00-httpbin.yaml
         - assert:
             file: 00-assert-httpbin.yaml
-        - assert:
-            file: 01-assert-prerequisites.yaml
     # Step 2: Create the HTTPRoute for testing the request header modifier filter
     - name: create-httproute-for-request-header-modifier-filter
       description: Create the HTTPRoute for testing and verify that request header modifier filter works


### PR DESCRIPTION
**What this PR does / why we need it**:

Add chainsaw e2e test cases for the following supported HTTPRoute filters:

- `RequestHeaderModifier`
- `ResponseHeaderModifier`
- `RequestRedirect`
- `URLRewrite`

**Which issue this PR fixes**

Fixes #2970 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
