### PR TITLE
fix: fix setting up indices for HTTPRoute and Gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
 
+## Unreleased
+
+### Fixes
+
+- Fix setting up indices for HTTPRoute and Gateway when Konnect controllers are disabled.
+  [#3229](https://github.com/Kong/kong-operator/pull/3229)
+
 ## [v2.1.0]
 
 ### Added

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -97,7 +97,11 @@ func SetupCacheIndexes(ctx context.Context, mgr manager.Manager, cfg Config) err
 	}
 
 	if cfg.GatewayControllerEnabled {
-		indexOptions = append(indexOptions, index.OptionsForGatewayClass()...)
+		indexOptions = slices.Concat(indexOptions,
+			index.OptionsForGatewayClass(),
+			index.OptionsForGateway(),
+			index.OptionsForHTTPRoute(),
+		)
 	}
 
 	if cfg.KonnectControllersEnabled {
@@ -128,8 +132,6 @@ func SetupCacheIndexes(ctx context.Context, mgr manager.Manager, cfg Config) err
 			index.OptionsForKonnectCloudGatewayNetwork(),
 			index.OptionsForKonnectExtension(),
 			index.OptionsForKonnectCloudGatewayDataPlaneGroupConfiguration(cl),
-			index.OptionsForHTTPRoute(),
-			index.OptionsForGateway(),
 		)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

HTTPRoute and Gateway indices should be set when Gateway controller is enabled not when connect controllers are enabled.

This will prevent:

```
{
	"level": "error",
	"ts": "2026-02-05T17:03:51Z",
	"msg": "failed to list indexed gateways for Secret watch",
	"secret": {
		"name": "kong-operator-ca",
		"namespace": "kong"
	},
	"error": "Index with name field:TLSCertificateSecretsOnGateway do
es not exist",
	"stacktrace": "github.com/kong/kong-operator/controller/gateway.(*Reconciler).listGatewayReconcileRequestsForSecret
        /workspace/controller/gateway/controller_watch.go:127\nsigs.k8s.io/controller-runtime/pkg/
handler.(*enqueueRequestsFromMapFunc[...]).mapAndEnqueue
    /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/handler/enqueue_mapped.go:140\nsigs.k8s.io/controller-runtime/pkg/handler.(*enqueueRequestsFrom
MapFunc[...]).Create
    /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/handler/enqueue_mapped.go:95\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*EventHandler[...]).OnAdd
    /home/runner/go/pkg/
mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/source/event_handler.go:86\nk8s.io/client-go/tools/cache.(*processorListener).run.func1
    /home/runner/go/pkg/mod/k8s.io/client-go@v0.35.0/tools/cache/shared_informe
r.go:1074\nk8s.io/client-go/tools/cache.(*processorListener).run
    /home/runner/go/pkg/mod/k8s.io/client-go@v0.35.0/tools/cache/shared_informer.go:1084\nk8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1
    /home/runn
er/go/pkg/mod/k8s.io/apimachinery@v0.35.0/pkg/util/wait/wait.go:72"
}
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
