### PR TITLE
fix(hybridgateway): dataplane deletion in case of konnect connectivity issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,12 @@
   [#3206](https://github.com/Kong/kong-operator/pull/3206)
 - Fix handling removal of annotations for DataPlane's Services
   [#3402](https://github.com/Kong/kong-operator/pull/3402)
+- Fix Gateway controller deleting all DataPlanes when KonnectExtension's
+  `ControlPlaneRefValid` condition is temporarily False due to transient Konnect
+  API failures. DataPlanes now continue serving traffic during Konnect
+  connectivity issues. Added `NotProgrammed` condition reason to differentiate
+  transient failures from permanent reference errors.
+  [#3463](https://github.com/Kong/kong-operator/pull/3463)
 
 ## [v2.1.1]
 

--- a/api/konnect/v1alpha1/konnect_conditions.go
+++ b/api/konnect/v1alpha1/konnect_conditions.go
@@ -80,6 +80,11 @@ const (
 	// ControlPlaneRefReasonInvalid is the reason used with the ControlPlaneRefValid
 	// condition type indicating that the ControlPlane reference is invalid.
 	ControlPlaneRefReasonInvalid = "Invalid"
+	// ControlPlaneRefReasonNotProgrammed is the reason used with the ControlPlaneRefValid
+	// condition type indicating that the referenced ControlPlane exists but is not
+	// yet programmed in Konnect. This is typically a transient condition that resolves
+	// when the ControlPlane successfully syncs with the Konnect API.
+	ControlPlaneRefReasonNotProgrammed = "NotProgrammed"
 )
 
 const (

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -880,8 +880,14 @@ func (r *Reconciler) provisionKonnectExtension(
 	// If we continue, there is only one konnect extension.
 	konnectExtension := konnectExtensions[0].DeepCopy()
 
-	// It happens e.g. when someone manually deleted the KonnectGatewayControlPlane, so for a recreated one update the KonnectExtension reference.
-	// To recreate the KonnectExtension, firstly all DataPlanes associated with the Gateway must be deleted, as they reference the KonnectExtension.
+	// Handle KonnectExtension whose ControlPlaneRef is not valid.
+	// Two cases:
+	// 1. Transient: CP exists, matches, but not yet programmed (Konnect API temporarily down)
+	//    → wait for KonnectExtension controller to re-validate
+	// 2. Stale ref: CP ref points to different/old KGCP (e.g., manual deletion+recreation)
+	//    → delete only the KonnectExtension for recreation (ref is immutable per CEL rule)
+	// DataPlanes are NEVER deleted: they handle missing extensions gracefully
+	// (setting KonnectExtensionApplied=False while continuing to serve traffic).
 	log.Debug(logger, "ensuring KonnectExtension references valid KonnectGatewayControlPlane")
 	if cond, ok := k8sutils.GetCondition(konnectv1alpha1.ControlPlaneRefValidConditionType, konnectExtension); ok && cond.Status != metav1.ConditionTrue {
 		k8sutils.SetCondition(
@@ -894,24 +900,26 @@ func (r *Reconciler) provisionKonnectExtension(
 			),
 			gatewayConditionsAndListenersAware(gateway),
 		)
-		dataPlanes, err := gatewayutils.ListDataPlanesForGateway(
-			ctx,
-			r.Client,
-			gateway,
+
+		// If extension refs the current CP, the condition is transient — wait for reconciliation.
+		cpRef := konnectExtension.Spec.Konnect.ControlPlane.Ref.KonnectNamespacedRef
+		if cpRef != nil && konnectControlPlane != nil && cpRef.Name == konnectControlPlane.Name {
+			log.Debug(logger,
+				"KonnectExtension ControlPlaneRef matches current KonnectGatewayControlPlane, waiting for reconciliation",
+				"KonnectExtension", client.ObjectKeyFromObject(konnectExtension),
+				"KonnectGatewayControlPlane", client.ObjectKeyFromObject(konnectControlPlane),
+			)
+			return nil
+		}
+
+		// Extension refs a different/stale CP — delete extension only for recreation.
+		log.Debug(logger,
+			"KonnectExtension references stale KonnectGatewayControlPlane, deleting for recreation",
+			"KonnectExtension", client.ObjectKeyFromObject(konnectExtension),
 		)
-		if err != nil {
-			log.Error(logger, err, "listing DataPlanes failed, will be requeued")
-			return nil
-		}
-		for _, dp := range dataPlanes {
-			if err := r.Delete(ctx, &dp); err != nil && !apierrors.IsNotFound(err) {
-				log.Error(logger, err, "deleting dataplane failed", "dataplane", client.ObjectKeyFromObject(&dp))
-			}
-			log.Trace(logger, "deleted associated dataplane", "dataplane", client.ObjectKeyFromObject(&dp))
-		}
-		if err := r.Delete(ctx, konnectExtension); err != nil {
-			log.Error(logger, err, "updating invalid KonnectExtension failed", "KonnectExtension", client.ObjectKeyFromObject(konnectExtension))
-			return nil
+		if err := r.Delete(ctx, konnectExtension); err != nil && !apierrors.IsNotFound(err) {
+			log.Error(logger, err, "deleting stale KonnectExtension failed",
+				"KonnectExtension", client.ObjectKeyFromObject(konnectExtension))
 		}
 		return nil
 	}

--- a/controller/gateway/controller_test.go
+++ b/controller/gateway/controller_test.go
@@ -3,7 +3,9 @@ package gateway
 import (
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -16,9 +18,12 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	kcfgconsts "github.com/kong/kong-operator/v2/api/common/consts"
+	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
 	kcfgdataplane "github.com/kong/kong-operator/v2/api/gateway-operator/dataplane"
 	kcfggateway "github.com/kong/kong-operator/v2/api/gateway-operator/gateway"
 	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
+	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	"github.com/kong/kong-operator/v2/pkg/consts"
@@ -792,5 +797,190 @@ func BenchmarkGatewayReconciler_Reconcile(b *testing.B) {
 		if err != nil {
 			b.Error(err)
 		}
+	}
+}
+
+func TestProvisionKonnectExtension_ControlPlaneRefNotValid(t *testing.T) {
+	const (
+		testNamespace = "test-ns"
+		gatewayName   = "test-gateway"
+		cpName        = "test-cp"
+		extName       = "test-konnect-ext"
+		dpName        = "test-dataplane"
+	)
+
+	gateway := &gwtypes.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gatewayName,
+			Namespace: testNamespace,
+			UID:       types.UID(uuid.NewString()),
+		},
+	}
+
+	konnectControlPlane := &konnectv1alpha2.KonnectGatewayControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cpName,
+			Namespace: testNamespace,
+		},
+	}
+
+	testCases := []struct {
+		name string
+		// konnectExtension is the KonnectExtension to provision.
+		konnectExtension *konnectv1alpha2.KonnectExtension
+		// dataPlane is the DataPlane associated with the Gateway.
+		dataPlane *operatorv1beta1.DataPlane
+		// expectDataPlaneExists indicates whether the DataPlane should still exist after provisioning.
+		expectDataPlaneExists bool
+		// expectExtensionExists indicates whether the KonnectExtension should still exist after provisioning.
+		expectExtensionExists bool
+		// expectReturnNil indicates whether provisionKonnectExtension should return nil.
+		expectReturnNil bool
+	}{
+		{
+			name: "transient failure - CP ref matches current CP, DataPlane and extension preserved",
+			konnectExtension: &konnectv1alpha2.KonnectExtension{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      extName,
+					Namespace: testNamespace,
+					UID:       types.UID(uuid.NewString()),
+					Labels: map[string]string{
+						consts.GatewayOperatorManagedByLabel: consts.GatewayManagedLabelValue,
+					},
+				},
+				Spec: konnectv1alpha2.KonnectExtensionSpec{
+					Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+						ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+							Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+								KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+									Name: cpName, // same as konnectControlPlane
+								},
+							},
+						},
+					},
+				},
+				Status: konnectv1alpha2.KonnectExtensionStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   konnectv1alpha1.ControlPlaneRefValidConditionType,
+							Status: metav1.ConditionFalse,
+							Reason: konnectv1alpha1.ControlPlaneRefReasonNotProgrammed,
+						},
+					},
+				},
+			},
+			dataPlane: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dpName,
+					Namespace: testNamespace,
+					UID:       types.UID(uuid.NewString()),
+					Labels: map[string]string{
+						consts.GatewayOperatorManagedByLabel: consts.GatewayManagedLabelValue,
+					},
+				},
+			},
+			expectDataPlaneExists: true,
+			expectExtensionExists: true,
+			expectReturnNil:       true,
+		},
+		{
+			name: "stale extension - CP ref differs from current CP, DataPlane preserved, extension deleted",
+			konnectExtension: &konnectv1alpha2.KonnectExtension{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      extName,
+					Namespace: testNamespace,
+					UID:       types.UID(uuid.NewString()),
+					Labels: map[string]string{
+						consts.GatewayOperatorManagedByLabel: consts.GatewayManagedLabelValue,
+					},
+				},
+				Spec: konnectv1alpha2.KonnectExtensionSpec{
+					Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+						ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+							Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+								KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+									Name: "old-cp-name", // different from konnectControlPlane
+								},
+							},
+						},
+					},
+				},
+				Status: konnectv1alpha2.KonnectExtensionStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   konnectv1alpha1.ControlPlaneRefValidConditionType,
+							Status: metav1.ConditionFalse,
+							Reason: konnectv1alpha1.ControlPlaneRefReasonInvalid,
+						},
+					},
+				},
+			},
+			dataPlane: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dpName,
+					Namespace: testNamespace,
+					UID:       types.UID(uuid.NewString()),
+					Labels: map[string]string{
+						consts.GatewayOperatorManagedByLabel: consts.GatewayManagedLabelValue,
+					},
+				},
+			},
+			expectDataPlaneExists: true,
+			expectExtensionExists: false,
+			expectReturnNil:       true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			logger := logr.Discard()
+
+			// Set owner references so list functions can find the objects.
+			k8sutils.SetOwnerForObject(tc.konnectExtension, gateway)
+			k8sutils.SetOwnerForObject(tc.dataPlane, gateway)
+
+			objects := []controllerruntimeclient.Object{
+				gateway, konnectControlPlane.DeepCopy(),
+				tc.konnectExtension, tc.dataPlane,
+			}
+
+			fakeClient := fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Get()).
+				WithObjects(objects...).
+				WithStatusSubresource(objects...).
+				Build()
+
+			reconciler := Reconciler{
+				Client: fakeClient,
+			}
+
+			result := reconciler.provisionKonnectExtension(ctx, logger, gateway, konnectControlPlane)
+
+			if tc.expectReturnNil {
+				assert.Nil(t, result, "provisionKonnectExtension should return nil")
+			} else {
+				assert.NotNil(t, result, "provisionKonnectExtension should return non-nil")
+			}
+
+			// Verify DataPlane existence.
+			dpList := &operatorv1beta1.DataPlaneList{}
+			require.NoError(t, fakeClient.List(ctx, dpList, controllerruntimeclient.InNamespace(testNamespace)))
+			if tc.expectDataPlaneExists {
+				assert.Len(t, dpList.Items, 1, "DataPlane should still exist")
+			} else {
+				assert.Empty(t, dpList.Items, "DataPlane should be deleted")
+			}
+
+			// Verify KonnectExtension existence.
+			extList := &konnectv1alpha2.KonnectExtensionList{}
+			require.NoError(t, fakeClient.List(ctx, extList, controllerruntimeclient.InNamespace(testNamespace)))
+			if tc.expectExtensionExists {
+				assert.Len(t, extList.Items, 1, "KonnectExtension should still exist")
+			} else {
+				assert.Empty(t, extList.Items, "KonnectExtension should be deleted")
+			}
+		})
 	}
 }

--- a/controller/konnect/konnectextension_controller_utils.go
+++ b/controller/konnect/konnectextension_controller_utils.go
@@ -89,9 +89,10 @@ func (r *KonnectExtensionReconciler) getGatewayKonnectControlPlane(
 	}
 
 	// Set the controlPlaneRefValidCond to false in case the KonnectGatewayControlPlane is not programmed yet.
+	// Use NotProgrammed reason to differentiate from permanent Invalid (e.g., CP not found).
 	if !k8sutils.HasConditionTrue(konnectv1alpha1.KonnectEntityProgrammedConditionType, cp) {
 		controlPlaneRefValidCond.Status = metav1.ConditionFalse
-		controlPlaneRefValidCond.Reason = konnectv1alpha1.ControlPlaneRefReasonInvalid
+		controlPlaneRefValidCond.Reason = konnectv1alpha1.ControlPlaneRefReasonNotProgrammed
 		controlPlaneRefValidCond.Message = fmt.Sprintf("Konnect control plane %s/%s not programmed yet", cp.Name, cp.Namespace)
 		if res, _, errPatch := patch.StatusWithConditions(
 			ctx,

--- a/controller/konnect/reconciler_controlplaneref.go
+++ b/controller/konnect/reconciler_controlplaneref.go
@@ -93,7 +93,7 @@ func handleControlPlaneRef[T constraints.SupportedKonnectEntityType, TEnt constr
 			ctx, cl, ent,
 			konnectv1alpha1.ControlPlaneRefValidConditionType,
 			metav1.ConditionFalse,
-			konnectv1alpha1.ControlPlaneRefReasonInvalid,
+			konnectv1alpha1.ControlPlaneRefReasonNotProgrammed,
 			fmt.Sprintf("Referenced ControlPlane %s is not programmed yet", cpRef.String()),
 		); errStatus != nil || !res.IsZero() {
 			return res, errStatus

--- a/controller/konnect/reconciler_controlplaneref_test.go
+++ b/controller/konnect/reconciler_controlplaneref_test.go
@@ -235,8 +235,10 @@ func TestHandleControlPlaneRef(t *testing.T) {
 			updatedEntAssertions: []func(svc *configurationv1alpha1.KongService) (ok bool, message string){
 				func(svc *configurationv1alpha1.KongService) (bool, string) {
 					return lo.ContainsBy(svc.Status.Conditions, func(c metav1.Condition) bool {
-						return c.Type == konnectv1alpha1.ControlPlaneRefValidConditionType && c.Status == metav1.ConditionFalse
-					}), "service should have ControlPlaneRefValid set to False"
+						return c.Type == konnectv1alpha1.ControlPlaneRefValidConditionType &&
+							c.Status == metav1.ConditionFalse &&
+							c.Reason == konnectv1alpha1.ControlPlaneRefReasonNotProgrammed
+					}), "service should have ControlPlaneRefValid set to False with NotProgrammed reason"
 				},
 			},
 		},

--- a/controller/pkg/extensions/apply.go
+++ b/controller/pkg/extensions/apply.go
@@ -78,13 +78,10 @@ func ApplyExtensions[t ExtendableT](ctx context.Context, cl client.Client, o t, 
 	// in case the extensionsCondition is true, let's apply the extensions.
 	konnectExtensionApplied := k8sutils.NewConditionWithGeneration(kcfgkonnect.KonnectExtensionAppliedType, metav1.ConditionTrue, kcfgkonnect.KonnectExtensionAppliedReason, "The Konnect extension has been successfully applied", o.GetGeneration())
 	if extensionsCondition.Status == metav1.ConditionTrue {
-		var (
-			extensionRefFound bool
-			err               error
-		)
+		var err error
 
 		// Process the extensions using the provided processor.
-		extensionRefFound, err = processor.Process(ctx, cl, o)
+		_, err = processor.Process(ctx, cl, o)
 		if err != nil {
 			switch {
 			case errors.Is(err, extensionserrors.ErrCrossNamespaceReference):
@@ -106,9 +103,8 @@ func ApplyExtensions[t ExtendableT](ctx context.Context, cl client.Client, o t, 
 			default:
 				return true, ctrl.Result{}, err
 			}
-		}
-		if !extensionRefFound {
-			return false, ctrl.Result{}, nil
+			// Don't spam with errors, so return stop and nil error
+			return true, ctrl.Result{}, nil
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a critical bug where transient Konnect API connectivity issues were causing the Gateway controller to permanently delete all DataPlane pods.

Root cause: The provisionKonnectExtension function in the Gateway controller treated all cases where `KonnectExtension.ControlPlaneRefValid=False` as permanent failures and deleted every DataPlane associated with the Gateway. This triggered a Kubernetes garbage collection cascade: DataPlane → Deployment → ReplicaSet → Pods destroyed.

However, `ControlPlaneRefValid=False` can be caused by transient conditions (when the Konnect API returns 5xx errors, timeouts, or connection resets), the KonnectGatewayControlPlane loses its `Programmed=True` condition, which propagates to the extension and then incorrectly triggers DataPlane deletion. Since the DataPlane controller handles missing extensions gracefully (by setting KonnectExtensionApplied=False while continuing to serve traffic), there is no reason to ever delete DataPlanes.

Changes:
 - New `ControlPlaneRefReasonNotProgrammed` condition reason: differentiates transient failures ("CP exists but not yet programmed in Konnect") from permanent failures ("CP not found / invalid ref"). Previously both used the same Invalid reason, making it impossible for downstream controllers to distinguish them.
- Updated reconciler_controlplaneref.go and konnectextension_controller_utils.go: The "CP not programmed yet" path now sets reason=NotProgrammed instead of reason=Invalid.
- Fixed `provisionKonnectExtension` in the Gateway controller: replaced the unconditional DataPlane-delete-then-extension-delete logic with a two-case check:
  - Transient failure (extension's CP ref matches the current KonnectGatewayControlPlane): just log and return, the KonnectExtension controller will re-validate on its own schedule.
  - Stale ref (extension's CP ref points to a different/old KGCP, e.g. after manual deletion+recreation): delete only the KonnectExtension for recreation (the `spec.konnect.controlPlane.ref` field is immutable per CEL validation, so recreation is the correct path).
  - DataPlanes are never deleted in either case.


**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
