### PR TITLE
chore: remove unused test deps

### DIFF
--- a/test/test_dependencies.yaml
+++ b/test/test_dependencies.yaml
@@ -1,15 +1,4 @@
 e2e:
-  kind:
-    # renovate: datasource=docker depName=kindest/node versioning=docker
-    - 'v1.33.7'
-    # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
-    - 'v1.32.5'
-    # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
-    - 'v1.31.14'
-    # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
-    - 'v1.30.13'
-    # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
-    - 'v1.29.14'
   gke:
     # renovate: datasource=custom.gke-rapid depName=gke versioning=semver
     - '1.33.1'


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove unused e2e kind versions as they [are not used anymore](https://github.com/Kong/kong-operator/blob/9bd2fa5c98925d29104c9c86a5142841ab293578/test/e2e/environment.go#L105-L179).

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
