### PR TITLE
test(chainsaw): Add tests for hostname matching in gateway listeners

### DIFF
--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/00-assert-httpbin.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/00-assert-httpbin.yaml
@@ -1,0 +1,20 @@
+---
+# Assert httpbin Service exists
+apiVersion: v1
+kind: Service
+metadata:
+  name: ($httpbin_service_name)
+  namespace:  ($httpbin_service_namespace)
+---
+# Assert httpbin Deployment is ready
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ($httpbin_service_name)
+  namespace: ($httpbin_service_namespace)
+status:
+  # Filter conditions array to check for Available condition
+  (conditions[?type == 'Available']):
+    - status: 'True'
+  readyReplicas: 1
+  replicas: 1

--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/00-httpbin.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/00-httpbin.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ($httpbin_service_name)
+  namespace: ($httpbin_service_namespace)
+  labels:
+    app: httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+  template:
+    metadata:
+      labels:
+        app: httpbin
+    spec:
+      containers:
+        - name: httpbin
+          image: ghcr.io/mccutchen/go-httpbin:2.19
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /status/200
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /status/200
+              port: http
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            runAsNonRoot: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ($httpbin_service_name)
+  namespace: ($httpbin_service_namespace)
+  labels:
+    app: httpbin
+spec:
+  selector:
+    app: httpbin
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+      appProtocol: http

--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/01-assert-prerequisites.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/01-assert-prerequisites.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($gateway_namespace)
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: ($gateway_class_name)
+status:
+  (conditions[?type == 'Accepted']):
+    - status: 'True'
+      reason: Accepted
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ($gateway_name_wildcard_listener_hostname)
+  namespace: ($gateway_namespace)
+status:
+  (conditions[?type == 'Accepted']):
+    - status: 'True'
+      reason: Accepted
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'DataPlaneReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'KonnectGatewayControlPlaneProgrammed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'KonnectExtensionReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'GatewayService']):
+    - status: 'True'
+      reason: Ready
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ($gateway_name_exact_listener_hostname)
+  namespace: ($gateway_namespace)
+status:
+  (conditions[?type == 'Accepted']):
+    - status: 'True'
+      reason: Accepted
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'DataPlaneReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'KonnectGatewayControlPlaneProgrammed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'KonnectExtensionReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'GatewayService']):
+    - status: 'True'
+      reason: Ready

--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/01-prerequisites.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/01-prerequisites.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($kong_namespace)
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($kong_namespace)
+---
+kind: KonnectAPIAuthConfiguration
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: ($konnect_api_auth_name)
+  namespace: ($kong_namespace)
+spec:
+  type: token
+  token: (env('KONNECT_TOKEN'))
+  serverURL: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+---
+kind: GatewayConfiguration
+apiVersion: gateway-operator.konghq.com/v2beta1
+metadata:
+  name: ($gateway_configuration_name)
+  namespace: ($gateway_namespace)
+spec:
+  konnect:
+    authRef:
+      name: ($konnect_api_auth_name)
+  dataPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        spec:
+          containers:
+          - name: proxy
+            image: kong/kong-gateway:3.12
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: ($gateway_class_name)
+spec:
+  controllerName: konghq.com/gateway-operator
+  parametersRef:
+    group: gateway-operator.konghq.com
+    kind: GatewayConfiguration
+    name: ($gateway_configuration_name)
+    namespace: ($gateway_namespace)
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  namespace: ($gateway_namespace)
+  name: ($gateway_name_wildcard_listener_hostname)
+spec:
+  gatewayClassName: ($gateway_class_name)
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    hostname: "*.httpbin.test"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  namespace: ($gateway_namespace)
+  name: ($gateway_name_exact_listener_hostname)
+spec:
+  gatewayClassName: ($gateway_class_name)
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    hostname: "exact.httpbin-2.test"

--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/02-assert-httproutes-attached-to-gateway-with-wildcard-hostname-listener.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/02-assert-httproutes-attached-to-gateway-with-wildcard-hostname-listener.yaml
@@ -1,0 +1,61 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ($http_route_name_wildcard_hostname)
+  namespace: ($http_route_namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name_wildcard_listener_hostname)
+        group: gateway.networking.k8s.io
+        kind: Gateway
+      controllerName: konghq.com/gateway-operator
+      (conditions[?type == 'Accepted']):
+        - status: "True"
+          reason: Accepted
+      (conditions[?type == 'ResolvedRefs']):
+        - status: "True"
+          reason: ResolvedRefs
+      (conditions[?type == 'KongRouteProgrammed']):
+        - status: "True"
+          reason: KongRouteProgrammed
+      (conditions[?type == 'KongServiceProgrammed']):
+        - status: "True"
+          reason: KongServiceProgrammed
+      (conditions[?type == 'KongUpstreamProgrammed']):
+        - status: "True"
+          reason: KongUpstreamProgrammed
+      (conditions[?type == 'KongTargetProgrammed']):
+        - status: "True"
+          reason: KongTargetProgrammed
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ($http_route_name_exact_hostname)
+  namespace: ($http_route_namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name_wildcard_listener_hostname)
+        group: gateway.networking.k8s.io
+        kind: Gateway
+      controllerName: konghq.com/gateway-operator
+      (conditions[?type == 'Accepted']):
+        - status: "True"
+          reason: Accepted
+      (conditions[?type == 'ResolvedRefs']):
+        - status: "True"
+          reason: ResolvedRefs
+      (conditions[?type == 'KongRouteProgrammed']):
+        - status: "True"
+          reason: KongRouteProgrammed
+      (conditions[?type == 'KongServiceProgrammed']):
+        - status: "True"
+          reason: KongServiceProgrammed
+      (conditions[?type == 'KongUpstreamProgrammed']):
+        - status: "True"
+          reason: KongUpstreamProgrammed
+      (conditions[?type == 'KongTargetProgrammed']):
+        - status: "True"
+          reason: KongTargetProgrammed

--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/02-httproutes-attached-to-gateway-with-wildcard-hostname-listener.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/02-httproutes-attached-to-gateway-with-wildcard-hostname-listener.yaml
@@ -1,0 +1,45 @@
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: ($http_route_namespace)
+  name: ($http_route_name_wildcard_hostname)
+spec:
+    parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name_wildcard_listener_hostname)
+    hostnames: 
+    - "*.httpbin.test"
+    rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: ($route_path_wildcard_hostname)
+      backendRefs:
+        - name: ($httpbin_service_name)
+          port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: ($http_route_namespace)
+  name: ($http_route_name_exact_hostname)
+spec:
+    parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name_wildcard_listener_hostname)
+    hostnames: 
+    - "exact.httpbin.test"
+    rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: ($route_path_exact_hostname)
+      backendRefs:
+        - name: ($httpbin_service_name)
+          port: 80
+
+              

--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/02-httproutes-attached-to-gateway-with-wildcard-hostname-listener.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/02-httproutes-attached-to-gateway-with-wildcard-hostname-listener.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -41,5 +40,3 @@ spec:
       backendRefs:
         - name: ($httpbin_service_name)
           port: 80
-
-              

--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/03-assert-httproute-attached-to-gateway-with-exact-listener-hostname.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/03-assert-httproute-attached-to-gateway-with-exact-listener-hostname.yaml
@@ -1,4 +1,4 @@
-
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/03-assert-httproute-attached-to-gateway-with-exact-listener-hostname.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/03-assert-httproute-attached-to-gateway-with-exact-listener-hostname.yaml
@@ -1,0 +1,31 @@
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name_exact_listener_hostname)
+        group: gateway.networking.k8s.io
+        kind: Gateway
+      controllerName: konghq.com/gateway-operator
+      (conditions[?type == 'Accepted']):
+        - status: "True"
+          reason: Accepted
+      (conditions[?type == 'ResolvedRefs']):
+        - status: "True"
+          reason: ResolvedRefs
+      (conditions[?type == 'KongRouteProgrammed']):
+        - status: "True"
+          reason: KongRouteProgrammed
+      (conditions[?type == 'KongServiceProgrammed']):
+        - status: "True"
+          reason: KongServiceProgrammed
+      (conditions[?type == 'KongUpstreamProgrammed']):
+        - status: "True"
+          reason: KongUpstreamProgrammed
+      (conditions[?type == 'KongTargetProgrammed']):
+        - status: "True"
+          reason: KongTargetProgrammed

--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/03-httproute-attached-to-gateway-with-exact-listener-hostname.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/03-httproute-attached-to-gateway-with-exact-listener-hostname.yaml
@@ -1,0 +1,22 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: ($http_route_namespace)
+  name: ($http_route_name)
+spec:
+    parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name_exact_listener_hostname)
+    hostnames: 
+    - "exact.httpbin-2.test"
+    rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: ($route_path)
+      backendRefs:
+        - name: ($httpbin_service_name)
+          port: 80
+
+              

--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/03-httproute-attached-to-gateway-with-exact-listener-hostname.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/03-httproute-attached-to-gateway-with-exact-listener-hostname.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -18,5 +19,3 @@ spec:
       backendRefs:
         - name: ($httpbin_service_name)
           port: 80
-
-              

--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/04-assert-httproutes-partial-hostname-match-wildcard.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/04-assert-httproutes-partial-hostname-match-wildcard.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/04-assert-httproutes-partial-hostname-match-wildcard.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/04-assert-httproutes-partial-hostname-match-wildcard.yaml
@@ -1,0 +1,61 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ($http_route_name_wildcard_hostname)
+  namespace: ($http_route_namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name_wildcard_listener_hostname)
+        group: gateway.networking.k8s.io
+        kind: Gateway
+      controllerName: konghq.com/gateway-operator
+      (conditions[?type == 'Accepted']):
+        - status: "True"
+          reason: Accepted
+      (conditions[?type == 'ResolvedRefs']):
+        - status: "True"
+          reason: ResolvedRefs
+      (conditions[?type == 'KongRouteProgrammed']):
+        - status: "True"
+          reason: KongRouteProgrammed
+      (conditions[?type == 'KongServiceProgrammed']):
+        - status: "True"
+          reason: KongServiceProgrammed
+      (conditions[?type == 'KongUpstreamProgrammed']):
+        - status: "True"
+          reason: KongUpstreamProgrammed
+      (conditions[?type == 'KongTargetProgrammed']):
+        - status: "True"
+          reason: KongTargetProgrammed
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ($http_route_name_exact_hostname)
+  namespace: ($http_route_namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name_wildcard_listener_hostname)
+        group: gateway.networking.k8s.io
+        kind: Gateway
+      controllerName: konghq.com/gateway-operator
+      (conditions[?type == 'Accepted']):
+        - status: "True"
+          reason: Accepted
+      (conditions[?type == 'ResolvedRefs']):
+        - status: "True"
+          reason: ResolvedRefs
+      (conditions[?type == 'KongRouteProgrammed']):
+        - status: "True"
+          reason: KongRouteProgrammed
+      (conditions[?type == 'KongServiceProgrammed']):
+        - status: "True"
+          reason: KongServiceProgrammed
+      (conditions[?type == 'KongUpstreamProgrammed']):
+        - status: "True"
+          reason: KongUpstreamProgrammed
+      (conditions[?type == 'KongTargetProgrammed']):
+        - status: "True"
+          reason: KongTargetProgrammed

--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/04-httproutes-partial-hostname-match-wildcard.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/04-httproutes-partial-hostname-match-wildcard.yaml
@@ -1,0 +1,47 @@
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: ($http_route_namespace)
+  name: ($http_route_name_wildcard_hostname)
+spec:
+    parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name_wildcard_listener_hostname)
+    hostnames: 
+    - "*.foo.httpbin.test"
+    - "*.foo.httpbin.example"
+    rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: ($route_path_wildcard_hostname)
+      backendRefs:
+        - name: ($httpbin_service_name)
+          port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: ($http_route_namespace)
+  name: ($http_route_name_exact_hostname)
+spec:
+    parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name_wildcard_listener_hostname)
+    hostnames: 
+    - "exact.httpbin.test"
+    - "exact.httpbin.example"
+    rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: ($route_path_exact_hostname)
+      backendRefs:
+        - name: ($httpbin_service_name)
+          port: 80
+
+              

--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/04-httproutes-partial-hostname-match-wildcard.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/04-httproutes-partial-hostname-match-wildcard.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -43,5 +42,3 @@ spec:
       backendRefs:
         - name: ($httpbin_service_name)
           port: 80
-
-              

--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/chainsaw-test.yaml
@@ -1,0 +1,471 @@
+# Gateway with listener hostnames test scenario
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: "httproute-listener-hostname-match"
+spec:
+  description: |
+    This test validates that the hybrid gateway controller correctly
+    processes the hostname specified in listener of Gateway. The
+    hostname of listener should be translated to hostname matches
+    in the routes when the HTTPRoute references the listener as its parent.
+
+  timeouts:
+    apply: 120s
+    assert: 300s
+    cleanup: 300s
+    delete: 120s
+
+  bindings:
+    - name: kong_namespace
+      value: (join('-', ['kong', 'httproute-listener-hostname-match', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: gateway_class_name
+      value: (join('-', ['kong', 'httproute-listener-hostname-match', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: konnect_api_auth_name
+      value: konnect-api-auth-dev-1
+    - name: gateway_configuration_name
+      value: ($gateway_class_name)
+    - name: gateway_namespace
+      value: ($kong_namespace)
+    - name: gateway_name_wildcard_listener_hostname
+      value: (join('-', ['kong', 'wildcard-hostname-listener', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: gateway_name_exact_listener_hostname
+      value: (join('-', ['kong', 'exact-hostname-listener', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: http_route_namespace
+      value: ($kong_namespace)
+    - name: httpbin_service_name
+      value: httpbin
+    - name: httpbin_service_namespace
+      value: ($kong_namespace)
+    - name: gateway_dataplane_image
+      value: "kong/kong-gateway:3.12"
+    - name: operator_namespace
+      value: kong-system
+  
+  steps:
+    # Step 1: Create prerequisite resources
+    - name: create-prerequisites
+      description: Create GatewayClass, KonnectAPIAuthConfiguration, and backend Service
+      try:
+        - apply:
+            file: 01-prerequisites.yaml
+        - apply:
+            file: 00-httpbin.yaml
+        - assert:
+            file: 00-assert-httpbin.yaml
+        - assert:
+            file: 01-assert-prerequisites.yaml
+    # Step 2: Create an HTTPRoute attached to the gateway with wildcard listener hostname.
+    # Both httproutes with the same wildcard hostname and exact name matching the wildcard should be able to attach.
+    - name: create-httproute-attached-to-gateway-with-wildcard-hostname-listener
+      description: Create HTTPRoutes attached to the Gateway with wildcard hostname listener
+      bindings:
+        - name: gateway_name
+          value: ($gateway_name_wildcard_listener_hostname)
+        - name: http_route_name_wildcard_hostname
+          value: (join('-', ['kong', 'wildcard-hostname', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+        - name: route_path_wildcard_hostname
+          value: "/wildcard-hostname-match"
+        - name: http_route_name_exact_hostname
+          value: (join('-', ['kong', 'exact-hostname', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+        - name: route_path_exact_hostname
+          value: "/exact-hostname-match"
+      try:
+        - apply:
+            file: 02-httproutes-attached-to-gateway-with-wildcard-hostname-listener.yaml
+        - assert:
+            file: 02-assert-httproutes-attached-to-gateway-with-wildcard-hostname-listener.yaml
+        # Get the Gateway proxy IP
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+            content: |
+              kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
+            outputs:
+              - name: proxy_ip
+                value: ($stdout)
+        # Wait until the route works
+        - description: Test connectivity from outside the cluster with the matching hostname
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path_wildcard_hostname)
+              - name: TEST_HOST
+                value: "foo.httpbin.test"
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors  --resolve "${TEST_HOST}:80:${PROXY_IP}" -s -o /dev/null -w "%{http_code}" http://${TEST_HOST}${ROUTE_PATH}/status/200
+            check:
+              (contains($stdout, '200')): true
+        - description: Verify that request with another hostname matching the sane wildcard matches
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path_wildcard_hostname)
+              - name: TEST_HOST
+                value: "bar.httpbin.test"
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors  --resolve "${TEST_HOST}:80:${PROXY_IP}" -s -o /dev/null -w "%{http_code}" http://${TEST_HOST}${ROUTE_PATH}/status/200
+            check:
+              (contains($stdout, '200')): true       
+        - description: Verify that request with not matching hostname is not matched
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path_wildcard_hostname)
+              - name: TEST_HOST
+                value: "foo.httpbin-1.test"
+            content: |
+              HTTP_CODE=$(curl --retry 5 --retry-delay 3 -s --resolve "${TEST_HOST}:80:${PROXY_IP}" -o /dev/null -w "%{http_code}" -X GET http://${TEST_HOST}${ROUTE_PATH}/status/200)
+              echo $HTTP_CODE
+              if [ "$HTTP_CODE" = "404" ]; then
+                echo "OK"
+              else
+                echo "FAIL"
+                exit 1
+              fi
+        - description: Verify that request without hostname is not matched
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path_wildcard_hostname)
+            content: |
+              HTTP_CODE=$(curl --retry 5 --retry-delay 3 -s -o /dev/null -w "%{http_code}" -X GET http://${PROXY_IP}${ROUTE_PATH}/status/200)
+              echo $HTTP_CODE
+              if [ "$HTTP_CODE" = "404" ]; then
+                echo "OK"
+              else
+                echo "FAIL"
+                exit 1
+              fi
+        - description: Verify the HTTPRoute with exact hostname matches the exact same hostname
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path_exact_hostname)
+              - name: TEST_HOST
+                value: "exact.httpbin.test"
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors  --resolve "${TEST_HOST}:80:${PROXY_IP}" -s -o /dev/null -w "%{http_code}" http://${TEST_HOST}${ROUTE_PATH}/status/200
+            check:
+              (contains($stdout, '200')): true
+        - description: Verify that the HTTPRoute with exact hostname does not match different hostname
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path_exact_hostname)
+              - name: TEST_HOST
+                value: "not-exact.httpbin.test"
+            content: |
+              HTTP_CODE=$(curl --retry 5 --retry-delay 3 -s --resolve "${TEST_HOST}:80:${PROXY_IP}" -o /dev/null -w "%{http_code}" -X GET http://${TEST_HOST}${ROUTE_PATH}/status/200)
+              echo $HTTP_CODE
+              if [ "$HTTP_CODE" = "404" ]; then
+                echo "OK"
+              else
+                echo "FAIL"
+                exit 1
+              fi             
+      catch:
+        - description: Dump HTTPRoutes
+          get:
+            apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongServices
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongService
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongRoutes
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongRoute
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongUpstreams
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongUpstream
+            namespace: ($http_route_namespace)
+            format: yaml 
+        - description: Dump KongTargets
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongTarget
+            namespace: ($http_route_namespace)
+            format: yaml                  
+      finally:
+        - delete:
+            ref:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: HTTPRoute
+              namespace: ($http_route_namespace)
+              name: ($http_route_name_exact_hostname)
+        - delete:
+            ref:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: HTTPRoute
+              namespace: ($http_route_namespace)
+              name: ($http_route_name_wildcard_hostname) 
+    # Step 3: Create HTTPRoutes to attach to the Gateway with exact listener hostname.
+    - name: create-httproutes-attached-to-gateway-with-exact-hostname
+      description: Create an HTTPRoute attached to the gateway with exact listener hostname.
+      bindings:
+        - name: http_route_name
+          value: (join('-', ['kong', 'exact-listener-hostname', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+        - name: route_path
+          value: "/gateway-exact-listener-hostname"
+      try:
+        - apply:
+            file: 03-httproute-attached-to-gateway-with-exact-listener-hostname.yaml
+        - assert:
+            file: 03-assert-httproute-attached-to-gateway-with-exact-listener-hostname.yaml
+        # Get the Gateway proxy IP
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name_exact_listener_hostname)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+            content: |
+              kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
+            outputs:
+              - name: proxy_ip
+                value: ($stdout)
+        # Wait until the route works
+        - description: Test connectivity from outside the cluster with the matching hostname
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path)
+              - name: TEST_HOST
+                value: "exact.httpbin-2.test"
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors  --resolve "${TEST_HOST}:80:${PROXY_IP}" -s -o /dev/null -w "%{http_code}" http://${TEST_HOST}${ROUTE_PATH}/status/200
+            check:
+              (contains($stdout, '200')): true
+        - description: Verify that request with not matching hostname cannot be matched 
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path)
+              - name: TEST_HOST
+                value: "not-exact.httpbin-2.test"
+            content: |
+              HTTP_CODE=$(curl --retry 5 --retry-delay 3 -s --resolve "${TEST_HOST}:80:${PROXY_IP}" -o /dev/null -w "%{http_code}" -X GET http://${TEST_HOST}${ROUTE_PATH}/status/200)
+              echo $HTTP_CODE
+              if [ "$HTTP_CODE" = "404" ]; then
+                echo "OK"
+              else
+                echo "FAIL"
+                exit 1
+              fi
+      catch:
+        - description: Dump HTTPRoutes
+          get:
+            apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongServices
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongService
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongRoutes
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongRoute
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongUpstreams
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongUpstream
+            namespace: ($http_route_namespace)
+            format: yaml 
+        - description: Dump KongTargets
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongTarget
+            namespace: ($http_route_namespace)
+            format: yaml                  
+      finally:
+        - delete:
+            ref:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: HTTPRoute
+              namespace: ($http_route_namespace)
+              name: ($http_route_name)
+    # Step 4: Create HTTPRoutes attached to the gateway with wildcard hostname listener, where only partial hostname in HTTPRoute matches the listener
+    - name: httproute-partial-hostname-match-wildcard-listener-hostname
+      description: Create HTTPRoutes with some of hostnames in their spec matching the listeners' hostname of their parent Gateways, where the parent gateway has wildcard hostname listener
+      bindings:
+        - name: gateway_name
+          value: ($gateway_name_wildcard_listener_hostname)
+        - name: http_route_name_wildcard_hostname
+          value: (join('-', ['kong', 'partial-hostname-match-wildcard', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+        - name: route_path_wildcard_hostname
+          value: "/wildcard-hostname-match"
+        - name: http_route_name_exact_hostname
+          value: (join('-', ['kong', 'partial-hostname-match-exact', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+        - name: route_path_exact_hostname
+          value: "/exact-hostname-match"
+      try:
+        - apply:
+            file: 04-httproutes-partial-hostname-match-wildcard.yaml
+        - assert:
+            file: 04-assert-httproutes-partial-hostname-match-wildcard.yaml
+      # Get the Gateway proxy IP
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+            content: |
+              kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
+            outputs:
+              - name: proxy_ip
+                value: ($stdout)
+        # Wait until the route works
+        - description: Test connectivity from outside the cluster with the matching hostname
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path_wildcard_hostname)
+              - name: TEST_HOST
+                value: "a.foo.httpbin.test"
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors  --resolve "${TEST_HOST}:80:${PROXY_IP}" -s -o /dev/null -w "%{http_code}" http://${TEST_HOST}${ROUTE_PATH}/status/200
+            check:
+              (contains($stdout, '200')): true
+        - description: Verify that request with another hostname matching the sane wildcard matches
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path_wildcard_hostname)
+              - name: TEST_HOST
+                value: "b.foo.httpbin.test"
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors  --resolve "${TEST_HOST}:80:${PROXY_IP}" -s -o /dev/null -w "%{http_code}" http://${TEST_HOST}${ROUTE_PATH}/status/200
+            check:
+              (contains($stdout, '200')): true       
+        - description: Verify that request with hostname included in the HTTPRoute but not in the listeners is not matched
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path_wildcard_hostname)
+              - name: TEST_HOST
+                value: "a.foo.httpbin.example"
+            content: |
+              HTTP_CODE=$(curl --retry 5 --retry-delay 3 -s --resolve "${TEST_HOST}:80:${PROXY_IP}" -o /dev/null -w "%{http_code}" -X GET http://${TEST_HOST}${ROUTE_PATH}/status/200)
+              echo $HTTP_CODE
+              if [ "$HTTP_CODE" = "404" ]; then
+                echo "OK"
+              else
+                echo "FAIL"
+                exit 1
+              fi
+        - description: Verify the HTTPRoute with exact hostname matches the exact same hostname
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path_exact_hostname)
+              - name: TEST_HOST
+                value: "exact.httpbin.test"
+            content: |
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors  --resolve "${TEST_HOST}:80:${PROXY_IP}" -s -o /dev/null -w "%{http_code}" http://${TEST_HOST}${ROUTE_PATH}/status/200
+            check:
+              (contains($stdout, '200')): true
+        - description: Verify that the HTTPRoute with exact hostname does not match hostname in HTTPRoute but not in listener
+          script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path_exact_hostname)
+              - name: TEST_HOST
+                value: "exact.httpbin.example"
+            content: |
+              HTTP_CODE=$(curl --retry 5 --retry-delay 3 -s --resolve "${TEST_HOST}:80:${PROXY_IP}" -o /dev/null -w "%{http_code}" -X GET http://${TEST_HOST}${ROUTE_PATH}/status/200)
+              echo $HTTP_CODE
+              if [ "$HTTP_CODE" = "404" ]; then
+                echo "OK"
+              else
+                echo "FAIL"
+                exit 1
+              fi           
+      catch:
+        - description: Dump HTTPRoutes
+          get:
+            apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongServices
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongService
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongRoutes
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongRoute
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongUpstreams
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongUpstream
+            namespace: ($http_route_namespace)
+            format: yaml 
+        - description: Dump KongTargets
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongTarget
+            namespace: ($http_route_namespace)
+            format: yaml                  
+      finally:
+        - delete:
+            ref:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: HTTPRoute
+              namespace: ($http_route_namespace)
+              name: ($http_route_name_exact_hostname)
+        - delete:
+            ref:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: HTTPRoute
+              namespace: ($http_route_namespace)
+              name: ($http_route_name_wildcard_hostname)


### PR DESCRIPTION
**What this PR does / why we need it**:

Add chainsaw test cases for the following scenarios:
- Wildcard hostname in listener of Gateway with HTTPRoutes attached
- Exact hostname in listener of Gateway with HTTPRotues attached
- Partial hostnames in HTTPRoute matches the listener names in Gateway

**Which issue this PR fixes**

Fixes #2975 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
