### PR TITLE
chore: remove k8s 1.30 from supported version matrix

### DIFF
--- a/.github/supported_k8s_node_versions.yaml
+++ b/.github/supported_k8s_node_versions.yaml
@@ -8,5 +8,3 @@
 - v1.32.11
 # renovate: datasource=docker packageName=kindest/node depName=kindest/node@only-patch
 - v1.31.14
-# renovate: datasource=docker packageName=kindest/node depName=kindest/node@only-patch
-- v1.30.13


### PR DESCRIPTION
**What this PR does / why we need it**:

To be done for https://github.com/Kong/kong-operator/pull/3468 as Gateway API 1.5.0 does include CEL rules that require k8s 1.31+.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
