### PR TITLE
chore: migrate to double brackets in .mise.toml

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -41,9 +41,9 @@ macos-arm64 = { asset_pattern = "telepresence-darwin-arm64" }
 # renovate: datasource=github-releases depName=helm/helm
 version = "4.1.3"
 [tools."http:helm".platforms]
-linux-x64 = { url = "https://get.helm.sh/helm-v{version}-linux-amd64.tar.gz" }
-linux-arm64 = { url = "https://get.helm.sh/helm-v{version}-linux-arm64.tar.gz" }
-macos-arm64 = { url = "https://get.helm.sh/helm-v{version}-darwin-arm64.tar.gz" }
+linux-x64 = { url = "https://get.helm.sh/helm-v{{version}}-linux-amd64.tar.gz" }
+linux-arm64 = { url = "https://get.helm.sh/helm-v{{version}}-linux-arm64.tar.gz" }
+macos-arm64 = { url = "https://get.helm.sh/helm-v{{version}}-darwin-arm64.tar.gz" }
 
 [tools."go:sigs.k8s.io/kube-api-linter/cmd/golangci-lint-kube-api-linter"]
 # renovate: datasource=git-refs packageName=https://github.com/kubernetes-sigs/kube-api-linter.git


### PR DESCRIPTION
**What this PR does / why we need it**:

Address:

```
mise WARN  deprecated [legacy-version-template]: Use {{ version }} instead of {version} in URL templates This will be removed in mise 2027.3.0.
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
