### PR TITLE
tests(envtest): don't install Gateway API CRDs by default

### DIFF
--- a/test/envtest/dataplane_konnectextensions_test.go
+++ b/test/envtest/dataplane_konnectextensions_test.go
@@ -41,7 +41,7 @@ func TestDataPlaneKonnectExtension(t *testing.T) {
 
 	for _, keyType := range []certificate.KeyType{certificate.RSA, certificate.ECDSA} {
 		t.Run("for CA with key type "+string(keyType), func(t *testing.T) {
-			cfg, ns := Setup(t, t.Context(), scheme.Get())
+			cfg, ns := Setup(t, t.Context(), scheme.Get(), WithInstallGatewayCRDs(true))
 			ctx := t.Context()
 
 			mgr, logs := NewManager(t, ctx, cfg, scheme.Get())

--- a/test/envtest/gateway_envtest_test.go
+++ b/test/envtest/gateway_envtest_test.go
@@ -26,7 +26,7 @@ func TestGatewayAddressOverride(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	scheme := Scheme(t, WithGatewayAPI, WithKong)
-	envcfg, _ := Setup(t, ctx, scheme)
+	envcfg, _ := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 
 	expected := []string{"10.0.0.1", "10.0.0.2"}
@@ -76,7 +76,7 @@ func TestGatewayReconciliation_MoreThan100Routes(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	scheme := Scheme(t, WithGatewayAPI, WithKong)
-	envcfg, _ := Setup(t, ctx, scheme)
+	envcfg, _ := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 
 	gw, _ := deployGateway(ctx, t, ctrlClient)

--- a/test/envtest/gateway_konnect_auth_referencegrant_envtest_test.go
+++ b/test/envtest/gateway_konnect_auth_referencegrant_envtest_test.go
@@ -26,7 +26,7 @@ func TestGatewayKonnectAPIAuthReferenceGrant(t *testing.T) {
 	scheme := managerscheme.Get()
 	ctx := t.Context()
 
-	cfg, gwNs := Setup(t, ctx, scheme)
+	cfg, gwNs := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
 	mgr, logs := NewManager(t, ctx, cfg, scheme)
 
 	r := &kogateway.Reconciler{
@@ -220,7 +220,7 @@ func TestGatewayKonnectAPIAuthReferenceGrant_CleanupOnGatewayDeletion(t *testing
 	scheme := managerscheme.Get()
 	ctx := t.Context()
 
-	cfg, gwNs := Setup(t, ctx, scheme)
+	cfg, gwNs := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
 	mgr, logs := NewManager(t, ctx, cfg, scheme)
 
 	r := &kogateway.Reconciler{

--- a/test/envtest/gateway_secret_watch_envtest_test.go
+++ b/test/envtest/gateway_secret_watch_envtest_test.go
@@ -24,7 +24,7 @@ func TestGatewaySecretWatch_UpdatesResolvedRefsOnSecretRotation(t *testing.T) {
 	scheme := managerscheme.Get()
 	ctx := t.Context()
 
-	cfg, ns := Setup(t, ctx, scheme)
+	cfg, ns := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
 	mgr, logs := NewManager(t, ctx, cfg, scheme)
 
 	r := &kogateway.Reconciler{

--- a/test/envtest/gatewayclass_envtest_test.go
+++ b/test/envtest/gatewayclass_envtest_test.go
@@ -56,7 +56,7 @@ func TestGatewayWithGatewayClassReconciliation(t *testing.T) {
 
 	ctx := t.Context()
 	scheme := Scheme(t, WithGatewayAPI)
-	cfg, _ := Setup(t, ctx, scheme)
+	cfg, _ := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
 
 	testcases := []testcaseGatewayWithGatewayClassReconciliation{
 		{

--- a/test/envtest/httproute_controller_test.go
+++ b/test/envtest/httproute_controller_test.go
@@ -39,7 +39,7 @@ func TestHTTPRouteReconcilerProperlyReactsToReferenceGrant(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	scheme := Scheme(t, WithGatewayAPI, WithKong)
-	cfg, _ := Setup(t, ctx, scheme)
+	cfg, _ := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
 	client := NewControllerClient(t, scheme, cfg)
 
 	reconciler := &gateway.HTTPRouteReconciler{
@@ -274,7 +274,7 @@ func TestHTTPRouteReconciler_RemovesOutdatedParentStatuses(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	scheme := Scheme(t, WithGatewayAPI, WithKong)
-	cfg, _ := Setup(t, ctx, scheme)
+	cfg, _ := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
 	client := NewControllerClient(t, scheme, cfg)
 
 	reconciler := &gateway.HTTPRouteReconciler{

--- a/test/envtest/k8s_objects_status_envtest_test.go
+++ b/test/envtest/k8s_objects_status_envtest_test.go
@@ -26,7 +26,7 @@ func TestHTTPRouteReconciliation_DoesNotBlockSyncLoopWhenStatusQueueBufferIsExce
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	scheme := Scheme(t, WithGatewayAPI)
-	envcfg, _ := Setup(t, ctx, scheme)
+	envcfg, _ := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 
 	gw, _ := deployGateway(ctx, t, ctrlClient)
@@ -125,7 +125,7 @@ func Test_WatchNamespaces(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	scheme := Scheme(t, WithGatewayAPI)
-	envcfg, _ := Setup(t, ctx, scheme)
+	envcfg, _ := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 	gw, _ := deployGateway(ctx, t, ctrlClient)
 	hidden := CreateNamespace(ctx, t, ctrlClient)

--- a/test/envtest/kongconsumercredential_acl_test.go
+++ b/test/envtest/kongconsumercredential_acl_test.go
@@ -35,7 +35,7 @@ func TestKongConsumerCredential_ACL(t *testing.T) {
 	defer cancel()
 
 	// Setup up the envtest environment.
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
 

--- a/test/envtest/kongconsumercredential_apikey_test.go
+++ b/test/envtest/kongconsumercredential_apikey_test.go
@@ -35,7 +35,7 @@ func TestKongConsumerCredential_APIKey(t *testing.T) {
 	defer cancel()
 
 	// Setup up the envtest environment.
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
 

--- a/test/envtest/kongconsumercredential_basicauth_test.go
+++ b/test/envtest/kongconsumercredential_basicauth_test.go
@@ -35,7 +35,7 @@ func TestKongConsumerCredential_BasicAuth(t *testing.T) {
 	defer cancel()
 
 	// Setup up the envtest environment.
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
 

--- a/test/envtest/kongconsumercredential_hmac_test.go
+++ b/test/envtest/kongconsumercredential_hmac_test.go
@@ -35,7 +35,7 @@ func TestKongConsumerCredential_HMAC(t *testing.T) {
 	defer cancel()
 
 	// Setup up the envtest environment.
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
 

--- a/test/envtest/kongconsumercredential_jwt_test.go
+++ b/test/envtest/kongconsumercredential_jwt_test.go
@@ -35,7 +35,7 @@ func TestKongConsumerCredential_JWT(t *testing.T) {
 	defer cancel()
 
 	// Setup up the envtest environment.
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
 

--- a/test/envtest/kongpluginbinding_adoption_test.go
+++ b/test/envtest/kongpluginbinding_adoption_test.go
@@ -30,7 +30,7 @@ func TestKongPluginBindingAdoption(t *testing.T) {
 	defer cancel()
 
 	// Set up the envtest environment.
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
 

--- a/test/envtest/kongpluginbinding_managed_test.go
+++ b/test/envtest/kongpluginbinding_managed_test.go
@@ -43,7 +43,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 	defer cancel()
 
 	// Setup up the envtest environment.
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
 

--- a/test/envtest/kongpluginbinding_unmanaged_test.go
+++ b/test/envtest/kongpluginbinding_unmanaged_test.go
@@ -29,7 +29,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 	defer cancel()
 
 	// Setup up the envtest environment.
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
 

--- a/test/envtest/kongplugincleanupfinalizer_test.go
+++ b/test/envtest/kongplugincleanupfinalizer_test.go
@@ -27,7 +27,7 @@ func TestKongPluginFinalizer(t *testing.T) {
 	defer cancel()
 
 	// Setup up the envtest environment.
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
 

--- a/test/envtest/kongupstreampolicy_test.go
+++ b/test/envtest/kongupstreampolicy_test.go
@@ -162,7 +162,7 @@ func TestKongUpstreamPolicyWithHTTPRoute(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	scheme := Scheme(t, WithKong, WithGatewayAPI)
-	envcfg, _ := Setup(t, ctx, scheme)
+	envcfg, _ := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
 
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 	ingressClassName := "kongenvtest"

--- a/test/envtest/konnect_entities_kongcacertificate_test.go
+++ b/test/envtest/konnect_entities_kongcacertificate_test.go
@@ -33,7 +33,7 @@ func TestKongCACertificate(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 	const (
 		tagName            = "tag1"
 		conflictingTagName = "xconflictx"

--- a/test/envtest/konnect_entities_kongcertificate_test.go
+++ b/test/envtest/konnect_entities_kongcertificate_test.go
@@ -34,7 +34,7 @@ func TestKongCertificate(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())

--- a/test/envtest/konnect_entities_kongconsumer_test.go
+++ b/test/envtest/konnect_entities_kongconsumer_test.go
@@ -40,7 +40,7 @@ func TestKongConsumer(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
@@ -513,7 +513,7 @@ func TestKongConsumerSecretCredentials(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
@@ -1012,7 +1012,7 @@ func TestAdoptingConsumerAndCredentials(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())

--- a/test/envtest/konnect_entities_kongconsumergroup_test.go
+++ b/test/envtest/konnect_entities_kongconsumergroup_test.go
@@ -36,7 +36,7 @@ func TestKongConsumerGroup(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())

--- a/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
+++ b/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
@@ -30,7 +30,7 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())

--- a/test/envtest/konnect_entities_kongkey_test.go
+++ b/test/envtest/konnect_entities_kongkey_test.go
@@ -42,7 +42,7 @@ func TestKongKey(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())

--- a/test/envtest/konnect_entities_kongkeyset_test.go
+++ b/test/envtest/konnect_entities_kongkeyset_test.go
@@ -39,7 +39,7 @@ func TestKongKeySet(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())

--- a/test/envtest/konnect_entities_kongroute_test.go
+++ b/test/envtest/konnect_entities_kongroute_test.go
@@ -32,7 +32,7 @@ func TestKongRoute(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())

--- a/test/envtest/konnect_entities_kongservice_test.go
+++ b/test/envtest/konnect_entities_kongservice_test.go
@@ -35,7 +35,7 @@ func TestKongService(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())

--- a/test/envtest/konnect_entities_kongsni_test.go
+++ b/test/envtest/konnect_entities_kongsni_test.go
@@ -30,7 +30,7 @@ func TestKongSNI(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())

--- a/test/envtest/konnect_entities_kongtarget_test.go
+++ b/test/envtest/konnect_entities_kongtarget_test.go
@@ -28,7 +28,7 @@ func TestKongTarget(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())

--- a/test/envtest/konnect_entities_kongupstream_test.go
+++ b/test/envtest/konnect_entities_kongupstream_test.go
@@ -29,7 +29,7 @@ func TestKongUpstream(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())

--- a/test/envtest/konnect_entities_kongvault_test.go
+++ b/test/envtest/konnect_entities_kongvault_test.go
@@ -33,7 +33,7 @@ func TestKongVault(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())

--- a/test/envtest/konnect_entities_konnectapiauthconfiguration_test.go
+++ b/test/envtest/konnect_entities_konnectapiauthconfiguration_test.go
@@ -26,7 +26,7 @@ func TestKonnectAPIAuthConfiguration(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())

--- a/test/envtest/konnect_entities_konnectcloudgatewaynetwork_test.go
+++ b/test/envtest/konnect_entities_konnectcloudgatewaynetwork_test.go
@@ -30,7 +30,7 @@ func TestKonnectCloudGatewayNetwork(t *testing.T) {
 
 	ctx, cancel := Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())

--- a/test/envtest/konnect_entities_konnectdataplanegroupconfiguration_test.go
+++ b/test/envtest/konnect_entities_konnectdataplanegroupconfiguration_test.go
@@ -44,7 +44,7 @@ func TestKonnectDataPlaneGroupConfiguration(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())

--- a/test/envtest/konnect_entities_konnecttransitgateway_test.go
+++ b/test/envtest/konnect_entities_konnecttransitgateway_test.go
@@ -28,7 +28,7 @@ func TestKonnectCloudGatewayTransitGateway(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get())
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
 	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())

--- a/test/envtest/konnect_entities_suite_test.go
+++ b/test/envtest/konnect_entities_suite_test.go
@@ -24,7 +24,7 @@ import (
 // TestKonnectEntityReconcilers tests Konnect entity reconcilers. The test cases are run against a real Kubernetes API
 // server provided by the envtest package and a mock Konnect SDK.
 func TestKonnectEntityReconcilers(t *testing.T) {
-	cfg, _ := Setup(t, t.Context(), scheme.Get())
+	cfg, _ := Setup(t, t.Context(), scheme.Get(), WithInstallGatewayCRDs(true))
 
 	testNewKonnectEntityReconciler(t, cfg, konnectv1alpha2.KonnectGatewayControlPlane{}, konnectGatewayControlPlaneTestCases)
 }

--- a/test/envtest/setup.go
+++ b/test/envtest/setup.go
@@ -40,7 +40,7 @@ type Options struct {
 }
 
 var DefaultEnvTestOpts = Options{
-	InstallGatewayCRDs: true,
+	InstallGatewayCRDs: false,
 	InstallKongCRDs:    true,
 }
 

--- a/test/envtest/specific_gateway_envtest_test.go
+++ b/test/envtest/specific_gateway_envtest_test.go
@@ -28,7 +28,7 @@ func TestSpecificGatewayNN(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	scheme := Scheme(t, WithGatewayAPI, WithKong)
-	envcfg, _ := Setup(t, ctx, scheme)
+	envcfg, _ := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 
 	var (

--- a/test/envtest/telemetry_test.go
+++ b/test/envtest/telemetry_test.go
@@ -38,7 +38,7 @@ func TestTelemetry(t *testing.T) {
 	ts.Start(ctx, t)
 
 	t.Log("configuring envtest and creating K8s objects for telemetry test")
-	envcfg, _ := Setup(t, ctx, scheme.Scheme)
+	envcfg, _ := Setup(t, ctx, scheme.Scheme, WithInstallGatewayCRDs(true))
 	// Let's have long duration due too rate limiter in K8s client.
 	cfg := managercfg.NewConfig(
 		WithDefaultEnvTestsConfig(envcfg),


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows us to save some time in tests that do not require Gateway API CRDs (like CRD validation tests).

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
