### PR TITLE
chore: bump go version to 1.25.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kong-operator
 
-go 1.25.5
+go 1.25.6
 
 require (
 	cloud.google.com/go/container v1.45.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Required to fix: GO-2026-4340 (aka CVE-2025-61730, CVE-2025-61730)

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
