### PR TITLE
test(e2e/chainsaw): Add chainsaw test case for cross namespace reference gwconf -> apiauthconf

### DIFF
--- a/test/e2e/chainsaw/common/_step_templates/apply-assert-gatewayConfiguration.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/apply-assert-gatewayConfiguration.yaml
@@ -3,6 +3,7 @@
 # Required bindings:
 #   - test_name: Test name used to compose the configuration name.
 #   - namespace: Namespace where the configuration will be created.
+#   - konnect_api_auth_namespace: Namespace where the referenced KonnectAPIAuthConfiguration is in.
 #   - gateway_image: Kong Gateway image to use (e.g., "kong/kong-gateway:3.12").
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: StepTemplate
@@ -22,6 +23,7 @@ spec:
               authRef:
                 # Reference the AuthConfig created by the previous template
                 name: (join('-', [($test_name), 'konnect-api-auth']))
+                namespace: ($konnect_api_auth_namespace)
             dataPlaneOptions:
               deployment:
                 podTemplateSpec:

--- a/test/e2e/chainsaw/hybridgateway/basic-httproute/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-httproute/chainsaw-test.yaml
@@ -14,6 +14,8 @@ spec:
       value: ($namespace)
     - name: konnect_token
       value: (env('KONNECT_TOKEN'))
+    - name: konnect_api_auth_namespace
+      value: ($namespace)
     - name: sni_hostname
       value: (join('.', ['*', ($test_name), 'example.com']))
     - name: fqdn

--- a/test/e2e/chainsaw/hybridgateway/gateway-tls-certificates/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/gateway-tls-certificates/chainsaw-test.yaml
@@ -15,6 +15,8 @@ spec:
       value: ($namespace)
     - name: konnect_token
       value: (env('KONNECT_TOKEN'))
+    - name: konnect_api_auth_namespace
+      value: ($namespace)
     - name: sni_hostname
       value: (join('.', ['*', ($test_name), 'example.com']))
     - name: fqdn

--- a/test/e2e/chainsaw/hybridgateway/gateway-tls-secret-cross-namespace/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/gateway-tls-secret-cross-namespace/chainsaw-test.yaml
@@ -40,6 +40,8 @@ spec:
       value: (join('-', [($test_name), 'konnect-api-auth']))
     - name: konnect_auth_namespace
       value: ($namespace)
+    - name: konnect_api_auth_namespace
+      value: ($namespace)
     - name: gateway_image
       value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
     - name: gateway_name

--- a/test/e2e/chainsaw/hybridgateway/gatewayconfiguration-konnectapiauthconfiguration-cross-namespace/01-gateway.yaml
+++ b/test/e2e/chainsaw/hybridgateway/gatewayconfiguration-konnectapiauthconfiguration-cross-namespace/01-gateway.yaml
@@ -1,0 +1,21 @@
+---
+# Apply Gateway with HTTP listener only.
+# This test focuses on cross-namespace KonnectAPIAuthConfiguration references,
+# not TLS, so only an HTTP listener is needed.
+#
+# Required bindings:
+#   - gateway_name: Name of the Gateway.
+#   - namespace: Namespace where the Gateway will be created.
+#   - test_name: Test name used to compose the GatewayClass name.
+#   - listener_http_port: HTTP listener port.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ($gateway_name)
+  namespace: ($namespace)
+spec:
+  gatewayClassName: (join('-', [($test_name), 'gateway-class']))
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: ($listener_http_port)

--- a/test/e2e/chainsaw/hybridgateway/gatewayconfiguration-konnectapiauthconfiguration-cross-namespace/02-assert-konnectgwcp-auth-not-resolved.yaml
+++ b/test/e2e/chainsaw/hybridgateway/gatewayconfiguration-konnectapiauthconfiguration-cross-namespace/02-assert-konnectgwcp-auth-not-resolved.yaml
@@ -1,0 +1,14 @@
+---
+# Assert KonnectGatewayControlPlane has APIAuthResolvedRef=False due to
+# missing KongReferenceGrant for cross-namespace KonnectAPIAuthConfiguration.
+#
+# Required bindings:
+#   - gateway_namespace: Namespace of the KonnectGatewayControlPlane.
+apiVersion: konnect.konghq.com/v1alpha2
+kind: KonnectGatewayControlPlane
+metadata:
+  namespace: ($gateway_namespace)
+status:
+  (conditions[?type == 'APIAuthResolvedRef']):
+    - status: 'False'
+      reason: RefNotPermitted

--- a/test/e2e/chainsaw/hybridgateway/gatewayconfiguration-konnectapiauthconfiguration-cross-namespace/03-assert-gateway-konnectcp-not-programmed.yaml
+++ b/test/e2e/chainsaw/hybridgateway/gatewayconfiguration-konnectapiauthconfiguration-cross-namespace/03-assert-gateway-konnectcp-not-programmed.yaml
@@ -1,0 +1,16 @@
+---
+# Assert Gateway has KonnectGatewayControlPlaneProgrammed=False.
+# This validates that without a KongReferenceGrant, the cross-namespace
+# auth reference prevents the KonnectGatewayControlPlane from being programmed.
+#
+# Required bindings:
+#   - gateway_name: Name of the Gateway.
+#   - gateway_namespace: Namespace of the Gateway.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ($gateway_name)
+  namespace: ($gateway_namespace)
+status:
+  (conditions[?type == 'KonnectGatewayControlPlaneProgrammed']):
+    - status: 'False'

--- a/test/e2e/chainsaw/hybridgateway/gatewayconfiguration-konnectapiauthconfiguration-cross-namespace/04-assert-gateway-programmed.yaml
+++ b/test/e2e/chainsaw/hybridgateway/gatewayconfiguration-konnectapiauthconfiguration-cross-namespace/04-assert-gateway-programmed.yaml
@@ -1,0 +1,30 @@
+---
+# Assert Gateway is fully programmed after KongReferenceGrant creation.
+#
+# Required bindings:
+#   - gateway_name: Name of the Gateway.
+#   - gateway_namespace: Namespace of the Gateway.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ($gateway_name)
+  namespace: ($gateway_namespace)
+status:
+  (conditions[?type == 'Accepted']):
+    - status: 'True'
+      reason: Accepted
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'DataPlaneReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'KonnectGatewayControlPlaneProgrammed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'KonnectExtensionReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'GatewayService']):
+    - status: 'True'
+      reason: Ready

--- a/test/e2e/chainsaw/hybridgateway/gatewayconfiguration-konnectapiauthconfiguration-cross-namespace/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/gatewayconfiguration-konnectapiauthconfiguration-cross-namespace/chainsaw-test.yaml
@@ -1,0 +1,177 @@
+# GatewayConfiguration -> KonnectAPIAuthConfiguration cross-namespace reference test scenario.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: gwconf-apiauthconf-cross-namespace
+spec:
+  description: |
+    This test validates that the hybrid gateway controller correctly
+    processes cross-namespace references from GatewayConfiguration to
+    KonnectAPIAuthConfiguration when a KongReferenceGrant grants the reference.
+    It verifies that the KonnectGatewayControlPlane is NOT programmed without
+    the grant, and becomes programmed after the grant is created.
+
+  bindings:
+    # Common bindings.
+    - name: test_name
+      value: ($namespace)
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_api_auth_namespace
+      value: (join('-', [($namespace), 'konnect-auth']))
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($konnect_api_auth_namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($konnect_api_auth_namespace)
+    - name: gateway_image
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+    - name: gateway_name
+      value: (join('-', [($test_name), 'gateway']))
+    - name: gateway_namespace
+      value: ($namespace)
+    - name: listener_http_port
+      value: 80
+
+  steps:
+    # Step 1: Create a separate namespace for KonnectAPIAuthConfiguration.
+    - name: 1-create-konnect-auth-namespace
+      description: Create a namespace for KonnectAPIAuthConfiguration separate from the test namespace
+      bindings:
+        - name: namespace_name
+          value: ($konnect_api_auth_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-namespace.yaml
+
+    # Step 2: Create the secret for Konnect authentication in the auth namespace.
+    - name: 2-create-auth-secret
+      description: Create Secret with Konnect token for KonnectAPIAuthConfiguration
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    # Step 3: Create KonnectAPIAuthConfiguration in the auth namespace.
+    - name: 3-create-konnect-api-auth
+      description: Create KonnectAPIAuthConfiguration in the auth namespace
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
+
+    # Step 4: Create the GatewayConfiguration that references the cross-namespace auth config.
+    - name: 4-create-gateway-configuration
+      description: Create GatewayConfiguration with cross-namespace authRef
+      use:
+        template: ../../common/_step_templates/apply-assert-gatewayConfiguration.yaml
+
+    # Step 5: Create the GatewayClass.
+    - name: 5-create-gateway-class
+      description: Create GatewayClass for the test
+      use:
+        template: ../../common/_step_templates/apply-assert-gatewayClass.yaml
+
+    # Step 6: Apply the Gateway (without asserting it's programmed yet).
+    - name: 6-apply-gateway
+      description: Apply Gateway with HTTP listener
+      try:
+        - apply:
+            file: 01-gateway.yaml
+
+    # Step 7: Assert KonnectGatewayControlPlane has APIAuthResolvedRef=False without KongReferenceGrant.
+    - name: 7-assert-konnectgwcp-auth-not-resolved
+      description: Verify KonnectGatewayControlPlane cannot resolve cross-namespace auth ref without KongReferenceGrant
+      try:
+        - assert:
+            file: 02-assert-konnectgwcp-auth-not-resolved.yaml
+
+    # Step 8: Assert Gateway KonnectGatewayControlPlaneProgrammed=False.
+    - name: 8-assert-gateway-konnectcp-not-programmed
+      description: Verify Gateway is not fully programmed because KonnectGatewayControlPlane auth ref is not resolved
+      try:
+        - assert:
+            file: 03-assert-gateway-konnectcp-not-programmed.yaml
+
+    # Step 9: Create KongReferenceGrant to allow KonnectGatewayControlPlane -> KonnectAPIAuthConfiguration.
+    - name: 9-create-kong-reference-grant
+      description: Create KongReferenceGrant to allow cross-namespace auth reference
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [($test_name), 'kong-reference-grant']))
+        - name: kong_reference_grant_namespace
+          value: ($konnect_api_auth_namespace)
+        - name: from
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectGatewayControlPlane
+              namespace: ($gateway_namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectAPIAuthConfiguration
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    # Step 10: Assert KonnectGatewayControlPlane is now programmed.
+    - name: 10-assert-konnect-gateway-control-plane
+      description: Assert KonnectGatewayControlPlane is programmed after KongReferenceGrant
+      use:
+        template: ../../common/_step_templates/assert-konnectGatewayControlPlane.yaml
+
+    # Step 11: Assert Gateway is fully programmed.
+    - name: 11-assert-gateway-programmed
+      description: Assert Gateway is fully programmed after KongReferenceGrant
+      try:
+        - assert:
+            file: 04-assert-gateway-programmed.yaml
+
+    # Step 12: Delete Gateway and wait for all Konnect resources to be fully cleaned up
+    # while the KongReferenceGrant (and thus auth access) still exists.
+    # Without this, chainsaw's reverse cleanup deletes the grant first, which prevents
+    # the operator from authenticating to Konnect to remove finalizers from
+    # KonnectGatewayControlPlane and KonnectExtension. Those resources hold a reference
+    # to KonnectAPIAuthConfiguration (via the "konnectapiauth-in-use" finalizer),
+    # so KonnectAPIAuthConfiguration deletion would also hang.
+    - name: 12-delete-gateway-and-wait-for-konnect-cleanup
+      description: Delete Gateway and wait for KonnectGatewayControlPlane and KonnectExtension to be fully removed
+      timeouts:
+        delete: 120s
+        error: 120s
+      try:
+        - delete:
+            ref:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              name: ($gateway_name)
+              namespace: ($gateway_namespace)
+        # Wait for KonnectGatewayControlPlane to be fully removed (Konnect API cleanup done).
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                namespace: ($gateway_namespace)
+        # Wait for KonnectExtension to be fully removed (Konnect API cleanup done).
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectExtension
+              metadata:
+                namespace: ($gateway_namespace)
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-gwconf-apiauthconf-cross-namespace
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: ADDITIONAL_NAMESPACES
+            value: ($konnect_api_auth_namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/chainsaw-test.yaml
@@ -14,6 +14,8 @@ spec:
       value: ($namespace)
     - name: konnect_token
       value: (env('KONNECT_TOKEN'))
+    - name: konnect_api_auth_namespace
+      value: ($namespace)
     - name: sni_hostname
       value: (join('.', ['*', ($test_name), 'example.com']))
     - name: fqdn

--- a/test/e2e/chainsaw/hybridgateway/httproute-complex-multiple-rules/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-complex-multiple-rules/chainsaw-test.yaml
@@ -19,6 +19,8 @@ spec:
       value: ($namespace)
     - name: konnect_api_auth_name
       value: konnect-api-auth-dev-1
+    - name: konnect_api_auth_namespace
+      value: ($namespace)
     - name: konnect_token
       value: (env('KONNECT_TOKEN'))
     - name: konnect_url

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/chainsaw-test.yaml
@@ -27,6 +27,8 @@ spec:
       value: (join('-', [($test_name), 'konnect-api-auth']))
     - name: konnect_auth_namespace
       value: ($namespace)
+    - name: konnect_api_auth_namespace
+      value: ($namespace)
 
     # TLS configuration.
     - name: sni_hostname

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
@@ -39,6 +39,8 @@ spec:
       value: (join('-', [($test_name), 'konnect-api-auth']))
     - name: konnect_auth_namespace
       value: ($namespace)
+    - name: konnect_api_auth_namespace
+      value: ($namespace)
     - name: gateway_image
       value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
     - name: gateway_name

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/chainsaw-test.yaml
@@ -16,6 +16,8 @@ spec:
       value: ($namespace)
     - name: konnect_api_auth_name
       value: konnect-api-auth-dev-1
+    - name: konnect_api_auth_namespace
+      value: ($namespace)
     - name: konnect_token
       value: (env('KONNECT_TOKEN'))
     - name: konnect_url

--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/chainsaw-test.yaml
@@ -18,6 +18,8 @@ spec:
       value: ($namespace)
     - name: konnect_api_auth_name
       value: konnect-api-auth-dev-1
+    - name: konnect_api_auth_namespace
+      value: ($namespace)
     - name: konnect_token
       value: (env('KONNECT_TOKEN'))
     - name: konnect_url

--- a/test/e2e/chainsaw/hybridgateway/httproute-method-matching/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-method-matching/chainsaw-test.yaml
@@ -17,6 +17,8 @@ spec:
       value: ($namespace)
     - name: konnect_api_auth_name
       value: konnect-api-auth-dev-1
+    - name: konnect_api_auth_namespace
+      value: ($namespace)
     - name: konnect_token
       value: (env('KONNECT_TOKEN'))
     - name: konnect_url

--- a/test/e2e/chainsaw/hybridgateway/httproute-multiple-backends/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-multiple-backends/chainsaw-test.yaml
@@ -23,6 +23,8 @@ spec:
       value: (join('-', [($namespace), 'xns']))
     - name: konnect_api_auth_name
       value: konnect-api-auth-dev-1
+    - name: konnect_api_auth_namespace
+      value: ($namespace)
     - name: konnect_token
       value: (env('KONNECT_TOKEN'))
     - name: konnect_url

--- a/test/e2e/chainsaw/hybridgateway/httproute-multiple-parentrefs/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-multiple-parentrefs/chainsaw-test.yaml
@@ -27,6 +27,8 @@ spec:
       value: ($namespace)
     - name: gateway_image
       value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+    - name: konnect_api_auth_namespace
+      value: ($namespace)
     
     # TLS configuration.
     - name: sni_hostname_1

--- a/test/e2e/chainsaw/hybridgateway/httproute-path-matching/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-path-matching/chainsaw-test.yaml
@@ -15,6 +15,8 @@ spec:
       value: ($namespace)
     - name: konnect_api_auth_name
       value: konnect-api-auth-dev-1
+    - name: konnect_api_auth_namespace
+      value: ($namespace)
     - name: konnect_token
       value: (env('KONNECT_TOKEN'))
     - name: konnect_url

--- a/test/e2e/chainsaw/hybridgateway/httproute-shared-backendrefs/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-shared-backendrefs/chainsaw-test.yaml
@@ -30,6 +30,8 @@ spec:
       value: ($namespace)
     - name: gateway_image
       value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+    - name: konnect_api_auth_namespace
+      value: ($namespace)
 
     - name: gateway_name
       value: (join('-', [($test_name), 'gateway']))

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/chainsaw-test.yaml
@@ -24,6 +24,8 @@ spec:
     value: ($namespace)
   - name: konnect_token
     value: (env('KONNECT_TOKEN'))
+  - name: konnect_api_auth_namespace
+    value: ($namespace)
   - name: sni_hostname
     value: (join('.', ['*', ($test_name), 'example.com']))
   - name: fqdn


### PR DESCRIPTION
**What this PR does / why we need it**:
Add e2e chainsaw test case for the cross namespace reference `GatewayConfiguration` to `KonnectAPIAuthConfiguration`.
The test case runs the following steps:
- Create a `KonnectAPIAuthConfiguration` in a namespace other than the test namespace, where `Gateway`, , `GatewayConfiguration`, `HTTPRoute` and other test resources are created.
- Create a `KongReferenceGrant` in the ns of `KonnectAPIAuthConfiguration` to allow reference from `KonnectGatewayControlPlane` in the test namespace to reference `KonnectAPIAuthConfiguration`.
  - TODO: change the `KongReferenceGrant` to `GatewayControlPlane` -> `KonnectAPIAuthConfiguration`: #2483 
- Create the `Gateway` in the test namespace and assert it is programmed.
- Create an `HTTPRoute` attached to the `Gateway` and assert it is programmed.
- Verify that the traffic is correctly routed as `HTTPRoute` specifies.
- Assert the `KongService`, `KongRoute`, `KongUpstream`, `KongTarget` resources created for the `HTTPRoute` are programmed.

**Which issue this PR fixes**

Fixes #2978 

**Special notes for your reviewer**:

The PR changed the template for creating and asserting the `GatewayConfiguration` because it requires the `GatewayConfiguration`  to reference a `KonnectAPIAuthConfiguration` in another namespace so the `konnect_api_auth_namespace` variable is added to the template and the other cases using the template are changed.
**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
