### PR TITLE
chore(test): get rid of redundant tags: `envtest` and `integration_tests`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,7 +3,6 @@ run:
   timeout: 8m
   build-tags:
     - integration_tests
-    - envtest
 linters:
   enable:
     - asasalint

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,8 +1,6 @@
 version: "2"
 run:
   timeout: 8m
-  build-tags:
-    - integration_tests
 linters:
   enable:
     - asasalint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,8 +75,8 @@ make test.charts.golden.update  # Update chart golden files
 
 ### Test File Locations
 
-- Unit tests: `*_test.go` files next to source code (no build tags)
-- Envtest: `test/envtest/` (requires `// +build envtest` tag)
+- Unit tests: `*_test.go` files next to source code
+- Envtest: `test/envtest/`
 - Integration: `test/integration/`
 - Conformance: `test/conformance/`
 - CRD validation: `test/crdsvalidation/`

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ golangci-lint-cache-path:
 
 .PHONY: go-fix
 go-fix:
-	GOFLAGS="-tags=integration_tests,envtest" go fix ./...
+	GOFLAGS="-tags=integration_tests" go fix ./...
 
 GOTESTSUM_VERSION = $(shell $(YQ) -r '.gotestsum' < $(TOOLS_VERSIONS_FILE))
 GOTESTSUM = $(PROJECT_DIR)/bin/installs/github-gotestyourself-gotestsum/$(GOTESTSUM_VERSION)/gotestsum
@@ -596,7 +596,6 @@ _test.envtest: gotestsum setup-envtest
 		$(GOTESTSUM) -- \
 		$(GOTESTFLAGS) \
 		-race \
-		-tags envtest \
 		-timeout $(ENVTEST_TIMEOUT) \
 		-covermode=atomic \
 		-coverpkg=$(PKG_LIST) \

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ golangci-lint-cache-path:
 
 .PHONY: go-fix
 go-fix:
-	GOFLAGS="-tags=integration_tests" go fix ./...
+	go fix ./...
 
 GOTESTSUM_VERSION = $(shell $(YQ) -r '.gotestsum' < $(TOOLS_VERSIONS_FILE))
 GOTESTSUM = $(PROJECT_DIR)/bin/installs/github-gotestyourself-gotestsum/$(GOTESTSUM_VERSION)/gotestsum
@@ -745,7 +745,6 @@ PKG_LIST_KIC = ./ingress-controller/pkg/...,./ingress-controller/internal/...
 _test.integration-kic: mise yq
 	TEST_KONG_HELM_CHART_VERSION="$(TEST_KONG_HELM_CHART_VERSION)" \
 	TEST_DATABASE_MODE="$(DBMODE)" \
-	GOFLAGS="-tags=integration_tests" \
 	KONG_CONTROLLER_FEATURE_GATES="$(KONG_CONTROLLER_FEATURE_GATES)" \
 	go test $(GOTESTFLAGS) \
 	-v \

--- a/ingress-controller/internal/adminapi/konnect_test.go
+++ b/ingress-controller/internal/adminapi/konnect_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package adminapi_test
 
 import (

--- a/test/envtest/adminapi_discoverer_envtest_test.go
+++ b/test/envtest/adminapi_discoverer_envtest_test.go
@@ -1,5 +1,3 @@
-//go:build envtest
-
 package envtest
 
 import (

--- a/test/envtest/configerrorevent_envtest_test.go
+++ b/test/envtest/configerrorevent_envtest_test.go
@@ -1,5 +1,3 @@
-//go:build envtest
-
 package envtest
 
 import (

--- a/test/envtest/control_plane_reference_test.go
+++ b/test/envtest/control_plane_reference_test.go
@@ -1,5 +1,3 @@
-//go:build envtest
-
 package envtest
 
 import (

--- a/test/envtest/crds_envtest_test.go
+++ b/test/envtest/crds_envtest_test.go
@@ -1,5 +1,3 @@
-//go:build envtest
-
 package envtest
 
 import (

--- a/test/envtest/gateway_envtest_test.go
+++ b/test/envtest/gateway_envtest_test.go
@@ -1,5 +1,3 @@
-//go:build envtest
-
 package envtest
 
 import (

--- a/test/envtest/gateway_konnect_auth_referencegrant_envtest_test.go
+++ b/test/envtest/gateway_konnect_auth_referencegrant_envtest_test.go
@@ -1,5 +1,3 @@
-//go:build envtest
-
 package envtest
 
 import (

--- a/test/envtest/gatewayclass_envtest_test.go
+++ b/test/envtest/gatewayclass_envtest_test.go
@@ -1,5 +1,3 @@
-//go:build envtest
-
 package envtest
 
 import (

--- a/test/envtest/httproute_controller_test.go
+++ b/test/envtest/httproute_controller_test.go
@@ -1,5 +1,3 @@
-//go:build envtest
-
 package envtest
 
 import (

--- a/test/envtest/ingress_test.go
+++ b/test/envtest/ingress_test.go
@@ -1,5 +1,3 @@
-//go:build envtest
-
 package envtest
 
 import (

--- a/test/envtest/k8s_objects_status_envtest_test.go
+++ b/test/envtest/k8s_objects_status_envtest_test.go
@@ -1,5 +1,3 @@
-//go:build envtest
-
 package envtest
 
 import (

--- a/test/envtest/kongadminapi_controller_envtest_test.go
+++ b/test/envtest/kongadminapi_controller_envtest_test.go
@@ -1,5 +1,3 @@
-//go:build envtest
-
 package envtest
 
 import (

--- a/test/envtest/kongstate_consumer_failures_test.go
+++ b/test/envtest/kongstate_consumer_failures_test.go
@@ -1,5 +1,3 @@
-//go:build envtest
-
 package envtest
 
 import (

--- a/test/envtest/kongupstreampolicy_test.go
+++ b/test/envtest/kongupstreampolicy_test.go
@@ -1,5 +1,3 @@
-//go:build envtest
-
 package envtest
 
 import (

--- a/test/envtest/manager_envtest_test.go
+++ b/test/envtest/manager_envtest_test.go
@@ -1,5 +1,3 @@
-//go:build envtest
-
 package envtest
 
 import (

--- a/test/envtest/metrics_envtest_test.go
+++ b/test/envtest/metrics_envtest_test.go
@@ -1,5 +1,3 @@
-//go:build envtest
-
 package envtest
 
 import (

--- a/test/envtest/multiinstance_helpers_test.go
+++ b/test/envtest/multiinstance_helpers_test.go
@@ -1,5 +1,3 @@
-//go:build envtest
-
 package envtest
 
 import (

--- a/test/envtest/specific_gateway_envtest_test.go
+++ b/test/envtest/specific_gateway_envtest_test.go
@@ -1,5 +1,3 @@
-//go:build envtest
-
 package envtest
 
 import (

--- a/test/envtest/telemetry_test.go
+++ b/test/envtest/telemetry_test.go
@@ -1,5 +1,3 @@
-//go:build envtest
-
 package envtest
 
 import (

--- a/test/integration/kic/consumer_group_test.go
+++ b/test/integration/kic/consumer_group_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package integration
 
 import (

--- a/test/integration/kic/consumer_test.go
+++ b/test/integration/kic/consumer_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package integration
 
 import (

--- a/test/integration/kic/gateway_test.go
+++ b/test/integration/kic/gateway_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package integration
 
 import (

--- a/test/integration/kic/helpers_test.go
+++ b/test/integration/kic/helpers_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package integration
 
 import (

--- a/test/integration/kic/httproute_test.go
+++ b/test/integration/kic/httproute_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package integration
 
 import (

--- a/test/integration/kic/ingress_https_test.go
+++ b/test/integration/kic/ingress_https_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package integration
 
 import (

--- a/test/integration/kic/ingress_regex_match_test.go
+++ b/test/integration/kic/ingress_regex_match_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package integration
 
 import (

--- a/test/integration/kic/ingress_test.go
+++ b/test/integration/kic/ingress_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package integration
 
 import (

--- a/test/integration/kic/isolated/backendtlspolicy_test.go
+++ b/test/integration/kic/isolated/backendtlspolicy_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/consts.go
+++ b/test/integration/kic/isolated/consts.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import "fmt"

--- a/test/integration/kic/isolated/ctx.go
+++ b/test/integration/kic/isolated/ctx.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/custom_entity_test.go
+++ b/test/integration/kic/isolated/custom_entity_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/examples_grpc_test.go
+++ b/test/integration/kic/isolated/examples_grpc_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/examples_httproute_rewrite_test.go
+++ b/test/integration/kic/isolated/examples_httproute_rewrite_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/examples_httproute_test.go
+++ b/test/integration/kic/isolated/examples_httproute_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/examples_ingress_fallback_test.go
+++ b/test/integration/kic/isolated/examples_ingress_fallback_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/examples_ingress_test.go
+++ b/test/integration/kic/isolated/examples_ingress_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/examples_kong_service_facade_test.go
+++ b/test/integration/kic/isolated/examples_kong_service_facade_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/examples_tcproute_test.go
+++ b/test/integration/kic/isolated/examples_tcproute_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/examples_tlsroute_test.go
+++ b/test/integration/kic/isolated/examples_tlsroute_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/examples_udproute_test.go
+++ b/test/integration/kic/isolated/examples_udproute_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/gateway_https_test.go
+++ b/test/integration/kic/isolated/gateway_https_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/grpc_test.go
+++ b/test/integration/kic/isolated/grpc_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/httproute_filter_request_redirect_test.go
+++ b/test/integration/kic/isolated/httproute_filter_request_redirect_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/ingress_test.go
+++ b/test/integration/kic/isolated/ingress_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/ingress_verify_upstream_tls_test.go
+++ b/test/integration/kic/isolated/ingress_verify_upstream_tls_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/kongupstreampolicy_test.go
+++ b/test/integration/kic/isolated/kongupstreampolicy_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/license_test.go
+++ b/test/integration/kic/isolated/license_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/name.go
+++ b/test/integration/kic/isolated/name.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/namespace.go
+++ b/test/integration/kic/isolated/namespace.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/skip.go
+++ b/test/integration/kic/isolated/skip.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/suite_test.go
+++ b/test/integration/kic/isolated/suite_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/tcproute_test.go
+++ b/test/integration/kic/isolated/tcproute_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/isolated/udproute_test.go
+++ b/test/integration/kic/isolated/udproute_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package isolated
 
 import (

--- a/test/integration/kic/plugin_test.go
+++ b/test/integration/kic/plugin_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package integration
 
 import (

--- a/test/integration/kic/suite_test.go
+++ b/test/integration/kic/suite_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package integration
 
 import (

--- a/test/integration/kic/tcproute_test.go
+++ b/test/integration/kic/tcproute_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package integration
 
 import (

--- a/test/integration/kic/tlsroute_test.go
+++ b/test/integration/kic/tlsroute_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package integration
 
 import (

--- a/test/integration/kic/translation_failures_test.go
+++ b/test/integration/kic/translation_failures_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package integration
 
 import (

--- a/test/integration/kic/utils_test.go
+++ b/test/integration/kic/utils_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package integration
 
 import (

--- a/test/integration/kic/vault_test.go
+++ b/test/integration/kic/vault_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package integration
 
 import (

--- a/test/integration/kic/version_test.go
+++ b/test/integration/kic/version_test.go
@@ -1,5 +1,3 @@
-//go:build integration_tests
-
 package integration
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:

Those tags are redundant, hence remove them for simplicity. 