### PR TITLE
chore(lint): enable golangci-lint: `dupword`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,6 +17,7 @@ linters:
     - containedctx
     - copyloopvar
     - dogsled
+    - dupword
     - durationcheck
     - errorlint
     - exhaustive

--- a/api/gateway-operator/v1alpha1/aigateway_types.go
+++ b/api/gateway-operator/v1alpha1/aigateway_types.go
@@ -12,7 +12,7 @@ import (
 // Machine Learning models such as Large Language Models (LLM).
 //
 // The underlying technology for the AIGateway is the Kong Gateway configured
-// with a variety of plugins which provide the the AI featureset.
+// with a variety of plugins which provide the AI featureset.
 //
 // This is a list of the plugins, which are available in Kong Gateway v3.6.x+:
 //

--- a/api/gateway-operator/v1beta1/controlplane_types.go
+++ b/api/gateway-operator/v1beta1/controlplane_types.go
@@ -119,7 +119,7 @@ type ControlPlaneOptions struct {
 
 // ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
 // configuration results in a Deployment which is managed by the Operator and
-// includes options for managing Deployments such as the the number of replicas
+// includes options for managing Deployments such as the number of replicas
 // or pod options like container image and resource requirements.
 // version, as well as Env variable overrides.
 // +apireference:kgo:include

--- a/api/konnect/v1alpha1/konnect_cloudgateway_transitgateway_types.go
+++ b/api/konnect/v1alpha1/konnect_cloudgateway_transitgateway_types.go
@@ -66,7 +66,7 @@ type KonnectCloudGatewayTransitGatewaySpec struct {
 type TransitGatewayType string
 
 const (
-	// TransitGatewayTypeAWSTransitGateway defines the the AWS transit gateway type.
+	// TransitGatewayTypeAWSTransitGateway defines the AWS transit gateway type.
 	TransitGatewayTypeAWSTransitGateway TransitGatewayType = "AWSTransitGateway"
 	// TransitGatewayTypeAzureTransitGateway defines the Azure transit gateway type.
 	TransitGatewayTypeAzureTransitGateway TransitGatewayType = "AzureTransitGateway"

--- a/api/konnect/v1alpha1/konnect_conditions.go
+++ b/api/konnect/v1alpha1/konnect_conditions.go
@@ -187,19 +187,19 @@ const (
 	DataPlaneCertificateProvisionedReasonProvisioned = "Provisioned"
 	// DataPlaneCertificateProvisionedReasonRefNotFound is the reason
 	// used with the DataPlaneCertificateProvisioned condition type indicating that the
-	// the referenced DataPlane client certificate is not found.
+	// referenced DataPlane client certificate is not found.
 	DataPlaneCertificateProvisionedReasonRefNotFound = "RefNotFound"
 	// DataPlaneCertificateProvisionedReasonInvalidSecret is the reason
 	// used with the DataPlaneCertificateProvisioned condition type indicating that the
-	// the referenced DataPlane client certificate secret is invalid.
+	// referenced DataPlane client certificate secret is invalid.
 	DataPlaneCertificateProvisionedReasonInvalidSecret = "InvalidSecret"
 	// DataPlaneCertificateProvisionedReasonKonnectAPIOpFailed is the reason
 	// used with the DataPlaneCertificateProvisioned condition type indicating that the
-	// the DataPlane client certificate creation in Konnect has failed.
+	// DataPlane client certificate creation in Konnect has failed.
 	DataPlaneCertificateProvisionedReasonKonnectAPIOpFailed = "KonnectAPIOpFailed"
 	// DataPlaneCertificateProvisionedReasonProvisioning is the reason
 	// used with the DataPlaneCertificateProvisioned condition type indicating that the
-	// the DataPlane client certificate creation in Konnect is in progress.
+	// DataPlane client certificate creation in Konnect is in progress.
 	DataPlaneCertificateProvisionedReasonProvisioning = "Provisioning"
 )
 

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -107,7 +107,7 @@ spec:
           Machine Learning models such as Large Language Models (LLM).
 
           The underlying technology for the AIGateway is the Kong Gateway configured
-          with a variety of plugins which provide the the AI featureset.
+          with a variety of plugins which provide the AI featureset.
 
           This is a list of the plugins, which are available in Kong Gateway v3.6.x+:
 
@@ -684,7 +684,7 @@ spec:
                 description: |-
                   ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                   configuration results in a Deployment which is managed by the Operator and
-                  includes options for managing Deployments such as the the number of replicas
+                  includes options for managing Deployments such as the number of replicas
                   or pod options like container image and resource requirements.
                   version, as well as Env variable overrides.
                 properties:
@@ -19215,7 +19215,7 @@ spec:
                     description: |-
                       ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                       configuration results in a Deployment which is managed by the Operator and
-                      includes options for managing Deployments such as the the number of replicas
+                      includes options for managing Deployments such as the number of replicas
                       or pod options like container image and resource requirements.
                       version, as well as Env variable overrides.
                     properties:

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -107,7 +107,7 @@ spec:
           Machine Learning models such as Large Language Models (LLM).
 
           The underlying technology for the AIGateway is the Kong Gateway configured
-          with a variety of plugins which provide the the AI featureset.
+          with a variety of plugins which provide the AI featureset.
 
           This is a list of the plugins, which are available in Kong Gateway v3.6.x+:
 
@@ -684,7 +684,7 @@ spec:
                 description: |-
                   ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                   configuration results in a Deployment which is managed by the Operator and
-                  includes options for managing Deployments such as the the number of replicas
+                  includes options for managing Deployments such as the number of replicas
                   or pod options like container image and resource requirements.
                   version, as well as Env variable overrides.
                 properties:
@@ -19215,7 +19215,7 @@ spec:
                     description: |-
                       ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                       configuration results in a Deployment which is managed by the Operator and
-                      includes options for managing Deployments such as the the number of replicas
+                      includes options for managing Deployments such as the number of replicas
                       or pod options like container image and resource requirements.
                       version, as well as Env variable overrides.
                     properties:

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -107,7 +107,7 @@ spec:
           Machine Learning models such as Large Language Models (LLM).
 
           The underlying technology for the AIGateway is the Kong Gateway configured
-          with a variety of plugins which provide the the AI featureset.
+          with a variety of plugins which provide the AI featureset.
 
           This is a list of the plugins, which are available in Kong Gateway v3.6.x+:
 
@@ -684,7 +684,7 @@ spec:
                 description: |-
                   ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                   configuration results in a Deployment which is managed by the Operator and
-                  includes options for managing Deployments such as the the number of replicas
+                  includes options for managing Deployments such as the number of replicas
                   or pod options like container image and resource requirements.
                   version, as well as Env variable overrides.
                 properties:
@@ -19215,7 +19215,7 @@ spec:
                     description: |-
                       ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                       configuration results in a Deployment which is managed by the Operator and
-                      includes options for managing Deployments such as the the number of replicas
+                      includes options for managing Deployments such as the number of replicas
                       or pod options like container image and resource requirements.
                       version, as well as Env variable overrides.
                     properties:

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -107,7 +107,7 @@ spec:
           Machine Learning models such as Large Language Models (LLM).
 
           The underlying technology for the AIGateway is the Kong Gateway configured
-          with a variety of plugins which provide the the AI featureset.
+          with a variety of plugins which provide the AI featureset.
 
           This is a list of the plugins, which are available in Kong Gateway v3.6.x+:
 
@@ -684,7 +684,7 @@ spec:
                 description: |-
                   ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                   configuration results in a Deployment which is managed by the Operator and
-                  includes options for managing Deployments such as the the number of replicas
+                  includes options for managing Deployments such as the number of replicas
                   or pod options like container image and resource requirements.
                   version, as well as Env variable overrides.
                 properties:
@@ -19215,7 +19215,7 @@ spec:
                     description: |-
                       ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                       configuration results in a Deployment which is managed by the Operator and
-                      includes options for managing Deployments such as the the number of replicas
+                      includes options for managing Deployments such as the number of replicas
                       or pod options like container image and resource requirements.
                       version, as well as Env variable overrides.
                     properties:

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -107,7 +107,7 @@ spec:
           Machine Learning models such as Large Language Models (LLM).
 
           The underlying technology for the AIGateway is the Kong Gateway configured
-          with a variety of plugins which provide the the AI featureset.
+          with a variety of plugins which provide the AI featureset.
 
           This is a list of the plugins, which are available in Kong Gateway v3.6.x+:
 
@@ -684,7 +684,7 @@ spec:
                 description: |-
                   ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                   configuration results in a Deployment which is managed by the Operator and
-                  includes options for managing Deployments such as the the number of replicas
+                  includes options for managing Deployments such as the number of replicas
                   or pod options like container image and resource requirements.
                   version, as well as Env variable overrides.
                 properties:
@@ -19215,7 +19215,7 @@ spec:
                     description: |-
                       ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                       configuration results in a Deployment which is managed by the Operator and
-                      includes options for managing Deployments such as the the number of replicas
+                      includes options for managing Deployments such as the number of replicas
                       or pod options like container image and resource requirements.
                       version, as well as Env variable overrides.
                     properties:

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -108,7 +108,7 @@ spec:
           Machine Learning models such as Large Language Models (LLM).
 
           The underlying technology for the AIGateway is the Kong Gateway configured
-          with a variety of plugins which provide the the AI featureset.
+          with a variety of plugins which provide the AI featureset.
 
           This is a list of the plugins, which are available in Kong Gateway v3.6.x+:
 
@@ -685,7 +685,7 @@ spec:
                 description: |-
                   ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                   configuration results in a Deployment which is managed by the Operator and
-                  includes options for managing Deployments such as the the number of replicas
+                  includes options for managing Deployments such as the number of replicas
                   or pod options like container image and resource requirements.
                   version, as well as Env variable overrides.
                 properties:
@@ -19216,7 +19216,7 @@ spec:
                     description: |-
                       ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                       configuration results in a Deployment which is managed by the Operator and
-                      includes options for managing Deployments such as the the number of replicas
+                      includes options for managing Deployments such as the number of replicas
                       or pod options like container image and resource requirements.
                       version, as well as Env variable overrides.
                     properties:

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -107,7 +107,7 @@ spec:
           Machine Learning models such as Large Language Models (LLM).
 
           The underlying technology for the AIGateway is the Kong Gateway configured
-          with a variety of plugins which provide the the AI featureset.
+          with a variety of plugins which provide the AI featureset.
 
           This is a list of the plugins, which are available in Kong Gateway v3.6.x+:
 
@@ -684,7 +684,7 @@ spec:
                 description: |-
                   ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                   configuration results in a Deployment which is managed by the Operator and
-                  includes options for managing Deployments such as the the number of replicas
+                  includes options for managing Deployments such as the number of replicas
                   or pod options like container image and resource requirements.
                   version, as well as Env variable overrides.
                 properties:
@@ -19215,7 +19215,7 @@ spec:
                     description: |-
                       ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                       configuration results in a Deployment which is managed by the Operator and
-                      includes options for managing Deployments such as the the number of replicas
+                      includes options for managing Deployments such as the number of replicas
                       or pod options like container image and resource requirements.
                       version, as well as Env variable overrides.
                     properties:

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -107,7 +107,7 @@ spec:
           Machine Learning models such as Large Language Models (LLM).
 
           The underlying technology for the AIGateway is the Kong Gateway configured
-          with a variety of plugins which provide the the AI featureset.
+          with a variety of plugins which provide the AI featureset.
 
           This is a list of the plugins, which are available in Kong Gateway v3.6.x+:
 
@@ -684,7 +684,7 @@ spec:
                 description: |-
                   ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                   configuration results in a Deployment which is managed by the Operator and
-                  includes options for managing Deployments such as the the number of replicas
+                  includes options for managing Deployments such as the number of replicas
                   or pod options like container image and resource requirements.
                   version, as well as Env variable overrides.
                 properties:
@@ -19215,7 +19215,7 @@ spec:
                     description: |-
                       ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                       configuration results in a Deployment which is managed by the Operator and
-                      includes options for managing Deployments such as the the number of replicas
+                      includes options for managing Deployments such as the number of replicas
                       or pod options like container image and resource requirements.
                       version, as well as Env variable overrides.
                     properties:

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -107,7 +107,7 @@ spec:
           Machine Learning models such as Large Language Models (LLM).
 
           The underlying technology for the AIGateway is the Kong Gateway configured
-          with a variety of plugins which provide the the AI featureset.
+          with a variety of plugins which provide the AI featureset.
 
           This is a list of the plugins, which are available in Kong Gateway v3.6.x+:
 
@@ -684,7 +684,7 @@ spec:
                 description: |-
                   ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                   configuration results in a Deployment which is managed by the Operator and
-                  includes options for managing Deployments such as the the number of replicas
+                  includes options for managing Deployments such as the number of replicas
                   or pod options like container image and resource requirements.
                   version, as well as Env variable overrides.
                 properties:
@@ -19215,7 +19215,7 @@ spec:
                     description: |-
                       ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                       configuration results in a Deployment which is managed by the Operator and
-                      includes options for managing Deployments such as the the number of replicas
+                      includes options for managing Deployments such as the number of replicas
                       or pod options like container image and resource requirements.
                       version, as well as Env variable overrides.
                     properties:

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -107,7 +107,7 @@ spec:
           Machine Learning models such as Large Language Models (LLM).
 
           The underlying technology for the AIGateway is the Kong Gateway configured
-          with a variety of plugins which provide the the AI featureset.
+          with a variety of plugins which provide the AI featureset.
 
           This is a list of the plugins, which are available in Kong Gateway v3.6.x+:
 
@@ -684,7 +684,7 @@ spec:
                 description: |-
                   ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                   configuration results in a Deployment which is managed by the Operator and
-                  includes options for managing Deployments such as the the number of replicas
+                  includes options for managing Deployments such as the number of replicas
                   or pod options like container image and resource requirements.
                   version, as well as Env variable overrides.
                 properties:
@@ -19215,7 +19215,7 @@ spec:
                     description: |-
                       ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                       configuration results in a Deployment which is managed by the Operator and
-                      includes options for managing Deployments such as the the number of replicas
+                      includes options for managing Deployments such as the number of replicas
                       or pod options like container image and resource requirements.
                       version, as well as Env variable overrides.
                     properties:

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -107,7 +107,7 @@ spec:
           Machine Learning models such as Large Language Models (LLM).
 
           The underlying technology for the AIGateway is the Kong Gateway configured
-          with a variety of plugins which provide the the AI featureset.
+          with a variety of plugins which provide the AI featureset.
 
           This is a list of the plugins, which are available in Kong Gateway v3.6.x+:
 
@@ -684,7 +684,7 @@ spec:
                 description: |-
                   ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                   configuration results in a Deployment which is managed by the Operator and
-                  includes options for managing Deployments such as the the number of replicas
+                  includes options for managing Deployments such as the number of replicas
                   or pod options like container image and resource requirements.
                   version, as well as Env variable overrides.
                 properties:
@@ -19215,7 +19215,7 @@ spec:
                     description: |-
                       ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                       configuration results in a Deployment which is managed by the Operator and
-                      includes options for managing Deployments such as the the number of replicas
+                      includes options for managing Deployments such as the number of replicas
                       or pod options like container image and resource requirements.
                       version, as well as Env variable overrides.
                     properties:

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -107,7 +107,7 @@ spec:
           Machine Learning models such as Large Language Models (LLM).
 
           The underlying technology for the AIGateway is the Kong Gateway configured
-          with a variety of plugins which provide the the AI featureset.
+          with a variety of plugins which provide the AI featureset.
 
           This is a list of the plugins, which are available in Kong Gateway v3.6.x+:
 
@@ -684,7 +684,7 @@ spec:
                 description: |-
                   ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                   configuration results in a Deployment which is managed by the Operator and
-                  includes options for managing Deployments such as the the number of replicas
+                  includes options for managing Deployments such as the number of replicas
                   or pod options like container image and resource requirements.
                   version, as well as Env variable overrides.
                 properties:
@@ -19215,7 +19215,7 @@ spec:
                     description: |-
                       ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                       configuration results in a Deployment which is managed by the Operator and
-                      includes options for managing Deployments such as the the number of replicas
+                      includes options for managing Deployments such as the number of replicas
                       or pod options like container image and resource requirements.
                       version, as well as Env variable overrides.
                     properties:

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -82,7 +82,7 @@ spec:
           Machine Learning models such as Large Language Models (LLM).
 
           The underlying technology for the AIGateway is the Kong Gateway configured
-          with a variety of plugins which provide the the AI featureset.
+          with a variety of plugins which provide the AI featureset.
 
           This is a list of the plugins, which are available in Kong Gateway v3.6.x+:
 

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -57,7 +57,7 @@ spec:
           Machine Learning models such as Large Language Models (LLM).
 
           The underlying technology for the AIGateway is the Kong Gateway configured
-          with a variety of plugins which provide the the AI featureset.
+          with a variety of plugins which provide the AI featureset.
 
           This is a list of the plugins, which are available in Kong Gateway v3.6.x+:
 
@@ -634,7 +634,7 @@ spec:
                 description: |-
                   ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                   configuration results in a Deployment which is managed by the Operator and
-                  includes options for managing Deployments such as the the number of replicas
+                  includes options for managing Deployments such as the number of replicas
                   or pod options like container image and resource requirements.
                   version, as well as Env variable overrides.
                 properties:
@@ -19165,7 +19165,7 @@ spec:
                     description: |-
                       ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                       configuration results in a Deployment which is managed by the Operator and
-                      includes options for managing Deployments such as the the number of replicas
+                      includes options for managing Deployments such as the number of replicas
                       or pod options like container image and resource requirements.
                       version, as well as Env variable overrides.
                     properties:

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -57,7 +57,7 @@ spec:
           Machine Learning models such as Large Language Models (LLM).
 
           The underlying technology for the AIGateway is the Kong Gateway configured
-          with a variety of plugins which provide the the AI featureset.
+          with a variety of plugins which provide the AI featureset.
 
           This is a list of the plugins, which are available in Kong Gateway v3.6.x+:
 

--- a/config/crd/kong-operator/gateway-operator.konghq.com_aigateways.yaml
+++ b/config/crd/kong-operator/gateway-operator.konghq.com_aigateways.yaml
@@ -32,7 +32,7 @@ spec:
           Machine Learning models such as Large Language Models (LLM).
 
           The underlying technology for the AIGateway is the Kong Gateway configured
-          with a variety of plugins which provide the the AI featureset.
+          with a variety of plugins which provide the AI featureset.
 
           This is a list of the plugins, which are available in Kong Gateway v3.6.x+:
 

--- a/config/crd/kong-operator/gateway-operator.konghq.com_controlplanes.yaml
+++ b/config/crd/kong-operator/gateway-operator.konghq.com_controlplanes.yaml
@@ -66,7 +66,7 @@ spec:
                 description: |-
                   ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                   configuration results in a Deployment which is managed by the Operator and
-                  includes options for managing Deployments such as the the number of replicas
+                  includes options for managing Deployments such as the number of replicas
                   or pod options like container image and resource requirements.
                   version, as well as Env variable overrides.
                 properties:

--- a/config/crd/kong-operator/gateway-operator.konghq.com_gatewayconfigurations.yaml
+++ b/config/crd/kong-operator/gateway-operator.konghq.com_gatewayconfigurations.yaml
@@ -63,7 +63,7 @@ spec:
                     description: |-
                       ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
                       configuration results in a Deployment which is managed by the Operator and
-                      includes options for managing Deployments such as the the number of replicas
+                      includes options for managing Deployments such as the number of replicas
                       or pod options like container image and resource requirements.
                       version, as well as Env variable overrides.
                     properties:

--- a/controller/dataplane/owned_deployment.go
+++ b/controller/dataplane/owned_deployment.go
@@ -129,7 +129,7 @@ func (d *DeploymentBuilder) BuildAndDeploy(
 	}
 
 	// TODO https://github.com/kong/kong-operator/issues/128
-	// This is a a workaround to avoid patches clobbering the wrong EnvVar. We want to find an improved patch mechanism
+	// This is a workaround to avoid patches clobbering the wrong EnvVar. We want to find an improved patch mechanism
 	// that doesn't clobber EnvVars (and other array fields) it shouldn't.
 	existingEnvVars := desiredDeployment.Spec.Template.Spec.Containers[0].Env
 	desiredDeployment.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{}

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -310,7 +310,7 @@ func (c *httpRouteConverter) UpdateRootObjectStatus(ctx context.Context, logger 
 func (c *httpRouteConverter) HandleOrphanedResource(ctx context.Context, logger logr.Logger, resource *unstructured.Unstructured) (skipDelete bool, err error) {
 	am := metadata.NewAnnotationManager(logger)
 
-	// If the route is not present in the the hybrid-routes annotation of the Kong resource, don't touch it.
+	// If the route is not present in the hybrid-routes annotation of the Kong resource, don't touch it.
 	if !am.ContainsRoute(resource, c.route) {
 		log.Trace(logger, "Route annotation not found, skipping resource", "kind", resource.GetKind(), "obj", client.ObjectKeyFromObject(resource))
 		return true, nil

--- a/controller/pkg/address/address.go
+++ b/controller/pkg/address/address.go
@@ -17,7 +17,7 @@ import (
 //     IPs are added first, then hostnames.
 //   - next, all service's ClusterIPs are added.
 //   - the result is not sorted, so the return value relies on the order in
-//     in which the addresses in the service were defined.
+//     which the addresses in the service were defined.
 //
 // If this ends up being the desired logic and aligns with what
 // has been agreed in https://github.com/kong/kong-operator/issues/281

--- a/docs/all-api-reference.md
+++ b/docs/all-api-reference.md
@@ -2281,7 +2281,7 @@ Package v1alpha1 contains API Schema definitions for the gateway-operator.konghq
 
 AIGateway is a network Gateway enabling access and management for AI &
 Machine Learning models such as Large Language Models (LLM).<br /><br />The underlying technology for the AIGateway is the Kong Gateway configured
-with a variety of plugins which provide the the AI featureset.<br /><br />This is a list of the plugins, which are available in Kong Gateway v3.6.x+:<br /><br />  - ai-proxy (https://github.com/kong/kong/tree/master/kong/plugins/ai-proxy)
+with a variety of plugins which provide the AI featureset.<br /><br />This is a list of the plugins, which are available in Kong Gateway v3.6.x+:<br /><br />  - ai-proxy (https://github.com/kong/kong/tree/master/kong/plugins/ai-proxy)
   - ai-request-transformer (https://github.com/kong/kong/tree/master/kong/plugins/ai-request-transformer)
   - ai-response-transformers (https://github.com/kong/kong/tree/master/kong/plugins/ai-response-transformer)
   - ai-prompt-template (https://github.com/kong/kong/tree/master/kong/plugins/ai-prompt-template)
@@ -2921,7 +2921,7 @@ _Appears in:_
 
 ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
 configuration results in a Deployment which is managed by the Operator and
-includes options for managing Deployments such as the the number of replicas
+includes options for managing Deployments such as the number of replicas
 or pod options like container image and resource requirements.
 version, as well as Env variable overrides.
 
@@ -5727,7 +5727,7 @@ Allowed values:
 
 | Value | Description |
 | --- | --- |
-| `AWSTransitGateway` | TransitGatewayTypeAWSTransitGateway defines the the AWS transit gateway type.<br /> |
+| `AWSTransitGateway` | TransitGatewayTypeAWSTransitGateway defines the AWS transit gateway type.<br /> |
 | `AzureTransitGateway` | TransitGatewayTypeAzureTransitGateway defines the Azure transit gateway type.<br /> |
 
 ## konnect.konghq.com/v1alpha2

--- a/docs/gateway-operator-api-reference.md
+++ b/docs/gateway-operator-api-reference.md
@@ -20,7 +20,7 @@ Package v1alpha1 contains API Schema definitions for the gateway-operator.konghq
 
 AIGateway is a network Gateway enabling access and management for AI &
 Machine Learning models such as Large Language Models (LLM).<br /><br />The underlying technology for the AIGateway is the Kong Gateway configured
-with a variety of plugins which provide the the AI featureset.<br /><br />This is a list of the plugins, which are available in Kong Gateway v3.6.x+:<br /><br />  - ai-proxy (https://github.com/kong/kong/tree/master/kong/plugins/ai-proxy)
+with a variety of plugins which provide the AI featureset.<br /><br />This is a list of the plugins, which are available in Kong Gateway v3.6.x+:<br /><br />  - ai-proxy (https://github.com/kong/kong/tree/master/kong/plugins/ai-proxy)
   - ai-request-transformer (https://github.com/kong/kong/tree/master/kong/plugins/ai-request-transformer)
   - ai-response-transformers (https://github.com/kong/kong/tree/master/kong/plugins/ai-response-transformer)
   - ai-prompt-template (https://github.com/kong/kong/tree/master/kong/plugins/ai-prompt-template)
@@ -660,7 +660,7 @@ _Appears in:_
 
 ControlPlaneDeploymentOptions is a shared type used on objects to indicate that their
 configuration results in a Deployment which is managed by the Operator and
-includes options for managing Deployments such as the the number of replicas
+includes options for managing Deployments such as the number of replicas
 or pod options like container image and resource requirements.
 version, as well as Env variable overrides.
 

--- a/docs/konnect-api-reference.md
+++ b/docs/konnect-api-reference.md
@@ -865,7 +865,7 @@ Allowed values:
 
 | Value | Description |
 | --- | --- |
-| `AWSTransitGateway` | TransitGatewayTypeAWSTransitGateway defines the the AWS transit gateway type.<br /> |
+| `AWSTransitGateway` | TransitGatewayTypeAWSTransitGateway defines the AWS transit gateway type.<br /> |
 | `AzureTransitGateway` | TransitGatewayTypeAzureTransitGateway defines the Azure transit gateway type.<br /> |
 
 ## konnect.konghq.com/v1alpha2

--- a/hack/generators/controllers/networking/main.go
+++ b/hack/generators/controllers/networking/main.go
@@ -350,7 +350,7 @@ type typeNeeded struct {
 	// the "kubernetes.io/ingress.class" annotation to decide whether or not the object is supported.
 	AcceptsIngressClassNameAnnotation bool
 
-	// AcceptsIngressClassNameSpec indicates the the object indicates the ingress.class that should support it via
+	// AcceptsIngressClassNameSpec indicates the object indicates the ingress.class that should support it via
 	// an attribute in its specification named .IngressClassName
 	AcceptsIngressClassNameSpec bool
 

--- a/ingress-controller/internal/admission/handler.go
+++ b/ingress-controller/internal/admission/handler.go
@@ -150,7 +150,7 @@ func (h *RequestHandler) RegisterValidator(id mgrID, validator KongValidator) {
 	h.validators[id.String()] = validator
 }
 
-// UnregisterValidator removes a validator from from the request handler.
+// UnregisterValidator removes a validator from the request handler.
 // An instance of validator is removed when a particular KIC instance
 // is removed from KO.
 func (h *RequestHandler) UnregisterValidator(id mgrID) {

--- a/ingress-controller/internal/annotations/annotations.go
+++ b/ingress-controller/internal/annotations/annotations.go
@@ -163,7 +163,7 @@ func ExtractClientCertificate(anns map[string]string) string {
 }
 
 // ExtractStripPath extracts the strip-path annotations containing the
-// the boolean string "true" or "false".
+// boolean string "true" or "false".
 func ExtractStripPath(anns map[string]string) string {
 	return anns[AnnotationPrefix+StripPathKey]
 }

--- a/ingress-controller/internal/controllers/gateway/backendtlspolicy_utils.go
+++ b/ingress-controller/internal/controllers/gateway/backendtlspolicy_utils.go
@@ -48,7 +48,7 @@ func (r *BackendTLSPolicyReconciler) getBackendTLSPoliciesByHTTPRoute(ctx contex
 
 // getBackendTLSPolicyAncestors returns the list of Gateways associated to the given BackendTLSPolicy.
 // To retrieve such a list, the following steps are performed:
-// 1. Get all the the HTTPRoutes that reference the backends targeted by the policy;
+// 1. Get all the HTTPRoutes that reference the backends targeted by the policy;
 // 2. Find all the parents in the HTTPRoute status that have already properly resolved by KIC and have the resolvedRefs condition set to true.
 // 3. Return all the successfully resolved Gateways.
 func (r *BackendTLSPolicyReconciler) getBackendTLSPolicyAncestors(ctx context.Context, policy gatewayapi.BackendTLSPolicy) ([]gatewayapi.Gateway, error) {

--- a/ingress-controller/internal/controllers/license/konglicense_controller.go
+++ b/ingress-controller/internal/controllers/license/konglicense_controller.go
@@ -349,7 +349,7 @@ func (r *KongV1Alpha1KongLicenseReconciler) setChosenLicense(l *configurationv1a
 	r.chosenLicense = l.DeepCopy()
 }
 
-// getChosenLicense fetches the the chosen effective KongLicense in the cache.
+// getChosenLicense fetches the chosen effective KongLicense in the cache.
 func (r *KongV1Alpha1KongLicenseReconciler) getChosenLicense() *configurationv1alpha1.KongLicense {
 	r.chosenLicenseLock.RLock()
 	defer r.chosenLicenseLock.RUnlock()

--- a/ingress-controller/internal/dataplane/kongstate/util_test.go
+++ b/ingress-controller/internal/dataplane/kongstate/util_test.go
@@ -53,7 +53,7 @@ func TestPrettyPrintServiceList(t *testing.T) {
 					},
 				},
 			},
-			expected: "default/test-service[0-9], default/test-service[0-9], default/test-service[0-9]",
+			expected: "default/test-service[0-9], default/test-service[0-9]",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/ingress-controller/internal/dataplane/translator/subtranslator/httproute_test.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/httproute_test.go
@@ -1153,7 +1153,7 @@ func TestTranslateHTTPRoutesToKongstateServices(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple HTTPRoutes with the same same backends in the same namespace",
+			name: "multiple HTTPRoutes with the same backends in the same namespace",
 			k8sServices: []*corev1.Service{
 				{
 					TypeMeta: serviceTypeMeta,
@@ -1223,7 +1223,7 @@ func TestTranslateHTTPRoutesToKongstateServices(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple HTTPRoutes with the same same backends in the same namespace with correct referenceGrant",
+			name: "multiple HTTPRoutes with the same backends in the same namespace with correct referenceGrant",
 			k8sServices: []*corev1.Service{
 				{
 					TypeMeta: serviceTypeMeta,
@@ -1317,7 +1317,7 @@ func TestTranslateHTTPRoutesToKongstateServices(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple HTTPRoutes with the same same backends in the same namespace without referenceGrant",
+			name: "multiple HTTPRoutes with the same backends in the same namespace without referenceGrant",
 			k8sServices: []*corev1.Service{
 				{
 					TypeMeta: serviceTypeMeta,

--- a/ingress-controller/internal/dataplane/translator/translator_test.go
+++ b/ingress-controller/internal/dataplane/translator/translator_test.go
@@ -1577,7 +1577,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 					Namespace: "default",
 					Annotations: map[string]string{
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
-						"konghq.com/preserve-host":  "wiggle wiggle wiggle",
+						"konghq.com/preserve-host":  "wiggle ",
 					},
 				},
 				Spec: netv1.IngressSpec{

--- a/ingress-controller/internal/versions/versions.go
+++ b/ingress-controller/internal/versions/versions.go
@@ -4,7 +4,7 @@ import (
 	"github.com/blang/semver/v4"
 )
 
-// KICv3VersionCutoff is the lowest version version of Kong Gateway supported by KIC >=v3.0.0.
+// KICv3VersionCutoff is the lowest version of Kong Gateway supported by KIC >=v3.0.0.
 var KICv3VersionCutoff = semver.Version{Major: 3, Minor: 4, Patch: 1}
 
 // KongRedirectPluginCutoff is the lowest version of Kong Gateway that supports `redirect` plugin.

--- a/ingress-controller/test/helpers/setup.go
+++ b/ingress-controller/test/helpers/setup.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Setup is a test helper function which:
-//   - creates a cluster cleaner which will be used to to clean up test resources
+//   - creates a cluster cleaner which will be used to clean up test resources
 //     automatically after the test finishes and creates a new namespace for the test
 //     to use.
 //   - creates a namespace for the provided test and adds it to the cleaner for

--- a/test/crdsvalidation/gateway-operator.konghq.com/dataplane_test.go
+++ b/test/crdsvalidation/gateway-operator.konghq.com/dataplane_test.go
@@ -274,7 +274,7 @@ func TestDataplane(t *testing.T) {
 				},
 			},
 			{
-				Name: "can leave nodePort empty when when service type is not specified",
+				Name: "can leave nodePort empty when service type is not specified",
 				TestObject: &operatorv1beta1.DataPlane{
 					ObjectMeta: common.CommonObjectMeta(ns.Name),
 					Spec: operatorv1beta1.DataPlaneSpec{

--- a/test/e2e/environment.go
+++ b/test/e2e/environment.go
@@ -230,7 +230,7 @@ func CreateEnvironment(t *testing.T, ctx context.Context, opts ...TestEnvOption)
 			t.Logf("deploying additional configuration to test cluster via kustomize (%s)", AdditionalKustomizeDir)
 			require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), AdditionalKustomizeDir))
 		} else {
-			t.Log("no additional additional configuration provided")
+			t.Log("no additional configuration provided")
 		}
 
 		t.Log("waiting for operator deployment to complete")


### PR DESCRIPTION
**What this PR does / why we need it**:

One from the series, to keep it reviewable. 

Enable and apply fixes for [dupword](https://golangci-lint.run/docs/linters/configuration/#dupword) (which discovered a lot of issues with our comments and docs that get overlooked during reviews)


**Which issue this PR fixes**

Part of 

- https://github.com/Kong/kong-operator/issues/1847