### PR TITLE
fix: don't allow specifying namespace for DataPlane extensions

### DIFF
--- a/api/gateway-operator/v1beta1/dataplane_types.go
+++ b/api/gateway-operator/v1beta1/dataplane_types.go
@@ -44,6 +44,7 @@ func init() {
 // +kubebuilder:validation:XValidation:message="DataPlane requires an image to be set on proxy container",rule="has(self.spec.deployment.podTemplateSpec) && has(self.spec.deployment.podTemplateSpec.spec.containers) && self.spec.deployment.podTemplateSpec.spec.containers.exists(c, c.name == 'proxy' && has(c.image))"
 // +kubebuilder:validation:XValidation:message="DataPlane supports only db mode 'off'",rule="!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size() == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name == 'proxy' ? (!has(self.spec.deployment.podTemplateSpec.spec.containers[0].env) ? true : self.spec.deployment.podTemplateSpec.spec.containers[0].env.all(e, e.name != 'KONG_DATABASE' || e.value == 'off' || size(e.value)==0)) : true)"
 // +kubebuilder:validation:XValidation:message="DataPlane spec cannot be updated when promotion is in progress",rule="(self.spec != oldSelf.spec && has(self.status) && has(self.status.rollout) && has(self.status.rollout.conditions)) ? self.status.rollout.conditions.all(c, c.type != 'RolledOut' || c.reason != 'PromotionInProgress') : true"
+// +kubebuilder:validation:XValidation:message="Cross namespace references not allowed for extension references",rule="!has(self.spec.extensions) || self.spec.extensions.all(e, ( !has(e.__namespace__)))"
 type DataPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -19130,6 +19130,8 @@ spec:
           rule: '!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size() == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name == ''proxy'' ? (!has(self.spec.deployment.podTemplateSpec.spec.containers[0].env) ? true : self.spec.deployment.podTemplateSpec.spec.containers[0].env.all(e, e.name != ''KONG_DATABASE'' || e.value == ''off'' || size(e.value)==0)) : true)'
         - message: DataPlane spec cannot be updated when promotion is in progress
           rule: '(self.spec != oldSelf.spec && has(self.status) && has(self.status.rollout) && has(self.status.rollout.conditions)) ? self.status.rollout.conditions.all(c, c.type != ''RolledOut'' || c.reason != ''PromotionInProgress'') : true'
+        - message: Cross namespace references not allowed for extension references
+          rule: '!has(self.spec.extensions) || self.spec.extensions.all(e, ( !has(e.__namespace__)))'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -19130,6 +19130,8 @@ spec:
           rule: '!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size() == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name == ''proxy'' ? (!has(self.spec.deployment.podTemplateSpec.spec.containers[0].env) ? true : self.spec.deployment.podTemplateSpec.spec.containers[0].env.all(e, e.name != ''KONG_DATABASE'' || e.value == ''off'' || size(e.value)==0)) : true)'
         - message: DataPlane spec cannot be updated when promotion is in progress
           rule: '(self.spec != oldSelf.spec && has(self.status) && has(self.status.rollout) && has(self.status.rollout.conditions)) ? self.status.rollout.conditions.all(c, c.type != ''RolledOut'' || c.reason != ''PromotionInProgress'') : true'
+        - message: Cross namespace references not allowed for extension references
+          rule: '!has(self.spec.extensions) || self.spec.extensions.all(e, ( !has(e.__namespace__)))'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -19130,6 +19130,8 @@ spec:
           rule: '!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size() == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name == ''proxy'' ? (!has(self.spec.deployment.podTemplateSpec.spec.containers[0].env) ? true : self.spec.deployment.podTemplateSpec.spec.containers[0].env.all(e, e.name != ''KONG_DATABASE'' || e.value == ''off'' || size(e.value)==0)) : true)'
         - message: DataPlane spec cannot be updated when promotion is in progress
           rule: '(self.spec != oldSelf.spec && has(self.status) && has(self.status.rollout) && has(self.status.rollout.conditions)) ? self.status.rollout.conditions.all(c, c.type != ''RolledOut'' || c.reason != ''PromotionInProgress'') : true'
+        - message: Cross namespace references not allowed for extension references
+          rule: '!has(self.spec.extensions) || self.spec.extensions.all(e, ( !has(e.__namespace__)))'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -19130,6 +19130,8 @@ spec:
           rule: '!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size() == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name == ''proxy'' ? (!has(self.spec.deployment.podTemplateSpec.spec.containers[0].env) ? true : self.spec.deployment.podTemplateSpec.spec.containers[0].env.all(e, e.name != ''KONG_DATABASE'' || e.value == ''off'' || size(e.value)==0)) : true)'
         - message: DataPlane spec cannot be updated when promotion is in progress
           rule: '(self.spec != oldSelf.spec && has(self.status) && has(self.status.rollout) && has(self.status.rollout.conditions)) ? self.status.rollout.conditions.all(c, c.type != ''RolledOut'' || c.reason != ''PromotionInProgress'') : true'
+        - message: Cross namespace references not allowed for extension references
+          rule: '!has(self.spec.extensions) || self.spec.extensions.all(e, ( !has(e.__namespace__)))'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -19130,6 +19130,8 @@ spec:
           rule: '!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size() == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name == ''proxy'' ? (!has(self.spec.deployment.podTemplateSpec.spec.containers[0].env) ? true : self.spec.deployment.podTemplateSpec.spec.containers[0].env.all(e, e.name != ''KONG_DATABASE'' || e.value == ''off'' || size(e.value)==0)) : true)'
         - message: DataPlane spec cannot be updated when promotion is in progress
           rule: '(self.spec != oldSelf.spec && has(self.status) && has(self.status.rollout) && has(self.status.rollout.conditions)) ? self.status.rollout.conditions.all(c, c.type != ''RolledOut'' || c.reason != ''PromotionInProgress'') : true'
+        - message: Cross namespace references not allowed for extension references
+          rule: '!has(self.spec.extensions) || self.spec.extensions.all(e, ( !has(e.__namespace__)))'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -19131,6 +19131,8 @@ spec:
           rule: '!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size() == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name == ''proxy'' ? (!has(self.spec.deployment.podTemplateSpec.spec.containers[0].env) ? true : self.spec.deployment.podTemplateSpec.spec.containers[0].env.all(e, e.name != ''KONG_DATABASE'' || e.value == ''off'' || size(e.value)==0)) : true)'
         - message: DataPlane spec cannot be updated when promotion is in progress
           rule: '(self.spec != oldSelf.spec && has(self.status) && has(self.status.rollout) && has(self.status.rollout.conditions)) ? self.status.rollout.conditions.all(c, c.type != ''RolledOut'' || c.reason != ''PromotionInProgress'') : true'
+        - message: Cross namespace references not allowed for extension references
+          rule: '!has(self.spec.extensions) || self.spec.extensions.all(e, ( !has(e.__namespace__)))'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -19130,6 +19130,8 @@ spec:
           rule: '!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size() == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name == ''proxy'' ? (!has(self.spec.deployment.podTemplateSpec.spec.containers[0].env) ? true : self.spec.deployment.podTemplateSpec.spec.containers[0].env.all(e, e.name != ''KONG_DATABASE'' || e.value == ''off'' || size(e.value)==0)) : true)'
         - message: DataPlane spec cannot be updated when promotion is in progress
           rule: '(self.spec != oldSelf.spec && has(self.status) && has(self.status.rollout) && has(self.status.rollout.conditions)) ? self.status.rollout.conditions.all(c, c.type != ''RolledOut'' || c.reason != ''PromotionInProgress'') : true'
+        - message: Cross namespace references not allowed for extension references
+          rule: '!has(self.spec.extensions) || self.spec.extensions.all(e, ( !has(e.__namespace__)))'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -19130,6 +19130,8 @@ spec:
           rule: '!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size() == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name == ''proxy'' ? (!has(self.spec.deployment.podTemplateSpec.spec.containers[0].env) ? true : self.spec.deployment.podTemplateSpec.spec.containers[0].env.all(e, e.name != ''KONG_DATABASE'' || e.value == ''off'' || size(e.value)==0)) : true)'
         - message: DataPlane spec cannot be updated when promotion is in progress
           rule: '(self.spec != oldSelf.spec && has(self.status) && has(self.status.rollout) && has(self.status.rollout.conditions)) ? self.status.rollout.conditions.all(c, c.type != ''RolledOut'' || c.reason != ''PromotionInProgress'') : true'
+        - message: Cross namespace references not allowed for extension references
+          rule: '!has(self.spec.extensions) || self.spec.extensions.all(e, ( !has(e.__namespace__)))'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -19130,6 +19130,8 @@ spec:
           rule: '!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size() == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name == ''proxy'' ? (!has(self.spec.deployment.podTemplateSpec.spec.containers[0].env) ? true : self.spec.deployment.podTemplateSpec.spec.containers[0].env.all(e, e.name != ''KONG_DATABASE'' || e.value == ''off'' || size(e.value)==0)) : true)'
         - message: DataPlane spec cannot be updated when promotion is in progress
           rule: '(self.spec != oldSelf.spec && has(self.status) && has(self.status.rollout) && has(self.status.rollout.conditions)) ? self.status.rollout.conditions.all(c, c.type != ''RolledOut'' || c.reason != ''PromotionInProgress'') : true'
+        - message: Cross namespace references not allowed for extension references
+          rule: '!has(self.spec.extensions) || self.spec.extensions.all(e, ( !has(e.__namespace__)))'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -19130,6 +19130,8 @@ spec:
           rule: '!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size() == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name == ''proxy'' ? (!has(self.spec.deployment.podTemplateSpec.spec.containers[0].env) ? true : self.spec.deployment.podTemplateSpec.spec.containers[0].env.all(e, e.name != ''KONG_DATABASE'' || e.value == ''off'' || size(e.value)==0)) : true)'
         - message: DataPlane spec cannot be updated when promotion is in progress
           rule: '(self.spec != oldSelf.spec && has(self.status) && has(self.status.rollout) && has(self.status.rollout.conditions)) ? self.status.rollout.conditions.all(c, c.type != ''RolledOut'' || c.reason != ''PromotionInProgress'') : true'
+        - message: Cross namespace references not allowed for extension references
+          rule: '!has(self.spec.extensions) || self.spec.extensions.all(e, ( !has(e.__namespace__)))'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -19130,6 +19130,8 @@ spec:
           rule: '!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size() == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name == ''proxy'' ? (!has(self.spec.deployment.podTemplateSpec.spec.containers[0].env) ? true : self.spec.deployment.podTemplateSpec.spec.containers[0].env.all(e, e.name != ''KONG_DATABASE'' || e.value == ''off'' || size(e.value)==0)) : true)'
         - message: DataPlane spec cannot be updated when promotion is in progress
           rule: '(self.spec != oldSelf.spec && has(self.status) && has(self.status.rollout) && has(self.status.rollout.conditions)) ? self.status.rollout.conditions.all(c, c.type != ''RolledOut'' || c.reason != ''PromotionInProgress'') : true'
+        - message: Cross namespace references not allowed for extension references
+          rule: '!has(self.spec.extensions) || self.spec.extensions.all(e, ( !has(e.__namespace__)))'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -19130,6 +19130,8 @@ spec:
           rule: '!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size() == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name == ''proxy'' ? (!has(self.spec.deployment.podTemplateSpec.spec.containers[0].env) ? true : self.spec.deployment.podTemplateSpec.spec.containers[0].env.all(e, e.name != ''KONG_DATABASE'' || e.value == ''off'' || size(e.value)==0)) : true)'
         - message: DataPlane spec cannot be updated when promotion is in progress
           rule: '(self.spec != oldSelf.spec && has(self.status) && has(self.status.rollout) && has(self.status.rollout.conditions)) ? self.status.rollout.conditions.all(c, c.type != ''RolledOut'' || c.reason != ''PromotionInProgress'') : true'
+        - message: Cross namespace references not allowed for extension references
+          rule: '!has(self.spec.extensions) || self.spec.extensions.all(e, ( !has(e.__namespace__)))'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -10748,6 +10748,8 @@ spec:
           rule: '!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size() == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name == ''proxy'' ? (!has(self.spec.deployment.podTemplateSpec.spec.containers[0].env) ? true : self.spec.deployment.podTemplateSpec.spec.containers[0].env.all(e, e.name != ''KONG_DATABASE'' || e.value == ''off'' || size(e.value)==0)) : true)'
         - message: DataPlane spec cannot be updated when promotion is in progress
           rule: '(self.spec != oldSelf.spec && has(self.status) && has(self.status.rollout) && has(self.status.rollout.conditions)) ? self.status.rollout.conditions.all(c, c.type != ''RolledOut'' || c.reason != ''PromotionInProgress'') : true'
+        - message: Cross namespace references not allowed for extension references
+          rule: '!has(self.spec.extensions) || self.spec.extensions.all(e, ( !has(e.__namespace__)))'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -19080,6 +19080,8 @@ spec:
           rule: '!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size() == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name == ''proxy'' ? (!has(self.spec.deployment.podTemplateSpec.spec.containers[0].env) ? true : self.spec.deployment.podTemplateSpec.spec.containers[0].env.all(e, e.name != ''KONG_DATABASE'' || e.value == ''off'' || size(e.value)==0)) : true)'
         - message: DataPlane spec cannot be updated when promotion is in progress
           rule: '(self.spec != oldSelf.spec && has(self.status) && has(self.status.rollout) && has(self.status.rollout.conditions)) ? self.status.rollout.conditions.all(c, c.type != ''RolledOut'' || c.reason != ''PromotionInProgress'') : true'
+        - message: Cross namespace references not allowed for extension references
+          rule: '!has(self.spec.extensions) || self.spec.extensions.all(e, ( !has(e.__namespace__)))'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -10723,6 +10723,8 @@ spec:
           rule: '!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size() == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name == ''proxy'' ? (!has(self.spec.deployment.podTemplateSpec.spec.containers[0].env) ? true : self.spec.deployment.podTemplateSpec.spec.containers[0].env.all(e, e.name != ''KONG_DATABASE'' || e.value == ''off'' || size(e.value)==0)) : true)'
         - message: DataPlane spec cannot be updated when promotion is in progress
           rule: '(self.spec != oldSelf.spec && has(self.status) && has(self.status.rollout) && has(self.status.rollout.conditions)) ? self.status.rollout.conditions.all(c, c.type != ''RolledOut'' || c.reason != ''PromotionInProgress'') : true'
+        - message: Cross namespace references not allowed for extension references
+          rule: '!has(self.spec.extensions) || self.spec.extensions.all(e, ( !has(e.__namespace__)))'
     served: true
     storage: true
     subresources:

--- a/config/crd/kong-operator/gateway-operator.konghq.com_dataplanes.yaml
+++ b/config/crd/kong-operator/gateway-operator.konghq.com_dataplanes.yaml
@@ -9985,6 +9985,8 @@ spec:
           rule: '(self.spec != oldSelf.spec && has(self.status) && has(self.status.rollout)
             && has(self.status.rollout.conditions)) ? self.status.rollout.conditions.all(c,
             c.type != ''RolledOut'' || c.reason != ''PromotionInProgress'') : true'
+        - message: Cross namespace references not allowed for extension references
+          rule: '!has(self.spec.extensions) || self.spec.extensions.all(e, ( !has(e.__namespace__)))'
     served: true
     storage: true
     subresources:

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -617,11 +617,7 @@ func (r *Reconciler) provisionDataPlane(
 		return nil, errWrap
 	}
 
-	var ns *string
-	if gateway.GetNamespace() != konnectExtension.GetNamespace() {
-		ns = new(gateway.GetNamespace())
-	}
-	expectedDataPlaneOptions.Extensions = extensions.MergeExtensionsForDataPlane(ns, gatewayConfig.Spec.Extensions, konnectExtension)
+	expectedDataPlaneOptions.Extensions = extensions.MergeExtensionsForDataPlane(gateway, gatewayConfig.Spec.Extensions, konnectExtension)
 
 	if !dataPlaneSpecDeepEqual(
 		&dataplane.Spec.DataPlaneOptions, expectedDataPlaneOptions, gwconfigutils.IsGatewayHybrid(gatewayConfig),

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -617,7 +617,11 @@ func (r *Reconciler) provisionDataPlane(
 		return nil, errWrap
 	}
 
-	expectedDataPlaneOptions.Extensions = extensions.MergeExtensionsForDataPlane(gatewayConfig.Spec.Extensions, konnectExtension)
+	var ns *string
+	if gateway.GetNamespace() != konnectExtension.GetNamespace() {
+		ns = new(gateway.GetNamespace())
+	}
+	expectedDataPlaneOptions.Extensions = extensions.MergeExtensionsForDataPlane(ns, gatewayConfig.Spec.Extensions, konnectExtension)
 
 	if !dataPlaneSpecDeepEqual(
 		&dataplane.Spec.DataPlaneOptions, expectedDataPlaneOptions, gwconfigutils.IsGatewayHybrid(gatewayConfig),

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -65,7 +65,11 @@ func (r *Reconciler) createDataPlane(
 		return nil, err
 	}
 
-	dataplane.Spec.Extensions = extensions.MergeExtensionsForDataPlane(gatewayConfig.Spec.Extensions, konnectExtension)
+	var ns *string
+	if gateway.GetNamespace() != konnectExtension.GetNamespace() {
+		ns = new(gateway.GetNamespace())
+	}
+	dataplane.Spec.Extensions = extensions.MergeExtensionsForDataPlane(ns, gatewayConfig.Spec.Extensions, konnectExtension)
 
 	k8sutils.SetOwnerForObject(dataplane, gateway)
 	gatewayutils.LabelObjectAsGatewayManaged(dataplane)

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -65,11 +65,7 @@ func (r *Reconciler) createDataPlane(
 		return nil, err
 	}
 
-	var ns *string
-	if gateway.GetNamespace() != konnectExtension.GetNamespace() {
-		ns = new(gateway.GetNamespace())
-	}
-	dataplane.Spec.Extensions = extensions.MergeExtensionsForDataPlane(ns, gatewayConfig.Spec.Extensions, konnectExtension)
+	dataplane.Spec.Extensions = extensions.MergeExtensionsForDataPlane(gateway, gatewayConfig.Spec.Extensions, konnectExtension)
 
 	k8sutils.SetOwnerForObject(dataplane, gateway)
 	gatewayutils.LabelObjectAsGatewayManaged(dataplane)

--- a/controller/pkg/extensions/konnect/utils.go
+++ b/controller/pkg/extensions/konnect/utils.go
@@ -6,7 +6,10 @@ import (
 )
 
 // KonnectExtensionToExtensionRef converts a KonnectExtension to the corresponding ExtensionRef.
-func KonnectExtensionToExtensionRef(extension *konnectv1alpha2.KonnectExtension) *commonv1alpha1.ExtensionRef {
+func KonnectExtensionToExtensionRef(
+	ns *string,
+	extension *konnectv1alpha2.KonnectExtension,
+) *commonv1alpha1.ExtensionRef {
 	if extension == nil {
 		return nil
 	}
@@ -15,7 +18,7 @@ func KonnectExtensionToExtensionRef(extension *konnectv1alpha2.KonnectExtension)
 		Kind:  konnectv1alpha2.KonnectExtensionKind,
 		NamespacedRef: commonv1alpha1.NamespacedRef{
 			Name:      extension.Name,
-			Namespace: new(extension.Namespace),
+			Namespace: ns,
 		},
 	}
 }

--- a/controller/pkg/extensions/konnect/utils_test.go
+++ b/controller/pkg/extensions/konnect/utils_test.go
@@ -13,16 +13,25 @@ import (
 func TestKonnectExtensionToExtensionRef(t *testing.T) {
 	tests := []struct {
 		name      string
+		ns        *string
 		extension *konnectv1alpha2.KonnectExtension
 		want      *commonv1alpha1.ExtensionRef
 	}{
 		{
 			name:      "nil extension returns nil",
+			ns:        new("default"),
 			extension: nil,
 			want:      nil,
 		},
 		{
-			name: "converts extension with name and namespace",
+			name:      "nil extension with nil ns returns nil",
+			ns:        nil,
+			extension: nil,
+			want:      nil,
+		},
+		{
+			name: "ns is used as namespace in the result",
+			ns:   new("default"),
 			extension: &konnectv1alpha2.KonnectExtension{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-extension",
@@ -39,11 +48,48 @@ func TestKonnectExtensionToExtensionRef(t *testing.T) {
 			},
 		},
 		{
-			name: "converts extension with additional fields (only name and namespace used)",
+			name: "ns differs from extension namespace",
+			ns:   new("other-namespace"),
+			extension: &konnectv1alpha2.KonnectExtension{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-extension",
+					Namespace: "extension-namespace",
+				},
+			},
+			want: &commonv1alpha1.ExtensionRef{
+				Group: konnectv1alpha2.SchemeGroupVersion.Group,
+				Kind:  konnectv1alpha2.KonnectExtensionKind,
+				NamespacedRef: commonv1alpha1.NamespacedRef{
+					Name:      "test-extension",
+					Namespace: new("other-namespace"),
+				},
+			},
+		},
+		{
+			name: "nil ns results in nil namespace",
+			ns:   nil,
+			extension: &konnectv1alpha2.KonnectExtension{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-extension",
+					Namespace: "default",
+				},
+			},
+			want: &commonv1alpha1.ExtensionRef{
+				Group: konnectv1alpha2.SchemeGroupVersion.Group,
+				Kind:  konnectv1alpha2.KonnectExtensionKind,
+				NamespacedRef: commonv1alpha1.NamespacedRef{
+					Name:      "test-extension",
+					Namespace: nil,
+				},
+			},
+		},
+		{
+			name: "ns is used regardless of extension metadata",
+			ns:   new("production"),
 			extension: &konnectv1alpha2.KonnectExtension{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "complex-extension",
-					Namespace: "production",
+					Namespace: "staging",
 					Labels: map[string]string{
 						"app": "test",
 					},
@@ -68,7 +114,7 @@ func TestKonnectExtensionToExtensionRef(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := KonnectExtensionToExtensionRef(tt.extension)
+			got := KonnectExtensionToExtensionRef(tt.ns, tt.extension)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/controller/pkg/extensions/merge.go
+++ b/controller/pkg/extensions/merge.go
@@ -60,14 +60,16 @@ func MergeExtensions[
 // MergeExtensionsForDataPlane is a wrapper around MergeExtensions for places where
 // we do not have an actual object to work on.
 func MergeExtensionsForDataPlane(
+	ns *string,
 	configExtensions []commonv1alpha1.ExtensionRef,
 	konnectExtension *konnectv1alpha2.KonnectExtension,
 ) []commonv1alpha1.ExtensionRef {
+
 	// Initialize the Konnect Extension by using the provided konnectExtension parameter.
 	// In case the GatewayConfiguration statically defines a KonnectExtension in its
 	// extensions list, the provided one will take precedence and be used.
 	extensionList := []commonv1alpha1.ExtensionRef{}
-	konnectExtensionRef := konnectextensionpkg.KonnectExtensionToExtensionRef(konnectExtension)
+	konnectExtensionRef := konnectextensionpkg.KonnectExtensionToExtensionRef(ns, konnectExtension)
 	if konnectExtensionRef != nil {
 		extensionList = append(extensionList, *konnectExtensionRef)
 	}

--- a/controller/pkg/extensions/merge.go
+++ b/controller/pkg/extensions/merge.go
@@ -2,6 +2,7 @@ package extensions
 
 import (
 	"github.com/samber/lo"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
 	operatorv1alpha1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1alpha1"
@@ -60,10 +61,14 @@ func MergeExtensions[
 // MergeExtensionsForDataPlane is a wrapper around MergeExtensions for places where
 // we do not have an actual object to work on.
 func MergeExtensionsForDataPlane(
-	ns *string,
+	managingObject client.Object,
 	configExtensions []commonv1alpha1.ExtensionRef,
 	konnectExtension *konnectv1alpha2.KonnectExtension,
 ) []commonv1alpha1.ExtensionRef {
+	var ns *string
+	if objNs := managingObject.GetNamespace(); konnectExtension != nil && objNs != konnectExtension.GetNamespace() {
+		ns = new(objNs)
+	}
 
 	// Initialize the Konnect Extension by using the provided konnectExtension parameter.
 	// In case the GatewayConfiguration statically defines a KonnectExtension in its

--- a/test/crdsvalidation/gateway-operator.konghq.com/dataplane_test.go
+++ b/test/crdsvalidation/gateway-operator.konghq.com/dataplane_test.go
@@ -95,6 +95,28 @@ func TestDataplane(t *testing.T) {
 				},
 				ExpectedErrorMessage: new("Extension not allowed for DataPlane"),
 			},
+			{
+				Name: "cross namespace extension reference is not allowed",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta(ns.Name),
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: validDataplaneOptions.Deployment,
+							Extensions: []commonv1alpha1.ExtensionRef{
+								{
+									Group: "konnect.konghq.com",
+									Kind:  "KonnectExtension",
+									NamespacedRef: commonv1alpha1.NamespacedRef{
+										Name:      "my-konnect-extension",
+										Namespace: new("namespace2"),
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: new("Cross namespace references not allowed for extension references"),
+			},
 		}.
 			RunWithConfig(t, cfg, scheme)
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #2554

**Special notes for your reviewer**:

The second commit in this PR adjusts the Hybrid Gateway reconciliation logic to not include the namespace in extension ref when it's the same as the managing object.

The reason for this is because object's namespace is not allowed in CEL CRD validation rules: https://github.com/kubernetes/kubernetes/issues/122163.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
