### PR TITLE
chore(ci): add GITHUB_TOKEN for getting ktf addons versions from GitHub

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -576,6 +576,10 @@ jobs:
         KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
         KONG_TEST_KONNECT_SERVER_URL: us.api.konghq.tech
         KONG_CLUSTER_VERSION: ${{ needs.matrix_k8s_node_versions.outputs.latest }}
+        # This is needed for ktf to find latest releases of addons.
+        # This could be changed so that ktf addons have their versions pinned
+        # in the test Makefile instead.
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: upload diagnostics
       if: always()
@@ -627,6 +631,10 @@ jobs:
         KONG_CONTROLLER_OUT: stdout
         GOTESTSUM_JUNITFILE: integration-tests.xml
         KONG_CLUSTER_VERSION: ${{ needs.matrix_k8s_node_versions.outputs.latest }}
+        # This is needed for ktf to find latest releases of addons.
+        # This could be changed so that ktf addons have their versions pinned
+        # in the test Makefile instead.
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: upload diagnostics
       if: always()
@@ -678,6 +686,10 @@ jobs:
         GOTESTSUM_JUNITFILE: integration-tests-bluegreen.xml
         KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
         KONG_TEST_KONNECT_SERVER_URL: us.api.konghq.tech
+        # This is needed for ktf to find latest releases of addons.
+        # This could be changed so that ktf addons have their versions pinned
+        # in the test Makefile instead.
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: upload diagnostics
       if: always()


### PR DESCRIPTION
**What this PR does / why we need it**:

This aims to address: https://github.com/Kong/kong-operator/actions/runs/20777932588/job/59668264126?pr=2988#step:7:308

```
ERROR: failed to deploy addon cert-manager: couldn't fetch latest jetstack/cert-manager release: GET https://api.github.com/repos/jetstack/cert-manager/releases/latest: 403 API rate limit exceeded for 52.159.245.169. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 3m18s]
 stack trace:
goroutine 1 [running]:
runtime/debug.Stack()
	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/debug/stack.go:26 +0x68
github.com/kong/kong-operator/test/integration.Suite.func1()
	/home/runner/work/kong-operator/kong-operator/test/integration/suite.go:72 +0x66
panic({0x7e312a0?, 0xc000c84190?})
	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/panic.go:783 +0x132
github.com/kong/kong-operator/test/integration.exitOnErr({0x9283de0, 0xc000c823a8})
	/home/runner/work/kong-operator/kong-operator/test/integration/suite.go:180 +0xc5
github.com/kong/kong-operator/test/integration.Suite(0xc000584000)
	/home/runner/work/kong-operator/kong-operator/test/integration/suite.go:105 +0x4f0
github.com/kong/kong-operator/test/integration/validatingwebhook.TestMain(...)
	/home/runner/work/kong-operator/kong-operator/test/integration/validatingwebhook/suite_test.go:10
main.main()
	_testmain.go:67 +0x173
```



**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
