### PR TITLE
fix: use the same defaults for `preserve_host` and `strip_path` in hybrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,10 +64,6 @@
 - Fix `ResolvedRefs` status condition on `HTTPRoute` not being updated when a
   referenced `KongPlugin` is deleted in self-managed ControlPlane mode.
   [#3206](https://github.com/Kong/kong-operator/pull/3206)
-- Name of Konnect Gateway Control Plane resource created in Konnect matches
-  the name of the corresponding `KonnectGatewayControlPlane` resource in Kubernetes
-  (the same random suffix is added). It prevents collisions in Konnect.
-  [#3357](https://github.com/Kong/kong-operator/pull/3357)
 
 ## [v2.1.1]
 
@@ -81,6 +77,13 @@
   [#3353](https://github.com/Kong/kong-operator/pull/3353)
 - Bump Go to 1.25.7
   [#3235](https://github.com/Kong/kong-operator/pull/3235)
+- Name of Konnect Gateway Control Plane resource created in Konnect matches
+  the name of the corresponding `KonnectGatewayControlPlane` resource in Kubernetes
+  (the same random suffix is added). It prevents collisions in Konnect.
+  [#3357](https://github.com/Kong/kong-operator/pull/3357)
+- Use the same defaults for `preserve_host` and `strip_path` in for Konnect Gateway Control Plane
+  as in self-managed.
+  [#3366](https://github.com/Kong/kong-operator/pull/3366)
 
 ## [v2.1.0]
 

--- a/controller/hybridgateway/builder/kongroute.go
+++ b/controller/hybridgateway/builder/kongroute.go
@@ -107,6 +107,12 @@ func (b *KongRouteBuilder) WithStripPath(stripPath bool) *KongRouteBuilder {
 	return b
 }
 
+// WithPreserveHost sets the preserve host option for the KongRoute.
+func (b *KongRouteBuilder) WithPreserveHost(preserveHost bool) *KongRouteBuilder {
+	b.route.Spec.PreserveHost = &preserveHost
+	return b
+}
+
 // WithOwner sets the owner reference for the KongRoute to the given HTTPRoute.
 func (b *KongRouteBuilder) WithOwner(owner *gwtypes.HTTPRoute) *KongRouteBuilder {
 	if owner == nil {

--- a/controller/hybridgateway/kongroute/route.go
+++ b/controller/hybridgateway/kongroute/route.go
@@ -64,6 +64,7 @@ func RouteForRule(
 		WithSpecName(routeName).
 		WithHosts(hostnames).
 		WithStripPath(metadata.ExtractStripPath(httpRoute.Annotations)).
+		WithPreserveHost(metadata.ExtractPreserveHost(httpRoute.Annotations)).
 		WithKongService(serviceName)
 
 	// Check if the rule contains a URLRewrite or RequestRedirect filter with ReplacePrefixMatch:

--- a/controller/hybridgateway/metadata/annotation_test.go
+++ b/controller/hybridgateway/metadata/annotation_test.go
@@ -24,12 +24,12 @@ func TestExtractStripPath(t *testing.T) {
 		{
 			name:        "nil annotations",
 			annotations: nil,
-			expected:    true,
+			expected:    false,
 		},
 		{
 			name:        "empty annotations",
 			annotations: map[string]string{},
-			expected:    true,
+			expected:    false,
 		},
 		{
 			name: "strip-path true",
@@ -50,14 +50,14 @@ func TestExtractStripPath(t *testing.T) {
 			annotations: map[string]string{
 				"konghq.com/strip-path": "invalid",
 			},
-			expected: true,
+			expected: false,
 		},
 		{
 			name: "strip-path empty value",
 			annotations: map[string]string{
 				"konghq.com/strip-path": "",
 			},
-			expected: true,
+			expected: false,
 		},
 		{
 			name: "other annotations present",
@@ -72,6 +72,68 @@ func TestExtractStripPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := ExtractStripPath(tt.annotations)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractPreserveHost(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			expected:    true,
+		},
+		{
+			name:        "empty annotations",
+			annotations: map[string]string{},
+			expected:    true,
+		},
+		{
+			name: "preserve-host true",
+			annotations: map[string]string{
+				"konghq.com/preserve-host": "true",
+			},
+			expected: true,
+		},
+		{
+			name: "preserve-host false",
+			annotations: map[string]string{
+				"konghq.com/preserve-host": "false",
+			},
+			expected: false,
+		},
+		{
+			name: "preserve-host invalid value",
+			annotations: map[string]string{
+				"konghq.com/preserve-host": "invalid",
+			},
+			expected: true,
+		},
+		{
+			name: "preserve-host empty value",
+			annotations: map[string]string{
+				"konghq.com/preserve-host": "",
+			},
+			expected: true,
+		},
+		{
+			name: "other annotations present",
+			annotations: map[string]string{
+				"other-annotation":         "value",
+				"konghq.com/preserve-host": "false",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractPreserveHost(tt.annotations)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/test/e2e/chainsaw/README.md
+++ b/test/e2e/chainsaw/README.md
@@ -42,6 +42,7 @@ Step templates in `common/_step_templates/` encapsulate common operations that a
 ```
 
 **Overriding bindings when needed:**
+
 ```yaml
 - name: Assert-kong-route
   use:

--- a/test/e2e/chainsaw/hybridgateway/basic-httproute/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-httproute/chainsaw-test.yaml
@@ -148,7 +148,7 @@ spec:
             - "~/echo$"
             - "/echo/"
         - name: strip_path
-          value: true
+          value: false
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
     

--- a/test/e2e/chainsaw/hybridgateway/gateway-tls-certificates/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/gateway-tls-certificates/chainsaw-test.yaml
@@ -145,7 +145,7 @@ spec:
             - "~/echo$"
             - "/echo/"
         - name: strip_path
-          value: true
+          value: false
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
     

--- a/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/chainsaw-test.yaml
@@ -153,7 +153,7 @@ spec:
             - "~/echo$"
             - "/echo/"
         - name: strip_path
-          value: true
+          value: false
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
     

--- a/test/e2e/chainsaw/hybridgateway/httproute-multiple-backends/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-multiple-backends/chainsaw-test.yaml
@@ -181,7 +181,7 @@ spec:
           - ~/echo$
           - /echo/
       - name: strip_path
-        value: true
+        value: false
     use:
       template: ../../common/_step_templates/assert-kongRoute.yaml
 
@@ -290,7 +290,7 @@ spec:
           - ~/echo$
           - /echo/
       - name: strip_path
-        value: true
+        value: false
     use:
       template: ../../common/_step_templates/assert-kongRoute.yaml
 
@@ -359,7 +359,7 @@ spec:
           - ~/echo$
           - /echo/
       - name: strip_path
-        value: true
+        value: false
     use:
       template: ../../common/_step_templates/assert-kongRoute.yaml
 
@@ -508,7 +508,7 @@ spec:
           - ~/echo$
           - /echo/
       - name: strip_path
-        value: true
+        value: false
     use:
       template: ../../common/_step_templates/assert-kongRoute.yaml
 

--- a/test/e2e/chainsaw/hybridgateway/httproute-multiple-parentrefs/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-multiple-parentrefs/chainsaw-test.yaml
@@ -267,7 +267,7 @@ spec:
             - "~/get$"
             - "/get/"
         - name: strip_path
-          value: true
+          value: false
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
 
@@ -297,7 +297,7 @@ spec:
             - "~/get$"
             - "/get/"
         - name: strip_path
-          value: true
+          value: false
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Make defaults the same as for on-prem to make the potential migration smooth for users and be more conformant. On-prem and Konnect should be fungible from users pov. 

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
