### PR TITLE
tests: handle Konnect rate limit in kongintegration tests

### DIFF
--- a/.github/workflows/_kongintegration_tests.yaml
+++ b/.github/workflows/_kongintegration_tests.yaml
@@ -56,6 +56,7 @@ jobs:
           MISE_VERBOSE: 1
           MISE_DEBUG: 1
           GOTESTSUM_JUNITFILE: ${{ env.GOTESTSUM_JUNITFILE }}
+          KONG_CUSTOM_DOMAIN: konghq.tech
           TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
           TEST_KONG_ENTERPRISE: ${{ matrix.enterprise }}

--- a/hack/cleanup/konnect_control_planes.go
+++ b/hack/cleanup/konnect_control_planes.go
@@ -17,13 +17,13 @@ import (
 
 	"github.com/kong/kong-operator/controller/konnect/ops"
 	"github.com/kong/kong-operator/test"
+	"github.com/kong/kong-operator/test/helpers/deploy"
 )
 
 const (
 	konnectControlPlanesLimit     = int64(100)
 	timeUntilControlPlaneOrphaned = time.Hour
 
-	testIDLabel                       = "operator-test-id"
 	k8sKindKonnectGatewayControlPlane = "KonnectGatewayControlPlane"
 )
 
@@ -104,7 +104,7 @@ func findOrphanedControlPlanes(
 	// 1. Control planes created by integration tests (with `operator-test-id` label)
 	// 2. Control planes managed by KO (with `k8s-kind:KonnectGatewayControlPlane` label)
 	labelFilters := []string{
-		testIDLabel,
+		deploy.KonnectTestIDLabel,
 		fmt.Sprintf("%s:%s", ops.KubernetesKindLabelKey, k8sKindKonnectGatewayControlPlane),
 	}
 

--- a/ingress-controller/test/e2e/konnect_test.go
+++ b/ingress-controller/test/e2e/konnect_test.go
@@ -40,8 +40,9 @@ func TestKonnectConfigPush(t *testing.T) {
 
 	ctx, env := setupE2ETest(t)
 
-	cpID := testkonnect.CreateTestControlPlane(ctx, t)
-	cert, key := testkonnect.CreateClientCertificate(ctx, t, cpID)
+	token := testkonnect.CreateTestPersonalAccessToken(ctx, t)
+	cpID := testkonnect.CreateTestControlPlane(ctx, t, token)
+	cert, key := testkonnect.CreateClientCertificate(ctx, t, cpID, token)
 	createKonnectClientSecretAndConfigMap(ctx, t, env, cert, key, cpID)
 
 	deployments := deployAllInOneKonnectManifest(ctx, t, env)
@@ -65,8 +66,9 @@ func TestKonnectLicenseActivation(t *testing.T) {
 
 	ctx, env := setupE2ETest(t)
 
-	rgID := testkonnect.CreateTestControlPlane(ctx, t)
-	cert, key := testkonnect.CreateClientCertificate(ctx, t, rgID)
+	token := testkonnect.CreateTestPersonalAccessToken(ctx, t)
+	rgID := testkonnect.CreateTestControlPlane(ctx, t, token)
+	cert, key := testkonnect.CreateClientCertificate(ctx, t, rgID, token)
 	createKonnectClientSecretAndConfigMap(ctx, t, env, cert, key, rgID)
 
 	const manifestFile = "manifests/all-in-one-dbless-konnect-enterprise.yaml"
@@ -130,8 +132,9 @@ func TestKonnectWhenMisconfiguredBasicIngressNotAffected(t *testing.T) {
 	testkonnect.SkipIfMissingRequiredKonnectEnvVariables(t)
 	ctx, env := setupE2ETest(t)
 
-	rgID := testkonnect.CreateTestControlPlane(ctx, t)
-	cert, key := testkonnect.CreateClientCertificate(ctx, t, rgID)
+	token := testkonnect.CreateTestPersonalAccessToken(ctx, t)
+	rgID := testkonnect.CreateTestControlPlane(ctx, t, token)
+	cert, key := testkonnect.CreateClientCertificate(ctx, t, rgID, token)
 
 	// create a Konnect client secret and config map with a non-existing control plane ID to simulate misconfiguration
 	notExistingRgID := "not-existing-cp-id"

--- a/ingress-controller/test/helpers/konnect/control_plane.go
+++ b/ingress-controller/test/helpers/konnect/control_plane.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/avast/retry-go/v4"
 	"github.com/google/uuid"
@@ -25,14 +26,21 @@ import (
 
 // CreateTestControlPlane creates a control plane to be used in tests. It returns the created control plane's ID.
 // It also sets up a cleanup function for it to be deleted.
-func CreateTestControlPlane(ctx context.Context, t *testing.T) string {
+// If a token is provided, it will be used to create the control plane.
+// Otherwise, the default access token will be used.
+func CreateTestControlPlane(ctx context.Context, t *testing.T, token ...string) string {
 	t.Helper()
 
-	sdk := sdk.New(accessToken(), serverURLOpt())
+	var s *sdkkonnectgo.SDK
+	if len(token) == 0 {
+		s = sdk.New(accessToken(), serverURLOpt())
+	} else {
+		s = sdk.New(token[0], serverURLOpt())
+	}
 
 	var cpID string
 	createRgErr := retry.Do(func() error {
-		createResp, err := sdk.ControlPlanes.CreateControlPlane(ctx,
+		createResp, err := s.ControlPlanes.CreateControlPlane(ctx,
 			sdkkonnectcomp.CreateControlPlaneRequest{
 				Name:        uuid.NewString(),
 				Description: lo.ToPtr(generateTestKonnectControlPlaneDescription(t)),
@@ -71,7 +79,7 @@ func CreateTestControlPlane(ctx context.Context, t *testing.T) string {
 		t.Logf("deleting test Konnect Control Plane: %q", cpID)
 		err := retry.Do(
 			func() error { //nolint:contextcheck
-				_, err := sdk.ControlPlanes.DeleteControlPlane(context.Background(), cpID)
+				_, err := s.ControlPlanes.DeleteControlPlane(context.Background(), cpID)
 				return err
 			},
 			retry.Attempts(5), retry.Delay(time.Second),

--- a/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
+++ b/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
@@ -106,8 +106,9 @@ func TestKongClientGoldenTestsOutputs_Konnect(t *testing.T) {
 
 	ctx := t.Context()
 
-	cpID := konnect.CreateTestControlPlane(ctx, t)
-	cert, key := konnect.CreateClientCertificate(ctx, t, cpID)
+	token := konnect.CreateTestPersonalAccessToken(ctx, t)
+	cpID := konnect.CreateTestControlPlane(ctx, t, token)
+	cert, key := konnect.CreateClientCertificate(ctx, t, cpID, token)
 	adminAPIClient := konnect.CreateKonnectAdminAPIClient(t, cpID, cert, key)
 	updateStrategy := sendconfig.NewUpdateStrategyDBModeKonnect(adminAPIClient.AdminAPIClient(), dump.Config{
 		SkipCACerts:         true,
@@ -120,8 +121,7 @@ func TestKongClientGoldenTestsOutputs_Konnect(t *testing.T) {
 			require.NoError(t, err)
 
 			content := &file.Content{}
-			err = yaml.Unmarshal(goldenTestOutput, content)
-			require.NoError(t, err)
+			require.NoError(t, yaml.Unmarshal(goldenTestOutput, content))
 
 			require.EventuallyWithT(t, func(t *assert.CollectT) {
 				configSize, err := updateStrategy.Update(ctx, sendconfig.ContentWithHash{Content: content})


### PR DESCRIPTION
## Summary

This PR addresses Konnect API rate limiting issues in `kongintegration` tests by enabling tests to create isolated Personal Access Tokens (PATs) instead of sharing a single access token across all tests.

Additionally, this PR adds 429 error handling in Konnect kongintegration test.

## Problem

Some kongintegration tests were hitting Konnect API rate limits because test runs shared the same access token (`TEST_KONG_KONNECT_ACCESS_TOKEN`). This caused tests to fail intermittently, especially when multiple tests ran concurrently or in quick succession.

## Solution

**Enable per-test PAT creation**: Tests can now create their own time-limited (1-hour) Personal Access Tokens, providing isolated rate limit quotas.

### Key Changes

1. **New PAT management** (`ingress-controller/test/internal/helpers/konnect/personal_access_tokens.go`)
   - Added `CreateTestPersonalAccessToken()` function that:
     - Creates a PAT for the authenticated user
     - Returns the token string for immediate use
     - Automatically cleans up (deletes) the PAT after test completion
     - Includes retry logic for reliability

2. **Updated test helpers** to accept optional token parameters:
   - `CreateTestControlPlane()` - now accepts optional token to use for CP creation
   - `CreateClientCertificate()` - now accepts optional token to use for certificate creation
   - Both functions remain backward compatible (use default token if none provided)

3. **Updated select e2e tests** (`ingress-controller/test/e2e/konnect_test.go`)
   - Modified `TestKonnectConfigPush`, `TestKonnectLicenseActivation`, and `TestKonnectWhenMisconfiguredBasicIngressNotAffected`
   - These tests now: create PAT → create control plane → create certificate
   - Other tests continue using the shared token approach

4. **CI configuration** (`.github/workflows/_kongintegration_tests.yaml`)
   - Added `KONG_CUSTOM_DOMAIN: konghq.tech` environment variable

## Benefits

- **Eliminates rate limit conflicts** for tests that create their own PATs
- **Improves test reliability** by providing isolated quotas where needed
- **Better resource cleanup** - PATs are automatically deleted after tests
- **Backward compatible** - existing tests continue to work unchanged
- **Opt-in approach** - tests can choose to use PATs when needed

## Testing

- PAT creation includes retry logic (5 attempts with 1s delay)
- Tokens expire after 1 hour to prevent token accumulation
- Cleanup ensures no orphaned tokens remain after test completion

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
