### PR TITLE
chore(lint): resolve all TODOs from `.golangci.yaml`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -85,9 +85,6 @@ linters:
       default-signifies-exhaustive: true
     forbidigo:
       forbid:
-        # Uncomment or remove - TODO: https://github.com/Kong/kong-operator/issues/1847
-        # - pattern: ^.*Dataplane[^G].*$
-        #   msg: Please use camel case 'DataPlane' instead of 'Dataplane'
         - pattern: ^.*Controlplane.*$
           msg: Please use camel case 'ControlPlane' instead of 'Controlplane'
         - pattern: ^.*operatorv1beta1.ControlPlane.*$
@@ -208,7 +205,6 @@ linters:
           - gosec
         path: .*_test\.go
         text: Use of weak random number generator
-      # Remove/adjust whole section - TODO: https://github.com/Kong/kong-operator/issues/1847
       - linters:
           - gosec
         path: .*_test\.go


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes all TODOs from `.golangci.yaml`. 

Diff for 
```
# Uncomment or remove - TODO: https://github.com/Kong/kong-operator/issues/1847
        # - pattern: ^.*Dataplane[^G].*$
        #   msg: Please use camel case 'DataPlane' instead of 'Dataplane'
```

is enormous and in sdk `Dataplane` is used, so interfaces etc. have to match.

For section

```
# Remove/adjust whole section - TODO: https://github.com/Kong/kong-operator/issues/1847
```

too many false positives.

Closes #1847