### PR TITLE
fix: don't report an error on HTTPRoute status update conflict

### DIFF
--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -278,6 +278,9 @@ func (c *httpRouteConverter) UpdateRootObjectStatus(ctx context.Context, logger 
 	if updated {
 		log.Debug(logger, "Updating HTTPRoute status in cluster", "status", c.route.Status)
 		if err := c.Status().Update(ctx, c.route); err != nil {
+			if k8serrors.IsConflict(err) {
+				return false, true, err
+			}
 			log.Error(logger, err, "Failed to update HTTPRoute status in cluster")
 			return false, stop, fmt.Errorf("failed to update HTTPRoute status: %w", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

The conflict error does not need to be logged like:

```
2026-01-27T12:26:53.2697525Z 2026-01-27T12:20:19Z	ERROR	hybridgateway	Failed to update HTTPRoute status in cluster	{"controller": "httproute", "controllerGroup": "gateway.networking.k8s.io", "controllerKind": "HTTPRoute", "HTTPRoute": {"name":"7b933df4-0e4e-4f31-8e1a-86c625d07f38","namespace":"88a83120-c745-4167-8876-61bdb3c7d759"}, "namespace": "88a83120-c745-4167-8876-61bdb3c7d759", "name": "7b933df4-0e4e-4f31-8e1a-86c625d07f38", "reconcileID": "c1baf9d5-49c7-4989-8280-a1b0e0dc9e39", "phase": "httproute-status", "error": "Operation cannot be fulfilled on httproutes.gateway.networking.k8s.io \"7b933df4-0e4e-4f31-8e1a-86c625d07f38\": the object has been modified; please apply your changes to the latest version and try again"}
2026-01-27T12:26:53.2697688Z github.com/kong/kong-operator/controller/pkg/log.Error
2026-01-27T12:26:53.2697950Z 	/home/runner/work/kong-operator/kong-operator/controller/pkg/log/log.go:33
2026-01-27T12:26:53.2698328Z github.com/kong/kong-operator/controller/hybridgateway/converter.(*httpRouteConverter).UpdateRootObjectStatus
2026-01-27T12:26:53.2698680Z 	/home/runner/work/kong-operator/kong-operator/controller/hybridgateway/converter/http_route.go:281
2026-01-27T12:26:53.2698907Z github.com/kong/kong-operator/controller/hybridgateway.enforceStatus[...]
2026-01-27T12:26:53.2699240Z 	/home/runner/work/kong-operator/kong-operator/controller/hybridgateway/reconciler_utils.go:212
2026-01-27T12:26:53.2699551Z github.com/kong/kong-operator/controller/hybridgateway.(*HybridGatewayReconciler[...]).Reconcile
2026-01-27T12:26:53.2699852Z 	/home/runner/work/kong-operator/kong-operator/controller/hybridgateway/controller.go:147
2026-01-27T12:26:53.2700106Z sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile
2026-01-27T12:26:53.2700469Z 	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/internal/controller/controller.go:222
2026-01-27T12:26:53.2700814Z sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
2026-01-27T12:26:53.2701170Z 	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/internal/controller/controller.go:479
2026-01-27T12:26:53.2701460Z sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
2026-01-27T12:26:53.2701807Z 	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/internal/controller/controller.go:438
2026-01-27T12:26:53.2702081Z sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
2026-01-27T12:26:53.2702445Z 	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/internal/controller/controller.go:313
```

It is handled in https://github.com/Kong/kong-operator/blob/a0878f91d66fc59aed360109339a65c8baea35dd/controller/hybridgateway/controller.go#L157-L159 where the reconciliation loop requeues the request.

Found when going through CI error logs.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
