### PR TITLE
fix: set Programmed condition to False when ref resouce is not valid

### DIFF
--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -214,6 +214,11 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 			return ctrl.Result{}, err
 		}
 	} else if !res.IsZero() {
+		// If the result is not zero (e.g., requeue), we still need to update the Programmed
+		// status condition based on other conditions.
+		if _, errStatus := patchWithProgrammedStatusConditionBasedOnOtherConditions(ctx, r.Client, ent); errStatus != nil {
+			return ctrl.Result{}, errStatus
+		}
 		return res, nil
 	}
 	// If a type has a KongConsumer ref, handle it.
@@ -254,6 +259,11 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 
 		return patchWithProgrammedStatusConditionBasedOnOtherConditions(ctx, r.Client, ent)
 	} else if !res.IsZero() {
+		// If the result is not zero (e.g., requeue), we still need to update the Programmed
+		// status condition based on other conditions.
+		if _, errStatus := patchWithProgrammedStatusConditionBasedOnOtherConditions(ctx, r.Client, ent); errStatus != nil {
+			return ctrl.Result{}, errStatus
+		}
 		return res, nil
 	}
 
@@ -291,6 +301,11 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 
 		return patchWithProgrammedStatusConditionBasedOnOtherConditions(ctx, r.Client, ent)
 	} else if !res.IsZero() {
+		// If the result is not zero (e.g., requeue), we still need to update the Programmed
+		// status condition based on other conditions.
+		if _, errStatus := patchWithProgrammedStatusConditionBasedOnOtherConditions(ctx, r.Client, ent); errStatus != nil {
+			return ctrl.Result{}, errStatus
+		}
 		return res, nil
 	}
 

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -331,6 +331,13 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 
 		return patchWithProgrammedStatusConditionBasedOnOtherConditions(ctx, r.Client, ent)
 	} else if !res.IsZero() {
+		// If the result is not zero (e.g., requeue), we still need to update the Programmed
+		// status condition based on other conditions (e.g., KongCertificateRefValid set to False
+		// when referenced KongCertificate is not programmed yet).
+		// We patch the status but still return the original requeue result.
+		if _, errStatus := patchWithProgrammedStatusConditionBasedOnOtherConditions(ctx, r.Client, ent); errStatus != nil {
+			return ctrl.Result{}, errStatus
+		}
 		return res, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:



When I adding chainsaw test in #3095 I found a test case failed.

https://github.com/Kong/kong-operator/pull/3095/changes#diff-8d346d1c09b2389dfd77f6d756bf49ee9c2b3fea4f1ace9901fbbb8511fc2034R178-R194

and

https://github.com/Kong/kong-operator/pull/3095/changes#diff-e5cdccb91cb9999cdda33cb989c59e5b575e4c30e9d7a55674228c5871fd2346

The `KongSNI` 's Programmed should be set to `False` when the referenced `KongCertificate` is not programmed yet.

This fix can resolve this bug.



**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
