### PR TITLE
chore(ci): remove write permissions on .github/workflows/charts-sync.yaml

### DIFF
--- a/.github/workflows/charts-sync.yaml
+++ b/.github/workflows/charts-sync.yaml
@@ -22,8 +22,6 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,8 @@ run-name: Pull Request Labeler, branch:${{ github.ref_name }}, triggered by @${{
 on:
 - pull_request
 
+permissions:
+  contents: read
 
 concurrency:
   # Run only for most recent commit in PRs but for all tags and commits on main


### PR DESCRIPTION
**What this PR does / why we need it**:

The workflow uses GH PAT from secret so no need for write permissions.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
