### PR TITLE
test(e2e/chainsaw): Add test case for cross namespace reference HTTPRoute -> backendRef

### DIFF
--- a/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/00-assert-httpbin.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/00-assert-httpbin.yaml
@@ -1,0 +1,20 @@
+---
+# Assert httpbin Service exists
+apiVersion: v1
+kind: Service
+metadata:
+  name: ($httpbin_service_name)
+  namespace:  ($httpbin_service_namespace)
+---
+# Assert httpbin Deployment is ready
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ($httpbin_service_name)
+  namespace: ($httpbin_service_namespace)
+status:
+  # Filter conditions array to check for Available condition
+  (conditions[?type == 'Available']):
+    - status: 'True'
+  readyReplicas: 1
+  replicas: 1

--- a/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/00-httpbin.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/00-httpbin.yaml
@@ -1,0 +1,65 @@
+---
+# Namespace for httpbin service as backendRef
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($httpbin_service_namespace)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ($httpbin_service_name)
+  namespace: ($httpbin_service_namespace)
+  labels:
+    app: httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+  template:
+    metadata:
+      labels:
+        app: httpbin
+    spec:
+      containers:
+        - name: httpbin
+          image: ghcr.io/mccutchen/go-httpbin:2.19
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /status/200
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /status/200
+              port: http
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            runAsNonRoot: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ($httpbin_service_name)
+  namespace: ($httpbin_service_namespace)
+  labels:
+    app: httpbin
+spec:
+  selector:
+    app: httpbin
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+      appProtocol: http

--- a/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/01-assert-prerequisites.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/01-assert-prerequisites.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($gateway_namespace)
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: ($gateway_class_name)
+status:
+  (conditions[?type == 'Accepted']):
+    - status: 'True'
+      reason: Accepted
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ($gateway_name)
+  namespace: ($gateway_namespace)
+status:
+  (conditions[?type == 'Accepted']):
+    - status: 'True'
+      reason: Accepted
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'DataPlaneReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'KonnectGatewayControlPlaneProgrammed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'KonnectExtensionReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'GatewayService']):
+    - status: 'True'
+      reason: Ready

--- a/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/01-prerequisites.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/01-prerequisites.yaml
@@ -1,0 +1,58 @@
+---
+# Namespace for gateway and HTTPRoute
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($gateway_namespace)
+---
+kind: KonnectAPIAuthConfiguration
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: ($konnect_api_auth_name)
+  namespace: ($gateway_namespace)
+spec:
+  type: token
+  token: (env('KONNECT_TOKEN'))
+  serverURL: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+---
+kind: GatewayConfiguration
+apiVersion: gateway-operator.konghq.com/v2beta1
+metadata:
+  name: ($gateway_configuration_name)
+  namespace: ($gateway_namespace)
+spec:
+  konnect:
+    authRef:
+      name: ($konnect_api_auth_name)
+  dataPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        spec:
+          containers:
+          - name: proxy
+            image: ($gateway_proxy_image)
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: ($gateway_class_name)
+spec:
+  controllerName: konghq.com/gateway-operator
+  parametersRef:
+    group: gateway-operator.konghq.com
+    kind: GatewayConfiguration
+    name: ($gateway_configuration_name)
+    namespace: ($gateway_namespace)
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: ($gateway_name)
+  namespace: ($gateway_namespace)
+spec:
+  gatewayClassName: ($gateway_class_name)
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---

--- a/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/02-assert-httproute-backendref-cross-namespace-reference.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/02-assert-httproute-backendref-cross-namespace-reference.yaml
@@ -1,0 +1,33 @@
+---
+# Assert HTTPRoute is accepted and programmed
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        group: gateway.networking.k8s.io
+        kind: Gateway
+      controllerName: konghq.com/gateway-operator
+      # Filter conditions array to check for all required conditions
+      (conditions[?type == 'Accepted']):
+        - status: "True"
+          reason: Accepted
+      (conditions[?type == 'ResolvedRefs']):
+        - status: "True"
+          reason: ResolvedRefs
+      (conditions[?type == 'KongRouteProgrammed']):
+        - status: "True"
+          reason: KongRouteProgrammed
+      (conditions[?type == 'KongServiceProgrammed']):
+        - status: "True"
+          reason: KongServiceProgrammed
+      (conditions[?type == 'KongUpstreamProgrammed']):
+        - status: "True"
+          reason: KongUpstreamProgrammed
+      (conditions[?type == 'KongTargetProgrammed']):
+        - status: "True"
+          reason: KongTargetProgrammed

--- a/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/02-httproute-backendref-cross-namespace-reference.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/02-httproute-backendref-cross-namespace-reference.yaml
@@ -1,0 +1,35 @@
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: ($route_path)
+      backendRefs:
+        - name: ($httpbin_service_name)
+          port: 80
+          namespace: ($httpbin_service_namespace)
+---
+kind: ReferenceGrant
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: ($reference_grant_name)
+  namespace: ($httpbin_service_namespace)
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: ($http_route_namespace)
+  to:
+  - group: ""
+    kind: Service
+    name: ($httpbin_service_name)

--- a/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/chainsaw-test.yaml
@@ -1,0 +1,159 @@
+# Scenario for HTTPRoute referencing Service as backendRef in another namespace granted by ReferenceGrant
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: httproute-backendref-cross-namespace-reference
+spec:
+  description: |
+    The case validates the scenario where an HTTPRoute can reference a
+    Service as its backendRef when granted by proper ReferenceGrant.
+
+  # Define the gateway_name binding based on TEST_ID environment variable
+  # This ensures unique names in Konnect to avoid 409 conflicts
+  bindings:
+    - name: gateway_namespace
+      # Name of namespace cannot exceed 63 characters, so we shortened the name.
+      value: (join('-', ['kong', 'httproute-backendref-x-ns-gateway', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: konnect_api_auth_name
+      value: konnect-api-auth-dev-1
+    - name: gateway_class_name
+      value: (join('-', ['kong', 'httproute-backendref-cross-namespace', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: gateway_configuration_name
+      value: ($gateway_class_name)
+    - name: gateway_name
+      value: ($gateway_class_name)
+    - name: http_route_name
+      value: (join('-', ['kong', 'httproute-backendref-cross-namespace-ref', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: http_route_namespace
+      value: ($gateway_namespace)
+    - name: reference_grant_name
+      value: (join('-', ['kong', 'httproute-backendref-cross-namespace-ref-service', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: httpbin_service_name
+      value: httpbin
+    - name: httpbin_service_namespace
+      value: (join('-', ['kong', 'httproute-backendref-x-ns-backend', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: operator_namespace
+      value: kong-system
+    - name: gateway_proxy_image
+      value: kong/kong-gateway:3.12
+  
+  timeouts:
+    apply: 120s
+    assert: 300s
+    cleanup: 120s
+    delete: 120s
+
+  steps:
+    # Step 01: Create backend service and gateway in different namespaces.
+    - name: create-prerequisites
+      description: Create GatewayClass, Gateway, and backend Service in different namespaces.
+      try:
+        - apply:
+            file: 00-httpbin.yaml
+        - apply:
+            file: 01-prerequisites.yaml
+        - assert:
+            file: 00-assert-httpbin.yaml
+        - assert:
+            file: 01-assert-prerequisites.yaml
+      catch:
+        - description: Get Gateway resource status
+          get:
+            apiVersion: gateway.networking.k8s.io/v1
+            kind: Gateway
+            namespace: ($gateway_namespace)
+        - description: Get Pods in gateway namespace
+          get:
+            apiVersion: v1
+            kind: Pod
+            namespace: ($gateway_namespace)
+        - description: Get operator logs
+          podLogs:
+            namespace: ($operator_namespace)
+            selector: control-plane=controller-manager
+            tail: 100
+    # Step 02: Create HTTPRoute and ReferenceGrant in the namepace of the Gateway, then verify the connectivity.
+    - name: create-httproute-with-cross-namespace-reference-to-backendRef
+      description: Create an HTTPRoute in another namespace with a cross-namespace backendRef with ReferenceGrant
+      bindings:
+        - name: route_path
+          value: "/httproute-cross-namespace-reference-to-backendref"
+      try:
+        - apply:
+            file: 02-httproute-backendref-cross-namespace-reference.yaml
+        - assert:
+            file: 02-assert-httproute-backendref-cross-namespace-reference.yaml
+        # Get the Gateway proxy IP
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+            content: |
+              kubectl get gateway ${GATEWAY_NAME} -n ${GATEWAY_NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
+            outputs:
+              - name: proxy_ip
+                value: ($stdout)
+        # Wait until the route works
+        - description: Test connectivity from outside the cluster
+          script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: ROUTE_PATH
+                value: ($route_path)
+            content: |
+              echo "Accessing gateway ${GATEWAY_NAMESPACE}/${GATEWAY_NAME} at ${PROXY_IP}"
+              curl --fail --retry 10 --retry-delay 5 --retry-all-errors -s -o /dev/null -w "%{http_code}" http://${PROXY_IP}${ROUTE_PATH}/status/200
+            check:
+              (contains($stdout, '200')): true
+      catch:
+        - description: Dump HTTPRoutes
+          get:
+            apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump ReferenceGrants
+          get:
+            apiVersion: gateway.networking.k8s.io/v1bata1
+            kind: ReferenceGrant
+            namespace: ($httpbin_service_namespace)
+            format: yaml
+        - description: dump KongServices
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongService
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongRoutes
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongRoute
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongUpstreams
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongUpstream
+            namespace: ($http_route_namespace)
+            format: yaml
+        - description: Dump KongTargets
+          get:
+            apiVersion: configuration.konghq.com/v1alpha1
+            kind: KongTarget
+            namespace: ($http_route_namespace)
+            format: yaml        
+      finally:
+        - description: Delete HTTPRoute
+          delete:
+            ref:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: HTTPRoute
+              namespace: ($http_route_namespace)
+              name: ($http_route_name)


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a chainsaw test case for cross namespace reference `HTTPRoute` -> `backendRef` (`Service`) with the proper grant by `ReferenceGrant`.

**Which issue this PR fixes**

Fixes #2979 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
