### PR TITLE
ci: fix release docs PR workflow

### DIFF
--- a/.github/workflows/__release-workflow.yaml
+++ b/.github/workflows/__release-workflow.yaml
@@ -395,7 +395,7 @@ jobs:
         run: |
           mkdir -p "$(dirname "${{ env.DOCS_REPO }}/${{ env.DOCS_REPO_PATH_CRD_DOC }}")"
           ./scripts/apidocs-gen/post-process-for-konghq.sh \
-            ./docs/gateway-operator-api-reference.md \
+            ./docs/all-api-reference.md \
             "${{ env.DOCS_REPO }}/${{ env.DOCS_REPO_PATH_CRD_DOC }}" \
             "${{ env.DOCS_REPO }}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes release docs PR workflow: it should include all CRD reference docs not just the operator one.

Related broken PR: https://github.com/Kong/developer.konghq.com/pull/4093/changes

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
