### PR TITLE
ci(chainsaw): test conversion webhook for `KonnectGatewayControlPlane`

### DIFF
--- a/test/e2e/chainsaw/conversion_webhook/konnect-gateway-controlplane/00-assert-konnect-gateway-controlplane.yml
+++ b/test/e2e/chainsaw/conversion_webhook/konnect-gateway-controlplane/00-assert-konnect-gateway-controlplane.yml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($kong_namespace)
+---
+apiVersion: konnect.konghq.com/v1alpha1
+kind: KonnectAPIAuthConfiguration
+metadata:
+  name: ($konnect_api_auth_name)
+  namespace: ($kong_namespace)
+status:
+  conditions:
+    - type: APIAuthValid
+      status: "True"
+---
+apiVersion: konnect.konghq.com/v1alpha2
+kind: KonnectGatewayControlPlane
+metadata:
+  name: ($konnect_gateway_controlplane_name)
+  namespace: ($kong_namespace)
+spec:
+  createControlPlaneRequest:
+    name: ($konnect_gateway_controlplane_name)
+  konnect:
+    authRef:
+      name: ($konnect_api_auth_name)
+  source: Origin
+status:
+  clusterType: CLUSTER_TYPE_CONTROL_PLANE
+  (conditions[?type == 'APIAuthResolvedRef']):
+    - status: 'True'
+      reason: ResolvedRef
+  (conditions[?type == 'APIAuthValid']):
+    - status: 'True'
+      reason: Valid
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (id != null): true
+  (konnectEndpoints.controlPlane != null): true
+  (konnectEndpoints.telemetry != null): true
+  (organizationID != null): true
+  (serverURL != null): true
+---

--- a/test/e2e/chainsaw/conversion_webhook/konnect-gateway-controlplane/00-konnect-gateway-controlplane.yml
+++ b/test/e2e/chainsaw/conversion_webhook/konnect-gateway-controlplane/00-konnect-gateway-controlplane.yml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($kong_namespace)
+---
+apiVersion: konnect.konghq.com/v1alpha1
+kind: KonnectAPIAuthConfiguration
+metadata:
+  name: ($konnect_api_auth_name)
+  namespace: ($kong_namespace)
+spec:
+  type: token
+  token: (env('KONNECT_TOKEN'))
+  serverURL: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+---
+apiVersion: konnect.konghq.com/v1alpha1
+kind: KonnectGatewayControlPlane
+metadata:
+  name: ($konnect_gateway_controlplane_name)
+  namespace: ($kong_namespace)
+spec:
+  name: ($konnect_gateway_controlplane_name)
+  konnect:
+    authRef:
+      name: ($konnect_api_auth_name)

--- a/test/e2e/chainsaw/conversion_webhook/konnect-gateway-controlplane/chainsaw-test.yml
+++ b/test/e2e/chainsaw/conversion_webhook/konnect-gateway-controlplane/chainsaw-test.yml
@@ -1,0 +1,37 @@
+# Test converting KonnectGatewayControlPlane from v1alpha1 to v2alpha1 by webhook.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: konnect-gateway-controlplane-conversion
+spec:
+  description: |
+    This test validates that the v1alpha1 KonnectGatewayControlPlane is converted to v2alpha1.
+
+  bindings:
+    - name: kong_namespace
+      value: (join('-', ['kong', 'konnect-gateway-controlplane', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: konnect_api_auth_name
+      value: (join('-', ['kong', 'konnect-api-auth', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: konnect_gateway_controlplane_name
+      value: (join('-', ['kong', 'konnect-gateway-controlplane', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+
+  timeouts:
+    apply: 120s
+    assert: 300s
+    cleanup: 120s
+    delete: 120s
+
+  steps:
+    - name: create-konnect-resources
+      description: Create KonnectGatewayControlPlane and KonnectAPIAuthConfiguration resources
+      try:
+        - apply:
+            file: 00-konnect-gateway-controlplane.yml
+        - assert:
+            file: 00-assert-konnect-gateway-controlplane.yml
+      catch:
+        - description: Get KonnectGatewayControlPlane resource status
+          get:
+            apiVersion: konnect.konghq.com/v1alpha2
+            kind: KonnectGatewayControlPlane
+            namespace: ($kong_namespace)


### PR DESCRIPTION
**What this PR does / why we need it**:

Add chainsaw e2e scenario for`KonnectGatewayControlPlane` conversion from `v1alpha1` to `v1alpha2` to cover conversion webhook with e2e test

**Which issue this PR fixes**

closes https://github.com/Kong/kong-operator/issues/1986