### PR TITLE
chore: port and re-enable `TestAdmissionWebhook_KongCustomEntities`, fix configuration

### DIFF
--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -57649,6 +57649,7 @@ webhooks:
     - kongclusterplugins
     - kongingresses
     - kongvaults
+    - kongcustomentities
     scope: '*'
   - apiGroups:
     - networking.k8s.io

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -57662,6 +57662,7 @@ webhooks:
     - kongclusterplugins
     - kongingresses
     - kongvaults
+    - kongcustomentities
     scope: '*'
   - apiGroups:
     - networking.k8s.io

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -57641,6 +57641,7 @@ webhooks:
     - kongclusterplugins
     - kongingresses
     - kongvaults
+    - kongcustomentities
     scope: '*'
   - apiGroups:
     - networking.k8s.io

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -57643,6 +57643,7 @@ webhooks:
     - kongclusterplugins
     - kongingresses
     - kongvaults
+    - kongcustomentities
     scope: '*'
   - apiGroups:
     - networking.k8s.io

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -57643,6 +57643,7 @@ webhooks:
     - kongclusterplugins
     - kongingresses
     - kongvaults
+    - kongcustomentities
     scope: '*'
   - apiGroups:
     - networking.k8s.io

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -57643,6 +57643,7 @@ webhooks:
     - kongclusterplugins
     - kongingresses
     - kongvaults
+    - kongcustomentities
     scope: '*'
   - apiGroups:
     - networking.k8s.io

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -57641,6 +57641,7 @@ webhooks:
     - kongclusterplugins
     - kongingresses
     - kongvaults
+    - kongcustomentities
     scope: '*'
   - apiGroups:
     - networking.k8s.io

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -57639,6 +57639,7 @@ webhooks:
     - kongclusterplugins
     - kongingresses
     - kongvaults
+    - kongcustomentities
     scope: '*'
   - apiGroups:
     - networking.k8s.io

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -57640,6 +57640,7 @@ webhooks:
     - kongclusterplugins
     - kongingresses
     - kongvaults
+    - kongcustomentities
     scope: '*'
   - apiGroups:
     - networking.k8s.io

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -57641,6 +57641,7 @@ webhooks:
     - kongclusterplugins
     - kongingresses
     - kongvaults
+    - kongcustomentities
     scope: '*'
   - apiGroups:
     - networking.k8s.io

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -57643,6 +57643,7 @@ webhooks:
     - kongclusterplugins
     - kongingresses
     - kongvaults
+    - kongcustomentities
     scope: '*'
   - apiGroups:
     - networking.k8s.io

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -57639,6 +57639,7 @@ webhooks:
     - kongclusterplugins
     - kongingresses
     - kongvaults
+    - kongcustomentities
     scope: '*'
   - apiGroups:
     - networking.k8s.io

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -31298,6 +31298,7 @@ webhooks:
     - kongclusterplugins
     - kongingresses
     - kongvaults
+    - kongcustomentities
     scope: '*'
   - apiGroups:
     - networking.k8s.io

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -57591,6 +57591,7 @@ webhooks:
     - kongclusterplugins
     - kongingresses
     - kongvaults
+    - kongcustomentities
     scope: '*'
   - apiGroups:
     - networking.k8s.io

--- a/charts/kong-operator/templates/validating-webhook.yaml
+++ b/charts/kong-operator/templates/validating-webhook.yaml
@@ -85,6 +85,7 @@ webhooks:
     - kongclusterplugins
     - kongingresses
     - kongvaults
+    - kongcustomentities
     scope: '*'
   - apiGroups:
     - networking.k8s.io

--- a/config/default/validating_webhook/zz_generated_validating_webhook.yaml
+++ b/config/default/validating_webhook/zz_generated_validating_webhook.yaml
@@ -36,6 +36,7 @@ webhooks:
     - kongclusterplugins
     - kongingresses
     - kongvaults
+    - kongcustomentities
     scope: '*'
   - apiGroups:
     - networking.k8s.io


### PR DESCRIPTION
**What this PR does / why we need it**:

Furthermore, the porting test unveils that `KongCustomEntities` is missing from the YAML configuration, so it is fixed too

**Which issue this PR fixes**

Closes #2895 

