### PR TITLE
[release/2.1.x] chart: fix rendering webhook-certs volume and volume mount when `ko-crds.enabled=false` (#3228)

### DIFF
--- a/.github/workflows/charts-tests.yaml
+++ b/.github/workflows/charts-tests.yaml
@@ -172,10 +172,12 @@ jobs:
       - name: Install cert-manager
         run: make install.helm.cert-manager
 
+      - name: Install CRDs
+        run: make install.crds
+
       - name: Run chart-testing (install)
         run: |
           kubectl create ns kong-test
-          make install.helm.cert-manager
           make test.charts.ct.install CHART_NAME=${{ matrix.chart-name}}
           # No need to delete the ns the cluster is scrapped after the job anyway.
 

--- a/charts/kong-operator/templates/_helpers.tpl
+++ b/charts/kong-operator/templates/_helpers.tpl
@@ -161,16 +161,13 @@ The dict maps raw env variable key to the suggested variable path.
 
 {{- define "kong.volumes" -}}
 {{ if .Values.global.webhooks.conversion.enabled }}
-{{- /* This volume is conditional on ko-crds being enabled because the certificate */ -}}
-{{- /* Secret is placed in that subchart. The reason for this is explained in */ -}}
-{{- /* https://github.com/Kong/kong-operator/blob/e555dbc0b6e57beecbb72cf79018ef8fdbe11ffa/hack/generators/conversion-webhook/main.go#L88-L95 */ -}}
-{{ $kocrds := (index .Values "ko-crds") }}
-{{ if $kocrds.enabled }}
+{{- /* Depending on the global.webhooks.options.certManager.enabled being true or false */ -}}
+{{- /* certificate below will either be sourced from chart generated Secret */ -}}
+{{- /* or from cert-manager generated Secret */ -}}
 - name: webhook-certs
   secret:
     defaultMode: 420
     secretName: {{ template "kong.webhookCertSecretName" . }}
-{{ end }}
 {{ end }}
 {{ if .Values.global.webhooks.validating.enabled }}
 - name: validating-webhook-certs
@@ -188,15 +185,12 @@ The dict maps raw env variable key to the suggested variable path.
 
 {{- define "kong.volumeMounts" -}}
 {{ if .Values.global.webhooks.conversion.enabled }}
-{{- /* This mount is conditional on ko-crds being enabled because the certificate */ -}}
-{{- /* Secret is placed in that subchart. The reason for this is explained in */ -}}
-{{- /* https://github.com/Kong/kong-operator/blob/e555dbc0b6e57beecbb72cf79018ef8fdbe11ffa/hack/generators/conversion-webhook/main.go#L88-L95 */ -}}
-{{ $kocrds := (index .Values "ko-crds") }}
-{{ if $kocrds.enabled }}
+{{- /* Depending on the global.webhooks.options.certManager.enabled being true or false */ -}}
+{{- /* certificate below will either be sourced from chart generated Secret */ -}}
+{{- /* or from cert-manager generated Secret */ -}}
 - name: webhook-certs
   mountPath: /tmp/k8s-webhook-server/serving-certs
   readOnly: true
-{{ end }}
 {{ end }}
 {{ if .Values.global.webhooks.validating.enabled }}
 - name: validating-webhook-certs


### PR DESCRIPTION
(cherry picked from commit 7d2425c3618506e3fe868891967bea3d43c58ee0)

**What this PR does / why we need it**:

2.1 backport of https://github.com/Kong/kong-operator/pull/3228

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
