### PR TITLE
fix: name in Konnect matches K8s name for `KonnectGatewayControlPlane`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@
 - Fix `ResolvedRefs` status condition on `HTTPRoute` not being updated when a
   referenced `KongPlugin` is deleted in self-managed ControlPlane mode.
   [#3206](https://github.com/Kong/kong-operator/pull/3206)
+- Name of Konnect Gateway Control Plane resource created in Konnect matches
+  the name of the corresponding `KonnectGatewayControlPlane` resource in Kubernetes
+  also in for name with random suffix. It prevents collisions in Konnect.
+  [#3357](https://github.com/Kong/kong-operator/pull/3357)
 
 ## [v2.1.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
   [#3206](https://github.com/Kong/kong-operator/pull/3206)
 - Name of Konnect Gateway Control Plane resource created in Konnect matches
   the name of the corresponding `KonnectGatewayControlPlane` resource in Kubernetes
-  also in for name with random suffix. It prevents collisions in Konnect.
+  (the same random suffix is added). It prevents collisions in Konnect.
   [#3357](https://github.com/Kong/kong-operator/pull/3357)
 
 ## [v2.1.0]

--- a/pkg/utils/kubernetes/metadata.go
+++ b/pkg/utils/kubernetes/metadata.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -93,4 +94,23 @@ func TrimGenerateName(name string) string {
 		name += "-"
 	}
 	return name
+}
+
+// GenerateName generates a name for the object by concatenating the provided base string with a random string of 5 characters.
+// It's implementation is based on the Kubernetes GenerateName field ([source]), argument base does not require calling
+// TrimGenerateName before, as the function calls it internally.
+//
+// [source]: https://github.com/kubernetes/kubernetes/blob/d820c046f5c520aab51ec850b263524b1fa5a4e9/staging/src/k8s.io/apiserver/pkg/storage/names/generate.go
+func GenerateName(base string) string {
+	base = TrimGenerateName(base)
+
+	const (
+		maxNameLength          = 63
+		randomLength           = 5
+		maxGeneratedNameLength = maxNameLength - randomLength
+	)
+	if len(base) > maxGeneratedNameLength {
+		base = base[:maxGeneratedNameLength]
+	}
+	return fmt.Sprintf("%s%s", base, utilrand.String(randomLength))
 }

--- a/pkg/utils/kubernetes/metadata.go
+++ b/pkg/utils/kubernetes/metadata.go
@@ -104,13 +104,6 @@ func TrimGenerateName(name string) string {
 func GenerateName(base string) string {
 	base = TrimGenerateName(base)
 
-	const (
-		maxNameLength          = 63
-		randomLength           = 5
-		maxGeneratedNameLength = maxNameLength - randomLength
-	)
-	if len(base) > maxGeneratedNameLength {
-		base = base[:maxGeneratedNameLength]
-	}
+	const randomLength = 5
 	return fmt.Sprintf("%s%s", base, utilrand.String(randomLength))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

To prevent

```
Message:               {"status":409,"title":"Conflict","instance":"","detail":"Key (org_id, name)=(8a6e97b1-b481-4fc2-8399-a59077076af6, gateway-conformance-infra-same-namespace) already exists."}
```

for `KonnectGatewayControlPlane` name specified in Spec section Create Control Plane Request in the field Name has to be unique across Konnect org.

In a real-world scenario, such colision may happen when a user has to separate K8s with the same configuration (e.g., `dev-1` and `dev-2`) in a single Konnect org. The fix proposed in this PR resolves the problem.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

To match the name in Konnect with the name in the K8s cluster, relying on server-side name generation is not an option, the code responsible for it has been incorporated in KO.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
