### PR TITLE
tests: use test dependencies versions from test/test_dependencies.yaml

### DIFF
--- a/ingress-controller/test/kongintegration/dbmode_update_strategy_test.go
+++ b/ingress-controller/test/kongintegration/dbmode_update_strategy_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kong/kong-operator/ingress-controller/internal/dataplane/sendconfig"
 	managercfg "github.com/kong/kong-operator/ingress-controller/pkg/manager/config"
 	"github.com/kong/kong-operator/ingress-controller/test/kongintegration/containers"
+	"github.com/kong/kong-operator/ingress-controller/test/testenv"
 )
 
 func TestUpdateStrategyDBMode(t *testing.T) {
@@ -43,13 +44,17 @@ func TestUpdateStrategyDBMode(t *testing.T) {
 	kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), managercfg.AdminAPIClientConfig{}, "")
 	require.NoError(t, err)
 
+	gatewayTag, err := testenv.GetDependencyVersion("kongintegration.kong-ee")
+	require.NoError(t, err)
+	gatewayTag = trimEnterpriseTagToSemver(gatewayTag)
+
 	logbase, err := zap.NewDevelopment()
 	require.NoError(t, err)
 	logger := zapr.NewLogger(logbase)
 	sut := sendconfig.NewUpdateStrategyDBMode(
 		kongClient,
 		dump.Config{},
-		semver.MustParse("3.6.0"),
+		semver.MustParse(gatewayTag),
 		10,
 		logger,
 	)

--- a/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
+++ b/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
@@ -106,14 +106,24 @@ func TestKongClientGoldenTestsOutputs_Konnect(t *testing.T) {
 
 	ctx := t.Context()
 
+	gatewayTag, err := testenv.GetDependencyVersion("kongintegration.kong-ee")
+	require.NoError(t, err)
+	gatewayTag = trimEnterpriseTagToSemver(gatewayTag)
+
 	token := konnect.CreateTestPersonalAccessToken(ctx, t)
 	cpID := konnect.CreateTestControlPlane(ctx, t, token)
 	cert, key := konnect.CreateClientCertificate(ctx, t, cpID, token)
 	adminAPIClient := konnect.CreateKonnectAdminAPIClient(t, cpID, cert, key)
-	updateStrategy := sendconfig.NewUpdateStrategyDBModeKonnect(adminAPIClient.AdminAPIClient(), dump.Config{
-		SkipCACerts:         true,
-		KonnectControlPlane: cpID,
-	}, semver.MustParse("3.5.0"), 10, logr.Discard())
+	updateStrategy := sendconfig.NewUpdateStrategyDBModeKonnect(
+		adminAPIClient.AdminAPIClient(),
+		dump.Config{
+			SkipCACerts:         true,
+			KonnectControlPlane: cpID,
+		},
+		semver.MustParse(gatewayTag),
+		10,
+		logr.Discard(),
+	)
 
 	for _, goldenTestOutputPath := range allGoldenTestsOutputsPaths(t) {
 		t.Run(goldenTestOutputPath, func(t *testing.T) {

--- a/ingress-controller/test/kongintegration/tags.go
+++ b/ingress-controller/test/kongintegration/tags.go
@@ -1,0 +1,12 @@
+package kongintegration
+
+import "strings"
+
+func trimEnterpriseTagToSemver(tag string) string {
+	// Enterprise tags can contain a fourth segment, trim it to adhere to semver.
+	if strings.Count(tag, ".") > 2 {
+		parts := strings.SplitN(tag, ".", 4)
+		tag = strings.Join(parts[:3], ".")
+	}
+	return tag
+}

--- a/renovate.json
+++ b/renovate.json
@@ -107,6 +107,14 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?)\\s+(packageName=(?<packageName>.*))\\s+depName=(?<depName>.*?)\\n.+v?(?<currentValue>[0-9]+\\.[0-9.]+\\.[0-9]+)\\n"
       ]
+    },
+    {
+      "description": "Match dependencies in test/test_dependencies.yaml that are properly annotated with `# renovate: datasource={} depName={} [packageName={}] [registryUrl={}] versioning={}.`",
+      "customType": "regex",
+      "fileMatch": ["^test/test_dependencies.yaml$"],
+      "matchStrings": [
+        "#\\s+renovate:\\s+datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)\\s+(packageName=(?<packageName>.*)\\s+)?(registryUrl=(?<registryUrl>.*)\\s+)?versioning=(?<versioning>.*?)\\n.+'(?<currentValue>.*?)'"
+      ]
     }
   ],
   "packageRules": [


### PR DESCRIPTION
**What this PR does / why we need it**:

Use versions from `test/test_dependencies.yaml`.
Add renovate config (copied from KIC) to bump those versions automatically.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
