### PR TITLE
chore(lint): enable golangci-lint: `revive` stop ignoring docs rule for `pkg/`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -187,8 +187,7 @@ linters:
     rules:
       - linters:
           - revive
-        # pkg/|test/ has been added, see TODO: https://github.com/Kong/kong-operator/issues/1847
-        path: internal/|pkg/|test/
+        path: internal/|test/
         text: 'exported: exported'
       - linters:
           - revive

--- a/ingress-controller/pkg/manager/manager.go
+++ b/ingress-controller/pkg/manager/manager.go
@@ -110,6 +110,7 @@ func (m *Manager) DiagnosticsHandler() http.Handler {
 	return m.manager.DiagnosticsHandler()
 }
 
+// KongValidator returns the Kong HTTP validator of the manager.
 func (m *Manager) KongValidator() admission.KongHTTPValidator {
 	return m.manager.KongValidator()
 }

--- a/ingress-controller/pkg/manager/multiinstance/diagnostics.go
+++ b/ingress-controller/pkg/manager/multiinstance/diagnostics.go
@@ -33,6 +33,7 @@ type DiagnosticsServer struct {
 // DiagnosticsServerOption is a functional option for configuring the DiagnosticsServer.
 type DiagnosticsServerOption func(*DiagnosticsServer)
 
+// WithPprofHandler is a functional option that enables pprof handlers for the DiagnosticsServer.
 func WithPprofHandler() DiagnosticsServerOption {
 	return func(s *DiagnosticsServer) {
 		s.pprofMux = http.NewServeMux()
@@ -44,6 +45,8 @@ func WithPprofHandler() DiagnosticsServerOption {
 	}
 }
 
+// NewDiagnosticsServer creates a new DiagnosticsServer with the given listener port and options.
+// It exposes diagnostics endpoints for each instance registered to it.
 func NewDiagnosticsServer(listenerPort int, opts ...DiagnosticsServerOption) *DiagnosticsServer {
 	s := &DiagnosticsServer{
 		listenerPort: listenerPort,

--- a/ingress-controller/pkg/manager/multiinstance/errors.go
+++ b/ingress-controller/pkg/manager/multiinstance/errors.go
@@ -7,6 +7,7 @@ type InstanceWithIDAlreadyScheduledError struct {
 	id manager.ID
 }
 
+// NewInstanceWithIDAlreadyScheduledError creates a new InstanceWithIDAlreadyScheduledError for the given ID.
 func NewInstanceWithIDAlreadyScheduledError(id manager.ID) InstanceWithIDAlreadyScheduledError {
 	return InstanceWithIDAlreadyScheduledError{id: id}
 }
@@ -21,6 +22,7 @@ type InstanceNotFoundError struct {
 	id manager.ID
 }
 
+// NewInstanceNotFoundError creates a new InstanceNotFoundError for the given ID.
 func NewInstanceNotFoundError(id manager.ID) InstanceNotFoundError {
 	return InstanceNotFoundError{id: id}
 }

--- a/ingress-controller/pkg/manager/multiinstance/manager.go
+++ b/ingress-controller/pkg/manager/multiinstance/manager.go
@@ -58,12 +58,16 @@ type Manager struct {
 // ManagerOption is a functional option that can be used to configure a new multi-instance manager.
 type ManagerOption func(*Manager)
 
+// WithDiagnosticsExposer configures the multi-instance manager to
+// register diagnostics handlers of manager.Manager instances.
 func WithDiagnosticsExposer(exposer DiagnosticsExposer) ManagerOption {
 	return func(m *Manager) {
 		m.diagnosticsExposer = exposer
 	}
 }
 
+// WithValidator configures the multi-instance manager to register
+// KongHTTPValidators of manager.Manager instances.
 func WithValidator(admissionReqHandler *admission.RequestHandler) ManagerOption {
 	return func(m *Manager) {
 		m.admissionReqHandler = admissionReqHandler
@@ -163,6 +167,8 @@ func (m *Manager) IsInstanceReady(id manager.ID) error {
 	return in.IsReady()
 }
 
+// GetInstanceConfigHash returns the hash of the configuration of a manager.Manager instance with the given ID.
+// If no instance with the given ID exists, it returns a InstanceNotFoundError.
 func (m *Manager) GetInstanceConfigHash(id manager.ID) (string, error) {
 	m.instancesLock.RLock()
 	defer m.instancesLock.RUnlock()

--- a/ingress-controller/pkg/telemetry/manager.go
+++ b/ingress-controller/pkg/telemetry/manager.go
@@ -23,10 +23,11 @@ import (
 
 const (
 	prefix      = "ko-ingress-controller"
-	SignalStart = prefix + "-start"
-	SignalPing  = prefix + "-ping"
+	signalStart = prefix + "-start"
+	signalPing  = prefix + "-ping"
 )
 
+// ReportValues holds values that are included in telemetry reports.
 type ReportValues struct {
 	FeatureGates                   map[string]bool
 	MeshDetection                  bool
@@ -86,7 +87,7 @@ func createManager(
 	opts ...telemetry.OptManager,
 ) (telemetry.Manager, error) {
 	m, err := telemetry.NewManager(
-		SignalPing,
+		signalPing,
 		opts...,
 	)
 	if err != nil {

--- a/ingress-controller/pkg/telemetry/reports.go
+++ b/ingress-controller/pkg/telemetry/reports.go
@@ -27,6 +27,7 @@ const (
 	telemetryPeriod                  = time.Hour
 )
 
+// ReportConfig holds configuration for telemetry reports.
 type ReportConfig struct {
 	SplunkEndpoint                   string
 	SplunkEndpointInsecureSkipVerify bool
@@ -115,7 +116,7 @@ func SetupAnonymousReports(
 		return nil, fmt.Errorf("anonymous reports failed to start: %w", err)
 	}
 
-	if err := tMgr.TriggerExecute(ctx, SignalStart); err != nil {
+	if err := tMgr.TriggerExecute(ctx, signalStart); err != nil {
 		tMgr.Stop()
 		return nil, fmt.Errorf("failed to trigger telemetry report during start: %w", err)
 	}

--- a/ingress-controller/pkg/telemetry/workflows/gateway_discovery.go
+++ b/ingress-controller/pkg/telemetry/workflows/gateway_discovery.go
@@ -10,17 +10,18 @@ import (
 	"github.com/kong/kubernetes-telemetry/pkg/types"
 )
 
-const GatewayDiscoveryWorkflowName = "gateway_discovery"
+const gatewayDiscoveryWorkflowName = "gateway_discovery"
 
 // DiscoveredGatewaysCounter is an interface that allows to count currently discovered Gateways.
 type DiscoveredGatewaysCounter interface {
 	GatewayClientsCount() int
 }
 
+// NewGatewayDiscoveryWorkflow creates a new telemetry workflow that reports the number of currently discovered Gateways.
 func NewGatewayDiscoveryWorkflow(gatewaysCounter DiscoveredGatewaysCounter) (telemetry.Workflow, error) {
-	w := telemetry.NewWorkflow(GatewayDiscoveryWorkflowName)
+	w := telemetry.NewWorkflow(gatewayDiscoveryWorkflowName)
 
-	discoveredGatewaysCountProvider, err := NewDiscoveredGatewaysCountProvider(gatewaysCounter)
+	discoveredGatewaysCountProvider, err := newDiscoveredGatewaysCountProvider(gatewaysCounter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discovered gateways count provider: %w", err)
 	}
@@ -29,35 +30,40 @@ func NewGatewayDiscoveryWorkflow(gatewaysCounter DiscoveredGatewaysCounter) (tel
 	return w, nil
 }
 
-// DiscoveredGatewaysCountProvider is a provider that reports the number of currently discovered Gateways.
-type DiscoveredGatewaysCountProvider struct {
+// discoveredGatewaysCountProvider is a provider that reports the number of currently discovered Gateways.
+type discoveredGatewaysCountProvider struct {
 	counter DiscoveredGatewaysCounter
 }
 
-func NewDiscoveredGatewaysCountProvider(counter DiscoveredGatewaysCounter) (*DiscoveredGatewaysCountProvider, error) {
+var _ provider.Provider = (*discoveredGatewaysCountProvider)(nil)
+
+func newDiscoveredGatewaysCountProvider(counter DiscoveredGatewaysCounter) (*discoveredGatewaysCountProvider, error) {
 	if counter == nil {
 		return nil, errors.New("discovered gateways counter is required")
 	}
 
-	return &DiscoveredGatewaysCountProvider{counter: counter}, nil
+	return &discoveredGatewaysCountProvider{counter: counter}, nil
 }
 
 const (
-	DiscoveredGatewaysCountProviderName = "discovered_gateways_count"
-	DiscoveredGatewaysCountProviderKind = provider.Kind(DiscoveredGatewaysCountProviderName)
-	DiscoveredGatewaysCountKey          = types.ProviderReportKey(DiscoveredGatewaysCountProviderName)
+	discoveredGatewaysCountProviderName = "discovered_gateways_count"
+	discoveredGatewaysCountProviderKind = provider.Kind(discoveredGatewaysCountProviderName)
+	discoveredGatewaysCountKey          = types.ProviderReportKey(discoveredGatewaysCountProviderName)
 )
 
-func (d *DiscoveredGatewaysCountProvider) Name() string {
-	return DiscoveredGatewaysCountProviderName
+// Name returns the name of the provider.
+func (d *discoveredGatewaysCountProvider) Name() string {
+	return discoveredGatewaysCountProviderName
 }
 
-func (d *DiscoveredGatewaysCountProvider) Kind() provider.Kind {
-	return DiscoveredGatewaysCountProviderKind
+// Kind returns the kind of the provider.
+func (d *discoveredGatewaysCountProvider) Kind() provider.Kind {
+	return discoveredGatewaysCountProviderKind
 }
 
-func (d *DiscoveredGatewaysCountProvider) Provide(context.Context) (types.ProviderReport, error) {
+// Provide returns the number of currently discovered Gateways as a provider report.
+func (d *discoveredGatewaysCountProvider) Provide(context.Context) (types.ProviderReport, error) {
 	return types.ProviderReport{
-		DiscoveredGatewaysCountKey: d.counter.GatewayClientsCount(),
+		discoveredGatewaysCountKey: d.counter.GatewayClientsCount(),
 	}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

One from the series, to keep it reviewable. 

Enable and apply fixes for the ignored docs rule for `pkg/name` for [revive](https://golangci-lint.run/docs/linters/configuration/#revive) to keep it consistent. For `internal/|test/`, it makes sense to leave it as is, so the TODO is considered resolved. 

**Which issue this PR fixes**

Part of 

- https://github.com/Kong/kong-operator/issues/1847