### PR TITLE
ci(chainsaw): HTTPRoute multiple path matches in single rule

### DIFF
--- a/test/e2e/chainsaw/hybridgateway/httproute-path-matching/04-httproute-multipaths.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-path-matching/04-httproute-multipaths.yaml
@@ -1,9 +1,13 @@
 ---
+# HTTPRoute with multiple path matches in a single rule
+# This tests that multiple path match conditions in one rule work correctly
 kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1
 metadata:
   name: ($httproute_name)
   namespace: ($kong_namespace)
+  annotations:
+    konghq.com/strip-path: "false"
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io

--- a/test/e2e/chainsaw/hybridgateway/httproute-path-matching/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-path-matching/chainsaw-test.yaml
@@ -315,17 +315,41 @@ spec:
     - name: test-strip-path-annotation
       description: Update HTTPRoute with strip-path annotation
       try:
-        - apply:
-            file: 05-httproute-strippath.yaml
-        - assert:
-            file: 05-assert-httproute-strippath.yaml
-        # Wait for KongRoute to be reprogrammed
+        # Collect old KongRoute name before update
         - script:
             env:
               - name: KONG_NAMESPACE
                 value: ($kong_namespace)
             content: |
-              kubectl wait --for=condition=Programmed --timeout=60s kongroute -n ${KONG_NAMESPACE} -l gateway-operator.konghq.com/managed-by=HTTPRoute
+              kubectl get kongroute -n ${KONG_NAMESPACE} -l gateway-operator.konghq.com/managed-by=HTTPRoute -o jsonpath='{.items[*].metadata.name}'
+            outputs:
+              - name: old_kongroute_names
+                value: ($stdout)
+        - apply:
+            file: 05-httproute-strippath.yaml
+        - assert:
+            file: 05-assert-httproute-strippath.yaml
+        # Wait for old KongRoute to be deleted
+        - script:
+            env:
+              - name: OLD_NAMES
+                value: ($old_kongroute_names)
+              - name: KONG_NAMESPACE
+                value: ($kong_namespace)
+            content: |
+              if [ -n "$OLD_NAMES" ]; then
+                for name in $OLD_NAMES; do
+                  echo "Waiting for old KongRoute $name to be deleted..."
+                  kubectl wait --for=delete kongroute/$name -n ${KONG_NAMESPACE} --timeout=60s || true
+                done
+              fi
+        # Wait for new KongRoute to be programmed
+        - script:
+            env:
+              - name: KONG_NAMESPACE
+                value: ($kong_namespace)
+            content: |
+              kubectl wait --for=condition=Programmed --timeout=120s kongroute -n ${KONG_NAMESPACE} -l gateway-operator.konghq.com/managed-by=HTTPRoute
         # Verify KongRoute has strip_path: true
         - script:
             env:

--- a/test/e2e/chainsaw/hybridgateway/httproute-path-matching/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-path-matching/chainsaw-test.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   description: |
     This test validates HTTPRoute path matching scenarios including PathPrefix,
-    PathExact, and the strip-path annotation.
+    PathExact, multiple path matches in single rule, and the strip-path annotation.
 
   bindings:
     - name: kong_namespace
@@ -176,7 +176,142 @@ spec:
             kind: KongRoute
             namespace: ($kong_namespace)
 
-    # Step 4: Test strip-path annotation
+    # Step 4: Test multiple path matches in single rule
+    - name: test-multiple-paths-single-rule
+      description: Update HTTPRoute to use multiple path matches (Exact and PathPrefix) in a single rule
+      try:
+        # Collect old KongRoute name before update
+        - script:
+            env:
+              - name: KONG_NAMESPACE
+                value: ($kong_namespace)
+            content: |
+              kubectl get kongroute -n ${KONG_NAMESPACE} -l gateway-operator.konghq.com/managed-by=HTTPRoute -o jsonpath='{.items[*].metadata.name}'
+            outputs:
+              - name: old_kongroute_names
+                value: ($stdout)
+        # Apply the update
+        - apply:
+            file: 04-httproute-multipaths.yaml
+        - assert:
+            file: 04-assert-httproute-multipaths.yaml
+        # Wait for old KongRoute to be deleted
+        - script:
+            env:
+              - name: OLD_NAMES
+                value: ($old_kongroute_names)
+              - name: KONG_NAMESPACE
+                value: ($kong_namespace)
+            content: |
+              if [ -n "$OLD_NAMES" ]; then
+                for name in $OLD_NAMES; do
+                  echo "Waiting for old KongRoute $name to be deleted..."
+                  kubectl wait --for=delete kongroute/$name -n ${KONG_NAMESPACE} --timeout=60s || true
+                done
+              fi
+        # Wait for new KongRoute to be programmed
+        - script:
+            env:
+              - name: KONG_NAMESPACE
+                value: ($kong_namespace)
+            content: |
+              kubectl wait --for=condition=Programmed --timeout=120s kongroute -n ${KONG_NAMESPACE} -l gateway-operator.konghq.com/managed-by=HTTPRoute
+        # Verify KongRoute has multiple paths
+        - script:
+            env:
+              - name: KONG_NAMESPACE
+                value: ($kong_namespace)
+            content: |
+              PATHS=$(kubectl get kongroute -n ${KONG_NAMESPACE} -l gateway-operator.konghq.com/managed-by=HTTPRoute -o jsonpath='{.items[0].spec.paths}')
+              echo "Paths: $PATHS"
+              echo "$PATHS" | grep -q "/get" && echo "$PATHS" | grep -q "/post" && echo "$PATHS" | grep -q "/status"
+        # Get the Gateway proxy IP
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($kong_namespace)
+            content: |
+              kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
+            outputs:
+              - name: proxy_ip
+                value: ($stdout)
+        # Test Exact path /get - should return 200
+        - description: Test Exact path /get returns 200
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -o /dev/null -w "%{http_code}" -X GET http://${PROXY_IP}/get
+            check:
+              (contains($stdout, '200')): true
+        # Test Exact path /post with POST method - should return 200
+        - description: Test Exact path /post with POST method returns 200
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -o /dev/null -w "%{http_code}" -X POST http://${PROXY_IP}/post
+            check:
+              (contains($stdout, '200')): true
+        # Test PathPrefix /status/200 - should return 200
+        - description: Test PathPrefix /status/200 returns 200
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/status/200
+            check:
+              (contains($stdout, '200')): true
+        # Test PathPrefix /status/201 - should return 201
+        - description: Test PathPrefix /status/201 returns 201
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+            content: |
+              curl --retry 10 --retry-delay 5 --retry-all-errors -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/status/201
+            check:
+              (contains($stdout, '201')): true
+        # Test unmatched path /other - should return 404
+        - description: Test unmatched path /other returns 404
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+            content: |
+              HTTP_CODE=$(curl --retry 5 --retry-delay 3 -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}/other)
+              echo $HTTP_CODE
+              if [ "$HTTP_CODE" = "404" ]; then
+                echo "OK"
+              else
+                echo "FAIL"
+                exit 1
+              fi
+      catch:
+        - description: Get HTTPRoute status
+          get:
+            apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            namespace: ($kong_namespace)
+        - description: Get KongRoute resources
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongRoute
+            namespace: ($kong_namespace)
+        - description: Describe KongRoute
+          script:
+            env:
+              - name: KONG_NAMESPACE
+                value: ($kong_namespace)
+            content: |
+              kubectl get kongroute -n ${KONG_NAMESPACE} -l gateway-operator.konghq.com/managed-by=HTTPRoute -o yaml
+
+    # Step 5: Test strip-path annotation
     - name: test-strip-path-annotation
       description: Update HTTPRoute with strip-path annotation
       try:


### PR DESCRIPTION
**What this PR does / why we need it**:

When I was implementing #3000, one test case was skipped; I’m completing it here.
 

**Which issue this PR fixes**

Fixes #https://github.com/Kong/kong-operator/issues/2967

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
