### PR TITLE
fix(chart): fix too long metrics service name

### DIFF
--- a/charts/kong-operator/CHANGELOG.md
+++ b/charts/kong-operator/CHANGELOG.md
@@ -1,12 +1,20 @@
 # Changelog
 
+## 1.1.2
+
+### Fixes
+
+- Fix broken installations using `--generate-name` or provided too long release name,
+- which caused the generated metrics `Service` name to exceed the 63 character limit.
+  [#3261](https://github.com/Kong/kong-operator/pull/3261)
+
 ## 1.1.1
 
 ### Fixes
 
 - Fix an issue with missing volume mount when `ko-crds.enabled=false` is set
   and conversion webhook is enabled.
-  [#2356](https://github.com/Kong/kong-operator/pull/2356)
+  [#3228](https://github.com/Kong/kong-operator/pull/3228)
 
 ## 1.1.0
 

--- a/charts/kong-operator/CHANGELOG.md
+++ b/charts/kong-operator/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
-## 1.1.2
+## 1.2.0
 
 ### Fixes
 
 - Fix broken installations using `--generate-name` or provided too long release name,
-- which caused the generated metrics `Service` name to exceed the 63 character limit.
+  which caused the generated metrics `Service` name to exceed the 63 character limit.
+  If you rely on metrics `Service` name in your integrations (e.g., for ServiceMonitor),
+  please make sure to update it to match the new naming convention,
+  which is `<release-name>-metrics` truncated to 63 characters if needed.
   [#3261](https://github.com/Kong/kong-operator/pull/3261)
 
 ## 1.1.1

--- a/charts/kong-operator/Chart.yaml
+++ b/charts/kong-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong-operator
 sources:
   - https://github.com/Kong/kong-operator/charts/kong-operator/
-version: 1.1.2
+version: 1.2.0
 appVersion: "2.1.0"
 annotations:
   artifacthub.io/category: networking

--- a/charts/kong-operator/Chart.yaml
+++ b/charts/kong-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong-operator
 sources:
   - https://github.com/Kong/kong-operator/charts/kong-operator/
-version: 1.1.1
+version: 1.1.2
 appVersion: "2.1.0"
 annotations:
   artifacthub.io/category: networking

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.2
+        helm.sh/chart: kong-operator-1.2.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57992,7 +57992,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57829,7 +57829,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/component: ko
-  name: chartsnap-kong-operator-metrics-service
+  name: chartsnap-kong-operator-metrics
   namespace: default
 spec:
   ports:
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.1
+        helm.sh/chart: kong-operator-1.1.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57992,7 +57992,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57864,7 +57864,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57892,7 +57892,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.2
+        helm.sh/chart: kong-operator-1.2.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -58005,7 +58005,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57846,7 +57846,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/component: ko
-  name: chartsnap-kong-operator-metrics-service
+  name: chartsnap-kong-operator-metrics
   namespace: default
 spec:
   ports:
@@ -57864,7 +57864,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57892,7 +57892,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.1
+        helm.sh/chart: kong-operator-1.1.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -58005,7 +58005,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.2
+        helm.sh/chart: kong-operator-1.2.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57984,7 +57984,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57829,7 +57829,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/component: ko
-  name: chartsnap-kong-operator-metrics-service
+  name: chartsnap-kong-operator-metrics
   namespace: default
 spec:
   ports:
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.1
+        helm.sh/chart: kong-operator-1.1.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57984,7 +57984,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57829,7 +57829,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/component: ko
-  name: chartsnap-kong-operator-metrics-service
+  name: chartsnap-kong-operator-metrics
   namespace: default
 spec:
   ports:
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.1
+        helm.sh/chart: kong-operator-1.1.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57986,7 +57986,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.2
+        helm.sh/chart: kong-operator-1.2.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57986,7 +57986,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57829,7 +57829,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/component: ko
-  name: chartsnap-kong-operator-metrics-service
+  name: chartsnap-kong-operator-metrics
   namespace: default
 spec:
   ports:
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.1
+        helm.sh/chart: kong-operator-1.1.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57986,7 +57986,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.2
+        helm.sh/chart: kong-operator-1.2.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57986,7 +57986,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     a: "b"
@@ -57830,7 +57830,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/component: ko
-  name: chartsnap-kong-operator-metrics-service
+  name: chartsnap-kong-operator-metrics
   namespace: default
 spec:
   ports:
@@ -57848,7 +57848,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     a: "b"
@@ -57877,7 +57877,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.1
+        helm.sh/chart: kong-operator-1.1.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         a: "b"
@@ -57985,7 +57985,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     a: "b"

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     a: "b"
@@ -57848,7 +57848,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     a: "b"
@@ -57877,7 +57877,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.2
+        helm.sh/chart: kong-operator-1.2.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         a: "b"
@@ -57985,7 +57985,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     a: "b"

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.2
+        helm.sh/chart: kong-operator-1.2.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57984,7 +57984,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57829,7 +57829,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/component: ko
-  name: chartsnap-kong-operator-metrics-service
+  name: chartsnap-kong-operator-metrics
   namespace: default
 spec:
   ports:
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.1
+        helm.sh/chart: kong-operator-1.1.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57984,7 +57984,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.2
+        helm.sh/chart: kong-operator-1.2.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57982,7 +57982,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57829,7 +57829,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/component: ko
-  name: chartsnap-kong-operator-metrics-service
+  name: chartsnap-kong-operator-metrics
   namespace: default
 spec:
   ports:
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.1
+        helm.sh/chart: kong-operator-1.1.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57982,7 +57982,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57876,7 +57876,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.2
+        helm.sh/chart: kong-operator-1.2.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57983,7 +57983,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57829,7 +57829,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/component: ko
-  name: chartsnap-kong-operator-metrics-service
+  name: chartsnap-kong-operator-metrics
   namespace: default
 spec:
   ports:
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57876,7 +57876,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.1
+        helm.sh/chart: kong-operator-1.1.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57983,7 +57983,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.2
+        helm.sh/chart: kong-operator-1.2.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57984,7 +57984,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57829,7 +57829,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/component: ko
-  name: chartsnap-kong-operator-metrics-service
+  name: chartsnap-kong-operator-metrics
   namespace: default
 spec:
   ports:
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.1
+        helm.sh/chart: kong-operator-1.1.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57984,7 +57984,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57829,7 +57829,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/component: ko
-  name: chartsnap-kong-operator-metrics-service
+  name: chartsnap-kong-operator-metrics
   namespace: default
 spec:
   ports:
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.1
+        helm.sh/chart: kong-operator-1.1.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57986,7 +57986,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.2
+        helm.sh/chart: kong-operator-1.2.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57986,7 +57986,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.2
+        helm.sh/chart: kong-operator-1.2.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57982,7 +57982,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57829,7 +57829,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/component: ko
-  name: chartsnap-kong-operator-metrics-service
+  name: chartsnap-kong-operator-metrics
   namespace: default
 spec:
   ports:
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.1
+        helm.sh/chart: kong-operator-1.1.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57982,7 +57982,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -30,7 +30,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -31319,7 +31319,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/component: ko
-  name: chartsnap-kong-operator-metrics-service
+  name: chartsnap-kong-operator-metrics
   namespace: default
 spec:
   ports:
@@ -31337,7 +31337,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -31365,7 +31365,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.1
+        helm.sh/chart: kong-operator-1.1.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -31464,7 +31464,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -30,7 +30,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -31337,7 +31337,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -31365,7 +31365,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.2
+        helm.sh/chart: kong-operator-1.2.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -31464,7 +31464,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -57779,7 +57779,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/component: ko
-  name: chartsnap-kong-operator-metrics-service
+  name: chartsnap-kong-operator-metrics
   namespace: default
 spec:
   ports:
@@ -57797,7 +57797,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57825,7 +57825,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.1
+        helm.sh/chart: kong-operator-1.1.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57935,7 +57935,7 @@ metadata:
     cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "internal" } }'
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -58052,7 +58052,7 @@ kind: Certificate
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -58073,7 +58073,7 @@ kind: Certificate
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -58094,7 +58094,7 @@ kind: Issuer
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -57797,7 +57797,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -57825,7 +57825,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.2
+        helm.sh/chart: kong-operator-1.2.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko
@@ -57935,7 +57935,7 @@ metadata:
     cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "internal" } }'
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -58052,7 +58052,7 @@ kind: Certificate
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -58073,7 +58073,7 @@ kind: Certificate
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -58094,7 +58094,7 @@ kind: Issuer
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -31277,7 +31277,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/component: ko
-  name: chartsnap-kong-operator-metrics-service
+  name: chartsnap-kong-operator-metrics
   namespace: default
 spec:
   ports:
@@ -31295,7 +31295,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.1
+    helm.sh/chart: kong-operator-1.1.2
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -31323,7 +31323,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.1
+        helm.sh/chart: kong-operator-1.1.2
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -31295,7 +31295,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.1.2
+    helm.sh/chart: kong-operator-1.2.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/component: ko
@@ -31323,7 +31323,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.1.2
+        helm.sh/chart: kong-operator-1.2.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.0"
         app.kubernetes.io/component: ko

--- a/charts/kong-operator/templates/services.yaml
+++ b/charts/kong-operator/templates/services.yaml
@@ -58,13 +58,14 @@ spec:
     app.kubernetes.io/component: ko
 {{- end }}
 ---
+{{- $metricsServiceName := printf "%s-metrics" (include "kong.fullname" . | trunc 63 | trimSuffix "-") -}}
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/component: ko
-  name: {{ template "kong.fullname" . }}-metrics
+  name: {{ $metricsServiceName }}
   namespace: {{ template "kong.namespace" . }}
 spec:
   ports:

--- a/charts/kong-operator/templates/services.yaml
+++ b/charts/kong-operator/templates/services.yaml
@@ -58,7 +58,7 @@ spec:
     app.kubernetes.io/component: ko
 {{- end }}
 ---
-{{- $metricsServiceName := printf "%s-metrics" (include "kong.fullname" . | trunc 63 | trimSuffix "-") -}}
+{{- $metricsServiceName := printf "%s-metrics" (include "kong.fullname" . | trunc 63 | trimSuffix "-") }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kong-operator/templates/services.yaml
+++ b/charts/kong-operator/templates/services.yaml
@@ -64,7 +64,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/component: ko
-  name: {{ template "kong.fullname" . }}-metrics-service
+  name: {{ template "kong.fullname" . }}-metrics
   namespace: {{ template "kong.namespace" . }}
 spec:
   ports:

--- a/charts/kong-operator/templates/services.yaml
+++ b/charts/kong-operator/templates/services.yaml
@@ -58,7 +58,7 @@ spec:
     app.kubernetes.io/component: ko
 {{- end }}
 ---
-{{- $metricsServiceName := printf "%s-metrics" (include "kong.fullname" . | trunc 63 | trimSuffix "-") }}
+{{- $metricsServiceName := printf "%s-metrics" (include "kong.fullname" .) | trunc 63 | trimSuffix "-" }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix too long metrics service name when installing with `--generate-name` through OCI chart.

**Which issue this PR fixes**

Fixes #3260 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
