### PR TITLE
chore: bump kubernetes-telemetry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/jpillora/backoff v1.0.0
 	github.com/kong/go-database-reconciler v1.31.6
 	github.com/kong/go-kong v0.72.1
-	github.com/kong/kubernetes-telemetry v0.1.11
+	github.com/kong/kubernetes-telemetry v0.1.12-0.20260227101019-6861cde03a30
 	github.com/kong/kubernetes-testing-framework v0.48.1-0.20260114143846-8c0e96b5bf82
 	github.com/kong/semver/v4 v4.0.1
 	github.com/kr/pretty v0.3.1
@@ -152,8 +152,8 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/gammazero/deque v0.2.0 // indirect
-	github.com/gammazero/workerpool v1.1.3 // indirect
+	github.com/gammazero/deque v1.2.1 // indirect
+	github.com/gammazero/workerpool v1.2.1 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -204,10 +204,10 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/gammazero/deque v0.2.0 h1:SkieyNB4bg2/uZZLxvya0Pq6diUlwx7m2TeT7GAIWaA=
-github.com/gammazero/deque v0.2.0/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=
-github.com/gammazero/workerpool v1.1.3 h1:WixN4xzukFoN0XSeXF6puqEqFTl2mECI9S6W44HWy9Q=
-github.com/gammazero/workerpool v1.1.3/go.mod h1:wPjyBLDbyKnUn2XwwyD3EEwo9dHutia9/fwNmSHWACc=
+github.com/gammazero/deque v1.2.1 h1:9fnQVFCCZ9/NOc7ccTNqzoKd1tCWOqeI05/lPqFPMGQ=
+github.com/gammazero/deque v1.2.1/go.mod h1:5nSFkzVm+afG9+gy0VIowlqVAW4N8zNcMne+CMQVD2g=
+github.com/gammazero/workerpool v1.2.1 h1:MEDvUJsNYGuCvl1RwIXNKu2YtQtHqCSF9XWF04N7lqs=
+github.com/gammazero/workerpool v1.2.1/go.mod h1:E32GVRUanF4d6QtRmdss3AScgaDkIyrvPtgRQUWgmx4=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
@@ -360,8 +360,8 @@ github.com/kong/go-database-reconciler v1.31.6 h1:Tfjh7NCp6mujfP53qCDOUrEyxw2ZN7
 github.com/kong/go-database-reconciler v1.31.6/go.mod h1:A6BBhnK1AQ7mQAsnLHoAitS62nJRGqUI8NbjC1aRGOc=
 github.com/kong/go-kong v0.72.1 h1:rQ69f3Wd0Fvc3JANkavo34vePqR4uZG/YQ2y5U7d2Po=
 github.com/kong/go-kong v0.72.1/go.mod h1:J0vGB3wsZ2i99zly1zTRe3v7rOKpkhQZRwbcTFP76qM=
-github.com/kong/kubernetes-telemetry v0.1.11 h1:HoyXYWc0+krE3x+tahYaNfUlkFTcpdcBQCAsBex6vyA=
-github.com/kong/kubernetes-telemetry v0.1.11/go.mod h1:xvEGAuVISm/R+dK3aR0GjFhMP3QbUqnhjRSj67kLdw4=
+github.com/kong/kubernetes-telemetry v0.1.12-0.20260227101019-6861cde03a30 h1:41XJx5dAibkSZGyCdDfyixFEX17108DthBwSmV/It9c=
+github.com/kong/kubernetes-telemetry v0.1.12-0.20260227101019-6861cde03a30/go.mod h1:7KSVQ1XV31B2W8kprxJ4Gm3IHC77JCQsUoqR4jmUJ/c=
 github.com/kong/kubernetes-testing-framework v0.48.1-0.20260114143846-8c0e96b5bf82 h1:GXO5LdlBxr/4kjZITg+Y/QXUM+23bC4YF3YZ6uBtu6M=
 github.com/kong/kubernetes-testing-framework v0.48.1-0.20260114143846-8c0e96b5bf82/go.mod h1:7d83ezAr/OJHKmB93k4NeA51SId8znXX0JqnLf3O9H4=
 github.com/kong/semver/v4 v4.0.1 h1:DIcNR8W3gfx0KabFBADPalxxsp+q/5COwIFkkhrFQ2Y=

--- a/internal/telemetry/provider.go
+++ b/internal/telemetry/provider.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kong/kubernetes-telemetry/pkg/types"
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/metadata"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1alpha1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1alpha1"
@@ -45,23 +45,23 @@ const (
 )
 
 // NewDataPlaneCountProvider creates a provider for number of dataplanes in the cluster.
-func NewDataPlaneCountProvider(dyn dynamic.Interface, restMapper meta.RESTMapper) (provider.Provider, error) {
+func NewDataPlaneCountProvider(m metadata.Interface, restMapper meta.RESTMapper) (provider.Provider, error) {
 	return provider.NewK8sObjectCountProviderWithRESTMapper(
-		DataPlaneK8sResourceName, DataPlaneCountKind, dyn, operatorv1beta1.DataPlaneGVR(), restMapper,
+		DataPlaneK8sResourceName, DataPlaneCountKind, m, operatorv1beta1.DataPlaneGVR(), restMapper,
 	)
 }
 
 // NewControlPlaneCountProvider creates a provider for number of dataplanes in the cluster.
-func NewControlPlaneCountProvider(dyn dynamic.Interface, restMapper meta.RESTMapper) (provider.Provider, error) {
+func NewControlPlaneCountProvider(m metadata.Interface, restMapper meta.RESTMapper) (provider.Provider, error) {
 	return provider.NewK8sObjectCountProviderWithRESTMapper(
-		ControlPlaneK8sResourceName, ControlPlaneCountKind, dyn, gwtypes.ControlPlaneGVR(), restMapper,
+		ControlPlaneK8sResourceName, ControlPlaneCountKind, m, gwtypes.ControlPlaneGVR(), restMapper,
 	)
 }
 
 // NewAIgatewayCountProvider creates a provider for number of dataplanes in the cluster.
-func NewAIgatewayCountProvider(dyn dynamic.Interface, restMapper meta.RESTMapper) (provider.Provider, error) {
+func NewAIgatewayCountProvider(m metadata.Interface, restMapper meta.RESTMapper) (provider.Provider, error) {
 	return provider.NewK8sObjectCountProviderWithRESTMapper(
-		AIGatewayK8sResourceName, AIGatewayCountKind, dyn, operatorv1alpha1.AIGatewayGVR(), restMapper,
+		AIGatewayK8sResourceName, AIGatewayCountKind, m, operatorv1alpha1.AIGatewayGVR(), restMapper,
 	)
 }
 

--- a/internal/telemetry/provider_objectcounter_konnect.go
+++ b/internal/telemetry/provider_objectcounter_konnect.go
@@ -4,7 +4,7 @@ import (
 	"github.com/kong/kubernetes-telemetry/pkg/provider"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/metadata"
 
 	"github.com/kong/kong-operator/v2/controller/konnect/constraints"
 )
@@ -13,7 +13,7 @@ import (
 func NewObjectCountProvider[
 	T constraints.SupportedKonnectEntityType,
 	TEnt constraints.EntityType[T],
-](dyn dynamic.Interface, restMapper meta.RESTMapper, group string, version string) (provider.Provider, error) {
+](metadataClient metadata.Interface, restMapper meta.RESTMapper, group string, version string) (provider.Provider, error) {
 	kind := constraints.EntityTypeName[T]()
 	restMapping, err := restMapper.RESTMapping(
 		schema.GroupKind{
@@ -35,7 +35,7 @@ func NewObjectCountProvider[
 	return provider.NewK8sObjectCountProviderWithRESTMapper(
 		restMapping.Resource.Resource,
 		provider.Kind(kind),
-		dyn,
+		metadataClient,
 		gvr,
 		restMapper,
 	)

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -17,13 +17,13 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
-	testdynclient "k8s.io/client-go/dynamic/fake"
 	testk8sclient "k8s.io/client-go/kubernetes/fake"
+	metadata_fake "k8s.io/client-go/metadata/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -40,6 +40,7 @@ import (
 	"github.com/kong/kong-operator/v2/modules/manager/metadata"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	"github.com/kong/kong-operator/v2/pkg/vars"
+	"github.com/kong/kong-operator/v2/test/helpers/convert"
 )
 
 type configOption func(*Config) *Config
@@ -632,6 +633,7 @@ func TestCreateManager(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			scheme := scheme.Get()
+			require.NoError(t, metav1.AddMetaToScheme(scheme))
 			k8sclient := testk8sclient.NewClientset()
 
 			ctrlClient := prepareControllerClient(scheme, tc.objects...)
@@ -640,18 +642,6 @@ func TestCreateManager(t *testing.T) {
 			require.True(t, ok)
 			d.FakedServerVersion = versionInfo()
 
-			// We need the custom list kinds to prevent:
-			// panic: coding error: you must register resource to list kind for every resource you're going
-			// to LIST when creating the client.
-			// See NewSimpleDynamicClientWithCustomListKinds:
-			// https://pkg.go.dev/k8s.io/client-go/dynamic/fake#NewSimpleDynamicClientWithCustomListKinds
-			// or register the list into the scheme:
-			dyn := testdynclient.NewSimpleDynamicClientWithCustomListKinds(scheme,
-				map[schema.GroupVersionResource]string{
-					operatorv1alpha1.AIGatewayGVR(): "AIGatewayList",
-				},
-				tc.objects...,
-			)
 			meta := metadata.Info{
 				Release: "0.6.2",
 			}
@@ -664,8 +654,10 @@ func TestCreateManager(t *testing.T) {
 				cfg = opt(cfg)
 			}
 
+			metadataClient := metadata_fake.NewSimpleMetadataClient(scheme, convert.ToPartialObjectMetadata(scheme, tc.objects...)...)
+
 			m, err := createManager(
-				types.Signal(SignalPing), k8sclient, ctrlClient, dyn, meta, *cfg,
+				types.Signal(SignalPing), k8sclient, ctrlClient, metadataClient, meta, *cfg,
 				logr.Discard(),
 				telemetry.OptManagerPeriod(time.Hour),
 			)
@@ -694,7 +686,7 @@ func TestTelemetryUpdates(t *testing.T) {
 		name                           string
 		objects                        []runtime.Object
 		expectedReportParts            []string
-		action                         func(t *testing.T, ctx context.Context, dyn *testdynclient.FakeDynamicClient)
+		action                         func(t *testing.T, tracker k8stesting.ObjectTracker)
 		expectedReportPartsAfterAction []string
 	}{
 		{
@@ -719,10 +711,8 @@ func TestTelemetryUpdates(t *testing.T) {
 				"k8s_pods_count=0",
 				"k8s_dataplanes_count=1",
 			},
-			action: func(t *testing.T, ctx context.Context, dyn *testdynclient.FakeDynamicClient) {
-				require.NoError(t, dyn.Resource(operatorv1beta1.DataPlaneGVR()).
-					Namespace("kong").
-					Delete(ctx, "cloud-gateway-0", metav1.DeleteOptions{}))
+			action: func(t *testing.T, tracker k8stesting.ObjectTracker) {
+				require.NoError(t, tracker.Delete(operatorv1beta1.DataPlaneGVR(), "kong", "cloud-gateway-0"))
 			},
 			expectedReportPartsAfterAction: []string{
 				"signal=test-signal",
@@ -741,65 +731,41 @@ func TestTelemetryUpdates(t *testing.T) {
 				"k8s_pods_count=0",
 				"k8s_dataplanes_count=0",
 			},
-			action: func(t *testing.T, ctx context.Context, dyn *testdynclient.FakeDynamicClient) {
-				_, err := dyn.Resource(operatorv1beta1.DataPlaneGVR()).
-					Namespace("kong").
-					Create(ctx, &unstructured.Unstructured{
-						Object: map[string]any{
-							"apiVersion": "gateway-operator.konghq.com/v1beta1",
-							"kind":       "DataPlane",
-							"metadata": map[string]any{
-								"name":      "cloud-gateway-0",
-								"namespace": "kong",
-							},
-						},
-					}, metav1.CreateOptions{})
-				require.NoError(t, err)
-				_, err = dyn.Resource(operatorv1beta1.DataPlaneGVR()).
-					Namespace("kong").
-					Create(ctx, &unstructured.Unstructured{
-						Object: map[string]any{
-							"apiVersion": "gateway-operator.konghq.com/v1beta1",
-							"kind":       "DataPlane",
-							"metadata": map[string]any{
-								"name":      "cloud-gateway-1",
-								"namespace": "kong",
-							},
-						},
-					}, metav1.CreateOptions{})
-				require.NoError(t, err)
+			action: func(t *testing.T, tracker k8stesting.ObjectTracker) {
+				require.NoError(t, tracker.Create(operatorv1beta1.DataPlaneGVR(), &metav1.PartialObjectMetadata{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "gateway-operator.konghq.com/v1beta1",
+						Kind:       "DataPlane",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cloud-gateway-0",
+						Namespace: "kong",
+					},
+				}, "kong"))
+				require.NoError(t, tracker.Create(operatorv1beta1.DataPlaneGVR(), &metav1.PartialObjectMetadata{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "gateway-operator.konghq.com/v1beta1",
+						Kind:       "DataPlane",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cloud-gateway-1",
+						Namespace: "kong",
+					},
+				}, "kong"))
 			},
 			expectedReportPartsAfterAction: []string{
 				"signal=test-signal",
 				"v=0.6.2",
 				"k8s_nodes_count=0",
 				"k8s_pods_count=0",
-				// NOTE: For some reason deletions do not work in tests.
-				// When we add a custom mapping to NewSimpleDynamicClientWithCustomListKinds:
-				//   operatorv1beta1.DataPlaneGVR():  "DataPlaneList",
-				// then this works but the previous test case for deletion fails.
-				// Surprisingly, this part of the report is not reported here after
-				// the update (create actions).
-				// "k8s_dataplanes_count=0",
+				"k8s_dataplanes_count=2",
 			},
 		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			scheme := scheme.Get()
-			// We need the custom list kinds to prevent:
-			// panic: coding error: you must register resource to list kind for every resource you're going
-			// to LIST when creating the client.
-			// See NewSimpleDynamicClientWithCustomListKinds:
-			// https://pkg.go.dev/k8s.io/client-go/dynamic/fake#NewSimpleDynamicClientWithCustomListKinds
-			// or register the list into the scheme:
-			dyn := testdynclient.NewSimpleDynamicClientWithCustomListKinds(
-				scheme,
-				map[schema.GroupVersionResource]string{
-					operatorv1alpha1.AIGatewayGVR(): "AIGatewayList",
-				},
-				tc.objects...,
-			)
+			require.NoError(t, metav1.AddMetaToScheme(scheme))
 
 			k8sclient := testk8sclient.NewClientset()
 			ctrlClient := prepareControllerClient(scheme)
@@ -816,8 +782,9 @@ func TestTelemetryUpdates(t *testing.T) {
 				DataPlaneControllerEnabled: true,
 			}
 
+			metadataClient := metadata_fake.NewSimpleMetadataClient(scheme, convert.ToPartialObjectMetadata(scheme, tc.objects...)...)
 			m, err := createManager(
-				types.Signal(SignalPing), k8sclient, ctrlClient, dyn, meta, cfg,
+				types.Signal(SignalPing), k8sclient, ctrlClient, metadataClient, meta, cfg,
 				testr.New(t),
 				telemetry.OptManagerPeriod(time.Hour),
 			)
@@ -838,7 +805,7 @@ func TestTelemetryUpdates(t *testing.T) {
 			t.Log("checking received report...")
 			requireReportContainsValuesEventually(t, ch, tc.expectedReportParts...)
 
-			tc.action(t, t.Context(), dyn)
+			tc.action(t, metadataClient.Tracker())
 
 			require.NoError(t, m.TriggerExecute(ctx, "test-signal"), "failed triggering signal execution")
 

--- a/test/helpers/convert/partialmetadata.go
+++ b/test/helpers/convert/partialmetadata.go
@@ -1,0 +1,34 @@
+package convert
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// ToPartialObjectMetadata converts typed Kubernetes objects into
+// *metav1.PartialObjectMetadata so they can be used with the metadata fake client.
+func ToPartialObjectMetadata(s *runtime.Scheme, objs ...runtime.Object) []runtime.Object {
+	out := make([]runtime.Object, 0, len(objs))
+	for _, obj := range objs {
+		gvks, _, err := s.ObjectKinds(obj)
+		if err != nil || len(gvks) == 0 {
+			continue
+		}
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			continue
+		}
+		out = append(out, &metav1.PartialObjectMetadata{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: gvks[0].GroupVersion().String(),
+				Kind:       gvks[0].Kind,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      accessor.GetName(),
+				Namespace: accessor.GetNamespace(),
+			},
+		})
+	}
+	return out
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Use [metadata.Interface](https://pkg.go.dev/k8s.io/client-go@v0.35.1/metadata#Interface) instead of dynamic client to only obtain metadata for object that we do not care about but which we only want to count.

The performance gains are explained in related PR: https://github.com/Kong/kubernetes-telemetry/pull/398

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
