### PR TITLE
refactor: migrate from `errors.As` to `erorrs.AsType` from go1.26

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -81,6 +81,8 @@ linters:
         # Incorrectly formatted error string.
         # https://staticcheck.dev/docs/checks/#ST1005
         - -ST1005
+        - -SA4006
+
     exhaustive:
       default-signifies-exhaustive: true
     forbidigo:
@@ -96,8 +98,8 @@ linters:
         - pattern: ^.*operatorv2alpha1.ControlPlane.*$
           msg: Please use the types package to refer to the type (through github.com/kong/kong-operator/internal/types)
         # NOTE: Don't enforce it just yet. Migrating all errors.As() calls is WIP.
-        # - pattern: ^errors.As$
-        #   msg: Please use errors.AsType instead
+        - pattern: ^errors.As$
+          msg: Please use errors.AsType instead
     gomodguard:
       blocked:
         modules:
@@ -297,6 +299,10 @@ linters:
           - godoclint
         text: symbol should have a godoc
         path: api/configuration/v1alpha1/zz_generated_funcs.go
+      - linters:
+          - forbidigo
+        text: use of `errors.As` forbidden because
+        path: ".*_test.go|test/.*|ingress-controller/.*"
     paths:
       - pkg/clientset
       - config/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -95,7 +95,6 @@ linters:
         # NOTE: When all references use the types package, this rule can use .* instead of listing types.
         - pattern: ^.*operatorv2alpha1.ControlPlane.*$
           msg: Please use the types package to refer to the type (through github.com/kong/kong-operator/internal/types)
-        # NOTE: Don't enforce it just yet. Migrating all errors.As() calls is WIP.
         - pattern: ^errors.As$
           msg: Please use errors.AsType instead
     gomodguard:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -300,6 +300,11 @@ linters:
           - forbidigo
         text: use of `errors.As` forbidden because
         path: ".*_test.go|test/.*|ingress-controller/.*"
+      # TODO: remove when https://github.com/golangci/golangci-lint/issues/6363
+      # is resolved and we can use new(expression) instead of ToPtr.
+      - linters:
+          - modernize
+        text: call of ToPtr\(x\) can be simplified to new\(x\)
     paths:
       - pkg/clientset
       - config/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -304,7 +304,10 @@ linters:
       # is resolved and we can use new(expression) instead of ToPtr.
       - linters:
           - modernize
-        text: call of ToPtr\(x\) can be simplified to new\(x\)
+        text: call of .+\(x\) can be simplified to new\(x\)
+      - linters:
+          - modernize
+        text: .+ can be an inlinable wrapper around new
     paths:
       - pkg/clientset
       - config/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -81,8 +81,6 @@ linters:
         # Incorrectly formatted error string.
         # https://staticcheck.dev/docs/checks/#ST1005
         - -ST1005
-        - -SA4006
-
     exhaustive:
       default-signifies-exhaustive: true
     forbidigo:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -95,6 +95,9 @@ linters:
         # NOTE: When all references use the types package, this rule can use .* instead of listing types.
         - pattern: ^.*operatorv2alpha1.ControlPlane.*$
           msg: Please use the types package to refer to the type (through github.com/kong/kong-operator/internal/types)
+        # NOTE: Don't enforce it just yet. Migrating all errors.As() calls is WIP.
+        # - pattern: ^errors.As$
+        #   msg: Please use errors.AsType instead
     gomodguard:
       blocked:
         modules:

--- a/controller/cpextensions/metricsscraper/enricher.go
+++ b/controller/cpextensions/metricsscraper/enricher.go
@@ -25,7 +25,8 @@ func init() {
 
 	for _, c := range collectors {
 		if err := metrics.Registry.Register(c); err != nil {
-			if !errors.As(err, &prometheus.AlreadyRegisteredError{}) {
+			_, ok := errors.AsType[prometheus.AlreadyRegisteredError](err)
+			if !ok {
 				panic(err)
 			}
 		}

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -174,15 +174,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	log.Trace(logger, "checking gatewayclass")
 	gwc, err := gatewayclass.Get(ctx, r.Client, string(gateway.Spec.GatewayClassName))
 	if err != nil {
+		_, isUnsupported := errors.AsType[operatorerrors.UnsupportedGatewayClassError](err)
+		_, isNotAccepted := errors.AsType[operatorerrors.NotAcceptedGatewayClassError](err)
 		switch {
-		case errors.As(err, &operatorerrors.UnsupportedGatewayClassError{}):
+		case isUnsupported:
 			log.Debug(logger, "resource not supported, ignoring",
 				"expectedGatewayClass", vars.ControllerName(),
 				"gatewayClass", gateway.Spec.GatewayClassName,
 				"reason", err.Error(),
 			)
 			return ctrl.Result{}, nil
-		case errors.As(err, &operatorerrors.NotAcceptedGatewayClassError{}):
+		case isNotAccepted:
 			log.Debug(logger, "GatewayClass not accepted, ignoring",
 				"gatewayClass", gateway.Spec.GatewayClassName,
 				"reason", err.Error(),

--- a/controller/gateway/controller_watch.go
+++ b/controller/gateway/controller_watch.go
@@ -362,8 +362,8 @@ func (r *Reconciler) listManagedGatewaysInNamespace(ctx context.Context, obj cli
 		objKey := client.ObjectKey{Name: string(gateway.Spec.GatewayClassName)}
 
 		if _, err := gatewayclass.Get(ctx, r.Client, string(gateway.Spec.GatewayClassName)); err != nil {
-			_, isUnsupported := errors.AsType[*operatorerrors.UnsupportedGatewayClassError](err)
-			_, isNotAccepted := errors.AsType[*operatorerrors.NotAcceptedGatewayClassError](err)
+			_, isUnsupported := errors.AsType[operatorerrors.UnsupportedGatewayClassError](err)
+			_, isNotAccepted := errors.AsType[operatorerrors.NotAcceptedGatewayClassError](err)
 			switch {
 			case isUnsupported:
 				log.Debug(logger, "gateway class not supported, ignoring")

--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -591,7 +591,7 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			}
 
 			if err := r.Create(ctx, &dpCert); err != nil {
-				if errS := (&apierrors.StatusError{}); errors.As(err, &errS) {
+				if errS, ok := errors.AsType[*apierrors.StatusError](err); ok {
 					if errS.ErrStatus.Reason == metav1.StatusReasonAlreadyExists {
 						log.Debug(logger, "DataPlane client certificate already exists", "name", dpCert.Name, "namespace", dpCert.Namespace)
 					}
@@ -652,7 +652,7 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			}
 
 			if err := r.Create(ctx, &dpCert); err != nil {
-				if errS := (&apierrors.StatusError{}); errors.As(err, &errS) {
+				if errS, ok := errors.AsType[*apierrors.StatusError](err); ok {
 					if errS.ErrStatus.Reason == metav1.StatusReasonAlreadyExists {
 						log.Debug(logger, "DataPlane client certificate already exists", "name", dpCert.Name, "namespace", dpCert.Namespace)
 					}

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -197,7 +197,7 @@ func Create[
 			statusCode = errSDK.StatusCode
 			SetKonnectEntityProgrammedConditionFalse(
 				e, kcfgkonnect.KonnectEntitiesFailedToCreateReason, errSDK)
-		} else if errRelationsFailed, ok := errors.AsType[*KonnectEntityCreatedButRelationsFailedError](err); ok {
+		} else if errRelationsFailed, ok := errors.AsType[KonnectEntityCreatedButRelationsFailedError](err); ok {
 			e.SetKonnectID(errRelationsFailed.KonnectID)
 			SetKonnectEntityProgrammedConditionFalse(e, errRelationsFailed.Reason, errRelationsFailed.Err)
 		} else {

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -118,11 +118,7 @@ func Create[
 		return nil, fmt.Errorf("unsupported entity type %T", ent)
 	}
 
-	var (
-		errRelationsFailed KonnectEntityCreatedButRelationsFailedError
-		errSDK             *sdkkonnecterrs.SDKError
-		errGet             error
-	)
+	var errGet error
 	switch {
 	case ErrorIsCreateConflict(err):
 		// If there was a conflict on the create request, we can assume the entity already exists.
@@ -196,16 +192,17 @@ func Create[
 
 			SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToCreateReason, err)
 		}
-
-	case errors.As(err, &errSDK):
-		statusCode = errSDK.StatusCode
-		SetKonnectEntityProgrammedConditionFalse(
-			e, kcfgkonnect.KonnectEntitiesFailedToCreateReason, errSDK)
-	case errors.As(err, &errRelationsFailed):
-		e.SetKonnectID(errRelationsFailed.KonnectID)
-		SetKonnectEntityProgrammedConditionFalse(e, errRelationsFailed.Reason, errRelationsFailed.Err)
 	case err != nil:
-		SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToCreateReason, err)
+		if errSDK, ok := errors.AsType[*sdkkonnecterrs.SDKError](err); ok {
+			statusCode = errSDK.StatusCode
+			SetKonnectEntityProgrammedConditionFalse(
+				e, kcfgkonnect.KonnectEntitiesFailedToCreateReason, errSDK)
+		} else if errRelationsFailed, ok := errors.AsType[*KonnectEntityCreatedButRelationsFailedError](err); ok {
+			e.SetKonnectID(errRelationsFailed.KonnectID)
+			SetKonnectEntityProgrammedConditionFalse(e, errRelationsFailed.Reason, errRelationsFailed.Err)
+		} else {
+			SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToCreateReason, err)
+		}
 	default:
 		SetKonnectEntityProgrammedConditionTrue(e)
 	}
@@ -325,8 +322,7 @@ func Delete[
 	}
 
 	if err != nil {
-		var errSDK *sdkkonnecterrs.SDKError
-		if errors.As(err, &errSDK) {
+		if errSDK, ok := errors.AsType[*sdkkonnecterrs.SDKError](err); ok {
 			statusCode = errSDK.StatusCode
 		}
 		metricRecorder.RecordKonnectEntityOperationFailure(
@@ -479,16 +475,14 @@ func Update[
 		return ctrl.Result{}, fmt.Errorf("unsupported entity type %T", ent)
 	}
 
-	var (
-		errRelationsFailed KonnectEntityCreatedButRelationsFailedError
-		errSDK             *sdkkonnecterrs.SDKError
-	)
+	errSDK, isSDKErr := errors.AsType[*sdkkonnecterrs.SDKError](err)
+	errRelationsFailed, isRelationsFailed := errors.AsType[KonnectEntityCreatedButRelationsFailedError](err)
 
 	switch {
-	case errors.As(err, &errSDK):
+	case isSDKErr:
 		statusCode = errSDK.StatusCode
 		SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToUpdateReason, errSDK)
-	case errors.As(err, &errRelationsFailed):
+	case isRelationsFailed:
 		e.SetKonnectID(errRelationsFailed.KonnectID)
 		SetKonnectEntityProgrammedConditionFalse(e, errRelationsFailed.Reason, err)
 	case err != nil:
@@ -607,28 +601,26 @@ func Adopt[
 	}
 
 	// Set "Adopted" and "Programmed" conditions of the object based on errors returned in the adopt operation.
-	var (
-		errSDK         *sdkkonnecterrs.SDKError
-		errFetch       KonnectEntityAdoptionFetchError
-		errUIDConflict KonnectEntityAdoptionUIDTagConflictError
-		errNotMatch    KonnectEntityAdoptionNotMatchError
-	)
+	errFetch, isFetchErr := errors.AsType[KonnectEntityAdoptionFetchError](err)
+	errUIDConflict, isUIDConflict := errors.AsType[KonnectEntityAdoptionUIDTagConflictError](err)
+	errNotMatch, isNotMatch := errors.AsType[KonnectEntityAdoptionNotMatchError](err)
+	errSDK, isSDKErr := errors.AsType[*sdkkonnecterrs.SDKError](err)
 
 	switch {
 	// If the adoption process failed to fetch the entity, we use the "FetchFailed" reason in the "adopted" condition.
-	case errors.As(err, &errFetch):
-		if errors.As(errFetch.Err, &errSDK) {
-			statusCode = errSDK.StatusCode
+	case isFetchErr:
+		if errSDKInner, ok := errors.AsType[*sdkkonnecterrs.SDKError](errFetch.Err); ok {
+			statusCode = errSDKInner.StatusCode
 		}
 		SetKonnectEntityAdoptedConditionFalse(e, konnectv1alpha1.KonnectEntityAdoptedReasonFetchFailed, err)
 		SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToAdoptReason, err)
-	case errors.As(err, &errUIDConflict):
+	case isUIDConflict:
 		SetKonnectEntityAdoptedConditionFalse(e, konnectv1alpha1.KonnectEntityAdoptedReasonUIDConflict, errUIDConflict)
 		SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToAdoptReason, errUIDConflict)
-	case errors.As(err, &errNotMatch):
+	case isNotMatch:
 		SetKonnectEntityAdoptedConditionFalse(e, konnectv1alpha1.KonnectEntityAdoptedReasonNotMatch, errNotMatch)
 		SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToAdoptReason, errNotMatch)
-	case errors.As(err, &errSDK):
+	case isSDKErr:
 		statusCode = errSDK.StatusCode
 		SetKonnectEntityAdoptedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToAdoptReason, errSDK)
 		SetKonnectEntityProgrammedConditionFalse(e, kcfgkonnect.KonnectEntitiesFailedToAdoptReason, errSDK)
@@ -714,8 +706,7 @@ func wrapErrIfKonnectOpFailed[
 	TEnt constraints.EntityType[T],
 ](err error, op Op, e TEnt) error {
 	if err != nil {
-		var errBadRequest *sdkkonnecterrs.BadRequestError
-		if errors.As(err, &errBadRequest) {
+		if errBadRequest, ok := errors.AsType[*sdkkonnecterrs.BadRequestError](err); ok {
 			errBadRequest.Instance = ""
 			err = errBadRequest
 		}
@@ -836,20 +827,17 @@ func getMatchingEntryFromListResponseData[
 // with each request and makes the reconciliation loop requeue the resource
 // instead of performing the backoff.
 func ClearInstanceFromError(err error) error {
-	var errBadRequest *sdkkonnecterrs.BadRequestError
-	if errors.As(err, &errBadRequest) {
+	if errBadRequest, ok := errors.AsType[*sdkkonnecterrs.BadRequestError](err); ok {
 		errBadRequest.Instance = ""
 		return errBadRequest
 	}
 
-	var errConflict *sdkkonnecterrs.ConflictError
-	if errors.As(err, &errConflict) {
+	if errConflict, ok := errors.AsType[*sdkkonnecterrs.ConflictError](err); ok {
 		errConflict.Instance = ""
 		return errConflict
 	}
 
-	var errNotFound *sdkkonnecterrs.NotFoundError
-	if errors.As(err, &errNotFound) {
+	if errNotFound, ok := errors.AsType[*sdkkonnecterrs.NotFoundError](err); ok {
 		errNotFound.Instance = ""
 		return errNotFound
 	}

--- a/controller/konnect/ops/ops_kongsni.go
+++ b/controller/konnect/ops/ops_kongsni.go
@@ -103,8 +103,7 @@ func deleteSNI(
 
 	if errWrapped := wrapErrIfKonnectOpFailed(err, DeleteOp, sni); errWrapped != nil {
 		// Service delete operation returns an SDKError instead of a NotFoundError.
-		var sdkError *sdkkonnecterrs.SDKError
-		if errors.As(errWrapped, &sdkError) {
+		if sdkError, ok := errors.AsType[*sdkkonnecterrs.SDKError](errWrapped); ok {
 			if sdkError.StatusCode == http.StatusNotFound {
 				ctrllog.FromContext(ctx).
 					Info("entity not found in Konnect, skipping delete",

--- a/controller/konnect/reconciler_controlplaneref.go
+++ b/controller/konnect/reconciler_controlplaneref.go
@@ -59,6 +59,12 @@ func handleControlPlaneRef[T constraints.SupportedKonnectEntityType, TEnt constr
 		); errStatus != nil || !res.IsZero() {
 			return res, errStatus
 		}
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, controlplane.ReferencedControlPlaneDoesNotExistError{
+				Reference: cpRef,
+				Err:       err,
+			}
+		}
 
 		return ctrl.Result{}, err
 	}

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -719,7 +719,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) adoptFromExistingEntity(
 	if retErr != nil {
 		// If the error is a rate limit error, requeue after the retry-after duration
 		// instead of returning an error.
-		if rateLimitErr, ok := errors.AsType[*ops.RateLimitError](retErr); ok {
+		if rateLimitErr, ok := errors.AsType[ops.RateLimitError](retErr); ok {
 			return ctrl.Result{RequeueAfter: rateLimitErr.RetryAfter}, nil
 		}
 		return ctrl.Result{}, ops.FailedKonnectOpError[T]{

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -478,8 +478,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 				// If the error was a network error, handle it here, there's no need to proceed,
 				// as no state has changed.
 				// Status conditions are updated in handleOpsErr.
-				var errURL *url.Error
-				if errors.As(err, &errURL) {
+				if errURL, ok := errors.AsType[*url.Error](err); ok {
 					return r.handleOpsErr(ctx, ent, errURL)
 				}
 
@@ -522,8 +521,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// If the error was a network error, handle it here, there's no need to proceed,
 		// as no state has changed.
 		// Status conditions are updated in handleOpsErr.
-		var errURL *url.Error
-		if errors.As(err, &errURL) {
+		if errURL, ok := errors.AsType[*url.Error](err); ok {
 			return r.handleOpsErr(ctx, ent, errURL)
 		}
 		return ctrl.Result{}, err

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -158,7 +158,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// If the referenced ControlPlane is not found, remove the finalizer and update the status.
 		// There's no need to remove the entity on Konnect because the ControlPlane
 		// does not exist anymore.
-		if errors.As(err, &controlplane.ReferencedControlPlaneDoesNotExistError{}) {
+		if _, ok := errors.AsType[*controlplane.ReferencedControlPlaneDoesNotExistError](err); ok {
 			if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 				if err := r.Client.Update(ctx, ent); err != nil {
 					if apierrors.IsConflict(err) {
@@ -228,7 +228,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// If the referenced KongConsumer is being deleted and the object
 		// is not being deleted yet then requeue until it will
 		// get the deletion timestamp set due to having the owner set to KongConsumer.
-		if errDel := (&ReferencedKongConsumerIsBeingDeletedError{}); errors.As(err, errDel) &&
+		if errDel, ok := errors.AsType[ReferencedKongConsumerIsBeingDeletedError](err); ok &&
 			ent.GetDeletionTimestamp().IsZero() {
 			return ctrl.Result{
 				RequeueAfter: time.Until(errDel.DeletionTimestamp),
@@ -239,7 +239,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// then remove the finalizer and let the deletion proceed without trying to delete the entity from Konnect
 		// as the KongConsumer deletion will (or already has - in case of the consumer being gone)
 		// take care of it on the Konnect side.
-		if errors.As(err, &ReferencedKongConsumerDoesNotExistError{}) {
+		if _, ok := errors.AsType[ReferencedKongConsumerDoesNotExistError](err); ok {
 			if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 				if err := r.Client.Update(ctx, ent); err != nil {
 					if apierrors.IsConflict(err) {
@@ -274,7 +274,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// If the referenced KongUpstream is being deleted and the object
 		// is not being deleted yet then requeue until it will
 		// get the deletion timestamp set due to having the owner set to KongUpstream.
-		if errDel := (&ReferencedKongUpstreamIsBeingDeletedError{}); errors.As(err, errDel) &&
+		if errDel, ok := errors.AsType[ReferencedKongUpstreamIsBeingDeletedError](err); ok &&
 			ent.GetDeletionTimestamp().IsZero() {
 			return ctrl.Result{
 				RequeueAfter: time.Until(errDel.DeletionTimestamp),
@@ -286,7 +286,9 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// as the KongUpstream deletion will (or already has - in case of the upstream being gone)
 		// take care of it on the Konnect side.
 		// In case the ControlPlane referenced by the KongUpstream is not found, do the same.
-		if errors.As(err, &ReferencedKongUpstreamDoesNotExistError{}) || errors.As(err, &controlplane.ReferencedControlPlaneDoesNotExistError{}) {
+		_, upstreamNotExist := errors.AsType[ReferencedKongUpstreamDoesNotExistError](err)
+		_, cpNotExist := errors.AsType[*controlplane.ReferencedControlPlaneDoesNotExistError](err)
+		if upstreamNotExist || cpNotExist {
 			if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 				if err := r.Client.Update(ctx, ent); err != nil {
 					if apierrors.IsConflict(err) {
@@ -316,7 +318,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// If the referenced KongCertificate is being deleted and the object
 		// is not being deleted yet then requeue until it will
 		// get the deletion timestamp set due to having the owner set to KongCertificate.
-		if errDel := (&ReferencedKongCertificateIsBeingDeletedError{}); errors.As(err, errDel) &&
+		if errDel, ok := errors.AsType[ReferencedKongCertificateIsBeingDeletedError](err); ok &&
 			ent.GetDeletionTimestamp().IsZero() {
 			return ctrl.Result{
 				RequeueAfter: time.Until(errDel.DeletionTimestamp),
@@ -327,7 +329,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// and the object is being deleted, remove the finalizer and let the
 		// deletion proceed without trying to delete the entity from Konnect
 		// as the KongCertificate deletion will take care of it on the Konnect side.
-		if errors.As(err, &ReferencedKongCertificateDoesNotExistError{}) {
+		if _, ok := errors.AsType[ReferencedKongCertificateDoesNotExistError](err); ok {
 			if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 				if err := r.Client.Update(ctx, ent); err != nil {
 					if apierrors.IsConflict(err) {
@@ -363,7 +365,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// If the referenced KongKeySet is being deleted and the object
 		// is not being deleted yet then requeue until it will
 		// get the deletion timestamp set due to having the owner set to KongKeySet.
-		if errDel := (&ReferencedKongKeySetIsBeingDeletedError{}); errors.As(err, errDel) &&
+		if errDel, ok := errors.AsType[ReferencedKongKeySetIsBeingDeletedError](err); ok &&
 			ent.GetDeletionTimestamp().IsZero() {
 			return ctrl.Result{
 				RequeueAfter: time.Until(errDel.DeletionTimestamp),
@@ -373,7 +375,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// If the referenced KongKeySet is not found, remove the finalizer and let the
 		// user delete the resource without trying to delete the entity from Konnect
 		// as the KongKeySet deletion will take care of it on the Konnect side.
-		if errors.As(err, &ReferencedKongKeySetDoesNotExistError{}) {
+		if _, ok := errors.AsType[ReferencedKongKeySetDoesNotExistError](err); ok {
 			if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 				if err := r.Client.Update(ctx, ent); err != nil {
 					if apierrors.IsConflict(err) {
@@ -447,7 +449,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// is being deleted then allow the reconciliation to continue as we want to
 		// proceed with object's deletion.
 		// Otherwise, just return the error and requeue.
-		if errDel := (&ReferencedObjectIsBeingDeletedError{}); !errors.As(err, errDel) ||
+		if _, ok := errors.AsType[ReferencedObjectIsBeingDeletedError](err); !ok ||
 			ent.GetDeletionTimestamp().IsZero() {
 			log.Debug(logger, "error handling KonnectNetwork ref", "error", err)
 			return patchWithProgrammedStatusConditionBasedOnOtherConditions(ctx, r.Client, ent)
@@ -711,8 +713,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) adoptFromExistingEntity(
 	if retErr != nil {
 		// If the error is a rate limit error, requeue after the retry-after duration
 		// instead of returning an error.
-		var rateLimitErr ops.RateLimitError
-		if errors.As(retErr, &rateLimitErr) {
+		if rateLimitErr, ok := errors.AsType[*ops.RateLimitError](retErr); ok {
 			return ctrl.Result{RequeueAfter: rateLimitErr.RetryAfter}, nil
 		}
 		return ctrl.Result{}, ops.FailedKonnectOpError[T]{

--- a/controller/specialized/aigateway_controller.go
+++ b/controller/specialized/aigateway_controller.go
@@ -77,15 +77,17 @@ func (r *AIGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// See: https://github.com/kubernetes-sigs/controller-runtime/issues/1996
 	gwc, err := gatewayclass.Get(ctx, r.Client, aigateway.Spec.GatewayClassName)
 	if err != nil {
+		_, okUnsupportedGatewayClass := errors.AsType[operatorerrors.UnsupportedGatewayClassError](err)
+		_, okNotAcceptedGatewayClass := errors.AsType[operatorerrors.NotAcceptedGatewayClassError](err)
 		switch {
-		case errors.As(err, &operatorerrors.UnsupportedGatewayClassError{}):
+		case okUnsupportedGatewayClass:
 			log.Debug(logger, "resource not supported, ignoring",
 				"expectedGatewayClass", vars.ControllerName(),
 				"gatewayClass", aigateway.Spec.GatewayClassName,
 				"reason", err.Error(),
 			)
 			return ctrl.Result{}, nil
-		case errors.As(err, &operatorerrors.NotAcceptedGatewayClassError{}):
+		case okNotAcceptedGatewayClass:
 			log.Debug(logger, "GatewayClass not accepted, ignoring",
 				"gatewayClass", aigateway.Spec.GatewayClassName,
 				"reason", err.Error(),

--- a/controller/specialized/aigateway_controller_watch.go
+++ b/controller/specialized/aigateway_controller_watch.go
@@ -39,8 +39,9 @@ func (r *AIGatewayReconciler) aiGatewayHasMatchingGatewayClass(obj client.Object
 		// class as well. If we fail here it's most likely because of some failure
 		// of the Kubernetes API and it's technically better to enqueue the object
 		// than to drop it for eventual consistency during cluster outages.
-		return !errors.As(err, &operatorerrors.UnsupportedGatewayClassError{}) &&
-			!errors.As(err, &operatorerrors.NotAcceptedGatewayClassError{})
+		_, isUnsupported := errors.AsType[operatorerrors.UnsupportedGatewayClassError](err)
+		_, isNotAccepted := errors.AsType[operatorerrors.NotAcceptedGatewayClassError](err)
+		return !isUnsupported && !isNotAccepted
 	}
 
 	return true

--- a/ingress-controller/internal/dataplane/deckerrors/conflict.go
+++ b/ingress-controller/internal/dataplane/deckerrors/conflict.go
@@ -29,14 +29,17 @@ func (e ConfigConflictError) Unwrap() error {
 }
 
 func IsConflictErr(err error) bool {
-	var apiErr *kong.APIError
-	if errors.As(err, &apiErr) && apiErr.Code() == http.StatusConflict ||
-		errors.Is(err, ConfigConflictError{}) {
+	if apiErr, ok := errors.AsType[*kong.APIError](err); ok {
+		if apiErr.Code() == http.StatusConflict {
+			return true
+		}
+	}
+
+	if _, ok := errors.AsType[ConfigConflictError](err); ok {
 		return true
 	}
 
-	var deckErrArray deckutils.ErrArray
-	if errors.As(err, &deckErrArray) {
+	if deckErrArray, ok := errors.AsType[deckutils.ErrArray](err); ok {
 		if slices.ContainsFunc(deckErrArray.Errors, IsConflictErr) {
 			return true
 		}

--- a/ingress-controller/internal/dataplane/kong_client.go
+++ b/ingress-controller/internal/dataplane/kong_client.go
@@ -596,10 +596,12 @@ func (c *KongClient) maybeTryRecoveringFromGatewaysSyncError(
 	gatewaysSyncErr error,
 ) error {
 	// If the error is not of the expected UpdateError type, we should log it and skip the recovery.
-	updateErr := sendconfig.UpdateError{}
-	if !errors.As(gatewaysSyncErr, &updateErr) {
-		c.logger.V(logging.DebugLevel).Info("Skipping recovery from gateways sync error - not enough details to recover",
-			"error", gatewaysSyncErr)
+	updateErr, ok := errors.AsType[sendconfig.UpdateError](gatewaysSyncErr)
+	if !ok {
+		c.logger.V(logging.DebugLevel).
+			Info("Skipping recovery from gateways sync error - not enough details to recover",
+				"error", gatewaysSyncErr,
+			)
 		return nil
 	}
 

--- a/ingress-controller/internal/konnect/config_synchronizer.go
+++ b/ingress-controller/internal/konnect/config_synchronizer.go
@@ -257,8 +257,7 @@ func (s *ConfigSynchronizer) uploadConfig(
 func logKonnectErrors(logger logr.Logger, err error) {
 	if crudActionErrors := deckerrors.ExtractCRUDActionErrors(err); len(crudActionErrors) > 0 {
 		for _, actionErr := range crudActionErrors {
-			apiErr := &kong.APIError{}
-			if errors.As(actionErr.Err, &apiErr) {
+			if apiErr, ok := errors.AsType[*kong.APIError](actionErr.Err); ok {
 				logger.Error(actionErr, "Failed to send request to Konnect",
 					"operation_type", actionErr.OperationType.String(),
 					"entity_kind", actionErr.Kind,

--- a/ingress-controller/internal/metrics/prometheus.go
+++ b/ingress-controller/internal/metrics/prometheus.go
@@ -750,8 +750,7 @@ func (c *GlobalCtrlRuntimeMetricsRecorder) recordFallbackPushBrokenResources(bro
 // pushFailureReason extracts config push failure reason from an error returned
 // from sendconfig's onUpdateInMemoryMode or onUpdateDBMode.
 func pushFailureReason(err error) string {
-	var netErr net.Error
-	if errors.As(err, &netErr) {
+	if _, ok := errors.AsType[net.Error](err); ok {
 		return FailureReasonNetwork
 	}
 

--- a/ingress-controller/test/kongintegration/containers/kong.go
+++ b/ingress-controller/test/kongintegration/containers/kong.go
@@ -142,7 +142,8 @@ func NewKong(ctx context.Context, t *testing.T, opts ...KongOpt) Kong {
 				t.Logf("failed validating Kong version: %v", err)
 			}),
 			retry.RetryIf(func(err error) bool {
-				return !errors.As(err, &helpers.TooOldKongGatewayError{})
+				_, ok := errors.AsType[helpers.TooOldKongGatewayError](err)
+				return !ok
 			}),
 		),
 	)

--- a/internal/utils/crossnamespace/kongreferencegrant.go
+++ b/internal/utils/crossnamespace/kongreferencegrant.go
@@ -39,8 +39,8 @@ func (e *ReferenceNotGrantedError) Error() string {
 // reference was attempted without the proper ReferenceGrant permissions.
 // It returns true if the error matches this type, false otherwise.
 func IsReferenceNotGranted(err error) bool {
-	var target *ReferenceNotGrantedError
-	return errors.As(err, &target)
+	_, ok := errors.AsType[*ReferenceNotGrantedError](err)
+	return ok
 }
 
 // CheckKongReferenceGrantForResource verifies that a cross-namespace reference is permitted by checking

--- a/internal/utils/gatewayconfig/get_test.go
+++ b/internal/utils/gatewayconfig/get_test.go
@@ -141,11 +141,8 @@ func TestGetFromParametersRef(t *testing.T) {
 			if tc.expectedError != nil {
 				assert.Error(t, err)
 				// For NotFound errors, check specific fields
-				statusErr := &k8serrors.StatusError{}
-				if errors.As(tc.expectedError, &statusErr) {
-					actualStatusErr := &k8serrors.StatusError{}
-					isActualStatusErr := errors.As(err, &actualStatusErr)
-					if isActualStatusErr {
+				if statusErr, ok := errors.AsType[*k8serrors.StatusError](tc.expectedError); ok {
+					if actualStatusErr, ok := errors.AsType[*k8serrors.StatusError](err); ok {
 						assert.Equal(t, statusErr.Status().Reason, actualStatusErr.Status().Reason)
 					} else {
 						t.Errorf("Expected StatusError, got %T", err)

--- a/pkg/utils/kubernetes/crd.go
+++ b/pkg/utils/kubernetes/crd.go
@@ -25,11 +25,11 @@ func (c CRDChecker) CRDExists(gvr schema.GroupVersionResource) (bool, error) {
 		return false, nil
 	}
 
-	if errD := (&discovery.ErrGroupDiscoveryFailed{}); errors.As(err, &errD) {
+	if errD, ok := errors.AsType[*discovery.ErrGroupDiscoveryFailed](err); ok {
 		for _, e := range errD.Groups {
 
 			// If this is an API StatusError:
-			if errS := (&apierrors.StatusError{}); errors.As(e, &errS) {
+			if errS, ok := errors.AsType[*apierrors.StatusError](e); ok {
 				switch errS.ErrStatus.Code {
 				case 404:
 					// If it's a 404 status code then we're sure that it's just
@@ -41,7 +41,7 @@ func (c CRDChecker) CRDExists(gvr schema.GroupVersionResource) (bool, error) {
 			}
 
 			// It is a network error.
-			if errU := (&url.Error{}); errors.As(e, &errU) {
+			if _, ok := errors.AsType[*url.Error](e); ok {
 				return false, fmt.Errorf("unexpected network error when looking up CRD (%v): %w", gvr, err)
 			}
 		}

--- a/pkg/utils/kubernetes/crd_test.go
+++ b/pkg/utils/kubernetes/crd_test.go
@@ -112,8 +112,6 @@ func TestCRDChecker(t *testing.T) {
 	}
 }
 
-// BenchmarkCRDExists benchmarks the CRDExists method to measure the impact
-// of using errors.AsType vs errors.As for error type checking.
 func BenchmarkCRDExists(b *testing.B) {
 	b.Run("CRD_found", func(b *testing.B) {
 		restMapper := meta.NewDefaultRESTMapper(nil)
@@ -131,7 +129,6 @@ func BenchmarkCRDExists(b *testing.B) {
 		checker := CRDChecker{Client: fakeClient}
 		gvr := operatorv1beta1.DataPlaneGVR()
 
-		b.ReportAllocs()
 		b.ResetTimer()
 		for b.Loop() {
 			_, _ = checker.CRDExists(gvr)
@@ -149,7 +146,6 @@ func BenchmarkCRDExists(b *testing.B) {
 		checker := CRDChecker{Client: fakeClient}
 		gvr := operatorv1beta1.DataPlaneGVR()
 
-		b.ReportAllocs()
 		b.ResetTimer()
 		for b.Loop() {
 			_, _ = checker.CRDExists(gvr)

--- a/pkg/utils/kubernetes/crd_test.go
+++ b/pkg/utils/kubernetes/crd_test.go
@@ -111,3 +111,48 @@ func TestCRDChecker(t *testing.T) {
 		})
 	}
 }
+
+// BenchmarkCRDExists benchmarks the CRDExists method to measure the impact
+// of using errors.AsType vs errors.As for error type checking.
+func BenchmarkCRDExists(b *testing.B) {
+	b.Run("CRD_found", func(b *testing.B) {
+		restMapper := meta.NewDefaultRESTMapper(nil)
+		restMapper.Add(schema.GroupVersionKind{
+			Group:   operatorv1beta1.SchemeGroupVersion.Group,
+			Version: operatorv1beta1.SchemeGroupVersion.Version,
+			Kind:    "DataPlane",
+		}, meta.RESTScopeNamespace)
+
+		fakeClient := fakectrlruntimeclient.
+			NewClientBuilder().
+			WithRESTMapper(restMapper).
+			Build()
+
+		checker := CRDChecker{Client: fakeClient}
+		gvr := operatorv1beta1.DataPlaneGVR()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_, _ = checker.CRDExists(gvr)
+		}
+	})
+
+	b.Run("CRD_not_found", func(b *testing.B) {
+		restMapper := meta.NewDefaultRESTMapper(nil)
+
+		fakeClient := fakectrlruntimeclient.
+			NewClientBuilder().
+			WithRESTMapper(restMapper).
+			Build()
+
+		checker := CRDChecker{Client: fakeClient}
+		gvr := operatorv1beta1.DataPlaneGVR()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_, _ = checker.CRDExists(gvr)
+		}
+	})
+}

--- a/test/integration/kic/suite_test.go
+++ b/test/integration/kic/suite_test.go
@@ -159,7 +159,8 @@ func TestMain(m *testing.M) {
 				},
 			),
 			retry.LastErrorOnly(true), retry.RetryIf(func(err error) bool {
-				return !errors.As(err, &helpers.TooOldKongGatewayError{})
+				_, ok := errors.AsType[helpers.TooOldKongGatewayError](err)
+				return !ok
 			}),
 		))
 


### PR DESCRIPTION
**What this PR does / why we need it**:

[Go 1.26 introduced errors.AsType](https://go.dev/doc/go1.26#errorspkgerrors) (doc: https://pkg.go.dev/errors#AsType) which is a generic version of `errors.As` which allocates less.

This PR migrates from `errors.As` to `erorrs.AsType`.

Additionally to measure some impact of this it adds `BenchmarkCRDExists` which can be tested between `main` and tip of this branch:

```
goos: darwin
goarch: arm64
pkg: github.com/kong/kong-operator/pkg/utils/kubernetes
cpu: Apple M4 Max
                           │      old      │                  new                  │
                           │    sec/op     │    sec/op     vs base                 │
CRDExists/CRD_found-14       135.20n ± ∞ ¹   66.03n ± ∞ ¹        ~ (p=1.000 n=1) ²
CRDExists/CRD_not_found-14    68.60n ± ∞ ¹   47.55n ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                       96.31n         56.03n        -41.82%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 2 samples to detect a difference at alpha level 0.5

                           │     old      │                 new                 │
                           │     B/op     │    B/op      vs base                │
CRDExists/CRD_found-14       112.00 ± ∞ ¹   96.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
CRDExists/CRD_not_found-14    96.00 ± ∞ ¹   96.00 ± ∞ ¹       ~ (p=1.000 n=1) ³
geomean                       103.7         96.00        -7.42%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 2 samples to detect a difference at alpha level 0.5
³ all samples are equal

                           │     old     │                 new                  │
                           │  allocs/op  │  allocs/op   vs base                 │
CRDExists/CRD_found-14       4.000 ± ∞ ¹   2.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
CRDExists/CRD_not_found-14   2.000 ± ∞ ¹   2.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
geomean                      2.828         2.000        -29.29%
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
