### PR TITLE
chore: remove redundant comments from validating webhook yaml

### DIFF
--- a/config/default/validating_webhook/zz_generated_validating_webhook.yaml
+++ b/config/default/validating_webhook/zz_generated_validating_webhook.yaml
@@ -15,9 +15,6 @@ webhooks:
       namespace: kong-system
       name: gateway-operator-webhook-service
       port: 5443
-  # NOTE: By default Kong's helm charts use Ignore for the failurePolicy
-  # e.g. https://github.com/Kong/charts/blob/fd9deb6ee34d9b9ac4ab4be2188d4564d0b655e5/charts/kong/values.yaml#L586
-  # but setting this to Fail here allows devs to see the errors sooner, during development.
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validations.kong.konghq.com
@@ -69,14 +66,10 @@ webhooks:
       namespace: kong-system
       name: gateway-operator-webhook-service
       port: 5443
-  # NOTE: By default Kong's helm charts use Ignore for the failurePolicy
-  # e.g. https://github.com/Kong/charts/blob/fd9deb6ee34d9b9ac4ab4be2188d4564d0b655e5/charts/kong/values.yaml#L586
-  # but setting this to Fail here allows devs to see the errors sooner, during development.
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: secrets.validations.kong.konghq.com
   rules:
-  # TODO: it tries to validate secret created by cert-manager, but KO is not ready to handle it.
   - apiGroups:
     - ""
     apiVersions:
@@ -89,10 +82,11 @@ webhooks:
     scope: '*'
   objectSelector:
     matchLabels:
-      # TODO: customize based on flags
       konghq.com/secret: "true"
   sideEffects: None
   timeoutSeconds: 10
+# TODO: remove below when https://github.com/Kong/kong-operator/issues/2544 is resolved,
+# because validation will be moved to admission policy.
 - admissionReviewVersions:
   - v1
   clientConfig:
@@ -100,9 +94,6 @@ webhooks:
       namespace: kong-system
       name: gateway-operator-webhook-service
       port: 5443
-  # NOTE: By default Kong's helm charts use Ignore for the failurePolicy
-  # e.g. https://github.com/Kong/charts/blob/fd9deb6ee34d9b9ac4ab4be2188d4564d0b655e5/charts/kong/values.yaml#L586
-  # but setting this to Fail here allows devs to see the errors sooner, during development.
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: services.validations.kong.konghq.com


### PR DESCRIPTION
**What this PR does / why we need it**:

- Regarding a stale comment

  ```
  # NOTE: By default Kong's helm charts use Ignore for the failurePolicy
  # e.g. https://github.com/Kong/charts/blob/fd9deb6ee34d9b9ac4ab4be2188d4564d0b655e5/charts/kong/values.yaml#L586
  # but setting this to Fail here allows devs to see the errors sooner, during development.
  ```
  On team-k8 sync meeting has been decided to keep `failurePolicy: Fail` as the default behavior for all other resources than `Service` is desired.
  
   For `Service`, actual work happens in the issue https://github.com/Kong/kong-operator/issues/2544 - migration to admission policy (a comment with TODO has been added).
   
- comment
     ```
     # TODO: it tries to validate secret created by cert-manager, but KO is not ready to handle it.
     ```
     is stale too, because the object selector (lines 91-93) prevents it, since certs created by cert-manager are not labeled with `konghq.com/secret`

- comment
  ```
   # TODO: customize based on flags
   ```
   does not have a dedicated issue, and it seems like an overkill to have it configurable. When someone explicitly requests it, it can be implemented 



**Which issue this PR fixes**

Spotted during work on
- https://github.com/Kong/kong-operator/issues/2186