### PR TITLE
test(chainsaw): add debug snapshot capture for chainsaw test failures

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -813,11 +813,25 @@ jobs:
           --wait
 
     - name: run chainsaw e2e tests
+      id: chainsaw-tests
       run: make test.e2e.chainsaw
       env:
         KONNECT_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
         KONNECT_SERVER_URL: us.api.konghq.tech
         TEST_ID: ${{ github.run_id }}
+
+    - name: Upload debug snapshots as artifacts
+      if: always() && steps.chainsaw-tests.outcome == 'failure'
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: chainsaw-debug-snapshots-${{ github.run_id }}
+        path: /tmp/chainsaw/
+        if-no-files-found: ignore
+        retention-days: 3
+
+    - name: Clean up debug snapshots
+      if: always() && steps.chainsaw-tests.outcome == 'failure'
+      run: rm -rf /tmp/chainsaw
 
   buildpulse-report:
     needs:

--- a/test/e2e/chainsaw/common/_step_templates/debug-snapshot.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/debug-snapshot.yaml
@@ -1,0 +1,38 @@
+# Template for capturing debug snapshot when tests fail.
+#
+# This template should be used in STEP-LEVEL catch blocks of chainsaw tests.
+# For SPEC-LEVEL catch blocks, call the script directly (see DEBUG_SNAPSHOT.md).
+#
+# The captured information includes all resources in the test namespace(s),
+# events, operator logs, and resource descriptions.
+#
+# Required bindings:
+#   - test_name: Name of the test (for output directory naming).
+#   - namespace: The main test namespace to capture state from.
+#
+# Optional bindings:
+#   - additional_namespaces: Comma-separated list of additional namespaces
+#                            (e.g., for cross-namespace tests).
+#   - output_dir: Base directory for debug output (default: /tmp/chainsaw).
+#   - operator_namespace: Namespace where operator runs (default: kong-system).
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: debug-snapshot
+spec:
+  catch:
+    - description: Capture debug snapshot for failed test
+      script:
+        env:
+          - name: TEST_NAME
+            value: ($test_name)
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: ADDITIONAL_NAMESPACES
+            value: ($additional_namespaces || '')
+          - name: OUTPUT_DIR
+            value: ($output_dir || '/tmp/chainsaw')
+          - name: OPERATOR_NAMESPACE
+            value: ($operator_namespace || 'kong-system')
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/common/scripts/debug_snapshot.sh
+++ b/test/e2e/chainsaw/common/scripts/debug_snapshot.sh
@@ -92,9 +92,9 @@ for ns in ${ALL_NAMESPACES}; do
     echo ""
   } >> "${RESOURCES_FILE}"
 
-  # Gateway API resources
+  # Gateway API resources (using category for all Gateway API resources)
   capture_resource_group "${RESOURCES_FILE}" "${ns}" "Gateway API Resources" \
-    "gateways.gateway.networking.k8s.io,gatewayclasses.gateway.networking.k8s.io,httproutes.gateway.networking.k8s.io,tcproutes.gateway.networking.k8s.io,udproutes.gateway.networking.k8s.io,tlsroutes.gateway.networking.k8s.io,grpcroutes.gateway.networking.k8s.io,referencegrants.gateway.networking.k8s.io"
+    "gateway-api"
 
   # Kong Configuration resources
   capture_resource_group "${RESOURCES_FILE}" "${ns}" "Kong Configuration Resources" \

--- a/test/e2e/chainsaw/common/scripts/debug_snapshot.sh
+++ b/test/e2e/chainsaw/common/scripts/debug_snapshot.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+
+# Debug snapshot script for capturing cluster state when tests fail.
+# This script captures all relevant resources, events, and logs for debugging.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Variables (from environment):
+#   TEST_NAME: Name of the test (used for output directory naming).
+#   NAMESPACE: The test namespace to capture state from.
+#   ADDITIONAL_NAMESPACES: Comma-separated list of additional namespaces (optional).
+#   OUTPUT_DIR: Base directory for debug output (default: /tmp/chainsaw).
+#   OPERATOR_NAMESPACE: Namespace where the operator runs (default: kong-system).
+
+TEST_NAME="${TEST_NAME:-unknown-test}"
+NAMESPACE="${NAMESPACE:-default}"
+ADDITIONAL_NAMESPACES="${ADDITIONAL_NAMESPACES:-}"
+OUTPUT_DIR="${OUTPUT_DIR:-/tmp/chainsaw}"
+OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-kong-system}"
+
+# Build list of all namespaces to capture
+ALL_NAMESPACES="${NAMESPACE}"
+if [ -n "${ADDITIONAL_NAMESPACES}" ]; then
+  # Convert comma-separated list to space-separated for iteration
+  ADDITIONAL_NS_LIST=$(echo "${ADDITIONAL_NAMESPACES}" | tr ',' ' ')
+  ALL_NAMESPACES="${NAMESPACE} ${ADDITIONAL_NS_LIST}"
+fi
+
+# Create output directory structure
+SNAPSHOT_DIR="${OUTPUT_DIR}/${TEST_NAME}"
+mkdir -p "${SNAPSHOT_DIR}"
+
+echo "=== Capturing debug snapshot for test: ${TEST_NAME} ==="
+echo "Test namespace(s): ${ALL_NAMESPACES}"
+echo "Operator namespace: ${OPERATOR_NAMESPACE}"
+echo "Output directory: ${SNAPSHOT_DIR}"
+echo ""
+
+# Function to safely run kubectl commands and capture output
+safe_kubectl() {
+  local output_file=$1
+  shift
+  echo "Running: kubectl $*" >> "${output_file}"
+  echo "---" >> "${output_file}"
+  if kubectl "$@" >> "${output_file}" 2>&1; then
+    echo "" >> "${output_file}"
+    return 0
+  else
+    echo "Error running command (exit code: $?)" >> "${output_file}"
+    echo "" >> "${output_file}"
+    return 0  # Don't fail the script if a command fails
+  fi
+}
+
+# 1. Capture all resources in test namespaces (YAML format)
+echo "Capturing all resources in namespace(s)..."
+RESOURCES_FILE="${SNAPSHOT_DIR}/resources.yaml"
+{
+  echo "# All resources in test namespaces"
+  echo "# Captured at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  echo "---"
+} > "${RESOURCES_FILE}"
+
+# Function to capture a group of resources with a header
+capture_resource_group() {
+  local output_file=$1
+  local namespace=$2
+  local group_name=$3
+  local resource_types=$4
+
+  {
+    echo ""
+    echo "# ------------------------------------------"
+    echo "# ${group_name}"
+    echo "# ------------------------------------------"
+    echo ""
+  } >> "${output_file}"
+
+  safe_kubectl "${output_file}" get "${resource_types}" -n "${namespace}" -o yaml
+}
+
+# Capture resources from all namespaces, organized by type for easy navigation
+for ns in ${ALL_NAMESPACES}; do
+  echo "Capturing resources from namespace: ${ns}..."
+  {
+    echo ""
+    echo "# =========================================="
+    echo "# Namespace: ${ns}"
+    echo "# =========================================="
+    echo ""
+  } >> "${RESOURCES_FILE}"
+
+  # Gateway API resources
+  capture_resource_group "${RESOURCES_FILE}" "${ns}" "Gateway API Resources" \
+    "gateways.gateway.networking.k8s.io,gatewayclasses.gateway.networking.k8s.io,httproutes.gateway.networking.k8s.io,tcproutes.gateway.networking.k8s.io,udproutes.gateway.networking.k8s.io,tlsroutes.gateway.networking.k8s.io,grpcroutes.gateway.networking.k8s.io,referencegrants.gateway.networking.k8s.io"
+
+  # Kong Configuration resources
+  capture_resource_group "${RESOURCES_FILE}" "${ns}" "Kong Configuration Resources" \
+    "kongcertificates.configuration.konghq.com,kongsnis.configuration.konghq.com,kongroutes.configuration.konghq.com,kongservices.configuration.konghq.com,kongupstreams.configuration.konghq.com,kongtargets.configuration.konghq.com,kongreferencegrants.configuration.konghq.com,kongplugins.configuration.konghq.com,kongclusterplugins.configuration.konghq.com,kongconsumers.configuration.konghq.com,kongconsumergroups.configuration.konghq.com"
+
+  # Konnect resources
+  capture_resource_group "${RESOURCES_FILE}" "${ns}" "Konnect Resources" \
+    "konnectgatewaycontrolplanes.konnect.konghq.com,konnectapiauthconfigurations.konnect.konghq.com,konnectextensions.konnect.konghq.com"
+
+  # Gateway Operator resources
+  capture_resource_group "${RESOURCES_FILE}" "${ns}" "Gateway Operator Resources" \
+    "gatewayconfigurations.gateway-operator.konghq.com,controlplanes.gateway-operator.konghq.com,dataplanes.gateway-operator.konghq.com,aigateways.gateway-operator.konghq.com,dataplanemetricsextensions.gateway-operator.konghq.com"
+
+  # Core Kubernetes resources
+  capture_resource_group "${RESOURCES_FILE}" "${ns}" "Core Kubernetes Resources" \
+    "pods,services,deployments.apps,replicasets.apps,statefulsets.apps,configmaps,serviceaccounts,roles.rbac.authorization.k8s.io,rolebindings.rbac.authorization.k8s.io"
+done
+
+# 2. Capture detailed descriptions of all resources
+echo "Capturing resource descriptions..."
+DESCRIBED_FILE="${SNAPSHOT_DIR}/resources-described.txt"
+{
+  echo "=== Detailed Resource Descriptions ==="
+  echo "Namespaces: ${ALL_NAMESPACES}"
+  echo "Captured at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  echo ""
+} > "${DESCRIBED_FILE}"
+
+# Loop through all namespaces
+for ns in ${ALL_NAMESPACES}; do
+  echo "Capturing descriptions from namespace: ${ns}..."
+  {
+    echo ""
+    echo "######################################################"
+    echo "# Namespace: ${ns}"
+    echo "######################################################"
+    echo ""
+  } >> "${DESCRIBED_FILE}"
+
+  safe_kubectl "${DESCRIBED_FILE}" describe all -n "${ns}"
+
+  # Also describe Gateway API and Kong resources specifically
+  {
+    echo ""
+    echo "=== Gateway API Resources in ${ns} ==="
+    echo ""
+  } >> "${DESCRIBED_FILE}"
+
+  safe_kubectl "${DESCRIBED_FILE}" describe gateways,gatewayclasses,httproutes,referencegrants -n "${ns}"
+
+  {
+    echo ""
+    echo "=== Kong Configuration Resources in ${ns} ==="
+    echo ""
+  } >> "${DESCRIBED_FILE}"
+
+  safe_kubectl "${DESCRIBED_FILE}" describe kongcertificates,kongsnis,kongroutes,kongservices,kongupstreams,kongtargets,kongreferencegrants,kongplugins -n "${ns}"
+
+  {
+    echo ""
+    echo "=== Konnect Resources in ${ns} ==="
+    echo ""
+  } >> "${DESCRIBED_FILE}"
+
+  safe_kubectl "${DESCRIBED_FILE}" describe konnectgatewaycontrolplanes,konnectapiauthconfigurations,konnectextensions -n "${ns}"
+
+  {
+    echo ""
+    echo "=== GatewayConfiguration Resources in ${ns} ==="
+    echo ""
+  } >> "${DESCRIBED_FILE}"
+
+  safe_kubectl "${DESCRIBED_FILE}" describe gatewayconfigurations -n "${ns}"
+done
+
+# 3. Capture events in test namespaces
+echo "Capturing events in test namespace(s)..."
+EVENTS_FILE="${SNAPSHOT_DIR}/events.txt"
+{
+  echo "=== Events in test namespaces ==="
+  echo "Captured at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  echo ""
+} > "${EVENTS_FILE}"
+
+for ns in ${ALL_NAMESPACES}; do
+  echo "Capturing events from namespace: ${ns}..."
+  {
+    echo ""
+    echo "######################################################"
+    echo "# Events in namespace: ${ns}"
+    echo "######################################################"
+    echo ""
+  } >> "${EVENTS_FILE}"
+
+  safe_kubectl "${EVENTS_FILE}" get events -n "${ns}" --sort-by='.lastTimestamp'
+done
+
+# 4. Capture events in operator namespace
+echo "Capturing events in operator namespace ${OPERATOR_NAMESPACE}..."
+OPERATOR_EVENTS_FILE="${SNAPSHOT_DIR}/operator-events.txt"
+{
+  echo "=== Events in operator namespace: ${OPERATOR_NAMESPACE} ==="
+  echo "Captured at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  echo ""
+} > "${OPERATOR_EVENTS_FILE}"
+
+safe_kubectl "${OPERATOR_EVENTS_FILE}" get events -n "${OPERATOR_NAMESPACE}" --sort-by='.lastTimestamp'
+
+# 5. Capture operator logs
+echo "Capturing operator logs from namespace ${OPERATOR_NAMESPACE}..."
+OPERATOR_LOGS_FILE="${SNAPSHOT_DIR}/operator-logs.txt"
+{
+  echo "=== Kong Operator Logs ==="
+  echo "Namespace: ${OPERATOR_NAMESPACE}"
+  echo "Captured at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  echo ""
+} > "${OPERATOR_LOGS_FILE}"
+
+# Get all operator pods
+OPERATOR_PODS=$(kubectl get pods -n "${OPERATOR_NAMESPACE}" -l app.kubernetes.io/name=kong-operator -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+
+if [ -n "${OPERATOR_PODS}" ]; then
+  for pod in ${OPERATOR_PODS}; do
+    echo "=== Logs from pod: ${pod} ===" >> "${OPERATOR_LOGS_FILE}"
+    echo "" >> "${OPERATOR_LOGS_FILE}"
+
+    # Get logs with timestamps
+    if kubectl logs "${pod}" -n "${OPERATOR_NAMESPACE}" --all-containers --timestamps >> "${OPERATOR_LOGS_FILE}" 2>&1; then
+      echo "" >> "${OPERATOR_LOGS_FILE}"
+    else
+      echo "Failed to get logs from pod ${pod}" >> "${OPERATOR_LOGS_FILE}"
+      echo "" >> "${OPERATOR_LOGS_FILE}"
+    fi
+
+    # Also get previous logs if container restarted
+    echo "=== Previous logs from pod: ${pod} (if any) ===" >> "${OPERATOR_LOGS_FILE}"
+    if kubectl logs "${pod}" -n "${OPERATOR_NAMESPACE}" --all-containers --timestamps --previous >> "${OPERATOR_LOGS_FILE}" 2>&1; then
+      echo "" >> "${OPERATOR_LOGS_FILE}"
+    else
+      echo "No previous logs or failed to get previous logs" >> "${OPERATOR_LOGS_FILE}"
+      echo "" >> "${OPERATOR_LOGS_FILE}"
+    fi
+  done
+else
+  echo "No operator pods found in namespace ${OPERATOR_NAMESPACE}" >> "${OPERATOR_LOGS_FILE}"
+fi
+
+# 6. Capture operator pod status
+echo "Capturing operator pod status..."
+OPERATOR_STATUS_FILE="${SNAPSHOT_DIR}/operator-pods-status.txt"
+{
+  echo "=== Kong Operator Pods Status ==="
+  echo "Namespace: ${OPERATOR_NAMESPACE}"
+  echo "Captured at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  echo ""
+} > "${OPERATOR_STATUS_FILE}"
+
+safe_kubectl "${OPERATOR_STATUS_FILE}" get pods -n "${OPERATOR_NAMESPACE}" -l app.kubernetes.io/name=kong-operator -o wide
+safe_kubectl "${OPERATOR_STATUS_FILE}" describe pods -n "${OPERATOR_NAMESPACE}" -l app.kubernetes.io/name=kong-operator
+
+# 7. Create summary file
+echo "Creating summary..."
+SUMMARY_FILE="${SNAPSHOT_DIR}/summary.txt"
+{
+  echo "=== Debug Snapshot Summary ==="
+  echo "Test Name: ${TEST_NAME}"
+  echo "Test Namespaces: ${ALL_NAMESPACES}"
+  echo "Operator Namespace: ${OPERATOR_NAMESPACE}"
+  echo "Captured at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  echo ""
+  echo "Files generated:"
+  echo "  - resources.yaml: All resources in test namespaces (YAML format)"
+  echo "  - resources-described.txt: Detailed descriptions of all resources"
+  echo "  - events.txt: Events in test namespaces"
+  echo "  - operator-events.txt: Events in operator namespace"
+  echo "  - operator-logs.txt: Kong operator logs (current and previous)"
+  echo "  - operator-pods-status.txt: Operator pod status and descriptions"
+  echo ""
+} > "${SUMMARY_FILE}"
+
+# Count resources by namespace
+for ns in ${ALL_NAMESPACES}; do
+  echo "Resource counts in namespace ${ns}:" >> "${SUMMARY_FILE}"
+
+  # Count resources by type
+  kubectl api-resources --verbs=list --namespaced -o name | while read -r resource; do
+    count=$(kubectl get "${resource}" -n "${ns}" --ignore-not-found 2>/dev/null | tail -n +2 | wc -l | tr -d ' ')
+    if [ "${count}" != "0" ]; then
+      echo "  - ${resource}: ${count}" >> "${SUMMARY_FILE}"
+    fi
+  done
+
+  echo "" >> "${SUMMARY_FILE}"
+done
+
+echo "Operator pod count: $(kubectl get pods -n "${OPERATOR_NAMESPACE}" -l app.kubernetes.io/name=kong-operator --no-headers 2>/dev/null | wc -l | tr -d ' ')" >> "${SUMMARY_FILE}"
+
+echo ""
+echo "=== Debug snapshot complete ==="
+echo "Output saved to: ${SNAPSHOT_DIR}"
+echo ""
+echo "Summary:"
+cat "${SUMMARY_FILE}"

--- a/test/e2e/chainsaw/hybridgateway/basic-httproute/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-httproute/chainsaw-test.yaml
@@ -28,6 +28,14 @@ spec:
       value: 80
     - name: konnect_url
       value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
     - name: gateway_image
       value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
     - name: gateway_name
@@ -56,11 +64,17 @@ spec:
       use:
         template: ../../common/_step_templates/apply-assert-tlsSecret.yaml
 
-    # Step 2: Create the KonnectAPIAuthConfiguration to authenticate with Konnect.
+    # Step 2a: Create the secret for Konnect authentication.
+    - name: Create-auth-secret
+      description: Create Secret with Konnect token for KonnectAPIAuthConfiguration.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    # Step 2b: Create the KonnectAPIAuthConfiguration to authenticate with Konnect.
     - name: Create-konnect-api-auth
       description: Create KonnectAPIAuthConfiguration for the test.
       use:
-        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
 
     # Step 3: Create the GatewayConfiguration that defines the hybrid gateway setup.
     - name: Create-gateway-configuration

--- a/test/e2e/chainsaw/hybridgateway/basic-httproute/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-httproute/chainsaw-test.yaml
@@ -587,3 +587,17 @@ spec:
           value: "DELETE"
         - name: insecure
           value: "true"
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-basic-httproute
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/hybridgateway/gateway-tls-certificates/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/gateway-tls-certificates/chainsaw-test.yaml
@@ -29,6 +29,14 @@ spec:
       value: 80
     - name: konnect_url
       value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
     - name: gateway_image
       value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
     - name: gateway_name
@@ -53,11 +61,17 @@ spec:
       use:
         template: ../../common/_step_templates/apply-assert-tlsSecret.yaml
 
-    # Step 2: Create the KonnectAPIAuthConfiguration to authenticate with Konnect.
+    # Step 2a: Create the secret for Konnect authentication.
+    - name: Create-auth-secret
+      description: Create Secret with Konnect token for KonnectAPIAuthConfiguration.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    # Step 2b: Create the KonnectAPIAuthConfiguration to authenticate with Konnect.
     - name: Create-konnect-api-auth
       description: Create KonnectAPIAuthConfiguration for the test.
       use:
-        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
 
     # Step 3: Create the GatewayConfiguration that defines the hybrid gateway setup.
     - name: Create-gateway-configuration

--- a/test/e2e/chainsaw/hybridgateway/gateway-tls-certificates/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/gateway-tls-certificates/chainsaw-test.yaml
@@ -222,3 +222,17 @@ spec:
           value: "/echo"
         - name: insecure
           value: "true"
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-gateway-tls-certificates
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/hybridgateway/gateway-tls-secret-cross-namespace/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/gateway-tls-secret-cross-namespace/chainsaw-test.yaml
@@ -32,6 +32,14 @@ spec:
       value: 80
     - name: konnect_url
       value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
     - name: gateway_image
       value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
     - name: gateway_name
@@ -63,11 +71,17 @@ spec:
       use:
         template: ../../common/_step_templates/apply-assert-tlsSecret.yaml
 
-    # Step 3: Create the KonnectAPIAuthConfiguration to authenticate with Konnect.
-    - name: 3-create-konnect-api-auth
+    # Step 3a: Create the secret for Konnect authentication.
+    - name: 3a-create-auth-secret
+      description: Create Secret with Konnect token for KonnectAPIAuthConfiguration
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    # Step 3b: Create the KonnectAPIAuthConfiguration to authenticate with Konnect.
+    - name: 3b-create-konnect-api-auth
       description: Create KonnectAPIAuthConfiguration for the test
       use:
-        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
 
     # Step 4: Create the GatewayConfiguration that defines the hybrid gateway setup.
     - name: 4-create-gateway-configuration

--- a/test/e2e/chainsaw/hybridgateway/gateway-tls-secret-cross-namespace/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/gateway-tls-secret-cross-namespace/chainsaw-test.yaml
@@ -237,3 +237,19 @@ spec:
           value: ($gateway_namespace)
         - name: resource_type
           value: kongcertificates.configuration.konghq.com
+  
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-gateway-tls-secret-cross-namespace
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: ADDITIONAL_NAMESPACES
+            value: ($secret_namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/chainsaw-test.yaml
@@ -28,6 +28,14 @@ spec:
       value: 80
     - name: konnect_url
       value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
     - name: gateway_image
       value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
     - name: gateway_name
@@ -56,11 +64,17 @@ spec:
       use:
         template: ../../common/_step_templates/apply-assert-tlsSecret.yaml
 
-    # Step 2: Create the KonnectAPIAuthConfiguration to authenticate with Konnect.
+    # Step 2a: Create the secret for Konnect authentication.
+    - name: Create-auth-secret
+      description: Create Secret with Konnect token for KonnectAPIAuthConfiguration.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    # Step 2b: Create the KonnectAPIAuthConfiguration to authenticate with Konnect.
     - name: Create-konnect-api-auth
       description: Create KonnectAPIAuthConfiguration for the test.
       use:
-        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
 
     # Step 3: Create the GatewayConfiguration that defines the hybrid gateway setup.
     - name: Create-gateway-configuration

--- a/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/chainsaw-test.yaml
@@ -219,3 +219,19 @@ spec:
           value: "80"
         - name: host_header
           value: ($fqdn)
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-httproute-backendref-cross-namespace-reference
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: ADDITIONAL_NAMESPACES
+            value: ($echo_deployment_namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/hybridgateway/httproute-complex-multiple-rules/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-complex-multiple-rules/chainsaw-test.yaml
@@ -397,3 +397,17 @@ spec:
         value: "404"
     use:
       template: ../../common/_step_templates/verify-header-match-routing.yaml
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-httproute-complex-multiple-rules
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/hybridgateway/httproute-complex-multiple-rules/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-complex-multiple-rules/chainsaw-test.yaml
@@ -23,6 +23,14 @@ spec:
       value: (env('KONNECT_TOKEN'))
     - name: konnect_url
       value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
     - name: gateway_image
       value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
     - name: gateway_class_name
@@ -53,11 +61,17 @@ spec:
       value: ($namespace)
 
   steps:
-  # Step 1: Create KonnectAPIAuthConfiguration.
-  - name: 1-create-konnect-api-auth
+  # Step 1a: Create the secret for Konnect authentication.
+  - name: 1a-create-auth-secret
+    description: Create Secret with Konnect token for KonnectAPIAuthConfiguration
+    use:
+      template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+  # Step 1b: Create KonnectAPIAuthConfiguration.
+  - name: 1b-create-konnect-api-auth
     description: Create KonnectAPIAuthConfiguration for the test.
     use:
-      template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+      template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
 
   # Step 2: Create GatewayConfiguration.
   - name: 2-create-gateway-configuration

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/chainsaw-test.yaml
@@ -19,6 +19,14 @@ spec:
       value: (env('KONNECT_TOKEN'))
     - name: konnect_url
       value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
 
     # TLS configuration.
     - name: sni_hostname
@@ -55,11 +63,17 @@ spec:
       use:
         template: ../../common/_step_templates/apply-assert-tlsSecret.yaml
 
-    # Step 1: Create Konnect API Auth Configuration.
-    - name: 1-Create-konnect-api-auth
+    # Step 1a: Create the secret for Konnect authentication.
+    - name: 1a-Create-auth-secret
+      description: Create Secret with Konnect token for KonnectAPIAuthConfiguration
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    # Step 1b: Create Konnect API Auth Configuration.
+    - name: 1b-Create-konnect-api-auth
       description: Create KonnectAPIAuthConfiguration for the test
       use:
-        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
 
     # Step 2: Create Gateway Configuration.
     - name: 2-Create-gateway-configuration

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/chainsaw-test.yaml
@@ -539,3 +539,17 @@ spec:
           value: "80"
       use:
         template: ../../common/_step_templates/verify-header-absent.yaml
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-httproute-extenstionref-filter
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
@@ -836,3 +836,17 @@ spec:
           value: "https"
         - name: insecure
           value: "true"
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-httproute-filters
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
@@ -31,6 +31,14 @@ spec:
       value: 80
     - name: konnect_url
       value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
     - name: gateway_image
       value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
     - name: gateway_name
@@ -65,11 +73,17 @@ spec:
       use:
         template: ../../common/_step_templates/apply-assert-tlsSecret.yaml
 
-    # Step 2: Create the KonnectAPIAuthConfiguration to authenticate with Konnect.
+    # Step 2a: Create the secret for Konnect authentication.
+    - name: Create-auth-secret
+      description: Create Secret with Konnect token for KonnectAPIAuthConfiguration.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    # Step 2b: Create the KonnectAPIAuthConfiguration to authenticate with Konnect.
     - name: Create-konnect-api-auth
       description: Create KonnectAPIAuthConfiguration for the test.
       use:
-        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
 
     # Step 3: Create the GatewayConfiguration that defines the hybrid gateway setup.
     - name: Create-gateway-configuration

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/chainsaw-test.yaml
@@ -266,3 +266,17 @@ spec:
         value: "regex-header-1:123"
       - name: expected_status
         value: "404"
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-httproute-header-match
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/chainsaw-test.yaml
@@ -20,6 +20,14 @@ spec:
       value: (env('KONNECT_TOKEN'))
     - name: konnect_url
       value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
     - name: gateway_class_name
       value: (join('-', [($test_name), 'gateway-class']))
     - name: gateway_configuration_name
@@ -55,11 +63,17 @@ spec:
       - name: namespace_name
         value: ($namespace)
 
-  # Step 2: Create KonnectAPIAuthConfiguration.
+  # Step 2a: Create the secret for Konnect authentication.
+  - name: Create-auth-secret
+    description: Create Secret with Konnect token for KonnectAPIAuthConfiguration.
+    use:
+      template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+  # Step 2b: Create KonnectAPIAuthConfiguration.
   - name: create-konnect-api-auth
     description: Create KonnectAPIAuthConfiguration for the test
     use:
-      template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+      template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
 
   # Step 3: Create GatewayConfiguration.
   - name: create-gateway-configuration

--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/chainsaw-test.yaml
@@ -567,3 +567,17 @@ spec:
         value: "exact.httpbin.example"
       - name: expected_status
         value: "404"
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-httproute-listener-hostname-match
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/chainsaw-test.yaml
@@ -22,6 +22,14 @@ spec:
       value: (env('KONNECT_TOKEN'))
     - name: konnect_url
       value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
     - name: gateway_image
       value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
     - name: gateway_class_name
@@ -121,11 +129,17 @@ spec:
       - name: namespace_name
         value: ($namespace)
 
-  # Step 2: Create KonnectAPIAuthConfiguration.
+  # Step 2a: Create the secret for Konnect authentication.
+  - name: Create-auth-secret
+    description: Create Secret with Konnect token for KonnectAPIAuthConfiguration.
+    use:
+      template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+  # Step 2b: Create KonnectAPIAuthConfiguration.
   - name: 2-create-konnect-api-auth
     description: Create KonnectAPIAuthConfiguration for the test
     use:
-      template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+      template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
 
   # Step 3: Create GatewayConfiguration.
   - name: 3-create-gateway-configuration

--- a/test/e2e/chainsaw/hybridgateway/httproute-method-matching/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-method-matching/chainsaw-test.yaml
@@ -550,3 +550,17 @@ spec:
         value: "/status/200"
       - name: expected_status
         value: "200"
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-httproute-method-matching
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/hybridgateway/httproute-method-matching/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-method-matching/chainsaw-test.yaml
@@ -21,6 +21,14 @@ spec:
       value: (env('KONNECT_TOKEN'))
     - name: konnect_url
       value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
     - name: gateway_class_name
       value: (join('-', [($test_name), 'gateway-class']))
     - name: gateway_configuration_name
@@ -63,11 +71,17 @@ spec:
       value: ""
 
   steps:
-  # Step 2: Create KonnectAPIAuthConfiguration.
+  # Step 2a: Create the secret for Konnect authentication.
+  - name: Create-auth-secret
+    description: Create Secret with Konnect token for KonnectAPIAuthConfiguration.
+    use:
+      template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+  # Step 2b: Create KonnectAPIAuthConfiguration.
   - name: create-konnect-api-auth
     description: Create KonnectAPIAuthConfiguration for the test
     use:
-      template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+      template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
 
   # Step 3: Create GatewayConfiguration.
   - name: create-gateway-configuration

--- a/test/e2e/chainsaw/hybridgateway/httproute-multiple-backends/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-multiple-backends/chainsaw-test.yaml
@@ -27,6 +27,14 @@ spec:
       value: (env('KONNECT_TOKEN'))
     - name: konnect_url
       value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
     - name: gateway_image
       value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
     - name: gateway_class_name
@@ -69,11 +77,17 @@ spec:
       value: ($cross_namespace)
 
   steps:
-  # Step 1: Create KonnectAPIAuthConfiguration.
-  - name: 1-create-konnect-api-auth
+  # Step 1a: Create the secret for Konnect authentication.
+  - name: 1a-create-auth-secret
+    description: Create Secret with Konnect token for KonnectAPIAuthConfiguration
+    use:
+      template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+  # Step 1b: Create KonnectAPIAuthConfiguration.
+  - name: 1b-create-konnect-api-auth
     description: Create KonnectAPIAuthConfiguration for the test
     use:
-      template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+      template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
 
   # Step 2: Create GatewayConfiguration.
   - name: 2-create-gateway-configuration

--- a/test/e2e/chainsaw/hybridgateway/httproute-multiple-backends/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-multiple-backends/chainsaw-test.yaml
@@ -515,3 +515,19 @@ spec:
         value: 9
     use:
       template: ../../common/_step_templates/assert-kongTarget.yaml
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-httproute-multiple-backends
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: ADDITIONAL_NAMESPACES
+            value: ($cross_namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/hybridgateway/httproute-multiple-parentrefs/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-multiple-parentrefs/chainsaw-test.yaml
@@ -636,3 +636,17 @@ spec:
           value: "80"
         - name: host_header
           value: ($fqdn_1)
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-httproute-multiple-parentrefs
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/hybridgateway/httproute-multiple-parentrefs/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-multiple-parentrefs/chainsaw-test.yaml
@@ -17,6 +17,14 @@ spec:
       value: (env('KONNECT_TOKEN'))
     - name: konnect_url
       value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
     - name: gateway_image
       value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
     
@@ -99,11 +107,17 @@ spec:
         - name: cert_secret_name
           value: ($cert_secret_name_2)
 
-    # Step 3: Create the KonnectAPIAuthConfiguration.
+    # Step 3a: Create the secret for Konnect authentication.
+    - name: Create-auth-secret
+      description: Create Secret with Konnect token for KonnectAPIAuthConfiguration.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    # Step 3b: Create the KonnectAPIAuthConfiguration.
     - name: Create-konnect-api-auth
       description: Create KonnectAPIAuthConfiguration for the test
       use:
-        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
 
     # Step 4: Create GatewayConfiguration for Gateway 1.
     - name: Create-gateway-configuration-1

--- a/test/e2e/chainsaw/hybridgateway/httproute-path-matching/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-path-matching/chainsaw-test.yaml
@@ -19,6 +19,14 @@ spec:
       value: (env('KONNECT_TOKEN'))
     - name: konnect_url
       value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
     - name: gateway_image
       value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
     - name: gateway_class_name
@@ -66,11 +74,17 @@ spec:
       - name: namespace_name
         value: ($namespace)
 
-  # Step 2: Create KonnectAPIAuthConfiguration
+  # Step 2a: Create the secret for Konnect authentication.
+  - name: Create-auth-secret
+    description: Create Secret with Konnect token for KonnectAPIAuthConfiguration.
+    use:
+      template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+  # Step 2b: Create KonnectAPIAuthConfiguration
   - name: 2-create-konnect-api-auth
     description: Create KonnectAPIAuthConfiguration for the test
     use:
-      template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+      template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
 
   # Step 3: Create GatewayConfiguration
   - name: 3-create-gateway-configuration

--- a/test/e2e/chainsaw/hybridgateway/httproute-path-matching/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-path-matching/chainsaw-test.yaml
@@ -310,3 +310,17 @@ spec:
         value: ""
       - name: expected_status
         value: "200"
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-httproute-path-matching
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/hybridgateway/httproute-shared-backendrefs/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-shared-backendrefs/chainsaw-test.yaml
@@ -295,3 +295,17 @@ spec:
           value: ($httproute_three_path)
         - name: listener_http_port
           value: "80"
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-httproute-shared-backendrefs
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/hybridgateway/httproute-shared-backendrefs/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-shared-backendrefs/chainsaw-test.yaml
@@ -20,6 +20,14 @@ spec:
       value: (env('KONNECT_TOKEN'))
     - name: konnect_url
       value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
     - name: gateway_image
       value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
 
@@ -70,11 +78,17 @@ spec:
       use:
         template: ../../common/_step_templates/apply-assert-tlsSecret.yaml
 
-    # Step 2: Create the KonnectAPIAuthConfiguration to authenticate with Konnect.
+    # Step 2a: Create the secret for Konnect authentication.
+    - name: Create-auth-secret
+      description: Create Secret with Konnect token for KonnectAPIAuthConfiguration.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    # Step 2b: Create the KonnectAPIAuthConfiguration to authenticate with Konnect.
     - name: Create-konnect-api-auth
       description: Create KonnectAPIAuthConfiguration for the test.
       use:
-        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
 
     # Step 3: Create the GatewayConfiguration that defines the hybrid gateway setup.
     - name: Create-gateway-configuration

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/chainsaw-test.yaml
@@ -281,3 +281,19 @@ spec:
             file: 27-httproute-mixed-extensionref-fails.yaml
         - assert:
             file: 28-httproute-mixed-extensionref-fails-assert.yaml
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-httproute-status-resolved-refs
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: ADDITIONAL_NAMESPACES
+            value: ($xns_namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/chainsaw-test.yaml
@@ -38,6 +38,14 @@ spec:
     value: 80
   - name: konnect_url
     value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+  - name: auth_secret_name
+    value: (join('-', [($test_name), 'konnect-auth-secret']))
+  - name: auth_secret_namespace
+    value: ($namespace)
+  - name: konnect_auth_name
+    value: (join('-', [($test_name), 'konnect-api-auth']))
+  - name: konnect_auth_namespace
+    value: ($namespace)
   - name: gateway_image
     value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
   - name: gateway_name
@@ -70,11 +78,17 @@ spec:
       use:
         template: ../../common/_step_templates/apply-assert-tlsSecret.yaml
 
-    # Step 2: Create the KonnectAPIAuthConfiguration to authenticate with Konnect.
+    # Step 2a: Create the secret for Konnect authentication.
+    - name: Create-auth-secret
+      description: Create Secret with Konnect token for KonnectAPIAuthConfiguration.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    # Step 2b: Create the KonnectAPIAuthConfiguration to authenticate with Konnect.
     - name: Create-konnect-api-auth
       description: Create KonnectAPIAuthConfiguration for the test.
       use:
-        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
 
     # Step 3: Create the GatewayConfiguration that defines the hybrid gateway setup.
     - name: Create-gateway-configuration

--- a/test/e2e/chainsaw/konnect/apiAuth_inline_token/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/konnect/apiAuth_inline_token/chainsaw-test.yaml
@@ -28,3 +28,17 @@ spec:
       description: Create KonnectAPIAuthConfiguration with inline token and verify it's ready.
       use:
         template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: konnect-apiAuth_inline_token
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/konnect/apiAuth_referencegrant/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/konnect/apiAuth_referencegrant/chainsaw-test.yaml
@@ -74,3 +74,19 @@ spec:
               value: ($secret_namespace)
             - name: konnect_url
               value: ($konnect_url)
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: konnect-apiAuth_referencegrant
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: ADDITIONAL_NAMESPACES
+            value: ($secret_namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/konnect/apiAuth_secretref/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/konnect/apiAuth_secretref/chainsaw-test.yaml
@@ -342,3 +342,17 @@ spec:
               kind: Secret
               name: (join('-', [($auth_secret_name_3), 'final']))
               namespace: ($auth_secret_namespace)
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: konnect-apiAuth_secretref
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh


### PR DESCRIPTION
**What this PR does / why we need it**:

```
Add debug snapshot capability to capture cluster state when
chainsaw E2E tests fail. This includes:

- New debug_snapshot.sh script that captures resources, events, logs, and
  descriptions from test namespaces and operator namespace
- Reusable step template for debug snapshot capture
- Catch blocks in all 18 chainsaw tests to trigger snapshot on failure
- GitHub Actions workflow steps to upload snapshots as artifacts (3-day
  retention) and clean up /tmp/chainsaw directory

The captured snapshots include all Gateway API resources, Kong configuration
resources, Konnect resources, core Kubernetes resources, operator logs, and
events across all test namespaces. This will significantly improve debugging
of test failures in CI.
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
