### PR TITLE
fix(konnect): prevent unrecoverable errors from unique constraint violations

### DIFF
--- a/controller/konnect/ops/ops_errors.go
+++ b/controller/konnect/ops/ops_errors.go
@@ -403,7 +403,6 @@ func IgnoreUnrecoverableAPIErr(err error, logger logr.Logger) error {
 	// We cannot recover from this error as this requires user to change object's
 	// manifest. The entity's status is already updated with the error.
 	if ErrorIsSDKBadRequestError(err) ||
-		ErrorIsSDKError400(err) ||
 		ErrorIsForbiddenError(err) ||
 		ErrorIsConflictError(err) {
 		log.Debug(logger, "ignoring unrecoverable API error, consult object's status for details", "err", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue where hybrid gateway HTTPRoute modifications could cause unique constraint violations in Konnect, resulting in unrecoverable errors that prevented proper resource reconciliation.

Problem:
When an HTTPRoute was modified in-place, the controller would attempt to create a new KongPluginBinding in Konnect even though a binding with the same hash already existed. Konnect returns a 400 error with "unique-plugin-per-entity constraint failed", which was being treated as unrecoverable and ignored, preventing the controller from retrying with proper conflict resolution logic.

Example error:
  unique-plugin-per-entity (type: unique) constraint failed
  Status 400: hash field constraint violation

Root causes:
1. The error handling in reconciler_generic.go was positioned after the status update logic, meaning create errors were not properly caught and handled before attempting status updates
2. ErrorIsSDKError400 was treating ALL 400 errors as unrecoverable, including unique constraint violations that should be surfaced to trigger proper adoption or retry logic

Changes:
- Move error handling immediately after ops.Create() call to catch and handle errors before any status update attempts
- Remove redundant ErrorIsSDKError400 check from IgnoreUnrecoverableAPIErr to ensure constraint violation errors are properly surfaced

This allows the controller to properly detect when resources already exist in Konnect and handle conflicts appropriately, rather than silently ignoring them as unrecoverable errors.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
