### PR TITLE
fix(api): add has() guards to KonnectGatewayControlPlane CEL validation rules

### DIFF
--- a/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
+++ b/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
@@ -25,8 +25,8 @@ func init() {
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:printcolumn:name="ID",description="Konnect ID",type=string,JSONPath=`.status.id`
 // +kubebuilder:printcolumn:name="OrgID",description="Konnect Organization ID this resource belongs to.",type=string,JSONPath=`.status.organizationID`
-// +kubebuilder:validation:XValidation:message="spec.konnect.authRef is immutable when an entity is already Programmed", rule="!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef"
-// +kubebuilder:validation:XValidation:message="spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration", rule="!self.status.conditions.exists(c, c.type == 'APIAuthValid' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef"
+// +kubebuilder:validation:XValidation:message="spec.konnect.authRef is immutable when an entity is already Programmed", rule="(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef"
+// +kubebuilder:validation:XValidation:message="spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration", rule="(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == 'APIAuthValid' && c.status == 'True')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef"
 // +kong:channels=kong-operator
 type KonnectGatewayControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/konnect/v1alpha2/konnect_gateway_controlplane_types.go
+++ b/api/konnect/v1alpha2/konnect_gateway_controlplane_types.go
@@ -25,8 +25,8 @@ func init() {
 // +kubebuilder:printcolumn:name="ID",description="Konnect ID",type=string,JSONPath=`.status.id`
 // +kubebuilder:printcolumn:name="OrgID",description="Konnect Organization ID this resource belongs to.",type=string,JSONPath=`.status.organizationID`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
-// +kubebuilder:validation:XValidation:message="spec.konnect.authRef is immutable when an entity is already Programmed", rule="!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef"
-// +kubebuilder:validation:XValidation:message="spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration", rule="!self.status.conditions.exists(c, c.type == 'APIAuthValid' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef"
+// +kubebuilder:validation:XValidation:message="spec.konnect.authRef is immutable when an entity is already Programmed", rule="(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef"
+// +kubebuilder:validation:XValidation:message="spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration", rule="(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == 'APIAuthValid' && c.status == 'True')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef"
 // +kong:channels=kong-operator
 type KonnectGatewayControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -56721,9 +56721,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: false
     subresources:
@@ -57040,9 +57040,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -56721,9 +56721,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: false
     subresources:
@@ -57040,9 +57040,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -56721,9 +56721,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: false
     subresources:
@@ -57040,9 +57040,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -56721,9 +56721,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: false
     subresources:
@@ -57040,9 +57040,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -56721,9 +56721,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: false
     subresources:
@@ -57040,9 +57040,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -56722,9 +56722,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: false
     subresources:
@@ -57041,9 +57041,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -56721,9 +56721,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: false
     subresources:
@@ -57040,9 +57040,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -56721,9 +56721,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: false
     subresources:
@@ -57040,9 +57040,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -56721,9 +56721,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: false
     subresources:
@@ -57040,9 +57040,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -56721,9 +56721,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: false
     subresources:
@@ -57040,9 +57040,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -56721,9 +56721,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: false
     subresources:
@@ -57040,9 +57040,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -56721,9 +56721,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: false
     subresources:
@@ -57040,9 +57040,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -30530,9 +30530,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -56671,9 +56671,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: false
     subresources:
@@ -56990,9 +56990,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: true
     subresources:

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -30505,9 +30505,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true
     storage: true
     subresources:

--- a/config/crd/kong-operator/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
+++ b/config/crd/kong-operator/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
@@ -337,12 +337,14 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
-            == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c,
+            c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef
+            == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid
             API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status
-            == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c,
+            c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef
+            == oldSelf.spec.konnect.authRef'
     served: true
     storage: false
     subresources:
@@ -704,12 +706,14 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: spec.konnect.authRef is immutable when an entity is already Programmed
-          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
-            == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c,
+            c.type == ''Programmed'' && c.status == ''True'')) ? true : self.spec.konnect.authRef
+            == oldSelf.spec.konnect.authRef'
         - message: spec.konnect.authRef is immutable when an entity refers to a Valid
             API Auth Configuration
-          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status
-            == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+          rule: '(!has(self.status) || !has(self.status.conditions) || !self.status.conditions.exists(c,
+            c.type == ''APIAuthValid'' && c.status == ''True'')) ? true : self.spec.konnect.authRef
+            == oldSelf.spec.konnect.authRef'
     served: true
     storage: true
     subresources:

--- a/test/crdsvalidation/konnect.konghq.com/konnectgatewaycontrolplane_test.go
+++ b/test/crdsvalidation/konnect.konghq.com/konnectgatewaycontrolplane_test.go
@@ -228,6 +228,26 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 				},
 			},
 			{
+				Name: "konnect.authRef change is allowed when status is not set",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta(ns.Name),
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: konnectv1alpha1.CreateControlPlaneRequest{
+							Name:        new("cp-1"),
+							ClusterType: new(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+						},
+						KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				Update: func(kcp *konnectv1alpha1.KonnectGatewayControlPlane) {
+					kcp.Spec.KonnectConfiguration.APIAuthConfigurationRef.Name = "name-2"
+				},
+			},
+			{
 				Name: "cluster_type change is not allowed",
 				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
 					ObjectMeta: common.CommonObjectMeta(ns.Name),

--- a/test/crdsvalidation/konnect.konghq.com/konnectgatewaycontrolplane_v1alpha2_test.go
+++ b/test/crdsvalidation/konnect.konghq.com/konnectgatewaycontrolplane_v1alpha2_test.go
@@ -221,6 +221,26 @@ func TestKonnectGatewayControlPlaneV1alpha2(t *testing.T) {
 				},
 			},
 			{
+				Name: "konnect.authRef change is allowed when status is not set",
+				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta(ns.Name),
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: new(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+						},
+						KonnectConfiguration: konnectv1alpha2.ControlPlaneKonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.ControlPlaneKonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				Update: func(kcp *konnectv1alpha2.KonnectGatewayControlPlane) {
+					kcp.Spec.KonnectConfiguration.APIAuthConfigurationRef.Name = "name-2"
+				},
+			},
+			{
 				Name: "spec.createControlPlaneRequest.cluster_type change is not allowed",
 				TestObject: &konnectv1alpha2.KonnectGatewayControlPlane{
 					ObjectMeta: common.CommonObjectMeta(ns.Name),


### PR DESCRIPTION




**What this PR does / why we need it**:

The CEL validation rules for `spec.konnect.authRef` immutability assumed `status` and `status.conditions` always exist, causing 'no such key: status' errors when updating a KonnectGatewayControlPlane that has no status set yet.

Add `has(self.status)` and `has(self.status.conditions)` guards before accessing status.conditions in the XValidation rules for both v1alpha1 and v1alpha2 versions.

Also add CRD validation test cases to verify that authRef changes are allowed when status is not set.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
