### PR TITLE
chore(ci): migrate modernize to new repo and add go fix

### DIFF
--- a/.tools_versions.yaml
+++ b/.tools_versions.yaml
@@ -5,7 +5,7 @@ controller-tools: "0.20.1"
 # renovate: datasource=github-releases depName=golangci/golangci-lint
 golangci-lint: "2.9.0"
 # TODO: Renovate comment is missing. This needs to be added at some point.
-modernize: "0.19.1"
+modernize: "0.42.0"
 # renovate: datasource=github-releases depName=GoogleContainerTools/skaffold
 skaffold: "2.17.2"
 # renovate: datasource=github-releases depName=go-delve/delve

--- a/controller/hybridgateway/managedfields/prune.go
+++ b/controller/hybridgateway/managedfields/prune.go
@@ -59,7 +59,7 @@ func pruneEmptyFields(m map[string]any) {
 			}
 			// Don't delete pointer fields that point to zero values (user explicitly set them to zero).
 			// Only delete if the pointer itself is nil.
-			if rv.Kind() == reflect.Ptr {
+			if rv.Kind() == reflect.Pointer {
 				if rv.IsNil() {
 					delete(m, k)
 				}

--- a/hack/generators/cache-stores/templates.go
+++ b/hack/generators/cache-stores/templates.go
@@ -47,7 +47,7 @@ func NewCacheStores() CacheStores {
 }
 
 // Get checks whether or not there's already some version of the provided object present in the cache.
-func (c CacheStores) Get(obj runtime.Object) (item interface{}, exists bool, err error) {
+func (c CacheStores) Get(obj runtime.Object) (item any, exists bool, err error) {
 	c.l.RLock()
 	defer c.l.RUnlock()
 

--- a/ingress-controller/internal/store/zz_generated.cache_stores.go
+++ b/ingress-controller/internal/store/zz_generated.cache_stores.go
@@ -82,7 +82,7 @@ func NewCacheStores() CacheStores {
 }
 
 // Get checks whether or not there's already some version of the provided object present in the cache.
-func (c CacheStores) Get(obj runtime.Object) (item interface{}, exists bool, err error) {
+func (c CacheStores) Get(obj runtime.Object) (item any, exists bool, err error) {
 	c.l.RLock()
 	defer c.l.RUnlock()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`modernize` added a note at https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize:

> Deprecated: use 'go run golang.org/x/tools/go/passes/modernize/cmd/modernize' instead. In due course the modernizer suite will be accessed through "go fix"; see https://go.dev/issue/71859.

Hence this PR uses the new location:  https://pkg.go.dev/golang.org/x/tools@v0.42.0/go/analysis/passes/modernize/cmd/modernize.

Additionally, add `go fix` call through `make lint.go.fix`

This PR doesn't get rid of `modernize` just yet because `go fix` doesn't seem to be reliable just yet.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
