### PR TITLE
chore: unse client.ApplyConfigurationFromUnstructured with unstructured

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -270,10 +270,6 @@ linters:
           - godoclint
         text: symbol should have a godoc
         path: api/configuration/v1alpha1/zz_generated_funcs.go
-      # TODO: https://github.com/kubernetes-sigs/controller-runtime/issues/3426
-      - linters:
-          - staticcheck
-        text: "client.Apply is deprecated: Use client.Client.Apply\\(\\) and client.Client.SubResource\\(\"subrsource\"\\).Apply\\(\\) instead"
       # TODO: https://github.com/kubernetes-sigs/controller-runtime/issues/2141#issuecomment-3783800430
       - linters:
           - staticcheck

--- a/controller/hybridgateway/reconciler_utils.go
+++ b/controller/hybridgateway/reconciler_utils.go
@@ -106,9 +106,8 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 			if errors.IsNotFound(err) {
 				// Object doesn't exist, create it using server-side apply.
 				log.Debug(logger, "Creating new object", "kind", desired.GetKind(), "obj", namespacedNameDesired)
-
 				// Set field manager for server-side apply
-				if err := cl.Patch(ctx, &desired, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
+				if err := cl.Apply(ctx, client.ApplyConfigurationFromUnstructured(&desired), client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
 					if errors.IsConflict(err) {
 						return false, fmt.Errorf("conflict during create of object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 					}
@@ -140,7 +139,7 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 		if managedFieldsObj == nil {
 			// No managed fields for our field manager, we should update.
 			log.Debug(logger, "No managed fields found for our field manager, will apply desired state", "kind", existing.GetKind(), "obj", namespacedNameExisting)
-			if err := cl.Patch(ctx, &desired, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
+			if err := cl.Apply(ctx, client.ApplyConfigurationFromUnstructured(&desired), client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
 				if errors.IsConflict(err) {
 					return false, fmt.Errorf("conflict during create of object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 				}
@@ -168,7 +167,7 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 		} else {
 			log.Info(logger, "Changes detected for obj, applying desired state", "kind", existing.GetKind(), "obj", namespacedNameExisting, "changes", compare.String())
 			// Changes detected, apply the desired state using server-side apply.
-			if err := cl.Patch(ctx, &desired, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
+			if err := cl.Apply(ctx, client.ApplyConfigurationFromUnstructured(&desired), client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
 				if errors.IsConflict(err) {
 					return false, fmt.Errorf("conflict during create of object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove exclusion rule from golangci-lint config through `client.ApplyConfigurationFromUnstructured`.

Upstream ref: https://github.com/kubernetes-sigs/controller-runtime/issues/3426#issuecomment-3784966770

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
