### PR TITLE
fix: proper handling of hostname intersection for counting attached routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@
   connectivity issues. Added `NotProgrammed` condition reason to differentiate
   transient failures from permanent reference errors.
   [#3463](https://github.com/Kong/kong-operator/pull/3463)
+- Fix counting of route attached to a listener by taking into account hostname intersection between the listener and the route.
+  [#3490](https://github.com/Kong/kong-operator/pull/3490)
 
 ## [v2.1.1]
 

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -910,7 +911,7 @@ func countAttachedRoutesForGatewayListener(ctx context.Context, g *gwtypes.Gatew
 							client.ObjectKeyFromObject(g), err,
 						)
 					}
-					count += countAttachedHTTPRoutes(listener.Name, httpRoutes)
+					count += countAttachedHTTPRoutes(listener, httpRoutes)
 				default:
 					return 0, fmt.Errorf("unsupported route kind: %T", k)
 				}
@@ -931,7 +932,7 @@ func countAttachedRoutesForGatewayListener(ctx context.Context, g *gwtypes.Gatew
 				)
 			}
 
-			count += countAttachedHTTPRoutes(listener.Name, httpRoutes)
+			count += countAttachedHTTPRoutes(listener, httpRoutes)
 		}
 	}
 
@@ -939,19 +940,48 @@ func countAttachedRoutesForGatewayListener(ctx context.Context, g *gwtypes.Gatew
 }
 
 // countAttachedHTTPRoutes counts the number of attached HTTPRoutes for a given listener,
-// taking into account the ParentRefs' sectionName.
-func countAttachedHTTPRoutes(listenerName gatewayv1.SectionName, httpRoutes []gatewayv1.HTTPRoute) int32 {
+// taking into account the ParentRefs' sectionName and hostname intersections between the listener and the route.
+func countAttachedHTTPRoutes(listener gwtypes.Listener, httpRoutes []gatewayv1.HTTPRoute) int32 {
 	var count int32
 
 	for _, httpRoute := range httpRoutes {
 		if lo.ContainsBy(httpRoute.Spec.ParentRefs, func(parentRef gatewayv1.ParentReference) bool {
-			return parentRef.SectionName == nil || *parentRef.SectionName == listenerName
+			return (parentRef.SectionName == nil || *parentRef.SectionName == listener.Name) &&
+				listenerHostnameIntersectsRouteHostnames(listener.Hostname, httpRoute.Spec.Hostnames)
 		}) {
 			count++
 		}
 	}
 
 	return count
+}
+
+func listenerHostnameIntersectsRouteHostnames(
+	listenerHostname *gatewayv1.Hostname,
+	routeHostnames []gatewayv1.Hostname,
+) bool {
+	lH := lo.FromPtr(listenerHostname)
+	if lH == "" || len(routeHostnames) == 0 {
+		return true
+	}
+
+	for _, routeHostname := range routeHostnames {
+		if hostnamesMatches(lH, routeHostname) || hostnamesMatches(routeHostname, lH) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hostnamesMatches(hostnamePattern, hostnameToTest gatewayv1.Hostname) bool {
+	pattern := strings.ToLower(string(hostnamePattern))
+	hostname := strings.ToLower(string(hostnameToTest))
+	res, err := path.Match(pattern, hostname)
+	if err != nil {
+		return false
+	}
+	return res
 }
 
 // setConflicted sets the gateway Conflicted condition according to the Gateway API specification.

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -1778,6 +1778,73 @@ func TestCountAttachedRoutesForGatewayListener(t *testing.T) {
 			ExpectedError:  []error{nil},
 		},
 		{
+			Name: "2 HTTPRoutes, only one matching listener hostname intersection",
+			Gateway: gwtypes.Gateway{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: gatewayv1.GroupVersion.String(),
+					Kind:       "Gateway",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gw",
+					Namespace: "test-namespace",
+				},
+				Spec: gwtypes.GatewaySpec{
+					Listeners: []gwtypes.Listener{
+						{
+							Name:     gatewayv1.SectionName("http"),
+							Protocol: gwtypes.HTTPProtocolType,
+							Hostname: new(gatewayv1.Hostname("*.example.com")),
+							AllowedRoutes: &gwtypes.AllowedRoutes{
+								Namespaces: &gwtypes.RouteNamespaces{
+									From: new(gwtypes.NamespacesFromSame),
+								},
+							},
+						},
+					},
+				},
+			},
+			Objects: []client.Object{
+				&gwtypes.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "route-1",
+						Namespace: "test-namespace",
+					},
+					Spec: gwtypes.HTTPRouteSpec{
+						CommonRouteSpec: gwtypes.CommonRouteSpec{
+							ParentRefs: []gwtypes.ParentReference{
+								{
+									Name:  gwtypes.ObjectName("test-gw"),
+									Group: (*gwtypes.Group)(&gatewayv1.GroupVersion.Group),
+									Kind:  new(gwtypes.Kind("Gateway")),
+								},
+							},
+						},
+						Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname("api.example.com")},
+					},
+				},
+				&gwtypes.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "route-2",
+						Namespace: "test-namespace",
+					},
+					Spec: gwtypes.HTTPRouteSpec{
+						CommonRouteSpec: gwtypes.CommonRouteSpec{
+							ParentRefs: []gwtypes.ParentReference{
+								{
+									Name:  gwtypes.ObjectName("test-gw"),
+									Group: (*gwtypes.Group)(&gatewayv1.GroupVersion.Group),
+									Kind:  new(gwtypes.Kind("Gateway")),
+								},
+							},
+						},
+						Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname("api.example.net")},
+					},
+				},
+			},
+			ExpectedRoutes: []int32{1},
+			ExpectedError:  []error{nil},
+		},
+		{
 			Name: "1 HTTPRoute, not matching due to namespace label selector not matching",
 			Gateway: gwtypes.Gateway{
 				TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:

GWAPI 1.5 includes fix

- https://github.com/kubernetes-sigs/gateway-api/pull/4362

which breaks conformance of the KO - test `GatewayWithAttachedRoutes` fails, and this PR fixes the underlying issue.

**Which issue this PR fixes**

Required for 
- https://github.com/Kong/kong-operator/pull/3491

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
