### PR TITLE
chore: warn about missing KongReferenceGrant for KonnectAPIAuthConfiguration to Secret references

### DIFF
--- a/controller/konnect/reconciler_konnectapiauth_rbac.go
+++ b/controller/konnect/reconciler_konnectapiauth_rbac.go
@@ -5,3 +5,5 @@ package konnect
 //+kubebuilder:rbac:groups=konnect.konghq.com,resources=konnectapiauthconfigurations/status,verbs=update;patch
 
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
+
+//+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=referencegrants,verbs=get;list;watch

--- a/controller/konnect/watch.go
+++ b/controller/konnect/watch.go
@@ -292,6 +292,37 @@ func enqueueObjectsForKonnectAPIAuthConfiguration[
 	}
 }
 
+// WatchableEntityType is a constraint that represents all Konnect-related
+// entity types that can be watched.
+type WatchableEntityType interface {
+	konnectv1alpha2.KonnectGatewayControlPlane |
+		konnectv1alpha1.KonnectCloudGatewayNetwork |
+		konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration |
+		konnectv1alpha1.KonnectCloudGatewayTransitGateway |
+		configurationv1alpha1.KongService |
+		configurationv1alpha1.KongRoute |
+		configurationv1.KongConsumer |
+		configurationv1beta1.KongConsumerGroup |
+		configurationv1alpha1.KongPluginBinding |
+		configurationv1alpha1.KongCredentialBasicAuth |
+		configurationv1alpha1.KongCredentialAPIKey |
+		configurationv1alpha1.KongCredentialACL |
+		configurationv1alpha1.KongCredentialJWT |
+		configurationv1alpha1.KongCredentialHMAC |
+		configurationv1alpha1.KongUpstream |
+		configurationv1alpha1.KongCACertificate |
+		configurationv1alpha1.KongCertificate |
+		configurationv1alpha1.KongTarget |
+		configurationv1alpha1.KongVault |
+		configurationv1alpha1.KongKey |
+		configurationv1alpha1.KongKeySet |
+		configurationv1alpha1.KongSNI |
+		configurationv1alpha1.KongDataPlaneClientCertificate |
+		konnectv1alpha1.KonnectAPIAuthConfiguration
+
+	GetTypeName() string
+}
+
 // enqueueObjectsForKongReferenceGrant returns a function that enqueues
 // reconcile.Requests for objects that are allowed by the KongReferenceGrant.
 // This is useful for situations where a KongReferenceGrant is created/updated/deleted
@@ -305,8 +336,12 @@ func enqueueObjectsForKongReferenceGrant[
 		client.ObjectList
 		GetItems() []T
 	},
-	T constraints.SupportedKonnectEntityType,
-	TT constraints.EntityType[T],
+	T WatchableEntityType,
+	TT interface {
+		*T
+		GetNamespace() string
+		GetName() string
+	},
 ](
 	cl client.Client,
 ) func(ctx context.Context, obj client.Object) []reconcile.Request {


### PR DESCRIPTION
**What this PR does / why we need it**:

Produce an error log ( there are no warnings available in https://pkg.go.dev/github.com/go-logr/logr#Logger which operator uses ) when `KongReferenceGrant` is not available for the cross namespace reference from `KonnectAPIAuthConfiguration` to `Secret` 

```
{
	"level": "error",
	"ts": "2026-01-23T11:19:40.255+0100",
	"msg": "WARNING: referencing Secret in a different namespace. This will require a KongReferenceGrant in Secret's namespace in future versions.",
	"controller": "KonnectAPIAuthConfiguration",
	"controllerGroup": "konnect.konghq.com",
	"controllerKind": "KonnectAPIAuthConfiguration",
	"KonnectAPIAuthConfiguration": {
		"name": "konnect-api-auth",
		"namespace": "default"
	},
	"namespace": "default",
	"name": "konnect-api-auth",
	"reconcileID": "6f027098-79fe-413d-ac4b-6c8e1a671fea",
	"error": "missing KongReferenceGrant from KonnectAPIAuthConfiguration default/konnect-api-auth to Secret kong/konnect-api-auth-secret",
	"stacktrace": "github.com/kong/kong-operator/controller/konnect.getTokenFromKonnectAPIAuthConfiguration\n\t/Users/patryk.malek/code_/gateway-operator/controller/konnect/reconciler_konnectapiauth.go:292\ngithub.com/kong/kong-operator/controller/konnect.(*KonnectAPIAuthConfigurationReconciler).Reconcile\n\t/Users/patryk.malek/code_/gateway-operator/controller/konnect/reconciler_konnectapiauth.go:150\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/Users/patryk.malek/.gvm/pkgsets/go1.25.5/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/internal/controller/controller.go:222\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/patryk.malek/.gvm/pkgsets/go1.25.5/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/internal/controller/controller.go:479\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/patryk.malek/.gvm/pkgsets/go1.25.5/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/internal/controller/controller.go:438\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/Users/patryk.malek/.gvm/pkgsets/go1.25.5/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/internal/controller/controller.go:313"
}
```

An alternative would be an info log:

```
{
	"level": "info",
	"ts": "2026-01-23T11:17:43.426+0100",
	"logger": "KongService",
	"msg": "WARNING: referencing Secret in a different namespace. This will require a KongReferenceGrant in Secret's namespace in future versions.",
	"controller": "KongService",
	"controllerGroup": "configuration.konghq.com",
	"controllerKind": "KongService",
	"KongService": {
		"name": "service-1",
		"namespace": "default"
	},
	"namespace": "default",
	"name": "service-1",
	"reconcileID": "3cda3cb4-889f-4f65-9043-bb704878c520",
	"konnect_id": "55d97019-2f78-4639-9600-391bbad24d51"
}
```

but the former has been proposed ( to minimize the chance that users miss it when going through the logs).

**Which issue this PR fixes**

Fixes #2907

**Special notes for your reviewer**:

The breaking change which will actually require the `KongReferenceGrant` will be introduced as part of https://github.com/Kong/kong-operator/issues/3116

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
