### PR TITLE
ci: manage ktf with mise

### DIFF
--- a/.github/workflows/__e2e_chainsaw_tests.yaml
+++ b/.github/workflows/__e2e_chainsaw_tests.yaml
@@ -1,0 +1,82 @@
+name: E2E Chainsaw tests
+run-name: "E2E Chainsaw tests ${{ format('{0}', inputs.node_image_version) }} "
+
+on:
+  workflow_call:
+    inputs:
+      node_image_version:
+        description: "Kind node image version"
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+env:
+  MISE_VERBOSE: 1
+  MISE_DEBUG: 1
+
+jobs:
+  e2e-tests-chainsaw:
+    timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES || 60) }}
+    runs-on: ubuntu-latest
+    name: ${{ format('{0}', inputs.node_image_version) }}
+    env:
+      IMG: kong-operator
+      TAG: e2e-${{ github.sha }}
+      CLUSTER_NAME: e2e-chainsaw
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+      with:
+        egress-policy: audit
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: build docker image
+      run: make docker.build
+
+    - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+      with:
+        install_args: github:Kong/kubernetes-testing-framework http:helm
+
+    - name: Create k8s KinD Cluster with ktf
+      run: |
+        ktf environments create \
+          --name ${{ env.CLUSTER_NAME }} \
+          --addon metallb \
+          --addon cert-manager \
+          --kubernetes-version ${{ inputs.node_image_version }}
+
+    - name: Load image to kind cluster
+      run: kind load docker-image ${{ env.IMG }}:${{ env.TAG }} --name ${{ env.CLUSTER_NAME }}
+
+    - name: Deploy operator with Helm
+      run: |
+        helm install kong-operator charts/kong-operator \
+          --namespace kong-system \
+          --create-namespace \
+          --set image.repository=${{ env.IMG }} \
+          --set image.tag=${{ env.TAG }} \
+          --set env.enable_controller_konnect=true \
+          --wait
+
+    - name: run chainsaw e2e tests
+      id: chainsaw-tests
+      run: make test.e2e.chainsaw
+      env:
+        KONNECT_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
+        KONNECT_SERVER_URL: us.api.konghq.tech
+        TEST_ID: ${{ github.run_id }}
+
+    - name: Upload debug snapshots as artifacts
+      if: always() && steps.chainsaw-tests.outcome == 'failure'
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: chainsaw-debug-snapshots-${{ github.run_id }}
+        path: /tmp/chainsaw/
+        if-no-files-found: ignore
+        retention-days: 3
+
+    - name: Clean up debug snapshots
+      if: always() && steps.chainsaw-tests.outcome == 'failure'
+      run: rm -rf /tmp/chainsaw

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -819,74 +819,14 @@ jobs:
         path: e2e-tests.xml
 
   e2e-tests-chainsaw:
-    runs-on: ubuntu-latest
     needs:
-    - check-docs-only
-    - matrix_k8s_node_versions
+      - check-docs-only
+      - matrix_k8s_node_versions
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
-    env:
-      IMG: kong-operator
-      TAG: e2e-${{ github.sha }}
-      CLUSTER_NAME: e2e-chainsaw
-    steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
-      with:
-        egress-policy: audit
-    - name: checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-    - name: setup golang
-      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-      with:
-        go-version-file: go.mod
-
-    - name: build docker image
-      run: make docker.build
-
-    - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
-      with:
-        install: false
-
-    - name: Create k8s KinD Cluster with ktf
-      run: |
-        # renovate: datasource=github-releases depName=kong/kubernetes-testing-framework
-        go install github.com/kong/kubernetes-testing-framework/cmd/ktf@83931d51792e99ec523aad1ccb69d2dbeb504465 # v0.48.0
-        ktf environments create --name ${{ env.CLUSTER_NAME }} --addon metallb --addon cert-manager
-
-    - name: Load image to kind cluster
-      run: kind load docker-image ${{ env.IMG }}:${{ env.TAG }} --name ${{ env.CLUSTER_NAME }}
-
-    - name: Deploy operator with Helm
-      run: |
-        helm install kong-operator charts/kong-operator \
-          --namespace kong-system \
-          --create-namespace \
-          --set image.repository=${{ env.IMG }} \
-          --set image.tag=${{ env.TAG }} \
-          --set env.enable_controller_konnect=true \
-          --wait
-
-    - name: run chainsaw e2e tests
-      id: chainsaw-tests
-      run: make test.e2e.chainsaw
-      env:
-        KONNECT_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
-        KONNECT_SERVER_URL: us.api.konghq.tech
-        TEST_ID: ${{ github.run_id }}
-
-    - name: Upload debug snapshots as artifacts
-      if: always() && steps.chainsaw-tests.outcome == 'failure'
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-      with:
-        name: chainsaw-debug-snapshots-${{ github.run_id }}
-        path: /tmp/chainsaw/
-        if-no-files-found: ignore
-        retention-days: 3
-
-    - name: Clean up debug snapshots
-      if: always() && steps.chainsaw-tests.outcome == 'failure'
-      run: rm -rf /tmp/chainsaw
+    uses: ./.github/workflows/__e2e_chainsaw_tests.yaml
+    secrets: inherit
+    with:
+      node_image_version: ${{ needs.matrix_k8s_node_versions.outputs.latest }}
 
   buildpulse-report:
     needs:

--- a/.mise.toml
+++ b/.mise.toml
@@ -15,6 +15,11 @@ github_attestations = false
 version = "v5.8.1"
 version_prefix = "kustomize/"
 
+[tools."github:Kong/kubernetes-testing-framework"]
+# renovate: datasource=github-releases depName=Kong/kubernetes-testing-framework
+version = "v0.48.0"
+bin = "ktf"
+
 [tools."github:telepresenceio/telepresence"]
 # renovate: datasource=github-releases depName=telepresenceio/telepresence
 version = "2.26.1"


### PR DESCRIPTION
**What this PR does / why we need it**:

For e2e chainsaw tests:

- Manage `ktf` with `mise`: this prevents the need to build it with Go and thus cuts the build time of `Create k8s KinD Cluster with ktf` step from [~2m16s](https://github.com/Kong/kong-operator/actions/runs/21995228444/job/63553301289#step:8:1) to [~1m5s](https://github.com/Kong/kong-operator/actions/runs/22060227645/job/63738384293#step:7:1)
- Extract e2e chainsaw test workflow to a dedicate workflow file in `.github/workflows/__e2e_chainsaw_tests.yaml`.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
