### PR TITLE
fix: name in Konnect matches K8s name for `KonnectGatewayControlPlane` (#3357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,23 @@
 - Fix setting up indices for HTTPRoute and Gateway when Konnect controllers are disabled.
   [#3229](https://github.com/Kong/kong-operator/pull/3229)
 
+## [v2.1.1]
+
+> Release date: 2026-02-19
+
+### Fixes
+
+- Fix setting up indices for HTTPRoute and Gateway when Konnect controllers are disabled.
+  [#3234](https://github.com/Kong/kong-operator/pull/3234)
+- Fix v2 module
+  [#3353](https://github.com/Kong/kong-operator/pull/3353)
+- Bump Go to 1.25.7
+  [#3235](https://github.com/Kong/kong-operator/pull/3235)
+- Name of Konnect Gateway Control Plane resource created in Konnect matches
+  the name of the corresponding `KonnectGatewayControlPlane` resource in Kubernetes
+  (the same random suffix is added). It prevents collisions in Konnect.
+  [#3357](https://github.com/Kong/kong-operator/pull/3357)
+
 ## [v2.1.0]
 
 ### Added

--- a/pkg/utils/kubernetes/metadata.go
+++ b/pkg/utils/kubernetes/metadata.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -93,4 +94,16 @@ func TrimGenerateName(name string) string {
 		name += "-"
 	}
 	return name
+}
+
+// GenerateName generates a name for the object by concatenating the provided base string with a random string of 5 characters.
+// It's implementation is based on the Kubernetes GenerateName field ([source]), argument base does not require calling
+// TrimGenerateName before, as the function calls it internally.
+//
+// [source]: https://github.com/kubernetes/kubernetes/blob/d820c046f5c520aab51ec850b263524b1fa5a4e9/staging/src/k8s.io/apiserver/pkg/storage/names/generate.go
+func GenerateName(base string) string {
+	base = TrimGenerateName(base)
+
+	const randomLength = 5
+	return fmt.Sprintf("%s%s", base, utilrand.String(randomLength))
 }


### PR DESCRIPTION
(cherry picked from commit c4ebf9cb9af4243d16563bb8f2f65def294c135e)

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
