### PR TITLE
chart: fix rendering webhook-certs volume and volume mount when `ko-crds.enabled=false`

### DIFF
--- a/.github/workflows/charts-tests.yaml
+++ b/.github/workflows/charts-tests.yaml
@@ -172,10 +172,12 @@ jobs:
       - name: Install cert-manager
         run: make install.helm.cert-manager
 
+      - name: Install CRDs
+        run: make install.crds
+
       - name: Run chart-testing (install)
         run: |
           kubectl create ns kong-test
-          make install.helm.cert-manager
           make test.charts.ct.install CHART_NAME=${{ matrix.chart-name}}
           # No need to delete the ns the cluster is scrapped after the job anyway.
 

--- a/Makefile
+++ b/Makefile
@@ -870,20 +870,23 @@ test.charts.golden.update:
 
 .PHONY: test.charts.ct.install
 test.charts.ct.install:
-# NOTE: We add ko-crds.keep=false below because allowing the chart to manage CRDs
+# NOTE: We add ko-crds.enabled=false below to handle CRD management outside of ct.
+# This is to work around the flaky CRD uninstall behavior of ct.
+# Without this, CRDs created by one test helm release installation
+# would sometimes not get removed upon uninstalling the release,
 # and keep them around after helm uninstall would yield ownership issues.
 # Error: INSTALLATION FAILED: Unable to continue with install: CustomResourceDefinition "aigateways.gateway-operator.konghq.com" in namespace ""
 # exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-name"
 # must equal "kong-operator-h39gau9scc": current value is "kong-operator-tiptva339m"
 #
-# NOTE: We add the --wait below to ensure that we wait for all objects to get removed
-# for each release. Without this, some objects like CRDs can still be around
-# when another test helm release is being installed and the above mentioned
-# ownership error will be returned.
+# This could potentially be solved by setting the --cascade foreground option
+# to helm uninstall command in ct, but ct does not currently support passing
+# extra args to helm uninstall.
+# There's an open PR for this: https://github.com/helm/chart-testing/pull/806
 
 	ct install --target-branch main \
 		--debug \
-		--helm-extra-set-args "--set=ko-crds.keep=false" \
+		--helm-extra-set-args "--set=ko-crds.enabled=false" \
 		--helm-extra-args "--wait" \
 		--helm-extra-args "--timeout=3m" \
 		--charts charts/$(CHART_NAME) \
@@ -1069,6 +1072,10 @@ uninstall.helm.cert-manager: download.helm
 # Install CRDs into the K8s cluster specified in ~/.kube/config.
 .PHONY: install
 install: install.helm.cert-manager manifests kustomize install.gateway-api-crds
+	$(MAKE) install.crds
+
+.PHONY: install.crds
+install.crds: kustomize
 	$(KUSTOMIZE) build config/crd | kubectl apply --server-side -f -
 
 # Install RBACs from config/rbac into the K8s cluster specified in ~/.kube/config.
@@ -1085,8 +1092,11 @@ install.all: install.helm.cert-manager manifests kustomize install.gateway-api-c
 # Call with ignore-not-found=true to ignore resource not found errors during deletion.
 .PHONY: uninstall
 uninstall: manifests kustomize uninstall.gateway-api-crds uninstall.helm.cert-manager
-	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+	$(MAKE) uninstall.crds
 
+.PHONY: uninstall.crds
+uninstall.crds: kustomize
+	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 # Uninstall standard and experimental CRDs from the K8s cluster specified in ~/.kube/config.
 # Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/charts/kong-operator/CHANGELOG.md
+++ b/charts/kong-operator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.1.1
+
+### Fixes
+
+- Fix an issue with missing volume mount when `ko-crds.enabled=false` is set
+  and conversion webhook is enabled.
+  [#2356](https://github.com/Kong/kong-operator/pull/2356)
+
 ## 1.1.0
 
 ### Changed

--- a/charts/kong-operator/Chart.yaml
+++ b/charts/kong-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong-operator
 sources:
   - https://github.com/Kong/kong-operator/charts/kong-operator/
-version: 1.1.0
+version: 1.1.1
 appVersion: "2.1.0"
 annotations:
   artifacthub.io/category: networking

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.0
+        helm.sh/chart: kong-operator-1.1.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57992,7 +57992,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57864,7 +57864,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57892,7 +57892,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.0
+        helm.sh/chart: kong-operator-1.1.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -58005,7 +58005,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.0
+        helm.sh/chart: kong-operator-1.1.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57984,7 +57984,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.0
+        helm.sh/chart: kong-operator-1.1.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57986,7 +57986,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.0
+        helm.sh/chart: kong-operator-1.1.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57986,7 +57986,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     a: "b"
@@ -57848,7 +57848,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     a: "b"
@@ -57877,7 +57877,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.0
+        helm.sh/chart: kong-operator-1.1.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         a: "b"
@@ -57985,7 +57985,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     a: "b"

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.0
+        helm.sh/chart: kong-operator-1.1.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57984,7 +57984,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.0
+        helm.sh/chart: kong-operator-1.1.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57982,7 +57982,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57876,7 +57876,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.0
+        helm.sh/chart: kong-operator-1.1.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57983,7 +57983,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.0
+        helm.sh/chart: kong-operator-1.1.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57984,7 +57984,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.0
+        helm.sh/chart: kong-operator-1.1.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57986,7 +57986,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.0
+        helm.sh/chart: kong-operator-1.1.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57982,7 +57982,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -30,7 +30,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -31337,7 +31337,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -31365,7 +31365,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.0
+        helm.sh/chart: kong-operator-1.1.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -31464,7 +31464,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -57797,7 +57797,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57825,7 +57825,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.0
+        helm.sh/chart: kong-operator-1.1.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57935,7 +57935,7 @@ metadata:
     cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "internal" } }'
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -58052,7 +58052,7 @@ kind: Certificate
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -58073,7 +58073,7 @@ kind: Certificate
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -58094,7 +58094,7 @@ kind: Issuer
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -31295,7 +31295,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.0
+    helm.sh/chart: kong-operator-1.1.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -31323,7 +31323,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.0
+        helm.sh/chart: kong-operator-1.1.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko

--- a/charts/kong-operator/templates/_helpers.tpl
+++ b/charts/kong-operator/templates/_helpers.tpl
@@ -161,16 +161,13 @@ The dict maps raw env variable key to the suggested variable path.
 
 {{- define "kong.volumes" -}}
 {{ if .Values.global.webhooks.conversion.enabled }}
-{{- /* This volume is conditional on ko-crds being enabled because the certificate */ -}}
-{{- /* Secret is placed in that subchart. The reason for this is explained in */ -}}
-{{- /* https://github.com/Kong/kong-operator/blob/e555dbc0b6e57beecbb72cf79018ef8fdbe11ffa/hack/generators/conversion-webhook/main.go#L88-L95 */ -}}
-{{ $kocrds := (index .Values "ko-crds") }}
-{{ if $kocrds.enabled }}
+{{- /* Depending on the global.webhooks.options.certManager.enabled being true or false */ -}}
+{{- /* certificate below will either be sourced from chart generated Secret */ -}}
+{{- /* or from cert-manager generated Secret */ -}}
 - name: webhook-certs
   secret:
     defaultMode: 420
     secretName: {{ template "kong.webhookCertSecretName" . }}
-{{ end }}
 {{ end }}
 {{ if .Values.global.webhooks.validating.enabled }}
 - name: validating-webhook-certs
@@ -188,15 +185,12 @@ The dict maps raw env variable key to the suggested variable path.
 
 {{- define "kong.volumeMounts" -}}
 {{ if .Values.global.webhooks.conversion.enabled }}
-{{- /* This mount is conditional on ko-crds being enabled because the certificate */ -}}
-{{- /* Secret is placed in that subchart. The reason for this is explained in */ -}}
-{{- /* https://github.com/Kong/kong-operator/blob/e555dbc0b6e57beecbb72cf79018ef8fdbe11ffa/hack/generators/conversion-webhook/main.go#L88-L95 */ -}}
-{{ $kocrds := (index .Values "ko-crds") }}
-{{ if $kocrds.enabled }}
+{{- /* Depending on the global.webhooks.options.certManager.enabled being true or false */ -}}
+{{- /* certificate below will either be sourced from chart generated Secret */ -}}
+{{- /* or from cert-manager generated Secret */ -}}
 - name: webhook-certs
   mountPath: /tmp/k8s-webhook-server/serving-certs
   readOnly: true
-{{ end }}
 {{ end }}
 {{ if .Values.global.webhooks.validating.enabled }}
 - name: validating-webhook-certs


### PR DESCRIPTION
**What this PR does / why we need it**:

This aims to fix an issue with chart-testing tests.

By default these install and uninstall helm chart releases, which also mean installing and uninstalling CRDs. This could potentially fail if e.g. CRD uninstallation hangs or takes too long. To mitigate this we use `ko-crds.enabled=false` and add CRD installation step before running tests.

This ensures that CRDs are not managed by the tool which sometimes causes flaky failures like:

```
Error: INSTALLATION FAILED: unable to continue with install: CustomResourceDefinition "kongcredentialacls.configuration.konghq.com" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-name" must equal "kong-operator-r7m2sw01j8": current value is "kong-operator-ul3dia4owf"
```

Additionally, while working on this it was discovered that `webhook-certs` volume was not mounted when `ko-crds.enabled=false`, this caused failures in operator container:

```
{"level":"error","ts":"2026-02-05T17:41:54Z","msg":"failed to run manager","error":"problem running manager: open /tmp/k8s-webhook-server/serving-certs/tls.crt: no such file or directory","stacktrace":"main.main\n\t/worksp
ace/cmd/main.go:42\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:285"}
```

To fix this, this PR also removes the conditional in chart template which does not look not at at the `ko-crds.enabled` when deciding whether to render the `webhook-certs` volume (and corresponding volume mount).

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
