### PR TITLE
tests(kongintegration): fix TestUpdateStrategyInMemory_PropagatesResourcesErrors

### DIFF
--- a/ingress-controller/test/kongintegration/inmemory_update_strategy_test.go
+++ b/ingress-controller/test/kongintegration/inmemory_update_strategy_test.go
@@ -116,14 +116,12 @@ func TestUpdateStrategyInMemory_PropagatesResourcesErrors(t *testing.T) {
 			return
 		}
 		resourceErr, found := lo.Find(updateError.ResourceFailures(), func(r failures.ResourceFailure) bool {
-			return lo.ContainsBy(r.CausingObjects(), func(obj client.Object) bool {
-				return obj.GetName() == "test-service"
-			})
+			return r.Message() == expectedMessage &&
+				lo.ContainsBy(r.CausingObjects(), func(obj client.Object) bool {
+					return obj.GetName() == "test-service"
+				})
 		})
-		if !assert.Truef(t, found, "expected resource error for test-service, got: %+v", updateError.ResourceFailures()) {
-			return
-		}
-		if !assert.Equal(t, expectedMessage, resourceErr.Message()) {
+		if !assert.Truef(t, found, "expected resource error for test-service with message %q, got: %+v", expectedMessage, updateError.ResourceFailures()) {
 			return
 		}
 		if diff := cmp.Diff(expectedCausingObjects, resourceErr.CausingObjects()); !assert.Empty(t, diff) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue with flaky test:

```
    inmemory_update_strategy_test.go:96: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/ingress-controller/test/kongintegration/inmemory_update_strategy_test.go:96
        	Error:      	Condition never satisfied
        	Test:       	TestUpdateStrategyInMemory_PropagatesResourcesErrors
```

The test was flaky due to non-deterministic Go map iteration order.

Kong returns 2 schema violations for the faulty gRPC service with a path:

```
path: "value must be null" (field error)
service:test-service: "failed conditional validation given value of field 'protocol'" (entity error)
```

Both violations produce separate ResourceFailure objects, both associated with the same causing object ("test-service"). The ResourceFailure slice is built by iterating over the Problems map in `ingress-controller/internal/dataplane/sendconfig/error_handling.go#L29`, so the order is non-deterministic.

The test used `lo.Find` to match on causing object name only, then asserted the message was the "path" one. When `lo.Find` happened to return the "protocol" error first, the message assertion failed.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
