### PR TITLE
chore: consistent k8s.io/apimachinery/pkg/api/errors imports as apierrors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -140,6 +140,8 @@ linters:
           alias: k8sutils
         - pkg: github.com/kong/kong-operator/pkg/utils/kubernetes/resources
           alias: k8sresources
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: apierrors
       no-unaliased: true
     revive:
       rules:

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -15,7 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -460,7 +460,7 @@ func (r *Reconciler) patchStatus(ctx context.Context, logger logr.Logger, update
 
 	log.Debug(logger, "patching ControlPlane status", "status", updated.Status)
 	if err := r.Client.Status().Patch(ctx, updated, client.MergeFrom(current)); client.IgnoreNotFound(err) != nil {
-		if k8serrors.IsConflict(err) {
+		if apierrors.IsConflict(err) {
 			log.Debug(logger, "conflict found when updating ControlPlane, retrying")
 			return ctrl.Result{Requeue: true, RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
 		}
@@ -850,7 +850,7 @@ func (r *Reconciler) cleanupOldManagedResources(ctx context.Context, cp *Control
 			}),
 		},
 	})
-	if err != nil && !k8serrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete old ControlPlane deployment %w", err)
 	}
 
@@ -863,7 +863,7 @@ func (r *Reconciler) cleanupOldManagedResources(ctx context.Context, cp *Control
 			}),
 		},
 	})
-	if err != nil && !k8serrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete old ControlPlane NetworkPolicy %w", err)
 	}
 
@@ -876,7 +876,7 @@ func (r *Reconciler) cleanupOldManagedResources(ctx context.Context, cp *Control
 			}),
 		},
 	})
-	if err != nil && !k8serrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete old ControlPlane Service %w", err)
 	}
 
@@ -890,7 +890,7 @@ func (r *Reconciler) cleanupOldManagedResources(ctx context.Context, cp *Control
 			}),
 		},
 	})
-	if err != nil && !k8serrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete old ControlPlane ValidatingWebhookConfiguration %w", err)
 	}
 
@@ -904,7 +904,7 @@ func (r *Reconciler) cleanupOldManagedResources(ctx context.Context, cp *Control
 			}),
 		},
 	})
-	if err != nil && !k8serrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete old ControlPlane ClusterRole %w", err)
 	}
 
@@ -918,7 +918,7 @@ func (r *Reconciler) cleanupOldManagedResources(ctx context.Context, cp *Control
 			}),
 		},
 	})
-	if err != nil && !k8serrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete old ControlPlane ClusterRoleBinding %w", err)
 	}
 

--- a/controller/controlplane/controller_watch.go
+++ b/controller/controlplane/controller_watch.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -92,7 +92,7 @@ func (r *Reconciler) getControlPlanesFromDataPlaneDeployment(ctx context.Context
 		}
 	)
 	if err := r.Get(ctx, nn, &dataPlane); err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			ctrllog.FromContext(ctx).Error(err, "failed to map ControlPlane on DataPlane Deployment")
 		}
 		return nil

--- a/controller/cpextensions/controller.go
+++ b/controller/cpextensions/controller.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -139,7 +139,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	controlplane := new(gwtypes.ControlPlane)
 
 	if err := r.Get(ctx, req.NamespacedName, controlplane); err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			r.DataPlaneScraperManagerNotifier.NotifyRemove(ctx, types.NamespacedName{
 				Name:      req.Name,
 				Namespace: req.Namespace,
@@ -342,7 +342,7 @@ func (r *Reconciler) ensurePrometheusPlugin(
 	pluginNN := client.ObjectKeyFromObject(generatedPlugin)
 	svcNN := client.ObjectKeyFromObject(svc)
 	if err = r.Get(ctx, pluginNN, &prometheusPluginActual); err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to get Prometheus KongPlugin %s for Service %s: %w", pluginNN, svcNN, err)
 		}
 

--- a/controller/dataplane/controller_reconciler_utils.go
+++ b/controller/dataplane/controller_reconciler_utils.go
@@ -11,7 +11,7 @@ import (
 	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -195,7 +195,7 @@ func populateDedicatedConfigMapForKongPluginInstallation(
 			log.Trace(logger, fmt.Sprintf("Update existing ConfigMap %s for KongPluginInstallation", client.ObjectKeyFromObject(&cm)))
 			cm.Data = underlyingCM.Data
 			if err := c.Update(ctx, &cm); err != nil {
-				if k8serrors.IsConflict(err) {
+				if apierrors.IsConflict(err) {
 					return customPlugin{}, true, nil
 				}
 				return customPlugin{}, false, fmt.Errorf("could not update mapped: %w", err)
@@ -225,7 +225,7 @@ func verifyKPIReadinessForDataPlane(
 	// Report to user when KPI does not exist or it hasn't been fully reconciled yet.
 	// It can be fixed by the user or it's transient.
 	if err := c.Get(ctx, kpiNN, &kpi); err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			msg := fmt.Sprintf("referenced KongPluginInstallation %s not found", kpiNN)
 			markErr := ensureDataPlaneIsMarkedNotReady(ctx, logger, c, dataplane, kcfgdataplane.DataPlaneConditionReferencedResourcesNotAvailable, msg)
 			return kpi, false, markErr

--- a/controller/dataplane/controller_test.go
+++ b/controller/dataplane/controller_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -181,7 +181,7 @@ func TestDataPlaneReconciler_Reconcile(t *testing.T) {
 
 				svcToBeDeleted, svcToBeKept := &corev1.Service{}, &corev1.Service{}
 				err = reconciler.Get(ctx, types.NamespacedName{Namespace: "test-namespace", Name: "svc-proxy-to-delete"}, svcToBeDeleted)
-				require.True(t, k8serrors.IsNotFound(err))
+				require.True(t, apierrors.IsNotFound(err))
 				err = reconciler.Get(ctx, types.NamespacedName{Namespace: "test-namespace", Name: "svc-proxy-to-keep"}, svcToBeKept)
 				require.NoError(t, err)
 			},

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -12,7 +12,7 @@ import (
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -250,7 +250,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 	if err := r.ensureKonnectAPIAuthReferenceGrant(ctx, &gateway, gatewayConfig); err != nil {
-		if k8serrors.IsConflict(err) {
+		if apierrors.IsConflict(err) {
 			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, err
@@ -902,7 +902,7 @@ func (r *Reconciler) provisionKonnectExtension(
 			return nil
 		}
 		for _, dp := range dataPlanes {
-			if err := r.Delete(ctx, &dp); err != nil && !k8serrors.IsNotFound(err) {
+			if err := r.Delete(ctx, &dp); err != nil && !apierrors.IsNotFound(err) {
 				log.Error(logger, err, "deleting dataplane failed", "dataplane", client.ObjectKeyFromObject(&dp))
 			}
 			log.Trace(logger, "deleted associated dataplane", "dataplane", client.ObjectKeyFromObject(&dp))

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -16,7 +16,7 @@ import (
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -875,7 +875,7 @@ func countAttachedRoutesForGatewayListener(ctx context.Context, g *gwtypes.Gatew
 		if err := cl.List(ctx, &nsList, &client.ListOptions{
 			LabelSelector: labelSelector,
 		}); err != nil {
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return 0, nil
 			}
 			return 0, fmt.Errorf("failed to list namespaces for gateway %s: %w", g.Name, err)
@@ -1136,7 +1136,7 @@ func getSupportedKindsWithResolvedRefsCondition(ctx context.Context, c client.Cl
 					Name:      string(certificateRef.Name),
 				}, certificateSecret)
 				if err != nil {
-					if !k8serrors.IsNotFound(err) {
+					if !apierrors.IsNotFound(err) {
 						return nil, metav1.Condition{}, fmt.Errorf("failed to get Secret: %w", err)
 					}
 					resolvedRefsCondition.Reason = string(gatewayv1.ListenerReasonInvalidCertificateRef)

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -2247,7 +2247,7 @@ func TestGetOrCreateGatewayConfiguration(t *testing.T) {
 			},
 			existingGatewayConfig: nil,
 			expectedGatewayConfig: nil,
-			expectedError: &k8serrors.StatusError{
+			expectedError: &apierrors.StatusError{
 				ErrStatus: metav1.Status{
 					Status:  metav1.StatusFailure,
 					Code:    http.StatusNotFound,

--- a/controller/gateway/konnect_auth_referencegrant.go
+++ b/controller/gateway/konnect_auth_referencegrant.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -84,7 +84,7 @@ func (r *Reconciler) ensureManagedKonnectAPIAuthReferenceGrant(
 	key := client.ObjectKeyFromObject(desired)
 	existing := &configurationv1alpha1.KongReferenceGrant{}
 	if err := r.Get(ctx, key, existing); err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return r.Create(ctx, desired)
 		}
 		return err
@@ -115,7 +115,7 @@ func (r *Reconciler) cleanupKonnectAPIAuthReferenceGrants(ctx context.Context, g
 		if !isManagedKonnectAPIAuthGrant(grant, gateway) {
 			continue
 		}
-		if err := r.Delete(ctx, grant); err != nil && !k8serrors.IsNotFound(err) {
+		if err := r.Delete(ctx, grant); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -144,7 +144,7 @@ func (r *Reconciler) cleanupStaleKonnectAPIAuthReferenceGrants(
 		if grant.Namespace == authNamespace && grant.Name == desiredName {
 			continue
 		}
-		if err := r.Delete(ctx, grant); err != nil && !k8serrors.IsNotFound(err) {
+		if err := r.Delete(ctx, grant); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}

--- a/controller/gatewayclass/controller.go
+++ b/controller/gatewayclass/controller.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -88,7 +88,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	if err := r.Client.Status().Patch(ctx, gwc.GatewayClass, client.MergeFrom(oldGwc)); err != nil {
-		if k8serrors.IsConflict(err) {
+		if apierrors.IsConflict(err) {
 			log.Debug(logger, "conflict found when updating GatewayClass, retrying")
 			return ctrl.Result{
 				Requeue:      true,

--- a/controller/gatewayclass/controller_reconciler_utils.go
+++ b/controller/gatewayclass/controller_reconciler_utils.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -48,7 +48,7 @@ func getAcceptedCondition(ctx context.Context, cl client.Client, gwc *gatewayv1.
 			if client.IgnoreNotFound(err) != nil {
 				return nil, err
 			}
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				reason = gatewayv1.GatewayClassReasonInvalidParameters
 				messages = append(messages, "The referenced GatewayConfiguration does not exist")
 			}

--- a/controller/hybridgateway/controller.go
+++ b/controller/hybridgateway/controller.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -146,7 +146,7 @@ func (r *HybridGatewayReconciler[t, tPtr]) Reconcile(ctx context.Context, req ct
 
 	// Phase 1: Status Update.
 	statusChanged, stop, err := enforceStatus(ctx, logger, conv)
-	if err != nil && !k8serrors.IsConflict(err) {
+	if err != nil && !apierrors.IsConflict(err) {
 		// Record status update failure event.
 		r.eventRecorder.Event(
 			obj,
@@ -155,7 +155,7 @@ func (r *HybridGatewayReconciler[t, tPtr]) Reconcile(ctx context.Context, req ct
 			fmt.Sprintf("Status update failed: %v", err),
 		)
 		return ctrl.Result{}, err
-	} else if k8serrors.IsConflict(err) {
+	} else if apierrors.IsConflict(err) {
 		return ctrl.Result{Requeue: true}, nil
 	}
 	if stop {

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -278,7 +278,7 @@ func (c *httpRouteConverter) UpdateRootObjectStatus(ctx context.Context, logger 
 	if updated {
 		log.Debug(logger, "Updating HTTPRoute status in cluster", "status", c.route.Status)
 		if err := c.Status().Update(ctx, c.route); err != nil {
-			if k8serrors.IsConflict(err) {
+			if apierrors.IsConflict(err) {
 				return false, true, err
 			}
 			log.Error(logger, err, "Failed to update HTTPRoute status in cluster")
@@ -322,7 +322,7 @@ func (c *httpRouteConverter) HandleOrphanedResource(ctx context.Context, logger 
 	// If other Routes are still present in the annotation, we just need to update the resource.
 	if len(am.GetRoutes(resource)) > 0 {
 		log.Debug(logger, "Updating hybrid-routes annotation", "kind", resource.GetKind(), "obj", client.ObjectKeyFromObject(resource))
-		if err := c.Patch(ctx, resource, client.MergeFrom(oldResource)); err != nil && !k8serrors.IsNotFound(err) {
+		if err := c.Patch(ctx, resource, client.MergeFrom(oldResource)); err != nil && !apierrors.IsNotFound(err) {
 			return true, fmt.Errorf("failed to update resource: %w", err)
 		}
 		return true, nil

--- a/controller/hybridgateway/plugin/plugin.go
+++ b/controller/hybridgateway/plugin/plugin.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -67,7 +67,7 @@ func PluginsForFilter(
 		log.Debug(logger, "Filter is an ExtensionRef, retrieving referenced KongPlugin")
 		plugin, err := getReferencedKongPlugin(ctx, cl, httpRoute.Namespace, filter)
 		if err != nil {
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				log.Debug(logger, "Referenced KongPlugin not found")
 				return plugins, nil
 			}

--- a/controller/hybridgateway/reconciler_utils_test.go
+++ b/controller/hybridgateway/reconciler_utils_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1030,7 +1030,7 @@ func TestRemoveFinalizerIfNotManaged_HTTPRoute(t *testing.T) {
 			},
 			interceptorFuncs: &interceptor.Funcs{
 				Patch: func(ctx context.Context, client client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-					return k8serrors.NewNotFound(schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "httproutes"}, "test-route")
+					return apierrors.NewNotFound(schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "httproutes"}, "test-route")
 				},
 			},
 			expectedRemoved: false,
@@ -1275,7 +1275,7 @@ func TestRemoveFinalizerIfNotManaged_Gateway(t *testing.T) {
 			},
 			interceptorFuncs: &interceptor.Funcs{
 				Patch: func(ctx context.Context, client client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-					return k8serrors.NewNotFound(schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "gateways"}, "test-gateway")
+					return apierrors.NewNotFound(schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "gateways"}, "test-gateway")
 				},
 			},
 			expectedRemoved: false,

--- a/controller/hybridgateway/refs/by.go
+++ b/controller/hybridgateway/refs/by.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -181,7 +181,7 @@ func byKonnectExtension(ctx context.Context, cl client.Client, konnectExtension 
 		Name:      cpRef.KonnectNamespacedRef.Name,
 		Namespace: ns,
 	}, &konnectGatewayControlPlane)
-	if k8serrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		return nil, false, nil
 	}
 	if err != nil {

--- a/controller/hybridgateway/refs/get.go
+++ b/controller/hybridgateway/refs/get.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hybridgatewayerrors "github.com/kong/kong-operator/controller/hybridgateway/errors"
@@ -48,7 +48,7 @@ func GetGatewaysByHTTPRoute(ctx context.Context, cl client.Client, r gwtypes.HTT
 // Returns an error if there's a problem accessing the GatewayClass.
 func IsGatewayInKonnect(ctx context.Context, cl client.Client, gateway *gwtypes.Gateway) (bool, error) {
 	_, found, err := byGateway(ctx, cl, *gateway)
-	if k8serrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		return false, nil
 	}
 	if err != nil {
@@ -110,7 +110,7 @@ func GetSupportedGatewayForParentRef(ctx context.Context, logger logr.Logger, cl
 	// Get the Gateway object.
 	gateway := gwtypes.Gateway{}
 	if err := cl.Get(ctx, client.ObjectKey{Namespace: namespace, Name: string(pRef.Name)}, &gateway); err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// Gateway doesn't exist, not supported.
 			return nil, false, hybridgatewayerrors.ErrNoGatewayFound
 		}
@@ -118,7 +118,7 @@ func GetSupportedGatewayForParentRef(ctx context.Context, logger logr.Logger, cl
 	}
 
 	_, found, err := byGateway(ctx, cl, gateway)
-	if k8serrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		return nil, false, nil
 	}
 	if err != nil {

--- a/controller/hybridgateway/route/status.go
+++ b/controller/hybridgateway/route/status.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -473,7 +473,7 @@ func BuildResolvedRefsCondition(ctx context.Context, logger logr.Logger, cl clie
 			service := &corev1.Service{}
 			err := cl.Get(ctx, client.ObjectKey{Namespace: bRefNamespace, Name: string(bRef.Name)}, service)
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					log.Debug(logger, "BackendRef not found", "namespace", bRefNamespace, "name", bRef.Name)
 					cond.Reason = string(gwtypes.RouteReasonBackendNotFound)
 					cond.Status = metav1.ConditionFalse
@@ -544,7 +544,7 @@ func BuildResolvedRefsCondition(ctx context.Context, logger logr.Logger, cl clie
 			kongPlugin := configurationv1.KongPlugin{}
 			err := cl.Get(ctx, client.ObjectKey{Namespace: extRefNamespace, Name: string(filter.ExtensionRef.Name)}, &kongPlugin)
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					log.Debug(logger, "ExtensionRef not found", "namespace", extRefNamespace, "name", filter.ExtensionRef.Name)
 					cond.Reason = string(gwtypes.RouteReasonBackendNotFound)
 					cond.Status = metav1.ConditionFalse

--- a/controller/hybridgateway/target/target_test.go
+++ b/controller/hybridgateway/target/target_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -921,7 +921,7 @@ func TestResolveEndpointSliceEndpoints(t *testing.T) {
 				},
 			},
 			servicePort:        createTestServicePort(),
-			mockError:          k8serrors.NewNotFound(discoveryv1.Resource("endpointslices"), "notfound-service"),
+			mockError:          apierrors.NewNotFound(discoveryv1.Resource("endpointslices"), "notfound-service"),
 			expectedEndpoints:  nil,
 			expectedShouldSkip: true,
 			expectedError:      false,
@@ -1919,7 +1919,7 @@ func TestFiltervalidBackendRefs(t *testing.T) {
 			List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
 				if _, ok := list.(*discoveryv1.EndpointSliceList); ok {
 					// Return a NotFound error for EndpointSlices.
-					return &k8serrors.StatusError{
+					return &apierrors.StatusError{
 						ErrStatus: metav1.Status{
 							Status:  metav1.StatusFailure,
 							Code:    404,

--- a/controller/kongplugininstallation/controller.go
+++ b/controller/kongplugininstallation/controller.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	orascreds "oras.land/oras-go/v2/registry/remote/credentials"
@@ -137,7 +137,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			secretNN,
 			&secret,
 		); err != nil {
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return ctrl.Result{}, setStatusConditionFailedForKongPluginInstallation(ctx, r.Client, &kpi, fmt.Sprintf("referenced Secret %q not found", secretNN))
 			}
 			return ctrl.Result{}, fmt.Errorf("something unexpected during fetching secret %s: %w", secretNN, err)

--- a/controller/konnect/handle_status_conditions.go
+++ b/controller/konnect/handle_status_conditions.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,7 +42,7 @@ func handleAPIAuthStatusCondition[T interface {
 
 	if err != nil {
 		resolvedRefCondition.Status = metav1.ConditionFalse
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			resolvedRefCondition.Reason = konnectv1alpha1.KonnectEntityAPIAuthConfigurationResolvedRefReasonRefNotFound
 			resolvedRefCondition.Message = fmt.Sprintf("Referenced KonnectAPIAuthConfiguration %s not found", apiAuthNN)
 			if res, _, err := patch.StatusWithConditions(

--- a/controller/konnect/konnectextension_controller_utils.go
+++ b/controller/konnect/konnectextension_controller_utils.go
@@ -11,7 +11,7 @@ import (
 	"github.com/samber/lo"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -54,7 +54,7 @@ func (r *KonnectExtensionReconciler) getGatewayKonnectControlPlane(
 	kgcp := &konnectv1alpha2.KonnectGatewayControlPlane{}
 	// Set the controlPlaneRefValidCond to false in case the KonnectGatewayControlPlane is not found.
 	if err := r.Get(ctx, cpNN, kgcp); err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			errGetFromK8s = err
 		} else {
 			return nil, ctrl.Result{}, err
@@ -178,7 +178,7 @@ func (r *KonnectExtensionReconciler) ensureExtendablesReferencesInStatus(
 	}
 
 	if err := r.Client.Status().Update(ctx, ext); err != nil {
-		if k8serrors.IsConflict(err) {
+		if apierrors.IsConflict(err) {
 			// Gracefully requeue in case of conflict.
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/controller/konnect/ops/ops_kongconsumer.go
+++ b/controller/konnect/ops/ops_kongconsumer.go
@@ -10,7 +10,7 @@ import (
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	"github.com/samber/lo"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -271,7 +271,7 @@ func resolveConsumerGroupsKonnectIDs(
 	for _, cgName := range consumer.ConsumerGroups {
 		var cg configurationv1beta1.KongConsumerGroup
 		if err := cl.Get(ctx, client.ObjectKey{Name: cgName, Namespace: consumer.Namespace}, &cg); err != nil {
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				invalidConsumerGroups = append(invalidConsumerGroups, invalidConsumerGroupRef{
 					Name:   cgName,
 					Reason: "NotFound",

--- a/controller/konnect/reconciler_certificateref.go
+++ b/controller/konnect/reconciler_certificateref.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/samber/mo"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -133,7 +133,7 @@ func handleKongCertificateRef[T constraints.SupportedKonnectEntityType, TEnt con
 		); errStatus != nil || !res.IsZero() {
 			return res, errStatus
 		}
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, controlplane.ReferencedControlPlaneDoesNotExistError{
 				Reference: cpRef,
 				Err:       err,
@@ -162,7 +162,7 @@ func handleKongCertificateRef[T constraints.SupportedKonnectEntityType, TEnt con
 		resource.SetControlPlaneID(cp.Status.ID)
 		_, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
 		if err != nil {
-			if k8serrors.IsConflict(err) {
+			if apierrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{}, err

--- a/controller/konnect/reconciler_consumerref.go
+++ b/controller/konnect/reconciler_consumerref.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/samber/mo"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -140,7 +140,7 @@ func handleKongConsumerRef[T constraints.SupportedKonnectEntityType, TEnt constr
 		); errStatus != nil || !res.IsZero() {
 			return res, errStatus
 		}
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, controlplane.ReferencedControlPlaneDoesNotExistError{
 				Reference: cpRef,
 				Err:       err,
@@ -169,7 +169,7 @@ func handleKongConsumerRef[T constraints.SupportedKonnectEntityType, TEnt constr
 		resource.SetControlPlaneID(cp.Status.ID)
 		_, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
 		if err != nil {
-			if k8serrors.IsConflict(err) {
+			if apierrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{}, err

--- a/controller/konnect/reconciler_controlplaneref.go
+++ b/controller/konnect/reconciler_controlplaneref.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -101,7 +101,7 @@ func handleControlPlaneRef[T constraints.SupportedKonnectEntityType, TEnt constr
 		resource.SetControlPlaneID(cp.Status.ID)
 		_, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
 		if err != nil {
-			if k8serrors.IsConflict(err) {
+			if apierrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{}, err

--- a/controller/konnect/reconciler_credential_secrets.go
+++ b/controller/konnect/reconciler_credential_secrets.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -412,7 +412,7 @@ func ensureExistingCredential[
 
 	if update {
 		if err := cl.Update(ctx, cred); err != nil {
-			if k8serrors.IsConflict(err) {
+			if apierrors.IsConflict(err) {
 				return ctrl.Result{
 					Requeue: true,
 				}, nil

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"time"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -161,11 +161,11 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		if errors.As(err, &controlplane.ReferencedControlPlaneDoesNotExistError{}) {
 			if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 				if err := r.Client.Update(ctx, ent); err != nil {
-					if k8serrors.IsConflict(err) {
+					if apierrors.IsConflict(err) {
 						return ctrl.Result{Requeue: true}, nil
 					}
 					// in case the finalizer removal fails because the resource does not exist, ignore the error.
-					if k8serrors.IsNotFound(err) {
+					if apierrors.IsNotFound(err) {
 						return ctrl.Result{}, nil
 					}
 					return ctrl.Result{}, fmt.Errorf("failed to remove finalizer %s: %w", KonnectCleanupFinalizer, err)
@@ -186,11 +186,11 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		case errors.As(err, &ReferencedObjectDoesNotExistError{}), errors.As(err, &controlplane.ReferencedControlPlaneDoesNotExistError{}):
 			if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 				if err := r.Client.Update(ctx, ent); err != nil {
-					if k8serrors.IsConflict(err) {
+					if apierrors.IsConflict(err) {
 						return ctrl.Result{RequeueAfter: time.Second}, nil
 					}
 					// in case the finalizer removal fails because the resource does not exist, ignore the error.
-					if k8serrors.IsNotFound(err) {
+					if apierrors.IsNotFound(err) {
 						return ctrl.Result{}, nil
 					}
 					return ctrl.Result{}, fmt.Errorf("failed to remove finalizer %s: %w", KonnectCleanupFinalizer, err)
@@ -242,11 +242,11 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		if errors.As(err, &ReferencedKongConsumerDoesNotExistError{}) {
 			if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 				if err := r.Client.Update(ctx, ent); err != nil {
-					if k8serrors.IsConflict(err) {
+					if apierrors.IsConflict(err) {
 						return ctrl.Result{Requeue: true}, nil
 					}
 					// in case the finalizer removal fails because the resource does not exist, ignore the error.
-					if k8serrors.IsNotFound(err) {
+					if apierrors.IsNotFound(err) {
 						return ctrl.Result{}, nil
 					}
 					return ctrl.Result{}, fmt.Errorf("failed to remove finalizer %s: %w", KonnectCleanupFinalizer, err)
@@ -289,7 +289,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		if errors.As(err, &ReferencedKongUpstreamDoesNotExistError{}) || errors.As(err, &controlplane.ReferencedControlPlaneDoesNotExistError{}) {
 			if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 				if err := r.Client.Update(ctx, ent); err != nil {
-					if k8serrors.IsConflict(err) {
+					if apierrors.IsConflict(err) {
 						return ctrl.Result{Requeue: true}, nil
 					}
 					return ctrl.Result{}, fmt.Errorf("failed to remove finalizer %s: %w", KonnectCleanupFinalizer, err)
@@ -330,11 +330,11 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		if errors.As(err, &ReferencedKongCertificateDoesNotExistError{}) {
 			if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 				if err := r.Client.Update(ctx, ent); err != nil {
-					if k8serrors.IsConflict(err) {
+					if apierrors.IsConflict(err) {
 						return ctrl.Result{Requeue: true}, nil
 					}
 					// in case the finalizer removal fails because the resource does not exist, ignore the error.
-					if k8serrors.IsNotFound(err) {
+					if apierrors.IsNotFound(err) {
 						return ctrl.Result{}, nil
 					}
 					return ctrl.Result{}, fmt.Errorf("failed to remove finalizer %s: %w", KonnectCleanupFinalizer, err)
@@ -376,7 +376,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		if errors.As(err, &ReferencedKongKeySetDoesNotExistError{}) {
 			if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 				if err := r.Client.Update(ctx, ent); err != nil {
-					if k8serrors.IsConflict(err) {
+					if apierrors.IsConflict(err) {
 						return ctrl.Result{Requeue: true}, nil
 					}
 					return ctrl.Result{}, fmt.Errorf("failed to remove finalizer %s: %w", KonnectCleanupFinalizer, err)
@@ -499,11 +499,11 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 				return ctrl.Result{}, err
 			}
 			if err := r.Client.Update(ctx, ent); err != nil {
-				if k8serrors.IsConflict(err) {
+				if apierrors.IsConflict(err) {
 					return ctrl.Result{Requeue: true}, nil
 				}
 				// in case the finalizer removal fails because the resource does not exist, ignore the error.
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return ctrl.Result{}, nil
 				}
 				return ctrl.Result{}, fmt.Errorf("failed to remove finalizer %s: %w", KonnectCleanupFinalizer, err)
@@ -571,7 +571,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		// Org ID, Server URL and status conditions.
 		// Konnect ID will be needed for the finalizer to work.
 		if _, err := patch.ApplyStatusPatchIfNotEmpty(ctx, r.Client, logger, any(ent).(client.Object), obj); err != nil {
-			if k8serrors.IsConflict(err) {
+			if apierrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{}, fmt.Errorf("failed to update status after creating object: %w", err)
@@ -611,7 +611,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 	setStatusServerURLAndOrgID(ent, server, apiAuth.Status.OrganizationID)
 	// Update the status of the object regardless of the error.
 	if errUpd := r.Client.Status().Update(ctx, ent); errUpd != nil {
-		if k8serrors.IsConflict(errUpd) {
+		if apierrors.IsConflict(errUpd) {
 			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to update in cluster resource after Konnect update: %w %w", errUpd, err)
@@ -700,7 +700,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) adoptFromExistingEntity(
 	// Org ID, Server URL and status conditions.
 	// Konnect ID will be needed for the finalizer to work.
 	if res, err := patch.ApplyStatusPatchIfNotEmpty(ctx, r.Client, logger, any(ent).(client.Object), obj); err != nil {
-		if k8serrors.IsConflict(err) {
+		if apierrors.IsConflict(err) {
 			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to update status after creating object: %w", err)

--- a/controller/konnect/reconciler_generic_error_handling_test.go
+++ b/controller/konnect/reconciler_generic_error_handling_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -67,7 +67,7 @@ func TestHandleOpsErr(t *testing.T) {
 					patch client.Patch,
 					opts ...client.SubResourcePatchOption,
 				) error {
-					return &k8serrors.StatusError{
+					return &apierrors.StatusError{
 						ErrStatus: metav1.Status{
 							Status: metav1.StatusFailure,
 							Reason: metav1.StatusReasonConflict,

--- a/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
+++ b/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -213,7 +213,7 @@ func (r *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]) Reconcile(
 
 	if finalizersChangedAction != "" {
 		if err = r.Client.Update(ctx, ent); err != nil {
-			if k8serrors.IsConflict(err) {
+			if apierrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{}, err

--- a/controller/konnect/reconciler_keysetref.go
+++ b/controller/konnect/reconciler_keysetref.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/samber/mo"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -45,7 +45,7 @@ func handleKongKeySetRef[T constraints.SupportedKonnectEntityType, TEnt constrai
 
 				// Patch the status
 				if _, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old); err != nil {
-					if k8serrors.IsConflict(err) {
+					if apierrors.IsConflict(err) {
 						return ctrl.Result{Requeue: true}, nil
 					}
 					return ctrl.Result{}, fmt.Errorf("failed to patch status: %w", err)
@@ -84,7 +84,7 @@ func handleKongKeySetRef[T constraints.SupportedKonnectEntityType, TEnt constrai
 		}
 
 		// If the KongKeySet is not found, we don't want to requeue.
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, ReferencedKongKeySetDoesNotExistError{
 				Reference: nn,
 				Err:       err,
@@ -138,7 +138,7 @@ func handleKongKeySetRef[T constraints.SupportedKonnectEntityType, TEnt constrai
 
 	_, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
 	if err != nil {
-		if k8serrors.IsConflict(err) {
+		if apierrors.IsConflict(err) {
 			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, err

--- a/controller/konnect/reconciler_kongplugin.go
+++ b/controller/konnect/reconciler_kongplugin.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -222,7 +222,7 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				existing.Spec.Targets = kongPluginBinding.Spec.Targets
 
 				if err = clientWithNamespace.Update(ctx, &existing); err != nil {
-					if k8serrors.IsConflict(err) {
+					if apierrors.IsConflict(err) {
 						return ctrl.Result{Requeue: true}, nil
 					}
 					return ctrl.Result{}, fmt.Errorf("failed to update KongPluginBinding: %w", err)
@@ -256,7 +256,7 @@ func (r *KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	} else { //nolint:gocritic
 		if controllerutil.RemoveFinalizer(&kongPlugin, consts.PluginInUseFinalizer) {
 			if err = r.client.Update(ctx, &kongPlugin); err != nil {
-				if k8serrors.IsConflict(err) {
+				if apierrors.IsConflict(err) {
 					return ctrl.Result{Requeue: true}, nil
 				}
 				return ctrl.Result{}, err
@@ -344,7 +344,7 @@ func deleteKongPluginBindings(
 			continue
 		}
 		if err := cl.Delete(ctx, &pb); err != nil {
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				continue
 			}
 			return err

--- a/controller/konnect/reconciler_konnectapiauth.go
+++ b/controller/konnect/reconciler_konnectapiauth.go
@@ -7,7 +7,7 @@ import (
 
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -210,7 +210,7 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 
 			_, errUpdate := patch.ApplyStatusPatchIfNotEmpty(ctx, r.client, ctrllog.FromContext(ctx), &apiAuth, old)
 			if errUpdate != nil {
-				if k8serrors.IsConflict(errUpdate) {
+				if apierrors.IsConflict(errUpdate) {
 					return ctrl.Result{Requeue: true}, nil
 				}
 				return ctrl.Result{}, errUpdate
@@ -255,7 +255,7 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 
 		_, errUpdate := patch.ApplyStatusPatchIfNotEmpty(ctx, r.client, ctrllog.FromContext(ctx), &apiAuth, old)
 		if errUpdate != nil {
-			if k8serrors.IsConflict(errUpdate) {
+			if apierrors.IsConflict(errUpdate) {
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{}, errUpdate

--- a/controller/konnect/reconciler_konnectnetworkref.go
+++ b/controller/konnect/reconciler_konnectnetworkref.go
@@ -7,7 +7,7 @@ import (
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/samber/lo"
 	"github.com/samber/mo"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -56,7 +56,7 @@ func handleKonnectNetworkRef[T constraints.SupportedKonnectEntityType, TEnt cons
 			err := cl.Get(ctx, nn, &network)
 			if err != nil {
 				setInvalidWithMsg(err.Error())
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return ctrl.Result{}, ReferencedObjectDoesNotExistError{
 						Reference: nn,
 						Err:       err,
@@ -132,7 +132,7 @@ func handleKonnectNetworkRef[T constraints.SupportedKonnectEntityType, TEnt cons
 		"Referenced KonnectCloudGatewayNetwork(s) are valid and programmed",
 	) {
 		if err := cl.Status().Patch(ctx, ent, client.MergeFrom(old)); err != nil {
-			if k8serrors.IsConflict(err) {
+			if apierrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{}, fmt.Errorf("failed to patch status with network refs valid condition: %w", err)

--- a/controller/konnect/reconciler_serviceref.go
+++ b/controller/konnect/reconciler_serviceref.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/samber/mo"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -50,7 +50,7 @@ func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constra
 
 				// Patch the status
 				if _, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old); err != nil {
-					if k8serrors.IsConflict(err) {
+					if apierrors.IsConflict(err) {
 						return ctrl.Result{Requeue: true}, nil
 					}
 					return ctrl.Result{}, fmt.Errorf("failed to patch status: %w", err)
@@ -114,7 +114,7 @@ func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constra
 		}
 
 		// If the KongService is not found, we don't want to requeue.
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, ReferencedObjectDoesNotExistError{
 				Reference: nn,
 				Err:       err,
@@ -137,7 +137,7 @@ func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constra
 		)
 		_, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
 		if err != nil {
-			if k8serrors.IsConflict(err) {
+			if apierrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{}, err
@@ -159,7 +159,7 @@ func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constra
 
 		res, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
 		if err != nil {
-			if k8serrors.IsConflict(err) {
+			if apierrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{}, err
@@ -188,7 +188,7 @@ func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constra
 
 	_, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
 	if err != nil {
-		if k8serrors.IsConflict(err) {
+		if apierrors.IsConflict(err) {
 			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, err
@@ -212,7 +212,7 @@ func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constra
 		); errStatus != nil || !res.IsZero() {
 			return res, errStatus
 		}
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, controlplane.ReferencedControlPlaneDoesNotExistError{
 				Reference: kongSvcCPRef,
 				Err:       err,

--- a/controller/konnect/reconciler_upstreamref.go
+++ b/controller/konnect/reconciler_upstreamref.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/samber/mo"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -95,7 +95,7 @@ func handleKongUpstreamRef[T constraints.SupportedKonnectEntityType, TEnt constr
 
 		res, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
 		if err != nil {
-			if k8serrors.IsConflict(err) {
+			if apierrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{}, err
@@ -142,7 +142,7 @@ func handleKongUpstreamRef[T constraints.SupportedKonnectEntityType, TEnt constr
 		); errStatus != nil || !res.IsZero() {
 			return res, errStatus
 		}
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, controlplane.ReferencedControlPlaneDoesNotExistError{
 				Reference: cpRef,
 				Err:       err,

--- a/controller/pkg/controlplane/ref.go
+++ b/controller/pkg/controlplane/ref.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/samber/mo"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -64,7 +64,7 @@ func getCPForNamespacedRef(
 
 	var cp konnectv1alpha2.KonnectGatewayControlPlane
 	if err := cl.Get(ctx, nn, &cp); err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil, ReferencedControlPlaneDoesNotExistError{
 				Reference: ref,
 				Err:       err,

--- a/controller/pkg/extensions/dataplanemetrics.go
+++ b/controller/pkg/extensions/dataplanemetrics.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/samber/lo"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -44,7 +44,7 @@ func GetAllDataPlaneMetricExtensionsForControlPlane(
 			nn.Namespace = *ext.Namespace
 		}
 		if err := cl.Get(ctx, nn, &metricsExt); err != nil {
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return nil, fmt.Errorf("failed to get %s %s", operatorv1alpha1.DataPlaneMetricsExtensionKind, nn)
 			}
 			return nil, err

--- a/controller/pkg/extensions/konnect/common.go
+++ b/controller/pkg/extensions/konnect/common.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	commonv1alpha1 "github.com/kong/kong-operator/api/common/v1alpha1"
@@ -29,7 +29,7 @@ func getExtension(ctx context.Context, cl client.Client, objNamespace string, ex
 		Namespace: objNamespace,
 		Name:      extRef.Name,
 	}, &konnectExt); err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil, errors.Join(extensionserrors.ErrKonnectExtensionNotFound, fmt.Errorf("the extension %s/%s is not found", objNamespace, extRef.Name))
 		}
 		return nil, err

--- a/controller/pkg/finalizer/handlerror.go
+++ b/controller/pkg/finalizer/handlerror.go
@@ -2,7 +2,7 @@ package finalizer
 
 import (
 	"github.com/go-logr/logr"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -18,7 +18,7 @@ func HandlePatchOrUpdateError(err error, logger logr.Logger) (ctrl.Result, error
 		return ctrl.Result{}, nil
 	}
 
-	if k8serrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		log.Debug(logger, "object not found when updating/patching")
 		return ctrl.Result{
 			RequeueAfter: ctrlconsts.RequeueWithoutBackoff,
@@ -26,7 +26,7 @@ func HandlePatchOrUpdateError(err error, logger logr.Logger) (ctrl.Result, error
 	}
 
 	// When there's a conflict when updating/patching, requeue without an error.
-	if k8serrors.IsConflict(err) {
+	if apierrors.IsConflict(err) {
 		log.Debug(logger, "conflict found when updating/patching, retrying")
 		return ctrl.Result{
 			RequeueAfter: ctrlconsts.RequeueWithoutBackoff,
@@ -37,7 +37,7 @@ func HandlePatchOrUpdateError(err error, logger logr.Logger) (ctrl.Result, error
 	// is in the API server and this causes:
 	// Forbidden: no new finalizers can be added if the object is being deleted, found new finalizers []string{...}
 	// Code below handles that gracefully to not show users the errors that are not actionable.
-	if cause, ok := k8serrors.StatusCause(err, metav1.CauseTypeForbidden); k8serrors.IsInvalid(err) && ok {
+	if cause, ok := apierrors.StatusCause(err, metav1.CauseTypeForbidden); apierrors.IsInvalid(err) && ok {
 		log.Debug(logger, "failed to delete a finalizer, requeueing request", "cause", cause)
 		return ctrl.Result{
 			RequeueAfter: ctrlconsts.RequeueWithoutBackoff,

--- a/controller/pkg/patch/finalizer.go
+++ b/controller/pkg/patch/finalizer.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -33,7 +33,7 @@ func WithFinalizer[
 	}
 
 	if errUpd := cl.Patch(ctx, objWithFinalizer, client.MergeFrom(ent)); errUpd != nil {
-		if k8serrors.IsConflict(errUpd) {
+		if apierrors.IsConflict(errUpd) {
 			return false, ctrl.Result{Requeue: true}, nil
 		}
 		return false, ctrl.Result{}, fmt.Errorf(
@@ -67,7 +67,7 @@ func WithoutFinalizer[
 	}
 
 	if errUpd := cl.Patch(ctx, objWithFinalizer, client.MergeFrom(ent)); errUpd != nil {
-		if k8serrors.IsConflict(errUpd) {
+		if apierrors.IsConflict(errUpd) {
 			return false, ctrl.Result{Requeue: true}, nil
 		}
 		return false, ctrl.Result{}, fmt.Errorf(

--- a/controller/pkg/patch/statuscondition.go
+++ b/controller/pkg/patch/statuscondition.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -78,7 +78,7 @@ func StatusWithConditions[T interface {
 
 	if needsUpdate {
 		if err := cl.Status().Patch(ctx, ent, client.MergeFrom(old)); err != nil {
-			if k8serrors.IsConflict(err) {
+			if apierrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, false, nil
 			}
 			return ctrl.Result{}, false, fmt.Errorf("failed to patch status with conditions %v: %w", conditions, err)
@@ -107,7 +107,7 @@ func StatusWithoutCondition[T interface {
 
 	old := ent.DeepCopyObject().(T)
 	if err := cl.Status().Patch(ctx, ent, client.MergeFrom(old)); err != nil {
-		if k8serrors.IsConflict(err) {
+		if apierrors.IsConflict(err) {
 			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to patch status without condition %v: %w", conditionType, err)
@@ -141,7 +141,7 @@ func StatusWithCondition[T interface {
 	}
 
 	if err := cl.Status().Patch(ctx, ent, client.MergeFrom(old)); err != nil {
-		if k8serrors.IsConflict(err) {
+		if apierrors.IsConflict(err) {
 			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to patch status with %s condition: %w", conditionType, err)

--- a/controller/pkg/patch/statuscondition_test.go
+++ b/controller/pkg/patch/statuscondition_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -216,7 +216,7 @@ func TestPatchStatusWithCondition(t *testing.T) {
 			},
 			interceptorFunc: interceptor.Funcs{
 				SubResourcePatch: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
-					return &k8serrors.StatusError{
+					return &apierrors.StatusError{
 						ErrStatus: metav1.Status{
 							Status: metav1.StatusFailure,
 							Reason: metav1.StatusReasonConflict,
@@ -241,7 +241,7 @@ func TestPatchStatusWithCondition(t *testing.T) {
 			expectedError:    true,
 			interceptorFunc: interceptor.Funcs{
 				SubResourcePatch: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
-					return &k8serrors.StatusError{
+					return &apierrors.StatusError{
 						ErrStatus: metav1.Status{
 							Status: metav1.StatusFailure,
 							Reason: metav1.StatusReason("unknown"),

--- a/controller/specialized/aigateway_controller_reconciler_owned_resources.go
+++ b/controller/specialized/aigateway_controller_reconciler_owned_resources.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -37,7 +37,7 @@ func (r *AIGatewayReconciler) createOrUpdateHTTPRoute(
 		Namespace: httpRoute.Namespace,
 	}, found)
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Info(logger, "creating httproute for aigateway")
 			return true, r.Create(ctx, httpRoute)
 		}
@@ -67,7 +67,7 @@ func (r *AIGatewayReconciler) createOrUpdatePlugin(
 		Namespace: kongPlugin.Namespace,
 	}, found)
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Info(logger, "creating plugin for aigateway")
 			return true, r.Create(ctx, kongPlugin)
 		}
@@ -97,7 +97,7 @@ func (r *AIGatewayReconciler) createOrUpdateGateway(
 		Namespace: gateway.Namespace,
 	}, found)
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Info(logger, "creating gateway for aigateway")
 			return true, r.Create(ctx, gateway)
 		}
@@ -128,7 +128,7 @@ func (r *AIGatewayReconciler) createOrUpdateSvc(
 		Namespace: service.Namespace,
 	}, found)
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Info(logger, "creating service for aigateway")
 			return true, r.Create(ctx, service)
 		}
@@ -210,7 +210,7 @@ func (r *AIGatewayReconciler) configurePlugins(
 
 	credentialSecret := &corev1.Secret{}
 	if err := r.Get(ctx, types.NamespacedName{Namespace: credentialSecretNamespace, Name: credentialSecretName}, credentialSecret); err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return changes, nil
 		}
 		return changes, fmt.Errorf(

--- a/modules/diagnostics/http_handler.go
+++ b/modules/diagnostics/http_handler.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kong-operator/ingress-controller/pkg/manager"
@@ -144,7 +144,7 @@ func (h *HTTPHandler) handleControlPlaneConfigDump(rw http.ResponseWriter, r *ht
 		Namespace: namespace,
 		Name:      name,
 	}, cp); err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			rw.WriteHeader(http.StatusNotFound)
 			_, _ = fmt.Fprintf(rw, "ControlPlane %s/%s not found", namespace, name)
 			return

--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -27,7 +27,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
@@ -387,7 +387,7 @@ func checkExistenceOfCertificateAuthoritySecret(
 	)
 
 	if err := c.Get(ctx, certObjectKey, &ca); err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return fmt.Errorf("cluster CA certificate not found")
 		}
 

--- a/pkg/utils/kubernetes/crd.go
+++ b/pkg/utils/kubernetes/crd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/url"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -29,7 +29,7 @@ func (c CRDChecker) CRDExists(gvr schema.GroupVersionResource) (bool, error) {
 		for _, e := range errD.Groups {
 
 			// If this is an API StatusError:
-			if errS := (&k8serrors.StatusError{}); errors.As(e, &errS) {
+			if errS := (&apierrors.StatusError{}); errors.As(e, &errS) {
 				switch errS.ErrStatus.Code {
 				case 404:
 					// If it's a 404 status code then we're sure that it's just

--- a/pkg/utils/test/predicates.go
+++ b/pkg/utils/test/predicates.go
@@ -16,7 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -670,7 +670,7 @@ func GatewayNotExist(t *testing.T, ctx context.Context, gatewayNSN types.Namespa
 		gateways := clients.GatewayClient.GatewayV1().Gateways(gatewayNSN.Namespace)
 		_, err := gateways.Get(ctx, gatewayNSN.Name, metav1.GetOptions{})
 		if err != nil {
-			return errors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}
 		return false
 	}

--- a/test/e2e/operator_logs_test.go
+++ b/test/e2e/operator_logs_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -199,7 +199,7 @@ func TestOperatorLogs(t *testing.T) {
 		if len(dataplanes) != 0 {
 			assert.Eventually(t, func() bool {
 				_, err := clients.OperatorClient.GatewayOperatorV1beta1().DataPlanes(testNamespace.Name).Get(ctx, dataplanes[0].Name, metav1.GetOptions{})
-				return errors.IsNotFound(err)
+				return apierrors.IsNotFound(err)
 			}, time.Minute, time.Second)
 		}
 
@@ -207,7 +207,7 @@ func TestOperatorLogs(t *testing.T) {
 		if len(controlplanes) != 0 {
 			assert.Eventually(t, func() bool {
 				_, err := clients.OperatorClient.GatewayOperatorV2beta1().ControlPlanes(testNamespace.Name).Get(ctx, controlplanes[0].Name, metav1.GetOptions{})
-				return errors.IsNotFound(err)
+				return apierrors.IsNotFound(err)
 			}, time.Minute, time.Second)
 		}
 

--- a/test/envtest/kongconsumercredential_acl_test.go
+++ b/test/envtest/kongconsumercredential_acl_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -153,7 +153,7 @@ func TestKongConsumerCredential_ACL(t *testing.T) {
 
 	assert.EventuallyWithT(t,
 		func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongCredentialACL), kongCredentialACL),
 			))
 		}, waitTime, tickTime,

--- a/test/envtest/kongconsumercredential_apikey_test.go
+++ b/test/envtest/kongconsumercredential_apikey_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -154,7 +154,7 @@ func TestKongConsumerCredential_APIKey(t *testing.T) {
 
 	assert.EventuallyWithT(t,
 		func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongCredentialAPIKey), kongCredentialAPIKey),
 			))
 		}, waitTime, tickTime,

--- a/test/envtest/kongconsumercredential_basicauth_test.go
+++ b/test/envtest/kongconsumercredential_basicauth_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -156,7 +156,7 @@ func TestKongConsumerCredential_BasicAuth(t *testing.T) {
 
 	assert.EventuallyWithT(t,
 		func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongCredentialBasicAuth), kongCredentialBasicAuth),
 			))
 		}, waitTime, tickTime,

--- a/test/envtest/kongconsumercredential_hmac_test.go
+++ b/test/envtest/kongconsumercredential_hmac_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -152,7 +152,7 @@ func TestKongConsumerCredential_HMAC(t *testing.T) {
 
 	assert.EventuallyWithT(t,
 		func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongCredentialHMAC), kongCredentialHMAC),
 			))
 		}, waitTime, tickTime,

--- a/test/envtest/kongconsumercredential_jwt_test.go
+++ b/test/envtest/kongconsumercredential_jwt_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -155,7 +155,7 @@ func TestKongConsumerCredential_JWT(t *testing.T) {
 
 	assert.EventuallyWithT(t,
 		func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongCredentialJWT), kongCredentialJWT),
 			))
 		}, waitTime, tickTime,

--- a/test/envtest/kongpluginbinding_managed_test.go
+++ b/test/envtest/kongpluginbinding_managed_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -194,7 +194,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		)
 		assert.EventuallyWithT(t,
 			func(c *assert.CollectT) {
-				assert.True(c, k8serrors.IsNotFound(
+				assert.True(c, apierrors.IsNotFound(
 					clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongPluginBinding), kongPluginBinding),
 				))
 			}, waitTime, tickTime,
@@ -300,7 +300,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		)
 		assert.EventuallyWithT(t,
 			func(c *assert.CollectT) {
-				assert.True(c, k8serrors.IsNotFound(
+				assert.True(c, apierrors.IsNotFound(
 					clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongPluginBinding), kongPluginBinding),
 				))
 			}, waitTime, tickTime,
@@ -409,7 +409,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		require.NoError(t, clientNamespaced.Update(ctx, kongRoute))
 		assert.EventuallyWithT(t,
 			func(c *assert.CollectT) {
-				assert.True(c, k8serrors.IsNotFound(
+				assert.True(c, apierrors.IsNotFound(
 					clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpbRoute), kpbRoute),
 				))
 			}, waitTime, tickTime,
@@ -427,7 +427,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 
 		assert.EventuallyWithT(t,
 			func(c *assert.CollectT) {
-				assert.True(c, k8serrors.IsNotFound(
+				assert.True(c, apierrors.IsNotFound(
 					clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpbService), kpbService),
 				))
 			}, waitTime, tickTime,
@@ -585,7 +585,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 
 		assert.EventuallyWithT(t,
 			func(c *assert.CollectT) {
-				assert.True(c, k8serrors.IsNotFound(
+				assert.True(c, apierrors.IsNotFound(
 					clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpbRoute), kpbRoute),
 				))
 			}, waitTime, tickTime,
@@ -799,7 +799,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 
 		assert.EventuallyWithT(t,
 			func(c *assert.CollectT) {
-				assert.True(c, k8serrors.IsNotFound(
+				assert.True(c, apierrors.IsNotFound(
 					clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpbRoute), kpbRoute),
 				))
 			}, waitTime, tickTime,

--- a/test/envtest/kongpluginbinding_unmanaged_test.go
+++ b/test/envtest/kongpluginbinding_unmanaged_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -113,7 +113,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 		require.NoError(t, clientNamespaced.Delete(ctx, kpb))
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
 			))
 		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
@@ -124,7 +124,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 		require.NoError(t, clientNamespaced.Delete(ctx, kongService))
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongService), kongService),
 			))
 		}, waitTime, tickTime)
@@ -189,7 +189,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 		require.NoError(t, clientNamespaced.Delete(ctx, kpb))
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
 			))
 		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
@@ -200,7 +200,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 		require.NoError(t, clientNamespaced.Delete(ctx, kongRoute))
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongRoute), kongRoute),
 			))
 		}, waitTime, tickTime)
@@ -271,7 +271,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 		require.NoError(t, clientNamespaced.Delete(ctx, kpb))
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
 			))
 		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
@@ -282,7 +282,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 		require.NoError(t, clientNamespaced.Delete(ctx, kongRoute))
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongRoute), kongRoute),
 			))
 		}, waitTime, tickTime)
@@ -362,7 +362,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 		require.NoError(t, clientNamespaced.Delete(ctx, kpb))
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
 			))
 		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
@@ -373,7 +373,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 		require.NoError(t, clientNamespaced.Delete(ctx, kongConsumer))
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongConsumer), kongConsumer),
 			))
 		}, waitTime, tickTime)
@@ -446,7 +446,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 		require.NoError(t, clientNamespaced.Delete(ctx, kpb))
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
 			))
 		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
@@ -457,7 +457,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 		require.NoError(t, clientNamespaced.Delete(ctx, kongConsumerGroup))
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongConsumerGroup), kongConsumerGroup),
 			))
 		}, waitTime, tickTime)
@@ -515,7 +515,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 		require.NoError(t, clientNamespaced.Delete(ctx, kpb))
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
 			))
 		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
@@ -605,7 +605,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 		require.NoError(t, clientNamespaced.Delete(ctx, kpb))
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
 			))
 		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
@@ -616,7 +616,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 		require.NoError(t, clientNamespaced.Delete(ctx, kongService))
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongService), kongService),
 			))
 		}, waitTime, tickTime)
@@ -662,7 +662,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 		require.NoError(t, clientNamespaced.Delete(ctx, kpb))
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
 			))
 		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
@@ -673,7 +673,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 		require.NoError(t, clientNamespaced.Delete(ctx, kongService))
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongService), kongService),
 			))
 		}, waitTime, tickTime)

--- a/test/envtest/konnect_entities_kongconsumer_test.go
+++ b/test/envtest/konnect_entities_kongconsumer_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -158,7 +158,7 @@ func TestKongConsumer(t *testing.T) {
 
 		require.EventuallyWithT(t,
 			func(c *assert.CollectT) {
-				assert.True(c, k8serrors.IsNotFound(
+				assert.True(c, apierrors.IsNotFound(
 					clientNamespaced.Get(ctx, client.ObjectKeyFromObject(createdConsumer), createdConsumer),
 				))
 			}, waitTime, tickTime,

--- a/test/envtest/konnect_entities_kongconsumergroup_test.go
+++ b/test/envtest/konnect_entities_kongconsumergroup_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -128,7 +128,7 @@ func TestKongConsumerGroup(t *testing.T) {
 
 		require.EventuallyWithT(t,
 			func(c *assert.CollectT) {
-				assert.True(c, k8serrors.IsNotFound(
+				assert.True(c, apierrors.IsNotFound(
 					clientNamespaced.Get(ctx, client.ObjectKeyFromObject(cg), cg),
 				))
 			}, waitTime, tickTime,

--- a/test/envtest/konnect_entities_kongkeyset_test.go
+++ b/test/envtest/konnect_entities_kongkeyset_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -125,7 +125,7 @@ func TestKongKeySet(t *testing.T) {
 		t.Log("Waiting for KongKeySet to be deleted")
 		require.EventuallyWithT(t,
 			func(c *assert.CollectT) {
-				assert.True(c, k8serrors.IsNotFound(
+				assert.True(c, apierrors.IsNotFound(
 					clientNamespaced.Get(ctx, client.ObjectKeyFromObject(createdKeySet), createdKeySet),
 				))
 			}, waitTime, tickTime,

--- a/test/envtest/konnect_entities_kongsni_test.go
+++ b/test/envtest/konnect_entities_kongsni_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apiwatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -118,7 +118,7 @@ func TestKongSNI(t *testing.T) {
 		require.NoError(t, clientNamespaced.Delete(ctx, createdSNI))
 
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.True(c, k8serrors.IsNotFound(
+			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(createdSNI), createdSNI),
 			))
 		}, waitTime, tickTime,

--- a/test/helpers/eventually/doesnotexist.go
+++ b/test/helpers/eventually/doesnotexist.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -37,7 +37,7 @@ func WaitForObjectToNotExist(
 	return assert.EventuallyWithT(t,
 		func(c *assert.CollectT) {
 			err := cl.Get(ctx, nn, obj)
-			assert.True(c, err != nil && k8serrors.IsNotFound(err))
+			assert.True(c, err != nil && apierrors.IsNotFound(err))
 		},
 		waitTime, tickTime,
 		errMsg,

--- a/test/integration/dataplane_ports_validating_admission_policy_test.go
+++ b/test/integration/dataplane_ports_validating_admission_policy_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -156,14 +156,14 @@ func TestDataPlanePortsValidatingAdmissionPolicy(t *testing.T) {
 					dpToUpdate, err = dataplaneClient.Get(GetCtx(), dpToUpdate.Name, metav1.GetOptions{})
 					tc.updateDataPlane(dpToUpdate)
 					_, err = dataplaneClient.Update(GetCtx(), dpToUpdate, metav1.UpdateOptions{})
-					return !k8serrors.IsConflict(err)
+					return !apierrors.IsConflict(err)
 				}, 10*time.Second, 100*time.Millisecond)
 
 			} else {
 				_, err = dataplaneClient.Create(GetCtx(), tc.dataPlane, metav1.CreateOptions{})
 			}
 			require.Error(t, err, "expected error when submitting DataPlane")
-			require.True(t, k8serrors.IsInvalid(err), "error should be of type Invalid, got: %v", err)
+			require.True(t, apierrors.IsInvalid(err), "error should be of type Invalid, got: %v", err)
 			require.Contains(t, err.Error(), tc.errorContains, "error message should contain expected substring")
 		})
 	}

--- a/test/integration/dataplane_test.go
+++ b/test/integration/dataplane_test.go
@@ -15,7 +15,7 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -1207,7 +1207,7 @@ func TestDataPlaneSpecifyingServiceName(t *testing.T) {
 	t.Logf("verifying that the old ingress service '%s' is deleted", oldServiceName)
 	require.Eventually(t, func() bool {
 		_, err := clients.K8sClient.CoreV1().Services(dataplane.Namespace).Get(GetCtx(), oldServiceName, metav1.GetOptions{})
-		return err != nil && k8serrors.IsNotFound(err)
+		return err != nil && apierrors.IsNotFound(err)
 	}, waitTime, tickTime)
 
 	t.Log("verifying dataplane services receive IP addresses after service name is updated")

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -15,7 +15,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -186,13 +186,13 @@ func TestGatewayEssentials(t *testing.T) {
 	t.Log("verifying that DataPlane sub-resources are deleted")
 	assert.Eventually(t, func() bool {
 		_, err := GetClients().OperatorClient.GatewayOperatorV1beta1().DataPlanes(namespace.Name).Get(GetCtx(), dataplane.Name, metav1.GetOptions{})
-		return errors.IsNotFound(err)
+		return apierrors.IsNotFound(err)
 	}, time.Minute, time.Second)
 
 	t.Log("verifying that ControlPlane sub-resources are deleted")
 	assert.Eventually(t, func() bool {
 		_, err := GetClients().OperatorClient.GatewayOperatorV2beta1().ControlPlanes(namespace.Name).Get(GetCtx(), controlplane.Name, metav1.GetOptions{})
-		return errors.IsNotFound(err)
+		return apierrors.IsNotFound(err)
 	}, time.Minute, time.Second)
 
 	t.Run("checking NetworkPolicies", func(t *testing.T) {
@@ -435,13 +435,13 @@ func TestGatewayHybridFull(t *testing.T) {
 	t.Log("verifying that DataPlane sub-resources are deleted")
 	assert.Eventually(t, func() bool {
 		_, err := GetClients().OperatorClient.GatewayOperatorV1beta1().DataPlanes(namespace.Name).Get(GetCtx(), dataplane.Name, metav1.GetOptions{})
-		return errors.IsNotFound(err)
+		return apierrors.IsNotFound(err)
 	}, time.Minute, time.Second)
 
 	t.Log("verifying that KonnectGatewayControlPlane sub-resources are deleted")
 	assert.Eventually(t, func() bool {
 		_, err := GetClients().OperatorClient.KonnectV1alpha2().KonnectGatewayControlPlanes(namespace.Name).Get(GetCtx(), konnectGatewayControlPlane.Name, metav1.GetOptions{})
-		return errors.IsNotFound(err)
+		return apierrors.IsNotFound(err)
 	}, time.Minute, time.Second)
 
 	t.Run("checking NetworkPolicies", func(t *testing.T) {
@@ -618,21 +618,21 @@ func TestGatewayMultiple(t *testing.T) {
 	t.Log("verifying that DataPlane sub-resources are deleted")
 	assert.Eventually(t, func() bool {
 		_, err := GetClients().OperatorClient.GatewayOperatorV1beta1().DataPlanes(namespace.Name).Get(GetCtx(), dataplaneOne.Name, metav1.GetOptions{})
-		return errors.IsNotFound(err)
+		return apierrors.IsNotFound(err)
 	}, time.Minute, time.Second)
 	assert.Eventually(t, func() bool {
 		_, err := GetClients().OperatorClient.GatewayOperatorV1beta1().DataPlanes(namespace.Name).Get(GetCtx(), dataplaneTwo.Name, metav1.GetOptions{})
-		return errors.IsNotFound(err)
+		return apierrors.IsNotFound(err)
 	}, time.Minute, time.Second)
 
 	t.Log("verifying that ControlPlane sub-resources are deleted")
 	assert.Eventually(t, func() bool {
 		_, err := GetClients().OperatorClient.GatewayOperatorV2beta1().ControlPlanes(namespace.Name).Get(GetCtx(), controlplaneOne.Name, metav1.GetOptions{})
-		return errors.IsNotFound(err)
+		return apierrors.IsNotFound(err)
 	}, time.Minute, time.Second)
 	assert.Eventually(t, func() bool {
 		_, err := GetClients().OperatorClient.GatewayOperatorV2beta1().ControlPlanes(namespace.Name).Get(GetCtx(), controlplaneTwo.Name, metav1.GetOptions{})
-		return errors.IsNotFound(err)
+		return apierrors.IsNotFound(err)
 	}, time.Minute, time.Second)
 
 	t.Log("verifying that gateways are deleted")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes the `k8s.io/apimachinery/pkg/api/errors` import paths eforced as `apierrors` consistently across the repo.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
