### PR TITLE
chore: use shorter proxy sync in TestSpecificGatewayNN to prevent flakiness

### DIFF
--- a/test/envtest/specific_gateway_envtest_test.go
+++ b/test/envtest/specific_gateway_envtest_test.go
@@ -21,7 +21,7 @@ func TestSpecificGatewayNN(t *testing.T) {
 	t.Parallel()
 
 	const (
-		waitTime = 3 * time.Second
+		waitTime = 10 * time.Second
 		tickTime = 500 * time.Millisecond
 	)
 
@@ -45,6 +45,7 @@ func TestSpecificGatewayNN(t *testing.T) {
 		WithGatewayFeatureEnabled,
 		WithGatewayAPIControllers(),
 		WithGatewayToReconcile(nn.String()),
+		WithProxySyncInterval(250*time.Millisecond),
 	)
 
 	const routeCount = 10


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent:

```
2026-01-29T11:11:01.7665530Z === [31mFAIL[0m: test/envtest TestSpecificGatewayNN/configured_specific_gateway_gets_its_listener_status_filled (3.00s)
2026-01-29T11:11:01.7667269Z     specific_gateway_envtest_test.go:65: Failed to find http listener status in gateway 417012ef-5397-4892-b10c-0b3ac28e5afd/65075577-b683-41a2-8e8d-061ae936f0ca
2026-01-29T11:11:01.7670161Z     specific_gateway_envtest_test.go:65: Failed to find http listener status in gateway 417012ef-5397-4892-b10c-0b3ac28e5afd/65075577-b683-41a2-8e8d-061ae936f0ca
2026-01-29T11:11:01.7672122Z     specific_gateway_envtest_test.go:65: Failed to find http listener status in gateway 417012ef-5397-4892-b10c-0b3ac28e5afd/65075577-b683-41a2-8e8d-061ae936f0ca
2026-01-29T11:11:01.7674290Z     specific_gateway_envtest_test.go:65: Failed to find http listener status in gateway 417012ef-5397-4892-b10c-0b3ac28e5afd/65075577-b683-41a2-8e8d-061ae936f0ca
2026-01-29T11:11:01.7676200Z     specific_gateway_envtest_test.go:65: Failed to find http listener status in gateway 417012ef-5397-4892-b10c-0b3ac28e5afd/65075577-b683-41a2-8e8d-061ae936f0ca
2026-01-29T11:11:01.7677788Z     specific_gateway_envtest_test.go:69: Expected 10 routes to be attached to the http listener, got 1
2026-01-29T11:11:01.7685961Z     specific_gateway_envtest_test.go:55: 
2026-01-29T11:11:01.7687385Z         	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/envtest/specific_gateway_envtest_test.go:55
2026-01-29T11:11:01.7688426Z         	Error:      	Condition never satisfied
2026-01-29T11:11:01.7689646Z         	Test:       	TestSpecificGatewayNN/configured_specific_gateway_gets_its_listener_status_filled
2026-01-29T11:11:01.7690832Z         	Messages:   	Failed to attach route to gateway
2026-01-29T11:11:01.7691271Z 
2026-01-29T11:11:01.7691680Z === [31mFAIL[0m: test/envtest TestSpecificGatewayNN (36.32s)
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
