### PR TITLE
chore: fix markdownlint bump

### DIFF
--- a/.tools_versions.yaml
+++ b/.tools_versions.yaml
@@ -45,8 +45,10 @@ govulncheck: "1.1.4"
 chartsnap: "0.6.0"
 # renovate: datasource=github-releases depName=stackrox/kube-linter
 kube-linter: "0.8.1"
+# TODO: using 0.16.0 as that's the last version that wasn't impacted by:
+# https://github.com/DavidAnson/markdownlint-cli2/issues/785
 # renovate: datasource=github-tags depName=DavidAnson/markdownlint-cli2
-markdownlint-cli2: "0.21.0"
+markdownlint-cli2: "0.16.0"
 # renovate: datasource=github-releases depName=cert-manager/cert-manager
 cert-manager: "1.19.4"
 # renovate: datasource=github-releases depName=kyverno/chainsaw

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ helm upgrade --install kong-operator \
   --set env.ENABLE_CONTROLLER_KONNECT=true
 ```
 
-> [!NOTE]
+> **NOTE**
 > When using the `nightly` tag the operator version assumed is the one of the `Chart.appversion`, which is set to the latest release.
 > If a specific version is required (e.g., to enable version-gated features) you can specify it by adding the `--set image.effectiveSemver=<DESIRED_VERSION>` argument.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Revert temporarily markdownlint to 0.16.0 which is the last version not impacted by https://github.com/DavidAnson/markdownlint-cli2/issues/785.

This PR aims to unblock CI which is currently failing constantly with:

```
/home/runner/work/kong-operator/kong-operator/bin/installs/npm-markdownlint-cli2/0.21.0/bin/markdownlint-cli2 \
	CHANGELOG.md \
	README.md \
	FEATURES.md \
	AGENTS.md \
	.github/ISSUE_TEMPLATE/*.md \
	charts/kong-operator/README.md \
	charts/kong-operator/UPGRADE.md \
	charts/kong-operator/CHANGELOG.md
file:///home/runner/work/kong-operator/kong-operator/bin/installs/npm-markdownlint-cli2/0.21.0/lib/node_modules/markdownlint-cli2/node_modules/katex/dist/katex.mjs:16340
const version = __VERSION__;
                ^

ReferenceError: __VERSION__ is not defined
    at file:///home/runner/work/kong-operator/kong-operator/bin/installs/npm-markdownlint-cli2/0.21.0/lib/node_modules/markdownlint-cli2/node_modules/katex/dist/katex.mjs:16340:17
    at ModuleJob.run (node:internal/modules/esm/module_job:325:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:606:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)

Node.js v20.20.0
```

https://github.com/Kong/kong-operator/actions/runs/22723966910/job/65901613042?pr=3506#step:4:109

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
