### PR TITLE
feat(hybridgateway): add support to PathPrefixMatch URL rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
   DataPlane, ControlPlane, and KonnectGatewayControlPlane resources will be
   named exactly as the Gateway resource instead of using auto-generated names.
   [#3015](https://github.com/Kong/kong-operator/issues/3015)
+- HybridGateway: Added support to PathPrefixMatch for the `URLRewrite` `HTTPRoute` filter.
+  [#3039](https://github.com/Kong/kong-operator/pull/3039)
 
 ### Fixes
 

--- a/controller/hybridgateway/builder/kongroute.go
+++ b/controller/hybridgateway/builder/kongroute.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"strings"
 
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -48,7 +49,14 @@ func (b *KongRouteBuilder) WithHosts(hosts []string) *KongRouteBuilder {
 func (b *KongRouteBuilder) WithHTTPRouteMatch(match gwtypes.HTTPRouteMatch, setCaptureGroup bool) *KongRouteBuilder {
 	// Path.
 	if match.Path != nil && match.Path.Value != nil {
-		b.route.Spec.Paths = append(b.route.Spec.Paths, GenerateKongRoutePathFromHTTPRouteMatch(match.Path, setCaptureGroup)...)
+		paths, setRegexPriority := GenerateKongRoutePathFromHTTPRouteMatch(match.Path, setCaptureGroup)
+		b.route.Spec.Paths = append(b.route.Spec.Paths, paths...)
+		if setRegexPriority {
+			// setRegexPriority is set to true when the match path is a prefix match, is not root ("/") and requires a
+			// capture group for filters. We need to set regex_priority > 1 to ensure that a root path match ("/") in
+			// another KongRoute does not take precedence becoming a catch-all rule.
+			b.route.Spec.RegexPriority = ptr.To[int64](1)
+		}
 	}
 
 	// Method
@@ -164,8 +172,11 @@ func (b *KongRouteBuilder) MustBuild() configurationv1alpha1.KongRoute {
 }
 
 // GenerateKongRoutePathFromHTTPRouteMatch translates the value in HTTPRoute's path match
-// to the path used in KongRoute.
-func GenerateKongRoutePathFromHTTPRouteMatch(pathMatch *gatewayv1.HTTPPathMatch, setCaptureGroup bool) []string {
+// to the path used in KongRoute and returns whether to set RegexPriority for the KongRoute.
+// RegexPriority must be set in the KongRoute when the HTTPRoute match is a prefix match,
+// is not root ("/") and requires a capture group for filters to ensure that a root path
+// match ("/") in another KongRoute does not take precedence.
+func GenerateKongRoutePathFromHTTPRouteMatch(pathMatch *gatewayv1.HTTPPathMatch, setCaptureGroup bool) (paths []string, setRegexPriority bool) {
 	// The default match type is PathMatchPathPrefix.
 	matchType := gatewayv1.PathMatchPathPrefix
 	if pathMatch.Type != nil {
@@ -184,7 +195,7 @@ func GenerateKongRoutePathFromHTTPRouteMatch(pathMatch *gatewayv1.HTTPPathMatch,
 	switch matchType {
 	// Since the path matches request in prefix way, we need to use a regex with the '$' suffix to do the exact match.
 	case gatewayv1.PathMatchExact:
-		return []string{KongPathRegexPrefix + value + "$"}
+		return []string{KongPathRegexPrefix + value + "$"}, false
 
 	// In HTTPRoute, the prefix match is specified in the "directory" manner but not simple string prefix.
 	// For example, '/abc' should match '/abc', '/abc/', '/abc/123' but not '/abcd'.
@@ -194,7 +205,7 @@ func GenerateKongRoutePathFromHTTPRouteMatch(pathMatch *gatewayv1.HTTPPathMatch,
 	case gatewayv1.PathMatchPathPrefix:
 		// For the '/' path to match all, we just return the item in KongRoute to do the same catch-all match.
 		if value == "/" && !setCaptureGroup {
-			return []string{"/"}
+			return []string{"/"}, false
 		}
 
 		paths := make([]string, 0, 2)
@@ -207,20 +218,20 @@ func GenerateKongRoutePathFromHTTPRouteMatch(pathMatch *gatewayv1.HTTPPathMatch,
 		if setCaptureGroup {
 			// If the path is "/", we have to skip capturing the slash as Kong Route's path must begin with a slash.
 			if value == "/" {
-				return append(paths, fmt.Sprintf("%s/(.*)", KongPathRegexPrefix))
+				return append(paths, fmt.Sprintf("%s/(.*)", KongPathRegexPrefix)), false
 			}
 			// When there is a prefix in the route path, we capture the slash and the rest of the path after the prefix.
-			return append(paths, fmt.Sprintf("%s%s%s", KongPathRegexPrefix, path, "(/.*)"))
+			return append(paths, fmt.Sprintf("%s%s%s", KongPathRegexPrefix, path, "(/.*)")), true
 		}
 
 		if !strings.HasSuffix(path, "/") {
 			path = fmt.Sprintf("%s/", path)
 		}
-		return append(paths, path)
+		return append(paths, path), false
 
 	// For RegularExpression path match, we simply use the same regex in the paths of KongRoute.
 	case gatewayv1.PathMatchRegularExpression:
-		return []string{KongPathRegexPrefix + value}
+		return []string{KongPathRegexPrefix + value}, false
 	}
-	return nil // Should be unreachable.
+	return nil, false // Should never be reached.
 }

--- a/controller/hybridgateway/builder/kongroute_test.go
+++ b/controller/hybridgateway/builder/kongroute_test.go
@@ -235,7 +235,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			builder := NewKongRoute().WithHTTPRouteMatch(tt.match)
+			builder := NewKongRoute().WithHTTPRouteMatch(tt.match, false)
 
 			route, err := builder.Build()
 			require.NoError(t, err)
@@ -513,7 +513,7 @@ func TestKongRouteBuilder_Chaining(t *testing.T) {
 		WithSpecName("test-spec").
 		WithStripPath(true).
 		WithHosts([]string{"example.com"}).
-		WithHTTPRouteMatch(match).
+		WithHTTPRouteMatch(match, false).
 		WithKongService("test-service").
 		WithOwner(httpRoute).
 		WithLabels(httpRoute, parentRef).

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -442,7 +442,7 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 				"filterCount", len(rule.Filters))
 
 			for _, filter := range rule.Filters {
-				plugins, selfManagedPlugin, err := plugin.PluginsForFilter(ctx, logger, c.Client, c.route, filter, &pRef)
+				plugins, selfManagedPlugin, err := plugin.PluginsForFilter(ctx, logger, c.Client, c.route, rule, filter, &pRef)
 				if err != nil {
 					log.Error(logger, err, "Failed to translate KongPlugin resource, skipping filter",
 						"filter", filter.Type)

--- a/controller/hybridgateway/kongroute/route.go
+++ b/controller/hybridgateway/kongroute/route.go
@@ -104,7 +104,6 @@ func needsCaptureGroup(rule gwtypes.HTTPRouteRule) bool {
 			filter.RequestRedirect.Path.ReplacePrefixMatch != nil:
 			return true
 		}
-
 	}
 	return false
 }

--- a/controller/hybridgateway/kongroute/route.go
+++ b/controller/hybridgateway/kongroute/route.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
@@ -65,9 +66,13 @@ func RouteForRule(
 		WithStripPath(metadata.ExtractStripPath(httpRoute.Annotations)).
 		WithKongService(serviceName)
 
+	// Check if the rule contains a URLRewrite or RequestRedirect filter with ReplacePrefixMatch:
+	// if so, we need to set a capture group on the KongRoute paths.
+	setCaptureGroup := needsCaptureGroup(rule)
+
 	// Add HTTPRoute matches
 	for _, match := range rule.Matches {
-		routeBuilder = routeBuilder.WithHTTPRouteMatch(match)
+		routeBuilder = routeBuilder.WithHTTPRouteMatch(match, setCaptureGroup)
 	}
 	newRoute, err := routeBuilder.Build()
 	if err != nil {
@@ -80,4 +85,26 @@ func RouteForRule(
 	}
 
 	return &newRoute, nil
+}
+
+// needsCaptureGroup checks if the given HTTPRoute rule requires a capture group
+// in the KongRoute paths based on the presence of URLRewrite or RequestRedirect
+// filters with ReplacePrefixMatch.
+func needsCaptureGroup(rule gwtypes.HTTPRouteRule) bool {
+	for _, filter := range rule.Filters {
+		switch {
+		case filter.Type == gatewayv1.HTTPRouteFilterURLRewrite &&
+			filter.URLRewrite != nil &&
+			filter.URLRewrite.Path != nil &&
+			filter.URLRewrite.Path.ReplacePrefixMatch != nil:
+			return true
+		case filter.Type == gatewayv1.HTTPRouteFilterRequestRedirect &&
+			filter.RequestRedirect != nil &&
+			filter.RequestRedirect.Path != nil &&
+			filter.RequestRedirect.Path.ReplacePrefixMatch != nil:
+			return true
+		}
+
+	}
+	return false
 }

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -124,7 +124,8 @@ func TestRouteForRule(t *testing.T) {
 
 			// Verify paths from rule matches
 			if len(rule.Matches) > 0 && rule.Matches[0].Path != nil {
-				assert.Subset(t, result.Spec.Paths, builder.GenerateKongRoutePathFromHTTPRouteMatch(rule.Matches[0].Path))
+				paths, _ := builder.GenerateKongRoutePathFromHTTPRouteMatch(rule.Matches[0].Path, false)
+				assert.Subset(t, result.Spec.Paths, paths)
 			}
 		})
 	}

--- a/controller/hybridgateway/plugin/plugin.go
+++ b/controller/hybridgateway/plugin/plugin.go
@@ -42,6 +42,7 @@ import (
 //   - logger: Structured logger.
 //   - cl: Kubernetes client.
 //   - httpRoute: Source HTTPRoute.
+//   - rule: The HTTPRouteRule being processed.
 //   - filter: The HTTPRouteFilter being processed.
 //   - pRef: Parent (Gateway) reference.
 //
@@ -54,6 +55,7 @@ func PluginsForFilter(
 	logger logr.Logger,
 	cl client.Client,
 	httpRoute *gwtypes.HTTPRoute,
+	rule gwtypes.HTTPRouteRule,
 	filter gwtypes.HTTPRouteFilter,
 	pRef *gwtypes.ParentReference,
 ) ([]configurationv1.KongPlugin, bool, error) {
@@ -74,7 +76,7 @@ func PluginsForFilter(
 		return plugins, true, nil
 	}
 
-	pluginConfs, err := translateFromFilter(filter)
+	pluginConfs, err := translateFromFilter(rule, filter)
 	if err != nil {
 		return nil, false, fmt.Errorf("translating filter to KongPlugins: %w", err)
 	}

--- a/controller/hybridgateway/plugin/plugin_test.go
+++ b/controller/hybridgateway/plugin/plugin_test.go
@@ -10,6 +10,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -126,6 +127,7 @@ func TestPluginForFilter(t *testing.T) {
 	tests := []struct {
 		name           string
 		filter         gwtypes.HTTPRouteFilter
+		rule           gwtypes.HTTPRouteRule
 		existingPlugin *configurationv1.KongPlugin
 		httpRoute      *gwtypes.HTTPRoute
 		parentRef      *gwtypes.ParentReference
@@ -139,6 +141,16 @@ func TestPluginForFilter(t *testing.T) {
 				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
 					Set: []gatewayv1.HTTPHeader{
 						{Name: "X-Custom-Header", Value: "custom-value"},
+					},
+				},
+			},
+			rule: gwtypes.HTTPRouteRule{
+				Matches: []gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  ptr.To(gatewayv1.PathMatchPathPrefix),
+							Value: ptr.To("/test"),
+						},
 					},
 				},
 			},
@@ -176,7 +188,7 @@ func TestPluginForFilter(t *testing.T) {
 				WithRuntimeObjects(objects...).
 				Build()
 
-			plugins, _, err := PluginsForFilter(ctx, logger, fakeClient, tt.httpRoute, tt.filter, tt.parentRef)
+			plugins, _, err := PluginsForFilter(ctx, logger, fakeClient, tt.httpRoute, tt.rule, tt.filter, tt.parentRef)
 
 			if tt.expectedError {
 				require.Error(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support to the `PathPrefixMatch` path rewrite functionality for the Gateway API `URLRewrite` filter.

**Which issue this PR fixes**

Fixes #2902

**Special notes for your reviewer**:

The `PathPrefixMatch` path matching performed via Kong entities requires a `KongPlugin` as usual but also to set up a `capture group` in the `KongRoute` used to translate the matching path of the  Gateway API `HTTPRoute` `Match`.
That's the way to capture the remaining part of the URL after the matching path is removed, which is then to be appended by the Kong plugin to the translated prefix path.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
