### PR TITLE
chore: release chart 1.2.1

### DIFF
--- a/charts/kong-operator/CHANGELOG.md
+++ b/charts/kong-operator/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## Unreleased
+## 1.2.1
+
+### Changed
+
+- Bump default version of the operator image to `2.1.1`
+  [#3394](https://github.com/Kong/kong-operator/pull/3394)
+
+## 1.2.0
 
 ### Changed
 

--- a/charts/kong-operator/Chart.yaml
+++ b/charts/kong-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong-operator
 sources:
   - https://github.com/Kong/kong-operator/charts/kong-operator/
-version: 1.0.2
+version: 1.2.1
 appVersion: "2.1.1"
 annotations:
   artifacthub.io/category: networking

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.2
+        helm.sh/chart: kong-operator-1.2.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.1"
         app.kubernetes.io/component: ko
@@ -57992,7 +57992,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57864,7 +57864,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57892,7 +57892,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.2
+        helm.sh/chart: kong-operator-1.2.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.1"
         app.kubernetes.io/component: ko
@@ -58005,7 +58005,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.2
+        helm.sh/chart: kong-operator-1.2.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.1"
         app.kubernetes.io/component: ko
@@ -57984,7 +57984,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.2
+        helm.sh/chart: kong-operator-1.2.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.1"
         app.kubernetes.io/component: ko
@@ -57986,7 +57986,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.2
+        helm.sh/chart: kong-operator-1.2.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.1"
         app.kubernetes.io/component: ko
@@ -57986,7 +57986,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     a: "b"
@@ -57848,7 +57848,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     a: "b"
@@ -57877,7 +57877,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.2
+        helm.sh/chart: kong-operator-1.2.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.1"
         a: "b"
@@ -57985,7 +57985,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     a: "b"

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.2
+        helm.sh/chart: kong-operator-1.2.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.1"
         app.kubernetes.io/component: ko
@@ -57984,7 +57984,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.2
+        helm.sh/chart: kong-operator-1.2.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.1"
         app.kubernetes.io/component: ko
@@ -57982,7 +57982,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57876,7 +57876,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.2
+        helm.sh/chart: kong-operator-1.2.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.1"
         app.kubernetes.io/component: ko
@@ -57983,7 +57983,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.2
+        helm.sh/chart: kong-operator-1.2.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.1"
         app.kubernetes.io/component: ko
@@ -57984,7 +57984,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.2
+        helm.sh/chart: kong-operator-1.2.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.1"
         app.kubernetes.io/component: ko
@@ -57986,7 +57986,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -55,7 +55,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57847,7 +57847,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57875,7 +57875,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.2
+        helm.sh/chart: kong-operator-1.2.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.1"
         app.kubernetes.io/component: ko
@@ -57982,7 +57982,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -30,7 +30,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -31337,7 +31337,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -31365,7 +31365,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.2
+        helm.sh/chart: kong-operator-1.2.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.1"
         app.kubernetes.io/component: ko
@@ -31464,7 +31464,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -57797,7 +57797,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -57825,7 +57825,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.2
+        helm.sh/chart: kong-operator-1.2.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.1"
         app.kubernetes.io/component: ko
@@ -57935,7 +57935,7 @@ metadata:
     cert-manager.io/secret-template: '{ "labels": { "konghq.com/secret" : "internal" } }'
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -58052,7 +58052,7 @@ kind: Certificate
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -58073,7 +58073,7 @@ kind: Certificate
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -58094,7 +58094,7 @@ kind: Issuer
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -31295,7 +31295,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kong-operator
-    helm.sh/chart: kong-operator-1.0.2
+    helm.sh/chart: kong-operator-1.2.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "2.1.1"
     app.kubernetes.io/component: ko
@@ -31323,7 +31323,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: kong-operator
-        helm.sh/chart: kong-operator-1.0.2
+        helm.sh/chart: kong-operator-1.2.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "2.1.1"
         app.kubernetes.io/component: ko


### PR DESCRIPTION
**What this PR does / why we need it**:

This targets the `release/2.1.x` branch and chart will be manually synced from that branch (via: https://github.com/Kong/kong-operator/actions/workflows/charts-sync.yaml).

The proposal on how to do this automatically is in https://github.com/Kong/kong-operator/pull/3393 and https://kongstrong.slack.com/archives/C011RQPHDC7/p1771602617667539?thread_ts=1763992394.599499&cid=C011RQPHDC7

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
