### PR TITLE
chore: rename hybrid finalizers

### DIFF
--- a/controller/hybridgateway/const/finalizers/finalizers.go
+++ b/controller/hybridgateway/const/finalizers/finalizers.go
@@ -6,14 +6,14 @@ import (
 )
 
 const (
-	// HTTPRouteFinalizer is the finalizer added to HTTPRoute objects to manage cleanup of generated resources.
-	HTTPRouteFinalizer = "gateway-operator.konghq.com/httproute-cleanup"
+	// HybridHTTPRouteFinalizer is the finalizer added to HTTPRoute objects to manage cleanup of generated resources.
+	HybridHTTPRouteFinalizer = "gateway-operator.konghq.com/hybrid-httproute-cleanup"
 
-	// GatewayFinalizer is the finalizer added to Gateway objects to manage cleanup of generated resources.
-	GatewayFinalizer = "gateway-operator.konghq.com/gateway-cleanup"
+	// HybridGatewayFinalizer is the finalizer added to Gateway objects to manage cleanup of generated resources.
+	HybridGatewayFinalizer = "gateway-operator.konghq.com/hybrid-gateway-cleanup"
 
-	// DefaultFinalizer is the default finalizer for resources that don't have a specific finalizer defined.
-	DefaultFinalizer = "gateway-operator.konghq.com/resource-cleanup"
+	// HybridDefaultFinalizer is the default finalizer for resources that don't have a specific finalizer defined.
+	HybridDefaultFinalizer = "gateway-operator.konghq.com/hybrid-resource-cleanup"
 )
 
 // GetFinalizerForType returns the appropriate finalizer name for the given resource type.
@@ -21,10 +21,10 @@ const (
 func GetFinalizerForType[t converter.RootObject](obj t) string {
 	switch any(obj).(type) {
 	case gwtypes.HTTPRoute:
-		return HTTPRouteFinalizer
+		return HybridHTTPRouteFinalizer
 	case gwtypes.Gateway:
-		return GatewayFinalizer
+		return HybridGatewayFinalizer
 	default:
-		return DefaultFinalizer
+		return HybridDefaultFinalizer
 	}
 }

--- a/controller/hybridgateway/const/finalizers/finalizers_test.go
+++ b/controller/hybridgateway/const/finalizers/finalizers_test.go
@@ -12,22 +12,22 @@ import (
 
 func TestFinalizerConstants(t *testing.T) {
 	t.Run("HTTPRouteFinalizer is defined", func(t *testing.T) {
-		assert.Equal(t, "gateway-operator.konghq.com/httproute-cleanup", HTTPRouteFinalizer)
-		assert.NotEmpty(t, HTTPRouteFinalizer)
+		assert.Equal(t, "gateway-operator.konghq.com/httproute-cleanup", HybridHTTPRouteFinalizer)
+		assert.NotEmpty(t, HybridHTTPRouteFinalizer)
 	})
 
 	t.Run("GatewayFinalizer is defined", func(t *testing.T) {
-		assert.Equal(t, "gateway-operator.konghq.com/gateway-cleanup", GatewayFinalizer)
-		assert.NotEmpty(t, GatewayFinalizer)
+		assert.Equal(t, "gateway-operator.konghq.com/gateway-cleanup", HybridGatewayFinalizer)
+		assert.NotEmpty(t, HybridGatewayFinalizer)
 	})
 
 	t.Run("DefaultFinalizer is defined", func(t *testing.T) {
-		assert.Equal(t, "gateway-operator.konghq.com/resource-cleanup", DefaultFinalizer)
-		assert.NotEmpty(t, DefaultFinalizer)
+		assert.Equal(t, "gateway-operator.konghq.com/resource-cleanup", HybridDefaultFinalizer)
+		assert.NotEmpty(t, HybridDefaultFinalizer)
 	})
 
 	t.Run("all finalizers are unique", func(t *testing.T) {
-		finalizers := []string{HTTPRouteFinalizer, GatewayFinalizer, DefaultFinalizer}
+		finalizers := []string{HybridHTTPRouteFinalizer, HybridGatewayFinalizer, HybridDefaultFinalizer}
 		seen := make(map[string]bool)
 		for _, f := range finalizers {
 			assert.False(t, seen[f], "Duplicate finalizer found: %s", f)
@@ -36,7 +36,7 @@ func TestFinalizerConstants(t *testing.T) {
 	})
 
 	t.Run("all finalizers follow naming convention", func(t *testing.T) {
-		finalizers := []string{HTTPRouteFinalizer, GatewayFinalizer, DefaultFinalizer}
+		finalizers := []string{HybridHTTPRouteFinalizer, HybridGatewayFinalizer, HybridDefaultFinalizer}
 		for _, f := range finalizers {
 			assert.Contains(t, f, "gateway-operator.konghq.com/", "Finalizer should contain domain prefix: %s", f)
 			assert.Contains(t, f, "-cleanup", "Finalizer should contain -cleanup suffix: %s", f)
@@ -53,7 +53,7 @@ func TestGetFinalizerForType(t *testing.T) {
 			},
 		}
 		finalizer := GetFinalizerForType(route)
-		assert.Equal(t, HTTPRouteFinalizer, finalizer)
+		assert.Equal(t, HybridHTTPRouteFinalizer, finalizer)
 		assert.Equal(t, "gateway-operator.konghq.com/httproute-cleanup", finalizer)
 	})
 
@@ -65,20 +65,20 @@ func TestGetFinalizerForType(t *testing.T) {
 			},
 		}
 		finalizer := GetFinalizerForType(gateway)
-		assert.Equal(t, GatewayFinalizer, finalizer)
+		assert.Equal(t, HybridGatewayFinalizer, finalizer)
 		assert.Equal(t, "gateway-operator.konghq.com/gateway-cleanup", finalizer)
 	})
 
 	t.Run("works with zero-value HTTPRoute", func(t *testing.T) {
 		route := gwtypes.HTTPRoute{}
 		finalizer := GetFinalizerForType(route)
-		assert.Equal(t, HTTPRouteFinalizer, finalizer)
+		assert.Equal(t, HybridHTTPRouteFinalizer, finalizer)
 	})
 
 	t.Run("works with zero-value Gateway", func(t *testing.T) {
 		gateway := gwtypes.Gateway{}
 		finalizer := GetFinalizerForType(gateway)
-		assert.Equal(t, GatewayFinalizer, finalizer)
+		assert.Equal(t, HybridGatewayFinalizer, finalizer)
 	})
 
 	t.Run("HTTPRoute and Gateway have different finalizers", func(t *testing.T) {

--- a/controller/hybridgateway/const/finalizers/finalizers_test.go
+++ b/controller/hybridgateway/const/finalizers/finalizers_test.go
@@ -12,17 +12,17 @@ import (
 
 func TestFinalizerConstants(t *testing.T) {
 	t.Run("HTTPRouteFinalizer is defined", func(t *testing.T) {
-		assert.Equal(t, "gateway-operator.konghq.com/httproute-cleanup", HybridHTTPRouteFinalizer)
+		assert.Equal(t, "gateway-operator.konghq.com/hybrid-httproute-cleanup", HybridHTTPRouteFinalizer)
 		assert.NotEmpty(t, HybridHTTPRouteFinalizer)
 	})
 
 	t.Run("GatewayFinalizer is defined", func(t *testing.T) {
-		assert.Equal(t, "gateway-operator.konghq.com/gateway-cleanup", HybridGatewayFinalizer)
+		assert.Equal(t, "gateway-operator.konghq.com/hybrid-gateway-cleanup", HybridGatewayFinalizer)
 		assert.NotEmpty(t, HybridGatewayFinalizer)
 	})
 
 	t.Run("DefaultFinalizer is defined", func(t *testing.T) {
-		assert.Equal(t, "gateway-operator.konghq.com/resource-cleanup", HybridDefaultFinalizer)
+		assert.Equal(t, "gateway-operator.konghq.com/hybrid-resource-cleanup", HybridDefaultFinalizer)
 		assert.NotEmpty(t, HybridDefaultFinalizer)
 	})
 
@@ -54,7 +54,7 @@ func TestGetFinalizerForType(t *testing.T) {
 		}
 		finalizer := GetFinalizerForType(route)
 		assert.Equal(t, HybridHTTPRouteFinalizer, finalizer)
-		assert.Equal(t, "gateway-operator.konghq.com/httproute-cleanup", finalizer)
+		assert.Equal(t, "gateway-operator.konghq.com/hybrid-httproute-cleanup", finalizer)
 	})
 
 	t.Run("Gateway returns GatewayFinalizer", func(t *testing.T) {
@@ -66,7 +66,7 @@ func TestGetFinalizerForType(t *testing.T) {
 		}
 		finalizer := GetFinalizerForType(gateway)
 		assert.Equal(t, HybridGatewayFinalizer, finalizer)
-		assert.Equal(t, "gateway-operator.konghq.com/gateway-cleanup", finalizer)
+		assert.Equal(t, "gateway-operator.konghq.com/hybrid-gateway-cleanup", finalizer)
 	})
 
 	t.Run("works with zero-value HTTPRoute", func(t *testing.T) {

--- a/controller/hybridgateway/finalizer_test.go
+++ b/controller/hybridgateway/finalizer_test.go
@@ -61,12 +61,12 @@ func TestFinalizerFunctionality(t *testing.T) {
 
 func TestFinalizerConstant(t *testing.T) {
 	t.Run("HTTPRoute finalizer is properly defined", func(t *testing.T) {
-		assert.Equal(t, "gateway-operator.konghq.com/httproute-cleanup", finalizerconst.HybridHTTPRouteFinalizer)
+		assert.Equal(t, "gateway-operator.konghq.com/hybrid-httproute-cleanup", finalizerconst.HybridHTTPRouteFinalizer)
 		assert.NotEmpty(t, finalizerconst.HybridHTTPRouteFinalizer)
 	})
 
 	t.Run("Gateway finalizer is properly defined", func(t *testing.T) {
-		assert.Equal(t, "gateway-operator.konghq.com/gateway-cleanup", finalizerconst.HybridGatewayFinalizer)
+		assert.Equal(t, "gateway-operator.konghq.com/hybrid-gateway-cleanup", finalizerconst.HybridGatewayFinalizer)
 		assert.NotEmpty(t, finalizerconst.HybridGatewayFinalizer)
 	})
 

--- a/controller/hybridgateway/finalizer_test.go
+++ b/controller/hybridgateway/finalizer_test.go
@@ -61,16 +61,16 @@ func TestFinalizerFunctionality(t *testing.T) {
 
 func TestFinalizerConstant(t *testing.T) {
 	t.Run("HTTPRoute finalizer is properly defined", func(t *testing.T) {
-		assert.Equal(t, "gateway-operator.konghq.com/httproute-cleanup", finalizerconst.HTTPRouteFinalizer)
-		assert.NotEmpty(t, finalizerconst.HTTPRouteFinalizer)
+		assert.Equal(t, "gateway-operator.konghq.com/httproute-cleanup", finalizerconst.HybridHTTPRouteFinalizer)
+		assert.NotEmpty(t, finalizerconst.HybridHTTPRouteFinalizer)
 	})
 
 	t.Run("Gateway finalizer is properly defined", func(t *testing.T) {
-		assert.Equal(t, "gateway-operator.konghq.com/gateway-cleanup", finalizerconst.GatewayFinalizer)
-		assert.NotEmpty(t, finalizerconst.GatewayFinalizer)
+		assert.Equal(t, "gateway-operator.konghq.com/gateway-cleanup", finalizerconst.HybridGatewayFinalizer)
+		assert.NotEmpty(t, finalizerconst.HybridGatewayFinalizer)
 	})
 
 	t.Run("different resource types have different finalizers", func(t *testing.T) {
-		assert.NotEqual(t, finalizerconst.HTTPRouteFinalizer, finalizerconst.GatewayFinalizer)
+		assert.NotEqual(t, finalizerconst.HybridHTTPRouteFinalizer, finalizerconst.HybridGatewayFinalizer)
 	})
 }

--- a/controller/hybridgateway/reconciler_utils_test.go
+++ b/controller/hybridgateway/reconciler_utils_test.go
@@ -409,7 +409,7 @@ func TestShouldProcessObject_HTTPRoute(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "test-route",
 						Namespace:  "default",
-						Finalizers: []string{finalizerconst.HTTPRouteFinalizer},
+						Finalizers: []string{finalizerconst.HybridHTTPRouteFinalizer},
 					},
 				}
 				return route
@@ -503,7 +503,7 @@ func TestShouldProcessObject_HTTPRoute(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "test-route",
 						Namespace:  "default",
-						Finalizers: []string{finalizerconst.HTTPRouteFinalizer},
+						Finalizers: []string{finalizerconst.HybridHTTPRouteFinalizer},
 					},
 					Spec: gwtypes.HTTPRouteSpec{
 						CommonRouteSpec: gwtypes.CommonRouteSpec{
@@ -704,7 +704,7 @@ func TestShouldProcessObject_Gateway(t *testing.T) {
 						Name:       "test-gateway",
 						Namespace:  "default",
 						UID:        "test-gateway-uid",
-						Finalizers: []string{finalizerconst.GatewayFinalizer},
+						Finalizers: []string{finalizerconst.HybridGatewayFinalizer},
 					},
 					Spec: gwtypes.GatewaySpec{
 						GatewayClassName: "kong",
@@ -952,7 +952,7 @@ func TestRemoveFinalizerIfNotManaged_HTTPRoute(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-route",
 					Namespace:  "default",
-					Finalizers: []string{finalizerconst.HTTPRouteFinalizer},
+					Finalizers: []string{finalizerconst.HybridHTTPRouteFinalizer},
 				},
 				Spec: gatewayv1.HTTPRouteSpec{
 					CommonRouteSpec: gatewayv1.CommonRouteSpec{
@@ -981,7 +981,7 @@ func TestRemoveFinalizerIfNotManaged_HTTPRoute(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-route",
 					Namespace:  "default",
-					Finalizers: []string{finalizerconst.HTTPRouteFinalizer},
+					Finalizers: []string{finalizerconst.HybridHTTPRouteFinalizer},
 				},
 				Spec: gatewayv1.HTTPRouteSpec{
 					CommonRouteSpec: gatewayv1.CommonRouteSpec{
@@ -1010,7 +1010,7 @@ func TestRemoveFinalizerIfNotManaged_HTTPRoute(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-route",
 					Namespace:  "default",
-					Finalizers: []string{finalizerconst.HTTPRouteFinalizer},
+					Finalizers: []string{finalizerconst.HybridHTTPRouteFinalizer},
 				},
 				Spec: gatewayv1.HTTPRouteSpec{
 					CommonRouteSpec: gatewayv1.CommonRouteSpec{
@@ -1042,7 +1042,7 @@ func TestRemoveFinalizerIfNotManaged_HTTPRoute(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-route",
 					Namespace:  "default",
-					Finalizers: []string{finalizerconst.HTTPRouteFinalizer},
+					Finalizers: []string{finalizerconst.HybridHTTPRouteFinalizer},
 				},
 				Spec: gatewayv1.HTTPRouteSpec{
 					CommonRouteSpec: gatewayv1.CommonRouteSpec{
@@ -1076,7 +1076,7 @@ func TestRemoveFinalizerIfNotManaged_HTTPRoute(t *testing.T) {
 					Namespace: "default",
 					Finalizers: []string{
 						"some-other-finalizer",
-						finalizerconst.HTTPRouteFinalizer,
+						finalizerconst.HybridHTTPRouteFinalizer,
 						"yet-another-finalizer",
 					},
 				},
@@ -1137,7 +1137,7 @@ func TestRemoveFinalizerIfNotManaged_HTTPRoute(t *testing.T) {
 				err := cl.Get(ctx, client.ObjectKeyFromObject(tt.httpRoute), updated)
 				require.NoError(t, err)
 
-				assert.Equal(t, tt.expectedHasFinalizer, slices.Contains(updated.GetFinalizers(), finalizerconst.HTTPRouteFinalizer), "finalizer presence mismatch")
+				assert.Equal(t, tt.expectedHasFinalizer, slices.Contains(updated.GetFinalizers(), finalizerconst.HybridHTTPRouteFinalizer), "finalizer presence mismatch")
 			}
 		})
 	}
@@ -1221,7 +1221,7 @@ func TestRemoveFinalizerIfNotManaged_Gateway(t *testing.T) {
 					Name:       "test-gateway",
 					Namespace:  "default",
 					UID:        "test-gateway-uid",
-					Finalizers: []string{finalizerconst.GatewayFinalizer},
+					Finalizers: []string{finalizerconst.HybridGatewayFinalizer},
 				},
 				Spec: gatewayv1.GatewaySpec{
 					GatewayClassName: "kong",
@@ -1242,7 +1242,7 @@ func TestRemoveFinalizerIfNotManaged_Gateway(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-gateway",
 					Namespace:  "default",
-					Finalizers: []string{finalizerconst.GatewayFinalizer},
+					Finalizers: []string{finalizerconst.HybridGatewayFinalizer},
 				},
 				Spec: gatewayv1.GatewaySpec{
 					GatewayClassName: "other",
@@ -1263,7 +1263,7 @@ func TestRemoveFinalizerIfNotManaged_Gateway(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-gateway",
 					Namespace:  "default",
-					Finalizers: []string{finalizerconst.GatewayFinalizer},
+					Finalizers: []string{finalizerconst.HybridGatewayFinalizer},
 				},
 				Spec: gatewayv1.GatewaySpec{
 					GatewayClassName: "other",
@@ -1287,7 +1287,7 @@ func TestRemoveFinalizerIfNotManaged_Gateway(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-gateway",
 					Namespace:  "default",
-					Finalizers: []string{finalizerconst.GatewayFinalizer},
+					Finalizers: []string{finalizerconst.HybridGatewayFinalizer},
 				},
 				Spec: gatewayv1.GatewaySpec{
 					GatewayClassName: "other",
@@ -1313,7 +1313,7 @@ func TestRemoveFinalizerIfNotManaged_Gateway(t *testing.T) {
 					Namespace: "default",
 					Finalizers: []string{
 						"some-other-finalizer",
-						finalizerconst.GatewayFinalizer,
+						finalizerconst.HybridGatewayFinalizer,
 						"yet-another-finalizer",
 					},
 				},
@@ -1366,7 +1366,7 @@ func TestRemoveFinalizerIfNotManaged_Gateway(t *testing.T) {
 				err := cl.Get(ctx, client.ObjectKeyFromObject(tt.gateway), updated)
 				require.NoError(t, err)
 
-				assert.Equal(t, tt.expectedHasFinalizer, slices.Contains(updated.GetFinalizers(), finalizerconst.GatewayFinalizer), "finalizer presence mismatch")
+				assert.Equal(t, tt.expectedHasFinalizer, slices.Contains(updated.GetFinalizers(), finalizerconst.HybridGatewayFinalizer), "finalizer presence mismatch")
 
 			}
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

The finalizers related to Hybrid resources have been renamed by prefixing "hybrid"

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
