### PR TITLE
tests: fix flakiness in envtest TestDataPlane

### DIFF
--- a/pkg/utils/kubernetes/reduce/filters_test.go
+++ b/pkg/utils/kubernetes/reduce/filters_test.go
@@ -317,6 +317,31 @@ func TestFilterServices(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "service1 is older than service2",
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "service1",
+						CreationTimestamp: metav1.NewTime(time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "service2",
+						CreationTimestamp: metav1.NewTime(time.Date(2024, time.January, 2, 0, 0, 0, 0, time.UTC)),
+					},
+				},
+			},
+			filteredServices: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "service2",
+						CreationTimestamp: metav1.NewTime(time.Date(2024, time.January, 2, 0, 0, 0, 0, time.UTC)),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/test/envtest/dataplane_test.go
+++ b/test/envtest/dataplane_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -106,6 +107,16 @@ func TestDataPlane(t *testing.T) {
 					},
 				},
 			},
+		}
+
+		// NOTE: we need to wait a second because CreationTimestamp is the ultimate
+		// tie breaker for the reduction logic, and if the extra service is created
+		// with the same timestamp as the primary service, the reduction logic won't
+		// be deterministic and might not delete the extra service but instead the primary one.
+		select {
+		case <-time.After(time.Second):
+		case <-ctx.Done():
+			require.Fail(t, "context done before creating extra ingress service")
 		}
 		require.NoError(t, cl.Create(ctx, extraIngressService))
 


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/Kong/kong-operator/actions/runs/22668146171/job/65705070512#step:12:4016

```
    dataplane_test.go:112: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/envtest/dataplane_test.go:123
        	            				/opt/hostedtoolcache/go/1.26.0/x64/src/runtime/asm_amd64.s:1771
        	Error:      	Not equal: 
        	            	expected: "dataplane-ingress-dp-service-reduction-k9ztn"
        	            	actual  : "extra-ingress-service"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-dataplane-ingress-dp-service-reduction-k9ztn
        	            	+extra-ingress-service
    dataplane_test.go:112: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/envtest/dataplane_test.go:112
        	Error:      	Condition never satisfied
        	Test:       	TestDataPlane/service_reduction
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
