### PR TITLE
feat: gracefully handle lack of connectivity with Konnect API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@
   For this reference to be allowed, a `KongReferenceGrant` resource must be created
   in the namespace of the `KongService`, allowing access for the `KongRoute`.
   [#3125](https://github.com/Kong/kong-operator/pull/3125)
+- Gracefully handle network errors when communicating with Konnect API.
+  When a network error occurs during Konnect API operations, the operator
+  will patch the resource status conditions to indicate the failure and
+  requeue the reconciliation for a later retry.
+  [#3184](https://github.com/Kong/kong-operator/pull/3184)
 
 ### Fixes
 

--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -371,6 +371,14 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 				return res, err
 			}
 
+			if !cleanup {
+				// ControlPlane not found and we're not in cleanup mode.
+				// The controlPlaneRefValid condition has already been set to false in getGatewayKonnectControlPlane.
+				// We've done the necessary cleanup above, now wait for the CP to be created or the reference to be corrected.
+				log.Debug(logger, "ControlPlane not found, waiting for it to be available")
+				return res, nil
+			}
+
 		default:
 			log.Debug(logger, "ControlPlane not ready yet")
 			return res, nil

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -494,9 +494,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 	// Handle type specific operations and stop reconciliation if needed.
 	// This can happen for instance when KongConsumer references credentials Secrets
 	// that do not exist or populate some Status fields based on Konnect API.
-	if stop, res, err := handleTypeSpecific(ctx, sdk, r.Client, ent); !res.IsZero() || stop {
-		return res, err
-	} else if err != nil {
+	if stop, res, err := handleTypeSpecific(ctx, sdk, r.Client, ent); err != nil {
 		// If the error was a network error, handle it here, there's no need to proceed,
 		// as no state has changed.
 		// Status conditions are updated in handleOpsErr.
@@ -505,6 +503,8 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 			return r.handleOpsErr(ctx, ent, errUrl)
 		}
 		return ctrl.Result{}, err
+	} else if !res.IsZero() || stop {
+		return res, err
 	}
 
 	// TODO: relying on status ID is OK but we need to rethink this because

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -548,13 +548,11 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// Regardless of the error, patch the status as it can contain the Konnect ID,
 		// Org ID, Server URL and status conditions.
 		// Konnect ID will be needed for the finalizer to work.
-		if res, err := patch.ApplyStatusPatchIfNotEmpty(ctx, r.Client, logger, any(ent).(client.Object), obj); err != nil {
+		if _, err := patch.ApplyStatusPatchIfNotEmpty(ctx, r.Client, logger, any(ent).(client.Object), obj); err != nil {
 			if k8serrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{}, fmt.Errorf("failed to update status after creating object: %w", err)
-		} else if res != op.Noop {
-			return ctrl.Result{}, nil
 		}
 
 		if err != nil {

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -586,9 +586,6 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 	res, err = ops.Update(ctx, sdk, r.SyncPeriod, r.Client, r.MetricRecorder, ent)
 	// If the error was a network error, handle it here, there's no need to proceed,
 	// as no state has changed.
-
-	// If the error was a network error, handle it here, there's no need to proceed,
-	// as no state has changed.
 	// Status conditions are updated in handleOpsErr.
 	var errUrl *url.Error
 	if errors.As(err, &errUrl) {

--- a/controller/konnect/reconciler_generic_error_handling.go
+++ b/controller/konnect/reconciler_generic_error_handling.go
@@ -1,0 +1,34 @@
+package konnect
+
+import (
+	"context"
+	"net/url"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	konnectv1alpha1 "github.com/kong/kong-operator/api/konnect/v1alpha1"
+	"github.com/kong/kong-operator/controller/pkg/patch"
+)
+
+// handleOpsErr handles network errors.
+// If the error is a network error, it patches the status condition
+// of the Konnect entity to reflect the failure to communicate with the Konnect API.
+func (r *KonnectEntityReconciler[T, TEnt]) handleOpsErr(
+	ctx context.Context, ent TEnt, errUrl *url.Error,
+) (ctrl.Result, error) {
+	if errUrl == nil {
+		return ctrl.Result{}, nil
+	}
+
+	if res, err := patch.StatusWithCondition(ctx, r.Client, ent,
+		konnectv1alpha1.KonnectEntityProgrammedConditionType,
+		metav1.ConditionFalse,
+		konnectv1alpha1.KonnectEntityProgrammedReasonKonnectAPIOpFailed,
+		errUrl.Error(),
+	); err != nil || !res.IsZero() {
+		return res, err
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/controller/konnect/reconciler_generic_error_handling.go
+++ b/controller/konnect/reconciler_generic_error_handling.go
@@ -8,6 +8,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	konnectv1alpha1 "github.com/kong/kong-operator/api/konnect/v1alpha1"
+	"github.com/kong/kong-operator/controller/consts"
 	"github.com/kong/kong-operator/controller/pkg/patch"
 )
 
@@ -30,5 +31,6 @@ func (r *KonnectEntityReconciler[T, TEnt]) handleOpsErr(
 		return res, err
 	}
 
-	return ctrl.Result{}, nil
+	// After patching the condition, requeue without backoff to retry the network operation.
+	return ctrl.Result{RequeueAfter: consts.RequeueWithoutBackoff}, nil
 }

--- a/controller/konnect/reconciler_generic_error_handling_test.go
+++ b/controller/konnect/reconciler_generic_error_handling_test.go
@@ -17,6 +17,7 @@ import (
 
 	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kong-operator/api/konnect/v1alpha1"
+	"github.com/kong/kong-operator/controller/consts"
 	"github.com/kong/kong-operator/modules/manager/scheme"
 	k8sutils "github.com/kong/kong-operator/pkg/utils/kubernetes"
 )
@@ -44,7 +45,7 @@ func TestHandleOpsErr(t *testing.T) {
 				URL: "https://api.konghq.com",
 				Err: errors.New("connection refused"),
 			},
-			expectedResult:         ctrl.Result{},
+			expectedResult:         ctrl.Result{RequeueAfter: consts.RequeueWithoutBackoff},
 			expectedErr:            false,
 			expectConditionPatched: true,
 		},
@@ -82,7 +83,7 @@ func TestHandleOpsErr(t *testing.T) {
 				URL: "https://api.konghq.com",
 				Err: errors.New("no such host"),
 			},
-			expectedResult:         ctrl.Result{},
+			expectedResult:         ctrl.Result{RequeueAfter: consts.RequeueWithoutBackoff},
 			expectedErr:            false,
 			expectConditionPatched: true,
 		},

--- a/controller/konnect/reconciler_generic_error_handling_test.go
+++ b/controller/konnect/reconciler_generic_error_handling_test.go
@@ -1,0 +1,147 @@
+package konnect
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/api/konnect/v1alpha1"
+	"github.com/kong/kong-operator/modules/manager/scheme"
+	k8sutils "github.com/kong/kong-operator/pkg/utils/kubernetes"
+)
+
+func TestHandleOpsErr(t *testing.T) {
+	tests := []struct {
+		name                   string
+		inputErr               *url.Error
+		expectedResult         ctrl.Result
+		expectedErr            bool
+		expectedErrMsg         string
+		expectConditionPatched bool
+		interceptorFunc        interceptor.Funcs
+	}{
+		{
+			name:           "nil error returns empty result",
+			inputErr:       nil,
+			expectedResult: ctrl.Result{},
+			expectedErr:    false,
+		},
+		{
+			name: "url.Error patches status condition and returns nil error",
+			inputErr: &url.Error{
+				Op:  "Get",
+				URL: "https://api.konghq.com",
+				Err: errors.New("connection refused"),
+			},
+			expectedResult:         ctrl.Result{},
+			expectedErr:            false,
+			expectConditionPatched: true,
+		},
+		{
+			name: "url.Error with patch conflict returns requeue",
+			inputErr: &url.Error{
+				Op:  "Post",
+				URL: "https://api.konghq.com",
+				Err: errors.New("timeout"),
+			},
+			expectedResult: ctrl.Result{Requeue: true},
+			expectedErr:    false,
+			interceptorFunc: interceptor.Funcs{
+				SubResourcePatch: func(
+					ctx context.Context,
+					client client.Client,
+					subResourceName string,
+					obj client.Object,
+					patch client.Patch,
+					opts ...client.SubResourcePatchOption,
+				) error {
+					return &k8serrors.StatusError{
+						ErrStatus: metav1.Status{
+							Status: metav1.StatusFailure,
+							Reason: metav1.StatusReasonConflict,
+						},
+					}
+				},
+			},
+		},
+		{
+			name: "wrapped url.Error is handled correctly",
+			inputErr: &url.Error{
+				Op:  "Get",
+				URL: "https://api.konghq.com",
+				Err: errors.New("no such host"),
+			},
+			expectedResult:         ctrl.Result{},
+			expectedErr:            false,
+			expectConditionPatched: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			ent := &configurationv1alpha1.KongService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-service",
+					Namespace:  "default",
+					Generation: 1,
+				},
+			}
+
+			clientBuilder := fake.NewClientBuilder().
+				WithObjects(ent).
+				WithStatusSubresource(ent).
+				WithScheme(scheme.Get())
+
+			if tt.interceptorFunc.SubResourcePatch != nil {
+				clientBuilder = clientBuilder.WithInterceptorFuncs(tt.interceptorFunc)
+			}
+
+			cl := clientBuilder.Build()
+
+			r := &KonnectEntityReconciler[
+				configurationv1alpha1.KongService, *configurationv1alpha1.KongService,
+			]{
+				Client: cl,
+			}
+
+			result, err := r.handleOpsErr(ctx, ent, tt.inputErr)
+
+			assert.Equal(t, tt.expectedResult, result)
+
+			if tt.expectedErr {
+				require.Error(t, err)
+				if tt.expectedErrMsg != "" {
+					assert.Contains(t, err.Error(), tt.expectedErrMsg)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tt.expectConditionPatched {
+				cond, ok := k8sutils.GetCondition(
+					konnectv1alpha1.KonnectEntityProgrammedConditionType, ent,
+				)
+				require.True(t, ok, "expected condition to be set")
+				assert.Equal(t, metav1.ConditionFalse, cond.Status)
+				assert.Equal(t,
+					string(konnectv1alpha1.KonnectEntityProgrammedReasonKonnectAPIOpFailed),
+					cond.Reason,
+				)
+			}
+		})
+	}
+}

--- a/controller/pkg/patch/patch.go
+++ b/controller/pkg/patch/patch.go
@@ -66,6 +66,13 @@ func ApplyStatusPatchIfNotEmpty[
 ) (res op.Result, err error) {
 	// Check if the patch to be applied is empty.
 	patch := client.MergeFrom(oldExisting)
+
+	// NOTE: Code below is not 100% correct as it generates a diff for whole object,
+	// not only for status subresource. However, controller-runtime does not provide
+	// an easy way to do that, so for now we rely on the fact that only status is
+	// being modified before calling this function.
+	// In future we might want to implement a custom patcher that would only
+	// consider status field.
 	b, err := patch.Data(existing)
 	if err != nil {
 		return op.Noop, fmt.Errorf("failed to generate patch for %T %s: %w",

--- a/test/envtest/konnect_entities_gatewaycontrolplane_test.go
+++ b/test/envtest/konnect_entities_gatewaycontrolplane_test.go
@@ -888,7 +888,6 @@ func conditionsContainProgrammedWithReason(
 	conds []metav1.Condition,
 	reason string,
 ) bool {
-	fmt.Printf("Checking conditions for reason %s: %+v\n", reason, conds)
 	return lo.ContainsBy(conds,
 		func(condition metav1.Condition) bool {
 			return condition.Type == konnectv1alpha1.KonnectEntityProgrammedConditionType &&

--- a/test/envtest/konnect_entities_gatewaycontrolplane_test.go
+++ b/test/envtest/konnect_entities_gatewaycontrolplane_test.go
@@ -3,7 +3,6 @@ package envtest
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/url"
 	"testing"
 

--- a/test/envtest/konnect_entities_gatewaycontrolplane_test.go
+++ b/test/envtest/konnect_entities_gatewaycontrolplane_test.go
@@ -349,7 +349,6 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 					&sdkkonnectops.PutControlPlanesIDGroupMembershipsResponse{},
 					errors.New("some error"),
 				)
-			// t.Cleanup(func() { putMembers.Unset() })
 
 			sdk.ControlPlaneSDK.EXPECT().
 				ListControlPlanes(

--- a/test/envtest/konnect_entities_suite_test.go
+++ b/test/envtest/konnect_entities_suite_test.go
@@ -30,6 +30,7 @@ func TestKonnectEntityReconcilers(t *testing.T) {
 }
 
 type konnectEntityReconcilerTestCase struct {
+	enabled             bool
 	name                string
 	objectOps           func(ctx context.Context, t *testing.T, cl client.Client, ns *corev1.Namespace)
 	mockExpectations    func(t *testing.T, sdk *sdkmocks.MockSDKWrapper, cl client.Client, ns *corev1.Namespace)
@@ -80,6 +81,9 @@ func testNewKonnectEntityReconciler[
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
+				if !tc.enabled {
+					t.Skip("test case disabled")
+				}
 				tc.mockExpectations(t, sdk, cl, ns)
 				tc.objectOps(ctx, t, cl, ns)
 				require.EventuallyWithT(t, func(collect *assert.CollectT) {


### PR DESCRIPTION
**What this PR does / why we need it**:

With this patch, Konnect related entities will get their status conditions updated (`Programmed` condition specifically) accordingly, when Konnect reconciler cannot reach Konnect.

Example status:

```
status:
  clusterType: CLUSTER_TYPE_CONTROL_PLANE
  conditions:
  - lastTransitionTime: "2026-01-30T10:06:31Z"
    message: KonnectAPIAuthConfiguration reference default/konnect-api-auth is resolved
    observedGeneration: 1
    reason: ResolvedRef
    status: "True"
    type: APIAuthResolvedRef
  - lastTransitionTime: "2026-01-30T10:53:34Z"
    message: referenced KonnectAPIAuthConfiguration default/konnect-api-auth is valid
    observedGeneration: 1
    reason: Valid
    status: "True"
    type: APIAuthValid
  - lastTransitionTime: "2026-01-30T12:16:09Z"
    message: 'Get "https://eu.api.konghq.tech/v2/control-planes?filter%5Bid%5D%5Beq%5D=5f86bd65-54e3-429d-bbde-1111111111111":
      dial tcp: lookup eu.api.konghq.tech: no such host'
    observedGeneration: 1
    reason: KonnectAPIOpFailed
    status: "False"
    type: Programmed
  id: 5f86bd65-54e3-429d-bbde-1111111111111
  konnectEndpoints:
    controlPlane: https://1111111111111.eu.cp0.konghq.tech
    telemetry: https://1111111111111.eu.tp0.konghq.tech
  organizationID: 5ca26716-02f7-4430-9117-1111111111111
  serverURL: https://eu.api.konghq.tech
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
