### PR TITLE
Fix not clearing dbmode resource errors

### DIFF
--- a/ingress-controller/internal/dataplane/sendconfig/dbmode.go
+++ b/ingress-controller/internal/dataplane/sendconfig/dbmode.go
@@ -145,6 +145,9 @@ func (s *UpdateStrategyDBMode) HandleEvents(
 	hash string,
 ) {
 	s.resourceErrorLock.Lock()
+	// Reset resource errors from previous Update() calls to prevent stale errors
+	// from leaking into subsequent calls when the UpdateStrategy is reused.
+	s.resourceErrors = nil
 	diff := diagnostics.ConfigDiff{
 		Hash:     hash,
 		Entities: []diagnostics.EntityDiff{},

--- a/ingress-controller/test/kongintegration/inmemory_update_strategy_test.go
+++ b/ingress-controller/test/kongintegration/inmemory_update_strategy_test.go
@@ -1,6 +1,7 @@
 package kongintegration
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -32,8 +33,9 @@ func TestUpdateStrategyInMemory_PropagatesResourcesErrors(t *testing.T) {
 	t.Parallel()
 
 	const (
-		timeout = time.Second * 5
-		period  = time.Millisecond * 200
+		timeout        = 30 * time.Second
+		period         = 200 * time.Millisecond
+		requestTimeout = 3 * time.Second
 	)
 
 	ctx := t.Context()
@@ -98,7 +100,9 @@ func TestUpdateStrategyInMemory_PropagatesResourcesErrors(t *testing.T) {
 	// Instead, we verify the essential structure and fields are present
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		configSize, err := sut.Update(ctx, generateFaultyConfig())
+		reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
+		defer cancel()
+		configSize, err := sut.Update(reqCtx, generateFaultyConfig())
 		if !assert.Error(t, err) {
 			fmt.Println("DEBUG: Update() returned no error (expected error)")
 			return

--- a/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
+++ b/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
@@ -136,35 +136,35 @@ func TestKongClientGoldenTestsOutputs_Konnect(t *testing.T) {
 			require.EventuallyWithT(t, func(t *assert.CollectT) {
 				configSize, err := updateStrategy.Update(ctx, sendconfig.ContentWithHash{Content: content})
 				if !assert.NoError(t, err) {
-					return
-				}
-
-				var (
-					apiErr        = &kong.APIError{}
-					sendconfigErr = &sendconfig.UpdateError{}
-				)
-				switch {
-				case errors.As(err, &apiErr):
-					if apiErr.Code() == http.StatusTooManyRequests {
-						details, ok := apiErr.Details().(kong.ErrTooManyRequestsDetails)
-						if !ok {
-							t.Errorf("failed to extract details from 429 error: %v", err)
-							return
+					var (
+						apiErr        = &kong.APIError{}
+						sendconfigErr sendconfig.UpdateError
+					)
+					switch {
+					case errors.As(err, &apiErr):
+						if apiErr.Code() == http.StatusTooManyRequests {
+							details, ok := apiErr.Details().(kong.ErrTooManyRequestsDetails)
+							if !ok {
+								t.Errorf("failed to extract details from 429 error: %v", err)
+								return
+							}
+							timer := time.NewTimer(details.RetryAfter)
+							defer timer.Stop()
+							select {
+							case <-timer.C:
+								t.Errorf("rate limited (429), retrying after %s", details.RetryAfter)
+								return
+							case <-ctx.Done():
+								t.Errorf("context done while waiting to retry after 429: %v", ctx.Err())
+								return
+							}
 						}
-						timer := time.NewTimer(details.RetryAfter)
-						defer timer.Stop()
-						select {
-						case <-timer.C:
-							t.Errorf("rate limited (429), retrying after %s", details.RetryAfter)
-							return
-						case <-ctx.Done():
-							t.Errorf("context done while waiting to retry after 429: %v", ctx.Err())
-							return
-						}
+					case errors.As(err, &sendconfigErr):
+						t.Errorf("sendconfig error: %v", sendconfigErr.Error())
+						t.Errorf("sendconfig error failures: %v", sendconfigErr.ResourceFailures())
+						return
 					}
-				case errors.As(err, &sendconfigErr):
-					t.Errorf("sendconfig error: %v", sendconfigErr.Error())
-					t.Errorf("sendconfig error failures: %v", sendconfigErr.ResourceFailures())
+					return
 				}
 
 				assert.Equal(t, mo.None[int](), configSize)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fix issues with kongintegration tests:

- In `TestUpdateStrategyInMemory_PropagatesResourcesErrors`
  - Adds debug logs
  - Adds request context so that a long hanging request doesn't block for the while duration of the tests which exceeds whole test time
- In `TestKongClientGoldenTestsOutputs_Konnect`
  - Fix error handling 
- In both `TestUpdateStrategyInMemory_PropagatesResourcesErrors` and `TestKongClientGoldenTestsOutputs_Konnect`
  - Do not reuse `&file.Content{}`. This is reused inside `go-database-internals` and causes issues in tests when a shared variable is used in a loop. This is not an issue in production code as target content is [always created fresh with `deckgen.ToDeckContent`](https://github.com/Kong/kong-operator/blob/b6f94e5cc77ea9e5c3479805344ffaf6a4e28fb5/ingress-controller/internal/dataplane/kong_client.go#L801).

**Special notes for your reviewer**:

This PR has been running for a while in a loop in CI and has proven to be stable:

<img width="329" height="713" alt="image" src="https://github.com/user-attachments/assets/aa79615f-dc72-4d23-94fd-f4db54555fa4" />

