### PR TITLE
chore: handle conflict errors in DataPlane controller

### DIFF
--- a/controller/dataplane/controller.go
+++ b/controller/dataplane/controller.go
@@ -16,6 +16,7 @@ import (
 
 	operatorv1beta1 "github.com/kong/kong-operator/api/gateway-operator/v1beta1"
 	kcfgkonnect "github.com/kong/kong-operator/api/konnect"
+	ctrlconsts "github.com/kong/kong-operator/controller/consts"
 	"github.com/kong/kong-operator/controller/pkg/extensions"
 	extensionserrors "github.com/kong/kong-operator/controller/pkg/extensions/errors"
 	extensionskonnect "github.com/kong/kong-operator/controller/pkg/extensions/konnect"
@@ -112,6 +113,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		k8sresources.LabelSelectorFromDataPlaneStatusSelectorServiceOpt(dataplane),
 	)
 	if err != nil {
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
+		}
 		return ctrl.Result{}, err
 	}
 	switch res {


### PR DESCRIPTION
**What this PR does / why we need it**:

Handle errors like:

```
2026-02-13T10:06:28Z	ERROR	Reconciler error	{"controller": "dataplane", "controllerGroup": "gateway-operator.konghq.com", "controllerKind": "DataPlane", "DataPlane": {"name":"dataplane-wcf6m","namespace":"8280cca6-e36f-4e3c-bc03-52e6981e12d0"}, "namespace": "8280cca6-e36f-4e3c-bc03-52e6981e12d0", "name": "dataplane-wcf6m", "reconcileID": "5574d9ac-b9a9-4f77-a5e9-dec3dd2670c6", "error": "Operation cannot be fulfilled on dataplanes.gateway-operator.konghq.com \"dataplane-wcf6m\": the object has been modified; please apply your changes to the latest version and try again"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:495
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:438
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:313
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
