### PR TITLE
chore: bump Go version to 1.26.1 to fix govulncheck failures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kong-operator/v2
 
-go 1.26.0
+go 1.26.1
 
 require (
 	cloud.google.com/go/container v1.46.0


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes https://github.com/Kong/kong-operator/actions/runs/22787439237/job/66107181608?pr=3520 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
