### PR TITLE
ci(chainsaw): test conversion webhook for `ControlPlane`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -749,7 +749,7 @@ test.e2e:
 	@$(MAKE) _test.e2e \
 		GOTESTFLAGS="$(GOTESTFLAGS)"
 
-CHAINSAW_TEST_DIR ?= ./test/e2e/chainsaw/hybridgateway
+CHAINSAW_TEST_DIR ?= ./test/e2e/chainsaw/hybridgateway,./test/e2e/chainsaw/conversion_webhook
 .PHONY: test.e2e.chainsaw
 test.e2e.chainsaw: chainsaw ## Run chainsaw e2e tests.
 	$(CHAINSAW) test --test-dir $(CHAINSAW_TEST_DIR)

--- a/test/e2e/chainsaw/conversion_webhook/controlplane/00-assert-controlplane.yml
+++ b/test/e2e/chainsaw/conversion_webhook/controlplane/00-assert-controlplane.yml
@@ -1,0 +1,101 @@
+apiVersion: gateway-operator.konghq.com/v1beta1
+kind: DataPlane
+metadata:
+  name: ($dataplane_name)
+  namespace: ($kong_namespace)
+status:
+  (conditions[?type == 'Ready']):
+    - status: 'True'
+      reason: Ready
+---
+
+apiVersion: gateway-operator.konghq.com/v2beta1
+kind: ControlPlane
+metadata:
+  name: ($controlplane_name)
+  namespace: ($kong_namespace)
+spec:
+  configDump:
+    dumpSensitive: disabled
+    state: disabled
+  dataplane:
+    ref:
+      name: ($dataplane_name)
+    type: ref
+  dataplaneSync:
+    reverseSync: disabled
+  ingressClass: kong
+  konnect:
+    consumersSync: enabled
+  translation:
+    combinedServicesFromDifferentHTTPRoutes: enabled
+    drainSupport: enabled
+  watchNamespaces:
+    type: list
+    list:
+    - ($kong_namespace)
+status:
+  # Assert referenced DataPlane.
+  dataPlane:
+    name: ($dataplane_name)
+  # Assert conditions.
+  (conditions[?type == 'Provisioned']):
+    - status: 'True'
+      reason: Provisioned
+  (conditions[?type == 'Ready']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'WatchNamespaceGrantValid']):
+    - status: 'True'
+      reason: WatchNamespaceGrantValid
+  (conditions[?type == 'OptionsValid']):
+    - status: 'True'
+      reason: OptionsValid
+  # Assert controllers.
+  (controllers[?name == 'INGRESS_NETWORKINGV1']):
+    - state: enabled
+  (controllers[?name == 'INGRESS_CLASS_NETWORKINGV1']):
+    - state: enabled
+  (controllers[?name == 'INGRESS_CLASS_PARAMETERS']):
+    - state: enabled
+  (controllers[?name == 'GWAPI_GATEWAY']):
+    - state: disabled
+  (controllers[?name == 'GWAPI_HTTPROUTE']):
+    - state: disabled
+  (controllers[?name == 'GWAPI_GRPCROUTE']):
+    - state: disabled
+  (controllers[?name == 'GWAPI_REFERENCE_GRANT']):
+    - state: disabled
+  (controllers[?name == 'KONG_CLUSTERPLUGIN']):
+    - state: enabled
+  (controllers[?name == 'KONG_PLUGIN']):
+    - state: enabled
+  (controllers[?name == 'KONG_CONSUMER']):
+    - state: enabled
+  (controllers[?name == 'KONG_UPSTREAM_POLICY']):
+    - state: enabled
+  (controllers[?name == 'KONG_SERVICE_FACADE']):
+    - state: enabled
+  (controllers[?name == 'KONG_VAULT']):
+    - state: enabled
+  (controllers[?name == 'KONG_LICENSE']):
+    - state: enabled
+  (controllers[?name == 'KONG_CUSTOM_ENTITY']):
+    - state: enabled
+  (controllers[?name == 'SERVICE']):
+    - state: enabled
+  # Assert feature gates.
+  (featureGates[?name == 'KongCustomEntity']):
+    - state: disabled
+  (featureGates[?name == 'FillIDs']):
+    - state: enabled
+  (featureGates[?name == 'GatewayAlpha']):
+    - state: enabled
+  (featureGates[?name == 'KongServiceFacade']):
+    - state: disabled
+  (featureGates[?name == 'SanitizeKonnectConfigDumps']):
+    - state: enabled
+  (featureGates[?name == 'FallbackConfiguration']):
+    - state: disabled
+  (featureGates[?name == 'RewriteURIs']):
+    - state: enabled

--- a/test/e2e/chainsaw/conversion_webhook/controlplane/00-assert-controlplane.yml
+++ b/test/e2e/chainsaw/conversion_webhook/controlplane/00-assert-controlplane.yml
@@ -8,7 +8,6 @@ status:
     - status: 'True'
       reason: Ready
 ---
-
 apiVersion: gateway-operator.konghq.com/v2beta1
 kind: ControlPlane
 metadata:
@@ -30,10 +29,6 @@ spec:
   translation:
     combinedServicesFromDifferentHTTPRoutes: enabled
     drainSupport: enabled
-  watchNamespaces:
-    type: list
-    list:
-    - ($kong_namespace)
 status:
   # Assert referenced DataPlane.
   dataPlane:
@@ -52,50 +47,29 @@ status:
     - status: 'True'
       reason: OptionsValid
   # Assert controllers.
-  (controllers[?name == 'INGRESS_NETWORKINGV1']):
-    - state: enabled
-  (controllers[?name == 'INGRESS_CLASS_NETWORKINGV1']):
-    - state: enabled
-  (controllers[?name == 'INGRESS_CLASS_PARAMETERS']):
-    - state: enabled
-  (controllers[?name == 'GWAPI_GATEWAY']):
-    - state: disabled
-  (controllers[?name == 'GWAPI_HTTPROUTE']):
-    - state: disabled
-  (controllers[?name == 'GWAPI_GRPCROUTE']):
-    - state: disabled
-  (controllers[?name == 'GWAPI_REFERENCE_GRANT']):
-    - state: disabled
-  (controllers[?name == 'KONG_CLUSTERPLUGIN']):
-    - state: enabled
-  (controllers[?name == 'KONG_PLUGIN']):
-    - state: enabled
-  (controllers[?name == 'KONG_CONSUMER']):
-    - state: enabled
-  (controllers[?name == 'KONG_UPSTREAM_POLICY']):
-    - state: enabled
-  (controllers[?name == 'KONG_SERVICE_FACADE']):
-    - state: enabled
-  (controllers[?name == 'KONG_VAULT']):
-    - state: enabled
-  (controllers[?name == 'KONG_LICENSE']):
-    - state: enabled
-  (controllers[?name == 'KONG_CUSTOM_ENTITY']):
-    - state: enabled
-  (controllers[?name == 'SERVICE']):
-    - state: enabled
+  (controllers[?name == 'INGRESS_NETWORKINGV1'] != null): true
+  (controllers[?name == 'INGRESS_CLASS_NETWORKINGV1'] != null): true
+  (controllers[?name == 'INGRESS_CLASS_PARAMETERS'] != null): true
+  (controllers[?name == 'GWAPI_GATEWAY'] != null): true
+  (controllers[?name == 'GWAPI_HTTPROUTE'] != null): true
+  (controllers[?name == 'GWAPI_GRPCROUTE'] != null): true
+  (controllers[?name == 'GWAPI_REFERENCE_GRANT'] != null): true
+  (controllers[?name == 'KONG_CLUSTERPLUGIN'] != null): true
+  (controllers[?name == 'KONG_PLUGIN'] != null): true
+  (controllers[?name == 'KONG_CONSUMER'] != null): true
+  (controllers[?name == 'KONG_UPSTREAM_POLICY'] != null): true
+  (controllers[?name == 'KONG_SERVICE_FACADE'] != null): true
+  (controllers[?name == 'KONG_VAULT'] != null): true
+  (controllers[?name == 'KONG_LICENSE'] != null): true
+  (controllers[?name == 'KONG_CUSTOM_ENTITY'] != null): true
+  (controllers[?name == 'SERVICE'] != null): true
   # Assert feature gates.
-  (featureGates[?name == 'KongCustomEntity']):
-    - state: disabled
-  (featureGates[?name == 'FillIDs']):
-    - state: enabled
+  (featureGates[?name == 'KongCustomEntity'] != null): true
+  (featureGates[?name == 'FillIDs'] != null): true
   (featureGates[?name == 'GatewayAlpha']):
     - state: enabled
-  (featureGates[?name == 'KongServiceFacade']):
-    - state: disabled
-  (featureGates[?name == 'SanitizeKonnectConfigDumps']):
-    - state: enabled
-  (featureGates[?name == 'FallbackConfiguration']):
-    - state: disabled
+  (featureGates[?name == 'KongServiceFacade'] != null): true
+  (featureGates[?name == 'SanitizeKonnectConfigDumps'] != null): true
+  (featureGates[?name == 'FallbackConfiguration'] != null): true
   (featureGates[?name == 'RewriteURIs']):
     - state: enabled

--- a/test/e2e/chainsaw/conversion_webhook/controlplane/00-controlplane.yml
+++ b/test/e2e/chainsaw/conversion_webhook/controlplane/00-controlplane.yml
@@ -1,0 +1,61 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($kong_namespace)
+---
+apiVersion: gateway-operator.konghq.com/v1alpha1
+kind: WatchNamespaceGrant
+metadata:
+  name: watchnamespacegrant
+  namespace: ($kong_namespace)
+spec:
+  from:
+  - group: gateway-operator.konghq.com
+    kind: ControlPlane
+    namespace: ($kong_namespace)
+---
+apiVersion: gateway-operator.konghq.com/v1beta1
+kind: DataPlane
+metadata:
+  name: ($dataplane_name)
+  namespace: ($kong_namespace)
+spec:
+  deployment:
+    podTemplateSpec:
+      spec:
+        containers:
+        - name: proxy
+          image: kong:3.9
+---
+apiVersion: gateway-operator.konghq.com/v1beta1
+kind: ControlPlane
+metadata:
+  name: ($controlplane_name)
+  namespace: ($kong_namespace)
+spec:
+  dataplane: ($dataplane_name)
+  gatewayClass: ($gateway_class_name)
+  watchNamespaces:
+    type: list
+    list:
+    - ($kong_namespace)
+  deployment:
+    podTemplateSpec:
+      spec:
+        containers:
+        - name: controller
+          image: kong/kubernetes-ingress-controller:3.5.0
+          env:
+          - name: CONTROLLER_FEATURE_GATES
+            value: "RewriteURIs=true,GatewayAlpha=true,KongCustomEntity=false"
+          readinessProbe:
+            initialDelaySeconds: 1
+            periodSeconds: 3
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "250m"
+            limits:
+              memory: "1024Mi"
+              cpu: "1000m"

--- a/test/e2e/chainsaw/conversion_webhook/controlplane/00-controlplane.yml
+++ b/test/e2e/chainsaw/conversion_webhook/controlplane/00-controlplane.yml
@@ -4,17 +4,6 @@ kind: Namespace
 metadata:
   name: ($kong_namespace)
 ---
-apiVersion: gateway-operator.konghq.com/v1alpha1
-kind: WatchNamespaceGrant
-metadata:
-  name: watchnamespacegrant
-  namespace: ($kong_namespace)
-spec:
-  from:
-  - group: gateway-operator.konghq.com
-    kind: ControlPlane
-    namespace: ($kong_namespace)
----
 apiVersion: gateway-operator.konghq.com/v1beta1
 kind: DataPlane
 metadata:
@@ -36,10 +25,6 @@ metadata:
 spec:
   dataplane: ($dataplane_name)
   gatewayClass: ($gateway_class_name)
-  watchNamespaces:
-    type: list
-    list:
-    - ($kong_namespace)
   deployment:
     podTemplateSpec:
       spec:
@@ -48,7 +33,7 @@ spec:
           image: kong/kubernetes-ingress-controller:3.5.0
           env:
           - name: CONTROLLER_FEATURE_GATES
-            value: "RewriteURIs=true,GatewayAlpha=true,KongCustomEntity=false"
+            value: "RewriteURIs=true,GatewayAlpha=true"
           readinessProbe:
             initialDelaySeconds: 1
             periodSeconds: 3

--- a/test/e2e/chainsaw/conversion_webhook/controlplane/chainsaw-test.yml
+++ b/test/e2e/chainsaw/conversion_webhook/controlplane/chainsaw-test.yml
@@ -1,0 +1,32 @@
+# Test converting ControlPlane from v1beta1 to v2beta1 by webhook.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: controlplane-conversion-from-v1beta1-to-v2beta1
+spec:
+  description: |
+    This test validates that the v1beta1 ControlPlane is converted to v2beta1.
+
+  bindings:
+    - name: kong_namespace
+      value: (join('-', ['kong', 'controlplane', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: dataplane_name
+      value: (join('-', ['kong', 'dataplane', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: controlplane_name
+      value: (join('-', ['kong', 'controlplane', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: gateway_class_name
+      value: ($controlplane_name)
+
+  timeouts:
+    apply: 120s
+    assert: 300s
+    cleanup: 120s
+    delete: 120s
+  steps:
+    - name: create-resources
+      description: Create ControlPlane v1beta1 (will be converted to v2beta1) and all other needed resources
+      try:
+        - apply:
+            file: 00-controlplane.yml
+        - assert:
+            file: 00-assert-controlplane.yml


### PR DESCRIPTION
**What this PR does / why we need it**:

Add chainsaw e2e scenario for `ControlPlane` conversion from `v1beta1` to `v2beta1` to cover conversion webhook with e2e test

**Which issue this PR fixes**

Part of #1986