### PR TITLE
tests: use Service Accounts instead of Personal Access tokens to avoid hitting the limit of 10 tokens per user

### DIFF
--- a/hack/cleanup/konnect_system_accounts.go
+++ b/hack/cleanup/konnect_system_accounts.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/go-logr/logr"
+
+	"github.com/kong/kong-operator/v2/test"
+)
+
+const (
+	systemAccountsPageSize         = int64(100)
+	timeUntilSystemAccountOrphaned = time.Hour
+)
+
+// cleanupKonnectSystemAccounts deletes orphaned system accounts created by the tests.
+func cleanupKonnectSystemAccounts(ctx context.Context, log logr.Logger) error {
+	serverURL, err := canonicalizedServerURL()
+	if err != nil {
+		return fmt.Errorf("invalid server URL %s: %w", test.KonnectServerURL(), err)
+	}
+
+	sdk := sdkkonnectgo.New(
+		sdkkonnectgo.WithSecurity(
+			sdkkonnectcomp.Security{
+				PersonalAccessToken: new(test.KonnectAccessToken()),
+			},
+		),
+		sdkkonnectgo.WithServerURL(serverURL),
+	)
+
+	orphanedSAs, err := findOrphanedSystemAccounts(ctx, log, sdk.SystemAccounts)
+	if err != nil {
+		return fmt.Errorf("failed to find orphaned system accounts: %w", err)
+	}
+	if err := deleteSystemAccounts(ctx, log, sdk.SystemAccounts, orphanedSAs); err != nil {
+		return fmt.Errorf("failed to delete system accounts: %w", err)
+	}
+
+	return nil
+}
+
+// findOrphanedSystemAccounts finds system accounts that were created more than timeUntilSystemAccountOrphaned ago.
+func findOrphanedSystemAccounts(
+	ctx context.Context,
+	log logr.Logger,
+	sdk *sdkkonnectgo.SystemAccounts,
+) ([]string, error) {
+	var orphanedSystemAccounts []string
+	pageNumber := int64(1)
+
+	for {
+		response, err := sdk.GetSystemAccounts(ctx, sdkkonnectops.GetSystemAccountsRequest{
+			PageSize:   new(systemAccountsPageSize),
+			PageNumber: &pageNumber,
+			Filter: &sdkkonnectops.GetSystemAccountsQueryParamFilter{
+				// Only consider non-Konnect-managed system accounts.
+				KonnectManaged: new(false),
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list system accounts (page %d): %w", pageNumber, err)
+		}
+		if response.SystemAccountCollection == nil {
+			return nil, fmt.Errorf("failed to list system accounts, response is nil (page %d)", pageNumber)
+		}
+
+		accounts := response.SystemAccountCollection.GetData()
+		if len(accounts) == 0 {
+			break
+		}
+
+		for _, sa := range accounts {
+			if sa.ID == nil {
+				log.Info("System account has no ID, skipping", "name", sa.GetName())
+				continue
+			}
+			if sa.CreatedAt == nil {
+				log.Info("System account has no creation timestamp, skipping", "id", *sa.ID, "name", sa.GetName())
+				continue
+			}
+			orphanedAfter := sa.CreatedAt.Add(timeUntilSystemAccountOrphaned)
+			if !time.Now().After(orphanedAfter) {
+				log.Info("System account is not old enough to be considered orphaned, skipping",
+					"id", *sa.ID, "name", sa.GetName(), "created_at", *sa.CreatedAt,
+				)
+				continue
+			}
+			orphanedSystemAccounts = append(orphanedSystemAccounts, *sa.ID)
+		}
+
+		if int64(len(accounts)) < systemAccountsPageSize {
+			break
+		}
+		pageNumber++
+	}
+
+	return orphanedSystemAccounts, nil
+}
+
+// deleteSystemAccounts deletes system accounts by their IDs.
+func deleteSystemAccounts(
+	ctx context.Context,
+	log logr.Logger,
+	sdk *sdkkonnectgo.SystemAccounts,
+	saIDs []string,
+) error {
+	if len(saIDs) == 0 {
+		log.Info("No system accounts to clean up")
+		return nil
+	}
+
+	var errs []error
+	for _, saID := range saIDs {
+		log.Info("Deleting system account", "id", saID)
+		if _, err := sdk.DeleteSystemAccountsID(ctx, saID); err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete system account %s: %w", saID, err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/hack/cleanup/main.go
+++ b/hack/cleanup/main.go
@@ -13,11 +13,15 @@
 // 1. It has a label `created_in_tests` with value `true`.
 // 2. It was created more than 1h ago.
 //
+// A system account is considered orphaned when all conditions are satisfied:
+// 1. It is not managed by Konnect.
+// 2. It was created more than 1h ago.
+//
 // Usage: `go run ./hack/cleanup [mode]`
 // Where `mode` is one of:
 // - `all` (default): clean up both GKE clusters and Konnect control planes
 // - `gke`: clean up only GKE clusters
-// - `konnect`: clean up only Konnect control planes
+// - `konnect`: clean up only Konnect control planes and system accounts
 package main
 
 import (
@@ -103,11 +107,13 @@ func resolveCleanupFuncs(mode string) []func(context.Context, logr.Logger) error
 	case cleanupModeKonnect:
 		return []func(context.Context, logr.Logger) error{
 			cleanupKonnectControlPlanes,
+			cleanupKonnectSystemAccounts,
 		}
 	default:
 		return []func(context.Context, logr.Logger) error{
 			cleanupGKEClusters,
 			cleanupKonnectControlPlanes,
+			cleanupKonnectSystemAccounts,
 		}
 	}
 }

--- a/ingress-controller/internal/konnect/sdk/sdk.go
+++ b/ingress-controller/internal/konnect/sdk/sdk.go
@@ -1,18 +1,23 @@
 package sdk
 
 import (
+	"strings"
+
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 )
 
 // New returns a new SDK instance.
 func New(token string, opts ...sdkkonnectgo.SDKOption) *sdkkonnectgo.SDK {
+	security := sdkkonnectcomp.Security{}
+	switch {
+	case strings.HasPrefix(token, "kpat_"):
+		security.PersonalAccessToken = new(token)
+	case strings.HasPrefix(token, "spat_"):
+		security.SystemAccountAccessToken = new(token)
+	}
 	sdkOpts := []sdkkonnectgo.SDKOption{
-		sdkkonnectgo.WithSecurity(
-			sdkkonnectcomp.Security{
-				PersonalAccessToken: new(token),
-			},
-		),
+		sdkkonnectgo.WithSecurity(security),
 	}
 	sdkOpts = append(sdkOpts, opts...)
 

--- a/ingress-controller/test/helpers/konnect/personal_access_tokens.go
+++ b/ingress-controller/test/helpers/konnect/personal_access_tokens.go
@@ -76,9 +76,11 @@ func CreateTestPersonalAccessToken(ctx context.Context, t *testing.T) string {
 	require.NoError(t, createServiceAccountToken)
 
 	t.Cleanup(func() {
-		fmt.Printf("deleting test Konnect Personal Access Token: %q", tokenID)
+		fmt.Printf("deleting test Konnect Personal Access Token: %q\n", tokenID)
 		err := retry.Do(
 			func() error { //nolint:contextcheck
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
 				_, err := s.PersonalAccessTokens.DeletePersonalAccessToken(ctx, *me.User.ID, tokenID)
 				return err
 			},
@@ -88,7 +90,7 @@ func CreateTestPersonalAccessToken(ctx context.Context, t *testing.T) string {
 		if err != nil {
 			// Don't fail the test if cleanup fails, just log the error.
 			// Cleanup job will eventually clean up konnect.
-			fmt.Printf("failed to delete test Konnect Personal Access Token %q: %v", tokenID, err)
+			fmt.Printf("failed to delete test Konnect Personal Access Token %q: %v\n", tokenID, err)
 		}
 	})
 

--- a/ingress-controller/test/helpers/konnect/system_account_tokens.go
+++ b/ingress-controller/test/helpers/konnect/system_account_tokens.go
@@ -1,0 +1,89 @@
+package konnect
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/avast/retry-go/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kong-operator/v2/ingress-controller/internal/konnect/sdk"
+)
+
+func CreateTestSystemAccountToken(ctx context.Context, t *testing.T, systemAccountID string) (string, string) {
+	t.Helper()
+
+	s := sdk.New(accessToken(), serverURLOpt())
+
+	var (
+		systemAccountToken     string
+		systemAccountTokenID   string
+		systemAccountTokenName = fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixMilli())
+	)
+	err := retry.Do(func() error {
+		createResp, err := s.SystemAccountsAccessTokens.
+			PostSystemAccountsIDAccessTokens(ctx,
+				systemAccountID,
+				&sdkkonnectcomp.CreateSystemAccountAccessToken{
+					Name:      systemAccountTokenName,
+					ExpiresAt: time.Now().Add(time.Hour),
+				},
+			)
+		if err != nil {
+			return err
+		}
+
+		if createResp == nil {
+			return fmt.Errorf("failed to create system account token: response is nil")
+		}
+
+		if createResp.GetStatusCode() != http.StatusCreated {
+			body, err := io.ReadAll(createResp.RawResponse.Body)
+			if err != nil {
+				body = []byte(err.Error())
+			}
+			return fmt.Errorf("failed to create system account token: code %d, message %s", createResp.GetStatusCode(), body)
+		}
+
+		if createResp.SystemAccountAccessTokenCreated == nil ||
+			createResp.SystemAccountAccessTokenCreated.ID == nil ||
+			createResp.SystemAccountAccessTokenCreated.Token == nil {
+			return fmt.Errorf(
+				"failed to create system account token: response fields are missing (status code %d)",
+				createResp.GetStatusCode(),
+			)
+		}
+
+		systemAccountToken = *createResp.SystemAccountAccessTokenCreated.Token
+		systemAccountTokenID = *createResp.SystemAccountAccessTokenCreated.ID
+		return nil
+	}, retry.Attempts(5), retry.Delay(time.Second))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		fmt.Printf("deleting test system account token: %q (ID: %q)\n", systemAccountTokenName, systemAccountTokenID)
+		err := retry.Do(
+			func() error {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				_, err := s.SystemAccountsAccessTokens.DeleteSystemAccountsIDAccessTokensID(ctx, systemAccountID, systemAccountTokenID)
+				return err
+			},
+			retry.Attempts(5),
+			retry.Delay(time.Second),
+		)
+		if err != nil {
+			// Don't fail the test if cleanup fails, just log the error.
+			// Cleanup job will eventually clean up konnect.
+			fmt.Printf("failed to delete test system account token %q (ID: %q): %v\n", systemAccountTokenName, systemAccountTokenID, err)
+		}
+	})
+
+	t.Logf("created test system account token : %q (ID:%q)", systemAccountTokenName, systemAccountTokenID)
+	return systemAccountTokenID, systemAccountToken
+}

--- a/ingress-controller/test/helpers/konnect/system_accounts.go
+++ b/ingress-controller/test/helpers/konnect/system_accounts.go
@@ -1,0 +1,111 @@
+package konnect
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/avast/retry-go/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kong-operator/v2/ingress-controller/internal/konnect/sdk"
+	"github.com/kong/kong-operator/v2/ingress-controller/test"
+)
+
+// CreateTestSystemAccount creates a system account in Konnect for testing purposes and returns its ID.
+// The system account is deleted during test cleanup.
+func CreateTestSystemAccount(ctx context.Context, t *testing.T) string {
+	t.Helper()
+
+	s := sdk.New(accessToken(), serverURLOpt())
+
+	var (
+		systemAccountID   string
+		systemAccountName = fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixMilli())
+	)
+	err := retry.Do(func() error {
+		createResp, err := s.SystemAccounts.
+			PostSystemAccounts(ctx,
+				&sdkkonnectcomp.CreateSystemAccount{
+					Name:           systemAccountName,
+					Description:    "Test system account for Kong Ingress Controller integration tests",
+					KonnectManaged: new(false),
+				},
+			)
+		if err != nil {
+			return err
+		}
+
+		if createResp == nil {
+			return fmt.Errorf("failed to create system account: response is nil")
+		}
+
+		if createResp.GetStatusCode() != http.StatusCreated {
+			body, err := io.ReadAll(createResp.RawResponse.Body)
+			if err != nil {
+				body = []byte(err.Error())
+			}
+			return fmt.Errorf("failed to create system account: code %d, message %s", createResp.GetStatusCode(), body)
+		}
+
+		if createResp.SystemAccount == nil ||
+			createResp.SystemAccount.ID == nil {
+			return fmt.Errorf(
+				"failed to create system account: response fields are missing (status code %d)",
+				createResp.GetStatusCode(),
+			)
+		}
+
+		systemAccountID = *createResp.SystemAccount.ID
+		return nil
+	}, retry.Attempts(5), retry.Delay(time.Second))
+	require.NoError(t, err)
+
+	assignRole(ctx, t, s.SystemAccountsRoles, systemAccountID, sdkkonnectcomp.RoleNameCreator)
+	assignRole(ctx, t, s.SystemAccountsRoles, systemAccountID, sdkkonnectcomp.RoleNameAdmin)
+
+	t.Cleanup(func() {
+		fmt.Printf("deleting test system account: %q\n", systemAccountID)
+		err := retry.Do(
+			func() error {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				_, err := s.SystemAccounts.DeleteSystemAccountsID(ctx, systemAccountID)
+				return err
+			},
+			retry.Attempts(5),
+			retry.Delay(time.Second),
+		)
+		if err != nil {
+			// Don't fail the test if cleanup fails, just log the error.
+			// Cleanup job will eventually clean up konnect.
+			fmt.Printf("failed to delete test system account %q: %v\n", systemAccountID, err)
+		}
+	})
+
+	t.Logf("created test system account: %q (ID:%q)", systemAccountName, systemAccountID)
+	return systemAccountID
+}
+
+func assignRole(ctx context.Context, t *testing.T, s *sdkkonnectgo.SystemAccountsRoles, systemAccountID string, role sdkkonnectcomp.RoleName) {
+	roleAssignResp, err := s.PostSystemAccountsAccountIDAssignedRoles(ctx, systemAccountID,
+		&sdkkonnectcomp.AssignRole{
+			RoleName:       new(role),
+			EntityTypeName: new(sdkkonnectcomp.EntityTypeNameControlPlanes),
+			EntityID:       new("*"),
+			EntityRegion:   new(sdkkonnectcomp.AssignRoleEntityRegion(test.KonnectServerRegion())),
+		},
+	)
+	require.NoError(t, err)
+	if roleAssignResp.AssignedRole.ID == nil {
+		t.Fatal("warning: assigned role response is missing ID field, cannot log assigned role ID")
+	}
+	t.Logf("assigned %q role (ID:%q)to system account %q for all control planes",
+		role, *roleAssignResp.AssignedRole.ID, systemAccountID,
+	)
+}

--- a/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
+++ b/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
@@ -110,7 +110,8 @@ func TestKongClientGoldenTestsOutputs_Konnect(t *testing.T) {
 	require.NoError(t, err)
 	gatewayTag = trimEnterpriseTagToSemver(gatewayTag)
 
-	token := konnect.CreateTestPersonalAccessToken(ctx, t)
+	systemAccountID := konnect.CreateTestSystemAccount(ctx, t)
+	_, token := konnect.CreateTestSystemAccountToken(ctx, t, systemAccountID)
 	cpID := konnect.CreateTestControlPlane(ctx, t, token)
 	cert, key := konnect.CreateClientCertificate(ctx, t, cpID, token)
 	adminAPIClient := konnect.CreateKonnectAdminAPIClient(t, cpID, cert, key)

--- a/ingress-controller/test/konnect.go
+++ b/ingress-controller/test/konnect.go
@@ -18,3 +18,17 @@ func KonnectServerURL() string {
 	}
 	return konnectDefaultDevServerURL
 }
+
+func KonnectServerRegion() string {
+	serverURL := KonnectServerURL()
+	switch serverURL {
+	case "https://eu.api.konghq.tech", "https://eu.kic.api.konghq.tech":
+		return "eu"
+	case "https://ap.api.konghq.tech", "https://ap.kic.api.konghq.tech":
+		return "ap"
+	case "https://us.api.konghq.tech", "https://us.kic.api.konghq.tech":
+		return "us"
+	default:
+		return "us"
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

https://developer.konghq.com/konnect-api/#personal-access-tokens says that there can only be 10 PATs per user which is easy to [hit](https://github.com/Kong/kong-operator/actions/runs/22177488444/job/64129865976?pr=3320#step:13:358) when PRs run in parallel on CI:

```
=== FAIL: ingress-controller/test/kongintegration TestKongClientGoldenTestsOutputs_Konnect (15.95s)
    kong_client_golden_tests_outputs_test.go:113: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/ingress-controller/test/helpers/konnect/personal_access_tokens.go:76
        	            				/home/runner/work/kong-operator/kong-operator/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go:113
        	Error:      	Received unexpected error:
        	            	All attempts fail:
        	            	#1: {"status":400,"title":"Bad Request","type":"https://kongapi.info/konnect/bad-request","instance":"konnect:trace:6996e25700000000f99a0a44fba0eb89","detail":"Bad Request: ","invalid_parameters":null}
        	            	#2: {"status":400,"title":"Bad Request","type":"https://kongapi.info/konnect/bad-request","instance":"konnect:trace:6996e25900000000aac394f1f538b02c","detail":"Bad Request: ","invalid_parameters":null}
        	            	#3: {"status":400,"title":"Bad Request","type":"https://kongapi.info/konnect/bad-request","instance":"konnect:trace:6996e25b000000008255aa4248ad618a","detail":"Bad Request: ","invalid_parameters":null}
        	            	#4: {"status":400,"title":"Bad Request","type":"https://kongapi.info/konnect/bad-request","instance":"konnect:trace:6996e25f00000000947e6388f60b0036","detail":"Bad Request: ","invalid_parameters":null}
        	            	#5: {"status":400,"title":"Bad Request","type":"https://kongapi.info/konnect/bad-request","instance":"konnect:trace:6996e2670000000006af3ce3c6711cc8","detail":"Bad Request: ","invalid_parameters":null}
        	Test:       	TestKongClientGoldenTestsOutputs_Konnect
```

This PR makes the kongintegration tests to use Service Account tokens instead.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
