### PR TITLE
test(e2e/chainsaw):  Add chainsaw test case for HTTPRoute extensionRef filter

### DIFF
--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/00-assert-httpbin.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/00-assert-httpbin.yaml
@@ -1,0 +1,20 @@
+---
+# Assert httpbin Service exists
+apiVersion: v1
+kind: Service
+metadata:
+  name: ($httpbin_service_name)
+  namespace:  ($httpbin_service_namespace)
+---
+# Assert httpbin Deployment is ready
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ($httpbin_service_name)
+  namespace: ($httpbin_service_namespace)
+status:
+  # Filter conditions array to check for Available condition
+  (conditions[?type == 'Available']):
+    - status: 'True'
+  readyReplicas: 1
+  replicas: 1

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/00-httpbin.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/00-httpbin.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ($httpbin_service_name)
+  namespace: ($httpbin_service_namespace)
+  labels:
+    app: httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+  template:
+    metadata:
+      labels:
+        app: httpbin
+    spec:
+      containers:
+        - name: httpbin
+          image: ghcr.io/mccutchen/go-httpbin:2.19
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /status/200
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /status/200
+              port: http
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            runAsNonRoot: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ($httpbin_service_name)
+  namespace: ($httpbin_service_namespace)
+  labels:
+    app: httpbin
+spec:
+  selector:
+    app: httpbin
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+      appProtocol: http

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/01-assert-prerequisites.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/01-assert-prerequisites.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($gateway_namespace)
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: ($gateway_class_name)
+status:
+  (conditions[?type == 'Accepted']):
+    - status: 'True'
+      reason: Accepted
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ($gateway_name)
+  namespace: ($gateway_namespace)
+status:
+  (conditions[?type == 'Accepted']):
+    - status: 'True'
+      reason: Accepted
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'DataPlaneReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'KonnectGatewayControlPlaneProgrammed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'KonnectExtensionReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'GatewayService']):
+    - status: 'True'
+      reason: Ready

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/01-prerequisites.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/01-prerequisites.yaml
@@ -1,0 +1,64 @@
+---
+# Namespace for Kong resources
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($gateway_namespace)
+---
+# Namespace for default resources
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+---
+kind: KonnectAPIAuthConfiguration
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: konnect-api-auth-dev-1
+  namespace: ($gateway_namespace)
+spec:
+  type: token
+  token: (env('KONNECT_TOKEN'))
+  serverURL: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+---
+kind: GatewayConfiguration
+apiVersion: gateway-operator.konghq.com/v2beta1
+metadata:
+  name: ($gateway_configuration_name)
+  namespace: ($gateway_namespace)
+spec:
+  konnect:
+    authRef:
+      name: konnect-api-auth-dev-1
+  dataPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        spec:
+          containers:
+          - name: proxy
+            image: ($gateway_dataplane_image)
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: ($gateway_class_name)
+spec:
+  controllerName: konghq.com/gateway-operator
+  parametersRef:
+    group: gateway-operator.konghq.com
+    kind: GatewayConfiguration
+    name: ($gateway_name)
+    namespace: ($gateway_namespace)
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: ($gateway_name)
+  namespace: ($gateway_namespace)
+spec:
+  gatewayClassName: ($gateway_class_name)
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/02-assert-httproute-extensionref-filter-single-plugin.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/02-assert-httproute-extensionref-filter-single-plugin.yaml
@@ -1,0 +1,33 @@
+---
+# Assert HTTPRoute is accepted and programmed
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        group: gateway.networking.k8s.io
+        kind: Gateway
+      controllerName: konghq.com/gateway-operator
+      # Filter conditions array to check for all required conditions
+      (conditions[?type == 'Accepted']):
+        - status: "True"
+          reason: Accepted
+      (conditions[?type == 'ResolvedRefs']):
+        - status: "True"
+          reason: ResolvedRefs
+      (conditions[?type == 'KongRouteProgrammed']):
+        - status: "True"
+          reason: KongRouteProgrammed
+      (conditions[?type == 'KongServiceProgrammed']):
+        - status: "True"
+          reason: KongServiceProgrammed
+      (conditions[?type == 'KongUpstreamProgrammed']):
+        - status: "True"
+          reason: KongUpstreamProgrammed
+      (conditions[?type == 'KongTargetProgrammed']):
+        - status: "True"
+          reason: KongTargetProgrammed

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/02-httproute-extensionref-filter-single-plugin.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/02-httproute-extensionref-filter-single-plugin.yaml
@@ -1,0 +1,36 @@
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: ($route_path)
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: configuration.konghq.com
+            kind: KongPlugin
+            name: ($rate_limiting_plugin_name)
+      backendRefs:
+        - name: ($httpbin_service_name)
+          port: 80
+---
+kind: KongPlugin
+apiVersion: configuration.konghq.com/v1
+metadata:
+  name: ($rate_limiting_plugin_name)
+  namespace: ($http_route_namespace)
+plugin: rate-limiting
+config:
+ minute: 20
+ policy: local
+

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/03-httproute-extensionref-multiple-plugins.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/03-httproute-extensionref-multiple-plugins.yaml
@@ -1,0 +1,51 @@
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: ($route_path)
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: configuration.konghq.com
+            kind: KongPlugin
+            name: ($rate_limiting_plugin_name)
+        - type: ExtensionRef
+          extensionRef:
+            group: configuration.konghq.com
+            kind: KongPlugin
+            name: ($response_transformer_plugin_name)            
+      backendRefs:
+        - name: ($httpbin_service_name)
+          port: 80
+---
+kind: KongPlugin
+apiVersion: configuration.konghq.com/v1
+metadata:
+  name: ($rate_limiting_plugin_name)
+  namespace: ($http_route_namespace)
+plugin: rate-limiting
+config:
+ minute: 20
+ policy: local
+--- 
+kind: KongPlugin
+apiVersion: configuration.konghq.com/v1
+metadata:
+  name: ($response_transformer_plugin_name)
+  namespace: ($http_route_namespace)
+plugin: response-transformer
+config:
+  add:
+    headers:
+     - "X-Add:foo"

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/04-httproute-extensionref-filter-update-kongplugin-base.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/04-httproute-extensionref-filter-update-kongplugin-base.yaml
@@ -1,0 +1,35 @@
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: ($route_path)
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: configuration.konghq.com
+            kind: KongPlugin
+            name: ($rate_limiting_plugin_name)
+      backendRefs:
+        - name: ($httpbin_service_name)
+          port: 80
+---
+kind: KongPlugin
+apiVersion: configuration.konghq.com/v1
+metadata:
+  name: ($rate_limiting_plugin_name)
+  namespace: ($http_route_namespace)
+plugin: rate-limiting
+config:
+ minute: 20
+ policy: local

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/04-httproute-extensionref-filter-update-kongplugin-patch.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/04-httproute-extensionref-filter-update-kongplugin-patch.yaml
@@ -1,0 +1,9 @@
+kind: KongPlugin
+apiVersion: configuration.konghq.com/v1
+metadata:
+  name: ($rate_limiting_plugin_name)
+  namespace: ($http_route_namespace)
+plugin: rate-limiting
+config:
+ minute: 30
+ policy: local

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/05-httproute-extensionref-add-filter-base.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/05-httproute-extensionref-add-filter-base.yaml
@@ -1,0 +1,35 @@
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: ($route_path)
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: configuration.konghq.com
+            kind: KongPlugin
+            name: ($rate_limiting_plugin_name)        
+      backendRefs:
+        - name: ($httpbin_service_name)
+          port: 80
+---
+kind: KongPlugin
+apiVersion: configuration.konghq.com/v1
+metadata:
+  name: ($rate_limiting_plugin_name)
+  namespace: ($http_route_namespace)
+plugin: rate-limiting
+config:
+ minute: 30
+ policy: local

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/05-httproute-extensionref-add-filter-patch.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/05-httproute-extensionref-add-filter-patch.yaml
@@ -1,0 +1,41 @@
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: ($route_path)
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: configuration.konghq.com
+            kind: KongPlugin
+            name: ($rate_limiting_plugin_name)
+        - type: ExtensionRef
+          extensionRef:
+            group: configuration.konghq.com
+            kind: KongPlugin
+            name: ($response_transformer_plugin_name)            
+      backendRefs:
+        - name: ($httpbin_service_name)
+          port: 80
+--- 
+kind: KongPlugin
+apiVersion: configuration.konghq.com/v1
+metadata:
+  name: ($response_transformer_plugin_name)
+  namespace: ($http_route_namespace)
+plugin: response-transformer
+config:
+  add:
+    headers:
+     - "X-Add:foo"

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/chainsaw-test.yaml
@@ -1,0 +1,373 @@
+# HTTPRoute extenstionRef filter test scenario
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: httproute-extensionref-filter
+spec:
+  description: |
+    This test validates that the hybrid gateway controller correctly
+    processes the `extensionRef` filter to attach plugins by `KongPlugin`
+    to HTTPRoutes.
+
+  bindings:
+    - name: kong_namespace
+      value: (join('-', ['kong', 'httproute-extensionref-filter', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: gateway_class_name
+      value:  (join('-', ['kong', 'httproute-extensionref-filter', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: gateway_name
+      value: ($gateway_class_name)
+    - name: gateway_configuration_name
+      value: ($gateway_class_name)
+    - name: gateway_namespace
+      value: ($kong_namespace)
+    - name: http_route_namespace
+      value: ($kong_namespace)
+    - name: httpbin_service_name
+      value: httpbin
+    - name: httpbin_service_namespace
+      value: ($kong_namespace)
+    - name: gateway_dataplane_image
+      value: "kong/kong-gateway:3.12"
+    - name: operator_namespace
+      value: kong-system
+
+  timeouts:
+    apply: 120s
+    assert: 300s
+    cleanup: 300s
+    delete: 120s
+
+  steps:
+  # Step 1: Create prerequisite resources
+    - name: create-prerequisites
+      description: Create GatewayClass, Gateway, and backend Service
+      try:
+        - apply:
+            file: 01-prerequisites.yaml
+        - apply:
+            file: 00-httpbin.yaml
+        - assert:
+            file: 00-assert-httpbin.yaml
+        - assert:
+            file: 01-assert-prerequisites.yaml
+      catch:
+        - description: Get Gateway resource status
+          get:
+            apiVersion: gateway.networking.k8s.io/v1
+            kind: Gateway
+            namespace: ($gateway_namespace)
+        - description: Get Pods in gateway namespace
+          get:
+            apiVersion: v1
+            kind: Pod
+            namespace: ($gateway_namespace)
+        - description: Get operator logs
+          podLogs:
+            namespace: ($operator_namespace)
+            selector: control-plane=controller-manager
+            tail: 100
+    # Step 2: Create the HTTPRoute and attach the rate-limiting plugin to it
+    - name: create-httproute-with-rate-limiting-plugin
+      description: Create an HTTPRoute with ExtensionRef filter to attach a rate-limiting plugin
+      bindings:
+        - name: http_route_name
+          value: (join('-', ['httproute-extensionref-filter-single-plugin', env('TEST_ID') || 'local']))
+        - name: route_path
+          value: "/extension-ref-with-single-plugin"
+        - name: rate_limiting_plugin_name
+          value: rate-limit-plugin-single-filter
+        - name: rate_limiting_plugin_namespace
+          value: ($http_route_namespace)
+      try:
+        - apply: 
+            file: 02-httproute-extensionref-filter-single-plugin.yaml
+        - assert:
+            file: 02-assert-httproute-extensionref-filter-single-plugin.yaml
+        # Get the Gateway proxy IP
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+            content: |
+              kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
+            outputs:
+              - name: proxy_ip
+                value: ($stdout)
+        # Try accessing the path and check the header related to rate limiting
+        - description: Test connectivity from outside the cluster
+          script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path)
+            content: |
+              echo "Accessing gateway ${GATEWAY_NAMESPACE}/${GATEWAY_NAME} at ${PROXY_IP}"
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s --include http://${PROXY_IP}${ROUTE_PATH}/status/200
+            check:
+              (contains($stdout, '200 OK')): true
+              "(contains($stdout, 'X-RateLimit-Limit-Minute: 20'))": true
+      catch:
+        # Dump HTTPRoute and related KongRoutes, KongPlugins and KongPluginBindings.
+        - description: Dump HTTPRoutes
+          get:
+            apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            namespace: ($http_route_namespace)
+            name: ($http_route_name)
+            format: yaml
+        - description: Dump KongRoutes
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongRoute
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongPlugins
+          get:
+            apiVersion: configuration.konghq.com/v1
+            kind: KongPlugin
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongPluginBindings
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongPluginBinding
+            namespace: ($http_route_namespace)
+    # Step 3: Create an HTTPRoute with multiple extentionRef filters with multiple plugins attached.
+    - name: create-httproute-with-multiple-plugins
+      description: Create an HTTPRoute with 2 ExtensionRef filters to attach a rate-limiting and a response-transformer plugins
+      bindings:
+        - name: http_route_name
+          value: (join('-', ['httproute-extensionref-filter-multiple-plugin', env('TEST_ID') || 'local']))
+        - name: route_path
+          value: "/extension-ref-with-multiple-plugins"
+        - name: rate_limiting_plugin_name
+          value: rate-limit-multiple-filters
+        - name: response_transformer_plugin_name
+          value: response-transformer-plugin-multiple-filters
+      try:
+        - apply:
+            file: 03-httproute-extensionref-multiple-plugins.yaml
+        # Get the Gateway proxy IP
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+            content: |
+              kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
+            outputs:
+              - name: proxy_ip
+                value: ($stdout)
+        # Try accessing the path and check the header related to rate limiting
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path)
+            content: |
+              echo "Accessing gateway ${GATEWAY_NAMESPACE}/${GATEWAY_NAME} at ${PROXY_IP}"
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s --include http://${PROXY_IP}${ROUTE_PATH}/status/200
+            check:
+              (contains($stdout, '200 OK')): true
+              "(contains($stdout, 'X-RateLimit-Limit-Minute: 20'))": true
+              "(contains($stdout, 'X-Add: foo'))": true
+      catch:
+        # Dump HTTPRoute and related KongRoutes, KongPlugins and KongPluginBindings.
+        - description: Dump HTTPRoutes
+          get:
+            apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            namespace: ($http_route_namespace)
+            name: ($http_route_name)
+            format: yaml
+        - description: Dump KongRoutes
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongRoute
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongPlugins
+          get:
+            apiVersion: configuration.konghq.com/v1
+            kind: KongPlugin
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongPluginBindings
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongPluginBinding
+            namespace: ($http_route_namespace)
+  # Step 4: Update the KongPlugin after HTTPRoute is programmed
+    - name: update-kongplugin-for-attached-httproute
+      description: Update KongPlugin which is attached to an HTTPRoute by extensionRef filter
+      bindings:
+        - name: http_route_name
+          value: (join('-', ['httproute-extensionref-filter-update-kongplugin', env('TEST_ID') || 'local'])) 
+        - name: route_path
+          value: "/httproute-extensionref-filter-update-kongplugin"
+        - name: rate_limiting_plugin_name
+          value: rate-limit-plugin-update-kongplugin
+        - name: rate_limiting_plugin_namespace
+          value: ($http_route_namespace)
+      try:
+        - apply: 
+            file: 04-httproute-extensionref-filter-update-kongplugin-base.yaml
+        # Get the Gateway proxy IP
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+            content: |
+              kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
+            outputs:
+              - name: proxy_ip
+                value: ($stdout)
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path)
+            content: |
+              echo "Accessing gateway ${GATEWAY_NAMESPACE}/${GATEWAY_NAME} at ${PROXY_IP}"
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s --include http://${PROXY_IP}${ROUTE_PATH}/status/200
+            check:
+              (contains($stdout, '200 OK')): true
+              "(contains($stdout, 'X-RateLimit-Limit-Minute: 20'))": true
+      # Update the KongPlugin.
+        - description: Update the KongPlugin
+          apply:
+            file: 04-httproute-extensionref-filter-update-kongplugin-patch.yaml
+      # Wait until the X-RateLimit-Limit-Minute header changes.
+        - script:
+            timeout: 90s
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path)
+            content: |
+              RATELIMIT_LIMIT_MINUTE_HEADER=""
+              while [ "$RATELIMIT_LIMIT_MINUTE_HEADER" != "X-RateLimit-Limit-Minute: 30" ]; do
+                RATELIMIT_LIMIT_MINUTE_HEADER=$(curl -s --include http://${PROXY_IP}${ROUTE_PATH}/status/200 | grep "X-RateLimit-Limit-Minute")
+                TIME=$(date "+%H:%M:%S")
+                echo $TIME
+                echo $RATELIMIT_LIMIT_MINUTE_HEADER
+                if [ "$RATELIMIT_LIMIT_MINUTE_HEADER" = "X-RateLimit-Limit-Minute: 30" ]; then echo OK; exit 0; fi
+                sleep 5
+              done
+              echo "FAIL"; exit 1
+            check:
+              "(contains($stdout, 'X-RateLimit-Limit-Minute: 30'))": true
+      catch:
+        # Dump HTTPRoute and related KongRoutes, KongPlugins and KongPluginBindings.
+        - description: Dump HTTPRoutes
+          get:
+            apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            namespace: ($http_route_namespace)
+            name: ($http_route_name)
+            format: yaml
+        - description: Dump KongRoutes
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongRoute
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongPlugins
+          get:
+            apiVersion: configuration.konghq.com/v1
+            kind: KongPlugin
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongPluginBindings
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongPluginBinding
+            namespace: ($http_route_namespace)
+    # Step 5: Add extensionRef filter to an HTTPRoute with an existing extensionRef filter
+    - name: create-httproute-with-multiple-plugins
+      description: Create an HTTPRoute with 2 ExtensionRef filters to attach a rate-limiting and a response-transformer plugins
+      bindings:
+        - name: http_route_name
+          value: (join('-', ['httproute-extensionref-filter-add-filter', env('TEST_ID') || 'local']))
+        - name: route_path
+          value: "/extension-ref-add-filter"
+        - name: rate_limiting_plugin_name
+          value: rate-limit-plugin-add-filter
+        - name: response_transformer_plugin_name
+          value: response-transformer-plugin-add-filter
+      try:
+        - apply:
+            file: 05-httproute-extensionref-add-filter-base.yaml
+        # Get the Gateway proxy IP
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+            content: |
+              kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
+            outputs:
+              - name: proxy_ip
+                value: ($stdout)
+        # Try accessing the path and check the header related to rate limiting
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path)
+            content: |
+              echo "Accessing gateway ${GATEWAY_NAMESPACE}/${GATEWAY_NAME} at ${PROXY_IP}"
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s --include http://${PROXY_IP}${ROUTE_PATH}/status/200
+            check:
+              (contains($stdout, '200 OK')): true
+              "(contains($stdout, 'X-RateLimit-Limit-Minute: 30'))": true
+        # Update the HTTPRoute to add an extensionRef
+        - apply:
+            file: 05-httproute-extensionref-add-filter-patch.yaml
+        # Wait until the X-Add header appears.
+        - script:
+            timeout: 60s
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path)
+            content: |
+              X_ADD_HEADER=""
+              while [ "$X_ADD_HEADER" != "X-Add: foo" ]; do
+                X_ADD_HEADER=$(curl -s --include http://${PROXY_IP}${ROUTE_PATH}/status/200 | grep "X-Add")
+                TIME=$(date "+%H:%M:%S")
+                echo $TIME
+                echo $X_ADD_HEADER
+                if [ "$X_ADD_HEADER" = "X-Add: foo" ]; then echo OK; exit 0; fi
+                sleep 5
+              done
+            check:
+              "(contains($stdout, 'X-Add: foo'))": true

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/chainsaw-test.yaml
@@ -139,6 +139,13 @@ spec:
             apiVersion: configuration.konghq.com/v1alpha1
             kind: KongPluginBinding
             namespace: ($http_route_namespace)
+      finally:
+        - delete:
+            ref:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: HTTPRoute
+              namespace: ($http_route_namespace)
+              name: ($http_route_name)
     # Step 3: Create an HTTPRoute with multiple extentionRef filters with multiple plugins attached.
     - name: create-httproute-with-multiple-plugins
       description: Create an HTTPRoute with 2 ExtensionRef filters to attach a rate-limiting and a response-transformer plugins
@@ -210,6 +217,13 @@ spec:
             apiVersion: configuration.konghq.com/v1alpha1
             kind: KongPluginBinding
             namespace: ($http_route_namespace)
+      finally:
+        - delete:
+            ref:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: HTTPRoute
+              namespace: ($http_route_namespace)
+              name: ($http_route_name)
   # Step 4: Update the KongPlugin after HTTPRoute is programmed
     - name: update-kongplugin-for-attached-httproute
       description: Update KongPlugin which is attached to an HTTPRoute by extensionRef filter
@@ -304,6 +318,13 @@ spec:
             apiVersion: configuration.konghq.com/v1alpha1
             kind: KongPluginBinding
             namespace: ($http_route_namespace)
+      finally:
+        - delete:
+            ref:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: HTTPRoute
+              namespace: ($http_route_namespace)
+              name: ($http_route_name)
     # Step 5: Add extensionRef filter to an HTTPRoute with an existing extensionRef filter
     - name: create-httproute-with-multiple-plugins
       description: Create an HTTPRoute with 2 ExtensionRef filters to attach a rate-limiting and a response-transformer plugins
@@ -371,3 +392,10 @@ spec:
               done
             check:
               "(contains($stdout, 'X-Add: foo'))": true
+      finally:
+        - delete:
+            ref:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: HTTPRoute
+              namespace: ($http_route_namespace)
+              name: ($http_route_name)


### PR DESCRIPTION
**What this PR does / why we need it**:

Add Chainsaw test cases for `HTTPRoute` using `extensionRef` filter to reference `KongPlugin`s.

**Which issue this PR fixes**

Fixes #2972 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
