### PR TITLE
Fix not clearing dbmode resource errors (#3315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@
   the name of the corresponding `KonnectGatewayControlPlane` resource in Kubernetes
   (the same random suffix is added). It prevents collisions in Konnect.
   [#3357](https://github.com/Kong/kong-operator/pull/3357)
+- Fix not resetting resource errors in ControlPlane's DB mode from previous `Update()`
+  calls to prevent stale errors from leaking into subsequent calls.
+  [#3369](https://github.com/Kong/kong-operator/pull/3369)
 
 ## [v2.1.0]
 

--- a/ingress-controller/internal/dataplane/sendconfig/dbmode.go
+++ b/ingress-controller/internal/dataplane/sendconfig/dbmode.go
@@ -145,6 +145,9 @@ func (s *UpdateStrategyDBMode) HandleEvents(
 	hash string,
 ) {
 	s.resourceErrorLock.Lock()
+	// Reset resource errors from previous Update() calls to prevent stale errors
+	// from leaking into subsequent calls when the UpdateStrategy is reused.
+	s.resourceErrors = nil
 	diff := diagnostics.ConfigDiff{
 		Hash:     hash,
 		Entities: []diagnostics.EntityDiff{},

--- a/ingress-controller/test/kongintegration/inmemory_update_strategy_test.go
+++ b/ingress-controller/test/kongintegration/inmemory_update_strategy_test.go
@@ -1,8 +1,10 @@
 package kongintegration
 
 import (
+	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
+	"maps"
 	"testing"
 	"time"
 
@@ -31,8 +33,9 @@ func TestUpdateStrategyInMemory_PropagatesResourcesErrors(t *testing.T) {
 	t.Parallel()
 
 	const (
-		timeout = time.Second * 5
-		period  = time.Millisecond * 200
+		timeout        = 30 * time.Second
+		period         = 200 * time.Millisecond
+		requestTimeout = 3 * time.Second
 	)
 
 	ctx := t.Context()
@@ -51,31 +54,33 @@ func TestUpdateStrategyInMemory_PropagatesResourcesErrors(t *testing.T) {
 	)
 
 	// This configuration is faulty and should return a resource error.
-	faultyConfig := sendconfig.ContentWithHash{
-		Content: &file.Content{
-			FormatVersion: "3.0",
-			Services: []file.FService{
-				{
-					Service: kong.Service{
-						Name:     kong.String("test-service"),
-						Host:     kong.String("konghq.com"),
-						Port:     kong.Int(80),
-						Protocol: kong.String("grpc"),
-						// Paths are not supported for gRPC services. This will trigger an error.
-						Path: kong.String("/test"),
-						Tags: []*string{
-							// Tags are used to identify the resource in the flattened errors response.
-							kong.String("k8s-name:test-service"),
-							kong.String("k8s-namespace:default"),
-							kong.String("k8s-kind:Service"),
-							kong.String("k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3"),
-							kong.String("k8s-group:"),
-							kong.String("k8s-version:v1"),
+	generateFaultyConfig := func() sendconfig.ContentWithHash {
+		return sendconfig.ContentWithHash{
+			Content: &file.Content{
+				FormatVersion: "3.0",
+				Services: []file.FService{
+					{
+						Service: kong.Service{
+							Name:     kong.String("test-service"),
+							Host:     kong.String("konghq.com"),
+							Port:     kong.Int(80),
+							Protocol: kong.String("grpc"),
+							// Paths are not supported for gRPC services. This will trigger an error.
+							Path: kong.String("/test"),
+							Tags: []*string{
+								// Tags are used to identify the resource in the flattened errors response.
+								kong.String("k8s-name:test-service"),
+								kong.String("k8s-namespace:default"),
+								kong.String("k8s-kind:Service"),
+								kong.String("k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3"),
+								kong.String("k8s-group:"),
+								kong.String("k8s-version:v1"),
+							},
 						},
 					},
 				},
 			},
-		},
+		}
 	}
 	expectedCausingObjects := []client.Object{
 		&metav1.PartialObjectMetadata{
@@ -95,26 +100,39 @@ func TestUpdateStrategyInMemory_PropagatesResourcesErrors(t *testing.T) {
 	// Instead, we verify the essential structure and fields are present
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		configSize, err := sut.Update(ctx, faultyConfig)
+		reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
+		defer cancel()
+		configSize, err := sut.Update(reqCtx, generateFaultyConfig())
 		if !assert.Error(t, err) {
+			fmt.Println("DEBUG: Update() returned no error (expected error)")
 			return
 		}
+		fmt.Printf("DEBUG: Update() returned error: %v\n", err)
 		// Default value 0 to discard, since error has been returned.
 		if !assert.Zero(t, configSize) {
+			fmt.Printf("DEBUG: configSize is not zero: %v\n", configSize)
 			return
 		}
 		var updateError sendconfig.UpdateError
-		if !assert.True(t, errors.As(err, &updateError)) {
+		if !assert.ErrorAs(t, err, &updateError) {
+			fmt.Printf("DEBUG: error is not UpdateError, actual type: %T, value: %v\n", err, err)
 			return
 		}
 		if wrappedErr := updateError.Unwrap(); !assert.Error(t, wrappedErr) || !assert.IsType(t, &kong.APIError{}, wrappedErr) {
+			fmt.Printf("DEBUG: unwrapped error is not *kong.APIError, type: %T, value: %v\n", wrappedErr, wrappedErr)
 			return
 		}
 		if !assert.NotEmpty(t, updateError.ResourceFailures()) {
+			fmt.Printf("DEBUG: ResourceFailures() is empty, raw response body: %s\n", string(updateError.RawResponseBody()))
 			return
 		}
 		if !assert.NotEmpty(t, updateError.RawResponseBody()) {
+			fmt.Println("DEBUG: RawResponseBody() is empty")
 			return
+		}
+		fmt.Printf("DEBUG: got %d resource failures\n", len(updateError.ResourceFailures()))
+		for i, rf := range updateError.ResourceFailures() {
+			fmt.Printf("DEBUG: resource failure [%d]: message=%q, causingObjects=%v\n", i, rf.Message(), rf.CausingObjects())
 		}
 		resourceErr, found := lo.Find(updateError.ResourceFailures(), func(r failures.ResourceFailure) bool {
 			return lo.ContainsBy(r.CausingObjects(), func(obj client.Object) bool {
@@ -128,32 +146,39 @@ func TestUpdateStrategyInMemory_PropagatesResourcesErrors(t *testing.T) {
 			return
 		}
 		if diff := cmp.Diff(expectedCausingObjects, resourceErr.CausingObjects()); !assert.Empty(t, diff) {
+			fmt.Printf("DEBUG: CausingObjects diff: %s\n", diff)
 			return
 		}
 		// Verify essential structure of the response body
 		actualBody := map[string]any{}
 		err = json.Unmarshal(updateError.RawResponseBody(), &actualBody)
 		if !assert.NoError(t, err) {
+			fmt.Printf("DEBUG: failed to unmarshal response body: %s\n", string(updateError.RawResponseBody()))
 			return
 		}
 
 		// Check for required fields in the error response
 		if !assert.Contains(t, actualBody, "code") {
+			fmt.Printf("DEBUG: response body missing 'code', keys: %v\n", maps.Keys(actualBody))
 			return
 		}
 		if !assert.Contains(t, actualBody, "name") {
+			fmt.Printf("DEBUG: response body missing 'name', keys: %v\n", maps.Keys(actualBody))
 			return
 		}
 		if !assert.Contains(t, actualBody, "flattened_errors") {
+			fmt.Printf("DEBUG: response body missing 'flattened_errors', keys: %v\n", maps.Keys(actualBody))
 			return
 		}
 
 		// Verify the flattened_errors contains our test service
 		flattenedErrors, ok := actualBody["flattened_errors"].([]any)
 		if !assert.True(t, ok) {
+			fmt.Printf("DEBUG: flattened_errors is not []any, type: %T, value: %v\n", actualBody["flattened_errors"], actualBody["flattened_errors"])
 			return
 		}
 		if !assert.NotEmpty(t, flattenedErrors) {
+			fmt.Println("DEBUG: flattened_errors is empty")
 			return
 		}
 
@@ -168,6 +193,7 @@ func TestUpdateStrategyInMemory_PropagatesResourcesErrors(t *testing.T) {
 			}
 		}
 		if !assert.True(t, foundServiceError, "Expected to find flattened error for test-service") {
+			fmt.Printf("DEBUG: no flattened error for test-service, flattenedErrors: %v\n", flattenedErrors)
 			return
 		}
 	}, timeout, period)


### PR DESCRIPTION
(cherry picked from commit 68c16f21d3fdcadd6be94fff3b0477a67ac90701)

**What this PR does / why we need it**:

Backporting test fixes to make releasing and merging PRs in 2.1 release branch less error prone.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
