### PR TITLE
fix(konnect): KonnectExtension cleanup condition

### DIFF
--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -563,10 +563,8 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		})
 	}
 
-	secretCleanup := certificateSecret.DeletionTimestamp != nil &&
-		certificateSecret.DeletionTimestamp.Before(&metav1.Time{Time: time.Now()})
 	switch {
-	case !cleanup && !secretCleanup:
+	case !cleanup:
 
 		if !certFound && !certSDKFound {
 			log.Debug(logger, "Creating KongDataPlaneClientCertificate custom resource")
@@ -692,7 +690,7 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			log.Info(logger, "KonnectExtension finalizer added", "finalizer", KonnectCleanupFinalizer)
 			return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
 		}
-	case cleanup || secretCleanup:
+	case cleanup:
 		// If there are no mapped IDs from KongDataPlaneClientCertificates in cluster,
 		// then let's use the SDK to query Konnect directly to find any existing certificates.
 		// This is just to make sure that users migrating from older versions of the operator


### PR DESCRIPTION


**What this PR does / why we need it**:

Remove the secretCleanup path that triggered cleanup when the certificate secret had a non-nil DeletionTimestamp. The cleanup flow should only be driven by the KonnectExtension finalizer/cleanup flag, not by the state of the associated secret. This avoids prematurely entering the cleanup branch when the secret is being deleted independently of the extension.

**Which issue this PR fixes**

Fixes #3376 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
