### PR TITLE
fix: fix clearing Routes' statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,12 @@
   [#3490](https://github.com/Kong/kong-operator/pull/3490)
 - Fix reducing `Secret`s with in use finalizers.
   [#3506](https://github.com/Kong/kong-operator/pull/3506)
+- Fix `ensureGatewayReferenceStatusRemoved` and `routeHasKongParentStatus` not
+  scoping to the specific Gateway when `GatewayNN` is set.
+  This could cause one ingress-controller instance to erroneously remove route
+  parent statuses set by another instance managing a different Gateway,
+  breaking cross-namespace HTTPRoute backend references via `ReferenceGrant`.
+  [#3524](https://github.com/Kong/kong-operator/pull/3524)
 
 ## [v2.1.2]
 

--- a/ingress-controller/internal/controllers/gateway/grpcroute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/grpcroute_controller.go
@@ -309,7 +309,7 @@ func (r *GRPCRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			// if there's no supported Gateway then this route could have been previously
 			// supported by this controller. As such we ensure that no supported Gateway
 			// references exist in the object status any longer.
-			if _, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, grpcroute); err != nil {
+			if _, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, grpcroute, r.GatewayNN); err != nil {
 				// some failure happened so we need to retry to avoid orphaned statuses
 				return ctrl.Result{}, err
 			}

--- a/ingress-controller/internal/controllers/gateway/httproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/httproute_controller.go
@@ -420,7 +420,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			// if there's no supported Gateway then this route could have been previously
 			// supported by this controller. As such we ensure that no supported Gateway
 			// references exist in the object status any longer.
-			if _, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, httproute); err != nil {
+			if _, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, httproute, r.GatewayNN); err != nil {
 				// some failure happened so we need to retry to avoid orphaned statuses
 				return ctrl.Result{}, err
 			}

--- a/ingress-controller/internal/controllers/gateway/route_predicate_test.go
+++ b/ingress-controller/internal/controllers/gateway/route_predicate_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/samber/mo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -207,5 +208,186 @@ func TestIsRouteAttachedToReconciledGateway(t *testing.T) {
 			require.Equal(t, tc.expectedResult, result)
 		},
 		)
+	}
+}
+
+func TestRouteHasKongParentStatus(t *testing.T) {
+	gwNamespace := gatewayapi.Namespace("default")
+	otherNamespace := gatewayapi.Namespace("other-ns")
+
+	testCases := []struct {
+		name      string
+		route     *gatewayapi.HTTPRoute
+		gatewayNN controllers.OptionalNamespacedName
+		expected  bool
+	}{
+		{
+			name: "no gatewayNN set, route has our controller status - returns true",
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Status: gatewayapi.HTTPRouteStatus{
+					RouteStatus: gatewayapi.RouteStatus{
+						Parents: []gatewayapi.RouteParentStatus{
+							{
+								ControllerName: GetControllerName(),
+								ParentRef: gatewayapi.ParentReference{
+									Name:      "gateway-a",
+									Namespace: &gwNamespace,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "no gatewayNN set, route has another controller status - returns false",
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Status: gatewayapi.HTTPRouteStatus{
+					RouteStatus: gatewayapi.RouteStatus{
+						Parents: []gatewayapi.RouteParentStatus{
+							{
+								ControllerName: "another-controller",
+								ParentRef: gatewayapi.ParentReference{
+									Name:      "gateway-a",
+									Namespace: &gwNamespace,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "gatewayNN set, route has matching gateway status - returns true",
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Status: gatewayapi.HTTPRouteStatus{
+					RouteStatus: gatewayapi.RouteStatus{
+						Parents: []gatewayapi.RouteParentStatus{
+							{
+								ControllerName: GetControllerName(),
+								ParentRef: gatewayapi.ParentReference{
+									Name:      "gateway-a",
+									Namespace: &gwNamespace,
+								},
+							},
+						},
+					},
+				},
+			},
+			gatewayNN: controllers.NewOptionalNamespacedName(mo.Some(k8stypes.NamespacedName{
+				Namespace: "default",
+				Name:      "gateway-a",
+			})),
+			expected: true,
+		},
+		{
+			name: "gatewayNN set, route has status for different gateway - returns false",
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Status: gatewayapi.HTTPRouteStatus{
+					RouteStatus: gatewayapi.RouteStatus{
+						Parents: []gatewayapi.RouteParentStatus{
+							{
+								ControllerName: GetControllerName(),
+								ParentRef: gatewayapi.ParentReference{
+									Name:      "gateway-b",
+									Namespace: &otherNamespace,
+								},
+							},
+						},
+					},
+				},
+			},
+			gatewayNN: controllers.NewOptionalNamespacedName(mo.Some(k8stypes.NamespacedName{
+				Namespace: "default",
+				Name:      "gateway-a",
+			})),
+			expected: false,
+		},
+		{
+			name: "gatewayNN set, route has status for matching and non-matching gateways - returns true",
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Status: gatewayapi.HTTPRouteStatus{
+					RouteStatus: gatewayapi.RouteStatus{
+						Parents: []gatewayapi.RouteParentStatus{
+							{
+								ControllerName: GetControllerName(),
+								ParentRef: gatewayapi.ParentReference{
+									Name:      "gateway-other",
+									Namespace: &gwNamespace,
+								},
+							},
+							{
+								ControllerName: GetControllerName(),
+								ParentRef: gatewayapi.ParentReference{
+									Name:      "gateway-a",
+									Namespace: &gwNamespace,
+								},
+							},
+						},
+					},
+				},
+			},
+			gatewayNN: controllers.NewOptionalNamespacedName(mo.Some(k8stypes.NamespacedName{
+				Namespace: "default",
+				Name:      "gateway-a",
+			})),
+			expected: true,
+		},
+		{
+			name: "gatewayNN set, parentRef namespace nil defaults to route namespace - returns true",
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Status: gatewayapi.HTTPRouteStatus{
+					RouteStatus: gatewayapi.RouteStatus{
+						Parents: []gatewayapi.RouteParentStatus{
+							{
+								ControllerName: GetControllerName(),
+								ParentRef: gatewayapi.ParentReference{
+									Name: "gateway-a",
+									// Namespace is nil, defaults to route's namespace
+								},
+							},
+						},
+					},
+				},
+			},
+			gatewayNN: controllers.NewOptionalNamespacedName(mo.Some(k8stypes.NamespacedName{
+				Namespace: "default",
+				Name:      "gateway-a",
+			})),
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := routeHasKongParentStatus[*gatewayapi.HTTPRoute](tc.route, tc.gatewayNN)
+			assert.Equal(t, tc.expected, result)
+		})
 	}
 }

--- a/ingress-controller/internal/controllers/gateway/route_predicates.go
+++ b/ingress-controller/internal/controllers/gateway/route_predicates.go
@@ -126,7 +126,7 @@ func isOrWasRouteAttachedToReconciledGateway[routeT gatewayapi.RouteT](
 		IsRouteAttachedToReconciledGateway[routeT](cl, log, gatewayNN, newObj) {
 		return true
 	}
-	return routeHasKongParentStatus[routeT](oldObj) || routeHasKongParentStatus[routeT](newObj)
+	return routeHasKongParentStatus[routeT](oldObj, gatewayNN) || routeHasKongParentStatus[routeT](newObj, gatewayNN)
 }
 
 // routeHasKongParentStatus checks if a route has a parent status set by our controller
@@ -134,15 +134,24 @@ func isOrWasRouteAttachedToReconciledGateway[routeT gatewayapi.RouteT](
 // due to external object modifications (e.g., GatewayClass controller name changes) that cause
 // both old and new parentRef-based checks to return false. It ensures we still reconcile routes
 // we previously managed so we can clean up stale parent status and dataplane state.
-func routeHasKongParentStatus[routeT gatewayapi.RouteT](obj client.Object) bool {
+// When gatewayNN is set, only statuses whose parentRef matches the specified Gateway
+// are considered, preventing cross-instance interference when multiple KIC instances
+// share the same controller name.
+func routeHasKongParentStatus[routeT gatewayapi.RouteT](obj client.Object, gatewayNN controllers.OptionalNamespacedName) bool {
 	route, ok := obj.(routeT)
 	if !ok {
 		return false
 	}
 	for _, parentStatus := range getRouteStatusParents(route) {
-		if parentStatus.ControllerName == GetControllerName() {
-			return true
+		if parentStatus.ControllerName != GetControllerName() {
+			continue
 		}
+		if gNN, ok := gatewayNN.Get(); ok {
+			if !parentRefMatchesGatewayNN(parentStatus.ParentRef, obj.GetNamespace(), gNN) {
+				continue
+			}
+		}
+		return true
 	}
 	return false
 }

--- a/ingress-controller/internal/controllers/gateway/route_utils.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -878,8 +879,11 @@ func isRouteAcceptedByListener[T gatewayapi.RouteT](ctx context.Context,
 // ensureGatewayReferenceStatusRemoved uses the ControllerName provided by the Gateway
 // implementation to prune status references to Gateways supported by this controller
 // in the provided route.
+// When gatewayNN is set, only status entries whose parentRef matches the specified
+// Gateway are removed. This prevents one KIC instance from removing statuses set
+// by another instance that manages a different Gateway.
 func ensureGatewayReferenceStatusRemoved[routeT gatewayapi.RouteT](
-	ctx context.Context, cl client.Client, log logr.Logger, route routeT,
+	ctx context.Context, cl client.Client, log logr.Logger, route routeT, gatewayNN controllers.OptionalNamespacedName,
 ) (bool, error) {
 	debug(log, route, "Unsupported route found, processing to verify whether it was ever supported")
 	kind := route.GetObjectKind().GroupVersionKind().Kind
@@ -890,13 +894,21 @@ func ensureGatewayReferenceStatusRemoved[routeT gatewayapi.RouteT](
 	for _, status := range parents {
 		if status.ControllerName != GetControllerName() {
 			newStatuses = append(newStatuses, status)
-		} else {
-			parentRefNN := string(status.ParentRef.Name)
-			if status.ParentRef.Namespace != nil {
-				parentRefNN = fmt.Sprintf("%s/%s", *status.ParentRef.Namespace, parentRefNN)
-			}
-			debug(log, route, "Removing parentRef from route status", "parentRef", parentRefNN, "kind", kind)
+			continue
 		}
+		// When gatewayNN is set, only remove statuses for the specific gateway
+		// this controller instance manages.
+		if gNN, ok := gatewayNN.Get(); ok {
+			if !parentRefMatchesGatewayNN(status.ParentRef, route.GetNamespace(), gNN) {
+				newStatuses = append(newStatuses, status)
+				continue
+			}
+		}
+		parentRefNN := string(status.ParentRef.Name)
+		if status.ParentRef.Namespace != nil {
+			parentRefNN = fmt.Sprintf("%s/%s", *status.ParentRef.Namespace, parentRefNN)
+		}
+		debug(log, route, "Removing parentRef from route status", "parentRef", parentRefNN, "kind", kind)
 	}
 
 	// If the new list of statuses is the same length as the old
@@ -934,4 +946,15 @@ func getRouteParentRefs[T gatewayapi.RouteT](route T) []gatewayapi.ParentReferen
 	default:
 		return nil
 	}
+}
+
+// parentRefMatchesGatewayNN returns true if the given parentRef references the
+// specified gateway. routeNamespace is used as the default namespace when
+// parentRef.Namespace is nil.
+func parentRefMatchesGatewayNN(parentRef gatewayapi.ParentReference, routeNamespace string, gatewayNN k8stypes.NamespacedName) bool {
+	ns := routeNamespace
+	if parentRef.Namespace != nil {
+		ns = string(*parentRef.Namespace)
+	}
+	return ns == gatewayNN.Namespace && string(parentRef.Name) == gatewayNN.Name
 }

--- a/ingress-controller/internal/controllers/gateway/tcproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tcproute_controller.go
@@ -304,7 +304,7 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			// if there's no supported Gateway then this route could have been previously
 			// supported by this controller. As such we ensure that no supported Gateway
 			// references exist in the object status any longer.
-			if _, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, tcproute); err != nil {
+			if _, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, tcproute, r.GatewayNN); err != nil {
 				// some failure happened so we need to retry to avoid orphaned statuses
 				return ctrl.Result{}, err
 			}

--- a/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
@@ -300,7 +300,7 @@ func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			// if there's no supported Gateway then this route could have been previously
 			// supported by this controller. As such we ensure that no supported Gateway
 			// references exist in the object status any longer.
-			if _, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, tlsroute); err != nil {
+			if _, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, tlsroute, r.GatewayNN); err != nil {
 				// some failure happened so we need to retry to avoid orphaned statuses
 				return ctrl.Result{}, err
 			}

--- a/ingress-controller/internal/controllers/gateway/udproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/udproute_controller.go
@@ -304,7 +304,7 @@ func (r *UDPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			// if there's no supported Gateway then this route could have been previously
 			// supported by this controller. As such we ensure that no supported Gateway
 			// references exist in the object status any longer.
-			_, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, udproute)
+			_, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, udproute, r.GatewayNN)
 			if err != nil {
 				// some failure happened so we need to retry to avoid orphaned statuses
 				return ctrl.Result{}, err


### PR DESCRIPTION
**What this PR does / why we need it**:

When the operator deploys a dedicated KIC instance per Gateway, each instance is scoped to a specific Gateway via the `GatewayNN` field. All these instances share the same controllerName (e.g. `konghq.com/kic-gateway-controller`).

The problem arises when a route is enqueued by a watch that isn't filtered by GatewayNN — for example, a `ReferenceGrant` create/update triggers `listHTTPRoutesForReferenceGrant`, which enqueues all HTTPRoutes in the matching namespace regardless of which gateway they belong to. A KIC instance that receives such an enqueue for a route it doesn't own will call getSupportedGatewayForRoute, which returns [ErrNoSupportedGateway](https://github.com/Kong/kong-operator/blob/5dce811c807ddb7a7da11ea65ee4e028ee2f094d/ingress-controller/internal/controllers/gateway/route_utils.go#L39) (because the route's parentRef doesn't match this instance's GatewayNN). It then calls `ensureGatewayReferenceStatusRemoved`, which previously removed **all** parent statuses matching controllerName — including statuses written by the correct KIC instance that actually manages that route.

Once the route's parent status is wiped, the correct KIC instance reconciles again but now finds no prior accepted status, and the route's ResolvedRefs condition is not properly populated. This prevents the cross-namespace backend reference (permitted by the `ReferenceGrant`) from being resolved, causing the `HTTPRouteReferenceGrant` conformance test to fail: requests never reach web-backend.

This PR fixes the issue by scoping both `ensureGatewayReferenceStatusRemoved` and `routeHasKongParentStatus` to the specific Gateway when GatewayNN is set. They now only consider/remove parent status entries whose parentRef matches the gateway this controller instance manages, leaving statuses owned by other KIC instances untouched.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

This should improve the stability of tests in CI.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
