### PR TITLE
configure dataplane options for TLS listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@
 
 ### Added
 
+- TLSRoute support: Configure DataPlaneOption in created `DataPlane` to
+  configure Kong DataPlane deployment and ingress service for listeners with
+  `TLS` protocol.
+  [#3493](https://github.com/Kong/kong-operator/pull/3493)
 - Allow cross-namespace reference for `KonnectAPIAuthConfiguration` from
   `GatewayConfiguration` using `KongReferenceGrant`. When a user creates a
   `KongReferenceGrant` allowing `GatewayConfiguration` to reference a

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -614,7 +614,8 @@ func (r *Reconciler) provisionDataPlane(
 	// Add the GEP-1762 gateway-name label unconditionally (after mergeInfrastructureIntoDataPlane
 	// so it cannot be overridden by spec.infrastructure).
 	setGatewayNameLabelInDataPlane(expectedDataPlaneOptions, gateway.Name)
-	err = setDataPlaneIngressServicePorts(expectedDataPlaneOptions, gateway.Spec.Listeners, gatewayConfig.Spec.ListenersOptions)
+
+	err = setDataPlaneOptionsForListeners(expectedDataPlaneOptions, gateway.Spec.Listeners, gatewayConfig.Spec.ListenersOptions)
 	if err != nil {
 		errWrap := fmt.Errorf("dataplane creation failed - error: %w", err)
 		k8sutils.SetCondition(

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -588,11 +588,12 @@ func generateDataPlaneNetworkPolicy(
 	podLabels map[string]string,
 ) (*networkingv1.NetworkPolicy, error) {
 	var (
-		protocolTCP     = corev1.ProtocolTCP
-		adminAPISSLPort = intstr.FromInt(consts.DataPlaneAdminAPIPort)
-		proxyPort       = intstr.FromInt(consts.DataPlaneProxyPort)
-		proxySSLPort    = intstr.FromInt(consts.DataPlaneProxySSLPort)
-		metricsPort     = intstr.FromInt(consts.DataPlaneMetricsPort)
+		protocolTCP       = corev1.ProtocolTCP
+		adminAPISSLPorts  = []intstr.IntOrString{intstr.FromInt(consts.DataPlaneAdminAPIPort)}
+		proxyPorts        = []intstr.IntOrString{intstr.FromInt(consts.DataPlaneProxyPort)}
+		proxySSLPorts     = []intstr.IntOrString{intstr.FromInt(consts.DataPlaneProxySSLPort)}
+		metricsPorts      = []intstr.IntOrString{intstr.FromInt(consts.DataPlaneMetricsPort)}
+		streamListenPorts = []intstr.IntOrString{}
 		// The label keys to match Kong operator pod.
 		// To not create new NetworkPolicy on upgrade of , we just keep the keys marking the application
 		// and remove the keys related to versions such as `version`,`pod-template-hash`,`helm.sh/chart`.
@@ -619,21 +620,33 @@ func generateDataPlaneNetworkPolicy(
 		if err != nil {
 			return nil, fmt.Errorf("failed parsing KONG_PROXY_LISTEN env: %w", err)
 		}
-		if kongListenConfig.Endpoint != nil {
-			proxyPort = intstr.FromInt(kongListenConfig.Endpoint.Port)
-		}
-		if kongListenConfig.SSLEndpoint != nil {
-			proxySSLPort = intstr.FromInt(kongListenConfig.SSLEndpoint.Port)
-		}
+
+		proxyPorts = lo.Map(kongListenConfig.Endpoints, func(ep *proxyListenEndpoint, _ int) intstr.IntOrString {
+			return intstr.FromInt(ep.Port)
+		})
+		proxySSLPorts = lo.Map(kongListenConfig.SSLEndpoints, func(ep *proxyListenEndpoint, _ int) intstr.IntOrString {
+			return intstr.FromInt(ep.Port)
+		})
 	}
 	if adminListen := k8sutils.EnvValueByName(container.Env, "KONG_ADMIN_LISTEN"); adminListen != "" {
 		kongListenConfig, err := parseKongListenEnv(adminListen)
 		if err != nil {
 			return nil, fmt.Errorf("failed parsing KONG_ADMIN_LISTEN env: %w", err)
 		}
-		if kongListenConfig.SSLEndpoint != nil {
-			adminAPISSLPort = intstr.FromInt(kongListenConfig.SSLEndpoint.Port)
+		adminAPISSLPorts = lo.Map(kongListenConfig.SSLEndpoints, func(ep *proxyListenEndpoint, _ int) intstr.IntOrString {
+			return intstr.FromInt(ep.Port)
+		})
+	}
+	if streamListen := k8sutils.EnvValueByName(container.Env, "KONG_STREAM_LISTEN"); streamListen != "" {
+		kongListenConfig, err := parseKongListenEnv(streamListen)
+		if err != nil {
+			return nil, fmt.Errorf("failed parsing KONG_STREAM_LISTEN env: %w", err)
 		}
+		// Since currently we only support TLS (TCP SSL) listeners, we only extract SSL ports here.
+		// For TCPRoute and UDPRoute, we also need to extract TCP endpoints and UDP endpoints.
+		streamListenPorts = lo.Map(kongListenConfig.SSLEndpoints, func(ep *proxyListenEndpoint, _ int) intstr.IntOrString {
+			return intstr.FromInt(ep.Port)
+		})
 	}
 
 	// Construct the policy to allow the KO pod to access DataPlane admin APIs.
@@ -658,25 +671,44 @@ func generateDataPlaneNetworkPolicy(
 		}
 	}
 	limitAdminAPIIngress := networkingv1.NetworkPolicyIngressRule{
-		Ports: []networkingv1.NetworkPolicyPort{
-			{Protocol: &protocolTCP, Port: &adminAPISSLPort},
-		},
+		Ports: lo.Map(adminAPISSLPorts, func(port intstr.IntOrString, _ int) networkingv1.NetworkPolicyPort {
+			return networkingv1.NetworkPolicyPort{Protocol: &protocolTCP, Port: &port}
+		}),
 		From: []networkingv1.NetworkPolicyPeer{
 			policyPeerForControllerPod,
 		},
 	}
 
 	allowProxyIngress := networkingv1.NetworkPolicyIngressRule{
-		Ports: []networkingv1.NetworkPolicyPort{
-			{Protocol: &protocolTCP, Port: &proxyPort},
-			{Protocol: &protocolTCP, Port: &proxySSLPort},
-		},
+		Ports: append(
+			lo.Map(proxyPorts, func(port intstr.IntOrString, _ int) networkingv1.NetworkPolicyPort {
+				return networkingv1.NetworkPolicyPort{Protocol: &protocolTCP, Port: &port}
+			}),
+			lo.Map(proxySSLPorts, func(port intstr.IntOrString, _ int) networkingv1.NetworkPolicyPort {
+				return networkingv1.NetworkPolicyPort{Protocol: &protocolTCP, Port: &port}
+			})...,
+		),
 	}
 
 	allowMetricsIngress := networkingv1.NetworkPolicyIngressRule{
-		Ports: []networkingv1.NetworkPolicyPort{
-			{Protocol: &protocolTCP, Port: &metricsPort},
-		},
+		Ports: lo.Map(metricsPorts, func(port intstr.IntOrString, _ int) networkingv1.NetworkPolicyPort {
+			return networkingv1.NetworkPolicyPort{Protocol: &protocolTCP, Port: &port}
+		}),
+	}
+
+	ingressRules := []networkingv1.NetworkPolicyIngressRule{
+		limitAdminAPIIngress,
+		allowProxyIngress,
+		allowMetricsIngress,
+	}
+
+	if len(streamListenPorts) > 0 {
+		allowStreamIngress := networkingv1.NetworkPolicyIngressRule{
+			Ports: lo.Map(streamListenPorts, func(port intstr.IntOrString, _ int) networkingv1.NetworkPolicyPort {
+				return networkingv1.NetworkPolicyPort{Protocol: &protocolTCP, Port: &port}
+			}),
+		}
+		ingressRules = append(ingressRules, allowStreamIngress)
 	}
 
 	return &networkingv1.NetworkPolicy{
@@ -693,11 +725,7 @@ func generateDataPlaneNetworkPolicy(
 			PolicyTypes: []networkingv1.PolicyType{
 				networkingv1.PolicyTypeIngress,
 			},
-			Ingress: []networkingv1.NetworkPolicyIngressRule{
-				limitAdminAPIIngress,
-				allowProxyIngress,
-				allowMetricsIngress,
-			},
+			Ingress: ingressRules,
 		},
 	}, nil
 }
@@ -1182,7 +1210,7 @@ func setDataPlaneOptionsForListeners(
 	return setDataPlaneIngressServicePorts(opts, listeners, listenersOpts, listenerPortToKongListenPort)
 }
 
-// setDataPlaneListenPorts configures deploymentOptions to set listen ports of the generated DataPlane.
+// setDataPlaneDeploymentListenPorts configures deploymentOptions to set listen ports of the generated DataPlane.
 // It returns the map from the listener's port to the port.
 func setDataPlaneDeploymentListenPorts(
 	opts *operatorv1beta1.DataPlaneOptions,
@@ -1487,8 +1515,8 @@ type proxyListenEndpoint struct {
 }
 
 type kongListenConfig struct {
-	Endpoint    *proxyListenEndpoint
-	SSLEndpoint *proxyListenEndpoint
+	Endpoints    []*proxyListenEndpoint
+	SSLEndpoints []*proxyListenEndpoint
 }
 
 // parseKongListenEnv parses the provided kong listen string and returns
@@ -1521,19 +1549,19 @@ func parseKongListenEnv(str string) (kongListenConfig, error) {
 			if err != nil {
 				return kongListenConfig, fmt.Errorf("failed parsing port %s: %w", port, err)
 			}
-			kongListenConfig.SSLEndpoint = &proxyListenEndpoint{
+			kongListenConfig.SSLEndpoints = append(kongListenConfig.SSLEndpoints, &proxyListenEndpoint{
 				Address: host,
 				Port:    p,
-			}
+			})
 		} else {
 			p, err := strconv.Atoi(port)
 			if err != nil {
 				return kongListenConfig, fmt.Errorf("failed parsing port %s: %w", port, err)
 			}
-			kongListenConfig.Endpoint = &proxyListenEndpoint{
+			kongListenConfig.Endpoints = append(kongListenConfig.Endpoints, &proxyListenEndpoint{
 				Address: host,
 				Port:    p,
-			}
+			})
 		}
 	}
 

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"math/rand"
 	"net"
 	"path"
 	"sort"
@@ -68,10 +69,18 @@ func (r *Reconciler) createDataPlane(
 	// so it cannot be overridden by spec.infrastructure).
 	setGatewayNameLabelInDataPlane(&dataplane.Spec.DataPlaneOptions, gateway.Name)
 	setDataPlaneOptionsDefaults(&dataplane.Spec.DataPlaneOptions, r.DefaultDataPlaneImage)
-	if err := setDataPlaneDeploymentListenPorts(&dataplane.Spec.DataPlaneOptions, gateway.Spec.Listeners); err != nil {
+
+	portMap, err := setDataPlaneDeploymentListenPorts(&dataplane.Spec.DataPlaneOptions, gateway.Spec.Listeners)
+	if err != nil {
 		return nil, err
 	}
-	if err := setDataPlaneIngressServicePorts(&dataplane.Spec.DataPlaneOptions, gateway.Spec.Listeners, gatewayConfig.Spec.ListenersOptions); err != nil {
+
+	if err := setDataPlaneIngressServicePorts(
+		&dataplane.Spec.DataPlaneOptions,
+		gateway.Spec.Listeners,
+		gatewayConfig.Spec.ListenersOptions,
+		portMap,
+	); err != nil {
 		return nil, err
 	}
 
@@ -79,7 +88,7 @@ func (r *Reconciler) createDataPlane(
 
 	k8sutils.SetOwnerForObject(dataplane, gateway)
 	gatewayutils.LabelObjectAsGatewayManaged(dataplane, gateway.Name)
-	err := r.Create(ctx, dataplane)
+	err = r.Create(ctx, dataplane)
 	if err != nil {
 		return nil, err
 	}
@@ -1030,7 +1039,7 @@ func countAttachedRoutesForGatewayListener(ctx context.Context, g *gwtypes.Gatew
 					// TODO: implement ListTLSRoute
 					return 0, nil
 				default:
-					return 0, fmt.Errorf("unsupported route kind: %q", k)
+					return 0, fmt.Errorf("unsupported route kind: %s", k)
 				}
 			}
 		}
@@ -1165,47 +1174,99 @@ func (g *gatewayConditionsAndListenersAwareT) setListenersStatus(status metav1.C
 	}
 }
 
-// setDataPlaneListenPorts configures deploymentOptions of the generated DataPlane
+// setDataPlaneListenPorts configures deploymentOptions to set listen ports of the generated DataPlane.
+// It returns the map from the listener's port to the port.
 func setDataPlaneDeploymentListenPorts(
 	opts *operatorv1beta1.DataPlaneOptions,
 	listeners []gatewayv1.Listener,
-) error {
-	// Extract listeners with TLS ports.
-	tlsPorts := []int{}
-	for _, l := range listeners {
-		if l.Protocol == gatewayv1.TLSProtocolType {
-			// TODO: schedule Kong listened ports and ingress service ports since listeners can use the same port.
-			tlsPorts = append(tlsPorts, int(l.Port))
-		}
-	}
+) (map[int]int, error) {
+
 	if opts.Deployment.PodTemplateSpec == nil {
-		return errors.New("PodTemplateSpec in DeploymentOptions not initialized")
+		return nil, errors.New("PodTemplateSpec in DeploymentOptions not initialized")
 	}
 	container := k8sutils.GetPodContainerByName(&opts.Deployment.PodTemplateSpec.Spec, consts.DataPlaneProxyContainerName)
 	if container == nil {
-		return errors.New("DataPlane proxy container not initialized")
+		return nil, errors.New("DataPlane proxy container not initialized")
 	}
+
+	listenerPortToKongListenPort := map[int]int{}
+	kongPortOccupied := map[int]struct{}{
+		consts.DataPlaneProxyPort:    {},
+		consts.DataPlaneProxySSLPort: {},
+		consts.DataPlaneMetricsPort:  {},
+		// Currently DataPlaneMetricsPort and DataPlaneStatusPort are the same port.
+		// We should uncomment this if they are changed to use different ports.
+		// consts.DataPlaneStatusPort:   {},
+		consts.DataPlaneAdminAPIPort: {},
+	}
+
+	// Extract listeners with TLS ports.
+	tlsPorts := []int{}
+	var errs error
+	for i, l := range listeners {
+		switch l.Protocol {
+		case gatewayv1.HTTPProtocolType:
+			listenerPortToKongListenPort[int(l.Port)] = consts.DataPlaneProxyPort
+		case gatewayv1.HTTPSProtocolType:
+			listenerPortToKongListenPort[int(l.Port)] = consts.DataPlaneProxySSLPort
+		case gatewayv1.TLSProtocolType:
+			portNumber := int(l.Port)
+			// TODO: support multiple listeners using the same port.
+			tlsPorts = append(tlsPorts, portNumber)
+			if _, occupied := kongPortOccupied[portNumber]; occupied {
+				for {
+					assignedPortNumber := rand.Intn(1024) + 16384 //nolint:gosec
+					if _, occupied := kongPortOccupied[assignedPortNumber]; !occupied {
+						listenerPortToKongListenPort[portNumber] = assignedPortNumber
+						kongPortOccupied[assignedPortNumber] = struct{}{}
+						break
+					}
+				}
+
+			} else {
+				listenerPortToKongListenPort[portNumber] = portNumber
+				kongPortOccupied[portNumber] = struct{}{}
+			}
+		default:
+			errs = errors.Join(errs, fmt.Errorf("listener %d uses unsupported protocol %s", i, l.Protocol))
+		}
+	}
+
+	if errs != nil {
+		return nil, errs
+	}
+
 	if len(tlsPorts) > 0 {
-		streamListenEnv := strings.Join(
-			lo.Map(tlsPorts, func(portNumber int, _ int) string {
-				return fmt.Sprintf("0.0.0.0:%d ssl reuseport", portNumber)
-			}), ",",
-		)
-		container.Env = append(
-			container.Env, corev1.EnvVar{
-				Name:  "KONG_STREAM_LISTEN",
-				Value: streamListenEnv,
-			},
-		)
-		// TODO: Configure env KONG_PORT_MAPS
+		sort.Ints(tlsPorts)
+		streamListenEnvs := make([]string, 0, len(tlsPorts))
+		for _, portNumber := range tlsPorts {
+			streamListenEnvs = append(streamListenEnvs, fmt.Sprintf("0.0.0.0:%d ssl reuseport", listenerPortToKongListenPort[portNumber]))
+		}
+		k8sutils.SetContainerEnv(container, corev1.EnvVar{
+			Name:  "KONG_STREAM_LISTEN",
+			Value: strings.Join(streamListenEnvs, ","),
+		})
 	}
-	return nil
+	// configure env KONG_PORT_MAPS
+	listenerPorts := lo.Keys(listenerPortToKongListenPort)
+	sort.Ints(listenerPorts)
+	portMapEnvs := make([]string, 0, len(listenerPorts))
+	for _, portNumber := range listenerPorts {
+		portMapEnvs = append(portMapEnvs, fmt.Sprintf("%d:%d", portNumber, listenerPortToKongListenPort[portNumber]))
+	}
+	k8sutils.SetContainerEnv(container, corev1.EnvVar{
+		Name:  "KONG_PORT_MAPS",
+		Value: strings.Join(portMapEnvs, ","),
+	})
+
+	return listenerPortToKongListenPort, nil
 }
 
 func setDataPlaneIngressServicePorts(
 	opts *operatorv1beta1.DataPlaneOptions,
 	listeners []gatewayv1.Listener,
 	listenersOpts []operatorv2beta1.GatewayConfigurationListenerOptions,
+	servicePortMap map[int]int,
 ) error {
 	// Check if all the names in GatewayConfiguration's spec.listenersOptions matches a listener in Gateway.
 	for i, listenerOpts := range listenersOpts {
@@ -1249,7 +1310,7 @@ func setDataPlaneIngressServicePorts(
 		case gatewayv1.HTTPProtocolType:
 			port.TargetPort = intstr.FromInt(consts.DataPlaneProxyPort)
 		case gatewayv1.TLSProtocolType:
-			port.TargetPort = intstr.FromInt(int(l.Port))
+			port.TargetPort = intstr.FromInt(servicePortMap[int(l.Port)])
 		default:
 			errs = errors.Join(errs, fmt.Errorf("listener %d uses unsupported protocol %s", i, l.Protocol))
 			continue

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -1210,6 +1210,12 @@ func setDataPlaneOptionsForListeners(
 	return setDataPlaneIngressServicePorts(opts, listeners, listenersOpts, listenerPortToKongListenPort)
 }
 
+// isKnownPort returns true if the required listener port number is a well-known port (below 1024)
+// that we usually cannot listen on Kong DP.
+func isKnownPort(portNumber int) bool {
+	return portNumber < 1024
+}
+
 // setDataPlaneDeploymentListenPorts configures deploymentOptions to set listen ports of the generated DataPlane.
 // It returns the map from the listener's port to the port.
 func setDataPlaneDeploymentListenPorts(
@@ -1256,8 +1262,9 @@ func setDataPlaneDeploymentListenPorts(
 			// https://github.com/Kong/kong-operator/issues/3511
 			tlsPorts = append(tlsPorts, portNumber)
 			// Assign another port if the listener's port is already allocated on Kong DP.
-			// REVIEW: Also re-assign a port if known ports (<1024) are used? Or always assign a port?
-			if _, occupied := kongPortOccupied[portNumber]; occupied {
+			// Also re-assign a port if known ports (<1024) are used because we usually cannot listen on those port on Kong DP.
+			_, occupied := kongPortOccupied[portNumber]
+			if isKnownPort(portNumber) || occupied {
 				for ; assignedPortNumber < assignedPortMax; assignedPortNumber++ {
 					if _, occupied := kongPortOccupied[assignedPortNumber]; !occupied {
 						listenerPortToKongListenPort[portNumber] = assignedPortNumber

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -1211,7 +1211,8 @@ func setDataPlaneDeploymentListenPorts(
 			listenerPortToKongListenPort[int(l.Port)] = consts.DataPlaneProxySSLPort
 		case gatewayv1.TLSProtocolType:
 			portNumber := int(l.Port)
-			// TODO: support multiple listeners using the same port.
+			// TODO: support multiple listeners using the same port:
+			// https://github.com/Kong/kong-operator/issues/3511
 			tlsPorts = append(tlsPorts, portNumber)
 			if _, occupied := kongPortOccupied[portNumber]; occupied {
 				for {
@@ -1236,6 +1237,7 @@ func setDataPlaneDeploymentListenPorts(
 		return nil, errs
 	}
 
+	// Configure env `KONG_STREAM_LISTEN` if there are TLS listeners.
 	if len(tlsPorts) > 0 {
 		sort.Ints(tlsPorts)
 		streamListenEnvs := make([]string, 0, len(tlsPorts))
@@ -1247,7 +1249,7 @@ func setDataPlaneDeploymentListenPorts(
 			Value: strings.Join(streamListenEnvs, ","),
 		})
 	}
-	// configure env KONG_PORT_MAPS
+	// Configure env KONG_PORT_MAPS.
 	listenerPorts := lo.Keys(listenerPortToKongListenPort)
 	sort.Ints(listenerPorts)
 	portMapEnvs := make([]string, 0, len(listenerPorts))

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -70,16 +70,10 @@ func (r *Reconciler) createDataPlane(
 	setGatewayNameLabelInDataPlane(&dataplane.Spec.DataPlaneOptions, gateway.Name)
 	setDataPlaneOptionsDefaults(&dataplane.Spec.DataPlaneOptions, r.DefaultDataPlaneImage)
 
-	portMap, err := setDataPlaneDeploymentListenPorts(&dataplane.Spec.DataPlaneOptions, gateway.Spec.Listeners)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := setDataPlaneIngressServicePorts(
+	if err := setDataPlaneOptionsForListeners(
 		&dataplane.Spec.DataPlaneOptions,
 		gateway.Spec.Listeners,
 		gatewayConfig.Spec.ListenersOptions,
-		portMap,
 	); err != nil {
 		return nil, err
 	}
@@ -88,7 +82,7 @@ func (r *Reconciler) createDataPlane(
 
 	k8sutils.SetOwnerForObject(dataplane, gateway)
 	gatewayutils.LabelObjectAsGatewayManaged(dataplane, gateway.Name)
-	err = r.Create(ctx, dataplane)
+	err := r.Create(ctx, dataplane)
 	if err != nil {
 		return nil, err
 	}
@@ -1174,6 +1168,21 @@ func (g *gatewayConditionsAndListenersAwareT) setListenersStatus(status metav1.C
 	}
 }
 
+// setDataPlaneOptionsForListeners configures DataPlaneOptions in generated DataPlane from listeners of the gateway.
+// It includes configuring deployment options and ingress service options.
+func setDataPlaneOptionsForListeners(
+	opts *operatorv1beta1.DataPlaneOptions,
+	listeners []gatewayv1.Listener,
+	listenersOpts []operatorv2beta1.GatewayConfigurationListenerOptions,
+) error {
+	listenerPortToKongListenPort, err := setDataPlaneDeploymentListenPorts(opts, listeners)
+	if err != nil {
+		return err
+	}
+
+	return setDataPlaneIngressServicePorts(opts, listeners, listenersOpts, listenerPortToKongListenPort)
+}
+
 // setDataPlaneListenPorts configures deploymentOptions to set listen ports of the generated DataPlane.
 // It returns the map from the listener's port to the port.
 func setDataPlaneDeploymentListenPorts(
@@ -1182,11 +1191,11 @@ func setDataPlaneDeploymentListenPorts(
 ) (map[int]int, error) {
 
 	if opts.Deployment.PodTemplateSpec == nil {
-		return nil, errors.New("PodTemplateSpec in DeploymentOptions not initialized")
+		return nil, errors.New("podTemplateSpec in DeploymentOptions not initialized")
 	}
 	container := k8sutils.GetPodContainerByName(&opts.Deployment.PodTemplateSpec.Spec, consts.DataPlaneProxyContainerName)
 	if container == nil {
-		return nil, errors.New("DataPlane proxy container not initialized")
+		return nil, errors.New("dataPlane proxy container not initialized")
 	}
 
 	listenerPortToKongListenPort := map[int]int{}
@@ -1214,9 +1223,11 @@ func setDataPlaneDeploymentListenPorts(
 			// TODO: support multiple listeners using the same port:
 			// https://github.com/Kong/kong-operator/issues/3511
 			tlsPorts = append(tlsPorts, portNumber)
+			// Assign another port if the listener's port is already allocated on Kong DP.
+			// REVIEW: Also re-assign a port if known ports  (<1024) are used? Or always assign a random port?
 			if _, occupied := kongPortOccupied[portNumber]; occupied {
 				for {
-					assignedPortNumber := rand.Intn(1024) + 16384 //nolint:gosec
+					assignedPortNumber := rand.Intn(1024) + 16384 //nolint:gosec // No Need to use the crypto safe algorithm to assign an available port, I think.
 					if _, occupied := kongPortOccupied[assignedPortNumber]; !occupied {
 						listenerPortToKongListenPort[portNumber] = assignedPortNumber
 						kongPortOccupied[assignedPortNumber] = struct{}{}
@@ -1238,6 +1249,7 @@ func setDataPlaneDeploymentListenPorts(
 	}
 
 	// Configure env `KONG_STREAM_LISTEN` if there are TLS listeners.
+	// To make the value of the env stable when listener not changed, we sort the ports here.
 	if len(tlsPorts) > 0 {
 		sort.Ints(tlsPorts)
 		streamListenEnvs := make([]string, 0, len(tlsPorts))
@@ -1249,7 +1261,9 @@ func setDataPlaneDeploymentListenPorts(
 			Value: strings.Join(streamListenEnvs, ","),
 		})
 	}
+
 	// Configure env KONG_PORT_MAPS.
+	// Also we sort the ports here to make the env stable.
 	listenerPorts := lo.Keys(listenerPortToKongListenPort)
 	sort.Ints(listenerPorts)
 	portMapEnvs := make([]string, 0, len(listenerPorts))
@@ -1292,6 +1306,10 @@ func setDataPlaneIngressServicePorts(
 		}
 	}
 
+	if servicePortMap == nil {
+		servicePortMap = map[int]int{}
+	}
+
 	var errs error
 	for i, l := range listeners {
 		var name string
@@ -1312,7 +1330,12 @@ func setDataPlaneIngressServicePorts(
 		case gatewayv1.HTTPProtocolType:
 			port.TargetPort = intstr.FromInt(consts.DataPlaneProxyPort)
 		case gatewayv1.TLSProtocolType:
-			port.TargetPort = intstr.FromInt(servicePortMap[int(l.Port)])
+			targetPort, ok := servicePortMap[int(l.Port)]
+			if !ok {
+				errs = errors.Join(errs, fmt.Errorf("no target port assigned listener %s on port %d", l.Name, l.Port))
+				continue
+			}
+			port.TargetPort = intstr.FromInt(targetPort)
 		default:
 			errs = errors.Join(errs, fmt.Errorf("listener %d uses unsupported protocol %s", i, l.Protocol))
 			continue

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -68,6 +68,9 @@ func (r *Reconciler) createDataPlane(
 	// so it cannot be overridden by spec.infrastructure).
 	setGatewayNameLabelInDataPlane(&dataplane.Spec.DataPlaneOptions, gateway.Name)
 	setDataPlaneOptionsDefaults(&dataplane.Spec.DataPlaneOptions, r.DefaultDataPlaneImage)
+	if err := setDataPlaneDeploymentListenPorts(&dataplane.Spec.DataPlaneOptions, gateway.Spec.Listeners); err != nil {
+		return nil, err
+	}
 	if err := setDataPlaneIngressServicePorts(&dataplane.Spec.DataPlaneOptions, gateway.Spec.Listeners, gatewayConfig.Spec.ListenersOptions); err != nil {
 		return nil, err
 	}
@@ -837,9 +840,8 @@ func supportedRoutesByProtocol() map[gatewayv1.ProtocolType]map[gatewayv1.Kind]s
 	return map[gatewayv1.ProtocolType]map[gatewayv1.Kind]struct{}{
 		gatewayv1.HTTPProtocolType:  {"HTTPRoute": {}},
 		gatewayv1.HTTPSProtocolType: {"HTTPRoute": {}},
-
-		// L4 routes not supported yet
-		// gatewayv1.TLSProtocolType:   {"TLSRoute": {}},
+		gatewayv1.TLSProtocolType:   {"TLSRoute": {}},
+		// TCPRoutes ad UDPRoutes are not supported yet
 		// gatewayv1.TCPProtocolType:   {"TCPRoute": {}},
 		// gatewayv1.UDPProtocolType:   {"UDPRoute": {}},
 	}
@@ -1024,8 +1026,11 @@ func countAttachedRoutesForGatewayListener(ctx context.Context, g *gwtypes.Gatew
 						)
 					}
 					count += countAttachedHTTPRoutes(listener, httpRoutes)
+				case "TLSRoute":
+					// TODO: implement ListTLSRoute
+					return 0, nil
 				default:
-					return 0, fmt.Errorf("unsupported route kind: %T", k)
+					return 0, fmt.Errorf("unsupported route kind: %q", k)
 				}
 			}
 		}
@@ -1160,6 +1165,43 @@ func (g *gatewayConditionsAndListenersAwareT) setListenersStatus(status metav1.C
 	}
 }
 
+// setDataPlaneListenPorts configures deploymentOptions of the generated DataPlane
+func setDataPlaneDeploymentListenPorts(
+	opts *operatorv1beta1.DataPlaneOptions,
+	listeners []gatewayv1.Listener,
+) error {
+	// Extract listeners with TLS ports.
+	tlsPorts := []int{}
+	for _, l := range listeners {
+		if l.Protocol == gatewayv1.TLSProtocolType {
+			// TODO: schedule Kong listened ports and ingress service ports since listeners can use the same port.
+			tlsPorts = append(tlsPorts, int(l.Port))
+		}
+	}
+	if opts.Deployment.PodTemplateSpec == nil {
+		return errors.New("PodTemplateSpec in DeploymentOptions not initialized")
+	}
+	container := k8sutils.GetPodContainerByName(&opts.Deployment.PodTemplateSpec.Spec, consts.DataPlaneProxyContainerName)
+	if container == nil {
+		return errors.New("DataPlane proxy container not initialized")
+	}
+	if len(tlsPorts) > 0 {
+		streamListenEnv := strings.Join(
+			lo.Map(tlsPorts, func(portNumber int, _ int) string {
+				return fmt.Sprintf("0.0.0.0:%d ssl reuseport", portNumber)
+			}), ",",
+		)
+		container.Env = append(
+			container.Env, corev1.EnvVar{
+				Name:  "KONG_STREAM_LISTEN",
+				Value: streamListenEnv,
+			},
+		)
+		// TODO: Configure env KONG_PORT_MAPS
+	}
+	return nil
+}
+
 func setDataPlaneIngressServicePorts(
 	opts *operatorv1beta1.DataPlaneOptions,
 	listeners []gatewayv1.Listener,
@@ -1206,6 +1248,8 @@ func setDataPlaneIngressServicePorts(
 			port.TargetPort = intstr.FromInt(consts.DataPlaneProxySSLPort)
 		case gatewayv1.HTTPProtocolType:
 			port.TargetPort = intstr.FromInt(consts.DataPlaneProxyPort)
+		case gatewayv1.TLSProtocolType:
+			port.TargetPort = intstr.FromInt(int(l.Port))
 		default:
 			errs = errors.Join(errs, fmt.Errorf("listener %d uses unsupported protocol %s", i, l.Protocol))
 			continue

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"math/rand"
 	"net"
 	"path"
 	"sort"
@@ -1212,6 +1211,11 @@ func setDataPlaneDeploymentListenPorts(
 	// Extract listeners with TLS ports.
 	tlsPorts := []int{}
 	var errs error
+	// assignedPortNumber and assignedPortMax defines the interval of ports to assign to listen on Kong stream proxy
+	// if the specified port in the listener is already occupied on Kong DataPlane.
+	assignedPortNumber := consts.DataPlaneAssignedPortStart
+	assignedPortMax := consts.DataPlaneAssignedPortStart + 1024
+
 	for i, l := range listeners {
 		switch l.Protocol {
 		case gatewayv1.HTTPProtocolType:
@@ -1224,15 +1228,19 @@ func setDataPlaneDeploymentListenPorts(
 			// https://github.com/Kong/kong-operator/issues/3511
 			tlsPorts = append(tlsPorts, portNumber)
 			// Assign another port if the listener's port is already allocated on Kong DP.
-			// REVIEW: Also re-assign a port if known ports  (<1024) are used? Or always assign a random port?
+			// REVIEW: Also re-assign a port if known ports (<1024) are used? Or always assign a port?
 			if _, occupied := kongPortOccupied[portNumber]; occupied {
-				for {
-					assignedPortNumber := rand.Intn(1024) + 16384 //nolint:gosec // No Need to use the crypto safe algorithm to assign an available port, I think.
+				for ; assignedPortNumber < assignedPortMax; assignedPortNumber++ {
 					if _, occupied := kongPortOccupied[assignedPortNumber]; !occupied {
 						listenerPortToKongListenPort[portNumber] = assignedPortNumber
 						kongPortOccupied[assignedPortNumber] = struct{}{}
 						break
 					}
+				}
+				// Although it should not happen where no ports can be assigned for the listener,
+				// we attach an error if the case really happens.
+				if assignedPortNumber >= assignedPortMax {
+					errs = errors.Join(errs, fmt.Errorf("listener %d's port %d already occupied and no available ports can be assinged", i, portNumber))
 				}
 
 			} else {

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -702,6 +702,9 @@ func generateDataPlaneNetworkPolicy(
 		allowMetricsIngress,
 	}
 
+	// Add a rule to allow ingress traffics to listened ports for stream proxy on dataplane pods.
+	// Only add the rule when there are at least one stream proxy port because a rule with an empty port list allows ingress traffics to ALL ports,
+	// then the whole NetworkPolicy allows ALL ingress traffics to the pods.
 	if len(streamListenPorts) > 0 {
 		allowStreamIngress := networkingv1.NetworkPolicyIngressRule{
 			Ports: lo.Map(streamListenPorts, func(port intstr.IntOrString, _ int) networkingv1.NetworkPolicyPort {
@@ -1275,7 +1278,7 @@ func setDataPlaneDeploymentListenPorts(
 				// Although it should not happen where no ports can be assigned for the listener,
 				// we attach an error if the case really happens.
 				if assignedPortNumber >= assignedPortMax {
-					errs = errors.Join(errs, fmt.Errorf("listener %d's port %d already occupied and no available ports can be assinged", i, portNumber))
+					errs = errors.Join(errs, fmt.Errorf("listener %d's port %d already occupied and no available ports can be assigned", i, portNumber))
 				}
 
 			} else {

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"errors"
+	"maps"
 	"net/http"
 	"testing"
 
@@ -556,6 +557,139 @@ func TestSetAcceptedOnGateway(t *testing.T) {
 	}
 }
 
+func TestSetDataPlaneDeploymentListenPorts(t *testing.T) {
+	testCases := []struct {
+		name            string
+		listeners       []gwtypes.Listener
+		expectedEnvs    []corev1.EnvVar
+		expectedPortMap map[int]int
+		expectedError   error
+	}{
+		{
+			name: "Only HTTP and HTTPS listener",
+			listeners: []gwtypes.Listener{
+				{
+					Name:     "http",
+					Protocol: gatewayv1.HTTPProtocolType,
+					Port:     gatewayv1.PortNumber(80),
+				},
+				{
+					Name:     "https",
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Port:     gatewayv1.PortNumber(443),
+				},
+			},
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "KONG_PORT_MAPS",
+					Value: "80:8000,443:8443",
+				},
+			},
+			expectedPortMap: map[int]int{
+				80:  8000,
+				443: 8443,
+			},
+		},
+		{
+			name: "HTTP and multiple TLS listeners",
+			listeners: []gwtypes.Listener{
+				{
+					Name:     "http",
+					Protocol: gatewayv1.HTTPProtocolType,
+					Port:     gatewayv1.PortNumber(80),
+				},
+				{
+					Name:     "tls-1",
+					Protocol: gatewayv1.TLSProtocolType,
+					Port:     gatewayv1.PortNumber(8899),
+				},
+				{
+					Name:     "tls-2",
+					Protocol: gatewayv1.TLSProtocolType,
+					Port:     gatewayv1.PortNumber(9999),
+				},
+			},
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "KONG_PORT_MAPS",
+					Value: "80:8000,8899:8899,9999:9999",
+				},
+				{
+					Name:  "KONG_STREAM_LISTEN",
+					Value: "0.0.0.0:8899 ssl reuseport,0.0.0.0:9999 ssl reuseport",
+				},
+			},
+			expectedPortMap: map[int]int{
+				80:   8000,
+				8899: 8899,
+				9999: 9999,
+			},
+		},
+		{
+			name: "unsupported protocol TCP in listeners",
+			listeners: []gwtypes.Listener{
+				{
+					Name:     "http",
+					Protocol: gatewayv1.HTTPProtocolType,
+					Port:     gatewayv1.PortNumber(80),
+				},
+				{
+					Name:     "https",
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Port:     gatewayv1.PortNumber(443),
+				},
+				{
+					Name:     "tcp",
+					Protocol: gatewayv1.TCPProtocolType,
+					Port:     gatewayv1.PortNumber(8888),
+				},
+			},
+			expectedError: errors.New("listener 2 uses unsupported protocol TCP"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := operatorv1beta1.DataPlaneOptions{
+				Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+					DeploymentOptions: operatorv1beta1.DeploymentOptions{
+						PodTemplateSpec: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: consts.DataPlaneProxyContainerName,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			portMap, err := setDataPlaneDeploymentListenPorts(&opts, tc.listeners)
+			if tc.expectedError != nil {
+				require.EqualError(t, tc.expectedError, err.Error())
+				return
+			}
+			require.NoError(t, err)
+
+			container := k8sutils.GetPodContainerByName(&opts.Deployment.PodTemplateSpec.Spec, consts.DataPlaneProxyContainerName)
+			require.NotNil(t, container, "Should find proxy container")
+			for _, env := range tc.expectedEnvs {
+				require.Containsf(
+					t, container.Env, env,
+					"Should contain env %s with value %s",
+					env.Name, env.Value,
+				)
+			}
+
+			require.Truef(t, maps.Equal(tc.expectedPortMap, portMap),
+				"listener port maps should equal: expected %v, actual %v",
+				tc.expectedPortMap, portMap,
+			)
+		})
+	}
+}
+
 func TestSetDataPlaneIngressServicePorts(t *testing.T) {
 	testCases := []struct {
 		name             string
@@ -678,7 +812,7 @@ func TestSetDataPlaneIngressServicePorts(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := setDataPlaneIngressServicePorts(&operatorv1beta1.DataPlaneOptions{}, tc.listeners, tc.listenersOptions)
+			err := setDataPlaneIngressServicePorts(&operatorv1beta1.DataPlaneOptions{}, tc.listeners, tc.listenersOptions, nil)
 			if tc.expectedError == nil {
 				require.NoError(t, err)
 			} else {

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -686,6 +686,35 @@ func TestSetDataPlaneDeploymentListenPorts(t *testing.T) {
 			},
 		},
 		{
+			name: "TLS listener uses known port",
+			listeners: []gwtypes.Listener{
+				{
+					Name:     "http",
+					Protocol: gatewayv1.HTTPProtocolType,
+					Port:     gatewayv1.PortNumber(80),
+				},
+				{
+					Name:     "tls",
+					Protocol: gatewayv1.TLSProtocolType,
+					Port:     gatewayv1.PortNumber(445),
+				},
+			},
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "KONG_PORT_MAPS",
+					Value: "80:8000,445:16384", // Should assign the first port in the assigned port interval
+				},
+				{
+					Name:  "KONG_STREAM_LISTEN",
+					Value: "0.0.0.0:16384 ssl reuseport",
+				},
+			},
+			expectedPortMap: map[int]int{
+				80:  8000,
+				445: 16384,
+			},
+		},
+		{
 			name: "unsupported protocol TCP in listeners",
 			listeners: []gwtypes.Listener{
 				{

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -695,6 +695,7 @@ func TestSetDataPlaneIngressServicePorts(t *testing.T) {
 		name             string
 		listeners        []gwtypes.Listener
 		listenersOptions []operatorv2beta1.GatewayConfigurationListenerOptions
+		portMap          map[int]int
 		expectedPorts    []operatorv1beta1.DataPlaneServicePort
 		expectedError    error
 	}{
@@ -714,7 +715,13 @@ func TestSetDataPlaneIngressServicePorts(t *testing.T) {
 					Protocol: gatewayv1.HTTPSProtocolType,
 					Port:     gatewayv1.PortNumber(443),
 				},
+				{
+					Name:     "tls",
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Port:     gatewayv1.PortNumber(9443),
+				},
 			},
+			portMap: map[int]int{9443: 9443},
 			expectedPorts: []operatorv1beta1.DataPlaneServicePort{
 				{
 					Name:       "http",
@@ -725,6 +732,11 @@ func TestSetDataPlaneIngressServicePorts(t *testing.T) {
 					Name:       "https",
 					Port:       443,
 					TargetPort: intstr.FromInt(consts.DataPlaneProxySSLPort),
+				},
+				{
+					Name:       "tls",
+					Port:       9443,
+					TargetPort: intstr.FromInt(9443),
 				},
 			},
 		},
@@ -812,7 +824,7 @@ func TestSetDataPlaneIngressServicePorts(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := setDataPlaneIngressServicePorts(&operatorv1beta1.DataPlaneOptions{}, tc.listeners, tc.listenersOptions, nil)
+			err := setDataPlaneIngressServicePorts(&operatorv1beta1.DataPlaneOptions{}, tc.listeners, tc.listenersOptions, tc.portMap)
 			if tc.expectedError == nil {
 				require.NoError(t, err)
 			} else {

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -626,6 +626,41 @@ func TestSetDataPlaneDeploymentListenPorts(t *testing.T) {
 			},
 		},
 		{
+			name: "TLS listener uses occupied port on Kong DP",
+			listeners: []gwtypes.Listener{
+				{
+					Name:     "http",
+					Protocol: gatewayv1.HTTPProtocolType,
+					Port:     gatewayv1.PortNumber(80),
+				},
+				{
+					Name:     "tls-1",
+					Protocol: gatewayv1.TLSProtocolType,
+					Port:     gatewayv1.PortNumber(7443),
+				},
+				{
+					Name:     "tls-2",
+					Protocol: gatewayv1.TLSProtocolType,
+					Port:     gatewayv1.PortNumber(8443),
+				},
+			},
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "KONG_PORT_MAPS",
+					Value: "80:8000,7443:7443,8443:16384", // Should assign the first port in the assigned port interval
+				},
+				{
+					Name:  "KONG_STREAM_LISTEN",
+					Value: "0.0.0.0:7443 ssl reuseport,0.0.0.0:16384 ssl reuseport",
+				},
+			},
+			expectedPortMap: map[int]int{
+				80:   8000,
+				7443: 7443,
+				8443: 16384,
+			},
+		},
+		{
 			name: "unsupported protocol TCP in listeners",
 			listeners: []gwtypes.Listener{
 				{
@@ -717,7 +752,7 @@ func TestSetDataPlaneIngressServicePorts(t *testing.T) {
 				},
 				{
 					Name:     "tls",
-					Protocol: gatewayv1.HTTPSProtocolType,
+					Protocol: gatewayv1.TLSProtocolType,
 					Port:     gatewayv1.PortNumber(9443),
 				},
 			},

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -39,9 +40,11 @@ func TestParseKongProxyListenEnv(t *testing.T) {
 			Name:            "basic http",
 			KongProxyListen: "0.0.0.0:8001 reuseport backlog=16384",
 			Expected: kongListenConfig{
-				Endpoint: &proxyListenEndpoint{
-					Address: "0.0.0.0",
-					Port:    8001,
+				Endpoints: []*proxyListenEndpoint{
+					{
+						Address: "0.0.0.0",
+						Port:    8001,
+					},
 				},
 			},
 		},
@@ -49,9 +52,11 @@ func TestParseKongProxyListenEnv(t *testing.T) {
 			Name:            "basic https",
 			KongProxyListen: "0.0.0.0:8443 http2 ssl reuseport backlog=16384",
 			Expected: kongListenConfig{
-				SSLEndpoint: &proxyListenEndpoint{
-					Address: "0.0.0.0",
-					Port:    8443,
+				SSLEndpoints: []*proxyListenEndpoint{
+					{
+						Address: "0.0.0.0",
+						Port:    8443,
+					},
 				},
 			},
 		},
@@ -59,13 +64,33 @@ func TestParseKongProxyListenEnv(t *testing.T) {
 			Name:            "basic http + https",
 			KongProxyListen: "0.0.0.0:8001 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport backlog=16384",
 			Expected: kongListenConfig{
-				Endpoint: &proxyListenEndpoint{
-					Address: "0.0.0.0",
-					Port:    8001,
+				Endpoints: []*proxyListenEndpoint{
+					{
+						Address: "0.0.0.0",
+						Port:    8001,
+					},
 				},
-				SSLEndpoint: &proxyListenEndpoint{
-					Address: "0.0.0.0",
-					Port:    8443,
+				SSLEndpoints: []*proxyListenEndpoint{
+					{
+						Address: "0.0.0.0",
+						Port:    8443,
+					},
+				},
+			},
+		},
+		{
+			Name:            "multiple https ports",
+			KongProxyListen: "0.0.0.0:6443 http2 ssl, 0.0.0.0:8443 http2 ssl reuseport backlog=16384",
+			Expected: kongListenConfig{
+				SSLEndpoints: []*proxyListenEndpoint{
+					{
+						Address: "0.0.0.0",
+						Port:    6443,
+					},
+					{
+						Address: "0.0.0.0",
+						Port:    8443,
+					},
 				},
 			},
 		},
@@ -3083,4 +3108,143 @@ func TestGatewayManagedLabelOnCreatedResources(t *testing.T) {
 		require.Equal(t, gwName, konnectExt.Labels[consts.GatewayNameLabel],
 			"KonnectExtension object must carry the GEP-1762 gateway-name label")
 	})
+}
+
+func TestGenerateDataPlaneNetworkPolicy(t *testing.T) {
+	const (
+		testNamespace     = "test-network-policy"
+		testDataPlaneName = "test-dp"
+	)
+	var (
+		protocolTCP = corev1.ProtocolTCP
+		podLabels   = map[string]string{
+			"app": "test",
+		}
+		defaultDataPlane = &operatorv1beta1.DataPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+				Name:      testDataPlaneName,
+			},
+			Spec: operatorv1beta1.DataPlaneSpec{
+				DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+					Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+						DeploymentOptions: operatorv1beta1.DeploymentOptions{
+							PodTemplateSpec: &corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name:  consts.DataPlaneProxyContainerName,
+											Image: consts.DefaultDataPlaneImage,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		defaultIngressRuleAdminAPI = networkingv1.NetworkPolicyIngressRule{
+			Ports: []networkingv1.NetworkPolicyPort{
+				{
+					Protocol: &protocolTCP,
+					Port:     new(intstr.FromInt(consts.DataPlaneAdminAPIPort)),
+				},
+			},
+			From: []networkingv1.NetworkPolicyPeer{
+				{
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test",
+						},
+					},
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/metadata.name": testNamespace,
+						},
+					},
+				},
+			},
+		}
+		defaultIngressRuleProxy = networkingv1.NetworkPolicyIngressRule{
+			Ports: []networkingv1.NetworkPolicyPort{
+				{
+					Protocol: &protocolTCP,
+					Port:     new(intstr.FromInt(consts.DataPlaneProxyPort)),
+				},
+				{
+					Protocol: &protocolTCP,
+					Port:     new(intstr.FromInt(consts.DataPlaneProxySSLPort)),
+				},
+			},
+		}
+		defaultIngressRuleMetrics = networkingv1.NetworkPolicyIngressRule{
+			Ports: []networkingv1.NetworkPolicyPort{
+				{
+					Protocol: &protocolTCP,
+					Port:     new(intstr.FromInt(consts.DataPlaneMetricsPort)),
+				},
+			},
+		}
+	)
+
+	testCases := []struct {
+		name                  string
+		proxyContainerOptions func(c *corev1.Container)
+		expectedIngressRules  []networkingv1.NetworkPolicyIngressRule
+	}{
+		{
+			name: "default DataPlane",
+			expectedIngressRules: []networkingv1.NetworkPolicyIngressRule{
+				defaultIngressRuleAdminAPI,
+				defaultIngressRuleProxy,
+				defaultIngressRuleMetrics,
+			},
+		},
+		{
+			name: "dataplane with stream listen",
+			proxyContainerOptions: func(c *corev1.Container) {
+				c.Env = append(c.Env, corev1.EnvVar{
+					Name:  "KONG_STREAM_LISTEN",
+					Value: "0.0.0.0:8899 ssl reuseport",
+				})
+			},
+			expectedIngressRules: []networkingv1.NetworkPolicyIngressRule{
+				defaultIngressRuleAdminAPI,
+				defaultIngressRuleProxy,
+				defaultIngressRuleMetrics,
+				{
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: &protocolTCP,
+							Port:     new(intstr.FromInt(8899)),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dp := defaultDataPlane.DeepCopy()
+			container := k8sutils.GetPodContainerByName(&dp.Spec.Deployment.PodTemplateSpec.Spec, consts.DataPlaneProxyContainerName)
+			if tc.proxyContainerOptions != nil {
+				tc.proxyContainerOptions(container)
+			}
+
+			policy, err := generateDataPlaneNetworkPolicy(testNamespace, dp, podLabels)
+			require.NoError(t, err)
+			// compare expected NetworkPolicy and the generated one.
+			require.Equal(t, testNamespace, policy.Namespace)
+			require.Equal(t, "test-dp-limit-admin-api-", policy.GenerateName)
+			// compare pod selector.
+			require.Equal(t, map[string]string{"app": "test-dp"}, policy.Spec.PodSelector.MatchLabels)
+			// compare ingress policies.
+			require.Len(t, policy.Spec.Ingress, len(tc.expectedIngressRules))
+			for i, ingressRule := range tc.expectedIngressRules {
+				require.Equal(t, ingressRule, policy.Spec.Ingress[i])
+			}
+		})
+	}
 }

--- a/pkg/consts/dataplane.go
+++ b/pkg/consts/dataplane.go
@@ -151,6 +151,9 @@ const (
 
 	// DataPlaneStatusPort is the port that the dataplane uses for status.
 	DataPlaneStatusPort = 8100
+
+	// DataPlaneAssignedPortStart is the port to assign when desired port is already occupied for other usage.
+	DataPlaneAssignedPortStart = 16384
 )
 
 // -----------------------------------------------------------------------------

--- a/pkg/utils/kubernetes/pod_utils.go
+++ b/pkg/utils/kubernetes/pod_utils.go
@@ -55,3 +55,19 @@ func GetContainerVolumeMountByMountPath(container *corev1.Container, mountPath s
 
 	return nil
 }
+
+// SetContainerEnv overrides the environment variable by given `env` with the same name in its envs.
+// If there are no env with the same name, it adds the `env` to `envs`.
+func SetContainerEnv(container *corev1.Container, env corev1.EnvVar) {
+	found := false
+	for i, existingEnv := range container.Env {
+		if env.Name == existingEnv.Name {
+			container.Env[i] = env
+			found = true
+			// In case there are multiple items in env with the same name, we should finish the loop always.
+		}
+	}
+	if !found {
+		container.Env = append(container.Env, env)
+	}
+}

--- a/pkg/utils/kubernetes/pod_utils_test.go
+++ b/pkg/utils/kubernetes/pod_utils_test.go
@@ -1,0 +1,101 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestSetContainerEnv(t *testing.T) {
+	testCases := []struct {
+		name         string
+		container    corev1.Container
+		env          corev1.EnvVar
+		expectedEnvs []corev1.EnvVar
+	}{
+		{
+			name: "env with same name does not exist",
+			container: corev1.Container{
+				Env: []corev1.EnvVar{
+					{
+						Name:  "ENV_0",
+						Value: "value_0",
+					},
+				},
+			},
+			env: corev1.EnvVar{
+				Name:  "ENV_1",
+				Value: "value_1",
+			},
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "ENV_0",
+					Value: "value_0",
+				},
+				{
+					Name:  "ENV_1",
+					Value: "value_1",
+				},
+			},
+		},
+		{
+			name: "one item in env with same name",
+			container: corev1.Container{
+				Env: []corev1.EnvVar{
+					{
+						Name:  "ENV_1",
+						Value: "value_0",
+					},
+				},
+			},
+			env: corev1.EnvVar{
+				Name:  "ENV_1",
+				Value: "value_1",
+			},
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "ENV_1",
+					Value: "value_1",
+				},
+			},
+		},
+		{
+			name: "multiple items in env with same name",
+			container: corev1.Container{
+				Env: []corev1.EnvVar{
+					{
+						Name:  "ENV_1",
+						Value: "value_0",
+					},
+					{
+						Name:  "ENV_1",
+						Value: "value_2",
+					},
+				},
+			},
+			env: corev1.EnvVar{
+				Name:  "ENV_1",
+				Value: "value_1",
+			},
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "ENV_1",
+					Value: "value_1",
+				},
+				{
+					Name:  "ENV_1",
+					Value: "value_1",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			SetContainerEnv(&tc.container, tc.env)
+			require.Equal(t, tc.expectedEnvs, tc.container.Env)
+		})
+
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Configure `DeploymentOptions` and ingress service ports in `DataPlane` for `TLS` listeners.

It configures the `KONG_STREAM_LISTEN` to start L4 proxy ports on Kong DP and `KONG_PORT_MAPS` env in deployment options, and open a port on the ingress service for each TLS listeneer.

**Which issue this PR fixes**

Fixes #64 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
