### PR TITLE
chore: bump min Go version to 1.25.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kong-operator
 
-go 1.25.6
+go 1.25.7
 
 require (
 	cloud.google.com/go/container v1.46.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix to mitigate: [GO-2026-4337](https://pkg.go.dev/vuln/GO-2026-4337) (aka CVE-2025-68121)

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
