### PR TITLE
fix: add HTTPRoute regex validation in admission webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 
 ## Unreleased
 
-### Fixed
+### Fixes
 
 - Admission webhook now validates HTTPRoute regex patterns before sending
   configuration to the Admin API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,11 @@
 
 ## Unreleased
 
-### Fixes
+### Fixed
 
+- Admission webhook now validates HTTPRoute regex patterns before sending
+  configuration to the Admin API.
+  [#3213](https://github.com/Kong/kong-operator/pull/3213)
 - Fix setting up indices for HTTPRoute and Gateway when Konnect controllers are disabled.
   [#3229](https://github.com/Kong/kong-operator/pull/3229)
 

--- a/test/integration/validatingwebhook/validating_helper_test.go
+++ b/test/integration/validatingwebhook/validating_helper_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func bootstrapGateway(ctx context.Context, t *testing.T, env environments.Environment, mgrClient client.Client) (
-	namespace *corev1.Namespace, cleaner *clusters.Cleaner, ingressClass string, ctrlClient client.Client,
+	namespace *corev1.Namespace, cleaner *clusters.Cleaner, ingressClass string, ctrlClient client.Client, gwc *gatewayv1.GatewayClass,
 ) {
 	namespace, cleaner = helpers.SetupTestEnv(t, ctx, env)
 
@@ -77,7 +77,7 @@ func bootstrapGateway(ctx context.Context, t *testing.T, env environments.Enviro
 	require.Eventually(t, testutils.GatewayIsProgrammed(t, ctx, gatewayNSN, mgrClient), 3*time.Minute, time.Second)
 	t.Log("Gateway is programmed, proceeding with the test cases")
 
-	return namespace, cleaner, ingressClass, ctrlClient
+	return namespace, cleaner, ingressClass, ctrlClient, gatewayClass
 }
 
 // kongRouterFlavor returns router mode of Kong in tests.

--- a/test/integration/validatingwebhook/validating_httproute_test.go
+++ b/test/integration/validatingwebhook/validating_httproute_test.go
@@ -20,7 +20,6 @@ type testCaseHTTPRouteValidation struct {
 	// ExpressionsRouterOnly indicates that the test case only applies to expressions router mode.
 	// If true and not in expressions router mode, the WantCreateErrSubstring is ignored (expect success).
 	ExpressionsRouterOnly bool
-	SkipReason            string
 }
 
 func TestAdmissionWebhook_HTTPRoute(t *testing.T) {
@@ -202,7 +201,6 @@ func TestAdmissionWebhook_HTTPRoute(t *testing.T) {
 				},
 			},
 			WantCreateErrSubstring: "HTTPRoute failed schema validation",
-			SkipReason:             "This test case is flaky. See https://github.com/Kong/kong-operator/issues/3207 for details.",
 		},
 		{
 			Name: "a httproute with an invalid header regex fails validation",
@@ -225,16 +223,11 @@ func TestAdmissionWebhook_HTTPRoute(t *testing.T) {
 				},
 			},
 			WantCreateErrSubstring: "HTTPRoute failed schema validation",
-			SkipReason:             "This test case is flaky. See https://github.com/Kong/kong-operator/issues/3207 for details.",
 		},
 	}
 
 	for _, tC := range testCases {
 		t.Run(tC.Name, func(t *testing.T) {
-			if tC.SkipReason != "" {
-				t.Skip(tC.SkipReason)
-			}
-
 			_, err := gatewayClient.GatewayV1().HTTPRoutes(ns.Name).Create(ctx, tC.Route, metav1.CreateOptions{})
 
 			wantErr := tC.WantCreateErrSubstring

--- a/test/integration/validatingwebhook/validating_ingress_test.go
+++ b/test/integration/validatingwebhook/validating_ingress_test.go
@@ -22,7 +22,7 @@ func TestAdmissionWebhook_Ingress(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	ns, _, ingressClass, _ := bootstrapGateway(ctx, t, integration.GetEnv(), integration.GetClients().MgrClient)
+	ns, _, ingressClass, _, _ := bootstrapGateway(ctx, t, integration.GetEnv(), integration.GetClients().MgrClient) //nolint:dogsled
 
 	k8sClient := integration.GetEnv().Cluster().Client()
 

--- a/test/integration/validatingwebhook/validating_kongconsumers_test.go
+++ b/test/integration/validatingwebhook/validating_kongconsumers_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestAdmissionWebhook_KongConsumers(t *testing.T) {
 	ctx := t.Context()
-	namespace, cleaner, ingressClass, ctrlClient := bootstrapGateway(
+	namespace, cleaner, ingressClass, ctrlClient, _ := bootstrapGateway(
 		ctx, t, integration.GetEnv(), integration.GetClients().MgrClient,
 	)
 

--- a/test/integration/validatingwebhook/validating_kongcustomentities_test.go
+++ b/test/integration/validatingwebhook/validating_kongcustomentities_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAdmissionWebhook_KongCustomEntities(t *testing.T) {
 	ctx := t.Context()
-	_, cleaner, ingressClass, ctrlClient := bootstrapGateway(
+	_, cleaner, ingressClass, ctrlClient, _ := bootstrapGateway(
 		ctx, t, integration.GetEnv(), integration.GetClients().MgrClient,
 	)
 

--- a/test/integration/validatingwebhook/validating_kongplugins_test.go
+++ b/test/integration/validatingwebhook/validating_kongplugins_test.go
@@ -25,7 +25,7 @@ var secretLabels = map[string]string{
 }
 
 func TestAdmissionWebhook_KongPlugins(t *testing.T) {
-	_, _, _, ctrlClient := bootstrapGateway(t.Context(), t, integration.GetEnv(), integration.GetClients().MgrClient) //nolint:dogsled
+	_, _, _, ctrlClient, _ := bootstrapGateway(t.Context(), t, integration.GetEnv(), integration.GetClients().MgrClient) //nolint:dogsled
 
 	testCases := []struct {
 		name          string
@@ -230,7 +230,7 @@ func TestAdmissionWebhook_KongClusterPlugins(t *testing.T) {
 
 	ctrlClientGlobal := integration.GetClients().MgrClient
 
-	ns, _, ingressClass, ctrlClient := bootstrapGateway(t.Context(), t, integration.GetEnv(), ctrlClientGlobal)
+	ns, _, ingressClass, ctrlClient, _ := bootstrapGateway(t.Context(), t, integration.GetEnv(), ctrlClientGlobal)
 
 	testCases := []struct {
 		name                string

--- a/test/integration/validatingwebhook/validating_kongvault_test.go
+++ b/test/integration/validatingwebhook/validating_kongvault_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestAdmissionWebhook_KongVault(t *testing.T) {
 	ctx := t.Context()
-	_, cleaner, ingressClass, ctrlClient := bootstrapGateway(
+	_, cleaner, ingressClass, ctrlClient, _ := bootstrapGateway(
 		ctx, t, integration.GetEnv(), integration.GetClients().MgrClient,
 	)
 

--- a/test/integration/validatingwebhook/validating_secretcredentials_test.go
+++ b/test/integration/validatingwebhook/validating_secretcredentials_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestAdmissionWebhook_SecretCredentials(t *testing.T) {
 	ctx := t.Context()
-	_, cleaner, ingressClass, ctrlClient := bootstrapGateway(
+	_, cleaner, ingressClass, ctrlClient, _ := bootstrapGateway(
 		ctx, t, integration.GetEnv(), integration.GetClients().MgrClient,
 	)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I have added a `validateHTTPRouteRegexes` function; the configuration will be checked via this function first, then sent to the Admin API.

**Which issue this PR fixes**

Fixes https://github.com/Kong/kong-operator/issues/3207

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
