### PR TITLE
fix: fix panic in KonnectExtension controller when CP is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@
   regular expression in the translated `KongRoute` when the `HTTPRoute`'s header
   match has the `RegularExpression` type.
   [#2995](https://github.com/Kong/kong-operator/pull/2995)
+- Fixes a panic in KonnectExtension controller when Control Plane is not found.
+  [#3054](https://github.com/Kong/kong-operator/pull/3054)
 
 ## [v2.1.0-beta.0]
 

--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -838,7 +838,7 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		Name:      apiAuth.Name,
 		Namespace: &apiAuth.Namespace,
 	}
-	if enforceKonnectExtensionStatus(*cp, authRef, *certificateSecret, &ext) {
+	if enforceKonnectExtensionStatus(cp, authRef, *certificateSecret, &ext) {
 		log.Debug(logger, "updating KonnectExtension status")
 		err := r.Client.Status().Update(ctx, &ext)
 		if k8serrors.IsConflict(err) {

--- a/controller/konnect/konnectextension_controller_utils.go
+++ b/controller/konnect/konnectextension_controller_utils.go
@@ -265,7 +265,7 @@ func (r *KonnectExtensionReconciler) getCertificateSecret(ctx context.Context, e
 }
 
 func enforceKonnectExtensionStatus(
-	cp konnectv1alpha2.KonnectGatewayControlPlane,
+	cp *konnectv1alpha2.KonnectGatewayControlPlane,
 	apiAuthRef konnectv1alpha2.ControlPlaneKonnectAPIAuthConfigurationRef,
 	certificateSecret corev1.Secret,
 	ext *konnectv1alpha2.KonnectExtension,
@@ -274,7 +274,8 @@ func enforceKonnectExtensionStatus(
 
 	// The Status schema requires non-empty endpoints; updating with empty values triggers validation errors.
 	// When endpoints are unavailable, clear the entire Konnect status struct.
-	if cp.Status.Endpoints == nil ||
+	if cp == nil ||
+		cp.Status.Endpoints == nil ||
 		cp.Status.Endpoints.ControlPlaneEndpoint == "" ||
 		cp.Status.Endpoints.TelemetryEndpoint == "" {
 		if ext.Status.Konnect != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes:

```
2026-01-13T14:04:31.7702622Z 2026-01-13T14:04:31Z	ERROR	Observed a panic	{"controller": "konnectextension", "controllerGroup": "konnect.konghq.com", "controllerKind": "KonnectExtension", "KonnectExtension": {"name":"c7627b9b-f97e-4d30-a744-5f72663417b1-rk5md","namespace":"e6d9bae1-f226-4592-9243-1ed76e6b01c3"}, "namespace": "e6d9bae1-f226-4592-9243-1ed76e6b01c3", "name": "c7627b9b-f97e-4d30-a744-5f72663417b1-rk5md", "reconcileID": "ac764966-d7f0-42e9-8617-bb4930143a04", "panic": "runtime error: invalid memory address or nil pointer dereference", "panicGoValue": "\"invalid memory address or nil pointer dereference\"", "stacktrace": "goroutine 2756 [running]:\nk8s.io/apimachinery/pkg/util/runtime.logPanic({0x94821b0, 0xc00599e450}, {0x8245d80, 0xbdedd50})\n\t/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.34.3/pkg/util/runtime/runtime.go:132 +0xdc\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1()\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:198 +0x1ee\npanic({0x8245d80?, 0xbdedd50?})\n\t/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/panic.go:783 +0x132\ngithub.com/kong/kong-operator/controller/konnect.(*KonnectExtensionReconciler).Reconcile(0xc000436e00, {0x94821b0, 0xc00599e450}, {{{0xc0056f3620?, 0x513f145?}, {0xc0056f35f0?, 0x2160ffb?}}})\n\t/home/runner/work/kong-operator/kong-operator/controller/konnect/konnectextension_controller.go:841 +0x82ce\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile(0x94f4b60, {0x94821b0, 0xc00599e450}, {{{0xc0056f3620, 0x0?}, {0xc0056f35f0?, 0x0?}}})\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:216 +0x25d\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler(0x94f4b60, {0x94821e8, 0xc0006e5220}, {{{0xc0056f3620, 0x24}, {0xc0056f35f0, 0x2a}}}, 0x0)\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:461 +0x51e\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem(0x94f4b60, {0x94821e8, 0xc0006e5220})\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:421 +0x3ad\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1()\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:296 +0xe5\ncreated by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1 in goroutine 1097\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:292 +0x418\n"}
2026-01-13T14:04:31.7734187Z k8s.io/apimachinery/pkg/util/runtime.logPanic
2026-01-13T14:04:31.7735143Z 	/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.34.3/pkg/util/runtime/runtime.go:142
2026-01-13T14:04:31.7743460Z sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1
2026-01-13T14:04:31.7744856Z 	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:198
2026-01-13T14:04:31.7745784Z runtime.gopanic
2026-01-13T14:04:31.7746449Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/panic.go:783
2026-01-13T14:04:31.7746985Z runtime.panicmem
2026-01-13T14:04:31.7747469Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/panic.go:262
2026-01-13T14:04:31.7747950Z runtime.sigpanic
2026-01-13T14:04:31.7748435Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/signal_unix.go:925
2026-01-13T14:04:31.7749264Z github.com/kong/kong-operator/controller/konnect.(*KonnectExtensionReconciler).Reconcile
2026-01-13T14:04:31.7757488Z 	/home/runner/work/kong-operator/kong-operator/controller/konnect/konnectextension_controller.go:841
2026-01-13T14:04:31.7758755Z sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile
2026-01-13T14:04:31.7760097Z 	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:216
2026-01-13T14:04:31.7761366Z sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
2026-01-13T14:04:31.7762672Z 	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:461
2026-01-13T14:04:31.7763875Z sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
2026-01-13T14:04:31.7765043Z 	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:421
2026-01-13T14:04:31.7766403Z sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
2026-01-13T14:04:31.7767632Z 	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:296
2026-01-13T14:04:31.7771334Z 2026-01-13T14:04:31Z	ERROR	Reconciler error	{"controller": "konnectextension", "controllerGroup": "konnect.konghq.com", "controllerKind": "KonnectExtension", "KonnectExtension": {"name":"c7627b9b-f97e-4d30-a744-5f72663417b1-rk5md","namespace":"e6d9bae1-f226-4592-9243-1ed76e6b01c3"}, "namespace": "e6d9bae1-f226-4592-9243-1ed76e6b01c3", "name": "c7627b9b-f97e-4d30-a744-5f72663417b1-rk5md", "reconcileID": "ac764966-d7f0-42e9-8617-bb4930143a04", "error": "panic: runtime error: invalid memory address or nil pointer dereference [recovered]"}
2026-01-13T14:04:31.7795577Z sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
2026-01-13T14:04:31.7797371Z 	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:474
2026-01-13T14:04:31.7798900Z sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
2026-01-13T14:04:31.7800375Z 	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:421
2026-01-13T14:04:31.7801569Z sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
2026-01-13T14:04:31.7802791Z 	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:296
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
