### PR TITLE
chore(refactor): remove hardcoded certs in tests

### DIFF
--- a/controller/controlplane_extensions/metricsscraper/manager_test.go
+++ b/controller/controlplane_extensions/metricsscraper/manager_test.go
@@ -21,6 +21,7 @@ import (
 	operatorv1beta1 "github.com/kong/kong-operator/api/gateway-operator/v1beta1"
 	"github.com/kong/kong-operator/controller/pkg/secrets"
 	gwtypes "github.com/kong/kong-operator/internal/types"
+	"github.com/kong/kong-operator/test/helpers/certificate"
 	"github.com/kong/kong-operator/test/mocks/metricsmocks"
 )
 
@@ -410,47 +411,16 @@ type mockConsumer struct{}
 func (mc *mockConsumer) Consume(_ context.Context, _ Metrics) error { return nil }
 
 func TestMetricsScrapeManager_Start(t *testing.T) {
+	cert, key := certificate.MustGenerateCertPEMFormat(certificate.WithKeyType(certificate.ECDSA))
 	caSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ca-secret",
 			Namespace: "kong-system",
 		},
 		Data: map[string][]byte{
-			"ca.crt": []byte(`` +
-				`-----BEGIN CERTIFICATE-----` + "\n" +
-				`MIIBwTCCAWigAwIBAgIIKs87j5BiGj4wCgYIKoZIzj0EAwIwRTELMAkGA1UEBhMC` +
-				`VVMxEzARBgNVBAoTCktvbmcsIEluYy4xITAfBgNVBAMTGEtvbmcgR2F0ZXdheSBP` +
-				`cGVyYXRvciBDQTAeFw0yNDAyMTIxMDM3NDRaFw0zNDAyMDkyMTQ0MjRaMEUxCzAJ` +
-				`BgNVBAYTAlVTMRMwEQYDVQQKEwpLb25nLCBJbmMuMSEwHwYDVQQDExhLb25nIEdh` +
-				`dGV3YXkgT3BlcmF0b3IgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQLj/6b` +
-				`NM6qJFqnFcv+MZeamXilwpI0y7SbKfaSu1IrbMSL/anHaqRTDTHuuft9AuMj00W2` +
-				`T3iQyVLT5cf7dqzxo0IwQDAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUwAwEB` +
-				`/zAdBgNVHQ4EFgQUXcm63z6XvW7V2QurDH2gesszVpAwCgYIKoZIzj0EAwIDRwAw` +
-				`RAIgUXfDI3Touxkhv1TQtU9piBDoaVMg2iVlvkXdJOdoBnICIBvwJLbX3u6Yr+ap` +
-				`WHQ15pbL+bpfn7O3LfGp7YpUWDv3` + "\n" +
-				`-----END CERTIFICATE-----`,
-			),
-			"tls.crt": []byte(`` +
-				`-----BEGIN CERTIFICATE-----` + "\n" +
-				`MIIBwTCCAWigAwIBAgIIKs87j5BiGj4wCgYIKoZIzj0EAwIwRTELMAkGA1UEBhMC` +
-				`VVMxEzARBgNVBAoTCktvbmcsIEluYy4xITAfBgNVBAMTGEtvbmcgR2F0ZXdheSBP` +
-				`cGVyYXRvciBDQTAeFw0yNDAyMTIxMDM3NDRaFw0zNDAyMDkyMTQ0MjRaMEUxCzAJ` +
-				`BgNVBAYTAlVTMRMwEQYDVQQKEwpLb25nLCBJbmMuMSEwHwYDVQQDExhLb25nIEdh` +
-				`dGV3YXkgT3BlcmF0b3IgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQLj/6b` +
-				`NM6qJFqnFcv+MZeamXilwpI0y7SbKfaSu1IrbMSL/anHaqRTDTHuuft9AuMj00W2` +
-				`T3iQyVLT5cf7dqzxo0IwQDAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUwAwEB` +
-				`/zAdBgNVHQ4EFgQUXcm63z6XvW7V2QurDH2gesszVpAwCgYIKoZIzj0EAwIDRwAw` +
-				`RAIgUXfDI3Touxkhv1TQtU9piBDoaVMg2iVlvkXdJOdoBnICIBvwJLbX3u6Yr+ap` +
-				`WHQ15pbL+bpfn7O3LfGp7YpUWDv3` + "\n" +
-				`-----END CERTIFICATE-----`,
-			),
-			"tls.key": []byte(`` +
-				`-----BEGIN EC PRIVATE KEY-----` + "\n" +
-				`MHcCAQEEIHj7JB7holIu7giiCIhKlQcRX6Xvst+EklaFANbAy6L2oAoGCCqGSM49` +
-				`AwEHoUQDQgAEC4/+mzTOqiRapxXL/jGXmpl4pcKSNMu0myn2krtSK2zEi/2px2qk` +
-				`Uw0x7rn7fQLjI9NFtk94kMlS0+XH+3as8Q==` + "\n" +
-				`-----END EC PRIVATE KEY-----`,
-			),
+			"ca.crt":  cert,
+			"tls.crt": cert,
+			"tls.key": key,
 		},
 	}
 

--- a/controller/hybridgateway/converter/gateway_test.go
+++ b/controller/hybridgateway/converter/gateway_test.go
@@ -22,6 +22,7 @@ import (
 	konnectv1alpha2 "github.com/kong/kong-operator/api/konnect/v1alpha2"
 	gwtypes "github.com/kong/kong-operator/internal/types"
 	"github.com/kong/kong-operator/modules/manager/scheme"
+	"github.com/kong/kong-operator/test/helpers/certificate"
 )
 
 func TestNewGatewayConverter(t *testing.T) {
@@ -321,6 +322,8 @@ func TestBuildKongSNI(t *testing.T) {
 }
 
 func TestProcessListenerCertificate(t *testing.T) {
+	cert, key := certificate.MustGenerateCertPEMFormat()
+
 	tests := []struct {
 		name            string
 		gateway         *gwtypes.Gateway
@@ -357,15 +360,8 @@ func TestProcessListenerCertificate(t *testing.T) {
 					},
 					Type: corev1.SecretTypeTLS,
 					Data: map[string][]byte{
-						"tls.crt": []byte(`-----BEGIN CERTIFICATE-----
-MIICljCCAX4CCQCKz8Zr8vLwRTANBgkqhkiG9w0BAQsFADANMQswCQYDVQQGEwJV
-UzAeFw0yMzAxMDEwMDAwMDBaFw0yNDAxMDEwMDAwMDBaMA0xCzAJBgNVBAYTAlVT
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Z5UmZKWmN6DXQT0x1xN
------END CERTIFICATE-----`),
-						"tls.key": []byte(`-----BEGIN PRIVATE KEY-----
-MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDRnlSZkpaY3oNd
-BPTHXE0wDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANGeVJmSlpjeg10E9Mdc
------END PRIVATE KEY-----`),
+						"tls.crt": cert,
+						"tls.key": key,
 					},
 				}
 				require.NoError(t, cl.Create(context.Background(), secret))
@@ -546,13 +542,8 @@ BPTHXE0wDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANGeVJmSlpjeg10E9Mdc
 					},
 					Type: corev1.SecretTypeTLS,
 					Data: map[string][]byte{
-						"tls.crt": []byte(`-----BEGIN CERTIFICATE-----
-MIICljCCAX4CCQCKz8Zr8vLwRTANBgkqhkiG9w0BAQsFADANMQswCQYDVQQGEwJV
-UzAeFw0yMzAxMDEwMDAwMDBaFw0yNDAxMDEwMDAwMDBaMA0xCzAJBgNVBAYTAlVT
------END CERTIFICATE-----`),
-						"tls.key": []byte(`-----BEGIN PRIVATE KEY-----
-MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDRnlSZkpaY3oNd
------END PRIVATE KEY-----`),
+						"tls.crt": cert,
+						"tls.key": key,
 					},
 				}
 				require.NoError(t, cl.Create(context.Background(), secret))
@@ -592,13 +583,8 @@ MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDRnlSZkpaY3oNd
 					},
 					Type: corev1.SecretTypeTLS,
 					Data: map[string][]byte{
-						"tls.crt": []byte(`-----BEGIN CERTIFICATE-----
-MIICljCCAX4CCQCKz8Zr8vLwRTANBgkqhkiG9w0BAQsFADANMQswCQYDVQQGEwJV
-UzAeFw0yMzAxMDEwMDAwMDBaFw0yNDAxMDEwMDAwMDBaMA0xCzAJBgNVBAYTAlVT
------END CERTIFICATE-----`),
-						"tls.key": []byte(`-----BEGIN PRIVATE KEY-----
-MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDRnlSZkpaY3oNd
------END PRIVATE KEY-----`),
+						"tls.crt": cert,
+						"tls.key": key,
 					},
 				}
 				// No ReferenceGrant created, so access should be denied
@@ -677,13 +663,8 @@ MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDRnlSZkpaY3oNd
 					},
 					Type: corev1.SecretTypeTLS,
 					Data: map[string][]byte{
-						"tls.crt": []byte(`-----BEGIN CERTIFICATE-----
-MIICljCCAX4CCQCKz8Zr8vLwRTANBgkqhkiG9w0BAQsFADANMQswCQYDVQQGEwJV
-UzAeFw0yMzAxMDEwMDAwMDBaFw0yNDAxMDEwMDAwMDBaMA0xCzAJBgNVBAYTAlVT
------END CERTIFICATE-----`),
-						"tls.key": []byte(`-----BEGIN PRIVATE KEY-----
-MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDRnlSZkpaY3oNd
------END PRIVATE KEY-----`),
+						"tls.crt": cert,
+						"tls.key": key,
 					},
 				}
 				require.NoError(t, cl.Create(context.Background(), secret))
@@ -742,10 +723,16 @@ MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDRnlSZkpaY3oNd
 }
 
 func TestTranslate(t *testing.T) {
-	httpsPort := gatewayv1.PortNumber(443)
-	tlsModeTerm := gatewayv1.TLSModeTerminate
-	httpsProtocol := gatewayv1.HTTPSProtocolType
-	httpProtocol := gatewayv1.HTTPProtocolType
+	const (
+		httpsPort     = gatewayv1.PortNumber(443)
+		httpsProtocol = gatewayv1.HTTPSProtocolType
+		httpProtocol  = gatewayv1.HTTPProtocolType
+	)
+	var (
+		testCert    = []byte("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----")
+		testKey     = []byte("-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----")
+		tlsModeTerm = gatewayv1.TLSModeTerminate
+	)
 
 	tests := []struct {
 		name           string
@@ -844,8 +831,8 @@ func TestTranslate(t *testing.T) {
 					},
 					Type: corev1.SecretTypeTLS,
 					Data: map[string][]byte{
-						"tls.crt": []byte("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"),
-						"tls.key": []byte("-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----"),
+						"tls.crt": testCert,
+						"tls.key": testKey,
 					},
 				}
 				require.NoError(t, cl.Create(context.Background(), secret))
@@ -971,8 +958,8 @@ func TestTranslate(t *testing.T) {
 						},
 						Type: corev1.SecretTypeTLS,
 						Data: map[string][]byte{
-							"tls.crt": []byte("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"),
-							"tls.key": []byte("-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----"),
+							"tls.crt": testCert,
+							"tls.key": testKey,
 						},
 					}
 					require.NoError(t, cl.Create(context.Background(), secret))
@@ -1075,8 +1062,8 @@ func TestTranslate(t *testing.T) {
 					},
 					Type: corev1.SecretTypeTLS,
 					Data: map[string][]byte{
-						"tls.crt": []byte("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"),
-						"tls.key": []byte("-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----"),
+						"tls.crt": testCert,
+						"tls.key": testKey,
 					},
 				}
 				require.NoError(t, cl.Create(context.Background(), secret))
@@ -1322,8 +1309,8 @@ func TestTranslate(t *testing.T) {
 					},
 					Type: corev1.SecretTypeTLS,
 					Data: map[string][]byte{
-						"tls.crt": []byte("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"),
-						"tls.key": []byte("-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----"),
+						"tls.crt": testCert,
+						"tls.key": testKey,
 					},
 				}
 				require.NoError(t, cl.Create(context.Background(), secret))
@@ -1542,8 +1529,8 @@ func TestTranslate(t *testing.T) {
 					},
 					Type: corev1.SecretTypeTLS,
 					Data: map[string][]byte{
-						"tls.crt": []byte("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"),
-						"tls.key": []byte("-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----"),
+						"tls.crt": testCert,
+						"tls.key": testKey,
 					},
 				}
 				require.NoError(t, cl.Create(context.Background(), validSecret))


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of hardcoding a cert in tests, use helpers from the `certificate` package. Now, the only places where certs are hardcoded are yaml files.

**Which issue this PR fixes**

Follow-up for the PR #3063
