### PR TITLE
chore(lint): enable golangci-lint: `errcheck`, `errchkjson`, `errname` and improvements

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -20,6 +20,9 @@ linters:
     - dupword
     - embeddedstructfieldcheck
     - durationcheck
+    - errcheck
+    - errchkjson
+    - errname
     - errorlint
     - exhaustive
     - forbidigo

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -170,14 +170,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	gwc, err := gatewayclass.Get(ctx, r.Client, string(gateway.Spec.GatewayClassName))
 	if err != nil {
 		switch {
-		case errors.As(err, &operatorerrors.ErrUnsupportedGatewayClass{}):
+		case errors.As(err, &operatorerrors.UnsupportedGatewayClassError{}):
 			log.Debug(logger, "resource not supported, ignoring",
 				"expectedGatewayClass", vars.ControllerName(),
 				"gatewayClass", gateway.Spec.GatewayClassName,
 				"reason", err.Error(),
 			)
 			return ctrl.Result{}, nil
-		case errors.As(err, &operatorerrors.ErrNotAcceptedGatewayClass{}):
+		case errors.As(err, &operatorerrors.NotAcceptedGatewayClassError{}):
 			log.Debug(logger, "GatewayClass not accepted, ignoring",
 				"gatewayClass", gateway.Spec.GatewayClassName,
 				"reason", err.Error(),

--- a/controller/gateway/controller_watch.go
+++ b/controller/gateway/controller_watch.go
@@ -49,8 +49,8 @@ func (r *Reconciler) gatewayHasMatchingGatewayClass(obj client.Object) bool {
 		// class as well. If we fail here it's most likely because of some failure
 		// of the Kubernetes API and it's technically better to enqueue the object
 		// than to drop it for eventual consistency during cluster outages.
-		return !errors.As(err, &operatorerrors.ErrUnsupportedGatewayClass{}) &&
-			!errors.As(err, &operatorerrors.ErrNotAcceptedGatewayClass{})
+		return !errors.As(err, &operatorerrors.UnsupportedGatewayClassError{}) &&
+			!errors.As(err, &operatorerrors.NotAcceptedGatewayClassError{})
 	}
 
 	return true
@@ -274,9 +274,9 @@ func (r *Reconciler) listManagedGatewaysInNamespace(ctx context.Context, obj cli
 
 		if _, err := gatewayclass.Get(ctx, r.Client, string(gateway.Spec.GatewayClassName)); err != nil {
 			switch {
-			case errors.As(err, &operatorerrors.ErrUnsupportedGatewayClass{}):
+			case errors.As(err, &operatorerrors.UnsupportedGatewayClassError{}):
 				log.Debug(logger, "gateway class not supported, ignoring")
-			case errors.As(err, &operatorerrors.ErrNotAcceptedGatewayClass{}):
+			case errors.As(err, &operatorerrors.NotAcceptedGatewayClassError{}):
 				log.Debug(logger, "gateway class not accepted, ignoring")
 			default:
 				log.Error(logger, err, "failed to get Gateway's GatewayClass",

--- a/controller/hybridgateway/builder/kongcertificate_test.go
+++ b/controller/hybridgateway/builder/kongcertificate_test.go
@@ -96,12 +96,10 @@ func TestKongCertificateBuilder_ErrorAccumulation(t *testing.T) {
 
 func TestKongCertificateBuilder_MustBuild_PanicsOnError(t *testing.T) {
 	b := NewKongCertificate().WithOwner(nil)
-	defer func() {
-		r := recover()
-		require.NotNil(t, r)
-		require.Contains(t, r.(error).Error(), "failed to build KongCertificate")
-	}()
-	_ = b.MustBuild()
+
+	require.PanicsWithError(t, "failed to build KongCertificate: owner cannot be nil", func() {
+		_ = b.MustBuild()
+	})
 }
 
 func TestKongCertificateBuilder_MustBuild_Success(t *testing.T) {

--- a/controller/hybridgateway/builder/kongsni_test.go
+++ b/controller/hybridgateway/builder/kongsni_test.go
@@ -79,12 +79,9 @@ func TestKongSNIBuilder_ErrorAccumulation(t *testing.T) {
 
 func TestKongSNIBuilder_MustBuild_PanicsOnError(t *testing.T) {
 	b := NewKongSNI().WithOwner(nil)
-	defer func() {
-		r := recover()
-		require.NotNil(t, r)
-		require.Contains(t, r.(error).Error(), "failed to build KongSNI")
-	}()
-	_ = b.MustBuild()
+	require.PanicsWithError(t, "failed to build KongSNI: owner cannot be nil", func() {
+		_ = b.MustBuild()
+	})
 }
 
 func TestKongSNIBuilder_MustBuild_Success(t *testing.T) {

--- a/controller/konnect/errors.go
+++ b/controller/konnect/errors.go
@@ -7,162 +7,162 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// ReferencedKongServiceIsBeingDeleted is an error type that is returned when
+// ReferencedKongServiceIsBeingDeletedError is an error type that is returned when
 // a Konnect entity references a Kong Service which is being deleted.
-type ReferencedKongServiceIsBeingDeleted struct {
+type ReferencedKongServiceIsBeingDeletedError struct {
 	Reference types.NamespacedName
 }
 
 // Error implements the error interface.
-func (e ReferencedKongServiceIsBeingDeleted) Error() string {
+func (e ReferencedKongServiceIsBeingDeletedError) Error() string {
 	return fmt.Sprintf("referenced Kong Service %s is being deleted", e.Reference)
 }
 
-// ReferencedKongConsumerIsBeingDeleted is an error type that is returned when
+// ReferencedKongConsumerIsBeingDeletedError is an error type that is returned when
 // a Konnect entity references a Kong Consumer which is being deleted.
-type ReferencedKongConsumerIsBeingDeleted struct {
+type ReferencedKongConsumerIsBeingDeletedError struct {
 	Reference         types.NamespacedName
 	DeletionTimestamp time.Time
 }
 
 // Error implements the error interface.
-func (e ReferencedKongConsumerIsBeingDeleted) Error() string {
+func (e ReferencedKongConsumerIsBeingDeletedError) Error() string {
 	return fmt.Sprintf("referenced Kong Consumer %s is being deleted (deletion timestamp: %s)",
 		e.Reference, e.DeletionTimestamp,
 	)
 }
 
-// ReferencedKongConsumerDoesNotExist is an error type that is returned when the referenced KongConsumer does not exist.
-type ReferencedKongConsumerDoesNotExist struct {
+// ReferencedKongConsumerDoesNotExistError is an error type that is returned when the referenced KongConsumer does not exist.
+type ReferencedKongConsumerDoesNotExistError struct {
 	Reference types.NamespacedName
 	Err       error
 }
 
 // Error implements the error interface.
-func (e ReferencedKongConsumerDoesNotExist) Error() string {
+func (e ReferencedKongConsumerDoesNotExistError) Error() string {
 	return fmt.Sprintf("referenced Kong Consumer %s does not exist: %v", e.Reference, e.Err)
 }
 
-// ReferencedKongUpstreamIsBeingDeleted is an error type that is returned when
+// ReferencedKongUpstreamIsBeingDeletedError is an error type that is returned when
 // a Konnect entity references a Kong Upstream which is being deleted.
-type ReferencedKongUpstreamIsBeingDeleted struct {
+type ReferencedKongUpstreamIsBeingDeletedError struct {
 	Reference         types.NamespacedName
 	DeletionTimestamp time.Time
 }
 
 // Error implements the error interface.
-func (e ReferencedKongUpstreamIsBeingDeleted) Error() string {
+func (e ReferencedKongUpstreamIsBeingDeletedError) Error() string {
 	return fmt.Sprintf("referenced Kong Upstream %s is being deleted (deletion timestamp: %s)",
 		e.Reference, e.DeletionTimestamp)
 }
 
-// ReferencedKongUpstreamDoesNotExist is an error type that is returned when
+// ReferencedKongUpstreamDoesNotExistError is an error type that is returned when
 // a Konnect entity references a Kong Upstream which does not exist.
-type ReferencedKongUpstreamDoesNotExist struct {
+type ReferencedKongUpstreamDoesNotExistError struct {
 	Reference types.NamespacedName
 	Err       error
 }
 
 // Error implements the error interface.
-func (e ReferencedKongUpstreamDoesNotExist) Error() string {
+func (e ReferencedKongUpstreamDoesNotExistError) Error() string {
 	return fmt.Sprintf("referenced Kong Upstream %s does not exist: %v", e.Reference, e.Err)
 }
 
-// ReferencedKongCertificateIsBeingDeleted is an error type that is returned when
+// ReferencedKongCertificateIsBeingDeletedError is an error type that is returned when
 // a Konnect entity references a Kong Certificate which is being deleted.
-type ReferencedKongCertificateIsBeingDeleted struct {
+type ReferencedKongCertificateIsBeingDeletedError struct {
 	Reference         types.NamespacedName
 	DeletionTimestamp time.Time
 }
 
 // Error implements the error interface.
-func (e ReferencedKongCertificateIsBeingDeleted) Error() string {
+func (e ReferencedKongCertificateIsBeingDeletedError) Error() string {
 	return fmt.Sprintf("referenced Kong Certificate %s is being deleted (deletion timestamp: %s)",
 		e.Reference, e.DeletionTimestamp)
 }
 
-// ReferencedKongCertificateDoesNotExist is an error type that is returned when
+// ReferencedKongCertificateDoesNotExistError is an error type that is returned when
 // a Konnect entity references a Kong Certificate which does not exist.
-type ReferencedKongCertificateDoesNotExist struct {
+type ReferencedKongCertificateDoesNotExistError struct {
 	Reference types.NamespacedName
 	Err       error
 }
 
 // Error implements the error interface.
-func (e ReferencedKongCertificateDoesNotExist) Error() string {
+func (e ReferencedKongCertificateDoesNotExistError) Error() string {
 	return fmt.Sprintf("referenced Kong Certificate %s does not exist: %v", e.Reference, e.Err)
 }
 
-// ReferencedKongKeySetDoesNotExist is an error type that is returned when
+// ReferencedKongKeySetDoesNotExistError is an error type that is returned when
 // a Konnect entity references a KongKeySet which does not exist.
-type ReferencedKongKeySetDoesNotExist struct {
+type ReferencedKongKeySetDoesNotExistError struct {
 	Reference types.NamespacedName
 	Err       error
 }
 
 // Error implements the error interface.
-func (e ReferencedKongKeySetDoesNotExist) Error() string {
+func (e ReferencedKongKeySetDoesNotExistError) Error() string {
 	return fmt.Sprintf("referenced KongKeySet %s does not exist: %v", e.Reference, e.Err)
 }
 
-// ReferencedKongKeySetIsBeingDeleted is an error type that is returned when
+// ReferencedKongKeySetIsBeingDeletedError is an error type that is returned when
 // a Konnect entity references a KongKeySet which is being deleted.
-type ReferencedKongKeySetIsBeingDeleted struct {
+type ReferencedKongKeySetIsBeingDeletedError struct {
 	Reference         types.NamespacedName
 	DeletionTimestamp time.Time
 }
 
 // Error implements the error interface.
-func (e ReferencedKongKeySetIsBeingDeleted) Error() string {
+func (e ReferencedKongKeySetIsBeingDeletedError) Error() string {
 	return fmt.Sprintf("referenced KongKeySet %s is being deleted (deletion timestamp: %s)",
 		e.Reference, e.DeletionTimestamp)
 }
 
-// ReferencedObjectDoesNotExist is an error type that is returned when
+// ReferencedObjectDoesNotExistError is an error type that is returned when
 // a Konnect entity references a non existing object.
-type ReferencedObjectDoesNotExist struct {
+type ReferencedObjectDoesNotExistError struct {
 	Reference types.NamespacedName
 	Err       error
 }
 
 // Error implements the error interface.
-func (e ReferencedObjectDoesNotExist) Error() string {
+func (e ReferencedObjectDoesNotExistError) Error() string {
 	return fmt.Sprintf("referenced object %s does not exist: %v", e.Reference, e.Err)
 }
 
-// ReferencedObjectIsBeingDeleted is an error type that is returned when
+// ReferencedObjectIsBeingDeletedError is an error type that is returned when
 // a Konnect entity references an object which is being deleted.
-type ReferencedObjectIsBeingDeleted struct {
+type ReferencedObjectIsBeingDeletedError struct {
 	Reference         types.NamespacedName
 	DeletionTimestamp time.Time
 }
 
 // Error implements the error interface.
-func (e ReferencedObjectIsBeingDeleted) Error() string {
+func (e ReferencedObjectIsBeingDeletedError) Error() string {
 	return fmt.Sprintf("referenced object %s is being deleted (deletion timestamp: %s)",
 		e.Reference, e.DeletionTimestamp)
 }
 
-// ReferencedObjectIsInvalid is an error type that is returned when
+// ReferencedObjectIsInvalidError is an error type that is returned when
 // the referenced object is invalid.
-type ReferencedObjectIsInvalid struct {
+type ReferencedObjectIsInvalidError struct {
 	Reference string
 	Msg       string
 }
 
 // Error implements the error interface.
-func (e ReferencedObjectIsInvalid) Error() string {
+func (e ReferencedObjectIsInvalidError) Error() string {
 	return fmt.Sprintf("referenced object %s is invalid: %v", e.Reference, e.Msg)
 }
 
-// ReferencedSecretDoesNotExist is an error type that is returned when
+// ReferencedSecretDoesNotExistError is an error type that is returned when
 // a Konnect entity references a Secret which does not exist.
-type ReferencedSecretDoesNotExist struct {
+type ReferencedSecretDoesNotExistError struct {
 	Reference types.NamespacedName
 	Err       error
 }
 
 // Error implements the error interface.
-func (e ReferencedSecretDoesNotExist) Error() string {
+func (e ReferencedSecretDoesNotExistError) Error() string {
 	return fmt.Sprintf("referenced Secret %s does not exist: %v", e.Reference, e.Err)
 }

--- a/controller/konnect/reconciler_certificateref.go
+++ b/controller/konnect/reconciler_certificateref.go
@@ -63,7 +63,7 @@ func handleKongCertificateRef[T constraints.SupportedKonnectEntityType, TEnt con
 			return res, errStatus
 		}
 
-		return ctrl.Result{}, ReferencedKongCertificateDoesNotExist{
+		return ctrl.Result{}, ReferencedKongCertificateDoesNotExistError{
 			Reference: nn,
 			Err:       err,
 		}
@@ -72,7 +72,7 @@ func handleKongCertificateRef[T constraints.SupportedKonnectEntityType, TEnt con
 	// If referenced KongCertificate is being deleted, return an error so that we
 	// can remove the entity from Konnect first.
 	if delTimestamp := cert.GetDeletionTimestamp(); !delTimestamp.IsZero() {
-		return ctrl.Result{}, ReferencedKongCertificateIsBeingDeleted{
+		return ctrl.Result{}, ReferencedKongCertificateIsBeingDeletedError{
 			Reference:         nn,
 			DeletionTimestamp: delTimestamp.Time,
 		}

--- a/controller/konnect/reconciler_consumerref.go
+++ b/controller/konnect/reconciler_consumerref.go
@@ -70,7 +70,7 @@ func handleKongConsumerRef[T constraints.SupportedKonnectEntityType, TEnt constr
 			return res, errStatus
 		}
 
-		return ctrl.Result{}, ReferencedKongConsumerDoesNotExist{
+		return ctrl.Result{}, ReferencedKongConsumerDoesNotExistError{
 			Reference: nn,
 			Err:       err,
 		}
@@ -79,7 +79,7 @@ func handleKongConsumerRef[T constraints.SupportedKonnectEntityType, TEnt constr
 	// If referenced KongConsumer is being deleted, return an error so that we
 	// can remove the entity from Konnect first.
 	if delTimestamp := consumer.GetDeletionTimestamp(); !delTimestamp.IsZero() {
-		return ctrl.Result{}, ReferencedKongConsumerIsBeingDeleted{
+		return ctrl.Result{}, ReferencedKongConsumerIsBeingDeletedError{
 			Reference:         nn,
 			DeletionTimestamp: delTimestamp.Time,
 		}

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -181,9 +181,9 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		switch {
 		// In case the referenced KongService is being deleted, disregard the error
 		// and continue.
-		case errors.As(err, &ReferencedKongServiceIsBeingDeleted{}):
+		case errors.As(err, &ReferencedKongServiceIsBeingDeletedError{}):
 			log.Info(logger, "referenced KongService is being deleted, proceeding with reconciliation", "error", err.Error())
-		case errors.As(err, &ReferencedObjectDoesNotExist{}), errors.As(err, &controlplane.ReferencedControlPlaneDoesNotExistError{}):
+		case errors.As(err, &ReferencedObjectDoesNotExistError{}), errors.As(err, &controlplane.ReferencedControlPlaneDoesNotExistError{}):
 			if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 				if err := r.Client.Update(ctx, ent); err != nil {
 					if k8serrors.IsConflict(err) {
@@ -228,7 +228,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// If the referenced KongConsumer is being deleted and the object
 		// is not being deleted yet then requeue until it will
 		// get the deletion timestamp set due to having the owner set to KongConsumer.
-		if errDel := (&ReferencedKongConsumerIsBeingDeleted{}); errors.As(err, errDel) &&
+		if errDel := (&ReferencedKongConsumerIsBeingDeletedError{}); errors.As(err, errDel) &&
 			ent.GetDeletionTimestamp().IsZero() {
 			return ctrl.Result{
 				RequeueAfter: time.Until(errDel.DeletionTimestamp),
@@ -239,7 +239,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// then remove the finalizer and let the deletion proceed without trying to delete the entity from Konnect
 		// as the KongConsumer deletion will (or already has - in case of the consumer being gone)
 		// take care of it on the Konnect side.
-		if errors.As(err, &ReferencedKongConsumerDoesNotExist{}) {
+		if errors.As(err, &ReferencedKongConsumerDoesNotExistError{}) {
 			if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 				if err := r.Client.Update(ctx, ent); err != nil {
 					if k8serrors.IsConflict(err) {
@@ -274,7 +274,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// If the referenced KongUpstream is being deleted and the object
 		// is not being deleted yet then requeue until it will
 		// get the deletion timestamp set due to having the owner set to KongUpstream.
-		if errDel := (&ReferencedKongUpstreamIsBeingDeleted{}); errors.As(err, errDel) &&
+		if errDel := (&ReferencedKongUpstreamIsBeingDeletedError{}); errors.As(err, errDel) &&
 			ent.GetDeletionTimestamp().IsZero() {
 			return ctrl.Result{
 				RequeueAfter: time.Until(errDel.DeletionTimestamp),
@@ -286,7 +286,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// as the KongUpstream deletion will (or already has - in case of the upstream being gone)
 		// take care of it on the Konnect side.
 		// In case the ControlPlane referenced by the KongUpstream is not found, do the same.
-		if errors.As(err, &ReferencedKongUpstreamDoesNotExist{}) || errors.As(err, &controlplane.ReferencedControlPlaneDoesNotExistError{}) {
+		if errors.As(err, &ReferencedKongUpstreamDoesNotExistError{}) || errors.As(err, &controlplane.ReferencedControlPlaneDoesNotExistError{}) {
 			if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 				if err := r.Client.Update(ctx, ent); err != nil {
 					if k8serrors.IsConflict(err) {
@@ -316,7 +316,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// If the referenced KongCertificate is being deleted and the object
 		// is not being deleted yet then requeue until it will
 		// get the deletion timestamp set due to having the owner set to KongCertificate.
-		if errDel := (&ReferencedKongCertificateIsBeingDeleted{}); errors.As(err, errDel) &&
+		if errDel := (&ReferencedKongCertificateIsBeingDeletedError{}); errors.As(err, errDel) &&
 			ent.GetDeletionTimestamp().IsZero() {
 			return ctrl.Result{
 				RequeueAfter: time.Until(errDel.DeletionTimestamp),
@@ -327,7 +327,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// and the object is being deleted, remove the finalizer and let the
 		// deletion proceed without trying to delete the entity from Konnect
 		// as the KongCertificate deletion will take care of it on the Konnect side.
-		if errors.As(err, &ReferencedKongCertificateDoesNotExist{}) {
+		if errors.As(err, &ReferencedKongCertificateDoesNotExistError{}) {
 			if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 				if err := r.Client.Update(ctx, ent); err != nil {
 					if k8serrors.IsConflict(err) {
@@ -363,7 +363,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// If the referenced KongKeySet is being deleted and the object
 		// is not being deleted yet then requeue until it will
 		// get the deletion timestamp set due to having the owner set to KongKeySet.
-		if errDel := (&ReferencedKongKeySetIsBeingDeleted{}); errors.As(err, errDel) &&
+		if errDel := (&ReferencedKongKeySetIsBeingDeletedError{}); errors.As(err, errDel) &&
 			ent.GetDeletionTimestamp().IsZero() {
 			return ctrl.Result{
 				RequeueAfter: time.Until(errDel.DeletionTimestamp),
@@ -373,7 +373,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// If the referenced KongKeySet is not found, remove the finalizer and let the
 		// user delete the resource without trying to delete the entity from Konnect
 		// as the KongKeySet deletion will take care of it on the Konnect side.
-		if errors.As(err, &ReferencedKongKeySetDoesNotExist{}) {
+		if errors.As(err, &ReferencedKongKeySetDoesNotExistError{}) {
 			if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 				if err := r.Client.Update(ctx, ent); err != nil {
 					if k8serrors.IsConflict(err) {
@@ -447,7 +447,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// is being deleted then allow the reconciliation to continue as we want to
 		// proceed with object's deletion.
 		// Otherwise, just return the error and requeue.
-		if errDel := (&ReferencedObjectIsBeingDeleted{}); !errors.As(err, errDel) ||
+		if errDel := (&ReferencedObjectIsBeingDeletedError{}); !errors.As(err, errDel) ||
 			ent.GetDeletionTimestamp().IsZero() {
 			log.Debug(logger, "error handling KonnectNetwork ref", "error", err)
 			return patchWithProgrammedStatusConditionBasedOnOtherConditions(ctx, r.Client, ent)

--- a/controller/konnect/reconciler_keysetref.go
+++ b/controller/konnect/reconciler_keysetref.go
@@ -85,7 +85,7 @@ func handleKongKeySetRef[T constraints.SupportedKonnectEntityType, TEnt constrai
 
 		// If the KongKeySet is not found, we don't want to requeue.
 		if k8serrors.IsNotFound(err) {
-			return ctrl.Result{}, ReferencedKongKeySetDoesNotExist{
+			return ctrl.Result{}, ReferencedKongKeySetDoesNotExistError{
 				Reference: nn,
 				Err:       err,
 			}
@@ -96,7 +96,7 @@ func handleKongKeySetRef[T constraints.SupportedKonnectEntityType, TEnt constrai
 
 	// If referenced KongKeySet is being deleted, return an error so that we can remove the entity from Konnect first.
 	if delTimestamp := keySet.GetDeletionTimestamp(); !delTimestamp.IsZero() {
-		return ctrl.Result{}, ReferencedKongKeySetIsBeingDeleted{
+		return ctrl.Result{}, ReferencedKongKeySetIsBeingDeletedError{
 			Reference:         nn,
 			DeletionTimestamp: delTimestamp.Time,
 		}

--- a/controller/konnect/reconciler_konnectnetworkref.go
+++ b/controller/konnect/reconciler_konnectnetworkref.go
@@ -57,7 +57,7 @@ func handleKonnectNetworkRef[T constraints.SupportedKonnectEntityType, TEnt cons
 			if err != nil {
 				setInvalidWithMsg(err.Error())
 				if k8serrors.IsNotFound(err) {
-					return ctrl.Result{}, ReferencedObjectDoesNotExist{
+					return ctrl.Result{}, ReferencedObjectDoesNotExistError{
 						Reference: nn,
 						Err:       err,
 					}
@@ -66,7 +66,7 @@ func handleKonnectNetworkRef[T constraints.SupportedKonnectEntityType, TEnt cons
 			}
 
 			if delTimestamp := network.GetDeletionTimestamp(); !delTimestamp.IsZero() {
-				return ctrl.Result{}, ReferencedObjectIsBeingDeleted{
+				return ctrl.Result{}, ReferencedObjectIsBeingDeletedError{
 					Reference:         nn,
 					DeletionTimestamp: delTimestamp.Time,
 				}
@@ -76,7 +76,7 @@ func handleKonnectNetworkRef[T constraints.SupportedKonnectEntityType, TEnt cons
 			cond, ok := k8sutils.GetCondition(konnectv1alpha1.KonnectEntityProgrammedConditionType, &network)
 			if !ok || cond.Status != metav1.ConditionTrue {
 				setInvalidWithMsg(fmt.Sprintf("Referenced KonnectCloudGatewayNetwork %s is not programmed yet", nn))
-				return ctrl.Result{}, ReferencedObjectIsInvalid{
+				return ctrl.Result{}, ReferencedObjectIsInvalidError{
 					Reference: nn.String(),
 					Msg:       "Referenced KonnectCloudGatewayNetwork is not programmed yet",
 				}
@@ -86,7 +86,7 @@ func handleKonnectNetworkRef[T constraints.SupportedKonnectEntityType, TEnt cons
 				nn := client.ObjectKeyFromObject(&network)
 				msg := fmt.Sprintf("Referenced KonnectCloudGatewayNetwork %s: is not ready yet, current state: %s", nn, network.Status.State)
 				setInvalidWithMsg(msg)
-				return ctrl.Result{}, ReferencedObjectIsInvalid{
+				return ctrl.Result{}, ReferencedObjectIsInvalidError{
 					Reference: nn.String(),
 					Msg:       msg,
 				}
@@ -98,7 +98,7 @@ func handleKonnectNetworkRef[T constraints.SupportedKonnectEntityType, TEnt cons
 			if err != nil {
 				msg := fmt.Sprintf("Could not get the referenced KonnectCloudGatewayNetwork <konnectID:%s>: %v", *ref.KonnectID, err)
 				setInvalidWithMsg(msg)
-				return ctrl.Result{}, ReferencedObjectIsInvalid{
+				return ctrl.Result{}, ReferencedObjectIsInvalidError{
 					Reference: *ref.KonnectID,
 					Msg:       msg,
 				}
@@ -106,7 +106,7 @@ func handleKonnectNetworkRef[T constraints.SupportedKonnectEntityType, TEnt cons
 			if n.Network.State != sdkkonnectcomp.NetworkStateReady {
 				msg := fmt.Sprintf("Referenced KonnectCloudGatewayNetwork <konnectID:%s>: is not ready yet, current state: %s", *ref.KonnectID, n.Network.State)
 				setInvalidWithMsg(msg)
-				return ctrl.Result{}, ReferencedObjectIsInvalid{
+				return ctrl.Result{}, ReferencedObjectIsInvalidError{
 					Reference: *ref.KonnectID,
 					Msg:       msg,
 				}

--- a/controller/konnect/reconciler_secretref.go
+++ b/controller/konnect/reconciler_secretref.go
@@ -77,7 +77,7 @@ func handleSecretRef[T constraints.SupportedKonnectEntityType, TEnt constraints.
 			); errStatus != nil || !res.IsZero() {
 				return res, true, errStatus
 			}
-			return ctrl.Result{}, true, &ReferencedSecretDoesNotExist{
+			return ctrl.Result{}, true, &ReferencedSecretDoesNotExistError{
 				Reference: nn,
 				Err:       err,
 			}

--- a/controller/konnect/reconciler_serviceref.go
+++ b/controller/konnect/reconciler_serviceref.go
@@ -115,7 +115,7 @@ func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constra
 
 		// If the KongService is not found, we don't want to requeue.
 		if k8serrors.IsNotFound(err) {
-			return ctrl.Result{}, ReferencedObjectDoesNotExist{
+			return ctrl.Result{}, ReferencedObjectDoesNotExistError{
 				Reference: nn,
 				Err:       err,
 			}
@@ -142,7 +142,7 @@ func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constra
 			}
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{}, ReferencedKongServiceIsBeingDeleted{
+		return ctrl.Result{}, ReferencedKongServiceIsBeingDeletedError{
 			Reference: nn,
 		}
 	}

--- a/controller/konnect/reconciler_upstreamref.go
+++ b/controller/konnect/reconciler_upstreamref.go
@@ -66,7 +66,7 @@ func handleKongUpstreamRef[T constraints.SupportedKonnectEntityType, TEnt constr
 			return res, errStatus
 		}
 
-		return ctrl.Result{}, ReferencedKongUpstreamDoesNotExist{
+		return ctrl.Result{}, ReferencedKongUpstreamDoesNotExistError{
 			Reference: nn,
 			Err:       err,
 		}
@@ -75,7 +75,7 @@ func handleKongUpstreamRef[T constraints.SupportedKonnectEntityType, TEnt constr
 	// If referenced KongUpstream is being deleted, return an error so that we
 	// can remove the entity from Konnect first.
 	if delTimestamp := kongUpstream.GetDeletionTimestamp(); !delTimestamp.IsZero() {
-		return ctrl.Result{}, ReferencedKongUpstreamIsBeingDeleted{
+		return ctrl.Result{}, ReferencedKongUpstreamIsBeingDeletedError{
 			Reference:         nn,
 			DeletionTimestamp: delTimestamp.Time,
 		}

--- a/controller/pkg/controlplane/errors.go
+++ b/controller/pkg/controlplane/errors.go
@@ -25,12 +25,12 @@ func (e ReferencedControlPlaneDoesNotExistError) Unwrap() error {
 	return e.Err
 }
 
-// ReferencedKongGatewayControlPlaneIsUnsupported is an error type that is returned when a given CP reference type is not
+// ReferencedKongGatewayControlPlaneIsUnsupportedError is an error type that is returned when a given CP reference type is not
 // supported.
-type ReferencedKongGatewayControlPlaneIsUnsupported struct {
+type ReferencedKongGatewayControlPlaneIsUnsupportedError struct {
 	Reference commonv1alpha1.ControlPlaneRef
 }
 
-func (e ReferencedKongGatewayControlPlaneIsUnsupported) Error() string {
+func (e ReferencedKongGatewayControlPlaneIsUnsupportedError) Error() string {
 	return fmt.Sprintf("referenced ControlPlaneRef %s is unsupported", e.Reference.String())
 }

--- a/controller/pkg/controlplane/ref.go
+++ b/controller/pkg/controlplane/ref.go
@@ -26,7 +26,7 @@ func GetCPForRef(
 	case commonv1alpha1.ControlPlaneRefKonnectNamespacedRef:
 		return getCPForNamespacedRef(ctx, cl, cpRef, namespace)
 	default:
-		return nil, ReferencedKongGatewayControlPlaneIsUnsupported{Reference: cpRef}
+		return nil, ReferencedKongGatewayControlPlaneIsUnsupportedError{Reference: cpRef}
 	}
 }
 

--- a/controller/specialized/aigateway_controller.go
+++ b/controller/specialized/aigateway_controller.go
@@ -78,14 +78,14 @@ func (r *AIGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	gwc, err := gatewayclass.Get(ctx, r.Client, aigateway.Spec.GatewayClassName)
 	if err != nil {
 		switch {
-		case errors.As(err, &operatorerrors.ErrUnsupportedGatewayClass{}):
+		case errors.As(err, &operatorerrors.UnsupportedGatewayClassError{}):
 			log.Debug(logger, "resource not supported, ignoring",
 				"expectedGatewayClass", vars.ControllerName(),
 				"gatewayClass", aigateway.Spec.GatewayClassName,
 				"reason", err.Error(),
 			)
 			return ctrl.Result{}, nil
-		case errors.As(err, &operatorerrors.ErrNotAcceptedGatewayClass{}):
+		case errors.As(err, &operatorerrors.NotAcceptedGatewayClassError{}):
 			log.Debug(logger, "GatewayClass not accepted, ignoring",
 				"gatewayClass", aigateway.Spec.GatewayClassName,
 				"reason", err.Error(),

--- a/controller/specialized/aigateway_controller_watch.go
+++ b/controller/specialized/aigateway_controller_watch.go
@@ -39,8 +39,8 @@ func (r *AIGatewayReconciler) aiGatewayHasMatchingGatewayClass(obj client.Object
 		// class as well. If we fail here it's most likely because of some failure
 		// of the Kubernetes API and it's technically better to enqueue the object
 		// than to drop it for eventual consistency during cluster outages.
-		return !errors.As(err, &operatorerrors.ErrUnsupportedGatewayClass{}) &&
-			!errors.As(err, &operatorerrors.ErrNotAcceptedGatewayClass{})
+		return !errors.As(err, &operatorerrors.UnsupportedGatewayClassError{}) &&
+			!errors.As(err, &operatorerrors.NotAcceptedGatewayClassError{})
 	}
 
 	return true

--- a/ingress-controller/internal/health/health_check.go
+++ b/ingress-controller/internal/health/health_check.go
@@ -2,6 +2,7 @@ package health
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -76,7 +77,7 @@ func (s *CheckServer) Start(ctx context.Context, addr string, logger logr.Logger
 	go func() {
 		err := server.ListenAndServe()
 		if err != nil {
-			if err == http.ErrServerClosed {
+			if errors.Is(err, http.ErrServerClosed) {
 				logger.Info("Healthz server closed")
 			} else {
 				logger.Error(err, "Healthz server failed")

--- a/ingress-controller/internal/konnect/nodes/client.go
+++ b/ingress-controller/internal/konnect/nodes/client.go
@@ -152,7 +152,10 @@ func (c *Client) ListAllNodes(ctx context.Context) ([]*NodeItem, error) {
 }
 
 func (c *Client) listNodes(ctx context.Context, nextCursor string) (*ListNodeResponse, error) {
-	url, _ := neturl.Parse(c.kicNodeAPIEndpoint())
+	url, err := neturl.Parse(c.kicNodeAPIEndpoint())
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse url %s: %w", c.kicNodeAPIEndpoint(), err)
+	}
 	if nextCursor != "" {
 		q := url.Query()
 		q.Set("page.next_cursor", nextCursor)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -19,36 +19,36 @@ var ErrUnexpectedObject = errors.New("unexpected object type provided")
 // Gateway - Errors
 // -----------------------------------------------------------------------------
 
-// ErrUnsupportedGatewayClass is an error which indicates that a provided GatewayClass
+// UnsupportedGatewayClassError is an error which indicates that a provided GatewayClass
 // is not supported.
-type ErrUnsupportedGatewayClass struct {
+type UnsupportedGatewayClassError struct {
 	reason string
 }
 
 // NewErrUnsupportedGateway creates a new ErrUnsupportedGatewayClass error
-func NewErrUnsupportedGateway(reason string) ErrUnsupportedGatewayClass {
-	return ErrUnsupportedGatewayClass{reason: reason}
+func NewErrUnsupportedGateway(reason string) UnsupportedGatewayClassError {
+	return UnsupportedGatewayClassError{reason: reason}
 }
 
 // Error returns the error message for the ErrUnsupportedGatewayClass error
-func (e ErrUnsupportedGatewayClass) Error() string {
+func (e UnsupportedGatewayClassError) Error() string {
 	return fmt.Sprintf("unsupported gateway class: %s", e.reason)
 }
 
-// ErrNotAcceptedGatewayClass is an error which indicates that a provided GatewayClass
+// NotAcceptedGatewayClassError is an error which indicates that a provided GatewayClass
 // is not accepted.
-type ErrNotAcceptedGatewayClass struct {
+type NotAcceptedGatewayClassError struct {
 	gatewayClass string
 	condition    metav1.Condition
 }
 
 // NewErrNotAcceptedGatewayClass creates a new ErrNotAcceptedGatewayClass error
-func NewErrNotAcceptedGatewayClass(gatewayClass string, condition metav1.Condition) ErrNotAcceptedGatewayClass {
-	return ErrNotAcceptedGatewayClass{gatewayClass: gatewayClass, condition: condition}
+func NewErrNotAcceptedGatewayClass(gatewayClass string, condition metav1.Condition) NotAcceptedGatewayClassError {
+	return NotAcceptedGatewayClassError{gatewayClass: gatewayClass, condition: condition}
 }
 
 // Error returns the error message for the ErrNotAcceptedGatewayClass error
-func (e ErrNotAcceptedGatewayClass) Error() string {
+func (e NotAcceptedGatewayClassError) Error() string {
 	return fmt.Sprintf("gateway class %s not accepted; reason: %s, message: %s", e.gatewayClass, e.condition.Reason, e.condition.Message)
 }
 

--- a/internal/utils/crossnamespace/kongreferencegrant.go
+++ b/internal/utils/crossnamespace/kongreferencegrant.go
@@ -11,9 +11,9 @@ import (
 	configurationv1alpha1 "github.com/kong/kong-operator/api/configuration/v1alpha1"
 )
 
-// ErrReferenceNotGranted is an error type that indicates a cross-namespace
+// ReferenceNotGrantedError is an error type that indicates a cross-namespace
 // reference is not granted by any KongReferenceGrant.
-type ErrReferenceNotGranted struct {
+type ReferenceNotGrantedError struct {
 	FromNamespace string
 	FromGVK       metav1.GroupVersionKind
 	ToNamespace   string
@@ -23,7 +23,7 @@ type ErrReferenceNotGranted struct {
 
 // Error returns a formatted error message indicating that a cross-namespace reference
 // is not permitted.
-func (e *ErrReferenceNotGranted) Error() string {
+func (e *ReferenceNotGrantedError) Error() string {
 	return fmt.Sprintf("cross-namespace reference to %s %s in namespace %s from %s.%s in namespace %s is not granted by any KongReferenceGrant",
 		e.ToGVK.Kind,
 		e.ToName,
@@ -39,7 +39,7 @@ func (e *ErrReferenceNotGranted) Error() string {
 // reference was attempted without the proper ReferenceGrant permissions.
 // It returns true if the error matches this type, false otherwise.
 func IsReferenceNotGranted(err error) bool {
-	var target *ErrReferenceNotGranted
+	var target *ReferenceNotGrantedError
 	return errors.As(err, &target)
 }
 
@@ -90,7 +90,7 @@ func CheckKongReferenceGrantForResource(
 		)
 	}
 	if !granted {
-		return &ErrReferenceNotGranted{
+		return &ReferenceNotGrantedError{
 			FromNamespace: fromNamespace,
 			FromGVK:       fromGVK,
 			ToNamespace:   toNamespace,

--- a/modules/diagnostics/http_handler.go
+++ b/modules/diagnostics/http_handler.go
@@ -93,7 +93,11 @@ func (h *HTTPHandler) handleListControlPlanes(rw http.ResponseWriter, r *http.Re
 		}),
 	}
 	rw.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(rw).Encode(resp)
+	if err := json.NewEncoder(rw).Encode(resp); err != nil {
+		h.logger.Error(err, "failed to encode response")
+		rw.WriteHeader(http.StatusInternalServerError)
+		_, _ = rw.Write([]byte("failed to encode response"))
+	}
 }
 
 func (h *HTTPHandler) handleAllControlPlanes(rw http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
**What this PR does / why we need it**:

One from the series, to keep it reviewable. 

Enable and apply fixes for [errcheck](https://golangci-lint.run/docs/linters/configuration/#errcheck), [errchkjson](https://golangci-lint.run/docs/linters/configuration/#errchkjson) and [errname](https://golangci-lint.run/docs/linters/configuration/#errchkjson).

It enforces consistent naming and error checking. It could be more restrictive, but it would introduce a lot of boilerplate for our code for dealing with cache without much gain. So having it like that seems to be a sweetspot.

Also, some opportunistic improvements regarding handling errors have been included in this PR. 


**Which issue this PR fixes**

Part of 

- https://github.com/Kong/kong-operator/issues/1847