### PR TITLE
chore: replace `lo` functions with stdlib functions and enforce with golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -88,8 +88,10 @@ linters:
           msg: Please use the types package to refer to the type (through github.com/kong/kong-operator/internal/types)
         - pattern: ^errors.As$
           msg: Please use errors.AsType instead
-        - pattern: ^.*lo\.ToPtr\(.*\).*$
+        - pattern: ^lo\.ToPtr$
           msg: Please use built-in new() instead
+        - pattern: ^lo\.Contains$
+          msg: Please use slices.Contains() instead
     gomodguard:
       blocked:
         modules:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -92,6 +92,8 @@ linters:
           msg: Please use built-in new() instead
         - pattern: ^lo\.Contains$
           msg: Please use slices.Contains() instead
+        - pattern: ^lo\.FindIndexOf$
+          msg: Please use slices.IndexFunc() instead
     gomodguard:
       blocked:
         modules:

--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/samber/lo"
 	certificatesv1 "k8s.io/api/certificates/v1"
@@ -228,7 +229,7 @@ func validateWatchNamespaces(
 		// NOTE: In case the operator Pod does not have watch namespaces flag/environment variable set
 		// to include the ControlPlane's namespace, it will not be able to watch
 		// the ControlPlane's own namespace, which is required for the operator to function properly.
-		if len(watchNamespaces) > 0 && !lo.Contains(watchNamespaces, cp.Namespace) {
+		if len(watchNamespaces) > 0 && !slices.Contains(watchNamespaces, cp.Namespace) {
 			return fmt.Errorf(
 				"ControlPlane's watchNamespaces is set to 'Own' (current ControlPlane namespace: %v), but operator is only allowed on: %v",
 				cp.Namespace, watchNamespaces,

--- a/controller/cpextensions/controller.go
+++ b/controller/cpextensions/controller.go
@@ -3,6 +3,7 @@ package cpextensions
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -305,7 +306,7 @@ func listServicesThatHavePluginsManagedByControlPlane(
 
 func ensureStringInCommaSeparatedString(v, commaSeparated string) string {
 	split := strings.Split(commaSeparated, ",")
-	if lo.Contains(split, v) {
+	if slices.Contains(split, v) {
 		return commaSeparated
 	}
 	return commaSeparated + "," + v
@@ -313,7 +314,7 @@ func ensureStringInCommaSeparatedString(v, commaSeparated string) string {
 
 func ensureStringNotInCommaSeparatedString(v, commaSeparated string) string {
 	split := strings.Split(commaSeparated, ",")
-	if lo.Contains(split, v) {
+	if slices.Contains(split, v) {
 		return strings.Join(
 			lo.Filter(split, func(s string, _ int) bool {
 				return s != v
@@ -387,7 +388,7 @@ func ensureKongPluginsAnnotationIsSetForPrometheusPlugin(svc *corev1.Service, pr
 		svc.Annotations[consts.KongIngressControllerPluginsAnnotation] = prometheusPlugin.Name
 	} else if ann != prometheusPlugin.Name {
 		pluginNames := strings.Split(ann, ",")
-		ok = lo.Contains(pluginNames, prometheusPlugin.Name)
+		ok = slices.Contains(pluginNames, prometheusPlugin.Name)
 		if !ok {
 			svc.Annotations[consts.KongIngressControllerPluginsAnnotation] = ann + "," + prometheusPlugin.Name
 		}

--- a/controller/dataplane/owned_finalizer_controller.go
+++ b/controller/dataplane/owned_finalizer_controller.go
@@ -3,6 +3,7 @@ package dataplane
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/samber/lo"
@@ -143,7 +144,7 @@ func (r DataPlaneOwnedResourceFinalizerReconciler[T, PT]) Reconcile(ctx context.
 	}
 
 	// If the object does not have the finalizer, we don't need to do anything.
-	hasDataPlaneOwnedFinalizer := lo.Contains(obj.GetFinalizers(), consts.DataPlaneOwnedWaitForOwnerFinalizer)
+	hasDataPlaneOwnedFinalizer := slices.Contains(obj.GetFinalizers(), consts.DataPlaneOwnedWaitForOwnerFinalizer)
 	if !hasDataPlaneOwnedFinalizer {
 		log.Debug(logger, "object has no finalizer",
 			"finalizer", consts.DataPlaneOwnedWaitForOwnerFinalizer,

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -1052,10 +1053,10 @@ func deploymentOptionsDeepEqual(o1, o2 *operatorv1beta1.DeploymentOptions, envVa
 		cmp.Comparer(func(a, b []corev1.EnvVar) bool {
 			// Throw out env vars that we ignore.
 			a = lo.Filter(a, func(e corev1.EnvVar, _ int) bool {
-				return !lo.Contains(envVarsToIgnore, e.Name)
+				return !slices.Contains(envVarsToIgnore, e.Name)
 			})
 			b = lo.Filter(b, func(e corev1.EnvVar, _ int) bool {
-				return !lo.Contains(envVarsToIgnore, e.Name)
+				return !slices.Contains(envVarsToIgnore, e.Name)
 			})
 
 			// And compare.

--- a/controller/kongplugininstallation/controller.go
+++ b/controller/kongplugininstallation/controller.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 
-	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -278,10 +278,10 @@ func setStatusConditionForKongPluginInstallation(
 		Reason:             string(reason),
 		Message:            msg,
 	}
-	_, index, found := lo.FindIndexOf(kpi.Status.Conditions, func(c metav1.Condition) bool {
+	index := slices.IndexFunc(kpi.Status.Conditions, func(c metav1.Condition) bool {
 		return c.Type == string(operatorv1alpha1.KongPluginInstallationConditionStatusAccepted)
 	})
-	if found {
+	if index < 0 {
 		// Nothing changed, condition doesn't need to be updated.
 		if c := kpi.Status.Conditions[index]; c.Status == status.Status && c.Reason == status.Reason && c.Message == status.Message {
 			return nil

--- a/controller/konnect/ops/ops_kongkeyset.go
+++ b/controller/konnect/ops/ops_kongkeyset.go
@@ -3,11 +3,11 @@ package ops
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
-	"github.com/samber/lo"
 
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
@@ -191,7 +191,7 @@ func keySetMatch(konnectKeySet *sdkkonnectcomp.KeySet, keySet *configurationv1al
 	}
 
 	for _, tag := range keySet.Spec.Tags {
-		if !lo.Contains(konnectKeySet.Tags, tag) {
+		if !slices.Contains(konnectKeySet.Tags, tag) {
 			return false
 		}
 	}

--- a/controller/pkg/dataplane/finalizer.go
+++ b/controller/pkg/dataplane/finalizer.go
@@ -3,6 +3,7 @@ package dataplane
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,7 +18,7 @@ func OwnedObjectPreDeleteHook(ctx context.Context, cl client.Client, obj client.
 	finalizers := obj.GetFinalizers()
 
 	// If there's no finalizer, we don't need to do anything.
-	if !lo.Contains(finalizers, consts.DataPlaneOwnedWaitForOwnerFinalizer) {
+	if !slices.Contains(finalizers, consts.DataPlaneOwnedWaitForOwnerFinalizer) {
 		return nil
 	}
 

--- a/ingress-controller/internal/admission/validation/ingress/ingress_test.go
+++ b/ingress-controller/internal/admission/validation/ingress/ingress_test.go
@@ -2,6 +2,7 @@ package ingress
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/go-logr/zapr"
@@ -106,7 +107,7 @@ type mockRoutesValidator struct{}
 
 func (mockRoutesValidator) Validate(_ context.Context, r *kong.Route) (bool, string, error) {
 	protocols := lo.FromSlicePtr(r.Protocols)
-	if lo.Contains(protocols, "http") && lo.Contains(protocols, "tcp") {
+	if slices.Contains(protocols, "http") && slices.Contains(protocols, "tcp") {
 		return false, "Invalid protocols: http and tcp are mutally exclusive", nil
 	}
 	return true, "", nil

--- a/ingress-controller/internal/controllers/license/konglicense_controller.go
+++ b/ingress-controller/internal/controllers/license/konglicense_controller.go
@@ -3,13 +3,13 @@ package license
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/kong/go-kong/kong"
-	"github.com/samber/lo"
 	"github.com/samber/mo"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -371,10 +371,10 @@ func (r *KongV1Alpha1KongLicenseReconciler) repickLicenseOnDelete(ctx context.Co
 }
 
 func setLicenseValidityCondition(ks *[]metav1.Condition, licenseValidationError error) {
-	_, index, found := lo.FindIndexOf(*ks, func(condition metav1.Condition) bool {
+	index := slices.IndexFunc(*ks, func(condition metav1.Condition) bool {
 		return condition.Type == ConditionTypeLicenseValid
 	})
-	if !found {
+	if index < 0 {
 		*ks = append(*ks, metav1.Condition{
 			Type: ConditionTypeLicenseValid,
 		})
@@ -410,10 +410,10 @@ func (r *KongV1Alpha1KongLicenseReconciler) ensureControllerStatusConditions(
 
 	fullControllerName := r.fullControllerName()
 	// Find the managed controller status item and append new item when absent.
-	_, controllerIndex, found := lo.FindIndexOf(license.Status.KongLicenseControllerStatuses, func(controllerStatus configurationv1alpha1.KongLicenseControllerStatus) bool {
+	controllerIndex := slices.IndexFunc(license.Status.KongLicenseControllerStatuses, func(controllerStatus configurationv1alpha1.KongLicenseControllerStatus) bool {
 		return controllerStatus.ControllerName == fullControllerName
 	})
-	if !found {
+	if controllerIndex < 0 {
 		wantedControllerStatus := configurationv1alpha1.KongLicenseControllerStatus{
 			ControllerName: fullControllerName,
 		}
@@ -433,10 +433,10 @@ func (r *KongV1Alpha1KongLicenseReconciler) ensureControllerStatusConditions(
 		Message:            message,
 	}
 	// Find the "programmed" condition in the condition list.
-	programmedCondition, conditionIndex, found := lo.FindIndexOf(*ctrlManagedConditions, func(condition metav1.Condition) bool {
+	conditionIndex := slices.IndexFunc(*ctrlManagedConditions, func(condition metav1.Condition) bool {
 		return condition.Type == ConditionTypeProgrammed
 	})
-	if !found {
+	if conditionIndex < 0 {
 		// Return error if the number of conditions already reached the limit.
 		if len(license.Status.KongLicenseControllerStatuses) >= maxConditionNum {
 			return fmt.Errorf("already %d condition items in controller status exceeding the limit %d, cannot add new item",
@@ -447,6 +447,7 @@ func (r *KongV1Alpha1KongLicenseReconciler) ensureControllerStatusConditions(
 		)
 		return r.Client.Status().Update(ctx, license)
 	}
+	programmedCondition := (*ctrlManagedConditions)[conditionIndex]
 	if programmedCondition.Status != programmedStatus {
 		(*ctrlManagedConditions)[conditionIndex] = wantedCondition
 	}

--- a/ingress-controller/internal/controllers/utils/conditions.go
+++ b/ingress-controller/internal/controllers/utils/conditions.go
@@ -1,7 +1,8 @@
 package utils
 
 import (
-	"github.com/samber/lo"
+	"slices"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
@@ -90,8 +91,8 @@ func EnsureProgrammedCondition(
 		return conditions, false
 	}
 
-	_, idx, ok := lo.FindIndexOf(conditions, func(c metav1.Condition) bool { return c.Type == string(configurationv1.ConditionProgrammed) })
-	if !ok {
+	idx := slices.IndexFunc(conditions, func(c metav1.Condition) bool { return c.Type == string(configurationv1.ConditionProgrammed) })
+	if idx < 0 {
 		conditions = append(conditions, desiredCondition)
 	} else {
 		// Do not update existing "Programmed" condition to Unknown to prevent races on updating status when new instance starts.

--- a/ingress-controller/internal/dataplane/configfetcher/kongrawstate_test.go
+++ b/ingress-controller/internal/dataplane/configfetcher/kongrawstate_test.go
@@ -2,12 +2,12 @@ package configfetcher_test
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/kong/go-database-reconciler/pkg/utils"
 	"github.com/kong/go-kong/kong"
 	"github.com/kong/go-kong/kong/custom"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -385,7 +385,7 @@ func ensureAllKongStateFieldsAreTested(t *testing.T, testedFields []string) {
 		typ := reflect.ValueOf(kongstate.KongState{}).Type()
 		for field := range typ.Fields() {
 			name := field.Name
-			if !lo.Contains(exempt, name) {
+			if !slices.Contains(exempt, name) {
 				fields = append(fields, name)
 			}
 		}
@@ -394,6 +394,6 @@ func ensureAllKongStateFieldsAreTested(t *testing.T, testedFields []string) {
 
 	// Meta test - ensure we have testcases covering all fields in KongRawState.
 	for _, field := range allKongStateFields {
-		assert.True(t, lo.Contains(testedFields, field), "field %s not tested", field)
+		assert.True(t, slices.Contains(testedFields, field), "field %s not tested", field)
 	}
 }

--- a/ingress-controller/internal/dataplane/translator/ingressrules.go
+++ b/ingress-controller/internal/dataplane/translator/ingressrules.go
@@ -3,6 +3,7 @@ package translator
 import (
 	"fmt"
 	"maps"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -592,5 +593,5 @@ func collectInconsistentAnnotations(
 func isNonTLSProtocol(proto string) bool {
 	// Strings used here for comparison reflect Kong's protocol names.
 	nonTLSProtocols := []string{"http", "grpc", "tcp", "tls_passthrough", "udp", "ws"}
-	return lo.Contains(nonTLSProtocols, proto)
+	return slices.Contains(nonTLSProtocols, proto)
 }

--- a/ingress-controller/test/helpers/controller_manager_flag_opts.go
+++ b/ingress-controller/test/helpers/controller_manager_flag_opts.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/samber/lo"
@@ -26,7 +27,7 @@ func ControllerManagerOptAdditionalWatchNamespace(ns string) ControllerManagerOp
 		// If it is, then check the existing value (split by a comma) if it's in the list.
 		v := strings.TrimPrefix(wn, "--watch-namespace=")
 		namespaces := strings.Split(v, ",")
-		if !lo.Contains(namespaces, ns) {
+		if !slices.Contains(namespaces, ns) {
 			// Replace the existing value with the new one.
 			args[idx] = fmt.Sprintf("%s,%s", wn, ns)
 		}

--- a/ingress-controller/test/helpers/controller_manager_flag_opts.go
+++ b/ingress-controller/test/helpers/controller_manager_flag_opts.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-
-	"github.com/samber/lo"
 )
 
 type ControllerManagerOpt func([]string) []string
@@ -15,15 +13,16 @@ type ControllerManagerOpt func([]string) []string
 func ControllerManagerOptAdditionalWatchNamespace(ns string) ControllerManagerOpt {
 	return func(args []string) []string {
 		// Check if watch namespace is set at all.
-		wn, idx, ok := lo.FindIndexOf(args, func(arg string) bool {
+		idx := slices.IndexFunc(args, func(arg string) bool {
 			return strings.HasPrefix(arg, "--watch-namespace=")
 		})
 		// If it isn't then append new watch namespace flag with the provided namespace.
-		if !ok {
+		if idx < 0 {
 			args = append(args, fmt.Sprintf("--watch-namespace=%s", ns))
 			return args
 		}
 
+		wn := args[idx]
 		// If it is, then check the existing value (split by a comma) if it's in the list.
 		v := strings.TrimPrefix(wn, "--watch-namespace=")
 		namespaces := strings.Split(v, ",")

--- a/test/crdsvalidation/common/suite_crd_ref_change.go
+++ b/test/crdsvalidation/common/suite_crd_ref_change.go
@@ -1,9 +1,9 @@
 package common
 
 import (
+	"slices"
 	"testing"
 
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -114,7 +114,7 @@ func NewCRDValidationTestCasesGroupCPRefChange[
 			// TODO: This list has to be updated as we progress through implementing
 			// ControlPlane cross namespaces references for various kinds.
 			// https://github.com/Kong/kong-operator/issues/2873
-			if lo.Contains([]string{"KongService", "KongRoute", "KongUpstream", "KongCertificate", "KongCACertificate", "KongConsumer", "KongConsumerGroup", "KongKey", "KongKeySet", "KongDataPlaneClientCertificate"}, obj.GetObjectKind().GroupVersionKind().Kind) {
+			if slices.Contains([]string{"KongService", "KongRoute", "KongUpstream", "KongCertificate", "KongCACertificate", "KongConsumer", "KongConsumerGroup", "KongKey", "KongKeySet", "KongDataPlaneClientCertificate"}, obj.GetObjectKind().GroupVersionKind().Kind) {
 				testcase.Name = "cpRef (type=konnectNamespacedRef) can have namespace"
 				testcase.ExpectedErrorMessage = nil
 			} else {

--- a/test/envtest/konnect_entities_kongcacertificate_test.go
+++ b/test/envtest/konnect_entities_kongcacertificate_test.go
@@ -100,7 +100,7 @@ func TestKongCACertificate(t *testing.T) {
 	t.Log("Setting up SDK expectations on KongCACertificate update")
 	sdk.CACertificatesSDK.EXPECT().UpsertCaCertificate(mock.Anything, mock.MatchedBy(func(r sdkkonnectops.UpsertCaCertificateRequest) bool {
 		return r.CACertificateID == "12345" &&
-			lo.Contains(r.CACertificate.Tags, "addedTag")
+			slices.Contains(r.CACertificate.Tags, "addedTag")
 	})).Return(&sdkkonnectops.UpsertCaCertificateResponse{}, nil)
 
 	t.Log("Patching KongCACertificate")

--- a/test/envtest/konnect_entities_kongcertificate_test.go
+++ b/test/envtest/konnect_entities_kongcertificate_test.go
@@ -113,7 +113,7 @@ func TestKongCertificate(t *testing.T) {
 		t.Log("Setting up SDK expectations on KongCertificate update")
 		sdk.CertificatesSDK.EXPECT().UpsertCertificate(mock.Anything, mock.MatchedBy(func(r sdkkonnectops.UpsertCertificateRequest) bool {
 			return r.CertificateID == "cert-12345" &&
-				lo.Contains(r.Certificate.Tags, "addedTag")
+				slices.Contains(r.Certificate.Tags, "addedTag")
 		})).Return(&sdkkonnectops.UpsertCertificateResponse{}, nil)
 
 		t.Log("Patching KongCertificate")

--- a/test/envtest/konnect_entities_kongkey_test.go
+++ b/test/envtest/konnect_entities_kongkey_test.go
@@ -102,7 +102,7 @@ func TestKongKey(t *testing.T) {
 		t.Log("Setting up SDK expectations on KongKey update")
 		sdk.KeysSDK.EXPECT().UpsertKey(mock.Anything, mock.MatchedBy(func(r sdkkonnectops.UpsertKeyRequest) bool {
 			return r.KeyID == keyID &&
-				lo.Contains(r.Key.Tags, "addedTag")
+				slices.Contains(r.Key.Tags, "addedTag")
 		})).Return(&sdkkonnectops.UpsertKeyResponse{}, nil)
 
 		t.Log("Patching KongKey")

--- a/test/envtest/konnect_entities_kongkeyset_test.go
+++ b/test/envtest/konnect_entities_kongkeyset_test.go
@@ -10,7 +10,6 @@ import (
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 	"github.com/google/uuid"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -95,7 +94,7 @@ func TestKongKeySet(t *testing.T) {
 		t.Log("Setting up SDK expectations on KongKeySet update")
 		sdk.KeySetsSDK.EXPECT().UpsertKeySet(mock.Anything, mock.MatchedBy(func(r sdkkonnectops.UpsertKeySetRequest) bool {
 			return r.KeySetID == keySetID &&
-				lo.Contains(r.KeySet.Tags, "addedTag")
+				slices.Contains(r.KeySet.Tags, "addedTag")
 		})).Return(&sdkkonnectops.UpsertKeySetResponse{}, nil)
 
 		t.Log("Patching KongKeySet")

--- a/test/integration/gatewayconfiguration_test.go
+++ b/test/integration/gatewayconfiguration_test.go
@@ -1,11 +1,11 @@
 package integration
 
 import (
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -204,7 +204,7 @@ func TestGatewayConfigurationEssentials(t *testing.T) {
 		}
 		cp := controlplanes[0]
 
-		return lo.Contains(cp.Spec.Controllers,
+		return slices.Contains(cp.Spec.Controllers,
 			gwtypes.ControlPlaneController{
 				Name:  controlplane.ControllerNameIngress,
 				State: gwtypes.ControlPlaneControllerStateDisabled,
@@ -284,7 +284,7 @@ func TestGatewayConfigurationEssentials(t *testing.T) {
 		}
 		cp := controlplanes[0]
 
-		return !lo.Contains(cp.Spec.Controllers,
+		return !slices.Contains(cp.Spec.Controllers,
 			gwtypes.ControlPlaneController{
 				Name:  controlplane.ControllerNameIngress,
 				State: gwtypes.ControlPlaneControllerStateDisabled,

--- a/test/integration/kic/gateway_test.go
+++ b/test/integration/kic/gateway_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"fmt"
 	"net/http"
+	"slices"
 	"testing"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -63,10 +63,10 @@ func TestUnmanagedGatewayBasics(t *testing.T) {
 	require.Eventually(t, func() bool {
 		gw, err = gatewayClient.GatewayV1().Gateways(ns.Name).Get(ctx, defaultGatewayName, metav1.GetOptions{})
 		require.NoError(t, err)
-		return lo.Contains(
+		return slices.Contains(
 			annotations.ExtractGatewayPublishService(gw.Annotations),
 			fmt.Sprintf("%s/%s", pubsvc.Namespace, pubsvc.Name),
-		) && lo.Contains(
+		) && slices.Contains(
 			annotations.ExtractGatewayPublishService(gw.Annotations),
 			fmt.Sprintf("%s/%s", pubsvcUDP.Namespace, pubsvcUDP.Name),
 		)

--- a/test/integration/kic/isolated/udproute_test.go
+++ b/test/integration/kic/isolated/udproute_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -142,7 +141,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 					CommonRouteSpec: gatewayapi.CommonRouteSpec{
 						ParentRefs: []gatewayapi.ParentReference{{
 							Name:        gatewayapi.ObjectName(gatewayName),
-							SectionName: lo.ToPtr(gatewayapi.SectionName(gatewayUDPPortName)),
+							SectionName: new(gatewayapi.SectionName(gatewayUDPPortName)),
 						}},
 					},
 					Rules: []gatewayapi.UDPRouteRule{{


### PR DESCRIPTION
**What this PR does / why we need it**:

- `lo.ToPtr` -> `new`
- `lo.Contains` -> `slices.Contains`
- `lo.FindIndexOf` -> `slices.IndexFunc`

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

Possibly there's more candidates to replace but no all are doable currently with stdlib:

```
      1 lo.Assign
      1 lo.Clamp
      1 lo.CountValues
      1 lo.CountValuesBy
      1 lo.Difference
      1 lo.EmptyableToPtr
      1 lo.Every
      1 lo.FindUniques
      1 lo.FlatMap
      1 lo.Flatten
      1 lo.HasKey
      1 lo.IsNotEmpty
      1 lo.MapValues
      1 lo.Range
      1 lo.SumBy
      2 lo.CountBy
      2 lo.Entry
      2 lo.FromSlicePtr
      2 lo.GroupBy
      2 lo.LowerCaseLettersCharset
      2 lo.NoneBy
      2 lo.Tuple
      3 lo.Compact
      3 lo.IsEmpty
      3 lo.ToSlicePtr
      4 lo.AllCharset
      4 lo.EveryBy
      4 lo.T
      5 lo.MapToSlice
      5 lo.Reject
      5 lo.UniqBy
      9 lo.Keys
     11 lo.ElementsMatch
     11 lo.Uniq
     13 lo.FilterMap
     15 lo.SliceToMap
     15 lo.Values
     16 lo.FromPtr
     19 lo.AlphanumericCharset
     20 lo.FromPtrOr
     21 lo.ToAnySlice
     25 lo.RandomString
     34 lo.Filter
     40 lo.Must
     47 lo.Find
     85 lo.Map
    155 lo.ContainsBy
```

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
