### PR TITLE
HybridGateway: backendRef pointer aliasing breaks KongTarget generation for multiple BackendRefs

### DIFF
--- a/controller/hybridgateway/target/target.go
+++ b/controller/hybridgateway/target/target.go
@@ -273,7 +273,8 @@ func filterValidBackendRefs(
 ) ([]validBackendRef, error) {
 	var validBackendRefs []validBackendRef
 
-	for _, bRef := range backendRefs {
+	for i := range backendRefs {
+		bRef := backendRefs[i]
 		// Check if the backendRef is supported.
 		if !route.IsBackendRefSupported(bRef.Group, bRef.Kind) {
 			log.Info(logger, "skipping unsupported backendRef", "group", bRef.Group, "kind", bRef.Kind)
@@ -334,7 +335,10 @@ func filterValidBackendRefs(
 
 		// If we reach here, the BackendRef is valid and has endpoints.
 		validBackendRefs = append(validBackendRefs, validBackendRef{
-			backendRef:     &bRef,
+			// IMPORTANT: take the address of the slice element, not the loop variable.
+			// The loop variable is reused across iterations which would make all pointers
+			// alias the same BackendRef.
+			backendRef:     &backendRefs[i],
 			service:        svc,
 			servicePort:    svcPort,
 			readyEndpoints: readyEndpoints,


### PR DESCRIPTION
**What this PR does / why we need it**:

Because the loop variable is reused, all stored pointers can end up referencing the last BackendRef, causing incorrect downstream behavior (e.g. KongTarget names/weights derived from the wrong backend, multiple backends effectively treated as one)

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
