### PR TITLE
chore(lint): enable golangci-lint: `testifylint`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -48,8 +48,7 @@ linters:
     - revive
     - sloglint
     - staticcheck
-    # Uncomment or remove - TODO: https://github.com/Kong/kong-operator/issues/1847
-    # - testifylint
+    - testifylint
     - unconvert
     - unused
     - unparam
@@ -171,6 +170,7 @@ linters:
     testifylint:
       enable-all: true
       disable:
+        - require-error
         - error-is-as
     usetesting:
       os-temp-dir: true

--- a/api/test/conversion/gateway-operator.konghq.com/v1beta1/gatewayconfiguration_test.go
+++ b/api/test/conversion/gateway-operator.konghq.com/v1beta1/gatewayconfiguration_test.go
@@ -442,7 +442,7 @@ func TestGatewayConfiguration_ConvertFrom(t *testing.T) {
 
 			require.Equal(t, src.ObjectMeta, obj.ObjectMeta)
 
-			require.EqualValues(t,
+			require.Equal(t,
 				tc.expectedControlPlane.Deployment.PodTemplateSpec.Spec.Containers[0].Env,
 				obj.Spec.ControlPlaneOptions.Deployment.PodTemplateSpec.Spec.Containers[0].Env)
 			require.Equal(t, tc.expectedControlPlane.Extensions, obj.Spec.ControlPlaneOptions.Extensions)

--- a/api/test/conversion/konnect.konghq.com/v1alpha1/konnectgatewaycontrolplane_test.go
+++ b/api/test/conversion/konnect.konghq.com/v1alpha1/konnectgatewaycontrolplane_test.go
@@ -194,7 +194,7 @@ func TestKonnectGatewayControlPlane_ConvertFrom(t *testing.T) {
 				assert.Equal(t, tc.src.CreateControlPlaneRequest.ProxyUrls, obj.Spec.ProxyUrls)
 				assert.Equal(t, tc.src.CreateControlPlaneRequest.Labels, obj.Spec.Labels)
 			} else {
-				assert.Equal(t, obj.Spec.CreateControlPlaneRequest, v1alpha1.CreateControlPlaneRequest{})
+				assert.Equal(t, v1alpha1.CreateControlPlaneRequest{}, obj.Spec.CreateControlPlaneRequest)
 			}
 			if tc.mirror != nil {
 				require.NotNil(t, obj.Spec.Mirror)

--- a/api/test/unit/konnect_funcs_test.go
+++ b/api/test/unit/konnect_funcs_test.go
@@ -108,7 +108,7 @@ func TestKonnectFuncs(t *testing.T) {
 			require.Empty(t, obj.GetKonnectStatus().GetOrgID())
 			require.Empty(t, obj.GetKonnectStatus().GetServerURL())
 
-			require.Equal(t, "", obj.GetControlPlaneID())
+			require.Empty(t, obj.GetControlPlaneID())
 			obj.SetControlPlaneID("123")
 			require.Equal(t, "123", obj.GetControlPlaneID())
 

--- a/controller/controlplane/manager_options_test.go
+++ b/controller/controlplane/manager_options_test.go
@@ -931,7 +931,7 @@ func TestWithClusterDomain(t *testing.T) {
 	cfg := &managercfg.Config{}
 	opt := WithClusterDomain("foo.bar")
 	opt(cfg)
-	assert.Equal(t, cfg.ClusterDomain, "foo.bar")
+	assert.Equal(t, "foo.bar", cfg.ClusterDomain)
 }
 
 func TestWithEmitKubernetesEvents(t *testing.T) {

--- a/controller/hybridgateway/builder/kongroute_test.go
+++ b/controller/hybridgateway/builder/kongroute_test.go
@@ -523,7 +523,7 @@ func TestKongRouteBuilder_Chaining(t *testing.T) {
 	assert.Equal(t, "test-route", route.Name)
 	assert.Equal(t, "test-namespace", route.Namespace)
 	assert.Equal(t, "test-spec", *route.Spec.Name)
-	assert.Equal(t, true, *route.Spec.StripPath)
+	assert.True(t, *route.Spec.StripPath)
 	assert.Equal(t, []string{"example.com"}, route.Spec.Hosts)
 	assert.Equal(t, []string{"~/api$", "/api/"}, route.Spec.Paths)
 	assert.Equal(t, []string{"GET"}, route.Spec.Methods)

--- a/controller/hybridgateway/converter/gateway_test.go
+++ b/controller/hybridgateway/converter/gateway_test.go
@@ -416,7 +416,7 @@ func TestProcessListenerCertificate(t *testing.T) {
 			},
 			expectError: false,
 			validateOutput: func(t *testing.T, objects []client.Object) {
-				require.Len(t, objects, 0, "should not create any resources for unsupported group")
+				require.Empty(t, objects, "should not create any resources for unsupported group")
 			},
 		},
 		{
@@ -446,7 +446,7 @@ func TestProcessListenerCertificate(t *testing.T) {
 			},
 			expectError: false,
 			validateOutput: func(t *testing.T, objects []client.Object) {
-				require.Len(t, objects, 0, "should not create any resources for unsupported kind")
+				require.Empty(t, objects, "should not create any resources for unsupported kind")
 			},
 		},
 		{
@@ -475,7 +475,7 @@ func TestProcessListenerCertificate(t *testing.T) {
 			},
 			expectError: false,
 			validateOutput: func(t *testing.T, objects []client.Object) {
-				require.Len(t, objects, 0, "should not create resources for non-existent secret")
+				require.Empty(t, objects, "should not create resources for non-existent secret")
 			},
 		},
 		{
@@ -515,7 +515,7 @@ func TestProcessListenerCertificate(t *testing.T) {
 			},
 			expectError: true,
 			validateOutput: func(t *testing.T, objects []client.Object) {
-				require.Len(t, objects, 0, "should not create resources for invalid secret")
+				require.Empty(t, objects, "should not create resources for invalid secret")
 			},
 		},
 		{
@@ -598,7 +598,7 @@ func TestProcessListenerCertificate(t *testing.T) {
 			},
 			expectError: false,
 			validateOutput: func(t *testing.T, objects []client.Object) {
-				require.Len(t, objects, 0, "should not create resources when cross-namespace reference not granted")
+				require.Empty(t, objects, "should not create resources when cross-namespace reference not granted")
 			},
 		},
 		{
@@ -635,7 +635,7 @@ func TestProcessListenerCertificate(t *testing.T) {
 			},
 			expectError: true,
 			validateOutput: func(t *testing.T, objects []client.Object) {
-				require.Len(t, objects, 0, "should not create resources when Get fails")
+				require.Empty(t, objects, "should not create resources when Get fails")
 			},
 		},
 		{
@@ -683,7 +683,7 @@ func TestProcessListenerCertificate(t *testing.T) {
 			},
 			expectError: true,
 			validateOutput: func(t *testing.T, objects []client.Object) {
-				require.Len(t, objects, 0, "should not create resources when ReferenceGrant check fails")
+				require.Empty(t, objects, "should not create resources when ReferenceGrant check fails")
 			},
 		},
 	}
@@ -1209,7 +1209,7 @@ func TestTranslate(t *testing.T) {
 			expectError:   false,
 			expectedCount: 0,
 			validateOutput: func(t *testing.T, objects []client.Object) {
-				require.Len(t, objects, 0, "should not create any resources when secrets are missing")
+				require.Empty(t, objects, "should not create any resources when secrets are missing")
 			},
 		},
 		{
@@ -1429,7 +1429,7 @@ func TestTranslate(t *testing.T) {
 			expectedCount: 0,
 			errorContains: "failed to process 2 listener(s)",
 			validateOutput: func(t *testing.T, objects []client.Object) {
-				require.Len(t, objects, 0, "should not create any resources when all secrets are invalid")
+				require.Empty(t, objects, "should not create any resources when all secrets are invalid")
 			},
 		},
 		{
@@ -1660,7 +1660,7 @@ func TestGatewayConverter_GetOutputStore(t *testing.T) {
 		converter.outputStore = []client.Object{badObj1, badObj2}
 		objs, err := converter.GetOutputStore(ctx, logger)
 		require.Error(t, err)
-		require.Len(t, objs, 0)
+		require.Empty(t, objs)
 		require.Contains(t, err.Error(), "output store conversion failed with 2 errors")
 		require.Contains(t, err.Error(), "failed to convert *converter.badObject bad1 to unstructured")
 		require.Contains(t, err.Error(), "failed to convert *converter.badObject bad2 to unstructured")

--- a/controller/hybridgateway/converter/http_route_test.go
+++ b/controller/hybridgateway/converter/http_route_test.go
@@ -123,11 +123,11 @@ func TestHostnamesIntersection(t *testing.T) {
 				kongRoutes = append(kongRoutes, kongroute)
 			}
 
-			require.Equal(t, len(tt.expectedOutput), len(kongRoutes), "KongRoute objects number different than expected")
+			require.Len(t, kongRoutes, len(tt.expectedOutput), "KongRoute objects number different than expected")
 
 			for _, expectedRoute := range tt.expectedOutput {
 				for _, actualRoute := range kongRoutes {
-					assert.Equal(t, len(expectedRoute.Spec.Hosts), len(actualRoute.Spec.Hosts), "KongRoute hosts length does not match the expected one")
+					assert.Len(t, actualRoute.Spec.Hosts, len(expectedRoute.Spec.Hosts), "KongRoute hosts length does not match the expected one")
 					for _, h := range expectedRoute.Spec.Hosts {
 						assert.Contains(t, actualRoute.Spec.Hosts, h, "KongRoute hosts does not contain expected hostname %s", h)
 					}

--- a/controller/hybridgateway/target/target_test.go
+++ b/controller/hybridgateway/target/target_test.go
@@ -1810,7 +1810,7 @@ func TestFiltervalidBackendRefs(t *testing.T) {
 
 			// Should succeed but return no valid backend refs since no ReferenceGrant exists.
 			require.NoError(t, err)
-			assert.Len(t, results, 0) // Cross-namespace access blocked without ReferenceGrant.
+			assert.Empty(t, results) // Cross-namespace access blocked without ReferenceGrant.
 		})
 
 		// Test case 2: ReferenceGrant exists but doesn't permit - should be blocked.
@@ -1861,7 +1861,7 @@ func TestFiltervalidBackendRefs(t *testing.T) {
 
 			// Should succeed but return no valid backend refs since ReferenceGrant doesn't permit.
 			require.NoError(t, err)
-			assert.Len(t, results, 0) // Cross-namespace access blocked by non-permitting ReferenceGrant.
+			assert.Empty(t, results) // Cross-namespace access blocked by non-permitting ReferenceGrant.
 		})
 
 		// Test case 3: Error in CheckReferenceGrant - should return error.
@@ -1945,14 +1945,14 @@ func TestFiltervalidBackendRefs(t *testing.T) {
 
 		// Should succeed but return no valid backend refs since no EndpointSlices found.
 		require.NoError(t, err)
-		assert.Len(t, results, 0) // Service skipped due to no EndpointSlices.
+		assert.Empty(t, results) // Service skipped due to no EndpointSlices.
 	})
 }
 
 // TestRecalculateWeightsAcrossBackendRefs tests the recalculateWeightsAcrossBackendRefs function.
 func TestRecalculateWeightsAcrossBackendRefs(t *testing.T) {
 	// Helper function to create test validBackendRef.
-	createTestvalidBackendRef := func(serviceName, namespace string, weight *int32, readyEndpoints []string) validBackendRef {
+	createTestValidBackendRef := func(serviceName, namespace string, weight *int32, readyEndpoints []string) validBackendRef {
 		serviceKind := gwtypes.Kind("Service")
 		return validBackendRef{
 			backendRef: &gwtypes.HTTPBackendRef{
@@ -1989,13 +1989,13 @@ func TestRecalculateWeightsAcrossBackendRefs(t *testing.T) {
 			name:  "Empty input should return empty output",
 			input: []validBackendRef{},
 			validateResult: func(t *testing.T, result []validBackendRef) {
-				assert.Len(t, result, 0)
+				assert.Empty(t, result)
 			},
 		},
 		{
 			name: "Single backend ref should get calculated weight",
 			input: []validBackendRef{
-				createTestvalidBackendRef("service1", "default", ptr.To[int32](100), []string{"10.0.1.1", "10.0.1.2"}),
+				createTestValidBackendRef("service1", "default", ptr.To[int32](100), []string{"10.0.1.1", "10.0.1.2"}),
 			},
 			validateResult: func(t *testing.T, result []validBackendRef) {
 				require.Len(t, result, 1)
@@ -2007,8 +2007,8 @@ func TestRecalculateWeightsAcrossBackendRefs(t *testing.T) {
 		{
 			name: "Multiple backend refs with equal weights",
 			input: []validBackendRef{
-				createTestvalidBackendRef("service1", "default", ptr.To[int32](50), []string{"10.0.1.1"}),
-				createTestvalidBackendRef("service2", "default", ptr.To[int32](50), []string{"10.0.2.1"}),
+				createTestValidBackendRef("service1", "default", ptr.To[int32](50), []string{"10.0.1.1"}),
+				createTestValidBackendRef("service2", "default", ptr.To[int32](50), []string{"10.0.2.1"}),
 			},
 			validateResult: func(t *testing.T, result []validBackendRef) {
 				require.Len(t, result, 2)
@@ -2020,8 +2020,8 @@ func TestRecalculateWeightsAcrossBackendRefs(t *testing.T) {
 		{
 			name: "Multiple backend refs with different weights",
 			input: []validBackendRef{
-				createTestvalidBackendRef("service1", "default", ptr.To[int32](80), []string{"10.0.1.1"}),
-				createTestvalidBackendRef("service2", "default", ptr.To[int32](20), []string{"10.0.2.1"}),
+				createTestValidBackendRef("service1", "default", ptr.To[int32](80), []string{"10.0.1.1"}),
+				createTestValidBackendRef("service2", "default", ptr.To[int32](20), []string{"10.0.2.1"}),
 			},
 			validateResult: func(t *testing.T, result []validBackendRef) {
 				require.Len(t, result, 2)
@@ -2033,8 +2033,8 @@ func TestRecalculateWeightsAcrossBackendRefs(t *testing.T) {
 		{
 			name: "Backend refs with different endpoint counts",
 			input: []validBackendRef{
-				createTestvalidBackendRef("service1", "default", ptr.To[int32](50), []string{"10.0.1.1", "10.0.1.2"}), // 2 endpoints.
-				createTestvalidBackendRef("service2", "default", ptr.To[int32](50), []string{"10.0.2.1"}),             // 1 endpoint.
+				createTestValidBackendRef("service1", "default", ptr.To[int32](50), []string{"10.0.1.1", "10.0.1.2"}), // 2 endpoints.
+				createTestValidBackendRef("service2", "default", ptr.To[int32](50), []string{"10.0.2.1"}),             // 1 endpoint.
 			},
 			validateResult: func(t *testing.T, result []validBackendRef) {
 				require.Len(t, result, 2)
@@ -2046,8 +2046,8 @@ func TestRecalculateWeightsAcrossBackendRefs(t *testing.T) {
 		{
 			name: "Backend refs with nil weights should default to 1",
 			input: []validBackendRef{
-				createTestvalidBackendRef("service1", "default", nil, []string{"10.0.1.1"}),              // No weight (defaults to 1).
-				createTestvalidBackendRef("service2", "default", ptr.To[int32](3), []string{"10.0.2.1"}), // Weight 3.
+				createTestValidBackendRef("service1", "default", nil, []string{"10.0.1.1"}),              // No weight (defaults to 1).
+				createTestValidBackendRef("service2", "default", ptr.To[int32](3), []string{"10.0.2.1"}), // Weight 3.
 			},
 			validateResult: func(t *testing.T, result []validBackendRef) {
 				require.Len(t, result, 2)
@@ -2059,13 +2059,13 @@ func TestRecalculateWeightsAcrossBackendRefs(t *testing.T) {
 		{
 			name: "Backend refs with no ready endpoints should get zero weight",
 			input: []validBackendRef{
-				createTestvalidBackendRef("service-with-endpoints", "default", ptr.To[int32](50), []string{"10.0.1.1"}),
-				createTestvalidBackendRef("service-no-endpoints", "default", ptr.To[int32](50), []string{}), // No endpoints.
+				createTestValidBackendRef("service-with-endpoints", "default", ptr.To[int32](50), []string{"10.0.1.1"}),
+				createTestValidBackendRef("service-no-endpoints", "default", ptr.To[int32](50), []string{}), // No endpoints.
 			},
 			validateResult: func(t *testing.T, result []validBackendRef) {
 				require.Len(t, result, 2)
 				// Service with endpoints should get positive weight.
-				assert.True(t, result[0].weight > 0, "service with endpoints should have positive weight")
+				assert.Positive(t, result[0].weight, "service with endpoints should have positive weight")
 				// Service with no endpoints should get zero weight.
 				assert.Equal(t, int32(0), result[1].weight, "service with no endpoints should have zero weight")
 			},
@@ -2073,13 +2073,13 @@ func TestRecalculateWeightsAcrossBackendRefs(t *testing.T) {
 		{
 			name: "Backend ref with zero weight should get zero weight regardless of endpoints",
 			input: []validBackendRef{
-				createTestvalidBackendRef("service-normal", "default", ptr.To[int32](50), []string{"10.0.1.1"}),
-				createTestvalidBackendRef("service-zero-weight", "default", ptr.To[int32](0), []string{"10.0.2.1"}), // Zero weight.
+				createTestValidBackendRef("service-normal", "default", ptr.To[int32](50), []string{"10.0.1.1"}),
+				createTestValidBackendRef("service-zero-weight", "default", ptr.To[int32](0), []string{"10.0.2.1"}), // Zero weight.
 			},
 			validateResult: func(t *testing.T, result []validBackendRef) {
 				require.Len(t, result, 2)
 				// Normal service should get positive weight.
-				assert.True(t, result[0].weight > 0, "normal service should have positive weight")
+				assert.Positive(t, result[0].weight, "normal service should have positive weight")
 				// Zero weight service should get zero weight.
 				assert.Equal(t, int32(0), result[1].weight, "zero weight service should have zero weight")
 			},
@@ -2087,17 +2087,17 @@ func TestRecalculateWeightsAcrossBackendRefs(t *testing.T) {
 		{
 			name: "Complex scenario with multiple services and varying endpoints",
 			input: []validBackendRef{
-				createTestvalidBackendRef("web", "frontend", ptr.To[int32](60), []string{"10.0.1.1", "10.0.1.2", "10.0.1.3"}), // 3 endpoints.
-				createTestvalidBackendRef("api", "backend", ptr.To[int32](30), []string{"10.0.2.1", "10.0.2.2"}),              // 2 endpoints.
-				createTestvalidBackendRef("cache", "backend", ptr.To[int32](10), []string{"10.0.3.1"}),                        // 1 endpoint.
+				createTestValidBackendRef("web", "frontend", ptr.To[int32](60), []string{"10.0.1.1", "10.0.1.2", "10.0.1.3"}), // 3 endpoints.
+				createTestValidBackendRef("api", "backend", ptr.To[int32](30), []string{"10.0.2.1", "10.0.2.2"}),              // 2 endpoints.
+				createTestValidBackendRef("cache", "backend", ptr.To[int32](10), []string{"10.0.3.1"}),                        // 1 endpoint.
 			},
 			validateResult: func(t *testing.T, result []validBackendRef) {
 				require.Len(t, result, 3)
 				// Complex weight calculation based on CalculateEndpointWeights logic.
 				// The exact values depend on the weight distribution algorithm.
-				assert.True(t, result[0].weight > 0, "web service should have positive weight")
-				assert.True(t, result[1].weight > 0, "api service should have positive weight")
-				assert.True(t, result[2].weight > 0, "cache service should have positive weight")
+				assert.Positive(t, result[0].weight, "web service should have positive weight")
+				assert.Positive(t, result[1].weight, "api service should have positive weight")
+				assert.Positive(t, result[2].weight, "cache service should have positive weight")
 				// Total weight should be reasonable.
 				totalWeight := result[0].weight + result[1].weight + result[2].weight
 				assert.True(t, totalWeight > 0 && totalWeight <= 200, "total weight should be reasonable")
@@ -2121,7 +2121,7 @@ func TestRecalculateWeightsAcrossBackendRefs(t *testing.T) {
 			// Verify that input structs are modified (weights updated).
 			for i, vbRef := range result {
 				// Weight should be >= 0 (can be 0 for backends with no endpoints or zero weight).
-				assert.True(t, vbRef.weight >= 0, "weight should be non-negative for backend %d", i)
+				assert.GreaterOrEqual(t, vbRef.weight, int32(0), "weight should be non-negative for backend %d", i)
 				// Verify that other fields are preserved.
 				assert.Equal(t, tt.input[i].backendRef, vbRef.backendRef, "backendRef should be preserved")
 				assert.Equal(t, tt.input[i].service, vbRef.service, "service should be preserved")
@@ -2626,7 +2626,7 @@ func TestTargetsForBackendRefs(t *testing.T) {
 				require.NotNil(t, service2Target, "service2 target should exist")
 
 				// Service1 should have higher weight than service2 (70 vs 30).
-				assert.True(t, service1Target.Spec.Weight > service2Target.Spec.Weight,
+				assert.Greater(t, service1Target.Spec.Weight, service2Target.Spec.Weight,
 					"service1 weight (%d) should be higher than service2 weight (%d)",
 					service1Target.Spec.Weight, service2Target.Spec.Weight)
 			},

--- a/controller/hybridgateway/target/weight_test.go
+++ b/controller/hybridgateway/target/weight_test.go
@@ -473,8 +473,8 @@ func TestCalculateEndpointWeights_EdgeCaseCombinations(t *testing.T) {
 		t.Logf("Overflow protection test results: overflow-1=%d, overflow-2=%d", weight1, weight2)
 
 		// Both weights should be non-zero and reasonable (not exceed uint32 max)
-		assert.Greater(t, weight1, uint32(0), "overflow-1 should have non-zero weight")
-		assert.Greater(t, weight2, uint32(0), "overflow-2 should have non-zero weight")
+		assert.Positive(t, weight1, "overflow-1 should have non-zero weight")
+		assert.Positive(t, weight2, "overflow-2 should have non-zero weight")
 		assert.LessOrEqual(t, weight1, uint32(1<<32-1), "overflow-1 should not exceed uint32 max")
 		assert.LessOrEqual(t, weight2, uint32(1<<32-1), "overflow-2 should not exceed uint32 max")
 	})
@@ -498,8 +498,8 @@ func TestCalculateEndpointWeights_EdgeCaseCombinations(t *testing.T) {
 
 		t.Logf("Multiplication overflow test: large-weight=%d, small=%d", largeWeight, smallWeight)
 
-		assert.Greater(t, largeWeight, uint32(0))
-		assert.Greater(t, smallWeight, uint32(0))
+		assert.Positive(t, largeWeight)
+		assert.Positive(t, smallWeight)
 		assert.LessOrEqual(t, largeWeight, uint32(1<<32-1))
 		assert.LessOrEqual(t, smallWeight, uint32(1<<32-1))
 
@@ -688,7 +688,7 @@ func TestCalculateEndpointWeights_WithKongLimits(t *testing.T) {
 			// Verify all non-zero weight backends have positive weights (participation preserved).
 			for _, backend := range tt.backends {
 				if backend.Weight > 0 && backend.Endpoints > 0 {
-					assert.Greater(t, result[backend.Name], uint32(0), "Backend %s should have non-zero weight", backend.Name)
+					assert.Positive(t, result[backend.Name], "Backend %s should have non-zero weight", backend.Name)
 				}
 			}
 

--- a/controller/hybridgateway/watch/mapfuncs_httproute_test.go
+++ b/controller/hybridgateway/watch/mapfuncs_httproute_test.go
@@ -463,7 +463,7 @@ func Test_MapHTTPRouteForService(t *testing.T) {
 		ctx := context.Background()
 		obj := otherSvc
 		requests := mapFuncDiffNS(ctx, obj)
-		require.Len(t, requests, 0)
+		require.Empty(t, requests)
 	})
 
 	t.Run("wrong type", func(t *testing.T) {
@@ -721,7 +721,7 @@ func Test_MapHTTPRouteForReferenceGrant(t *testing.T) {
 		mapFunc := MapHTTPRouteForReferenceGrant(cl)
 		ctx := context.Background()
 		requests := mapFunc(ctx, rgWithWrongKind)
-		require.Len(t, requests, 0)
+		require.Empty(t, requests)
 	})
 
 	t.Run("skip wrong group", func(t *testing.T) {
@@ -747,7 +747,7 @@ func Test_MapHTTPRouteForReferenceGrant(t *testing.T) {
 		mapFunc := MapHTTPRouteForReferenceGrant(cl)
 		ctx := context.Background()
 		requests := mapFunc(ctx, rgWithWrongGroup)
-		require.Len(t, requests, 0)
+		require.Empty(t, requests)
 	})
 
 	t.Run("accept empty group", func(t *testing.T) {
@@ -787,7 +787,7 @@ func Test_MapHTTPRouteForReferenceGrant(t *testing.T) {
 		mapFunc := MapHTTPRouteForReferenceGrant(cl)
 		ctx := context.Background()
 		requests := mapFunc(ctx, referenceGrant)
-		require.Len(t, requests, 0)
+		require.Empty(t, requests)
 	})
 
 	t.Run("error listing HTTPRoutes", func(t *testing.T) {
@@ -914,7 +914,7 @@ func Test_MapHTTPRouteForReferenceGrant(t *testing.T) {
 		mapFunc := MapHTTPRouteForReferenceGrant(cl)
 		ctx := context.Background()
 		requests := mapFunc(ctx, rgEmptyFrom)
-		require.Len(t, requests, 0)
+		require.Empty(t, requests)
 	})
 
 	t.Run("multiple routes in from namespace but only cross-namespace ref returned", func(t *testing.T) {

--- a/controller/konnect/ops/ops_errors_test.go
+++ b/controller/konnect/ops/ops_errors_test.go
@@ -801,7 +801,7 @@ func TestGetRetryAfterFromRateLimitError(t *testing.T) {
 
 			gotDuration, gotIsRateLimited := GetRetryAfterFromRateLimitError(err)
 			require.True(t, gotIsRateLimited)
-			require.Equal(t, gotDuration, 60*time.Second)
+			require.Equal(t, 60*time.Second, gotDuration)
 		})
 	})
 }

--- a/controller/konnect/ops/ops_kongconsumer_test.go
+++ b/controller/konnect/ops/ops_kongconsumer_test.go
@@ -226,7 +226,7 @@ func TestAdoptKongConsumerMatchNotMatching(t *testing.T) {
 	err := adoptConsumer(ctx, sdk, cgSDK, cl, consumer, adoptOptions)
 	require.Error(t, err)
 	var notMatch KonnectEntityAdoptionNotMatchError
-	assert.True(t, errors.As(err, &notMatch))
+	assert.ErrorAs(t, err, &notMatch)
 }
 
 func TestAdoptKongConsumerFetchError(t *testing.T) {
@@ -261,5 +261,5 @@ func TestAdoptKongConsumerFetchError(t *testing.T) {
 	err := adoptConsumer(ctx, sdk, cgSDK, cl, consumer, adoptOptions)
 	require.Error(t, err)
 	var fetchErr KonnectEntityAdoptionFetchError
-	assert.True(t, errors.As(err, &fetchErr))
+	assert.ErrorAs(t, err, &fetchErr)
 }

--- a/controller/konnect/ops/ops_kongconsumergroup_test.go
+++ b/controller/konnect/ops/ops_kongconsumergroup_test.go
@@ -177,7 +177,7 @@ func TestAdoptKongConsumerGroupMatchNotMatching(t *testing.T) {
 	err := adoptConsumerGroup(ctx, sdk, group, adoptOptions)
 	require.Error(t, err)
 	var notMatch KonnectEntityAdoptionNotMatchError
-	assert.True(t, errors.As(err, &notMatch))
+	assert.ErrorAs(t, err, &notMatch)
 }
 
 func TestAdoptKongConsumerGroupUIDConflict(t *testing.T) {
@@ -220,7 +220,7 @@ func TestAdoptKongConsumerGroupUIDConflict(t *testing.T) {
 	err := adoptConsumerGroup(ctx, sdk, group, adoptOptions)
 	require.Error(t, err)
 	var uidConflict KonnectEntityAdoptionUIDTagConflictError
-	assert.True(t, errors.As(err, &uidConflict))
+	assert.ErrorAs(t, err, &uidConflict)
 }
 
 func TestAdoptKongConsumerGroupFetchError(t *testing.T) {
@@ -256,5 +256,5 @@ func TestAdoptKongConsumerGroupFetchError(t *testing.T) {
 	err := adoptConsumerGroup(ctx, sdk, group, adoptOptions)
 	require.Error(t, err)
 	var fetchErr KonnectEntityAdoptionFetchError
-	assert.True(t, errors.As(err, &fetchErr))
+	assert.ErrorAs(t, err, &fetchErr)
 }

--- a/ingress-controller/internal/clients/manager_test.go
+++ b/ingress-controller/internal/clients/manager_test.go
@@ -225,7 +225,7 @@ func TestAdminAPIClientsManager_Clients_DBMode(t *testing.T) {
 
 	configureClients := m.GatewayClientsToConfigure()
 	require.Len(t, configureClients, 1, "Expecting 1 client to configure")
-	require.Truef(t, lo.ContainsBy(initialClients, func(c *adminapi.Client) bool {
+	require.True(t, lo.ContainsBy(initialClients, func(c *adminapi.Client) bool {
 		return c.BaseRootURL() == configureClients[0].BaseRootURL()
 	}), "Client's address %s should be in initial clients")
 

--- a/ingress-controller/internal/dataplane/translator/subtranslator/httproute_atc_test.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/httproute_atc_test.go
@@ -1040,9 +1040,13 @@ func TestGroupHTTPRouteMatchesWithPrioritiesByRule(t *testing.T) {
 						return actualMatches[i].Match.MatchIndex < actualMatches[j].Match.MatchIndex
 					})
 					for i, expectedMatch := range expectedMatches {
-						require.Equalf(t, expectedMatch.Match.Hostname, actualMatches[i].Match.Hostname, "Split match %d in rule %s, HTTPRoute %s/%s should have expected hostname",
+						require.Equalf(
+							t, expectedMatch.Match.Hostname, actualMatches[i].Match.Hostname,
+							"Split match %d in rule %s, HTTPRoute %s/%s should have expected hostname",
 							i, ruleIndex, route.Namespace, route.Name)
-						require.Equalf(t, expectedMatch.Match.Match, actualMatches[i].Match.Match, "Split match %d should have expected HTTPRoute match",
+						require.Equalf(
+							t, expectedMatch.Match.Match, actualMatches[i].Match.Match,
+							"Split match %d in rule %s, HTTPRoute %s/%s should have expected HTTPRoute match",
 							i, ruleIndex, route.Namespace, route.Name)
 					}
 				}

--- a/ingress-controller/internal/diagnostics/server_test.go
+++ b/ingress-controller/internal/diagnostics/server_test.go
@@ -156,7 +156,7 @@ func TestDiagnosticsServer_Diffs(t *testing.T) {
 	_, err = b.ReadFrom(second.Body)
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(b.Bytes(), &got))
-	require.Equal(t, diffHistorySize, len(got.Available))
+	require.Len(t, got.Available, diffHistorySize)
 
 	// confirm that the by hash endpoints cannot retrieve the last diff sent, and get a 404 for the first (now discarded)
 	// diff sent
@@ -205,13 +205,13 @@ func setupTestServer(ctx context.Context, t *testing.T) (Client, int) {
 
 	go func() {
 		err := s.Listen(ctx)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 	t.Log("Started diagnostics server")
 
 	go func() {
 		err := diagnosticsCollector.Start(ctx)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 	t.Log("Started diagnostics collector")
 

--- a/ingress-controller/internal/konnect/config_synchronizer_test.go
+++ b/ingress-controller/internal/konnect/config_synchronizer_test.go
@@ -353,6 +353,6 @@ func runSynchronizer(ctx context.Context, t *testing.T, s *konnect.ConfigSynchro
 	t.Log("Running Konnect config synchronizer")
 	go func() {
 		err := s.Start(ctx)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 }

--- a/ingress-controller/internal/konnect/controlplanes/client_test.go
+++ b/ingress-controller/internal/konnect/controlplanes/client_test.go
@@ -7,6 +7,7 @@ import (
 
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kong-operator/ingress-controller/internal/konnect/sdk"
@@ -26,12 +27,10 @@ func newMockControlPlanesServer(t *testing.T) *mockControlPlanesServer {
 func (m *mockControlPlanesServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodPost:
-		require.Equal(m.t, metadata.Metadata().UserAgent(), r.Header.Get("User-Agent"))
+		assert.Equal(m.t, metadata.Metadata().UserAgent(), r.Header.Get("User-Agent"))
 		w.WriteHeader(http.StatusCreated)
-
 	case http.MethodDelete:
-		require.Equal(m.t, metadata.Metadata().UserAgent(), r.Header.Get("User-Agent"))
-
+		assert.Equal(m.t, metadata.Metadata().UserAgent(), r.Header.Get("User-Agent"))
 	}
 }
 

--- a/ingress-controller/internal/konnect/license/client_test.go
+++ b/ingress-controller/internal/konnect/license/client_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	konnectlicense "github.com/kong/kong-operator/ingress-controller/internal/konnect/license"
@@ -32,7 +33,7 @@ func newMockKonnectLicenseServer(t *testing.T, response []byte, statusCode int) 
 }
 
 func (m *mockKonnectLicenseServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	require.Equal(m.t, metadata.Metadata().UserAgent(), r.Header.Get("User-Agent"))
+	assert.Equal(m.t, metadata.Metadata().UserAgent(), r.Header.Get("User-Agent"))
 	w.WriteHeader(m.statusCode)
 	_, _ = w.Write(m.response)
 }

--- a/ingress-controller/internal/konnect/node_agent_test.go
+++ b/ingress-controller/internal/konnect/node_agent_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kong-operator/ingress-controller/internal/clients"
@@ -354,7 +355,7 @@ func TestNodeAgent_StartDoesntReturnUntilContextGetsCancelled(t *testing.T) {
 	agentReturned := make(chan struct{})
 	go func() {
 		err := nodeAgent.Start(ctx)
-		require.ErrorIs(t, err, context.Canceled)
+		assert.ErrorIs(t, err, context.Canceled)
 		close(agentReturned)
 	}()
 
@@ -612,7 +613,7 @@ func runAgent(t *testing.T, nodeAgent *konnect.NodeAgent) {
 	agentReturned := make(chan struct{})
 	go func() {
 		err := nodeAgent.Start(ctx)
-		require.ErrorIs(t, err, context.Canceled)
+		assert.ErrorIs(t, err, context.Canceled)
 		close(agentReturned)
 	}()
 

--- a/ingress-controller/internal/konnect/nodes/client_test.go
+++ b/ingress-controller/internal/konnect/nodes/client_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kong-operator/ingress-controller/internal/konnect/nodes"
@@ -23,7 +24,7 @@ func newMockNodesServer(t *testing.T) *mockNodesServer {
 }
 
 func (m *mockNodesServer) ServeHTTP(_ http.ResponseWriter, r *http.Request) {
-	require.Equal(m.t, metadata.Metadata().UserAgent(), r.Header.Get("User-Agent"))
+	assert.Equal(m.t, metadata.Metadata().UserAgent(), r.Header.Get("User-Agent"))
 }
 
 func TestNodesClientUserAgent(t *testing.T) {

--- a/ingress-controller/internal/store/fake_store_test.go
+++ b/ingress-controller/internal/store/fake_store_test.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/samber/lo"
@@ -189,7 +188,7 @@ func TestFakeStoreService(t *testing.T) {
 
 	service, err = store.GetService("default", "does-not-exists")
 	assert.Error(err)
-	assert.True(errors.As(err, &NotFoundError{}))
+	assert.ErrorAs(err, &NotFoundError{})
 	assert.Nil(service)
 }
 
@@ -274,7 +273,7 @@ func TestFakeStoreConsumer(t *testing.T) {
 	c, err = store.GetKongConsumer("default", "does-not-exist")
 	assert.Nil(c)
 	assert.Error(err)
-	assert.True(errors.As(err, &NotFoundError{}))
+	assert.ErrorAs(err, &NotFoundError{})
 }
 
 func TestFakeStoreConsumerGroup(t *testing.T) {
@@ -303,7 +302,7 @@ func TestFakeStoreConsumerGroup(t *testing.T) {
 	c, err = store.GetKongConsumerGroup("default", "does-not-exist")
 	assert.Nil(c)
 	assert.Error(err)
-	assert.True(errors.As(err, &NotFoundError{}))
+	assert.ErrorAs(err, &NotFoundError{})
 }
 
 func TestFakeStorePlugins(t *testing.T) {
@@ -399,7 +398,7 @@ func TestFakeStoreClusterPlugins(t *testing.T) {
 
 	plugin, err = store.GetKongClusterPlugin("does-not-exist")
 	assert.Error(err)
-	assert.True(errors.As(err, &NotFoundError{}))
+	assert.ErrorAs(err, &NotFoundError{})
 	assert.Nil(plugin)
 }
 
@@ -425,7 +424,7 @@ func TestFakeStoreSecret(t *testing.T) {
 	secret, err = store.GetSecret("default", "does-not-exist")
 	assert.Nil(secret)
 	assert.Error(err)
-	assert.True(errors.As(err, &NotFoundError{}))
+	assert.ErrorAs(err, &NotFoundError{})
 }
 
 func TestFakeStore_ListCACerts(t *testing.T) {

--- a/ingress-controller/pkg/manager/multiinstance/manager_test.go
+++ b/ingress-controller/pkg/manager/multiinstance/manager_test.go
@@ -50,7 +50,7 @@ func TestManager_Scheduling(t *testing.T) {
 	t.Run("can run the manager", func(t *testing.T) {
 		go func() {
 			close(managerRunning)
-			require.NoError(t, multiManager.Start(ctx))
+			assert.NoError(t, multiManager.Start(ctx))
 		}()
 	})
 
@@ -101,7 +101,7 @@ func TestManager_WithDiagnosticsExposer(t *testing.T) {
 	multiManager := multiinstance.NewManager(testr.New(t), multiinstance.WithDiagnosticsExposer(diagnosticsExposer))
 
 	go func() {
-		require.NoError(t, multiManager.Start(ctx))
+		assert.NoError(t, multiManager.Start(ctx))
 	}()
 
 	instanceID1 := manager.NewRandomID()

--- a/ingress-controller/test/e2e/all_in_one_test.go
+++ b/ingress-controller/test/e2e/all_in_one_test.go
@@ -113,7 +113,7 @@ func TestDeployAllInOnePostgresWithMultipleReplicas(t *testing.T) {
 	}
 	podList, err := env.Cluster().Client().CoreV1().Pods(deployment.Namespace).List(ctx, forDeployment)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(podList.Items))
+	require.Len(t, podList.Items, 1)
 	initialPod := podList.Items[0]
 
 	t.Log("adding a second replica to the Kong deployment")

--- a/ingress-controller/test/e2e/features_test.go
+++ b/ingress-controller/test/e2e/features_test.go
@@ -513,7 +513,7 @@ func TestDefaultIngressClass(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			if value, ok := resp.Header["Access-Control-Allow-Origin"]; ok {
 				return strings.Contains(b.String(), "<title>httpbin.org</title>") && value[0] == "example.com"
 			}

--- a/ingress-controller/test/e2e/helpers_gateway_test.go
+++ b/ingress-controller/test/e2e/helpers_gateway_test.go
@@ -226,7 +226,7 @@ func verifyHTTPRoute(ctx context.Context, t *testing.T, env environments.Environ
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false

--- a/ingress-controller/test/e2e/helpers_test.go
+++ b/ingress-controller/test/e2e/helpers_test.go
@@ -590,7 +590,7 @@ func verifyEnterprise(ctx context.Context, t *testing.T, env environments.Enviro
 	t.Log("finding the ip address for the admin API")
 	service, err := env.Cluster().Client().CoreV1().Services(namespace).Get(ctx, adminServiceName, metav1.GetOptions{})
 	require.NoError(t, err)
-	require.Equal(t, 1, len(service.Status.LoadBalancer.Ingress))
+	require.Len(t, service.Status.LoadBalancer.Ingress, 1)
 	adminIP := service.Status.LoadBalancer.Ingress[0].IP
 
 	t.Log("building a GET request to gather admin api information")
@@ -630,10 +630,10 @@ func verifyEnterprise(ctx context.Context, t *testing.T, env environments.Enviro
 	if string(adminOutput.Version[0]) == "3" {
 		// 3.x removed the "-enterprise-edition" string but provided no other indication that something is enterprise
 		require.Len(t, strings.Split(adminOutput.Version, "."), 4,
-			fmt.Sprintf("actual kong version: %s", adminOutput.Version))
+			"actual kong version: %s", adminOutput.Version)
 	} else {
 		require.Contains(t, adminOutput.Version, "enterprise-edition",
-			fmt.Sprintf("actual kong version: %s", adminOutput.Version))
+			"actual kong version: %s", adminOutput.Version)
 	}
 }
 
@@ -643,7 +643,7 @@ func verifyEnterpriseWithPostgres(ctx context.Context, t *testing.T, env environ
 	t.Log("finding the ip address for the admin API")
 	service, err := env.Cluster().Client().CoreV1().Services(namespace).Get(ctx, adminServiceName, metav1.GetOptions{})
 	require.NoError(t, err)
-	require.Equal(t, 1, len(service.Status.LoadBalancer.Ingress))
+	require.Len(t, service.Status.LoadBalancer.Ingress, 1)
 	adminIP := service.Status.LoadBalancer.Ingress[0].IP
 
 	t.Log("building a POST request to create a new kong workspace")
@@ -660,7 +660,7 @@ func verifyEnterpriseWithPostgres(ctx context.Context, t *testing.T, env environ
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusCreated, resp.StatusCode, fmt.Sprintf("STATUS=(%s), BODY=(%s)", resp.Status, string(body)))
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "STATUS=(%s), BODY=(%s)", resp.Status, string(body))
 }
 
 // licenseOutput is the license section of the admin API root response.

--- a/ingress-controller/test/e2e/performance_basic_test.go
+++ b/ingress-controller/test/e2e/performance_basic_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -187,7 +188,7 @@ func TestResourceApplyAndUpdatePerf(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 
-			require.Eventually(t, func() bool {
+			assert.Eventually(t, func() bool {
 				return isRouteActive(ctx, t, helpers.DefaultHTTPClient(), proxyURLForDefaultIngress, "get", i)
 			}, ingressWait*10, time.Millisecond*500)
 		}(i)
@@ -247,7 +248,7 @@ func isRouteActive(ctx context.Context, t *testing.T, client *http.Client, proxy
 		b := new(bytes.Buffer)
 		n, err := b.ReadFrom(resp.Body)
 		require.NoError(t, err)
-		require.True(t, n > 0)
+		require.Positive(t, n)
 		return strings.Contains(b.String(), "origin")
 	}
 	return false

--- a/ingress-controller/test/e2e/utils_test.go
+++ b/ingress-controller/test/e2e/utils_test.go
@@ -203,7 +203,7 @@ func getKongProxyIP(ctx context.Context, t *testing.T, env environments.Environm
 	}
 
 	svc := refreshService()
-	require.NotEqual(t, svc.Spec.Type, corev1.ServiceTypeClusterIP, "ClusterIP service is not supported")
+	require.NotEqual(t, corev1.ServiceTypeClusterIP, svc.Spec.Type, "ClusterIP service is not supported")
 
 	switch svc.Spec.Type {
 	case corev1.ServiceTypeLoadBalancer:

--- a/ingress-controller/test/kongintegration/dbmode_update_strategy_test.go
+++ b/ingress-controller/test/kongintegration/dbmode_update_strategy_test.go
@@ -1,7 +1,6 @@
 package kongintegration
 
 import (
-	"errors"
 	"testing"
 	"time"
 
@@ -97,7 +96,7 @@ func TestUpdateStrategyDBMode(t *testing.T) {
 			return
 		}
 		var updateError sendconfig.UpdateError
-		if !assert.True(t, errors.As(err, &updateError)) {
+		if !assert.ErrorAs(t, err, &updateError) {
 			return
 		}
 		if !assert.NotEmpty(t, updateError.ResourceFailures()) {

--- a/ingress-controller/test/kongintegration/inmemory_update_strategy_test.go
+++ b/ingress-controller/test/kongintegration/inmemory_update_strategy_test.go
@@ -2,7 +2,6 @@ package kongintegration
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
 	"time"
 
@@ -104,7 +103,7 @@ func TestUpdateStrategyInMemory_PropagatesResourcesErrors(t *testing.T) {
 			return
 		}
 		var updateError sendconfig.UpdateError
-		if !assert.True(t, errors.As(err, &updateError)) {
+		if !assert.ErrorAs(t, err, &updateError) {
 			return
 		}
 		if wrappedErr := updateError.Unwrap(); !assert.Error(t, wrappedErr) || !assert.IsType(t, &kong.APIError{}, wrappedErr) {
@@ -124,7 +123,7 @@ func TestUpdateStrategyInMemory_PropagatesResourcesErrors(t *testing.T) {
 		if !assert.Truef(t, found, "expected resource error for test-service, got: %+v", updateError.ResourceFailures()) {
 			return
 		}
-		if !assert.Equal(t, resourceErr.Message(), expectedMessage) {
+		if !assert.Equal(t, expectedMessage, resourceErr.Message()) {
 			return
 		}
 		if diff := cmp.Diff(expectedCausingObjects, resourceErr.CausingObjects()); !assert.Empty(t, diff) {

--- a/modules/cli/cli_test.go
+++ b/modules/cli/cli_test.go
@@ -141,7 +141,7 @@ func TestSetFlagFromEnvVar(t *testing.T) {
 				require.Nil(t, panicErr, "test case should not have panicked: %v", panicErr)
 			}
 
-			require.Equal(t, output, tC.expectedOutput)
+			require.Equal(t, tC.expectedOutput, output)
 
 			if !tC.shouldFail && !tC.skipCheckingValue {
 				require.Equal(t, tC.expectedVal, *val)

--- a/test/crdsvalidation/common/testcase.go
+++ b/test/crdsvalidation/common/testcase.go
@@ -221,7 +221,7 @@ func (tc *TestCase[T]) RunWithConfig(t *testing.T, cfg *rest.Config, scheme *run
 				// If the expected update error message is defined, check if the error message contains the expected message
 				// and return. Otherwise, expect no error.
 				if tc.ExpectedUpdateErrorMessage != nil {
-					require.NotNil(c, err)
+					require.Error(c, err)
 					assert.Contains(c, err.Error(), *tc.ExpectedUpdateErrorMessage)
 					return
 				}

--- a/test/envtest/configerrorevent_envtest_test.go
+++ b/test/envtest/configerrorevent_envtest_test.go
@@ -340,7 +340,7 @@ func assertExpectedEvents(t *testing.T, predicatesToCheck []func(e corev1.Event)
 			break
 		}
 	}
-	if !assert.Equal(t, 0, len(collectedEvents), "expected all warning events to match test predicates, but some were left") {
+	if !assert.Empty(t, collectedEvents, "expected all warning events to match test predicates, but some were left") {
 		t.Logf("remaining events %d:", len(collectedEvents))
 		for _, e := range collectedEvents {
 			t.Logf("  - %s | %s | %s | %s | %s", e.Type, e.Reason, e.InvolvedObject.Kind, e.InvolvedObject.Name, e.Message)

--- a/test/envtest/log.go
+++ b/test/envtest/log.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
@@ -58,7 +58,7 @@ func DumpLogsIfTestFailed(t *testing.T, logs LogsObserver) {
 	t.Logf("Test %s failed: dumping controller logs\n", t.Name())
 	for _, entry := range logs.All() {
 		b, err := encoder.EncodeEntry(entry.Entry, entry.Context)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		t.Logf("%s", b.String())
 	}
 }

--- a/test/envtest/manager_envtest_test.go
+++ b/test/envtest/manager_envtest_test.go
@@ -106,7 +106,7 @@ func TestManager_NoLeakedGoroutinesAfterContextCancellation(t *testing.T) {
 	)
 	go func() {
 		err := m.Run(ctx)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 
 	t.Log("Waiting for the manager to become ready")

--- a/test/envtest/multiinstance_manager_diagnostics_test.go
+++ b/test/envtest/multiinstance_manager_diagnostics_test.go
@@ -36,11 +36,11 @@ func TestMultiInstanceManagerDiagnostics(t *testing.T) {
 	t.Log("Starting the diagnostics server and the multi-instance manager")
 	diagServer := multiinstance.NewDiagnosticsServer(diagPort)
 	go func() {
-		require.ErrorIs(t, diagServer.Start(ctx), http.ErrServerClosed)
+		assert.ErrorIs(t, diagServer.Start(ctx), http.ErrServerClosed)
 	}()
 	multimgr := multiinstance.NewManager(testr.New(t), multiinstance.WithDiagnosticsExposer(diagServer))
 	go func() {
-		require.NoError(t, multimgr.Start(ctx))
+		assert.NoError(t, multimgr.Start(ctx))
 	}()
 
 	t.Log("Setting up two instances of the manager and scheduling them in the multi-instance manager")
@@ -86,11 +86,11 @@ func TestMultiInstanceManager_Profiling(t *testing.T) {
 	t.Log("Starting the diagnostics server and the multi-instance manager")
 	diagServer := multiinstance.NewDiagnosticsServer(diagPort, multiinstance.WithPprofHandler())
 	go func() {
-		require.ErrorIs(t, diagServer.Start(ctx), http.ErrServerClosed)
+		assert.ErrorIs(t, diagServer.Start(ctx), http.ErrServerClosed)
 	}()
 	multimgr := multiinstance.NewManager(testr.New(t), multiinstance.WithDiagnosticsExposer(diagServer))
 	go func() {
-		require.NoError(t, multimgr.Start(ctx))
+		assert.NoError(t, multimgr.Start(ctx))
 	}()
 
 	m1 := SetupManager(ctx, t, lo.Must(manager.NewID("cp-1")), envcfg, AdminAPIOptFns(), WithDiagnosticsWithoutServer())

--- a/test/envtest/run.go
+++ b/test/envtest/run.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/samber/mo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest/observer"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -239,7 +240,7 @@ func SetupManager(
 
 	logger := ctrl.LoggerFrom(ctx)
 	mgr, err := manager.NewManager(ctx, mgrID, logger, cfg)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	if cfg.ProbeAddr != "" {
 		t.Log("Starting standalone health check server")
@@ -261,7 +262,7 @@ func RunManager(
 	modifyCfgFns ...managercfg.Opt,
 ) LogsObserver {
 	mgrID, err := manager.NewID(t.Name())
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	ctx, _, logs := CreateTestLogger(ctx)
 
@@ -270,7 +271,7 @@ func RunManager(
 	wg := sync.WaitGroup{}
 	wg.Go(func() {
 		mgr := SetupManager(ctx, t, mgrID, envcfg, adminAPIOpts, modifyCfgFns...)
-		require.NoError(t, mgr.Run(ctx))
+		assert.NoError(t, mgr.Run(ctx))
 	})
 	t.Cleanup(func() {
 		wg.Wait()

--- a/test/envtest/run.go
+++ b/test/envtest/run.go
@@ -240,7 +240,7 @@ func SetupManager(
 
 	logger := ctrl.LoggerFrom(ctx)
 	mgr, err := manager.NewManager(ctx, mgrID, logger, cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	if cfg.ProbeAddr != "" {
 		t.Log("Starting standalone health check server")

--- a/test/envtest/setup.go
+++ b/test/envtest/setup.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
@@ -113,7 +114,7 @@ func Setup(t *testing.T, ctx context.Context, scheme *k8sruntime.Scheme, optModi
 	})
 	ws.Register("/convert", conversion.NewWebhookHandler(scheme, conversion.NewRegistry()))
 	go func() {
-		require.NoError(t, ws.Start(ctx))
+		assert.NoError(t, ws.Start(ctx))
 	}()
 
 	wg := sync.WaitGroup{}

--- a/test/envtest/telemetry_test.go
+++ b/test/envtest/telemetry_test.go
@@ -49,12 +49,10 @@ func TestTelemetry(t *testing.T) {
 	createK8sObjectsForTelemetryTest(ctx, t, c)
 
 	t.Log("starting the controller manager")
-	go func() {
-		RunManager(ctx, t, envcfg, AdminAPIOptFns(),
-			WithDefaultEnvTestsConfig(envcfg),
-			WithTelemetry(ts.Endpoint(), 100*time.Millisecond),
-		)
-	}()
+	_ = RunManager(ctx, t, envcfg, AdminAPIOptFns(),
+		WithDefaultEnvTestsConfig(envcfg),
+		WithTelemetry(ts.Endpoint(), 100*time.Millisecond),
+	)
 
 	dcl, err := discoveryclient.NewDiscoveryClientForConfig(envcfg)
 	require.NoError(t, err)

--- a/test/integration/kic/consumer_group_test.go
+++ b/test/integration/kic/consumer_group_test.go
@@ -216,7 +216,7 @@ func TestConsumerGroup(t *testing.T) {
 			return
 		}
 		defer clearResp.Body.Close()
-		if !assert.Equal(c, clearResp.StatusCode, http.StatusOK) {
+		if !assert.Equal(c, http.StatusOK, clearResp.StatusCode) {
 			return
 		}
 		hv = clearResp.Header.Get(addedHeader.K)
@@ -233,7 +233,7 @@ func TestConsumerGroup(t *testing.T) {
 			return
 		}
 		defer emptyResp.Body.Close()
-		if !assert.Equal(c, emptyResp.StatusCode, http.StatusOK) {
+		if !assert.Equal(c, http.StatusOK, emptyResp.StatusCode) {
 			return
 		}
 		hv = emptyResp.Header.Get(addedHeader.K)

--- a/test/integration/kic/consumer_test.go
+++ b/test/integration/kic/consumer_test.go
@@ -67,7 +67,7 @@ func TestConsumerCredential(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false

--- a/test/integration/kic/ingress_https_test.go
+++ b/test/integration/kic/ingress_https_test.go
@@ -231,7 +231,7 @@ func TestHTTPSIngress(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>") && resp.TLS.PeerCertificates[0].Subject.CommonName == "secure-foo-bar"
 		}
 		return false
@@ -249,7 +249,7 @@ func TestHTTPSIngress(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>") && resp.TLS.PeerCertificates[0].Subject.CommonName == "foo.com"
 		}
 		return false
@@ -267,7 +267,7 @@ func TestHTTPSIngress(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
@@ -303,7 +303,7 @@ func TestHTTPSIngress(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false

--- a/test/integration/kic/ingress_test.go
+++ b/test/integration/kic/ingress_test.go
@@ -93,7 +93,7 @@ func TestIngressEssentials(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
@@ -142,7 +142,7 @@ func TestIngressEssentials(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
@@ -257,7 +257,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
@@ -288,7 +288,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
@@ -347,7 +347,7 @@ func TestIngressServiceUpstream(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
@@ -598,7 +598,7 @@ func TestIngressClassRegexToggle(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
@@ -725,7 +725,7 @@ func TestIngressRegexPrefix(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
@@ -741,7 +741,7 @@ func TestIngressRegexPrefix(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
@@ -757,7 +757,7 @@ func TestIngressRegexPrefix(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
@@ -838,7 +838,7 @@ func TestIngressRecoverFromInvalidPath(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
@@ -912,7 +912,7 @@ func TestIngressRecoverFromInvalidPath(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
@@ -967,7 +967,7 @@ func TestIngressRecoverFromInvalidPath(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
@@ -1017,7 +1017,7 @@ func TestIngressMatchByHost(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
@@ -1028,7 +1028,7 @@ func TestIngressMatchByHost(t *testing.T) {
 	resp, err := helpers.DefaultHTTPClient(helpers.WithResolveHostTo(proxyHTTPURL.Host)).Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	require.Equal(t, resp.StatusCode, http.StatusNotFound)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 
 	t.Log("change the ingress to wildcard host")
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -1060,7 +1060,7 @@ func TestIngressMatchByHost(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
@@ -1071,7 +1071,7 @@ func TestIngressMatchByHost(t *testing.T) {
 	resp, err = helpers.DefaultHTTPClient(helpers.WithResolveHostTo(proxyHTTPURL.Host)).Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	require.Equal(t, resp.StatusCode, http.StatusNotFound)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 
 func TestIngressRewriteURI(t *testing.T) {

--- a/test/integration/kic/isolated/examples_httproute_test.go
+++ b/test/integration/kic/isolated/examples_httproute_test.go
@@ -108,7 +108,7 @@ func TestHTTPRouteWithBrokenPluginFallback(t *testing.T) {
 				if !assert.NoError(c, err) {
 					return
 				}
-				assert.Equal(t, response.Status, diagnostics.FallbackStatusTriggered)
+				assert.Equal(t, diagnostics.FallbackStatusTriggered, response.Status)
 				assert.NotEmpty(t, response.ExcludedObjects)
 				contains := lo.ContainsBy(response.ExcludedObjects, func(obj diagnostics.FallbackAffectedObjectMeta) bool {
 					return obj.Group == "configuration.konghq.com" && obj.Kind == "KongPlugin" && obj.Name == "key-auth"

--- a/test/integration/kic/isolated/examples_ingress_fallback_test.go
+++ b/test/integration/kic/isolated/examples_ingress_fallback_test.go
@@ -139,7 +139,7 @@ func TestIngressWithBrokenPluginFallback(t *testing.T) {
 				if !assert.NoError(c, err) {
 					return
 				}
-				assert.Equal(t, response.Status, diagnostics.FallbackStatusTriggered)
+				assert.Equal(t, diagnostics.FallbackStatusTriggered, response.Status)
 				assert.NotEmpty(t, response.ExcludedObjects)
 				contains := lo.ContainsBy(response.ExcludedObjects, func(obj diagnostics.FallbackAffectedObjectMeta) bool {
 					return obj.Group == "configuration.konghq.com" && obj.Kind == "KongPlugin" && obj.Name == "key-auth"

--- a/test/integration/kic/isolated/license_test.go
+++ b/test/integration/kic/isolated/license_test.go
@@ -34,7 +34,7 @@ func TestKongLicense(t *testing.T) {
 				require.NotNil(t, adminURL, "Should get URL to access Kong gateway admin APIs from context")
 				licenses, err := helpers.GetKongLicenses(ctx, adminURL, consts.KongTestPassword)
 				require.NoError(t, err, "Expect No errors in listing all licenses in Kong gateway")
-				require.Len(t, licenses, 0, "Expect No licenses in Kong gateway now")
+				require.Empty(t, licenses, "Expect No licenses in Kong gateway now")
 
 				return ctx
 			},

--- a/test/integration/kic/plugin_test.go
+++ b/test/integration/kic/plugin_test.go
@@ -76,7 +76,7 @@ func TestPluginEssentials(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
@@ -207,7 +207,7 @@ func TestPluginConfigPatch(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
@@ -531,7 +531,7 @@ func TestPluginCrossNamespaceReference(t *testing.T) {
 			b := new(bytes.Buffer)
 			_, err := b.ReadFrom(resp.Body)
 			assert.NoError(c, err)
-			assert.True(c, strings.Contains(b.String(), "<title>httpbin.org</title>"))
+			assert.Contains(c, b.String(), "<title>httpbin.org</title>")
 		}
 	}, ingressWait, waitTick)
 
@@ -714,7 +714,7 @@ func TestPluginCrossNamespaceReference(t *testing.T) {
 			return
 		}
 		defer resp.Body.Close()
-		assert.True(c, resp.StatusCode == http.StatusTeapot)
+		assert.Equal(c, http.StatusTeapot, resp.StatusCode)
 	}, ingressWait, waitTick)
 }
 
@@ -760,7 +760,7 @@ func TestPluginNullInConfig(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false

--- a/test/integration/kic/vault_test.go
+++ b/test/integration/kic/vault_test.go
@@ -71,7 +71,7 @@ func TestCustomVault(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
@@ -142,7 +142,7 @@ func TestCustomVault(t *testing.T) {
 			b := new(bytes.Buffer)
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
-			require.True(t, n > 0)
+			require.Positive(t, n)
 			return strings.Contains(b.String(), `"H1": "v1"`)
 		}
 		return false


### PR DESCRIPTION
**What this PR does / why we need it**:

One from the series, to keep it reviewable. 

Enable and apply fixes for [testifylint](https://golangci-lint.run/docs/linters/configuration/#testifylint), which are resonable

Rule [require-error](https://github.com/Antonboom/testifylint?tab=readme-ov-file#require-error) has been disabled, because it's not crucial and leads to hundreds of changes, so it's not worth doing.

Rule [error-is-as](https://github.com/Antonboom/testifylint?tab=readme-ov-file#error-is-as) will be enabled in a separate PR because it finds legit issues with the codebase that have to be addressed.

**Which issue this PR fixes**

Part of 

- https://github.com/Kong/kong-operator/issues/1847