### PR TITLE
tests: don't report goroutine leaks for priorityqueue.handleWaitingItems

### DIFF
--- a/test/envtest/manager_envtest_test.go
+++ b/test/envtest/manager_envtest_test.go
@@ -86,7 +86,8 @@ func TestManager_NoLeakedGoroutinesAfterContextCancellation(t *testing.T) {
 		// https://github.com/kubernetes-sigs/controller-runtime/issues/3218
 		ignoreManagerReconcile := goleak.IgnoreTopFunction("sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1")
 		ignoreManagerEnagageProcedure := goleak.IgnoreAnyFunction("sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).engageStopProcedure.func3.(*runnableGroup).StopAndWait.3.2")
-		goleak.VerifyNone(t, ignoreManagerReconcile, ignoreManagerEnagageProcedure)
+		ignorePriorityQueueHandleItems := goleak.IgnoreAnyFunction("sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue.(*priorityqueue[...]).handleReadyItems")
+		goleak.VerifyNone(t, ignoreManagerReconcile, ignoreManagerEnagageProcedure, ignorePriorityQueueHandleItems)
 	})
 
 	scheme := Scheme(t, WithKong)


### PR DESCRIPTION
**What this PR does / why we need it**:

Address 

```
    manager_envtest_test.go:89: found unexpected goroutines:
        [Goroutine 6070 in state sync.Mutex.Lock, with internal/sync.runtime_SemacquireMutex on top of the stack:
        internal/sync.runtime_SemacquireMutex(0x2?, 0x0?, 0xc00181dee0?)
        	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/sema.go:95 +0x25
        internal/sync.(*Mutex).lockSlow(0xc002002220)
        	/opt/hostedtoolcache/go/1.25.5/x64/src/internal/sync/mutex.go:149 +0x210
        internal/sync.(*Mutex).Lock(0xc002002220)
        	/opt/hostedtoolcache/go/1.25.5/x64/src/internal/sync/mutex.go:70 +0x55
        sync.(*Mutex).Lock(0xc002002220)
        	/opt/hostedtoolcache/go/1.25.5/x64/src/sync/mutex.go:46 +0x29
        sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue.(*priorityqueue[...]).handleWaitingItems.func1(0xc00145bad8, 0x88d6280)
        	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/controller/priorityqueue/priorityqueue.go:324 +0x5a
        sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue.(*priorityqueue[...]).handleWaitingItems(0x88d6280)
        	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/controller/priorityqueue/priorityqueue.go:356 +0xeb
        created by sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue.New[...] in goroutine 6066
        	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/controller/priorityqueue/priorityqueue.go:100 +0x11d3
         Goroutine 6069 in state chan send, with sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue.(*priorityqueue[...]).handleReadyItems.func1.1 on top of the stack:
        sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue.(*priorityqueue[...]).handleReadyItems.func1.1()
        	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/controller/priorityqueue/priorityqueue.go:400 +0x5d4
        github.com/google/btree.(*node[...]).iterate(0x88d7300, 0x1, {0x0, 0xe0?}, {0x0?, 0x0?}, 0x0?, 0x0, 0xc002453b80)
        	/home/runner/go/pkg/mod/github.com/google/btree@v1.1.3/btree_generic.go:522 +0x61b
        github.com/google/btree.(*BTreeG[...]).Ascend(0x88d6540, 0xc002453b80)
        	/home/runner/go/pkg/mod/github.com/google/btree@v1.1.3/btree_generic.go:779 +0xe5
        sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue.(*priorityqueue[...]).handleReadyItems.func1(0x88d6280)
        	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/controller/priorityqueue/priorityqueue.go:389 +0x2fd
        sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue.(*priorityqueue[...]).handleReadyItems(0x88d6280)
        	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/controller/priorityqueue/priorityqueue.go:408 +0x46
        created by sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue.New[...] in goroutine 6066
        	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/controller/priorityqueue/priorityqueue.go:99 +0x10f3
        ]
```

by adding an exception in the test.

Observed in https://github.com/Kong/kong-operator/actions/runs/21382502496/job/61552080574?pr=3148#step:8:870

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
