### PR TITLE
test(chainsaw): align conversion webhook tests with chainsaw best practices

### DIFF
--- a/test/e2e/chainsaw/conversion_webhook/controlplane/00-assert-controlplane.yml
+++ b/test/e2e/chainsaw/conversion_webhook/controlplane/00-assert-controlplane.yml
@@ -2,7 +2,7 @@ apiVersion: gateway-operator.konghq.com/v1beta1
 kind: DataPlane
 metadata:
   name: ($dataplane_name)
-  namespace: ($kong_namespace)
+  namespace: ($namespace)
 status:
   (conditions[?type == 'Ready']):
     - status: 'True'
@@ -12,7 +12,7 @@ apiVersion: gateway-operator.konghq.com/v2beta1
 kind: ControlPlane
 metadata:
   name: ($controlplane_name)
-  namespace: ($kong_namespace)
+  namespace: ($namespace)
 spec:
   configDump:
     dumpSensitive: disabled

--- a/test/e2e/chainsaw/conversion_webhook/controlplane/00-controlplane.yml
+++ b/test/e2e/chainsaw/conversion_webhook/controlplane/00-controlplane.yml
@@ -1,14 +1,9 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ($kong_namespace)
----
 apiVersion: gateway-operator.konghq.com/v1beta1
 kind: DataPlane
 metadata:
   name: ($dataplane_name)
-  namespace: ($kong_namespace)
+  namespace: ($namespace)
 spec:
   deployment:
     podTemplateSpec:
@@ -21,7 +16,7 @@ apiVersion: gateway-operator.konghq.com/v1beta1
 kind: ControlPlane
 metadata:
   name: ($controlplane_name)
-  namespace: ($kong_namespace)
+  namespace: ($namespace)
 spec:
   dataplane: ($dataplane_name)
   gatewayClass: ($gateway_class_name)

--- a/test/e2e/chainsaw/conversion_webhook/controlplane/chainsaw-test.yml
+++ b/test/e2e/chainsaw/conversion_webhook/controlplane/chainsaw-test.yml
@@ -8,20 +8,15 @@ spec:
     This test validates that the v1beta1 ControlPlane is converted to v2beta1.
 
   bindings:
-    - name: kong_namespace
-      value: (join('-', ['kong', 'controlplane', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: test_name
+      value: ($namespace)
     - name: dataplane_name
-      value: (join('-', ['kong', 'dataplane', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+      value: (join('-', [($test_name), 'dataplane']))
     - name: controlplane_name
-      value: (join('-', ['kong', 'controlplane', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+      value: (join('-', [($test_name), 'controlplane']))
     - name: gateway_class_name
       value: ($controlplane_name)
 
-  timeouts:
-    apply: 120s
-    assert: 300s
-    cleanup: 120s
-    delete: 120s
   steps:
     - name: create-resources
       description: Create ControlPlane v1beta1 (will be converted to v2beta1) and all other needed resources
@@ -30,3 +25,17 @@ spec:
             file: 00-controlplane.yml
         - assert:
             file: 00-assert-controlplane.yml
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: conversion-webhook-controlplane
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/conversion_webhook/konnect-gateway-controlplane/00-assert-konnect-gateway-controlplane.yml
+++ b/test/e2e/chainsaw/conversion_webhook/konnect-gateway-controlplane/00-assert-konnect-gateway-controlplane.yml
@@ -1,13 +1,8 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ($kong_namespace)
----
 apiVersion: konnect.konghq.com/v1alpha1
 kind: KonnectAPIAuthConfiguration
 metadata:
   name: ($konnect_api_auth_name)
-  namespace: ($kong_namespace)
+  namespace: ($namespace)
 status:
   conditions:
     - type: APIAuthValid
@@ -17,7 +12,7 @@ apiVersion: konnect.konghq.com/v1alpha2
 kind: KonnectGatewayControlPlane
 metadata:
   name: ($konnect_gateway_controlplane_name)
-  namespace: ($kong_namespace)
+  namespace: ($namespace)
 spec:
   createControlPlaneRequest:
     name: ($konnect_gateway_controlplane_name)
@@ -41,4 +36,3 @@ status:
   (konnectEndpoints.telemetry != null): true
   (organizationID != null): true
   (serverURL != null): true
----

--- a/test/e2e/chainsaw/conversion_webhook/konnect-gateway-controlplane/00-konnect-gateway-controlplane.yml
+++ b/test/e2e/chainsaw/conversion_webhook/konnect-gateway-controlplane/00-konnect-gateway-controlplane.yml
@@ -1,14 +1,9 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ($kong_namespace)
----
 apiVersion: konnect.konghq.com/v1alpha1
 kind: KonnectAPIAuthConfiguration
 metadata:
   name: ($konnect_api_auth_name)
-  namespace: ($kong_namespace)
+  namespace: ($namespace)
 spec:
   type: token
   token: (env('KONNECT_TOKEN'))
@@ -18,7 +13,7 @@ apiVersion: konnect.konghq.com/v1alpha1
 kind: KonnectGatewayControlPlane
 metadata:
   name: ($konnect_gateway_controlplane_name)
-  namespace: ($kong_namespace)
+  namespace: ($namespace)
 spec:
   name: ($konnect_gateway_controlplane_name)
   konnect:

--- a/test/e2e/chainsaw/conversion_webhook/konnect-gateway-controlplane/chainsaw-test.yml
+++ b/test/e2e/chainsaw/conversion_webhook/konnect-gateway-controlplane/chainsaw-test.yml
@@ -8,18 +8,12 @@ spec:
     This test validates that the v1alpha1 KonnectGatewayControlPlane is converted to v2alpha1.
 
   bindings:
-    - name: kong_namespace
-      value: (join('-', ['kong', 'konnect-gateway-controlplane', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+    - name: test_name
+      value: ($namespace)
     - name: konnect_api_auth_name
-      value: (join('-', ['kong', 'konnect-api-auth', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
+      value: (join('-', [($test_name), 'konnect-api-auth']))
     - name: konnect_gateway_controlplane_name
-      value: (join('-', ['kong', 'konnect-gateway-controlplane', (env('GITHUB_RUN_ID') || env('TEST_ID') || 'local')]))
-
-  timeouts:
-    apply: 120s
-    assert: 300s
-    cleanup: 120s
-    delete: 120s
+      value: (join('-', [($test_name), 'konnect-gateway-controlplane']))
 
   steps:
     - name: create-konnect-resources
@@ -29,9 +23,17 @@ spec:
             file: 00-konnect-gateway-controlplane.yml
         - assert:
             file: 00-assert-konnect-gateway-controlplane.yml
-      catch:
-        - description: Get KonnectGatewayControlPlane resource status
-          get:
-            apiVersion: konnect.konghq.com/v1alpha2
-            kind: KonnectGatewayControlPlane
-            namespace: ($kong_namespace)
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: conversion-webhook-konnect-gateway-controlplane
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh


### PR DESCRIPTION
**What this PR does / why we need it**:

Use chainsaw's auto-created namespace instead of manually creating custom namespaces, add debug snapshot capture on test failure, and remove unnecessary spec-level timeouts.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
