### PR TITLE
feat(hybridgateway): add ExtensionRef validation to HTTPRoute ResolvedRefs condition

### DIFF
--- a/controller/hybridgateway/route/status.go
+++ b/controller/hybridgateway/route/status.go
@@ -415,7 +415,8 @@ func BuildProgrammedCondition(ctx context.Context, logger logr.Logger, cl client
 	return DeduplicateConditionsByType(conditions), nil
 }
 
-// BuildResolvedRefsCondition evaluates all BackendRefs and ExtensionRefs in an HTTPRoute to determine if their references are valid and permitted.
+// BuildResolvedRefsCondition evaluates all BackendRefs and ExtensionRefs in an HTTPRoute to determine if their
+// references are valid and permitted.
 // It checks that each BackendRef:
 //   - Has a supported group/kind
 //   - Exists in the target namespace

--- a/internal/types/gatewaytypes.go
+++ b/internal/types/gatewaytypes.go
@@ -22,8 +22,11 @@ type (
 	GroupVersionKind       = gatewayv1.Group
 	Hostname               = gatewayv1.Hostname
 	HTTPBackendRef         = gatewayv1.HTTPBackendRef
+	HTTPHeader             = gatewayv1.HTTPHeader
+	HTTPHeaderFilter       = gatewayv1.HTTPHeaderFilter
 	HTTPRoute              = gatewayv1.HTTPRoute
 	HTTPRouteFilter        = gatewayv1.HTTPRouteFilter
+	HTTPRouteFilterType    = gatewayv1.HTTPRouteFilterType
 	HTTPRouteList          = gatewayv1.HTTPRouteList
 	HTTPRouteMatch         = gatewayv1.HTTPRouteMatch
 	HTTPRouteRule          = gatewayv1.HTTPRouteRule
@@ -31,6 +34,7 @@ type (
 	HTTPRouteStatus        = gatewayv1.HTTPRouteStatus
 	Kind                   = gatewayv1.Kind
 	Listener               = gatewayv1.Listener
+	LocalObjectReference   = gatewayv1.LocalObjectReference
 	Namespace              = gatewayv1.Namespace
 	ObjectName             = gatewayv1.ObjectName
 	ParametersReference    = gatewayv1.ParametersReference
@@ -51,6 +55,8 @@ const (
 	GroupName                             = gatewayv1.GroupName
 	HTTPProtocolType                      = gatewayv1.HTTPProtocolType
 	HTTPSProtocolType                     = gatewayv1.HTTPSProtocolType
+	HTTPRouteFilterExtensionRef           = gatewayv1.HTTPRouteFilterExtensionRef
+	HTTPRouteFilterRequestHeaderModifier  = gatewayv1.HTTPRouteFilterRequestHeaderModifier
 	ListenerConditionProgrammed           = gatewayv1.ListenerConditionProgrammed
 	NamespacesFromAll                     = gatewayv1.NamespacesFromAll
 	NamespacesFromSame                    = gatewayv1.NamespacesFromSame

--- a/test/e2e/chainsaw/common/_step_templates/apply-assert-kongPlugin.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/apply-assert-kongPlugin.yaml
@@ -1,0 +1,32 @@
+# Template for creating and asserting a custom KongPlugin resource.
+#
+# Required bindings:
+#   - kong_plugin_name: Name of the KongPlugin to create
+#   - kong_plugin_namespace: Namespace where the KongPlugin should be created
+#   - plugin_type: Type of the Kong plugin (e.g., 'rate-limiting', 'cors', 'request-transformer')
+#   - plugin_config: JSON string of the plugin configuration
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: apply-assert-kong-plugin
+spec:
+  try:
+    - apply:
+        resource:
+          # Create KongPlugin.
+          apiVersion: configuration.konghq.com/v1
+          kind: KongPlugin
+          metadata:
+            name: ($kong_plugin_name)
+            namespace: ($kong_plugin_namespace)
+          plugin: ($plugin_type)
+          config: (json_parse($plugin_config))
+    - assert:
+        resource:
+          # Assert KongPlugin exists with expected configuration.
+          apiVersion: configuration.konghq.com/v1
+          kind: KongPlugin
+          metadata:
+            name: ($kong_plugin_name)
+            namespace: ($kong_plugin_namespace)
+          plugin: ($plugin_type)

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/01-httproute-valid-extensionref.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/01-httproute-valid-extensionref.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-with-valid-plugin
+  namespace: ($namespace)
+spec:
+  parentRefs:
+    - name: ($gateway_name)
+      namespace: ($gateway_namespace)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /with-plugin
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: configuration.konghq.com
+            kind: KongPlugin
+            name: rate-limit-5-min
+      backendRefs:
+        - name: ($echo_deployment_name)
+          port: 8080

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/02-httproute-valid-extensionref-assert.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/02-httproute-valid-extensionref-assert.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-with-valid-plugin
+  namespace: ($namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        namespace: ($gateway_namespace)
+      (conditions[?type == 'ResolvedRefs'] | [0]):
+        type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: "All references resolved"
+      (conditions[?type == 'Accepted'] | [0]):
+        type: Accepted
+        status: "True"

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/03-httproute-extensionref-not-found.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/03-httproute-extensionref-not-found.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-with-nonexistent-plugin
+  namespace: ($namespace)
+spec:
+  parentRefs:
+    - name: ($gateway_name)
+      namespace: ($gateway_namespace)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /plugin-not-found
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: configuration.konghq.com
+            kind: KongPlugin
+            name: nonexistent-plugin
+      backendRefs:
+        - name: ($echo_deployment_name)
+          port: 8080

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/04-httproute-extensionref-not-found-assert.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/04-httproute-extensionref-not-found-assert.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-with-nonexistent-plugin
+  namespace: ($namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        namespace: ($gateway_namespace)
+      (conditions[?type == 'ResolvedRefs'] | [0]):
+        type: ResolvedRefs
+        status: "False"
+        reason: BackendNotFound
+        message: (join('', ['ExtensionRef ', ($namespace), '/nonexistent-plugin not found']))
+      (conditions[?type == 'Accepted'] | [0]):
+        type: Accepted
+        status: "True"

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/05-httproute-unsupported-extensionref.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/05-httproute-unsupported-extensionref.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-with-unsupported-extensionref
+  namespace: ($namespace)
+spec:
+  parentRefs:
+    - name: ($gateway_name)
+      namespace: ($gateway_namespace)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /unsupported-extension
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: unsupported.example.com
+            kind: UnsupportedKind
+            name: some-resource
+      backendRefs:
+        - name: ($echo_deployment_name)
+          port: 8080

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/06-httproute-unsupported-extensionref-assert.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/06-httproute-unsupported-extensionref-assert.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-with-unsupported-extensionref
+  namespace: ($namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        namespace: ($gateway_namespace)
+      (conditions[?type == 'ResolvedRefs'] | [0]):
+        type: ResolvedRefs
+        status: "False"
+        reason: InvalidKind
+        message: "(join('', ['Unsupported ExtensionRef ', ($namespace), '/some-resource group/kind: ', 'unsupported.example.com/UnsupportedKind']))"
+      (conditions[?type == 'Accepted'] | [0]):
+        type: Accepted
+        status: "True"

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/07-httproute-multiple-extensionrefs-first-fails.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/07-httproute-multiple-extensionrefs-first-fails.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-multiple-extensionrefs-first-fails
+  namespace: ($namespace)
+spec:
+  parentRefs:
+  - name: ($gateway_name)
+    namespace: ($gateway_namespace)
+  rules:
+  - filters:
+    - type: ExtensionRef
+      extensionRef:
+        group: configuration.konghq.com
+        kind: KongPlugin
+        name: nonexistent-plugin
+    - type: ExtensionRef
+      extensionRef:
+        group: configuration.konghq.com
+        kind: KongPlugin
+        name: rate-limit-5-min
+    backendRefs:
+    - name: ($echo_deployment_name)
+      port: 8080

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/08-httproute-multiple-extensionrefs-first-fails-assert.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/08-httproute-multiple-extensionrefs-first-fails-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-multiple-extensionrefs-first-fails
+  namespace: ($namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        namespace: ($gateway_namespace)
+      (conditions[?type == 'ResolvedRefs'] | [0]):
+        type: ResolvedRefs
+        status: "False"
+        reason: BackendNotFound
+        message: (join('', ['ExtensionRef ', ($namespace), '/nonexistent-plugin not found']))

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/09-httproute-non-extensionref-filter.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/09-httproute-non-extensionref-filter.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-non-extensionref-filter
+  namespace: ($namespace)
+spec:
+  parentRefs:
+  - name: ($gateway_name)
+    namespace: ($gateway_namespace)
+  rules:
+  - filters:
+    - type: RequestHeaderModifier
+      requestHeaderModifier:
+        set:
+        - name: X-Custom-Header
+          value: custom-value
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        set:
+        - name: X-Response-Header
+          value: response-value
+    backendRefs:
+    - name: ($echo_deployment_name)
+      port: 8080

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/10-httproute-non-extensionref-filter-assert.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/10-httproute-non-extensionref-filter-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-non-extensionref-filter
+  namespace: ($namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        namespace: ($gateway_namespace)
+      (conditions[?type == 'ResolvedRefs'] | [0]):
+        type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: "All references resolved"

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/11-httproute-valid-backendref.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/11-httproute-valid-backendref.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-valid-backendref
+  namespace: ($namespace)
+spec:
+  parentRefs:
+    - name: ($gateway_name)
+      namespace: ($gateway_namespace)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /valid-backend
+      backendRefs:
+        - name: ($echo_deployment_name)
+          port: 8080

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/12-httproute-valid-backendref-assert.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/12-httproute-valid-backendref-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-valid-backendref
+  namespace: ($namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        namespace: ($gateway_namespace)
+      (conditions[?type == 'ResolvedRefs'] | [0]):
+        type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: "All references resolved"

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/13-httproute-backendref-not-found.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/13-httproute-backendref-not-found.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-backendref-not-found
+  namespace: ($namespace)
+spec:
+  parentRefs:
+    - name: ($gateway_name)
+      namespace: ($gateway_namespace)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /backend-not-found
+      backendRefs:
+        - name: nonexistent-service
+          port: 8080

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/14-httproute-backendref-not-found-assert.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/14-httproute-backendref-not-found-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-backendref-not-found
+  namespace: ($namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        namespace: ($gateway_namespace)
+      (conditions[?type == 'ResolvedRefs'] | [0]):
+        type: ResolvedRefs
+        status: "False"
+        reason: BackendNotFound
+        message: (join('', ['BackendRef ', ($namespace), '/nonexistent-service not found']))

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/15-httproute-unsupported-backendref.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/15-httproute-unsupported-backendref.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-unsupported-backendref
+  namespace: ($namespace)
+spec:
+  parentRefs:
+    - name: ($gateway_name)
+      namespace: ($gateway_namespace)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /unsupported-backend
+      backendRefs:
+        - name: some-resource
+          kind: UnsupportedKind
+          group: unsupported.example.com
+          port: 8080

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/16-httproute-unsupported-backendref-assert.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/16-httproute-unsupported-backendref-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-unsupported-backendref
+  namespace: ($namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        namespace: ($gateway_namespace)
+      (conditions[?type == 'ResolvedRefs'] | [0]):
+        type: ResolvedRefs
+        status: "False"
+        reason: InvalidKind
+        message: "(join('', ['Unsupported BackendRef ', ($namespace), '/some-resource group/kind: ', 'unsupported.example.com/UnsupportedKind']))"

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/17-httproute-cross-namespace-no-grant.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/17-httproute-cross-namespace-no-grant.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-cross-namespace-no-grant
+  namespace: ($namespace)
+spec:
+  parentRefs:
+    - name: ($gateway_name)
+      namespace: ($gateway_namespace)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /cross-ns-no-grant
+      backendRefs:
+        - name: ($xns_echo_deployment_name)
+          namespace: ($xns_namespace)
+          port: 8080

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/18-httproute-cross-namespace-no-grant-assert.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/18-httproute-cross-namespace-no-grant-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-cross-namespace-no-grant
+  namespace: ($namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        namespace: ($gateway_namespace)
+      (conditions[?type == 'ResolvedRefs'] | [0]):
+        type: ResolvedRefs
+        status: "False"
+        reason: RefNotPermitted
+        message: (join('', ['No ReferenceGrants found in namespace ', ($xns_namespace), ' for BackendRef ', ($xns_namespace), '/', ($xns_echo_deployment_name)]))

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/19-httproute-cross-namespace-grant-not-permitted.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/19-httproute-cross-namespace-grant-not-permitted.yaml
@@ -1,0 +1,33 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-specific-service
+  namespace: ($xns_namespace)
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: ($namespace)
+  to:
+  - group: ""
+    kind: Service
+    name: allowed-service-only
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-cross-namespace-grant-not-permitted
+  namespace: ($namespace)
+spec:
+  parentRefs:
+    - name: ($gateway_name)
+      namespace: ($gateway_namespace)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /cross-ns-grant-not-permitted
+      backendRefs:
+        - name: ($xns_echo_deployment_name)
+          namespace: ($xns_namespace)
+          port: 8080

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/20-httproute-cross-namespace-grant-not-permitted-assert.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/20-httproute-cross-namespace-grant-not-permitted-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-cross-namespace-grant-not-permitted
+  namespace: ($namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        namespace: ($gateway_namespace)
+      (conditions[?type == 'ResolvedRefs'] | [0]):
+        type: ResolvedRefs
+        status: "False"
+        reason: RefNotPermitted
+        message: (join('', ['BackendRef ', ($xns_namespace), '/', ($xns_echo_deployment_name), ' not permitted by any ReferenceGrant']))

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/21-httproute-cross-namespace-with-grant.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/21-httproute-cross-namespace-with-grant.yaml
@@ -1,0 +1,32 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-all-services
+  namespace: ($xns_namespace)
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: ($namespace)
+  to:
+  - group: ""
+    kind: Service
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-cross-namespace-with-grant
+  namespace: ($namespace)
+spec:
+  parentRefs:
+    - name: ($gateway_name)
+      namespace: ($gateway_namespace)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /cross-ns-with-grant
+      backendRefs:
+        - name: ($xns_echo_deployment_name)
+          namespace: ($xns_namespace)
+          port: 8080

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/22-httproute-cross-namespace-with-grant-assert.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/22-httproute-cross-namespace-with-grant-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-cross-namespace-with-grant
+  namespace: ($namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        namespace: ($gateway_namespace)
+      (conditions[?type == 'ResolvedRefs'] | [0]):
+        type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: "All references resolved"

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/23-httproute-mixed-both-valid.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/23-httproute-mixed-both-valid.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-mixed-both-valid
+  namespace: ($namespace)
+spec:
+  parentRefs:
+    - name: ($gateway_name)
+      namespace: ($gateway_namespace)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /mixed-both-valid
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: configuration.konghq.com
+            kind: KongPlugin
+            name: rate-limit-5-min
+      backendRefs:
+        - name: ($echo_deployment_name)
+          port: 8080

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/24-httproute-mixed-both-valid-assert.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/24-httproute-mixed-both-valid-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-mixed-both-valid
+  namespace: ($namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        namespace: ($gateway_namespace)
+      (conditions[?type == 'ResolvedRefs'] | [0]):
+        type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: "All references resolved"

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/25-httproute-mixed-backendref-fails.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/25-httproute-mixed-backendref-fails.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-mixed-backendref-fails
+  namespace: ($namespace)
+spec:
+  parentRefs:
+    - name: ($gateway_name)
+      namespace: ($gateway_namespace)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /mixed-backendref-fails
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: configuration.konghq.com
+            kind: KongPlugin
+            name: rate-limit-5-min
+      backendRefs:
+        - name: nonexistent-service
+          port: 8080

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/26-httproute-mixed-backendref-fails-assert.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/26-httproute-mixed-backendref-fails-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-mixed-backendref-fails
+  namespace: ($namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        namespace: ($gateway_namespace)
+      (conditions[?type == 'ResolvedRefs'] | [0]):
+        type: ResolvedRefs
+        status: "False"
+        reason: BackendNotFound
+        message: (join('', ['BackendRef ', ($namespace), '/nonexistent-service not found']))

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/27-httproute-mixed-extensionref-fails.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/27-httproute-mixed-extensionref-fails.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-mixed-extensionref-fails
+  namespace: ($namespace)
+spec:
+  parentRefs:
+    - name: ($gateway_name)
+      namespace: ($gateway_namespace)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /mixed-extensionref-fails
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: configuration.konghq.com
+            kind: KongPlugin
+            name: nonexistent-plugin
+      backendRefs:
+        - name: ($echo_deployment_name)
+          port: 8080

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/28-httproute-mixed-extensionref-fails-assert.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/28-httproute-mixed-extensionref-fails-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-mixed-extensionref-fails
+  namespace: ($namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        namespace: ($gateway_namespace)
+      (conditions[?type == 'ResolvedRefs'] | [0]):
+        type: ResolvedRefs
+        status: "False"
+        reason: BackendNotFound
+        message: (join('', ['ExtensionRef ', ($namespace), '/nonexistent-plugin not found']))

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/chainsaw-test.yaml
@@ -1,0 +1,291 @@
+# HTTPRoute ResolvedRefs condition test scenario.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: httproute-resolved-refs
+spec:
+  description: |
+    This test validates that the hybrid gateway controller correctly
+    sets the ResolvedRefs condition on HTTPRoute resources based on
+    BackendRef and ExtensionRef validation.
+    
+    Test scenarios:
+    - Valid BackendRef (service exists in same namespace)
+    - Invalid BackendRef (service not found)
+    - Valid ExtensionRef (KongPlugin exists)
+    - Invalid ExtensionRef (KongPlugin not found)
+    - Unsupported ExtensionRef (wrong group/kind)
+    - Cross-namespace BackendRef without ReferenceGrant
+    - Cross-namespace BackendRef with ReferenceGrant
+  
+  timeouts:
+    apply: 120s
+    assert: 120s
+    delete: 120s
+    exec: 120s
+
+  
+
+  bindings:
+  # Common bindings.
+  - name: test_name
+    value: ($namespace)
+  - name: konnect_token
+    value: (env('KONNECT_TOKEN'))
+  - name: sni_hostname
+    value: (join('.', ['*', ($test_name), 'example.com']))
+  - name: fqdn
+    value: (join('.', ['echo', ($test_name), 'example.com']))
+  - name: cert_secret_name
+    value: test-tls-secret
+  - name: cert_secret_namespace
+    value: ($namespace)
+  - name: listener_https_port
+    value: 443
+  - name: listener_http_port
+    value: 80
+  - name: konnect_url
+    value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+  - name: gateway_image
+    value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+  - name: gateway_name
+    value: (join('-', [($test_name), 'gateway']))
+  - name: gateway_namespace
+    value: ($namespace)
+  - name: http_route_name
+    value: (join('-', [($test_name), 'echo-route']))
+  - name: http_route_namespace
+    value: ($namespace)
+  - name: echo_deployment_name
+    value: (join('-', [($test_name), 'echo']))
+  - name: echo_deployment_namespace
+    value: ($namespace)
+  - name: http_method
+    value: "GET"
+  
+  # Cross-namespace testing bindings
+  - name: xns_namespace
+    value: (join('-', [($namespace), 'xns']))
+  - name: xns_echo_deployment_name
+    value: (join('-', [($test_name), 'xns-echo']))
+  - name: xns_echo_deployment_namespace
+    value: ($xns_namespace)
+
+  steps:
+    # Step 1: Create the TLS secret that will be referenced by the Gateway TLS listener.
+    - name: Create-tls-secret
+      description: Create TLS Secret for the Gateway TLS listener.
+      use:
+        template: ../../common/_step_templates/apply-assert-tlsSecret.yaml
+
+    # Step 2: Create the KonnectAPIAuthConfiguration to authenticate with Konnect.
+    - name: Create-konnect-api-auth
+      description: Create KonnectAPIAuthConfiguration for the test.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    # Step 3: Create the GatewayConfiguration that defines the hybrid gateway setup.
+    - name: Create-gateway-configuration
+      description: Create GatewayConfiguration for the test.
+      use:
+        template: ../../common/_step_templates/apply-assert-gatewayConfiguration.yaml
+
+    # Step 4: Create the GatewayClass that will be used by the Gateway.
+    - name: Create-gateway-class
+      description: Create GatewayClass for the test.
+      use:
+        template: ../../common/_step_templates/apply-assert-gatewayClass.yaml
+
+    # Step 5: Create the Gateway with a TLS listener that references the TLS secret.
+    - name: Create-gateway
+      description: Create Gateway with TLS listener for the test.
+      use:
+        template: ../../common/_step_templates/apply-assert-gateway.yaml
+
+    # Step 6: Verify that the KonnectGatewayControlPlane is created and synchronized with Konnect.
+    - name: Assert-konnect-gateway-control-plane
+      description: Assert that the KonnectGatewayControlplane resource is created and synchronized.
+      use:
+        template: ../../common/_step_templates/assert-konnectGatewayControlPlane.yaml
+
+    # Step 7: Verify that the KongCertificate resource is created from the TLS secret.
+    - name: Assert-kong-certificate
+      description: Assert that the KongCertificate resource is created for the TLS secret.
+      use:
+       template: ../../common/_step_templates/assert-kongCertificate.yaml
+  
+    # Step 8: Verify that the KongSNI resource is created for the SNI hostname.
+    - name: Assert-kong-sni
+      description: Assert that the KongSNI resource is created for the SNI hostname.
+      use:
+       template: ../../common/_step_templates/assert-kongSNI.yaml
+      bindings:
+        - name: resource_type
+          value: "kongcertificates.configuration.konghq.com"
+  
+    # Step 9: Create the echo service that will receive the routed traffic.
+    - name: Create-echo-service
+      description: Create and assert an echo service to route traffic to.
+      use:
+        template: ../../common/_step_templates/apply-assert-echoService.yaml
+    
+    # Step 10: Create cross-namespace for testing cross-namespace references.
+    - name: Create-xns-namespace
+      description: Create namespace for cross-namespace reference testing.
+      use:
+        template: ../../common/_step_templates/apply-assert-namespace.yaml
+      bindings:
+        - name: namespace_name
+          value: ($xns_namespace)
+    
+    # Step 11: Create echo service in the cross-namespace for testing.
+    - name: Create-xns-echo-service
+      description: Create and assert an echo service in the cross-namespace.
+      use:
+        template: ../../common/_step_templates/apply-assert-echoService.yaml
+      bindings:
+        - name: echo_deployment_name
+          value: ($xns_echo_deployment_name)
+        - name: echo_deployment_namespace
+          value: ($xns_echo_deployment_namespace)
+    
+    # Step 12: Create a KongPlugin for ExtensionRef testing.
+    - name: Create-kong-plugin
+      description: Create and assert a KongPlugin for ExtensionRef validation.
+      use:
+        template: ../../common/_step_templates/apply-assert-kongPlugin.yaml
+      bindings:
+        - name: kong_plugin_name
+          value: rate-limit-5-min
+        - name: kong_plugin_namespace
+          value: ($namespace)
+        - name: plugin_type
+          value: rate-limiting
+        - name: plugin_config
+          value: '{"minute": 5, "policy": "local"}'
+    
+    # Test Case 1: Valid ExtensionRef - HTTPRoute with valid KongPlugin reference
+    - name: Test-valid-extensionref
+      description: Create HTTPRoute with valid ExtensionRef and verify ResolvedRefs=True.
+      try:
+        - apply:
+            file: 01-httproute-valid-extensionref.yaml
+        - assert:
+            file: 02-httproute-valid-extensionref-assert.yaml
+    
+    # Test Case 2: Invalid ExtensionRef - KongPlugin not found
+    - name: Test-extensionref-not-found
+      description: Create HTTPRoute with non-existent ExtensionRef and verify ResolvedRefs=False with BackendNotFound reason.
+      try:
+        - apply:
+            file: 03-httproute-extensionref-not-found.yaml
+        - assert:
+            file: 04-httproute-extensionref-not-found-assert.yaml
+    
+    # Test Case 3: Invalid ExtensionRef - Unsupported group/kind
+    - name: Test-unsupported-extensionref
+      description: Create HTTPRoute with unsupported ExtensionRef group/kind and verify ResolvedRefs=False with InvalidKind reason.
+      try:
+        - apply:
+            file: 05-httproute-unsupported-extensionref.yaml
+        - assert:
+            file: 06-httproute-unsupported-extensionref-assert.yaml
+    
+    # Test Case 4: Multiple ExtensionRef filters - first fails
+    - name: Test-multiple-extensionrefs-first-fails
+      description: Create HTTPRoute with multiple ExtensionRef filters where the first fails and verify ResolvedRefs=False.
+      try:
+        - apply:
+            file: 07-httproute-multiple-extensionrefs-first-fails.yaml
+        - assert:
+            file: 08-httproute-multiple-extensionrefs-first-fails-assert.yaml
+    
+    # Test Case 5: Non-ExtensionRef filter types - should be ignored
+    - name: Test-non-extensionref-filter
+      description: Create HTTPRoute with non-ExtensionRef filter types (RequestHeaderModifier, ResponseHeaderModifier) and verify they are ignored (ResolvedRefs=True).
+      try:
+        - apply:
+            file: 09-httproute-non-extensionref-filter.yaml
+        - assert:
+            file: 10-httproute-non-extensionref-filter-assert.yaml
+    
+    # Test Case 6: Valid BackendRef - same namespace
+    - name: Test-valid-backendref
+      description: Create HTTPRoute with valid BackendRef in same namespace and verify ResolvedRefs=True.
+      try:
+        - apply:
+            file: 11-httproute-valid-backendref.yaml
+        - assert:
+            file: 12-httproute-valid-backendref-assert.yaml
+    
+    # Test Case 7: BackendRef not found
+    - name: Test-backendref-not-found
+      description: Create HTTPRoute with non-existent BackendRef and verify ResolvedRefs=False with BackendNotFound reason.
+      try:
+        - apply:
+            file: 13-httproute-backendref-not-found.yaml
+        - assert:
+            file: 14-httproute-backendref-not-found-assert.yaml
+    
+    # Test Case 8: Unsupported BackendRef group/kind
+    - name: Test-unsupported-backendref
+      description: Create HTTPRoute with unsupported BackendRef group/kind and verify ResolvedRefs=False with InvalidKind reason.
+      try:
+        - apply:
+            file: 15-httproute-unsupported-backendref.yaml
+        - assert:
+            file: 16-httproute-unsupported-backendref-assert.yaml
+    
+    # Test Case 9: Cross-namespace BackendRef without ReferenceGrant
+    - name: Test-cross-namespace-no-grant
+      description: Create HTTPRoute with cross-namespace BackendRef without any ReferenceGrant and verify ResolvedRefs=False with RefNotPermitted reason.
+      try:
+        - apply:
+            file: 17-httproute-cross-namespace-no-grant.yaml
+        - assert:
+            file: 18-httproute-cross-namespace-no-grant-assert.yaml
+    
+    # Test Case 10: Cross-namespace BackendRef with ReferenceGrant that doesn't permit
+    - name: Test-cross-namespace-grant-not-permitted
+      description: Create ReferenceGrant that permits specific service and HTTPRoute that references a different service, verify ResolvedRefs=False with RefNotPermitted reason.
+      try:
+        - apply:
+            file: 19-httproute-cross-namespace-grant-not-permitted.yaml
+        - assert:
+            file: 20-httproute-cross-namespace-grant-not-permitted-assert.yaml
+    
+    # Test Case 11: Cross-namespace BackendRef with permissive ReferenceGrant
+    - name: Test-cross-namespace-with-grant
+      description: Create ReferenceGrant that permits all services and HTTPRoute with cross-namespace BackendRef, verify ResolvedRefs=True.
+      try:
+        - apply:
+            file: 21-httproute-cross-namespace-with-grant.yaml
+        - assert:
+            file: 22-httproute-cross-namespace-with-grant-assert.yaml
+    
+    # Test Case 12: Mixed - Both BackendRef and ExtensionRef valid
+    - name: Test-mixed-both-valid
+      description: Create HTTPRoute with both valid BackendRef and valid ExtensionRef and verify ResolvedRefs=True.
+      try:
+        - apply:
+            file: 23-httproute-mixed-both-valid.yaml
+        - assert:
+            file: 24-httproute-mixed-both-valid-assert.yaml
+    
+    # Test Case 13: Mixed - BackendRef fails, ExtensionRef valid
+    - name: Test-mixed-backendref-fails
+      description: Create HTTPRoute with invalid BackendRef and valid ExtensionRef and verify ResolvedRefs=False with BackendNotFound reason.
+      try:
+        - apply:
+            file: 25-httproute-mixed-backendref-fails.yaml
+        - assert:
+            file: 26-httproute-mixed-backendref-fails-assert.yaml
+    
+    # Test Case 14: Mixed - BackendRef valid, ExtensionRef fails
+    - name: Test-mixed-extensionref-fails
+      description: Create HTTPRoute with valid BackendRef and invalid ExtensionRef and verify ResolvedRefs=False with BackendNotFound reason.
+      try:
+        - apply:
+            file: 27-httproute-mixed-extensionref-fails.yaml
+        - assert:
+            file: 28-httproute-mixed-extensionref-fails-assert.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

```
Add support for validating ExtensionRef references in HTTPRoute filters
to the BuildResolvedRefsCondition function. The implementation checks
that ExtensionRef filters reference supported KongPlugin resources and
that these resources exist in the route's namespace.

Changes:
- Add IsExtensionRefSupported() to validate configuration.konghq.com/KongPlugin
- Extend BuildResolvedRefsCondition() to evaluate ExtensionRef in addition to BackendRef
- Implement test coverage for ExtensionRef validation scenarios

ExtensionRefs are always validated in the same namespace as the HTTPRoute,
unlike BackendRefs which may reference cross-namespace resources with
ReferenceGrants.
```

E2E tests:

```
Add E2E tests validating HTTPRoute ResolvedRefs condition for
both ExtensionRef and BackendRef references using the Chainsaw test framework.

Test coverage includes:

ExtensionRef validation (5 test cases):
- Valid ExtensionRef to KongPlugin
- ExtensionRef not found
- Unsupported ExtensionRef group/kind
- Multiple ExtensionRef filters where first fails
- Non-ExtensionRef filters (should be ignored)

BackendRef validation (6 test cases):
- Valid BackendRef to Service in same namespace
- BackendRef not found
- Unsupported BackendRef group/kind
- Cross-namespace BackendRef without ReferenceGrant
- Cross-namespace BackendRef with ReferenceGrant for different service
- Cross-namespace BackendRef with ReferenceGrant allowing all services

Mixed scenarios (3 test cases):
- Both BackendRef and ExtensionRef valid
- BackendRef fails, ExtensionRef valid
- BackendRef valid, ExtensionRef fails

All tests validate status.parents[].conditions structure with proper
ResolvedRefs condition status, reason, and message. ReferenceGrants are
bundled with HTTPRoutes in multi-document YAML to prevent test interference.
```

**Which issue this PR fixes**

Fixes 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
