### PR TITLE
chore(ci): remove redundant `modernize`

### DIFF
--- a/.tools_versions.yaml
+++ b/.tools_versions.yaml
@@ -4,8 +4,6 @@ code-generator: "0.35.1"
 controller-tools: "0.20.1"
 # renovate: datasource=github-releases depName=golangci/golangci-lint
 golangci-lint: "2.10.1"
-# TODO: Renovate comment is missing. This needs to be added at some point.
-modernize: "0.19.1"
 # renovate: datasource=github-releases depName=GoogleContainerTools/skaffold
 skaffold: "2.17.2"
 # renovate: datasource=github-releases depName=go-delve/delve

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,11 +19,11 @@ make tools              # Install all required development tools via mise
 ## Linting
 
 ```bash
-make lint               # Run Go linters (modules, golangci-lint, modernize)
+make lint               # Run Go linters (modules, golangci-lint)
 make lint.all           # Full lint: Go + charts + GitHub Actions + markdown
 make lint.api           # Lint Kubernetes API types
 make lint.golangci-lint # Run golangci-lint linter for Go code
-make lint.modernize     # Run modernize on the codebase to ensure you're not using old or deprecated Go constructs.
+make go-fix             # Run go-fix on the codebase to ensure you're not using old or deprecated Go constructs.
 ```
 
 CI runs `make lint` with `GOLANGCI_LINT_FLAGS="--fix=false"` (auto-fix is enabled locally but disabled in CI).


### PR DESCRIPTION
**What this PR does / why we need it**:

First of all CI dependency modernize hasn't been updated for a long time (current version is `v0.42.0`), furthermore, it's covered by `make lint.go-fix`, which does similar to what modernize does, [see](https://go.dev/blog/gofix).

**Which issue this PR fixes**

Spotted during work on https://github.com/Kong/kong-operator/pull/2096 see the problem
```
WARN  go:golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize installed but not activated — it is not in any config file.
To install and activate, run:
  mise use go:golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize
make[1]: Leaving directory '/home/runner/work/kong-operator/kong-operator'
/home/runner/work/kong-operator/kong-operator/bin/installs/go-golang-org-x-tools-gopls-internal-analysis-modernize-cmd-modernize/0.19.1/bin/modernize -category=-omitzero ./...
-: # github.com/kong/kong-operator/v2/test/envtest [github.com/kong/kong-operator/v2/test/envtest.test]
Error: test/envtest/multiinstance_manager_diagnostics_test.go:37:14: undefined: setupMultiInstanceDiagnosticsManager
Error: test/envtest/multiinstance_manager_diagnostics_test.go:121:14: undefined: setupMultiInstanceDiagnosticsManager
Error: /home/runner/work/kong-operator/kong-operator/test/envtest/multiinstance_manager_diagnostics_test.go:37:14: undefined: setupMultiInstanceDiagnosticsManager
Error: /home/runner/work/kong-operator/kong-operator/test/envtest/multiinstance_manager_diagnostics_test.go:121:14: undefined: setupMultiInstanceDiagnosticsManager
modernize: analysis skipped due to errors in package
modernize: analysis skipped due to errors in package
make: *** [Makefile:280: lint.modernize] Error 1
Error: Process completed with exit code 2.
```

also locally it can't be run either.