### PR TITLE
feat(hybridgateway): generate KongPlugin copies for HTTPRoute filters

### DIFF
--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -445,7 +445,7 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 				"filterCount", len(rule.Filters))
 
 			for _, filter := range rule.Filters {
-				plugins, selfManagedPlugin, err := plugin.PluginsForFilter(ctx, logger, c.Client, c.route, rule, filter, &pRef)
+				plugins, err := plugin.PluginsForFilter(ctx, logger, c.Client, c.route, rule, filter, &pRef)
 				if err != nil {
 					log.Error(logger, err, "Failed to translate KongPlugin resource, skipping filter",
 						"filter", filter.Type)
@@ -455,9 +455,7 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 
 				for _, plugin := range plugins {
 					pluginName := plugin.Name
-					if !selfManagedPlugin {
-						c.outputStore = append(c.outputStore, &plugin)
-					}
+					c.outputStore = append(c.outputStore, &plugin)
 					// Create a KongPluginBinding to bind the KongPlugin to each KongRoute.
 					bindingPtr, err := pluginbinding.BindingForPluginAndRoute(
 						ctx,

--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -315,16 +315,16 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 				fakeClient := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(objects...).Build()
 				return newHTTPRouteConverter(route, fakeClient, false, "").(*httpRouteConverter)
 			},
-			wantCount: 7,
+			wantCount: 8,
 			wantOutputs: outputCount{
 				upstreams: 1,
 				services:  1,
 				routes:    1,
 				targets:   1,
 				bindings:  2,
-				plugins:   1,
+				plugins:   2,
 			},
-			wantStoreLen: 7,
+			wantStoreLen: 8,
 		},
 		{
 			name: "returns error when filter translation fails",

--- a/controller/hybridgateway/namegen/name.go
+++ b/controller/hybridgateway/namegen/name.go
@@ -113,8 +113,8 @@ func NewKongRouteName(route *gwtypes.HTTPRoute, cp *commonv1alpha1.ControlPlaneR
 }
 
 // NewKongPluginName generates a KongPlugin name based on the HTTPRouteFilter passed as argument.
-func NewKongPluginName(filter gatewayv1.HTTPRouteFilter, pluginName string) string {
-	return newName(pluginName, utils.Hash32(filter))
+func NewKongPluginName(filter gatewayv1.HTTPRouteFilter, namespace string, pluginName string) string {
+	return newName(namespace, pluginName, utils.Hash32(filter))
 }
 
 // NewKongPluginBindingName generates a KongPlugin name based on the KongRoute and the KongPlugin names.

--- a/controller/hybridgateway/namegen/name_test.go
+++ b/controller/hybridgateway/namegen/name_test.go
@@ -455,9 +455,9 @@ func TestNewKongPluginName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := NewKongPluginName(tt.filter, "request-transformer")
+			result := NewKongPluginName(tt.filter, "default", "request-transformer")
 			assert.NotEmpty(t, result)
-			assert.True(t, strings.HasPrefix(result, "request-transformer."), "should start with plugin name prefix")
+			assert.True(t, strings.HasPrefix(result, "default.request-transformer."), "should start with plugin namespace.name prefix")
 		})
 	}
 }
@@ -641,8 +641,8 @@ func TestNameGenerationConsistency(t *testing.T) {
 	})
 
 	t.Run("plugin name consistency", func(t *testing.T) {
-		result1 := NewKongPluginName(filter, "request-transformer")
-		result2 := NewKongPluginName(filter, "request-transformer")
+		result1 := NewKongPluginName(filter, "default", "request-transformer")
+		result2 := NewKongPluginName(filter, "default", "request-transformer")
 		assert.Equal(t, result1, result2)
 	})
 

--- a/controller/hybridgateway/plugin/plugin.go
+++ b/controller/hybridgateway/plugin/plugin.go
@@ -71,7 +71,6 @@ func PluginsForFilter(
 				log.Debug(logger, "Referenced KongPlugin not found")
 				return plugins, nil
 			}
-			log.Error(logger, err, "Failed to retrieve referenced KongPlugin")
 			return nil, fmt.Errorf("failed to retrieve referenced KongPlugin: %w", err)
 		}
 		pluginName := plugin.Name
@@ -85,7 +84,6 @@ func PluginsForFilter(
 			WithAnnotations(httpRoute, pRef).
 			Build()
 		if err != nil {
-			log.Error(logger, err, "Failed to build KongPlugin resource")
 			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)
 		}
 		plugins = append(plugins, pluginCopy)
@@ -111,7 +109,6 @@ func PluginsForFilter(
 			WithAnnotations(httpRoute, pRef).
 			Build()
 		if err != nil {
-			log.Error(logger, err, "Failed to build KongPlugin resource")
 			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)
 		}
 

--- a/controller/hybridgateway/plugin/plugin.go
+++ b/controller/hybridgateway/plugin/plugin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -48,7 +49,6 @@ import (
 //
 // Returns:
 //   - kongPlugins: The translated plugin(s).
-//   - selfManaged: True if sourced from ExtensionRef.
 //   - err: Any error encountered.
 func PluginsForFilter(
 	ctx context.Context,
@@ -58,7 +58,7 @@ func PluginsForFilter(
 	rule gwtypes.HTTPRouteRule,
 	filter gwtypes.HTTPRouteFilter,
 	pRef *gwtypes.ParentReference,
-) ([]configurationv1.KongPlugin, bool, error) {
+) ([]configurationv1.KongPlugin, error) {
 	logger = logger.WithValues("filter-type", filter.Type)
 	plugins := []configurationv1.KongPlugin{}
 
@@ -66,23 +66,39 @@ func PluginsForFilter(
 	if filter.Type == gatewayv1.HTTPRouteFilterExtensionRef {
 		log.Debug(logger, "Filter is an ExtensionRef, retrieving referenced KongPlugin")
 		plugin, err := getReferencedKongPlugin(ctx, cl, httpRoute.Namespace, filter)
-		pluginName := plugin.Name
 		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				log.Debug(logger, "Referenced KongPlugin not found")
+				return plugins, nil
+			}
 			log.Error(logger, err, "Failed to retrieve referenced KongPlugin")
-			return nil, false, fmt.Errorf("failed to retrieve referenced KongPlugin %s: %w", pluginName, err)
+			return nil, fmt.Errorf("failed to retrieve referenced KongPlugin: %w", err)
 		}
+		pluginName := plugin.Name
 		log.Debug(logger, "Successfully retrieved referenced KongPlugin")
-		plugins = append(plugins, *plugin)
-		return plugins, true, nil
+		pluginCopy, err := builder.NewKongPlugin().
+			WithName(namegen.NewKongPluginName(filter, httpRoute.Namespace, plugin.PluginName)).
+			WithNamespace(metadata.NamespaceFromParentRef(httpRoute, pRef)).
+			WithLabels(httpRoute, pRef).
+			WithPluginName(plugin.PluginName).
+			WithPluginConfig(plugin.Config.Raw).
+			WithAnnotations(httpRoute, pRef).
+			Build()
+		if err != nil {
+			log.Error(logger, err, "Failed to build KongPlugin resource")
+			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)
+		}
+		plugins = append(plugins, pluginCopy)
+		return plugins, nil
 	}
 
 	pluginConfs, err := translateFromFilter(rule, filter)
 	if err != nil {
-		return nil, false, fmt.Errorf("translating filter to KongPlugins: %w", err)
+		return nil, fmt.Errorf("translating filter to KongPlugins: %w", err)
 	}
 	for i := range pluginConfs {
 		pConf := &pluginConfs[i]
-		pluginName := namegen.NewKongPluginName(filter, pConf.name)
+		pluginName := namegen.NewKongPluginName(filter, httpRoute.Namespace, pConf.name)
 		logger := logger.WithValues("kongplugin", pluginName)
 		log.Debug(logger, "Generating KongPlugin for HTTPRoute filter")
 
@@ -96,16 +112,16 @@ func PluginsForFilter(
 			Build()
 		if err != nil {
 			log.Error(logger, err, "Failed to build KongPlugin resource")
-			return nil, false, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)
+			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)
 		}
 
 		if _, err = translator.VerifyAndUpdate(ctx, logger, cl, &plugin, httpRoute, false); err != nil {
-			return nil, false, err
+			return nil, err
 		}
 		plugins = append(plugins, plugin)
 	}
 
-	return plugins, false, nil
+	return plugins, nil
 }
 
 func getReferencedKongPlugin(ctx context.Context, cl client.Client, namespace string, filter gwtypes.HTTPRouteFilter) (*configurationv1.KongPlugin, error) {
@@ -127,7 +143,6 @@ func getReferencedKongPlugin(ctx context.Context, cl client.Client, namespace st
 		Namespace: namespace,
 	}, plugin)
 	if err != nil {
-		err = fmt.Errorf("failed to get KongPlugin for ExtensionRef %s: %w", filter.ExtensionRef.Name, err)
 		return nil, err
 	}
 

--- a/controller/hybridgateway/plugin/plugin_test.go
+++ b/controller/hybridgateway/plugin/plugin_test.go
@@ -188,7 +188,7 @@ func TestPluginForFilter(t *testing.T) {
 				WithRuntimeObjects(objects...).
 				Build()
 
-			plugins, _, err := PluginsForFilter(ctx, logger, fakeClient, tt.httpRoute, tt.rule, tt.filter, tt.parentRef)
+			plugins, err := PluginsForFilter(ctx, logger, fakeClient, tt.httpRoute, tt.rule, tt.filter, tt.parentRef)
 
 			if tt.expectedError {
 				require.Error(t, err)
@@ -286,7 +286,7 @@ func TestGetReferencedKongPlugin(t *testing.T) {
 				},
 			},
 			namespace:     "default",
-			expectedError: "failed to get KongPlugin for ExtensionRef non-existent-plugin",
+			expectedError: "kongplugins.configuration.konghq.com \"non-existent-plugin\" not found",
 		},
 		{
 			name: "ExtensionRef with complex plugin configuration",

--- a/controller/hybridgateway/watch/mapfuncs_httproute.go
+++ b/controller/hybridgateway/watch/mapfuncs_httproute.go
@@ -291,8 +291,8 @@ func MapHTTPRouteForKongPlugin(cl client.Client) handler.MapFunc {
 			}
 		}
 
+		// Add requests for Plugins referencing the HTTPRoute via annotation.
 		requests := MapHTTPRouteForKongResource[*configurationv1.KongPlugin](cl)(ctx, obj)
 		return append(requests, indexRequests...)
 	}
-
 }

--- a/controller/hybridgateway/watch/watch.go
+++ b/controller/hybridgateway/watch/watch.go
@@ -58,7 +58,7 @@ func Watches(obj client.Object, cl client.Client) []Watcher {
 			},
 			{
 				&configurationv1.KongPlugin{},
-				MapHTTPRouteForKongResource[*configurationv1.KongPlugin](cl),
+				MapHTTPRouteForKongPlugin(cl),
 			},
 			{
 				&configurationv1alpha1.KongPluginBinding{},

--- a/internal/utils/index/httproute.go
+++ b/internal/utils/index/httproute.go
@@ -117,8 +117,7 @@ func KongPluginsOnHTTPRoute(o client.Object) []string {
 			if filter.ExtensionRef.Group != gatewayv1.Group(configurationv1.GroupVersion.Group) || filter.ExtensionRef.Kind != "KongPlugin" {
 				continue
 			}
-			ns := httpRoute.Namespace
-			plugins = append(plugins, ns+"/"+string(filter.ExtensionRef.Name))
+			plugins = append(plugins, httpRoute.Namespace+"/"+string(filter.ExtensionRef.Name))
 		}
 	}
 	return lo.Uniq(plugins)


### PR DESCRIPTION
**What this PR does / why we need it**:

Add logic to automatically create copies of KongPlugins when they are referenced by HTTPRoute extensionRef filters. When an HTTPRoute uses a KongPlugin via Gateway API filters, the controller now generates a dedicated copy of that plugin with proper ownership and annotations linking it back to the HTTPRoute.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

Manifests

```yaml
kind: Gateway
apiVersion: gateway.networking.k8s.io/v1
metadata:
  name: jw-gw
  namespace: default
spec:
  gatewayClassName: kong-v2beta1
  listeners:
  - name: http
    protocol: HTTP
    port: 80
    allowedRoutes:
      namespaces:
        from: All
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: httproute-echo
  namespace: route-ns
spec:
  parentRefs:
  - name: jw-gw
    namespace: default
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /echo
    filters:
    - type: ExtensionRef
      extensionRef:
        group: configuration.konghq.com
        kind: KongPlugin
        name: rate-limit-5-min
    backendRefs:
    - name: echo
      kind: Service
      port: 80
---
apiVersion: configuration.konghq.com/v1
kind: KongPlugin
metadata:
 name: rate-limit-5-min
 namespace: route-ns
config:
 minute: 5
 policy: local
plugin: rate-limiting
```

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
