### PR TITLE
chore(lint): enable golangci-lint: `testifylint` rule `error-is-as`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -172,7 +172,6 @@ linters:
       enable-all: true
       disable:
         - require-error
-        - error-is-as
     usetesting:
       os-temp-dir: true
   exclusions:

--- a/controller/konnect/ops/errors.go
+++ b/controller/konnect/ops/errors.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+
 	kcfgconsts "github.com/kong/kong-operator/api/common/consts"
 	"github.com/kong/kong-operator/controller/konnect/constraints"
 )
@@ -39,6 +41,14 @@ type KonnectEntityCreatedButRelationsFailedError struct {
 // Error implements the error interface.
 func (e KonnectEntityCreatedButRelationsFailedError) Error() string {
 	return fmt.Sprintf("Konnect entity (ID: %s) created but relations failed: %s: %v", e.KonnectID, e.Reason, e.Err)
+}
+
+// Is reports any error in err's tree matches target.
+func (e KonnectEntityCreatedButRelationsFailedError) Is(target error) bool {
+	if t, ok := target.(KonnectEntityCreatedButRelationsFailedError); ok {
+		return e.KonnectID == t.KonnectID && e.Reason == t.Reason
+	}
+	return false
 }
 
 // GetControlPlaneGroupMemberFailedError is an error type returned when
@@ -87,6 +97,48 @@ func (e KonnectEntityAdoptionFetchError) Unwrap() error {
 	return e.Err
 }
 
+// Is reports any error in err's tree matches target.
+func (e KonnectEntityAdoptionFetchError) Is(target error) bool {
+	if t, ok := target.(KonnectEntityAdoptionFetchError); ok {
+		return e.KonnectID == t.KonnectID
+	}
+	return false
+}
+
+// KonnectEntityAdoptionReferenceServiceIDMismatchError is an error type returned when
+// adopting an existing entity but the reference service ID does not match.
+type KonnectEntityAdoptionReferenceServiceIDMismatchError struct{}
+
+// Error implements the error interface.
+func (e KonnectEntityAdoptionReferenceServiceIDMismatchError) Error() string {
+	return "failed to adopt: reference service ID does not match"
+}
+
+// Is reports any error in err's tree matches target.
+func (e KonnectEntityAdoptionReferenceServiceIDMismatchError) Is(target error) bool {
+	_, ok := target.(KonnectEntityAdoptionReferenceServiceIDMismatchError)
+	return ok
+}
+
+// KonnectEntityAdoptionRouteTypeNotSupportedError is an error type returned when
+// adopting an existing entity but the route type is not supported.
+type KonnectEntityAdoptionRouteTypeNotSupportedError struct {
+	RouteType sdkkonnectcomp.RouteType
+}
+
+// Error implements the error interface.
+func (e KonnectEntityAdoptionRouteTypeNotSupportedError) Error() string {
+	return fmt.Sprintf("failed to adopt: route type %q not supported", e.RouteType)
+}
+
+// Is reports any error in err's tree matches target.
+func (e KonnectEntityAdoptionRouteTypeNotSupportedError) Is(target error) bool {
+	if t, ok := target.(KonnectEntityAdoptionRouteTypeNotSupportedError); ok {
+		return e.RouteType == t.RouteType
+	}
+	return false
+}
+
 // KonnectEntityAdoptionUIDTagConflictError is an error type returned in adopting an existing entity
 // when the entity has a tag to note that the entity is managed by another object with a different UID.
 type KonnectEntityAdoptionUIDTagConflictError struct {
@@ -108,6 +160,59 @@ type KonnectEntityAdoptionNotMatchError struct {
 // Error implements the error interface.
 func (e KonnectEntityAdoptionNotMatchError) Error() string {
 	return fmt.Sprintf("Konnect entity (ID: %s) does not match the spec of the object when adopting in match mode", e.KonnectID)
+}
+
+// Is reports any error in err's tree matches target.
+func (e KonnectEntityAdoptionNotMatchError) Is(target error) bool {
+	if t, ok := target.(KonnectEntityAdoptionNotMatchError); ok {
+		return e.KonnectID == t.KonnectID
+	}
+	return false
+}
+
+// KonnectEntityAdoptionMissingControlPlaneIDError is an error type returned particular ControlPlane ID does not exist.
+type KonnectEntityAdoptionMissingControlPlaneIDError struct{}
+
+// Error implements the error interface.
+func (e KonnectEntityAdoptionMissingControlPlaneIDError) Error() string {
+	return "no Control Plane ID"
+}
+
+// Is reports any error in err's tree matches target.
+func (e KonnectEntityAdoptionMissingControlPlaneIDError) Is(target error) bool {
+	_, ok := target.(KonnectEntityAdoptionMissingControlPlaneIDError)
+	return ok
+}
+
+// KonnectOperationFailedError is an error type returned when a Konnect API operation fails.
+// It includes the operation type, entity type name, entity key, and underlying error.
+type KonnectOperationFailedError struct {
+	Op         Op
+	EntityType string
+	EntityKey  string
+	Err        error
+}
+
+// Error implements the error interface.
+func (e KonnectOperationFailedError) Error() string {
+	return fmt.Sprintf("failed to %s %s %s: %v", e.Op, e.EntityType, e.EntityKey, e.Err)
+}
+
+func (e KonnectOperationFailedError) Unwrap() error {
+	return e.Err
+}
+
+// Is reports any error in err's tree matches target.
+func (e KonnectOperationFailedError) Is(target error) bool {
+	if t, ok := target.(KonnectOperationFailedError); ok {
+		return e.Op == t.Op &&
+			e.EntityType == t.EntityType &&
+			e.EntityKey == t.EntityKey &&
+			(e.Err != nil && t.Err != nil &&
+				e.Err.Error() == t.Err.Error() ||
+				e.Err == nil && t.Err == nil)
+	}
+	return false
 }
 
 // RateLimitError is an error type returned when a Konnect API operation

--- a/controller/konnect/ops/errors.go
+++ b/controller/konnect/ops/errors.go
@@ -45,10 +45,8 @@ func (e KonnectEntityCreatedButRelationsFailedError) Error() string {
 
 // Is reports any error in err's tree matches target.
 func (e KonnectEntityCreatedButRelationsFailedError) Is(target error) bool {
-	if t, ok := target.(KonnectEntityCreatedButRelationsFailedError); ok {
-		return e.KonnectID == t.KonnectID && e.Reason == t.Reason
-	}
-	return false
+	t, ok := target.(KonnectEntityCreatedButRelationsFailedError)
+	return ok && e.KonnectID == t.KonnectID && e.Reason == t.Reason
 }
 
 // GetControlPlaneGroupMemberFailedError is an error type returned when
@@ -99,10 +97,8 @@ func (e KonnectEntityAdoptionFetchError) Unwrap() error {
 
 // Is reports any error in err's tree matches target.
 func (e KonnectEntityAdoptionFetchError) Is(target error) bool {
-	if t, ok := target.(KonnectEntityAdoptionFetchError); ok {
-		return e.KonnectID == t.KonnectID
-	}
-	return false
+	t, ok := target.(KonnectEntityAdoptionFetchError)
+	return ok && e.KonnectID == t.KonnectID
 }
 
 // KonnectEntityAdoptionReferenceServiceIDMismatchError is an error type returned when
@@ -133,10 +129,8 @@ func (e KonnectEntityAdoptionRouteTypeNotSupportedError) Error() string {
 
 // Is reports any error in err's tree matches target.
 func (e KonnectEntityAdoptionRouteTypeNotSupportedError) Is(target error) bool {
-	if t, ok := target.(KonnectEntityAdoptionRouteTypeNotSupportedError); ok {
-		return e.RouteType == t.RouteType
-	}
-	return false
+	t, ok := target.(KonnectEntityAdoptionRouteTypeNotSupportedError)
+	return ok && e.RouteType == t.RouteType
 }
 
 // KonnectEntityAdoptionUIDTagConflictError is an error type returned in adopting an existing entity
@@ -164,10 +158,8 @@ func (e KonnectEntityAdoptionNotMatchError) Error() string {
 
 // Is reports any error in err's tree matches target.
 func (e KonnectEntityAdoptionNotMatchError) Is(target error) bool {
-	if t, ok := target.(KonnectEntityAdoptionNotMatchError); ok {
-		return e.KonnectID == t.KonnectID
-	}
-	return false
+	t, ok := target.(KonnectEntityAdoptionNotMatchError)
+	return ok && e.KonnectID == t.KonnectID
 }
 
 // KonnectEntityAdoptionMissingControlPlaneIDError is an error type returned particular ControlPlane ID does not exist.
@@ -204,15 +196,13 @@ func (e KonnectOperationFailedError) Unwrap() error {
 
 // Is reports any error in err's tree matches target.
 func (e KonnectOperationFailedError) Is(target error) bool {
-	if t, ok := target.(KonnectOperationFailedError); ok {
-		return e.Op == t.Op &&
-			e.EntityType == t.EntityType &&
-			e.EntityKey == t.EntityKey &&
-			(e.Err != nil && t.Err != nil &&
-				e.Err.Error() == t.Err.Error() ||
-				e.Err == nil && t.Err == nil)
-	}
-	return false
+	t, ok := target.(KonnectOperationFailedError)
+	return ok && e.Op == t.Op &&
+		e.EntityType == t.EntityType &&
+		e.EntityKey == t.EntityKey &&
+		(e.Err != nil && t.Err != nil &&
+			e.Err.Error() == t.Err.Error() ||
+			e.Err == nil && t.Err == nil)
 }
 
 // RateLimitError is an error type returned when a Konnect API operation

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -726,9 +726,12 @@ func wrapErrIfKonnectOpFailed[
 				op, entityTypeName, err,
 			)
 		}
-		return fmt.Errorf("failed to %s %s %s: %w",
-			op, entityTypeName, client.ObjectKeyFromObject(e), err,
-		)
+		return KonnectOperationFailedError{
+			Op:         op,
+			EntityType: entityTypeName,
+			EntityKey:  client.ObjectKeyFromObject(e).String(),
+			Err:        err,
+		}
 	}
 	return nil
 }

--- a/controller/konnect/ops/ops_credentialacl.go
+++ b/controller/konnect/ops/ops_credentialacl.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
@@ -111,7 +110,7 @@ func adoptKongCredentialACL(
 ) error {
 	cpID := cred.GetControlPlaneID()
 	if cpID == "" {
-		return errors.New("No Control Plane ID")
+		return KonnectEntityAdoptionMissingControlPlaneIDError{}
 	}
 	if cred.Status.Konnect == nil || cred.Status.Konnect.GetConsumerID() == "" {
 		return fmt.Errorf("can't adopt %T %s without a Konnect Consumer ID", cred, client.ObjectKeyFromObject(cred))

--- a/controller/konnect/ops/ops_credentialapikey.go
+++ b/controller/konnect/ops/ops_credentialapikey.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
@@ -108,7 +107,7 @@ func adoptKongCredentialAPIKey(
 ) error {
 	cpID := cred.GetControlPlaneID()
 	if cpID == "" {
-		return errors.New("No Control Plane ID")
+		return KonnectEntityAdoptionMissingControlPlaneIDError{}
 	}
 	if cred.Status.Konnect == nil || cred.Status.Konnect.GetConsumerID() == "" {
 		return fmt.Errorf("can't adopt %T %s without a Konnect Consumer ID", cred, client.ObjectKeyFromObject(cred))

--- a/controller/konnect/ops/ops_credentialbasicauth.go
+++ b/controller/konnect/ops/ops_credentialbasicauth.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
@@ -107,7 +106,7 @@ func adoptKongCredentialBasicAuth(
 ) error {
 	cpID := cred.GetControlPlaneID()
 	if cpID == "" {
-		return errors.New("No Control Plane ID")
+		return KonnectEntityAdoptionMissingControlPlaneIDError{}
 	}
 	if cred.Status.Konnect == nil || cred.Status.Konnect.GetConsumerID() == "" {
 		return fmt.Errorf("can't adopt %T %s without a Konnect Consumer ID", cred, client.ObjectKeyFromObject(cred))

--- a/controller/konnect/ops/ops_credentialhmac.go
+++ b/controller/konnect/ops/ops_credentialhmac.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
@@ -108,7 +107,7 @@ func adoptKongCredentialHMAC(
 ) error {
 	cpID := cred.GetControlPlaneID()
 	if cpID == "" {
-		return errors.New("No Control Plane ID")
+		return KonnectEntityAdoptionMissingControlPlaneIDError{}
 	}
 	if cred.Status.Konnect == nil || cred.Status.Konnect.GetConsumerID() == "" {
 		return fmt.Errorf("can't adopt %T %s without a Konnect Consumer ID", cred, client.ObjectKeyFromObject(cred))

--- a/controller/konnect/ops/ops_credentialjwt.go
+++ b/controller/konnect/ops/ops_credentialjwt.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
@@ -108,7 +107,7 @@ func adoptKongCredentialJWT(
 ) error {
 	cpID := cred.GetControlPlaneID()
 	if cpID == "" {
-		return errors.New("No Control Plane ID")
+		return KonnectEntityAdoptionMissingControlPlaneIDError{}
 	}
 	if cred.Status.Konnect == nil || cred.Status.Konnect.GetConsumerID() == "" {
 		return fmt.Errorf("can't adopt %T %s without a Konnect Consumer ID", cred, client.ObjectKeyFromObject(cred))

--- a/controller/konnect/ops/ops_errors.go
+++ b/controller/konnect/ops/ops_errors.go
@@ -79,6 +79,17 @@ func (e CantPerformOperationWithoutControlPlaneIDError) Error() string {
 	)
 }
 
+// Is reports any error in err's tree matches target.
+func (e CantPerformOperationWithoutControlPlaneIDError) Is(target error) bool {
+	t, ok := target.(CantPerformOperationWithoutControlPlaneIDError)
+	if !ok {
+		return false
+	}
+	return e.Entity.GetTypeName() == t.Entity.GetTypeName() &&
+		client.ObjectKeyFromObject(e.Entity) == client.ObjectKeyFromObject(t.Entity) &&
+		e.Op == t.Op
+}
+
 // CantPerformOperationWithoutNetworkIDError is an error indicating that an
 // operation cannot be performed without a Konnect network ID.
 type CantPerformOperationWithoutNetworkIDError struct {

--- a/controller/konnect/ops/ops_errors.go
+++ b/controller/konnect/ops/ops_errors.go
@@ -82,10 +82,7 @@ func (e CantPerformOperationWithoutControlPlaneIDError) Error() string {
 // Is reports any error in err's tree matches target.
 func (e CantPerformOperationWithoutControlPlaneIDError) Is(target error) bool {
 	t, ok := target.(CantPerformOperationWithoutControlPlaneIDError)
-	if !ok {
-		return false
-	}
-	return e.Entity.GetTypeName() == t.Entity.GetTypeName() &&
+	return ok && e.Entity.GetTypeName() == t.Entity.GetTypeName() &&
 		client.ObjectKeyFromObject(e.Entity) == client.ObjectKeyFromObject(t.Entity) &&
 		e.Op == t.Op
 }

--- a/controller/konnect/ops/ops_kongcacertificate.go
+++ b/controller/konnect/ops/ops_kongcacertificate.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
@@ -119,7 +118,7 @@ func adoptCACertificate(
 ) error {
 	cpID := cert.GetControlPlaneID()
 	if cpID == "" {
-		return errors.New("No Control Plane ID")
+		return KonnectEntityAdoptionMissingControlPlaneIDError{}
 	}
 
 	adoptOptions := cert.Spec.Adopt

--- a/controller/konnect/ops/ops_kongcertificate.go
+++ b/controller/konnect/ops/ops_kongcertificate.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -147,7 +146,7 @@ func adoptCertificate(
 ) error {
 	cpID := cert.GetControlPlaneID()
 	if cpID == "" {
-		return errors.New("No Control Plane ID")
+		return KonnectEntityAdoptionMissingControlPlaneIDError{}
 	}
 	adoptOptions := cert.Spec.Adopt
 	konnectID := adoptOptions.Konnect.ID

--- a/controller/konnect/ops/ops_kongkey.go
+++ b/controller/konnect/ops/ops_kongkey.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
@@ -99,7 +98,7 @@ func adoptKey(
 ) error {
 	cpID := key.GetControlPlaneID()
 	if cpID == "" {
-		return errors.New("No Control Plane ID")
+		return KonnectEntityAdoptionMissingControlPlaneIDError{}
 	}
 
 	adoptOptions := key.Spec.Adopt

--- a/controller/konnect/ops/ops_kongkeyset.go
+++ b/controller/konnect/ops/ops_kongkeyset.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
@@ -100,7 +99,7 @@ func adoptKeySet(
 ) error {
 	cpID := keySet.GetControlPlaneID()
 	if cpID == "" {
-		return errors.New("No Control Plane ID")
+		return KonnectEntityAdoptionMissingControlPlaneIDError{}
 	}
 
 	adoptOptions := keySet.Spec.Adopt

--- a/controller/konnect/ops/ops_kongpluginbinding.go
+++ b/controller/konnect/ops/ops_kongpluginbinding.go
@@ -151,7 +151,7 @@ func adoptPluginBinding(
 	cpID := pluginBinding.GetControlPlaneID()
 	adoptOptions := pluginBinding.Spec.Adopt
 	if cpID == "" {
-		return errors.New("No Control Plane ID")
+		return KonnectEntityAdoptionMissingControlPlaneIDError{}
 	}
 	if adoptOptions == nil || adoptOptions.Konnect == nil {
 		return errors.New("Konnect adopt options must be provided")

--- a/controller/konnect/ops/ops_kongroute.go
+++ b/controller/konnect/ops/ops_kongroute.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
@@ -114,7 +113,7 @@ func adoptRoute(
 ) error {
 	cpID := route.GetControlPlaneID()
 	if cpID == "" {
-		return errors.New("No Control Plane ID")
+		return KonnectEntityAdoptionMissingControlPlaneIDError{}
 	}
 
 	adoptOptions := route.Spec.Adopt
@@ -129,7 +128,9 @@ func adoptRoute(
 	}
 	// KO only supports routes with "RouteJSON" type now.
 	if resp.Route.Type != sdkkonnectcomp.RouteTypeRouteJSON {
-		return fmt.Errorf("failed to adopt: route type %q not supported", resp.Route.Type)
+		return KonnectEntityAdoptionRouteTypeNotSupportedError{
+			RouteType: resp.Route.Type,
+		}
 	}
 	if resp.Route.RouteJSON == nil {
 		return fmt.Errorf("route content in RouteJSON is empty")
@@ -146,7 +147,7 @@ func adoptRoute(
 			return fmt.Errorf("failed to adopt: existing route does not have service reference")
 		}
 		if *resp.Route.RouteJSON.Service.ID != route.Status.Konnect.ServiceID {
-			return fmt.Errorf("failed to adopt: reference service ID does not match")
+			return KonnectEntityAdoptionReferenceServiceIDMismatchError{}
 		}
 	} else if resp.Route.RouteJSON.Service != nil {
 		// if the KongRoute does not have a service reference, the existing route should not have a reference service.

--- a/controller/konnect/ops/ops_kongservice.go
+++ b/controller/konnect/ops/ops_kongservice.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -116,7 +115,7 @@ func adoptService(
 	adoptOptions := svc.Spec.Adopt
 	konnectID := adoptOptions.Konnect.ID
 	if cpID == "" {
-		return errors.New("No Control Plane ID")
+		return KonnectEntityAdoptionMissingControlPlaneIDError{}
 	}
 	resp, err := sdk.GetService(ctx, konnectID, cpID)
 	if err != nil {

--- a/controller/konnect/ops/ops_kongsni.go
+++ b/controller/konnect/ops/ops_kongsni.go
@@ -133,7 +133,7 @@ func adoptSNI(
 ) error {
 	cpID := sni.GetControlPlaneID()
 	if cpID == "" {
-		return errors.New("No Control Plane ID")
+		return KonnectEntityAdoptionMissingControlPlaneIDError{}
 	}
 	if sni.Status.Konnect == nil || sni.Status.Konnect.CertificateID == "" {
 		return fmt.Errorf("can't adopt %T %s without a Konnect Certificate ID", sni, client.ObjectKeyFromObject(sni))

--- a/controller/konnect/ops/ops_kongtarget.go
+++ b/controller/konnect/ops/ops_kongtarget.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
@@ -110,7 +109,7 @@ func adoptTarget(
 	cpID := target.GetControlPlaneID()
 
 	if cpID == "" {
-		return errors.New("No Control Plane ID")
+		return KonnectEntityAdoptionMissingControlPlaneIDError{}
 	}
 	if target.Status.Konnect == nil || target.Status.Konnect.UpstreamID == "" {
 		return fmt.Errorf("can't adopt %T %s without a Konnect Upstream ID", target, client.ObjectKeyFromObject(target))

--- a/controller/konnect/ops/ops_kongupstream.go
+++ b/controller/konnect/ops/ops_kongupstream.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
@@ -96,7 +95,7 @@ func adoptUpstream(
 	adoptOptions := upstream.Spec.Adopt
 	konnectID := adoptOptions.Konnect.ID
 	if cpID == "" {
-		return errors.New("No Control Plane ID")
+		return KonnectEntityAdoptionMissingControlPlaneIDError{}
 	}
 	resp, err := sdk.GetUpstream(ctx, konnectID, cpID)
 	if err != nil {

--- a/controller/konnect/ops/ops_kongvault.go
+++ b/controller/konnect/ops/ops_kongvault.go
@@ -3,7 +3,6 @@ package ops
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"reflect"
 
@@ -83,7 +82,7 @@ func deleteVault(ctx context.Context, sdk sdkops.VaultSDK, vault *configurationv
 func adoptVault(ctx context.Context, sdk sdkops.VaultSDK, vault *configurationv1alpha1.KongVault) error {
 	cpID := vault.GetControlPlaneID()
 	if cpID == "" {
-		return errors.New("No Control Plane ID")
+		return KonnectEntityAdoptionMissingControlPlaneIDError{}
 	}
 
 	adoptOptions := vault.Spec.Adopt

--- a/ingress-controller/internal/adminapi/kong.go
+++ b/ingress-controller/internal/adminapi/kong.go
@@ -29,6 +29,11 @@ func (e KongGatewayUnsupportedVersionError) Error() string {
 	return fmt.Sprintf("Kong Gateway version is not supported: %s", e.msg)
 }
 
+func (e KongGatewayUnsupportedVersionError) Is(target error) bool {
+	_, ok := target.(KongGatewayUnsupportedVersionError)
+	return ok
+}
+
 // NewKongAPIClient returns a Kong API client for a given root API URL.
 // It ensures that proper User-Agent is set. Do not use kong.NewClient directly.
 func NewKongAPIClient(adminURL string, kongAdminAPIConfig managercfg.AdminAPIClientConfig, kongAdminToken string) (*kong.Client, error) {

--- a/ingress-controller/internal/adminapi/kong_test.go
+++ b/ingress-controller/internal/adminapi/kong_test.go
@@ -210,9 +210,8 @@ func TestNewKongClientForWorkspace(t *testing.T) {
 				managercfg.AdminAPIClientConfig{},
 				"",
 			)
-
 			if tc.expectError != nil {
-				require.IsType(t, err, tc.expectError)
+				require.ErrorIs(t, err, tc.expectError)
 				return
 			}
 			require.NoError(t, err)

--- a/ingress-controller/pkg/errors/errors.go
+++ b/ingress-controller/pkg/errors/errors.go
@@ -36,3 +36,9 @@ func (e KongClientNotReadyError) Error() string {
 func (e KongClientNotReadyError) Unwrap() error {
 	return e.Err
 }
+
+// Is reports any error in err's tree matches target.
+func (e KongClientNotReadyError) Is(target error) bool {
+	_, ok := target.(KongClientNotReadyError)
+	return ok
+}

--- a/ingress-controller/pkg/manager/multiinstance/manager_test.go
+++ b/ingress-controller/pkg/manager/multiinstance/manager_test.go
@@ -42,8 +42,7 @@ func TestManager_Scheduling(t *testing.T) {
 
 	t.Run("scheduling an instance with the same ID should fail", func(t *testing.T) {
 		err := multiManager.ScheduleInstance(mockInstance1)
-		require.Error(t, err)
-		require.IsType(t, multiinstance.InstanceWithIDAlreadyScheduledError{}, err)
+		require.ErrorIs(t, err, multiinstance.NewInstanceWithIDAlreadyScheduledError(mockInstance1.ID()))
 	})
 
 	managerRunning := make(chan struct{})
@@ -85,8 +84,7 @@ func TestManager_Scheduling(t *testing.T) {
 		// because the information hasn't been sent on StopChannel yet.
 		require.EventuallyWithT(t, func(t *assert.CollectT) {
 			err := multiManager.IsInstanceReady(mockInstance1.ID())
-			require.Error(t, err)
-			require.IsType(t, multiinstance.InstanceNotFoundError{}, err)
+			require.ErrorIs(t, err, multiinstance.NewInstanceNotFoundError(mockInstance1.ID()))
 		}, waitTime, tickTime)
 	})
 }

--- a/ingress-controller/test/kongintegration/inmemory_update_strategy_test.go
+++ b/ingress-controller/test/kongintegration/inmemory_update_strategy_test.go
@@ -118,8 +118,8 @@ func TestUpdateStrategyInMemory_PropagatesResourcesErrors(t *testing.T) {
 			fmt.Printf("DEBUG: error is not UpdateError, actual type: %T, value: %v\n", err, err)
 			return
 		}
-		if wrappedErr := updateError.Unwrap(); !assert.Error(t, wrappedErr) || !assert.IsType(t, &kong.APIError{}, wrappedErr) {
-			fmt.Printf("DEBUG: unwrapped error is not *kong.APIError, type: %T, value: %v\n", wrappedErr, wrappedErr)
+		var apiErr *kong.APIError
+		if !assert.ErrorAs(t, updateError, &apiErr) {
 			return
 		}
 		if !assert.NotEmpty(t, updateError.ResourceFailures()) {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -19,6 +19,28 @@ var ErrUnexpectedObject = errors.New("unexpected object type provided")
 // Gateway - Errors
 // -----------------------------------------------------------------------------
 
+// FetchingError is a custom error that must be used when an error occurs while
+// fetching a resource from the Kubernetes API.
+type FetchingError struct {
+	err error
+}
+
+// NewFetchingError creates a new FetchingError with the provided error.
+func NewFetchingError(err error) FetchingError {
+	return FetchingError{err: err}
+}
+
+// Error returns the error message for the FetchingError.
+func (e FetchingError) Error() string {
+	return fmt.Sprintf("error while fetching resource: %v", e.err)
+}
+
+// Is reports any error in err's tree matches target.
+func (e FetchingError) Is(target error) bool {
+	_, ok := target.(FetchingError)
+	return ok
+}
+
 // UnsupportedGatewayClassError is an error which indicates that a provided GatewayClass
 // is not supported.
 type UnsupportedGatewayClassError struct {

--- a/internal/utils/gatewayclass/get.go
+++ b/internal/utils/gatewayclass/get.go
@@ -24,7 +24,7 @@ func Get(ctx context.Context, cl client.Client, gatewayClassName string) (*Decor
 
 	gwc := NewDecorator()
 	if err := cl.Get(ctx, client.ObjectKey{Name: gatewayClassName}, gwc.GatewayClass); err != nil {
-		return nil, fmt.Errorf("error while fetching GatewayClass %q: %w", gatewayClassName, err)
+		return nil, operatorerrors.NewFetchingError(err)
 	}
 
 	if string(gwc.Spec.ControllerName) != vars.ControllerName() {

--- a/internal/versions/validation_test.go
+++ b/internal/versions/validation_test.go
@@ -84,10 +84,8 @@ func Test_versionFromImage(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Tag, func(t *testing.T) {
 			actual, err := FromImage(tc.Tag)
-
 			if tc.ExpectedError != nil {
-				require.Error(t, err)
-				require.ErrorAs(t, err, &tc.ExpectedError)
+				require.ErrorIs(t, err, tc.ExpectedError)
 			} else {
 				require.NoError(t, err)
 				expected := tc.Expected(t)


### PR DESCRIPTION
**What this PR does / why we need it**:

One from the series, to keep it reviewable. 

Enable and apply fixes for `error-is-as` rule for [testifylint](https://golangci-lint.run/docs/linters/configuration/#testifylint), which finds some legitimate cases. Some tests asserted nothing, because any error implements the Error interface. Now testing is more concrete. The example report

```
error-is-as: second argument to require.ErrorAs should not be *error (testifylint)
```


**Which issue this PR fixes**

Part of 

- https://github.com/Kong/kong-operator/issues/1847