### PR TITLE
[release/2.1.x]: Backport 3361 to release/2.1.x

### DIFF
--- a/.github/workflows/_kongintegration_tests.yaml
+++ b/.github/workflows/_kongintegration_tests.yaml
@@ -56,6 +56,7 @@ jobs:
           MISE_VERBOSE: 1
           MISE_DEBUG: 1
           GOTESTSUM_JUNITFILE: ${{ env.GOTESTSUM_JUNITFILE }}
+          KONG_CUSTOM_DOMAIN: konghq.tech
           TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
           TEST_KONG_ENTERPRISE: ${{ matrix.enterprise }}

--- a/hack/cleanup/konnect_system_accounts.go
+++ b/hack/cleanup/konnect_system_accounts.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/go-logr/logr"
+	"github.com/samber/lo"
+
+	"github.com/kong/kong-operator/v2/test"
+)
+
+const (
+	systemAccountsPageSize         = int64(100)
+	timeUntilSystemAccountOrphaned = time.Hour
+)
+
+// cleanupKonnectSystemAccounts deletes orphaned system accounts created by the tests.
+func cleanupKonnectSystemAccounts(ctx context.Context, log logr.Logger) error {
+	serverURL, err := canonicalizedServerURL()
+	if err != nil {
+		return fmt.Errorf("invalid server URL %s: %w", test.KonnectServerURL(), err)
+	}
+
+	sdk := sdkkonnectgo.New(
+		sdkkonnectgo.WithSecurity(
+			sdkkonnectcomp.Security{
+				PersonalAccessToken: lo.ToPtr(test.KonnectAccessToken()),
+			},
+		),
+		sdkkonnectgo.WithServerURL(serverURL),
+	)
+
+	orphanedSAs, err := findOrphanedSystemAccounts(ctx, log, sdk.SystemAccounts)
+	if err != nil {
+		return fmt.Errorf("failed to find orphaned system accounts: %w", err)
+	}
+	if err := deleteSystemAccounts(ctx, log, sdk.SystemAccounts, orphanedSAs); err != nil {
+		return fmt.Errorf("failed to delete system accounts: %w", err)
+	}
+
+	return nil
+}
+
+// findOrphanedSystemAccounts finds system accounts that were created more than timeUntilSystemAccountOrphaned ago.
+func findOrphanedSystemAccounts(
+	ctx context.Context,
+	log logr.Logger,
+	sdk *sdkkonnectgo.SystemAccounts,
+) ([]string, error) {
+	var orphanedSystemAccounts []string
+	pageNumber := int64(1)
+
+	for {
+		response, err := sdk.GetSystemAccounts(ctx, sdkkonnectops.GetSystemAccountsRequest{
+			PageSize:   lo.ToPtr(systemAccountsPageSize),
+			PageNumber: &pageNumber,
+			Filter: &sdkkonnectops.GetSystemAccountsQueryParamFilter{
+				// Only consider non-Konnect-managed system accounts.
+				KonnectManaged: lo.ToPtr(false),
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list system accounts (page %d): %w", pageNumber, err)
+		}
+		if response.SystemAccountCollection == nil {
+			return nil, fmt.Errorf("failed to list system accounts, response is nil (page %d)", pageNumber)
+		}
+
+		accounts := response.SystemAccountCollection.GetData()
+		if len(accounts) == 0 {
+			break
+		}
+
+		for _, sa := range accounts {
+			if sa.ID == nil {
+				log.Info("System account has no ID, skipping", "name", sa.GetName())
+				continue
+			}
+			if sa.CreatedAt == nil {
+				log.Info("System account has no creation timestamp, skipping", "id", *sa.ID, "name", sa.GetName())
+				continue
+			}
+			orphanedAfter := sa.CreatedAt.Add(timeUntilSystemAccountOrphaned)
+			if !time.Now().After(orphanedAfter) {
+				log.Info("System account is not old enough to be considered orphaned, skipping",
+					"id", *sa.ID, "name", sa.GetName(), "created_at", *sa.CreatedAt,
+				)
+				continue
+			}
+			orphanedSystemAccounts = append(orphanedSystemAccounts, *sa.ID)
+		}
+
+		if int64(len(accounts)) < systemAccountsPageSize {
+			break
+		}
+		pageNumber++
+	}
+
+	return orphanedSystemAccounts, nil
+}
+
+// deleteSystemAccounts deletes system accounts by their IDs.
+func deleteSystemAccounts(
+	ctx context.Context,
+	log logr.Logger,
+	sdk *sdkkonnectgo.SystemAccounts,
+	saIDs []string,
+) error {
+	if len(saIDs) == 0 {
+		log.Info("No system accounts to clean up")
+		return nil
+	}
+
+	var errs []error
+	for _, saID := range saIDs {
+		log.Info("Deleting system account", "id", saID)
+		if _, err := sdk.DeleteSystemAccountsID(ctx, saID); err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete system account %s: %w", saID, err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/hack/cleanup/main.go
+++ b/hack/cleanup/main.go
@@ -13,11 +13,15 @@
 // 1. It has a label `created_in_tests` with value `true`.
 // 2. It was created more than 1h ago.
 //
+// A system account is considered orphaned when all conditions are satisfied:
+// 1. It is not managed by Konnect.
+// 2. It was created more than 1h ago.
+//
 // Usage: `go run ./hack/cleanup [mode]`
 // Where `mode` is one of:
 // - `all` (default): clean up both GKE clusters and Konnect control planes
 // - `gke`: clean up only GKE clusters
-// - `konnect`: clean up only Konnect control planes
+// - `konnect`: clean up only Konnect control planes and system accounts
 package main
 
 import (
@@ -103,11 +107,13 @@ func resolveCleanupFuncs(mode string) []func(context.Context, logr.Logger) error
 	case cleanupModeKonnect:
 		return []func(context.Context, logr.Logger) error{
 			cleanupKonnectControlPlanes,
+			cleanupKonnectSystemAccounts,
 		}
 	default:
 		return []func(context.Context, logr.Logger) error{
 			cleanupGKEClusters,
 			cleanupKonnectControlPlanes,
+			cleanupKonnectSystemAccounts,
 		}
 	}
 }

--- a/ingress-controller/internal/konnect/sdk/sdk.go
+++ b/ingress-controller/internal/konnect/sdk/sdk.go
@@ -1,18 +1,24 @@
 package sdk
 
 import (
+	"strings"
+
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/samber/lo"
 )
 
 // New returns a new SDK instance.
 func New(token string, opts ...sdkkonnectgo.SDKOption) *sdkkonnectgo.SDK {
+	security := sdkkonnectcomp.Security{}
+	switch {
+	case strings.HasPrefix(token, "kpat_"):
+		security.PersonalAccessToken = lo.ToPtr(token)
+	case strings.HasPrefix(token, "spat_"):
+		security.SystemAccountAccessToken = lo.ToPtr(token)
+	}
 	sdkOpts := []sdkkonnectgo.SDKOption{
-		sdkkonnectgo.WithSecurity(
-			sdkkonnectcomp.Security{
-				PersonalAccessToken: sdkkonnectgo.String(token),
-			},
-		),
+		sdkkonnectgo.WithSecurity(security),
 	}
 	sdkOpts = append(sdkOpts, opts...)
 

--- a/ingress-controller/test/internal/helpers/konnect/certificates.go
+++ b/ingress-controller/test/internal/helpers/konnect/certificates.go
@@ -9,7 +9,6 @@ import (
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkretry "github.com/Kong/sdk-konnect-go/retry"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/ingress-controller/test/internal/helpers/konnect/certificates.go
+++ b/ingress-controller/test/internal/helpers/konnect/certificates.go
@@ -8,7 +8,8 @@ import (
 
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
-	"github.com/Kong/sdk-konnect-go/retry"
+	sdkretry "github.com/Kong/sdk-konnect-go/retry"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -18,24 +19,29 @@ import (
 
 // CreateClientCertificate creates a TLS client certificate and POSTs it to Konnect Control Plane configuration API
 // so that KIC can use the certificates to authenticate against Konnect Admin API.
-func CreateClientCertificate(ctx context.Context, t *testing.T, cpID string) (certPEM string, keyPEM string) {
+func CreateClientCertificate(ctx context.Context, t *testing.T, cpID string, token ...string) (certPEM string, keyPEM string) {
 	t.Helper()
 
-	sdk := sdk.New(accessToken(), serverURLOpt(),
-		sdkkonnectgo.WithRetryConfig(retry.Config{
-			Backoff: &retry.BackoffStrategy{
-				InitialInterval: 100,
-				MaxInterval:     2000,
-				Exponent:        1.2,
-				MaxElapsedTime:  10000,
-			},
-		}),
-	)
+	retryConfig := sdkkonnectgo.WithRetryConfig(sdkretry.Config{
+		Backoff: &sdkretry.BackoffStrategy{
+			InitialInterval: 100,
+			MaxInterval:     2000,
+			Exponent:        1.2,
+			MaxElapsedTime:  10000,
+		},
+	})
+
+	var s *sdkkonnectgo.SDK
+	if len(token) == 0 {
+		s = sdk.New(accessToken(), serverURLOpt(), retryConfig)
+	} else {
+		s = sdk.New(token[0], serverURLOpt(), retryConfig)
+	}
 
 	cert, key := certificate.MustGenerateCertPEMFormat()
 
 	t.Log("creating client certificate in Konnect")
-	resp, err := sdk.DPCertificates.CreateDataplaneCertificate(ctx, cpID, &sdkkonnectcomp.DataPlaneClientCertificateRequest{
+	resp, err := s.DPCertificates.CreateDataplaneCertificate(ctx, cpID, &sdkkonnectcomp.DataPlaneClientCertificateRequest{
 		Cert: string(cert),
 	})
 	require.NoError(t, err)

--- a/ingress-controller/test/internal/helpers/konnect/control_plane.go
+++ b/ingress-controller/test/internal/helpers/konnect/control_plane.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 	"time"
 
+	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/avast/retry-go/v4"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/adminapi"
@@ -25,14 +25,18 @@ import (
 
 // CreateTestControlPlane creates a control plane to be used in tests. It returns the created control plane's ID.
 // It also sets up a cleanup function for it to be deleted.
-func CreateTestControlPlane(ctx context.Context, t *testing.T) string {
+func CreateTestControlPlane(ctx context.Context, t *testing.T, token ...string) string {
 	t.Helper()
 
-	sdk := sdk.New(accessToken(), serverURLOpt())
-
+	var s *sdkkonnectgo.SDK
+	if len(token) == 0 {
+		s = sdk.New(accessToken(), serverURLOpt())
+	} else {
+		s = sdk.New(token[0], serverURLOpt())
+	}
 	var cpID string
 	createRgErr := retry.Do(func() error {
-		createResp, err := sdk.ControlPlanes.CreateControlPlane(ctx,
+		createResp, err := s.ControlPlanes.CreateControlPlane(ctx,
 			sdkkonnectcomp.CreateControlPlaneRequest{
 				Name:        uuid.NewString(),
 				Description: lo.ToPtr(generateTestKonnectControlPlaneDescription(t)),
@@ -63,20 +67,29 @@ func CreateTestControlPlane(ctx context.Context, t *testing.T) string {
 
 		cpID = createResp.ControlPlane.ID
 		return nil
-	}, retry.Attempts(5), retry.Delay(time.Second))
+	},
+		retry.Attempts(5),
+		retry.Delay(time.Second),
+		retry.OnRetry(func(_ uint, err error) {
+			t.Logf("failed to create control plane, retrying: %v", err)
+		}),
+	)
 	require.NoError(t, createRgErr)
 
 	t.Cleanup(func() {
-		ctx = context.Background()
-		t.Logf("deleting test Konnect Control Plane: %q", cpID)
+		fmt.Printf("deleting test Konnect Control Plane: %q\n", cpID)
 		err := retry.Do(
 			func() error { //nolint:contextcheck
-				_, err := sdk.ControlPlanes.DeleteControlPlane(context.Background(), cpID)
+				_, err := s.ControlPlanes.DeleteControlPlane(context.Background(), cpID)
 				return err
 			},
 			retry.Attempts(5), retry.Delay(time.Second),
 		)
-		assert.NoErrorf(t, err, "failed to cleanup a control plane: %q", cpID)
+		if err != nil {
+			// Don't fail the test if cleanup fails, just log the error.
+			// Cleanup job will eventually clean up the control plane.
+			fmt.Printf("failed to delete control plane %q: %v\n", cpID, err)
+		}
 
 		// Since Konnect authorization v2 supports cleanup of roles after control plane deleted, we do not need to delete them manually.
 	})

--- a/ingress-controller/test/internal/helpers/konnect/system_account_tokens.go
+++ b/ingress-controller/test/internal/helpers/konnect/system_account_tokens.go
@@ -1,0 +1,89 @@
+package konnect
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/avast/retry-go/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kong-operator/v2/ingress-controller/internal/konnect/sdk"
+)
+
+func CreateTestSystemAccountToken(ctx context.Context, t *testing.T, systemAccountID string) (string, string) {
+	t.Helper()
+
+	s := sdk.New(accessToken(), serverURLOpt())
+
+	var (
+		systemAccountToken     string
+		systemAccountTokenID   string
+		systemAccountTokenName = fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixMilli())
+	)
+	err := retry.Do(func() error {
+		createResp, err := s.SystemAccountsAccessTokens.
+			PostSystemAccountsIDAccessTokens(ctx,
+				systemAccountID,
+				&sdkkonnectcomp.CreateSystemAccountAccessToken{
+					Name:      systemAccountTokenName,
+					ExpiresAt: time.Now().Add(time.Hour),
+				},
+			)
+		if err != nil {
+			return err
+		}
+
+		if createResp == nil {
+			return fmt.Errorf("failed to create system account token: response is nil")
+		}
+
+		if createResp.GetStatusCode() != http.StatusCreated {
+			body, err := io.ReadAll(createResp.RawResponse.Body)
+			if err != nil {
+				body = []byte(err.Error())
+			}
+			return fmt.Errorf("failed to create system account token: code %d, message %s", createResp.GetStatusCode(), body)
+		}
+
+		if createResp.SystemAccountAccessTokenCreated == nil ||
+			createResp.SystemAccountAccessTokenCreated.ID == nil ||
+			createResp.SystemAccountAccessTokenCreated.Token == nil {
+			return fmt.Errorf(
+				"failed to create system account token: response fields are missing (status code %d)",
+				createResp.GetStatusCode(),
+			)
+		}
+
+		systemAccountToken = *createResp.SystemAccountAccessTokenCreated.Token
+		systemAccountTokenID = *createResp.SystemAccountAccessTokenCreated.ID
+		return nil
+	}, retry.Attempts(5), retry.Delay(time.Second))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		fmt.Printf("deleting test system account token: %q (ID: %q)\n", systemAccountTokenName, systemAccountTokenID)
+		err := retry.Do(
+			func() error {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				_, err := s.SystemAccountsAccessTokens.DeleteSystemAccountsIDAccessTokensID(ctx, systemAccountID, systemAccountTokenID)
+				return err
+			},
+			retry.Attempts(5),
+			retry.Delay(time.Second),
+		)
+		if err != nil {
+			// Don't fail the test if cleanup fails, just log the error.
+			// Cleanup job will eventually clean up konnect.
+			fmt.Printf("failed to delete test system account token %q (ID: %q): %v\n", systemAccountTokenName, systemAccountTokenID, err)
+		}
+	})
+
+	t.Logf("created test system account token : %q (ID:%q)", systemAccountTokenName, systemAccountTokenID)
+	return systemAccountTokenID, systemAccountToken
+}

--- a/ingress-controller/test/internal/helpers/konnect/system_accounts.go
+++ b/ingress-controller/test/internal/helpers/konnect/system_accounts.go
@@ -1,0 +1,112 @@
+package konnect
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/avast/retry-go/v4"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kong-operator/v2/ingress-controller/internal/konnect/sdk"
+	"github.com/kong/kong-operator/v2/ingress-controller/test"
+)
+
+// CreateTestSystemAccount creates a system account in Konnect for testing purposes and returns its ID.
+// The system account is deleted during test cleanup.
+func CreateTestSystemAccount(ctx context.Context, t *testing.T) string {
+	t.Helper()
+
+	s := sdk.New(accessToken(), serverURLOpt())
+
+	var (
+		systemAccountID   string
+		systemAccountName = fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixMilli())
+	)
+	err := retry.Do(func() error {
+		createResp, err := s.SystemAccounts.
+			PostSystemAccounts(ctx,
+				&sdkkonnectcomp.CreateSystemAccount{
+					Name:           systemAccountName,
+					Description:    "Test system account for Kong Ingress Controller integration tests",
+					KonnectManaged: lo.ToPtr(false),
+				},
+			)
+		if err != nil {
+			return err
+		}
+
+		if createResp == nil {
+			return fmt.Errorf("failed to create system account: response is nil")
+		}
+
+		if createResp.GetStatusCode() != http.StatusCreated {
+			body, err := io.ReadAll(createResp.RawResponse.Body)
+			if err != nil {
+				body = []byte(err.Error())
+			}
+			return fmt.Errorf("failed to create system account: code %d, message %s", createResp.GetStatusCode(), body)
+		}
+
+		if createResp.SystemAccount == nil ||
+			createResp.SystemAccount.ID == nil {
+			return fmt.Errorf(
+				"failed to create system account: response fields are missing (status code %d)",
+				createResp.GetStatusCode(),
+			)
+		}
+
+		systemAccountID = *createResp.SystemAccount.ID
+		return nil
+	}, retry.Attempts(5), retry.Delay(time.Second))
+	require.NoError(t, err)
+
+	assignRole(ctx, t, s.SystemAccountsRoles, systemAccountID, sdkkonnectcomp.RoleNameCreator)
+	assignRole(ctx, t, s.SystemAccountsRoles, systemAccountID, sdkkonnectcomp.RoleNameAdmin)
+
+	t.Cleanup(func() {
+		fmt.Printf("deleting test system account: %q\n", systemAccountID)
+		err := retry.Do(
+			func() error {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				_, err := s.SystemAccounts.DeleteSystemAccountsID(ctx, systemAccountID)
+				return err
+			},
+			retry.Attempts(5),
+			retry.Delay(time.Second),
+		)
+		if err != nil {
+			// Don't fail the test if cleanup fails, just log the error.
+			// Cleanup job will eventually clean up konnect.
+			fmt.Printf("failed to delete test system account %q: %v\n", systemAccountID, err)
+		}
+	})
+
+	t.Logf("created test system account: %q (ID:%q)", systemAccountName, systemAccountID)
+	return systemAccountID
+}
+
+func assignRole(ctx context.Context, t *testing.T, s *sdkkonnectgo.SystemAccountsRoles, systemAccountID string, role sdkkonnectcomp.RoleName) {
+	roleAssignResp, err := s.PostSystemAccountsAccountIDAssignedRoles(ctx, systemAccountID,
+		&sdkkonnectcomp.AssignRole{
+			RoleName:       lo.ToPtr(role),
+			EntityTypeName: lo.ToPtr(sdkkonnectcomp.EntityTypeNameControlPlanes),
+			EntityID:       lo.ToPtr("*"),
+			EntityRegion:   lo.ToPtr(sdkkonnectcomp.AssignRoleEntityRegion(test.KonnectServerRegion())),
+		},
+	)
+	require.NoError(t, err)
+	if roleAssignResp.AssignedRole.ID == nil {
+		t.Fatal("warning: assigned role response is missing ID field, cannot log assigned role ID")
+	}
+	t.Logf("assigned %q role (ID:%q)to system account %q for all control planes",
+		role, *roleAssignResp.AssignedRole.ID, systemAccountID,
+	)
+}

--- a/ingress-controller/test/kongintegration/consts.go
+++ b/ingress-controller/test/kongintegration/consts.go
@@ -1,0 +1,7 @@
+package kongintegration
+
+const (
+	// concurrency is the number of concurrent workers used in tests that apply
+	// configuration to Kong in DB mode.
+	concurrency = 4
+)

--- a/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
+++ b/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
@@ -100,8 +100,14 @@ func TestKongClientGoldenTestsOutputs_Konnect(t *testing.T) {
 
 	ctx := t.Context()
 
-	cpID := konnect.CreateTestControlPlane(ctx, t)
-	cert, key := konnect.CreateClientCertificate(ctx, t, cpID)
+	gatewayTag, err := testenv.GetDependencyVersion("kongintegration.kong-ee")
+	require.NoError(t, err)
+	gatewayTag = trimEnterpriseTagToSemver(gatewayTag)
+
+	systemAccountID := konnect.CreateTestSystemAccount(ctx, t)
+	_, token := konnect.CreateTestSystemAccountToken(ctx, t, systemAccountID)
+	cpID := konnect.CreateTestControlPlane(ctx, t, token)
+	cert, key := konnect.CreateClientCertificate(ctx, t, cpID, token)
 	adminAPIClient := konnect.CreateKonnectAdminAPIClient(t, cpID, cert, key)
 	updateStrategy := sendconfig.NewUpdateStrategyDBModeKonnect(adminAPIClient.AdminAPIClient(), dump.Config{
 		SkipCACerts:         true,

--- a/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
+++ b/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
@@ -109,10 +109,16 @@ func TestKongClientGoldenTestsOutputs_Konnect(t *testing.T) {
 	cpID := konnect.CreateTestControlPlane(ctx, t, token)
 	cert, key := konnect.CreateClientCertificate(ctx, t, cpID, token)
 	adminAPIClient := konnect.CreateKonnectAdminAPIClient(t, cpID, cert, key)
-	updateStrategy := sendconfig.NewUpdateStrategyDBModeKonnect(adminAPIClient.AdminAPIClient(), dump.Config{
-		SkipCACerts:         true,
-		KonnectControlPlane: cpID,
-	}, semver.MustParse("3.5.0"), 10, logr.Discard())
+	updateStrategy := sendconfig.NewUpdateStrategyDBModeKonnect(
+		adminAPIClient.AdminAPIClient(),
+		dump.Config{
+			SkipCACerts:         true,
+			KonnectControlPlane: cpID,
+		},
+		semver.MustParse(gatewayTag),
+		concurrency,
+		logr.Discard(),
+	)
 
 	for _, goldenTestOutputPath := range allGoldenTestsOutputsPaths(t) {
 		t.Run(goldenTestOutputPath, func(t *testing.T) {

--- a/ingress-controller/test/kongintegration/tags.go
+++ b/ingress-controller/test/kongintegration/tags.go
@@ -1,0 +1,12 @@
+package kongintegration
+
+import "strings"
+
+func trimEnterpriseTagToSemver(tag string) string {
+	// Enterprise tags can contain a fourth segment, trim it to adhere to semver.
+	if strings.Count(tag, ".") > 2 {
+		parts := strings.SplitN(tag, ".", 4)
+		tag = strings.Join(parts[:3], ".")
+	}
+	return tag
+}

--- a/ingress-controller/test/konnect.go
+++ b/ingress-controller/test/konnect.go
@@ -18,3 +18,17 @@ func KonnectServerURL() string {
 	}
 	return konnectDefaultDevServerURL
 }
+
+func KonnectServerRegion() string {
+	serverURL := KonnectServerURL()
+	switch serverURL {
+	case "https://eu.api.konghq.tech", "https://eu.kic.api.konghq.tech":
+		return "eu"
+	case "https://ap.api.konghq.tech", "https://ap.kic.api.konghq.tech":
+		return "ap"
+	case "https://us.api.konghq.tech", "https://us.kic.api.konghq.tech":
+		return "us"
+	default:
+		return "us"
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Backporting #3361 which includes fixes to kongintegration tests and migrates from using PATs to SPATs in tests.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
