### PR TITLE
tests: fix flakiness in TestDataPlaneBlueGreen from envtest suite

### DIFF
--- a/pkg/utils/test/predicates.go
+++ b/pkg/utils/test/predicates.go
@@ -464,19 +464,17 @@ func DataPlaneHasServiceAndAddressesInStatus(t *testing.T, ctx context.Context, 
 // DataPlaneUpdateEventually is a helper function for tests that returns a function
 // that can be used to update the DataPlane.
 // Should be used in conjunction with require.Eventually or assert.Eventually.
-func DataPlaneUpdateEventually(t *testing.T, ctx context.Context, dataplaneNN types.NamespacedName, clients K8sClients, updateFunc func(*operatorv1beta1.DataPlane)) func() bool {
+func DataPlaneUpdateEventually(t *testing.T, ctx context.Context, dataplaneNN types.NamespacedName, cl client.Client, updateFunc func(*operatorv1beta1.DataPlane)) func() bool {
 	return func() bool {
-		cl := clients.OperatorClient.GatewayOperatorV1beta1().DataPlanes(dataplaneNN.Namespace)
-		dp, err := cl.Get(ctx, dataplaneNN.Name, metav1.GetOptions{})
-		if err != nil {
+		var dp operatorv1beta1.DataPlane
+		if err := cl.Get(ctx, dataplaneNN, &dp); err != nil {
 			t.Logf("error getting dataplane: %v", err)
 			return false
 		}
 
-		updateFunc(dp)
+		updateFunc(&dp)
 
-		_, err = cl.Update(ctx, dp, metav1.UpdateOptions{})
-		if err != nil {
+		if err := cl.Update(ctx, &dp); err != nil {
 			t.Logf("error updating dataplane: %v", err)
 			return false
 		}

--- a/test/envtest/dataplane_bluegreen_test.go
+++ b/test/envtest/dataplane_bluegreen_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	"github.com/kong/kong-operator/v2/pkg/consts"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+	testutils "github.com/kong/kong-operator/v2/pkg/utils/test"
 )
 
 func TestDataPlaneBlueGreen(t *testing.T) {
@@ -121,12 +122,15 @@ func TestDataPlaneBlueGreen(t *testing.T) {
 		assert.Equal(ct, metav1.ConditionFalse, condition.Status)
 	}, waitTime, tickTime)
 
-	updated := &operatorv1beta1.DataPlane{}
-	require.NoError(t, mgr.GetClient().Get(ctx, client.ObjectKeyFromObject(dp), updated))
-	updated.Spec.Deployment.PodTemplateSpec.Spec.Containers = append(updated.Spec.Deployment.PodTemplateSpec.Spec.Containers,
-		corev1.Container{Name: "proxy-rollout-trigger", Image: consts.DefaultDataPlaneBaseImage + ":3.3"},
-	)
-	require.NoError(t, mgr.GetClient().Update(ctx, updated))
+	dataplaneName := client.ObjectKeyFromObject(dp)
+	require.Eventually(t,
+		testutils.DataPlaneUpdateEventually(t, ctx, dataplaneName, mgr.GetClient(), func(dp *operatorv1beta1.DataPlane) {
+			dp.Spec.Deployment.PodTemplateSpec.Spec.Containers = append(
+				dp.Spec.Deployment.PodTemplateSpec.Spec.Containers,
+				corev1.Container{Name: "proxy-rollout-trigger", Image: consts.DefaultDataPlaneBaseImage + ":3.3"},
+			)
+		}),
+		waitTime, tickTime)
 
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		var previewDeployments appsv1.DeploymentList

--- a/test/integration/dataplane_test.go
+++ b/test/integration/dataplane_test.go
@@ -279,7 +279,7 @@ func TestDataPlaneServiceTypes(t *testing.T) {
 
 		t.Logf("updating dataplane spec with proxy service type of %s", serviceType)
 		require.Eventually(t,
-			testutils.DataPlaneUpdateEventually(t, ctx, dataplaneName, clients, func(dp *operatorv1beta1.DataPlane) {
+			testutils.DataPlaneUpdateEventually(t, ctx, dataplaneName, clients.MgrClient, func(dp *operatorv1beta1.DataPlane) {
 				dp.Spec.Network.Services.Ingress.Type = serviceType
 			}),
 			waitTime, tickTime)
@@ -400,7 +400,7 @@ func TestDataPlaneUpdate(t *testing.T) {
 
 	t.Logf("updating TEST_ENV in dataplane")
 	require.Eventually(t,
-		testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients, func(dp *operatorv1beta1.DataPlane) {
+		testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients.MgrClient, func(dp *operatorv1beta1.DataPlane) {
 			container := k8sutils.GetPodContainerByName(&dp.Spec.Deployment.PodTemplateSpec.Spec, consts.DataPlaneProxyContainerName)
 			require.NotNil(t, container)
 			container.Env = []corev1.EnvVar{
@@ -445,7 +445,7 @@ func TestDataPlaneUpdate(t *testing.T) {
 
 	t.Run("dataplane is not Ready when the underlying deployment changes state to not Ready", func(t *testing.T) {
 		require.Eventually(t,
-			testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients, func(dp *operatorv1beta1.DataPlane) {
+			testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients.MgrClient, func(dp *operatorv1beta1.DataPlane) {
 				container := k8sutils.GetPodContainerByName(&dp.Spec.Deployment.PodTemplateSpec.Spec, consts.DataPlaneProxyContainerName)
 				require.NotNil(t, container)
 				container.ReadinessProbe = &corev1.Probe{
@@ -483,7 +483,7 @@ func TestDataPlaneUpdate(t *testing.T) {
 	})
 	t.Run("dataplane gets Ready when the underlying deployment changes state to Ready", func(t *testing.T) {
 		require.Eventually(t,
-			testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients, func(dp *operatorv1beta1.DataPlane) {
+			testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients.MgrClient, func(dp *operatorv1beta1.DataPlane) {
 				container := k8sutils.GetPodContainerByName(&dp.Spec.Deployment.PodTemplateSpec.Spec, consts.DataPlaneProxyContainerName)
 				require.NotNil(t, container)
 				container.ReadinessProbe = &corev1.Probe{
@@ -522,7 +522,7 @@ func TestDataPlaneUpdate(t *testing.T) {
 
 	t.Run("dataplane Ready condition gets properly update with correct ObservedGeneration", func(t *testing.T) {
 		require.Eventually(t,
-			testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients, func(dp *operatorv1beta1.DataPlane) {
+			testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients.MgrClient, func(dp *operatorv1beta1.DataPlane) {
 				container := k8sutils.GetPodContainerByName(&dp.Spec.Deployment.PodTemplateSpec.Spec, consts.DataPlaneProxyContainerName)
 				require.NotNil(t, container)
 				container.StartupProbe = &corev1.Probe{
@@ -559,7 +559,7 @@ func TestDataPlaneUpdate(t *testing.T) {
 
 	t.Run("dataplane gets properly updated with a ReadinessProbe using port names instead of numbers", func(t *testing.T) {
 		require.Eventually(t,
-			testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients, func(dp *operatorv1beta1.DataPlane) {
+			testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients.MgrClient, func(dp *operatorv1beta1.DataPlane) {
 				container := k8sutils.GetPodContainerByName(&dp.Spec.Deployment.PodTemplateSpec.Spec, consts.DataPlaneProxyContainerName)
 				require.NotNil(t, container)
 				container.StartupProbe = &corev1.Probe{
@@ -652,7 +652,7 @@ func TestDataPlaneHorizontalScaling(t *testing.T) {
 
 	t.Log("changing replicas in dataplane spec to 1 should scale down the deployment back to 1")
 	require.Eventually(t,
-		testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients, func(dp *operatorv1beta1.DataPlane) { dp.Spec.Deployment.Replicas = new(int32(1)) }),
+		testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients.MgrClient, func(dp *operatorv1beta1.DataPlane) { dp.Spec.Deployment.Replicas = new(int32(1)) }),
 		waitTime, tickTime)
 
 	t.Log("verifying that dataplane has indeed 1 ready replica after scaling down")
@@ -660,7 +660,7 @@ func TestDataPlaneHorizontalScaling(t *testing.T) {
 
 	t.Log("changing from replicas to using autoscaling should create an HPA targeting the dataplane deployment")
 	require.Eventually(t,
-		testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients, func(dp *operatorv1beta1.DataPlane) {
+		testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients.MgrClient, func(dp *operatorv1beta1.DataPlane) {
 			dp.Spec.Deployment.Scaling = &operatorv1beta1.Scaling{
 				HorizontalScaling: &operatorv1beta1.HorizontalScaling{
 					MaxReplicas: 3,
@@ -695,7 +695,7 @@ func TestDataPlaneHorizontalScaling(t *testing.T) {
 
 	t.Log("updating the horizontal scaling spec should update the relevant HPA")
 	require.Eventuallyf(t,
-		testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients, func(dp *operatorv1beta1.DataPlane) {
+		testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients.MgrClient, func(dp *operatorv1beta1.DataPlane) {
 			dp.Spec.Deployment.Scaling.HorizontalScaling.MaxReplicas = 5
 			dp.Spec.Deployment.Scaling.HorizontalScaling.Metrics[0].Resource.Target.AverageUtilization = new(int32(50))
 			dp.Spec.Deployment.Replicas = nil
@@ -723,7 +723,7 @@ func TestDataPlaneHorizontalScaling(t *testing.T) {
 
 	t.Log("removing the horizontal scaling spec should delete the relevant HPA")
 	require.Eventuallyf(t,
-		testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients, func(dp *operatorv1beta1.DataPlane) {
+		testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients.MgrClient, func(dp *operatorv1beta1.DataPlane) {
 			dp.Spec.Deployment.Scaling = nil
 		}),
 		time.Minute, time.Second, "failed to update dataplane %s", dataplane.Name)
@@ -986,7 +986,7 @@ func TestDataPlanePodDisruptionBudget(t *testing.T) {
 	assert.EqualValues(t, 1, pdb.Status.DisruptionsAllowed)
 
 	t.Log("changing the PodDisruptionBudget spec in DataPlane")
-	require.Eventually(t, testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients, func(dp *operatorv1beta1.DataPlane) {
+	require.Eventually(t, testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients.MgrClient, func(dp *operatorv1beta1.DataPlane) {
 		dp.Spec.Resources.PodDisruptionBudget.Spec.MinAvailable = new(intstr.FromInt32(2))
 	}), waitTime, tickTime)
 
@@ -998,7 +998,7 @@ func TestDataPlanePodDisruptionBudget(t *testing.T) {
 	}), waitTime, tickTime)
 
 	t.Log("removing the PodDisruptionBudget spec in DataPlane")
-	require.Eventually(t, testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients, func(dp *operatorv1beta1.DataPlane) {
+	require.Eventually(t, testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients.MgrClient, func(dp *operatorv1beta1.DataPlane) {
 		dp.Spec.Resources.PodDisruptionBudget = nil
 	}), waitTime, tickTime)
 
@@ -1088,7 +1088,7 @@ func TestDataPlaneServiceExternalTrafficPolicy(t *testing.T) {
 	verifyEventuallyExternalTrafficPolicy(t, dataplaneName, corev1.ServiceExternalTrafficPolicyLocal)
 
 	t.Log("setting DataPlane Service ExternalTrafficPolicy to Cluster")
-	require.Eventually(t, testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients,
+	require.Eventually(t, testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients.MgrClient,
 		func(dp *operatorv1beta1.DataPlane) {
 			dp.Spec.Network.Services.Ingress.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyCluster
 		},
@@ -1098,7 +1098,7 @@ func TestDataPlaneServiceExternalTrafficPolicy(t *testing.T) {
 	verifyEventuallyExternalTrafficPolicy(t, dataplaneName, corev1.ServiceExternalTrafficPolicyCluster)
 
 	t.Log("changing in ExternalTrafficPolicy to Local")
-	require.Eventually(t, testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients, func(dp *operatorv1beta1.DataPlane) {
+	require.Eventually(t, testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients.MgrClient, func(dp *operatorv1beta1.DataPlane) {
 		dp.Spec.Network.Services = &operatorv1beta1.DataPlaneServices{
 			Ingress: &operatorv1beta1.DataPlaneServiceOptions{
 				ServiceOptions: operatorv1beta1.ServiceOptions{
@@ -1190,7 +1190,7 @@ func TestDataPlaneSpecifyingServiceName(t *testing.T) {
 	serviceName = "ingress-service-" + uuid.NewString()
 	t.Logf("updating ingress service name from '%s' to '%s' in dataplane", oldServiceName, serviceName)
 	require.Eventually(t,
-		testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients, func(dp *operatorv1beta1.DataPlane) {
+		testutils.DataPlaneUpdateEventually(t, GetCtx(), dataplaneName, clients.MgrClient, func(dp *operatorv1beta1.DataPlane) {
 			dp.Spec.Network.Services.Ingress.Name = &serviceName
 		}),
 		time.Minute, time.Second,


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixing flakiness:

```
    dataplane_bluegreen_test.go:129: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/envtest/dataplane_bluegreen_test.go:129
        	Error:      	Received unexpected error:
        	            	Operation cannot be fulfilled on dataplanes.gateway-operator.konghq.com "dp-bluegreen-reconcile": the object has been modified; please apply your changes to the latest version and try again
        	Test:       	TestDataPlaneBlueGreen
```

https://github.com/Kong/kong-operator/actions/runs/22631366018/job/65582159292?pr=3460#step:12:409

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
