### PR TITLE
ci: share GHA cache between bluegreen and ko integration tests

### DIFF
--- a/.github/workflows/__integration_tests.yaml
+++ b/.github/workflows/__integration_tests.yaml
@@ -52,8 +52,10 @@ jobs:
     # Create cache keys just for the suite. Different e.g. flavors do not warrant
     # a separate cache since they all use the same dependencies, so we can save some
     # cache storage and increase hit rate by not including the router flavor in the key.
-    - run: echo "GO_CACHE_KEY=go-integrationtests-${{ matrix.suite }}-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
-    - run: echo "GO_CACHE_KEY_2=go-integrationtests-${{ matrix.suite }}-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
+    #
+    # bluegreen and ko suites are using the same dependencies, so we can use the same cache for them.
+    - run: echo "GO_CACHE_KEY=go-integrationtests-${{ matrix.suite == 'bluegreen' && 'ko' || matrix.suite }}-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
+    - run: echo "GO_CACHE_KEY_2=go-integrationtests-${{ matrix.suite == 'bluegreen' && 'ko' || matrix.suite }}-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
 
     - name: Go cache main branch
       if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Bluegreen and KO integration tests run the same code so they can share the cache.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
