### PR TITLE
fix: fix nil pointer dereference when access KongService Konnect ID

### DIFF
--- a/controller/konnect/reconciler_serviceref.go
+++ b/controller/konnect/reconciler_serviceref.go
@@ -176,7 +176,7 @@ func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constra
 		if route.Status.Konnect == nil {
 			route.Status.Konnect = &konnectv1alpha2.KonnectEntityStatusWithControlPlaneAndServiceRefs{}
 		}
-		route.Status.Konnect.ServiceID = kongSvc.Status.Konnect.GetKonnectID()
+		route.Status.Konnect.ServiceID = kongSvc.GetKonnectID()
 	}
 
 	_ = patch.SetStatusWithConditionIfDifferent(ent,

--- a/controller/konnect/reconciler_serviceref_test.go
+++ b/controller/konnect/reconciler_serviceref_test.go
@@ -1,6 +1,7 @@
 package konnect
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -98,6 +99,33 @@ var testKongServiceNotProgrammed = &configurationv1alpha1.KongService{
 		Namespace: "default",
 	},
 	Status: configurationv1alpha1.KongServiceStatus{
+		Conditions: []metav1.Condition{
+			{
+				Type:   konnectv1alpha1.KonnectEntityProgrammedConditionType,
+				Status: metav1.ConditionFalse,
+			},
+		},
+	},
+}
+
+// testKongServiceNotProgrammedWithCPRef is a KongService with KonnectEntityProgrammed=False,
+// a ControlPlane ref, and Status.Konnect == nil (never synced to Konnect).
+// Used to test the nil pointer dereference regression in handleKongServiceRef.
+var testKongServiceNotProgrammedWithCPRef = &configurationv1alpha1.KongService{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "svc-not-programmed-with-cp-ref",
+		Namespace: "default",
+	},
+	Spec: configurationv1alpha1.KongServiceSpec{
+		ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+			Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+			KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+				Name: "cp-ok",
+			},
+		},
+	},
+	Status: configurationv1alpha1.KongServiceStatus{
+		// Status.Konnect is intentionally nil to simulate a service not yet synced to Konnect.
 		Conditions: []metav1.Condition{
 			{
 				Type:   konnectv1alpha1.KonnectEntityProgrammedConditionType,
@@ -215,6 +243,61 @@ func TestHandleServiceRef(t *testing.T) {
 					return lo.NoneBy(ks.OwnerReferences, func(o metav1.OwnerReference) bool {
 						return o.Kind == "KongService" && o.Name == "svc-ok"
 					}), "OwnerReference of KongRoute is set but it shouldn't be"
+				},
+			},
+		},
+		{
+			// Regression test: on the 2nd+ reconciliation the KongRoute already has both the
+			// KongServiceRefValid=False condition AND Status.Konnect initialized (from the 1st
+			// reconciliation's SetKonnectID("") call). In that state, patch.ApplyStatusPatchIfNotEmpty
+			// returns op.Noop (nothing changed), causing a fall-through to the ServiceID assignment.
+			// If KongService.Status.Konnect is nil, the old code panicked with a nil pointer dereference
+			// on kongSvc.Status.Konnect.GetKonnectID().
+			// The fix uses kongSvc.GetKonnectID() which is nil-safe.
+			name: "has service ref to an unprogrammed service with nil Konnect status (2nd reconciliation, regression for nil panic)",
+			ent: &configurationv1alpha1.KongRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "route-1",
+					Namespace: "default",
+				},
+				Spec: configurationv1alpha1.KongRouteSpec{
+					ServiceRef: &configurationv1alpha1.ServiceRef{
+						Type: configurationv1alpha1.ServiceRefNamespacedRef,
+						NamespacedRef: &commonv1alpha1.NamespacedRef{
+							Name: "svc-not-programmed-with-cp-ref",
+						},
+					},
+				},
+				Status: configurationv1alpha1.KongRouteStatus{
+					// Both Konnect and condition are pre-set as they would be after the 1st reconciliation.
+					Konnect: &konnectv1alpha2.KonnectEntityStatusWithControlPlaneAndServiceRefs{},
+					Conditions: []metav1.Condition{
+						{
+							Type:               konnectv1alpha1.KongServiceRefValidConditionType,
+							Status:             metav1.ConditionFalse,
+							Reason:             konnectv1alpha1.KongServiceRefReasonInvalid,
+							Message:            "Referenced KongService default/svc-not-programmed-with-cp-ref is not programmed yet",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			objects: []client.Object{
+				testKongServiceNotProgrammedWithCPRef,
+				testControlPlaneOK,
+			},
+			expectResult: ctrl.Result{},
+			expectError:  false,
+			updatedEntAssertions: []func(*configurationv1alpha1.KongRoute) (bool, string){
+				func(ks *configurationv1alpha1.KongRoute) (bool, string) {
+					if ks.Status.Konnect == nil {
+						return false, "KongRoute.Status.Konnect is nil"
+					}
+					return ks.Status.Konnect.ServiceID == "",
+						fmt.Sprintf(
+							"KongRoute.Status.Konnect.ServiceID should be empty (KongService has no Konnect ID), got %q",
+							ks.Status.Konnect.ServiceID,
+						)
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the following panic in hybrid conformance tests:

```
2026-03-10T17:07:10Z	ERROR	Observed a panic	{"controller": "KongRoute", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongRoute", "KongRoute": {"name":"http.gateway-conformance-infra-request-header-modifier.cpc3529cc1.42e3e6a8","namespace":"gateway-conformance-infra"}, "namespace": "gateway-conformance-infra", "name": "http.gateway-conformance-infra-request-header-modifier.cpc3529cc1.42e3e6a8", "reconcileID": "93f7d377-a6ea-4b8f-ae71-a50625f34aec", "panic": "runtime error: invalid memory address or nil pointer dereference", "panicGoValue": "\"invalid memory address or nil pointer dereference\"", "stacktrace": "goroutine 2479 [running]:\nk8s.io/apimachinery/pkg/util/runtime.logPanic({0x9163d48, 0xc0056fb110}, {0x84db340, 0xc40bf50})\n\t/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.35.2/pkg/util/runtime/runtime.go:132 +0xdc\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1()\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:202 +0x1f8\npanic({0x84db340?, 0xc40bf50?})\n\t/opt/hostedtoolcache/go/1.26.1/x64/src/runtime/panic.go:860 +0x13a\ngithub.com/kong/kong-operator/v2/controller/konnect.handleKongServiceRef[...]({0x9163d48, 0xc0056fb200}, {0x919afa8, 0xc00278e900}, 0xc004b6cc88)\n\t/home/runner/work/kong-operator/kong-operator/controller/konnect/reconciler_serviceref.go:179 +0x1d45\ngithub.com/kong/kong-operator/v2/controller/konnect.(*KonnectEntityReconciler[...]).Reconcile(0x91f2c20, {0x9163d48, 0xc0056fb110}, {{{0xc005214280, 0x88e9660?}, {0xc0016bb090?, 0xc005c0bab0?}}})\n\t/home/runner/work/kong-operator/kong-operator/controller/konnect/reconciler_generic.go:179 +0xad2\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile(0x91e1fe0, {0x9163d48, 0xc0056fb110}, {{{0xc005214280, 0x0?}, {0xc0016bb090?, 0x0?}}})\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:222 +0x2b4\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler(0x91e1fe0, {0x9163d80, 0xc001201b30}, {{{0xc005214280, 0x19}, {0xc0016bb090, 0x4a}}}, 0x0)\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:479 +0x516\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem(0x91e1fe0, {0x9163d80, 0xc001201b30})\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:438 +0x3a5\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1()\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:313 +0xe5\ncreated by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1 in goroutine 725\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:309 +0x40c\n"}
k8s.io/apimachinery/pkg/util/runtime.logPanic
	/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.35.2/pkg/util/runtime/runtime.go:142
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:202
runtime.gopanic
	/opt/hostedtoolcache/go/1.26.1/x64/src/runtime/panic.go:860
runtime.panicmem
	/opt/hostedtoolcache/go/1.26.1/x64/src/runtime/panic.go:336
runtime.sigpanic
	/opt/hostedtoolcache/go/1.26.1/x64/src/runtime/signal_unix.go:931
github.com/kong/kong-operator/v2/controller/konnect.handleKongServiceRef[...]
	/home/runner/work/kong-operator/kong-operator/controller/konnect/reconciler_serviceref.go:179
github.com/kong/kong-operator/v2/controller/konnect.(*KonnectEntityReconciler[...]).Reconcile
	/home/runner/work/kong-operator/kong-operator/controller/konnect/reconciler_generic.go:179
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:222
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:479
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:438
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:313
2026-03-10T17:07:10Z	ERROR	Reconciler error	{"controller": "KongRoute", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongRoute", "KongRoute": {"name":"http.gateway-conformance-infra-request-header-modifier.cpc3529cc1.42e3e6a8","namespace":"gateway-conformance-infra"}, "namespace": "gateway-conformance-infra", "name": "http.gateway-conformance-infra-request-header-modifier.cpc3529cc1.42e3e6a8", "reconcileID": "93f7d377-a6ea-4b8f-ae71-a50625f34aec", "error": "panic: runtime error: invalid memory address or nil pointer dereference [recovered]"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:495
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:438
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:313
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
