### PR TITLE
chore(lint): enable golangci-lint: `asasalint`, `bidichk`, `canonicalheader`, `containedctx`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,8 +9,12 @@ run:
     - performance_tests
 linters:
   enable:
+    - asasalint
     - asciicheck
+    - bidichk
     - bodyclose
+    - canonicalheader
+    - containedctx
     - copyloopvar
     - dogsled
     - durationcheck

--- a/ingress-controller/test/e2e/performance_basic_test.go
+++ b/ingress-controller/test/e2e/performance_basic_test.go
@@ -234,7 +234,7 @@ func isRouteActive(ctx context.Context, t *testing.T, client *http.Client, proxy
 	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/%s", proxyIP, path), nil)
 	require.NoError(t, err)
 	req.Host = fmt.Sprintf("example-%d.com", index)
-	req.Header.Set("apikey", fmt.Sprintf(consumerUsername, index))
+	req.Header.Set("Apikey", fmt.Sprintf(consumerUsername, index))
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/test/integration/kic/isolated/examples_kong_service_facade_test.go
+++ b/test/integration/kic/isolated/examples_kong_service_facade_test.go
@@ -105,13 +105,13 @@ func TestKongServiceFacadeExample(t *testing.T) {
 			t.Run("key-auth endpoint responses", func(t *testing.T) {
 				t.Log("ensuring key-auth endpoint allows a valid key")
 				validKeyAuthReq := newRequest(keyAuthSecuredEndpoint, func(r *http.Request) {
-					r.Header.Set("key", keyAuthValidKey)
+					r.Header.Set("Key", keyAuthValidKey)
 				})
 				respondsWithExpectedStatusCode(t, validKeyAuthReq, http.StatusOK)
 
 				t.Log("ensuring key-auth endpoint doesn't allow an invalid key")
 				invalidKeyAuthReq := newRequest(keyAuthSecuredEndpoint, func(r *http.Request) {
-					r.Header.Set("key", "invalid-pass")
+					r.Header.Set("Key", "invalid-pass")
 				})
 				respondsWithExpectedStatusCode(t, invalidKeyAuthReq, http.StatusUnauthorized)
 
@@ -137,7 +137,7 @@ func TestKongServiceFacadeExample(t *testing.T) {
 
 				t.Log("ensuring basic-auth endpoint doesn't allow a valid key-auth key")
 				invalidBasicAuthUsingKeyAuthReq := newRequest(basicAuthSecuredEndpoint, func(r *http.Request) {
-					r.Header.Set("key", keyAuthValidKey)
+					r.Header.Set("Key", keyAuthValidKey)
 				})
 				respondsWithExpectedStatusCode(t, invalidBasicAuthUsingKeyAuthReq, http.StatusUnauthorized)
 			})


### PR DESCRIPTION
**What this PR does / why we need it**:

One from the series, to keep it reviewable. 

Enable and apply fixes for [asasalint](https://golangci-lint.run/docs/linters/configuration/#asasalint), [bidichk](https://golangci-lint.run/docs/linters/configuration/#bidichk), [canonicalheader](https://golangci-lint.run/docs/linters/configuration/#canonicalheader), [containedctx](https://golangci-lint.run/docs/linters/configuration/#contextcheck)




**Which issue this PR fixes**

Part of 

- https://github.com/Kong/kong-operator/issues/1847

