### PR TITLE
chore: remove renovate tag for vuln

### DIFF
--- a/.tools_versions.yaml
+++ b/.tools_versions.yaml
@@ -34,8 +34,16 @@ shellcheck: "0.11.0"
 #  WARN: Attempting to use non-git url for git operations (repository=local)
 #        "url": "vuln"
 #
+# Renovate UI errors:
+# These problems occurred while renovating this repository.
+
+# ⚠️ Custom registries are not allowed for this datasource and will be ignored
+# ⚠️ Attempting to use non-git url for git operations
+# ⚠️ Package lookup failures
+#
 # TODO: Make this work.
-# renovate: datasource=git-tags depName=vuln registryUrl=https://go.googlesource.com
+#
+# todo: datasource=git-tags depName=vuln registryUrl=https://go.googlesource.com
 govulncheck: "1.1.4"
 # renovate: datasource=github-releases depName=jlandowner/helm-chartsnap
 chartsnap: "0.6.0"


### PR DESCRIPTION
**What this PR does / why we need it**:

`vuln` cannot be updated with renovate and it causes errors in UI (and when running renovate cli):

```
WARN: Custom registries are not allowed for this datasource and will be ignored (repository=local)
      "datasource": "git-tags",
      "registryUrls": ["https://go.googlesource.com/"],
      "defaultRegistryUrls": null,
      "additionalRegistryUrls": undefined
WARN: Attempting to use non-git url for git operations (repository=local)
      "url": "vuln"
```

So this PR removes it.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
