### PR TITLE
Do not access plugin if error happens in getReferencedKongPlugin

### DIFF
--- a/controller/hybridgateway/plugin/plugin.go
+++ b/controller/hybridgateway/plugin/plugin.go
@@ -66,11 +66,11 @@ func PluginsForFilter(
 	if filter.Type == gatewayv1.HTTPRouteFilterExtensionRef {
 		log.Debug(logger, "Filter is an ExtensionRef, retrieving referenced KongPlugin")
 		plugin, err := getReferencedKongPlugin(ctx, cl, httpRoute.Namespace, filter)
-		pluginName := plugin.Name
 		if err != nil {
 			log.Error(logger, err, "Failed to retrieve referenced KongPlugin")
-			return nil, false, fmt.Errorf("failed to retrieve referenced KongPlugin %s: %w", pluginName, err)
+			return nil, false, fmt.Errorf("failed to retrieve referenced KongPlugin: %w", err)
 		}
+
 		log.Debug(logger, "Successfully retrieved referenced KongPlugin")
 		plugins = append(plugins, *plugin)
 		return plugins, true, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

When the referenced plugin in `extensionRef` is not found or other errors happen in `getReferencedKongPlugin`, the `plugin` is `nil` and accessing `plugin.Name` causes a panic. This PR fixes the panic by not accessing `plugin.Name before checking the error.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
