### PR TITLE
chore: expose `--konnect-request-timeout`  and set Konnect API timeout to 10s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@
   When both a `GatewayConfiguration` and `Gateway.spec.infrastructure` specify the same
   key, the infrastructure value takes precedence.
   [#3412](https://github.com/Kong/kong-operator/pull/3412)
+- Added `--konnect-request-timeout` flag to control Konnect API calls timeout.
+  Be default that is set to 15 seconds.
+  [#3513](https://github.com/Kong/kong-operator/pull/3513)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
   key, the infrastructure value takes precedence.
   [#3412](https://github.com/Kong/kong-operator/pull/3412)
 - Added `--konnect-request-timeout` flag to control Konnect API calls timeout.
-  Be default that is set to 15 seconds.
+  Be default that is set to 10 seconds.
   [#3513](https://github.com/Kong/kong-operator/pull/3513)
 
 ### Fixes

--- a/controller/konnect/ops/sdk/sdkfactory.go
+++ b/controller/konnect/ops/sdk/sdkfactory.go
@@ -1,6 +1,8 @@
 package sdk
 
 import (
+	"net/http"
+
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 
@@ -178,24 +180,47 @@ type SDKFactory interface {
 	NewKonnectSDK(server server.Server, token SDKToken) SDKWrapper
 }
 
-type sdkFactory struct{}
+type sdkFactory struct {
+	httpClient *http.Client
+}
+
+// SDKFactoryOpt is a functional option for configuring the SDKFactory.
+type SDKFactoryOpt func(*sdkFactory)
+
+// WithHTTPClient allows to set a custom HTTP client for the SDK,
+// which can be useful for testing or customizing timeouts.
+func WithHTTPClient(client *http.Client) SDKFactoryOpt {
+	return func(f *sdkFactory) {
+		f.httpClient = client
+	}
+}
 
 // NewSDKFactory creates a new SDKFactory.
-func NewSDKFactory() SDKFactory {
-	return sdkFactory{}
+func NewSDKFactory(opts ...SDKFactoryOpt) SDKFactory {
+	factory := &sdkFactory{}
+	for _, opt := range opts {
+		opt(factory)
+	}
+	return factory
 }
 
 // NewKonnectSDK creates a new Konnect SDK.
 func (f sdkFactory) NewKonnectSDK(server server.Server, token SDKToken) SDKWrapper {
+	opts := []sdkkonnectgo.SDKOption{
+		sdkkonnectgo.WithSecurity(
+			sdkkonnectcomp.Security{
+				PersonalAccessToken: new(string(token)),
+			},
+		),
+		sdkkonnectgo.WithServerURL(server.URL()),
+	}
+
+	if f.httpClient != nil {
+		opts = append(opts, sdkkonnectgo.WithClient(f.httpClient))
+	}
+
 	return sdkWrapper{
 		server: server,
-		sdk: sdkkonnectgo.New(
-			sdkkonnectgo.WithSecurity(
-				sdkkonnectcomp.Security{
-					PersonalAccessToken: new(string(token)),
-				},
-			),
-			sdkkonnectgo.WithServerURL(server.URL()),
-		),
+		sdk:    sdkkonnectgo.New(opts...),
 	}
 }

--- a/docs/cli-arguments-for-developer-konghq-com.md
+++ b/docs/cli-arguments-for-developer-konghq-com.md
@@ -176,6 +176,10 @@ rows:
     type: '`uint`'
     description: "Deprecated: Please use '--max-concurrent-reconciles-konnect-controller' instead."
     default: '`8`'
+  - flag: '`--konnect-request-timeout`'
+    type: '`duration`'
+    description: "Timeout for Konnect API requests."
+    default: '`10s`'
   - flag: '`--konnect-sync-period`'
     type: '`duration`'
     description: "Sync period for Konnect entities. After a successful reconciliation of Konnect entities the controller will wait this duration before enforcing configuration on Konnect once again."

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -137,6 +137,10 @@ rows:
     type: '`uint`'
     description: "Deprecated: Please use '--max-concurrent-reconciles-konnect-controller' instead."
     default: '`8`'
+  - flag: '`--konnect-request-timeout`'
+    type: '`duration`'
+    description: "Timeout for Konnect API requests."
+    default: '`10s`'
   - flag: '`--konnect-sync-period`'
     type: '`duration`'
     description: "Sync period for Konnect entities. After a successful reconciliation of Konnect entities the controller will wait this duration before enforcing configuration on Konnect once again."

--- a/modules/cli/cli.go
+++ b/modules/cli/cli.go
@@ -82,6 +82,7 @@ func New(m metadata.Info) *CLI {
 	// controllers for Konnect APIs
 	flagSet.BoolVar(&cfg.KonnectControllersEnabled, "enable-controller-konnect", false, "Enable the Konnect controllers.")
 	flagSet.DurationVar(&cfg.KonnectSyncPeriod, "konnect-sync-period", consts.DefaultKonnectSyncPeriod, "Sync period for Konnect entities. After a successful reconciliation of Konnect entities the controller will wait this duration before enforcing configuration on Konnect once again.")
+	flagSet.DurationVar(&cfg.KonnectRequestTimeout, "konnect-request-timeout", consts.DefaultKonnectRequestTimeout, "Timeout for Konnect API requests.")
 	flagSet.UintVar(&cfg.KonnectControllerMaxConcurrentReconciles, "konnect-controller-max-concurrent-reconciles", consts.DefaultMaxConcurrentReconcilesKonnect, "Deprecated: Please use '--max-concurrent-reconciles-konnect-controller' instead.")
 	flagSet.UintVar(&cfg.MaxConcurrentReconcilesKonnect, "max-concurrent-reconciles-konnect-controller", consts.DefaultMaxConcurrentReconcilesKonnect, "Maximum number of concurrent reconciles for Konnect controllers.")
 	flagSet.UintVar(&cfg.MaxConcurrentReconcilesDataPlane, "max-concurrent-reconciles-dataplane-controller", consts.DefaultMaxConcurrentReconcilesDataPlane, "Maximum number of concurrent reconciles for DataPlane controllers.")

--- a/modules/cli/cli_test.go
+++ b/modules/cli/cli_test.go
@@ -327,6 +327,17 @@ func TestParse(t *testing.T) {
 				return cfg
 			},
 		},
+		{
+			name: "konnect api request timeout env vars are set",
+			envVars: map[string]string{
+				"KONG_OPERATOR_KONNECT_REQUEST_TIMEOUT": "20s",
+			},
+			expectedCfg: func() manager.Config {
+				cfg := expectedDefaultCfg()
+				cfg.KonnectRequestTimeout = 20 * time.Second
+				return cfg
+			},
+		},
 	}
 
 	for _, tC := range testCases {
@@ -379,6 +390,7 @@ func expectedDefaultCfg() manager.Config {
 		ControlPlaneExtensionsControllerEnabled:  true,
 		KonnectControllersEnabled:                false,
 		KonnectSyncPeriod:                        consts.DefaultKonnectSyncPeriod,
+		KonnectRequestTimeout:                    consts.DefaultKonnectRequestTimeout,
 		KongPluginInstallationControllerEnabled:  false,
 		LoggerOpts:                               &zap.Options{},
 		MaxConcurrentReconcilesKonnect:           consts.DefaultMaxConcurrentReconcilesKonnect,

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"reflect"
 	"slices"
 	"time"
@@ -528,7 +529,9 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 
 	// Konnect controllers
 	if c.KonnectControllersEnabled {
-		sdkFactory := sdkops.NewSDKFactory()
+		httpClient := *http.DefaultClient
+		httpClient.Timeout = c.KonnectRequestTimeout
+		sdkFactory := sdkops.NewSDKFactory(sdkops.WithHTTPClient(&httpClient))
 		ctrlOpts := controllerOptions(ctrlOpts, withMaxConcurrentReconciles(int(c.MaxConcurrentReconcilesKonnect)))
 
 		controllerFactory := konnectControllerFactory{

--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -51,6 +51,7 @@ import (
 	mgrconfig "github.com/kong/kong-operator/v2/modules/manager/config"
 	"github.com/kong/kong-operator/v2/modules/manager/logging"
 	"github.com/kong/kong-operator/v2/modules/manager/metadata"
+	"github.com/kong/kong-operator/v2/pkg/consts"
 	"github.com/kong/kong-operator/v2/pkg/vars"
 )
 
@@ -111,6 +112,7 @@ type Config struct {
 	AIGatewayControllerEnabled              bool
 	KongPluginInstallationControllerEnabled bool
 	KonnectSyncPeriod                       time.Duration
+	KonnectRequestTimeout                   time.Duration
 	// TODO: remove this a couple of versions after 2.1 release
 	// TODO: https://github.com/Kong/kong-operator/issues/2768
 	KonnectControllerMaxConcurrentReconciles uint
@@ -165,6 +167,8 @@ func DefaultConfig() Config {
 		DataPlaneControllerEnabled:    true,
 		ConversionWebhookEnabled:      true,
 		ValidatingWebhookEnabled:      true,
+		KonnectSyncPeriod:             consts.DefaultKonnectSyncPeriod,
+		KonnectRequestTimeout:         consts.DefaultKonnectRequestTimeout,
 	}
 }
 

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -163,6 +163,9 @@ const (
 	// DefaultKonnectSyncPeriod is the default sync period for Konnect entities.
 	DefaultKonnectSyncPeriod = time.Minute
 
+	// DefaultKonnectRequestTimeout is the default timeout for requests to Konnect API.
+	DefaultKonnectRequestTimeout = 10 * time.Second
+
 	// DefaultMaxConcurrentReconcilesKonnect is the default max concurrent
 	// reconciles for Konnect entities controllers.
 	DefaultMaxConcurrentReconcilesKonnect = uint(8)


### PR DESCRIPTION
**What this PR does / why we need it**:

Expose `--konnect-request-timeout` flag for configuring Konnect API requests timeout.

Decrease the default timeout from 60s (set by default in speakeasy generated SDK code) to 10s.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
