### PR TITLE
chore: remove `kongingresses` from webhook, format yaml consistently

### DIFF
--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -58025,7 +58025,6 @@ webhooks:
     - kongconsumergroups
     - kongplugins
     - kongclusterplugins
-    - kongingresses
     - kongvaults
     - kongcustomentities
     scope: '*'

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -58038,7 +58038,6 @@ webhooks:
     - kongconsumergroups
     - kongplugins
     - kongclusterplugins
-    - kongingresses
     - kongvaults
     - kongcustomentities
     scope: '*'

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -58017,7 +58017,6 @@ webhooks:
     - kongconsumergroups
     - kongplugins
     - kongclusterplugins
-    - kongingresses
     - kongvaults
     - kongcustomentities
     scope: '*'

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -58019,7 +58019,6 @@ webhooks:
     - kongconsumergroups
     - kongplugins
     - kongclusterplugins
-    - kongingresses
     - kongvaults
     - kongcustomentities
     scope: '*'

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -58019,7 +58019,6 @@ webhooks:
     - kongconsumergroups
     - kongplugins
     - kongclusterplugins
-    - kongingresses
     - kongvaults
     - kongcustomentities
     scope: '*'

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -58019,7 +58019,6 @@ webhooks:
     - kongconsumergroups
     - kongplugins
     - kongclusterplugins
-    - kongingresses
     - kongvaults
     - kongcustomentities
     scope: '*'

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -58017,7 +58017,6 @@ webhooks:
     - kongconsumergroups
     - kongplugins
     - kongclusterplugins
-    - kongingresses
     - kongvaults
     - kongcustomentities
     scope: '*'

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -58015,7 +58015,6 @@ webhooks:
     - kongconsumergroups
     - kongplugins
     - kongclusterplugins
-    - kongingresses
     - kongvaults
     - kongcustomentities
     scope: '*'

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -58016,7 +58016,6 @@ webhooks:
     - kongconsumergroups
     - kongplugins
     - kongclusterplugins
-    - kongingresses
     - kongvaults
     - kongcustomentities
     scope: '*'

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -58017,7 +58017,6 @@ webhooks:
     - kongconsumergroups
     - kongplugins
     - kongclusterplugins
-    - kongingresses
     - kongvaults
     - kongcustomentities
     scope: '*'

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -58019,7 +58019,6 @@ webhooks:
     - kongconsumergroups
     - kongplugins
     - kongclusterplugins
-    - kongingresses
     - kongvaults
     - kongcustomentities
     scope: '*'

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -58015,7 +58015,6 @@ webhooks:
     - kongconsumergroups
     - kongplugins
     - kongclusterplugins
-    - kongingresses
     - kongvaults
     - kongcustomentities
     scope: '*'

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -31497,7 +31497,6 @@ webhooks:
     - kongconsumergroups
     - kongplugins
     - kongclusterplugins
-    - kongingresses
     - kongvaults
     - kongcustomentities
     scope: '*'

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -57967,7 +57967,6 @@ webhooks:
     - kongconsumergroups
     - kongplugins
     - kongclusterplugins
-    - kongingresses
     - kongvaults
     - kongcustomentities
     scope: '*'

--- a/charts/kong-operator/templates/validating-webhook.yaml
+++ b/charts/kong-operator/templates/validating-webhook.yaml
@@ -83,7 +83,6 @@ webhooks:
     - kongconsumergroups
     - kongplugins
     - kongclusterplugins
-    - kongingresses
     - kongvaults
     - kongcustomentities
     scope: '*'

--- a/config/default/validating_webhook/zz_generated_validating_webhook.yaml
+++ b/config/default/validating_webhook/zz_generated_validating_webhook.yaml
@@ -34,7 +34,6 @@ webhooks:
     - kongconsumergroups
     - kongplugins
     - kongclusterplugins
-    - kongingresses
     - kongvaults
     - kongcustomentities
     scope: '*'
@@ -77,17 +76,17 @@ webhooks:
   matchPolicy: Equivalent
   name: secrets.validations.kong.konghq.com
   rules:
-    # TODO: it tries to validate secret created by cert-manager, but KO is not ready to handle it.
-    - apiGroups:
-      - ""
-      apiVersions:
-      - v1
-      operations:
-      - CREATE
-      - UPDATE
-      resources:
-      - secrets
-      scope: '*'
+  # TODO: it tries to validate secret created by cert-manager, but KO is not ready to handle it.
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+    scope: '*'
   objectSelector:
     matchLabels:
       # TODO: customize based on flags
@@ -108,15 +107,15 @@ webhooks:
   matchPolicy: Equivalent
   name: services.validations.kong.konghq.com
   rules:
-    - apiGroups:
-      - ""
-      apiVersions:
-      - v1
-      operations:
-      - CREATE
-      - UPDATE
-      resources:
-      - services
-      scope: '*'
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - services
+    scope: '*'
   sideEffects: None
   timeoutSeconds: 10


### PR DESCRIPTION
**What this PR does / why we need it**:

`KongIngress` has been deprecated and removed from the codebase, but overlooked in validating webhook YAML. Furthermore, make list formatting consistent with the format generated by kubebuilder in validating webhook YAML. 

**Which issue this PR fixes**

Spotted during work on
- https://github.com/Kong/kong-operator/issues/2186