### PR TITLE
Revert #3552

### DIFF
--- a/controller/hybridgateway/controller.go
+++ b/controller/hybridgateway/controller.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -143,7 +144,38 @@ func (r *HybridGatewayReconciler[t, tPtr]) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, err
 	}
 
-	// Phase 1: Translation.
+	// Phase 1: Status Update.
+	statusChanged, stop, err := enforceStatus(ctx, logger, conv)
+	if err != nil && !apierrors.IsConflict(err) {
+		// Record status update failure event.
+		r.eventRecorder.Event(
+			obj,
+			corev1.EventTypeWarning,
+			eventconst.EventReasonStatusUpdateFailed,
+			fmt.Sprintf("Status update failed: %v", err),
+		)
+		return ctrl.Result{}, err
+	} else if apierrors.IsConflict(err) {
+		return ctrl.Result{Requeue: true}, nil
+	}
+	if stop {
+		log.Debug(logger, "Stopping further reconciliation as the resource is not ready for processing")
+		return ctrl.Result{}, nil
+	}
+
+	// Only emit success event if status was actually changed.
+	if statusChanged {
+		r.eventRecorder.Event(
+			obj,
+			corev1.EventTypeNormal,
+			eventconst.EventReasonStatusUpdateSucceeded,
+			"Status successfully updated",
+		)
+		log.Trace(logger, "Status updated, requeueing")
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Phase 2: Translation.
 	resourceCount, err := translate(conv, ctx, logger)
 	if err != nil {
 		// Record translation failure event.
@@ -164,7 +196,7 @@ func (r *HybridGatewayReconciler[t, tPtr]) Reconcile(ctx context.Context, req ct
 		fmt.Sprintf("Successfully translated to %d Kong resources", resourceCount),
 	)
 
-	// Phase 2: State Enforcement.
+	// Phase 3: State Enforcement.
 	stateChanged, err := enforceState(ctx, r.Client, logger, conv)
 	if err != nil {
 		// Record state enforcement failure event.
@@ -189,7 +221,7 @@ func (r *HybridGatewayReconciler[t, tPtr]) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	// Phase 3: Orphan Cleanup.
+	// Phase 4: Orphan Cleanup.
 	orphansDeleted, err := cleanOrphanedResources[t, tPtr](ctx, r.Client, logger, conv)
 	if err != nil {
 		// Record orphan cleanup failure event.

--- a/controller/hybridgateway/converter/converter.go
+++ b/controller/hybridgateway/converter/converter.go
@@ -24,6 +24,8 @@ type APIConverter[t RootObject] interface {
 	GetRootObject() t
 	// GetOutputStore returns a slice of unstructured.Unstructured objects representing the current state of the store, using the provided context.
 	GetOutputStore(ctx context.Context, logger logr.Logger) ([]unstructured.Unstructured, error)
+	// UpdateRootObjectStatus updates the status for the root object.
+	UpdateRootObjectStatus(ctx context.Context, logger logr.Logger) (updated bool, stop bool, err error)
 }
 
 // OrphanedResourceHandler is an optional interface that converters can implement

--- a/controller/hybridgateway/converter/gateway.go
+++ b/controller/hybridgateway/converter/gateway.go
@@ -194,6 +194,22 @@ func (c *gatewayConverter) GetExpectedGVKs() []schema.GroupVersionKind {
 	return c.expectedGVKs
 }
 
+// UpdateRootObjectStatus updates the status of the Gateway resource.
+//
+// Parameters:
+//   - ctx: The context for the operation, used for cancellation and timeouts
+//   - logger: A logger instance for recording operational information and errors
+//
+// Returns:
+//   - updated: true if the status was modified
+//   - stop: true if reconciliation should halt
+//   - err: any error encountered during status update processing
+func (c *gatewayConverter) UpdateRootObjectStatus(ctx context.Context, logger logr.Logger) (updated bool, stop bool, err error) {
+	// TODO: implement status update logic
+
+	return false, false, nil
+}
+
 // HandleOrphanedResource implements OrphanedResourceHandler.
 //
 // Determines whether an orphaned resource should be deleted or preserved during cleanup.

--- a/controller/hybridgateway/converter/gateway.go
+++ b/controller/hybridgateway/converter/gateway.go
@@ -196,17 +196,11 @@ func (c *gatewayConverter) GetExpectedGVKs() []schema.GroupVersionKind {
 
 // UpdateRootObjectStatus updates the status of the Gateway resource.
 //
-// Parameters:
-//   - ctx: The context for the operation, used for cancellation and timeouts
-//   - logger: A logger instance for recording operational information and errors
-//
-// Returns:
-//   - updated: true if the status was modified
-//   - stop: true if reconciliation should halt
-//   - err: any error encountered during status update processing
+// NOTE: This method is not implemented for Gateway resource as status updates
+// are handled by the Gateway controller.
+// Implementing this would cause more than 1 controller to update the status of
+// the same resource which can lead to conflicts and endless update loops.
 func (c *gatewayConverter) UpdateRootObjectStatus(ctx context.Context, logger logr.Logger) (updated bool, stop bool, err error) {
-	// TODO: implement status update logic
-
 	return false, false, nil
 }
 

--- a/controller/hybridgateway/reconciler_utils.go
+++ b/controller/hybridgateway/reconciler_utils.go
@@ -191,6 +191,27 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 	return stateChanged && waitingForSkipped, nil
 }
 
+// enforceStatus updates the status of the root object managed by the provided APIConverter.
+// This function delegates to the converter's UpdateRootObjectStatus method to handle
+// status condition management and cluster updates.
+//
+// Parameters:
+//   - ctx: The context for API calls
+//   - logger: Logger for debugging information
+//   - conv: The APIConverter that manages the root object and its status
+//
+// Returns:
+//   - bool: true if the status was actually updated in the cluster
+//   - bool: true if the reconciliation loop should stop further processing
+//   - error: Any error that occurred during status processing
+//
+// This is a generic wrapper function that works with any converter implementing
+// the APIConverter interface, providing a consistent interface for status enforcement
+// across different resource types.
+func enforceStatus[t converter.RootObject](ctx context.Context, logger logr.Logger, conv converter.APIConverter[t]) (updated bool, stop bool, err error) {
+	return conv.UpdateRootObjectStatus(ctx, logger)
+}
+
 // cleanOrphanedResources deletes resources previously managed by the converter but no longer present in the desired output.
 //
 // The function performs the following operations:


### PR DESCRIPTION
**What this PR does / why we need it**:

Revert https://github.com/Kong/kong-operator/pull/3552.

Adds a comment about `Gateway` status reconciliation not needed to be done in hybrid Gateway controller.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
