### PR TITLE
tests: fix telepresence config in tests

### DIFF
--- a/test/helpers/kcfg/crds.go
+++ b/test/helpers/kcfg/crds.go
@@ -7,24 +7,25 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/samber/lo"
 	"golang.org/x/mod/modfile"
+
+	"github.com/kong/kong-operator/v2/test/helpers"
 )
 
 const gatewayAPIModule = "sigs.k8s.io/gateway-api"
 
 var (
-	cfgPath = filepath.Join(projectRootPath(), "config")
+	cfgPath = filepath.Join(helpers.ProjectRootPath(), "config")
 	crdPath = filepath.Join(cfgPath, "crd")
 
 	rbacBase           = filepath.Join(cfgPath, "rbac", "base")
 	rbacRole           = filepath.Join(cfgPath, "rbac", "role")
 	validatingPolicies = filepath.Join(cfgPath, "default", "validating_policies")
 
-	chartPath = path.Join(projectRootPath(), "charts/kong-operator")
+	chartPath = path.Join(helpers.ProjectRootPath(), "charts/kong-operator")
 
 	gatewayAPIPackageVersion = lo.Must(extractModuleVersion(gatewayAPIModule))
 	gatewayAPIModulePath     = constructModulePath(gatewayAPIModule, gatewayAPIPackageVersion)
@@ -62,7 +63,7 @@ func GatewayAPIConformanceTestsFilesystemsWithManifests() []fs.FS {
 // If the module is not found, or the module version can't be parsed, it returns an error.
 func extractModuleVersion(moduleName string) (string, error) {
 	const moduleFile = "go.mod"
-	content, err := os.ReadFile(filepath.Join(projectRootPath(), moduleFile))
+	content, err := os.ReadFile(filepath.Join(helpers.ProjectRootPath(), moduleFile))
 	if err != nil {
 		return "", err
 	}
@@ -86,13 +87,4 @@ func constructModulePath(moduleName, version string) string {
 	modulePath = filepath.Join(append([]string{modulePath}, strings.Split(moduleName, "/")...)...)
 	modulePath += "@" + version
 	return modulePath
-}
-
-// projectRootPath returns the root directory of this project.
-func projectRootPath() string {
-	_, b, _, _ := runtime.Caller(0) //nolint:dogsled
-
-	// Returns root directory of this project.
-	// NOTE: it depends on the path of this file itself. When the file is moved, the second param may need updating.
-	return filepath.Join(filepath.Dir(b), "../../..")
 }

--- a/test/helpers/projectroot.go
+++ b/test/helpers/projectroot.go
@@ -1,0 +1,15 @@
+package helpers
+
+import (
+	"path/filepath"
+	"runtime"
+)
+
+// ProjectRootPath returns the root directory of this project.
+func ProjectRootPath() string {
+	_, b, _, _ := runtime.Caller(0) //nolint:dogsled
+
+	// Returns root directory of this project.
+	// NOTE: it depends on the path of this file itself. When the file is moved, the second param may need updating.
+	return filepath.Join(filepath.Dir(b), "../..")
+}

--- a/test/helpers/telepresence.go
+++ b/test/helpers/telepresence.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/kong/kong-operator/v2/test"
 )
@@ -25,6 +26,13 @@ func SetupTelepresence(ctx context.Context) (func(), error) {
 		telepresenceExecutable = "telepresence"
 		fmt.Printf("WARN: environment variable %s is not set, try to fallback to a system wide 'telepresnce'", telepresenceBin)
 	} else {
+		_, err := os.Stat(telepresenceExecutable)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"error checking telepresence executable at %s specified by %s environment variable: %w",
+				telepresenceExecutable, telepresenceBin, err,
+			)
+		}
 		fmt.Printf("INFO: path to binary from %s environment variable is %s\n", telepresenceBin, telepresenceExecutable)
 	}
 
@@ -37,6 +45,7 @@ func SetupTelepresence(ctx context.Context) (func(), error) {
 	// rules which only allow traffic from kong-system namespace.
 	// See: https://github.com/Kong/kong-operator/issues/2074
 	commonHelmFlags := []string{
+		"--config", filepath.Join(ProjectRootPath(), ".config_telepresence.yaml"),
 		"--manager-namespace", "kong-system",
 		"--set", "podLabels.app\\.kubernetes\\.io/name=kong-operator",
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes the go tests use the telepresense config https://github.com/Kong/kong-operator/blob/main/.config_telepresence.yaml

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
