### PR TITLE
ci: fix cache

### DIFF
--- a/.github/workflows/__envtest_tests.yaml
+++ b/.github/workflows/__envtest_tests.yaml
@@ -1,0 +1,85 @@
+name: envtest tests
+run-name: "envtest tests ${{ format('{0}', inputs.cluster_version) }} "
+
+on:
+  workflow_call:
+    inputs:
+      cluster_version:
+        description: "The Kubernetes cluster version to use for envtest"
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+env:
+  MISE_VERBOSE: 1
+  MISE_DEBUG: 1
+
+jobs:
+  envtest-tests:
+    timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES || 60) }}
+    runs-on: ubuntu-latest
+    name: envtest tests ${{ format('{0}', inputs.cluster_version) }}
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+      with:
+        egress-policy: audit
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      with:
+        go-version-file: go.mod
+        cache: false
+    - run: |
+        echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
+        echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
+    - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+      with:
+        install: false
+
+    - uses: Kong/kong-license@c4decf08584f84ff8fe8e7cd3c463e0192f6111b # master @ 20250107
+      id: license
+      with:
+        op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+    - run: echo "GO_CACHE_KEY=go-envtest-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
+    - run: echo "GO_CACHE_KEY_2=go-envtest-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
+
+    - name: Go cache
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+      with:
+        path: |
+          ${{ env.GO_MOD_CACHE }}
+          ${{ env.GO_BUILD_CACHE }}
+        key: ${{ env.GO_CACHE_KEY }}
+        restore-keys: |
+          ${{ env.GO_CACHE_KEY }}
+          ${{ env.GO_CACHE_KEY_2 }}
+
+    - name: run envtest tests
+      env:
+        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
+        GOTESTSUM_JUNITFILE: envtest-tests.xml
+      run: |
+        VERSION="${{ inputs.cluster_version }}"
+        # Remove leading 'v'
+        VERSION="${VERSION#v}"
+        # Remove patch number as envtest releases are not provided for every patch version
+        VERSION="${VERSION%.*}"
+        echo "Cluster version: $VERSION"
+        make test.envtest CLUSTER_VERSION=${VERSION}
+
+    - name: collect test coverage
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: coverage-envtest-tests
+        path: coverage.envtest.out
+
+    - name: collect test report
+      if: ${{ always() }}
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: tests-report-envtest-tests
+        path: envtest-tests.xml

--- a/.github/workflows/__unit_tests.yaml
+++ b/.github/workflows/__unit_tests.yaml
@@ -1,4 +1,4 @@
-name: kong integration tests
+name: unit tests
 
 on:
   workflow_call: {}

--- a/.github/workflows/__unit_tests.yaml
+++ b/.github/workflows/__unit_tests.yaml
@@ -1,0 +1,67 @@
+name: kong integration tests
+
+on:
+  workflow_call: {}
+
+permissions:
+  contents: read
+
+env:
+  MISE_VERBOSE: 1
+  MISE_DEBUG: 1
+
+jobs:
+  unit-tests:
+    timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES || 60) }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+      with:
+        egress-policy: audit
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      with:
+        go-version-file: go.mod
+        cache: false
+    - run: |
+        echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
+        echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
+    - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+      with:
+        install: false
+
+    - run: echo "GO_CACHE_KEY=go-unittests-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
+    - run: echo "GO_CACHE_KEY_2=go-unittests-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
+
+    - name: Go cache
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+      with:
+        path: |
+          ${{ env.GO_MOD_CACHE }}
+          ${{ env.GO_BUILD_CACHE }}
+        key: ${{ env.GO_CACHE_KEY }}
+        restore-keys: |
+          ${{ env.GO_CACHE_KEY }}
+          ${{ env.GO_CACHE_KEY_2 }}
+
+    - name: run unit tests
+      run: make test.unit
+      env:
+        KONG_PLUGIN_IMAGE_REGISTRY_CREDENTIALS: ${{ secrets.KONG_PLUGIN_IMAGE_REGISTRY_CREDENTIALS }}
+        GOTESTSUM_JUNITFILE: "unit-tests.xml"
+
+    - name: collect test coverage
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: coverage-unit-tests
+        path: coverage.unit.out
+
+    - name: collect test report
+      if: ${{ always() }}
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: tests-report-unit-tests
+        path: unit-tests.xml

--- a/.github/workflows/_kongintegration_tests.yaml
+++ b/.github/workflows/_kongintegration_tests.yaml
@@ -59,7 +59,7 @@ jobs:
       - run: echo "GO_CACHE_KEY=go-kongintegration-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
       - run: echo "GO_CACHE_KEY_2=go-kongintegration-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
 
-      - name: Save Go cache
+      - name: Go cache
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
         with:
           path: |

--- a/.github/workflows/_kongintegration_tests.yaml
+++ b/.github/workflows/_kongintegration_tests.yaml
@@ -6,6 +6,10 @@ on:
 permissions:
   contents: read
 
+env:
+  MISE_VERBOSE: 1
+  MISE_DEBUG: 1
+
 jobs:
   kongintegration-tests:
     timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES || 60) }}
@@ -19,13 +23,16 @@ jobs:
           - name: oss
             enterprise: false
     steps:
-      - name: checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: setup golang
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        id: setup-go
         with:
           go-version-file: go.mod
+          cache: false
+      - run: |
+          echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
+          echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
 
       - uses: Kong/kong-license@c4decf08584f84ff8fe8e7cd3c463e0192f6111b # master @ 20250107
         id: license
@@ -49,12 +56,23 @@ jobs:
           install: false
 
       - run: echo "GOTESTSUM_JUNITFILE=kongintegration-${{ matrix.name }}-tests.xml" >> $GITHUB_ENV
+      - run: echo "GO_CACHE_KEY=go-kongintegration-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
+      - run: echo "GO_CACHE_KEY_2=go-kongintegration-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
+
+      - name: Save Go cache
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        with:
+          path: |
+            ${{ env.GO_MOD_CACHE }}
+            ${{ env.GO_BUILD_CACHE }}
+          key: ${{ env.GO_CACHE_KEY }}
+          restore-keys: |
+            ${{ env.GO_CACHE_KEY }}
+            ${{ env.GO_CACHE_KEY_2 }}
 
       - name: run kong integration tests
         run: make test.kongintegration
         env:
-          MISE_VERBOSE: 1
-          MISE_DEBUG: 1
           GOTESTSUM_JUNITFILE: ${{ env.GOTESTSUM_JUNITFILE }}
           KONG_CUSTOM_DOMAIN: konghq.tech
           TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -382,8 +382,8 @@ jobs:
         echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
         echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
 
-    - run: echo "GO_CACHE_KEY=go-integrationtests-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
-    - run: echo "GO_CACHE_KEY_2=go-integrationtests-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
+    - run: echo "GO_CACHE_KEY=go-crdsvalidationtests-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
+    - run: echo "GO_CACHE_KEY_2=go-crdsvalidationtests-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
 
     - name: Go cache
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -111,7 +111,7 @@ jobs:
         {
           echo "GO_MOD_CACHE=$(go env GOMODCACHE)"
           echo "GO_BUILD_CACHE=$(go env GOCACHE)"
-          echo "GOLANGCI_LINT_CACHE=$(golangci-lint cache status | awk '{ print $2 }')"
+          echo "GOLANGCI_LINT_CACHE=$(make golangci-lint-cache-path)"
           echo "GO_CACHE_KEY=go-lint-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}"
           echo "GO_CACHE_KEY_2=go-lint-${{ runner.os }}-${{ runner.arch }}-go-"
         } >> $GITHUB_ENV

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -341,6 +341,25 @@ jobs:
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
       with:
         go-version-file: go.mod
+        cache: false
+
+    - run: |
+        echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
+        echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
+    - run: echo "GO_CACHE_KEY=go-build-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
+    - run: echo "GO_CACHE_KEY_2=go-build-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
+
+    - name: Go cache
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+      with:
+        path: |
+          ${{ env.GO_MOD_CACHE }}
+          ${{ env.GO_BUILD_CACHE }}
+        key: ${{ env.GO_CACHE_KEY }}
+        restore-keys: |
+          ${{ env.GO_CACHE_KEY }}
+          ${{ env.GO_CACHE_KEY_2 }}
 
     - run: make build.operator
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -700,8 +700,8 @@ jobs:
         echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
         echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
 
-    - run: echo "GO_CACHE_KEY=go-integrationtestsbluegreen-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
-    - run: echo "GO_CACHE_KEY_2=go-integrationtestsbluegreen-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
+    - run: echo "GO_CACHE_KEY=go-integrationtests-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
+    - run: echo "GO_CACHE_KEY_2=go-integrationtests-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
 
     - name: Go cache
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -384,13 +384,14 @@ jobs:
       uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
       with:
         egress-policy: audit
-    - name: checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-    - name: setup golang
-      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
       with:
         go-version-file: go.mod
+        cache: false
+    - run: |
+        echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
+        echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
 
     - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
       with:
@@ -400,6 +401,20 @@ jobs:
       id: license
       with:
         op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+    - run: echo "GO_CACHE_KEY=go-envtest-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
+    - run: echo "GO_CACHE_KEY_2=go-envtest-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
+
+    - name: Go cache
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+      with:
+        path: |
+          ${{ env.GO_MOD_CACHE }}
+          ${{ env.GO_BUILD_CACHE }}
+        key: ${{ env.GO_CACHE_KEY }}
+        restore-keys: |
+          ${{ env.GO_CACHE_KEY }}
+          ${{ env.GO_CACHE_KEY_2 }}
 
     - name: run envtest tests
       env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -106,13 +106,15 @@ jobs:
         install: false
 
     - run: make golangci-lint
-    - run: |
-        echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
-        echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
-        echo "GOLANGCI_LINT_CACHE=$(golangci-lint cache status | awk '{ print $2 }')" >> $GITHUB_ENV
 
-    - run: echo "GO_CACHE_KEY=go-lint-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
-    - run: echo "GO_CACHE_KEY_2=go-lint-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
+    - run: |
+        {
+          echo "GO_MOD_CACHE=$(go env GOMODCACHE)"
+          echo "GO_BUILD_CACHE=$(go env GOCACHE)"
+          echo "GOLANGCI_LINT_CACHE=$(golangci-lint cache status | awk '{ print $2 }')"
+          echo "GO_CACHE_KEY=go-lint-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}"
+          echo "GO_CACHE_KEY_2=go-lint-${{ runner.os }}-${{ runner.arch }}-go-"
+        } >> $GITHUB_ENV
 
     - name: Go cache
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -124,11 +124,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Setup go
-      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-      with:
-        go-version-file: go.mod
-
     - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
       with:
         install: false
@@ -355,10 +350,29 @@ jobs:
     - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
       with:
         go-version-file: go.mod
+        cache: false
 
     - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
       with:
         install: false
+
+    - run: |
+        echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
+        echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
+    - run: echo "GO_CACHE_KEY=go-integrationtests-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
+    - run: echo "GO_CACHE_KEY_2=go-integrationtests-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
+
+    - name: Go cache
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+      with:
+        path: |
+          ${{ env.GO_MOD_CACHE }}
+          ${{ env.GO_BUILD_CACHE }}
+        key: ${{ env.GO_CACHE_KEY }}
+        restore-keys: |
+          ${{ env.GO_CACHE_KEY }}
+          ${{ env.GO_CACHE_KEY_2 }}
 
     - name: Run the crds validation tests
       run: |
@@ -414,10 +428,29 @@ jobs:
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
       with:
         go-version-file: go.mod
+        cache: false
 
     - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
       with:
         install: false
+
+    - run: |
+        echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
+        echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
+    - run: echo "GO_CACHE_KEY=go-conformancetests-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
+    - run: echo "GO_CACHE_KEY_2=go-conformancetests-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
+
+    - name: Go cache
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+      with:
+        path: |
+          ${{ env.GO_MOD_CACHE }}
+          ${{ env.GO_BUILD_CACHE }}
+        key: ${{ env.GO_CACHE_KEY }}
+        restore-keys: |
+          ${{ env.GO_CACHE_KEY }}
+          ${{ env.GO_CACHE_KEY_2 }}
 
     - name: run conformance tests
       run: make test.conformance
@@ -478,10 +511,29 @@ jobs:
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
       with:
         go-version-file: go.mod
+        cache: false
 
     - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
       with:
         install: false
+
+    - run: |
+        echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
+        echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
+    - run: echo "GO_CACHE_KEY=go-integrationtests-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
+    - run: echo "GO_CACHE_KEY_2=go-integrationtests-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
+
+    - name: Go cache
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+      with:
+        path: |
+          ${{ env.GO_MOD_CACHE }}
+          ${{ env.GO_BUILD_CACHE }}
+        key: ${{ env.GO_CACHE_KEY }}
+        restore-keys: |
+          ${{ env.GO_CACHE_KEY }}
+          ${{ env.GO_CACHE_KEY_2 }}
 
     - name: run integration tests
       run: make test.integration-${{ matrix.suite }}
@@ -542,10 +594,29 @@ jobs:
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
       with:
         go-version-file: go.mod
+        cache: false
 
     - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
       with:
         install: false
+
+    - run: |
+        echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
+        echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
+    - run: echo "GO_CACHE_KEY=go-integrationtestsvalidatingwebhook-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
+    - run: echo "GO_CACHE_KEY_2=go-integrationtestsvalidatingwebhook-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
+
+    - name: Go cache
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+      with:
+        path: |
+          ${{ env.GO_MOD_CACHE }}
+          ${{ env.GO_BUILD_CACHE }}
+        key: ${{ env.GO_CACHE_KEY }}
+        restore-keys: |
+          ${{ env.GO_CACHE_KEY }}
+          ${{ env.GO_CACHE_KEY_2 }}
 
     - name: run integration tests
       run: make test.integration_validatingwebhook
@@ -597,10 +668,29 @@ jobs:
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
       with:
         go-version-file: go.mod
+        cache: false
 
     - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
       with:
         install: false
+
+    - run: |
+        echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
+        echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
+    - run: echo "GO_CACHE_KEY=go-integrationtestsbluegreen-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
+    - run: echo "GO_CACHE_KEY_2=go-integrationtestsbluegreen-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
+
+    - name: Go cache
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+      with:
+        path: |
+          ${{ env.GO_MOD_CACHE }}
+          ${{ env.GO_BUILD_CACHE }}
+        key: ${{ env.GO_CACHE_KEY }}
+        restore-keys: |
+          ${{ env.GO_CACHE_KEY }}
+          ${{ env.GO_CACHE_KEY_2 }}
 
     - name: run integration tests
       run: make test.integration_bluegreen

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -331,44 +331,10 @@ jobs:
       run: ./bin/manager -version | ./scripts/verify-version.sh ${{ github.repository }}
 
   unit-tests:
-    runs-on: ubuntu-latest
     needs: [check-docs-only]
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
-    steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
-      with:
-        egress-policy: audit
-    - name: checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-    - name: setup golang
-      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-      with:
-        go-version-file: go.mod
-
-    - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
-      with:
-        install: false
-
-    - name: run unit tests
-      run: make test.unit
-      env:
-        KONG_PLUGIN_IMAGE_REGISTRY_CREDENTIALS: ${{ secrets.KONG_PLUGIN_IMAGE_REGISTRY_CREDENTIALS }}
-        GOTESTSUM_JUNITFILE: "unit-tests.xml"
-
-    - name: collect test coverage
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-      with:
-        name: coverage-unit-tests
-        path: coverage.unit.out
-
-    - name: collect test report
-      if: ${{ always() }}
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-      with:
-        name: tests-report-unit-tests
-        path: unit-tests.xml
+    uses: ./.github/workflows/__unit_tests.yaml
+    secrets: inherit
 
   CRDs:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -99,10 +99,32 @@ jobs:
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
       with:
         go-version-file: go.mod
+        cache: false
 
     - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
       with:
         install: false
+
+    - run: make golangci-lint
+    - run: |
+        echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
+        echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+        echo "GOLANGCI_LINT_CACHE=$(golangci-lint cache status | awk '{ print $2 }')" >> $GITHUB_ENV
+
+    - run: echo "GO_CACHE_KEY=go-lint-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
+    - run: echo "GO_CACHE_KEY_2=go-lint-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
+
+    - name: Go cache
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+      with:
+        path: |
+          ${{ env.GO_MOD_CACHE }}
+          ${{ env.GO_BUILD_CACHE }}
+          ${{ env.GOLANGCI_LINT_CACHE }}
+        key: ${{ env.GO_CACHE_KEY }}
+        restore-keys: |
+          ${{ env.GO_CACHE_KEY }}
+          ${{ env.GO_CACHE_KEY_2 }}
 
     - name: run lint
       env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -721,8 +721,8 @@ jobs:
         echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
         echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
 
-    - run: echo "GO_CACHE_KEY=go-integrationtests-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
-    - run: echo "GO_CACHE_KEY_2=go-integrationtests-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
+    - run: echo "GO_CACHE_KEY=go-integrationtestsbluegreen-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
+    - run: echo "GO_CACHE_KEY_2=go-integrationtestsbluegreen-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
 
     - name: Go cache
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -374,73 +374,14 @@ jobs:
       run: make test.api
 
   envtest-tests:
-    runs-on: ubuntu-latest
     needs:
     - check-docs-only
     - matrix_k8s_node_versions
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
-    steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
-      with:
-        egress-policy: audit
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-      with:
-        go-version-file: go.mod
-        cache: false
-    - run: |
-        echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
-        echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
-
-    - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
-      with:
-        install: false
-
-    - uses: Kong/kong-license@c4decf08584f84ff8fe8e7cd3c463e0192f6111b # master @ 20250107
-      id: license
-      with:
-        op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-
-    - run: echo "GO_CACHE_KEY=go-envtest-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
-    - run: echo "GO_CACHE_KEY_2=go-envtest-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
-
-    - name: Go cache
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
-      with:
-        path: |
-          ${{ env.GO_MOD_CACHE }}
-          ${{ env.GO_BUILD_CACHE }}
-        key: ${{ env.GO_CACHE_KEY }}
-        restore-keys: |
-          ${{ env.GO_CACHE_KEY }}
-          ${{ env.GO_CACHE_KEY_2 }}
-
-    - name: run envtest tests
-      env:
-        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-        GOTESTSUM_JUNITFILE: envtest-tests.xml
-      run: |
-        VERSION="${{ needs.matrix_k8s_node_versions.outputs.latest }}"
-        # Remove leading 'v'
-        VERSION="${VERSION#v}"
-        # Remove patch number as envtest releases are not provided for every patch version
-        VERSION="${VERSION%.*}"
-        echo "Cluster version: $VERSION"
-        make test.envtest CLUSTER_VERSION=${VERSION}
-
-    - name: collect test coverage
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-      with:
-        name: coverage-envtest-tests
-        path: coverage.envtest.out
-
-    - name: collect test report
-      if: ${{ always() }}
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-      with:
-        name: tests-report-envtest-tests
-        path: envtest-tests.xml
+    uses: ./.github/workflows/__envtest_tests.yaml
+    secrets: inherit
+    with:
+      cluster_version: ${{ needs.matrix_k8s_node_versions.outputs.latest }}
   
   kongintegration-tests:
     needs: [check-docs-only]

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,10 @@ GOLANGCI_LINT = $(PROJECT_DIR)/bin/installs/github-golangci-golangci-lint/$(GOLA
 golangci-lint: mise yq ## Download golangci-lint locally if necessary.
 	$(MAKE) mise-install DEP_VER=github:golangci/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
+.PHONY: golangci-lint-cache-path
+golangci-lint-cache-path:
+	@$(GOLANGCI_LINT) cache status | awk '{ print $$2 }'
+
 MODERNIZE_VERSION = $(shell $(YQ) -r '.modernize' < $(TOOLS_VERSIONS_FILE))
 MODERNIZE = $(PROJECT_DIR)/bin/installs/go-golang-org-x-tools-gopls-internal-analysis-modernize-cmd-modernize/$(MODERNIZE_VERSION)/bin/modernize
 # Flags for modernize analyzer. Disable the "omitzero" category to avoid


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR aims to finally solve the CI cache issue.

The culprit here is how `actions/setup-go` handles cache: it uses a single cache prefix and a hash of (as of now) `go.sum` (which has already been reported to be an incorrect approach: https://github.com/actions/setup-go/issues/478).

A proof of caching not working properly now are 2 things:

- lines indicating downloading of go modules, e.g. `go: downloading golang.org/x/sync v0.19.0
`
- long build/test times: note the 3 minute pause between downloading the last go module and tests starting:
  
  ```
  Fri, 13 Feb 2026 16:55:13 GMT
  go: downloading github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1
  Fri, 13 Feb 2026 16:58:24 GMT
  === RUN   TestDiscoverer_GetAdminAPIsForServiceReturnsAllAddressesCorrectlyPagingThroughResults
  ```

This PR does the following:

- it disables caching for `actions/setup-go`
- it sets the cache keys: e.g. for unit tests (the second one is a fallback in case `go.mod` changed ever so slightly)
  ```
      - run: echo "GO_CACHE_KEY=go-unittests-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
      - run: echo "GO_CACHE_KEY_2=go-unittests-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
  ```
- adds explicit `actions/cache` to each job which uses go:
  
  ```
      - name: Go cache
        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
        with:
          path: |
            ${{ env.GO_MOD_CACHE }}
            ${{ env.GO_BUILD_CACHE }}
          key: ${{ env.GO_CACHE_KEY }}
          restore-keys: |
            ${{ env.GO_CACHE_KEY }}
            ${{ env.GO_CACHE_KEY_2 }}
  ```

**Effect**:

- build
  - from: 2m6s https://github.com/Kong/kong-operator/actions/runs/21995228444/job/63553301230#step:6:1
  - to: 14s (8s cache + 6s build) https://github.com/Kong/kong-operator/actions/runs/22040505624/job/63680519178?pr=3316#step:10:1

  <img width="761" height="95" alt="image" src="https://github.com/user-attachments/assets/b08ed49a-7942-421c-9ea9-014e976f0b63" />


- lint
  - from: 6m57s https://github.com/Kong/kong-operator/actions/runs/21995228444/job/63553301236#step:7:1
  - to: 45s (23s cache + 22s lint) https://github.com/Kong/kong-operator/actions/runs/22040505624/job/63680519206?pr=3316#step:10:1

  <img width="765" height="100" alt="image" src="https://github.com/user-attachments/assets/76662ab0-2082-474f-9268-a5f2e814918a" />


- envtest suite
  - from: 11m7s https://github.com/Kong/kong-operator/actions/runs/21995228444/job/63553301241#step:8:1
  - to: 8m14s (13s cache + 8m1s test) https://github.com/Kong/kong-operator/actions/runs/22040505624/job/63680519292?pr=3316#step:12:1

  <img width="763" height="96" alt="image" src="https://github.com/user-attachments/assets/0e77016b-7167-450c-ad81-9690704387ba" />


- CRD validation tests (per k8s version workflow)
  - from: 8m35s https://github.com/Kong/kong-operator/actions/runs/21995228444/job/63553301290#step:7:1
  - to: 4m10s (15s cache + 3m55s test) https://github.com/Kong/kong-operator/actions/runs/22040505624/job/63680519273?pr=3316#step:11:1

  <img width="759" height="95" alt="image" src="https://github.com/user-attachments/assets/c0b6be24-13da-4a95-9a71-4badf7212963" />


- kongintegration tests
  - from: 3m5s https://github.com/Kong/kong-operator/actions/runs/21995228444/job/63553301444#step:9:1
  - to: 1m8s (7s cache + 1m1s test) https://github.com/Kong/kong-operator/actions/runs/22040505624/job/63680519294?pr=3316#step:13:1

  <img width="777" height="94" alt="image" src="https://github.com/user-attachments/assets/ea05080b-5b2e-4419-8246-de5827d255cb" />


- integration tests (ko suite)
  - from: 13m27s https://github.com/Kong/kong-operator/actions/runs/21995228444/job/63553301336#step:7:1
  - to: 11m42s (19s cache + 11m23s test) https://github.com/Kong/kong-operator/actions/runs/22040505624/job/63680519219?pr=3316#step:11:1

  <img width="754" height="99" alt="image" src="https://github.com/user-attachments/assets/e3e60a4d-e7bd-4048-8458-0f2d625a5d53" />


- integration tests validating webhook (expressions)
  - from: 9m42s https://github.com/Kong/kong-operator/actions/runs/21995228444/job/63553301394#step:7:1
  - to: 6m31s (12s cache + 6m19s test) https://github.com/Kong/kong-operator/actions/runs/22040505624/job/63680519233?pr=3316#step:11:1

  <img width="1217" height="104" alt="image" src="https://github.com/user-attachments/assets/6b0f78a3-856d-4c81-b06c-813840e90c55" />


- conformance tests (expressions)
  - from: 9m37s https://github.com/Kong/kong-operator/actions/runs/21995228444/job/63553301370#step:7:1
  - to: 7m02s (15s cache + 6m47s test) https://github.com/Kong/kong-operator/actions/runs/22040505624/job/63680519236?pr=3316#step:11:1

  <img width="770" height="101" alt="image" src="https://github.com/user-attachments/assets/ccf54307-1f04-4a6d-bdbf-a162c802526b" />

**Special notes for your reviewer**:

The approach used here means that every job has its own cache. This has advantages as well as disadvantages.

The big advantage is that everything needed for the job, is in the cache.
The disadvantage is that these caches are relatively big:

```
gh cache list --repo Kong/kong-operator --key go
2865977323	go-conformancetests-Linux-X64-go-f80fb11d5fda36c1617b8a046600b95f1a56649cca1900e192203773702787a4646.47 MiB	2026-02-15T17:37:17Z	2026-02-15T18:07:07Z
2866091193	go-lint-Linux-X64-go-f80fb11d5fda36c1617b8a046600b95f1a56649cca1900e192203773702787a4	1.24 GiB	2026-02-15T18:01:41Z	2026-02-15T18:06:55Z
2865347122	go-integrationtests-Linux-X64-go-f80fb11d5fda36c1617b8a046600b95f1a56649cca1900e192203773702787a4	835.19 MiB	2026-02-15T15:27:25Z	2026-02-15T18:06:54Z
2864136287	go-envtest-Linux-X64-go-f80fb11d5fda36c1617b8a046600b95f1a56649cca1900e192203773702787a4	757.58 MiB	2026-02-15T10:41:04Z	2026-02-15T18:06:54Z
2865970004	go-crdsvalidationtests-Linux-X64-go-f80fb11d5fda36c1617b8a046600b95f1a56649cca1900e192203773702787a4	835.31 MiB	2026-02-15T17:35:50Z	2026-02-15T18:06:54Z
2865353965	go-integrationtestsvalidatingwebhook-Linux-X64-go-f80fb11d5fda36c1617b8a046600b95f1a56649cca1900e192203773702787a4	727.73 MiB	2026-02-15T15:28:47Z	2026-02-15T18:06:52Z
2864034265	go-unittests-Linux-X64-go-f80fb11d5fda36c1617b8a046600b95f1a56649cca1900e192203773702787a4	766.71 MiB	2026-02-15T10:12:51Z	2026-02-15T18:06:52Z
2865350462	go-integrationtestsbluegreen-Linux-X64-go-f80fb11d5fda36c1617b8a046600b95f1a56649cca1900e192203773702787a4	647.40 MiB	2026-02-15T15:28:06Z	2026-02-15T18:06:52Z
```

and with GitHub's 10GB total cache limit this might mean a lot of evicting of caches but:

- cache key is based on `go.mod`'s cache and that rarely changes
- if `go.mod` changes that happens in dependabot/renovate's PR and cache new cache is created there which means when developers create PRs, their workflows will already leverage the cache.

When cache limit becomes a problem, we can always consider using S3 for cache storage.

---

envtest and UT test suites have been extracted into their dedicated workflows as an exercise. This could also be done for other tests but it's not the main goal of this PR. Feedback on this is more than welcome.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
