### PR TITLE
fix: prevent nil panic in PAT creation and fix false-positive 429 handling in EventuallyWithT

### DIFF
--- a/ingress-controller/test/helpers/konnect/personal_access_tokens.go
+++ b/ingress-controller/test/helpers/konnect/personal_access_tokens.go
@@ -49,14 +49,8 @@ func CreateTestPersonalAccessToken(ctx context.Context, t *testing.T) string {
 			return err
 		}
 
-		if createResp == nil ||
-			createResp.PersonalAccessTokenCreateResponse == nil ||
-			createResp.PersonalAccessTokenCreateResponse.ID == "" ||
-			createResp.PersonalAccessTokenCreateResponse.KonnectToken == "" {
-			return fmt.Errorf(
-				"failed to create personal account access token: response is nil, status code %d, response: %v",
-				createResp.GetStatusCode(), createResp,
-			)
+		if createResp == nil {
+			return fmt.Errorf("failed to create personal access token: response is nil")
 		}
 
 		if createResp.GetStatusCode() != http.StatusCreated {
@@ -65,6 +59,15 @@ func CreateTestPersonalAccessToken(ctx context.Context, t *testing.T) string {
 				body = []byte(err.Error())
 			}
 			return fmt.Errorf("failed to create personal access token: code %d, message %s", createResp.GetStatusCode(), body)
+		}
+
+		if createResp.PersonalAccessTokenCreateResponse == nil ||
+			createResp.PersonalAccessTokenCreateResponse.ID == "" ||
+			createResp.PersonalAccessTokenCreateResponse.KonnectToken == "" {
+			return fmt.Errorf(
+				"failed to create personal access token: response fields are missing (status code %d)",
+				createResp.GetStatusCode(),
+			)
 		}
 
 		tokenID = createResp.PersonalAccessTokenCreateResponse.ID

--- a/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
+++ b/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
@@ -134,8 +134,10 @@ func TestKongClientGoldenTestsOutputs_Konnect(t *testing.T) {
 								return
 							}
 							timer := time.NewTimer(details.RetryAfter)
+							defer timer.Stop()
 							select {
 							case <-timer.C:
+								t.Errorf("rate limited (429), retrying after %s", details.RetryAfter)
 								return
 							case <-ctx.Done():
 								t.Errorf("context done while waiting to retry after 429: %v", ctx.Err())


### PR DESCRIPTION

**What this PR does / why we need it**:


- Split nil check for createResp to avoid panic when calling `GetStatusCode()` on a nil response.
- Use `t.Errorf` record error on CollectT  to help `require.EventuallyWithT` retries  https://pkg.go.dev/github.com/stretchr/testify/require#EventuallyWithT 

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
