### PR TITLE
feat(hybridgateway): add support to PathPrefixMatch RequestRedirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
   For this reference to be allowed, a `KongReferenceGrant` resource must be created
   in the namespace of the `KongPlugin`, allowing access for the `KongPluginBinding`.
   [#31038](https://github.com/Kong/kong-operator/pull/3108)
+- HybridGateway: Added support to PathPrefixMatch for the `RequestRedirect` `HTTPRoute` filter.
+  [#3065](https://github.com/Kong/kong-operator/pull/3065)
 
 ### Fixes
 

--- a/controller/hybridgateway/plugin/converter.go
+++ b/controller/hybridgateway/plugin/converter.go
@@ -260,7 +260,7 @@ func translateRequestRedirectPath(rr *gatewayv1.HTTPRequestRedirectFilter) (stri
 	pathModifier := rr.Path
 	switch pathModifier.Type {
 	case gatewayv1.FullPathHTTPPathModifier:
-		path = translateRequestRedirectPathFullPath(pathModifier.ReplaceFullPath)
+		path = translatePathReplaceFullPath(pathModifier.ReplaceFullPath)
 	case gatewayv1.PrefixMatchHTTPPathModifier:
 		path = translateRequestRedirectPathPrefixMatch(pathModifier.ReplacePrefixMatch)
 	default:
@@ -269,7 +269,7 @@ func translateRequestRedirectPath(rr *gatewayv1.HTTPRequestRedirectFilter) (stri
 	return path, err
 }
 
-func translateRequestRedirectPathFullPath(replaceFullPath *string) string {
+func translatePathReplaceFullPath(replaceFullPath *string) string {
 	if replaceFullPath == nil || *replaceFullPath == "" {
 		return "/"
 	}
@@ -300,7 +300,7 @@ func translateURLRewrite(filter gwtypes.HTTPRouteFilter, path string) (transform
 	if ur.Path != nil {
 		switch ur.Path.Type {
 		case gatewayv1.FullPathHTTPPathModifier:
-			pluginConf.Replace.Uri = translateURLRewritePathFullPath(ur.Path.ReplaceFullPath)
+			pluginConf.Replace.Uri = translatePathReplaceFullPath(ur.Path.ReplaceFullPath)
 		case gatewayv1.PrefixMatchHTTPPathModifier:
 			pluginConf.Replace.Uri = translateURLRewritePathPrefixMatch(
 				normalizePath(ur.Path.ReplacePrefixMatch),
@@ -318,13 +318,6 @@ func normalizePath(path *string) string {
 		return "/"
 	}
 	return strings.TrimSuffix(*path, "/")
-}
-
-func translateURLRewritePathFullPath(replaceFullPath *string) string {
-	if replaceFullPath == nil || *replaceFullPath == "" {
-		return "/"
-	}
-	return *replaceFullPath
 }
 
 // translateURLRewritePathPrefixMatch generates the replacement URI for the request-transformer

--- a/controller/hybridgateway/plugin/converter.go
+++ b/controller/hybridgateway/plugin/converter.go
@@ -302,7 +302,7 @@ func translateURLRewrite(filter gwtypes.HTTPRouteFilter, path string) (transform
 		case gatewayv1.FullPathHTTPPathModifier:
 			pluginConf.Replace.Uri = translatePathReplaceFullPath(ur.Path.ReplaceFullPath)
 		case gatewayv1.PrefixMatchHTTPPathModifier:
-			pluginConf.Replace.Uri = translateURLRewritePathPrefixMatch(
+			pluginConf.Replace.Uri = translatePathReplacePrefixMatch(
 				normalizePath(ur.Path.ReplacePrefixMatch),
 				normalizePath(&path))
 		default:
@@ -320,11 +320,11 @@ func normalizePath(path *string) string {
 	return strings.TrimSuffix(*path, "/")
 }
 
-// translateURLRewritePathPrefixMatch generates the replacement URI for the request-transformer
+// translatePathReplacePrefixMatch generates the replacement URI for the request-transformer
 // plugin for the URLRewrite filter with a PrefixMatchHTTPPathModifier.
 // The logic here is copied from KIC's implementation to ensure consistent behavior, see:
 // https://github.com/Kong/kubernetes-ingress-controller/blob/main/internal/dataplane/translator/subtranslator/httproute.go#L1434.
-func translateURLRewritePathPrefixMatch(replacePrefixMatch string, path string) string {
+func translatePathReplacePrefixMatch(replacePrefixMatch string, path string) string {
 	// Trim the trailing slash from the ReplacePrefixMatch to avoid double slashes in the final URI.
 	replacePrefixMatch = strings.TrimSuffix(replacePrefixMatch, "/")
 	pathIsRoot := path == "/"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support to the PathPrefixMatch path rewrite functionality for the Gateway API RequestRedirect filter.
RequestRedirect filter is required for CORE conformance.

**Which issue this PR fixes**

Fixes #2466 

**Special notes for your reviewer**:

There is no way to perform a redirect with standard Kong plugins to an URL where the matching prefix is replaced with a custom one AND the remaining path from the user is preserved.
The solution adopted in this PR is to generate a custom Lua pre-function  for the PathPrefixMatch case only.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
