### PR TITLE
fix(hybrid): fix hybrid gateway upstream and service name collisions for backendless HTTPRoute rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,11 @@
   [#3526](https://github.com/Kong/kong-operator/pull/3526)
 - Fix configuring SNIs in ingress-controller when running with local controlplane.
   [#3554](https://github.com/Kong/kong-operator/pull/3554)
+- Fix KongUpstream and KongService names in hybrid mode not taking into account
+  backendless rules. When a rule has no BackendRefs, the generated KongUpsteam and KongService names
+  now include a hash of rule's other field to avoid naming collisions with other
+  rules that also have no BackendRefs.
+  [#3576](https://github.com/Kong/kong-operator/pull/3576)
 
 ## [v2.1.2]
 

--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -14,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -295,6 +295,7 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 		wantErrSub   string
 		wantOutputs  outputCount
 		wantStoreLen int
+		assertFn     func(t *testing.T, store []client.Object)
 	}{
 		{
 			name: "translates route with plugins and targets",
@@ -323,6 +324,109 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 				plugins:   2,
 			},
 			wantStoreLen: 8,
+		},
+		{
+			name: "translates multi rule redirect only route end to end",
+			setup: func() *httpRouteConverter {
+				route := newHTTPRouteWithRules(
+					[]string{"api.example.com"},
+					[]gwtypes.HTTPRouteRule{
+						{
+							Matches: []gwtypes.HTTPRouteMatch{{
+								Path: &gatewayv1.HTTPPathMatch{
+									Type:  new(gatewayv1.PathMatchPathPrefix),
+									Value: new("/hostname-redirect"),
+								},
+							}},
+							Filters: []gwtypes.HTTPRouteFilter{
+								newRequestRedirectFilter("example.org", nil),
+							},
+						},
+						{
+							Matches: []gwtypes.HTTPRouteMatch{{
+								Path: &gatewayv1.HTTPPathMatch{
+									Type:  new(gatewayv1.PathMatchPathPrefix),
+									Value: new("/host-and-status"),
+								},
+							}},
+							Filters: []gwtypes.HTTPRouteFilter{
+								newRequestRedirectFilter("example.org", new(301)),
+							},
+						},
+					},
+				)
+				gateway := baseGateway()
+				objects := append(newKonnectGatewayStandardObjects(gateway), newNamespace())
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(objects...).Build()
+				return newHTTPRouteConverter(route, fakeClient, false, "").(*httpRouteConverter)
+			},
+			wantCount: 10,
+			wantOutputs: outputCount{
+				upstreams: 2,
+				services:  2,
+				routes:    2,
+				targets:   0,
+				bindings:  2,
+				plugins:   2,
+			},
+			wantStoreLen: 10,
+			assertFn: func(t *testing.T, store []client.Object) {
+				t.Helper()
+
+				upstreamNames := map[string]struct{}{}
+				serviceNames := map[string]struct{}{}
+				routeNames := map[string]struct{}{}
+				pluginNames := map[string]struct{}{}
+				bindingNames := map[string]struct{}{}
+
+				pluginConfigs := map[string]map[string]any{}
+
+				for _, obj := range store {
+					switch typed := obj.(type) {
+					case *configurationv1alpha1.KongUpstream:
+						upstreamNames[typed.Name] = struct{}{}
+					case *configurationv1alpha1.KongService:
+						serviceNames[typed.Name] = struct{}{}
+					case *configurationv1alpha1.KongRoute:
+						routeNames[typed.Name] = struct{}{}
+					case *configurationv1.KongPlugin:
+						pluginNames[typed.Name] = struct{}{}
+						var config map[string]any
+						require.NoError(t, json.Unmarshal(typed.Config.Raw, &config))
+						pluginConfigs[typed.Name] = config
+					case *configurationv1alpha1.KongPluginBinding:
+						bindingNames[typed.Name] = struct{}{}
+						require.NotNil(t, typed.Spec.Targets)
+						require.NotNil(t, typed.Spec.Targets.RouteReference)
+						assert.Contains(t, routeNames, typed.Spec.Targets.RouteReference.Name)
+						require.NotNil(t, typed.Spec.PluginReference)
+						assert.Contains(t, pluginNames, typed.Spec.PluginReference.Name)
+					}
+				}
+
+				assert.Len(t, upstreamNames, 2)
+				assert.Len(t, serviceNames, 2)
+				assert.Len(t, routeNames, 2)
+				assert.Len(t, pluginNames, 2)
+				assert.Len(t, bindingNames, 2)
+
+				var sawDefaultStatus bool
+				var sawCustomStatus bool
+				for _, config := range pluginConfigs {
+					assert.Equal(t, "http://example.org/", config["location"])
+					assert.Equal(t, true, config["keep_incoming_path"])
+					statusCode, ok := config["status_code"].(float64)
+					require.True(t, ok)
+					switch int(statusCode) {
+					case 301:
+						sawCustomStatus = true
+					case 302:
+						sawDefaultStatus = true
+					}
+				}
+				assert.True(t, sawDefaultStatus)
+				assert.True(t, sawCustomStatus)
+			},
 		},
 		{
 			name: "returns error when filter translation fails",
@@ -538,6 +642,9 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 			if (tt.wantOutputs != outputCount{}) {
 				assert.Equal(t, tt.wantOutputs, countOutputs(converter.outputStore))
 			}
+			if tt.assertFn != nil {
+				tt.assertFn(t, converter.outputStore)
+			}
 		})
 	}
 }
@@ -618,7 +725,7 @@ func TestHTTPRouteConverter_UpdateRootObjectStatus(t *testing.T) {
 						To: []gwtypes.ReferenceGrantTo{{
 							Group: "",
 							Kind:  gatewayv1.Kind("Service"),
-							Name:  ptr.To(gatewayv1.ObjectName("backend-service")),
+							Name:  new(gatewayv1.ObjectName("backend-service")),
 						}},
 					},
 				}
@@ -1099,6 +1206,19 @@ func assertConditionStatus(t *testing.T, conditions []metav1.Condition, conditio
 }
 
 func newHTTPRouteForTranslation(hostnames []string, backendRefs []gwtypes.HTTPBackendRef, filters []gwtypes.HTTPRouteFilter) *gwtypes.HTTPRoute {
+	return newHTTPRouteWithRules(hostnames, []gwtypes.HTTPRouteRule{{
+		Matches: []gwtypes.HTTPRouteMatch{{
+			Path: &gatewayv1.HTTPPathMatch{
+				Type:  new(gatewayv1.PathMatchPathPrefix),
+				Value: new("/"),
+			},
+		}},
+		BackendRefs: backendRefs,
+		Filters:     filters,
+	}})
+}
+
+func newHTTPRouteWithRules(hostnames []string, rules []gwtypes.HTTPRouteRule) *gwtypes.HTTPRoute {
 	var gwHostnames []gatewayv1.Hostname
 	for _, hostname := range hostnames {
 		gwHostnames = append(gwHostnames, gatewayv1.Hostname(hostname))
@@ -1111,20 +1231,7 @@ func newHTTPRouteForTranslation(hostnames []string, backendRefs []gwtypes.HTTPBa
 		},
 		Spec: gwtypes.HTTPRouteSpec{
 			Hostnames: gwHostnames,
-			Rules: []gwtypes.HTTPRouteRule{
-				{
-					Matches: []gwtypes.HTTPRouteMatch{
-						{
-							Path: &gatewayv1.HTTPPathMatch{
-								Type:  new(gatewayv1.PathMatchPathPrefix),
-								Value: new("/"),
-							},
-						},
-					},
-					BackendRefs: backendRefs,
-					Filters:     filters,
-				},
-			},
+			Rules:     rules,
 			CommonRouteSpec: gwtypes.CommonRouteSpec{
 				ParentRefs: []gwtypes.ParentReference{
 					{
@@ -1136,6 +1243,19 @@ func newHTTPRouteForTranslation(hostnames []string, backendRefs []gwtypes.HTTPBa
 			},
 		},
 	}
+}
+
+func newRequestRedirectFilter(hostname string, statusCode *int) gwtypes.HTTPRouteFilter {
+	filter := gwtypes.HTTPRouteFilter{
+		Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+		RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+			Hostname: new(gatewayv1.PreciseHostname(hostname)),
+		},
+	}
+	if statusCode != nil {
+		filter.RequestRedirect.StatusCode = statusCode
+	}
+	return filter
 }
 
 func newBackendRef(namespace string) gwtypes.HTTPBackendRef {
@@ -1218,7 +1338,7 @@ func newEndpointSlice(serviceName, namespace string, port int32, addresses []str
 			{
 				Name:     new("http"),
 				Port:     new(port),
-				Protocol: ptr.To(corev1.ProtocolTCP),
+				Protocol: new(corev1.ProtocolTCP),
 			},
 		},
 		Endpoints: []discoveryv1.Endpoint{

--- a/controller/hybridgateway/namegen/name.go
+++ b/controller/hybridgateway/namegen/name.go
@@ -79,10 +79,7 @@ func NewKongUpstreamName(route *gwtypes.HTTPRoute, cp *commonv1alpha1.ControlPla
 		[]string{httpProcolPrefix},
 		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
 	)
-	hashElements := []string{
-		defaultCPPrefix + utils.Hash32(cp),
-		utils.Hash32(rule.BackendRefs),
-	}
+	hashElements := hashElementsForServiceLikeName(route, cp, rule)
 	return newNameWithHashSuffix(readableElements, hashElements)
 }
 
@@ -92,11 +89,37 @@ func NewKongServiceName(route *gwtypes.HTTPRoute, cp *commonv1alpha1.ControlPlan
 		[]string{httpProcolPrefix},
 		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
 	)
-	hashElements := []string{
-		defaultCPPrefix + utils.Hash32(cp),
-		utils.Hash32(rule.BackendRefs),
-	}
+	hashElements := hashElementsForServiceLikeName(route, cp, rule)
 	return newNameWithHashSuffix(readableElements, hashElements)
+}
+
+func hashElementsForServiceLikeName(
+	route *gwtypes.HTTPRoute,
+	cp *commonv1alpha1.ControlPlaneRef,
+	rule gatewayv1.HTTPRouteRule,
+) []string {
+	var hash string
+	if len(rule.BackendRefs) > 0 {
+		hash = utils.Hash32(rule.BackendRefs)
+	} else {
+		zeroBackendRuleIdentity := struct {
+			RouteNamespace string
+			RouteName      string
+			Matches        []gatewayv1.HTTPRouteMatch
+			Filters        []gatewayv1.HTTPRouteFilter
+		}{
+			RouteNamespace: route.Namespace,
+			RouteName:      route.Name,
+			Matches:        rule.Matches,
+			Filters:        rule.Filters,
+		}
+		hash = utils.Hash32(zeroBackendRuleIdentity)
+	}
+
+	return []string{
+		defaultCPPrefix + utils.Hash32(cp),
+		hash,
+	}
 }
 
 // NewKongRouteName generates a KongRoute name based on the HTTPRoute, ControlPlaneRef, and HTTPRouteRule passed as arguments.

--- a/controller/hybridgateway/namegen/name_test.go
+++ b/controller/hybridgateway/namegen/name_test.go
@@ -14,6 +14,50 @@ import (
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 )
 
+func testRoute(namespace, name string) *gwtypes.HTTPRoute {
+	return &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+func testControlPlaneRef(name string) *commonv1alpha1.ControlPlaneRef {
+	return &commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: name,
+		},
+	}
+}
+
+func testPathMatch(path string) []gatewayv1.HTTPRouteMatch {
+	matchType := gatewayv1.PathMatchPathPrefix
+	return []gatewayv1.HTTPRouteMatch{
+		{
+			Path: &gatewayv1.HTTPPathMatch{
+				Type:  &matchType,
+				Value: &path,
+			},
+		},
+	}
+}
+
+func testBackendRef(
+	name string, namespace *gatewayv1.Namespace, port *gatewayv1.PortNumber,
+) gatewayv1.HTTPBackendRef {
+	return gatewayv1.HTTPBackendRef{
+		BackendRef: gatewayv1.BackendRef{
+			BackendObjectReference: gatewayv1.BackendObjectReference{
+				Name:      gatewayv1.ObjectName(name),
+				Namespace: namespace,
+				Port:      port,
+			},
+		},
+	}
+}
+
 func TestNewName(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -64,83 +108,115 @@ func TestNewName(t *testing.T) {
 
 func TestNewKongUpstreamName(t *testing.T) {
 	tests := []struct {
-		name             string
-		route            *gwtypes.HTTPRoute
-		cp               *commonv1alpha1.ControlPlaneRef
-		rule             gatewayv1.HTTPRouteRule
-		expectedReadable string
+		name     string
+		route    *gwtypes.HTTPRoute
+		cp       *commonv1alpha1.ControlPlaneRef
+		rule     gatewayv1.HTTPRouteRule
+		expected string
 	}{
 		{
-			name: "basic upstream name generation",
-			route: &gwtypes.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-route",
-					Namespace: "default",
-				},
-			},
-			cp: &commonv1alpha1.ControlPlaneRef{
-				Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
-				KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
-					Name: "test-cp",
-				},
-			},
+			name:  "basic upstream name generation",
+			route: testRoute("default", "test-route"),
+			cp:    testControlPlaneRef("test-cp"),
 			rule: gatewayv1.HTTPRouteRule{
 				BackendRefs: []gatewayv1.HTTPBackendRef{
-					{
-						BackendRef: gatewayv1.BackendRef{
-							BackendObjectReference: gatewayv1.BackendObjectReference{
-								Name: "service1",
-								Port: func() *gatewayv1.PortNumber { p := gatewayv1.PortNumber(8080); return &p }(),
-							},
-						},
-					},
+					testBackendRef("service1", nil, new(gatewayv1.PortNumber(8080))),
 				},
 			},
-			expectedReadable: "http.default-service1-8080.1",
+			expected: "http.default-service1-8080.1.cp1fbfa93f.e25441d7",
 		},
 		{
-			name: "multiple backend refs",
-			route: &gwtypes.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-route",
-					Namespace: "default",
-				},
-			},
-			cp: &commonv1alpha1.ControlPlaneRef{
-				Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
-				KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
-					Name: "multi-cp",
-				},
-			},
+			name:  "multiple backend refs use lowest lexical backend in readable prefix",
+			route: testRoute("default", "test-route"),
+			cp:    testControlPlaneRef("multi-cp"),
 			rule: gatewayv1.HTTPRouteRule{
 				BackendRefs: []gatewayv1.HTTPBackendRef{
+					testBackendRef("service2", nil, new(gatewayv1.PortNumber(9090))),
+					testBackendRef("service1", nil, new(gatewayv1.PortNumber(8080))),
+				},
+			},
+			expected: "http.default-service1-8080.2.cp918460a.2c5d1acf",
+		},
+		{
+			name:  "cross namespace backend is reflected in readable prefix",
+			route: testRoute("default", "test-route"),
+			cp:    testControlPlaneRef("namespaced-cp"),
+			rule: gatewayv1.HTTPRouteRule{
+				BackendRefs: []gatewayv1.HTTPBackendRef{
+					testBackendRef("backend-service", new(gatewayv1.Namespace("backend-ns")), nil),
+				},
+			},
+			expected: "http.backend-ns-backend-service.1.cpba78230e.1f2a8c5",
+		},
+		{
+			name:  "backendless rule produces readable prefix with just http and cp hash",
+			route: testRoute("default", "test-route"),
+			cp:    testControlPlaneRef("namespaced-cp"),
+			rule: gatewayv1.HTTPRouteRule{
+				BackendRefs: []gatewayv1.HTTPBackendRef{},
+				Filters: []gatewayv1.HTTPRouteFilter{
 					{
-						BackendRef: gatewayv1.BackendRef{
-							BackendObjectReference: gatewayv1.BackendObjectReference{
-								Name: "service1",
-								Port: func() *gatewayv1.PortNumber { p := gatewayv1.PortNumber(8080); return &p }(),
-							},
-						},
-					},
-					{
-						BackendRef: gatewayv1.BackendRef{
-							BackendObjectReference: gatewayv1.BackendObjectReference{
-								Name: "service2",
-								Port: func() *gatewayv1.PortNumber { p := gatewayv1.PortNumber(9090); return &p }(),
+						Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+							Set: []gatewayv1.HTTPHeader{
+								{
+									Name:  "header",
+									Value: "value",
+								},
 							},
 						},
 					},
 				},
+				Matches: []gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  new(gatewayv1.PathMatchPathPrefix),
+							Value: new("/prefix"),
+						},
+					},
+				},
 			},
-			expectedReadable: "http.default-service1-8080.2",
+			expected: "http.cpba78230e.7f99a851",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := NewKongUpstreamName(tt.route, tt.cp, tt.rule)
-			expected := tt.expectedReadable + ".cp" + utils.Hash32(tt.cp) + "." + utils.Hash32(tt.rule.BackendRefs)
-			assert.Equal(t, expected, result)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewKongUpstreamName_Equality(t *testing.T) {
+	tests := []struct {
+		name  string
+		route *gwtypes.HTTPRoute
+		cp    *commonv1alpha1.ControlPlaneRef
+		ruleA gatewayv1.HTTPRouteRule
+		ruleB gatewayv1.HTTPRouteRule
+		equal bool
+	}{
+		{
+			name:  "different matches with no backends produce different results",
+			route: testRoute("gateway-conformance-infra", "redirect-host-and-status"),
+			cp:    testControlPlaneRef("same-namespace-rrfhd"),
+			ruleA: gatewayv1.HTTPRouteRule{Matches: testPathMatch("/hostname-redirect")},
+			ruleB: gatewayv1.HTTPRouteRule{Matches: testPathMatch("/host-and-status")},
+			equal: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nameA := NewKongUpstreamName(tt.route, tt.cp, tt.ruleA)
+			nameB := NewKongUpstreamName(tt.route, tt.cp, tt.ruleB)
+
+			if tt.equal {
+				assert.Equal(t, nameA, nameB)
+			} else {
+				assert.NotEqual(t, nameA, nameB)
+			}
 		})
 	}
 }
@@ -154,41 +230,19 @@ func TestNewKongServiceName(t *testing.T) {
 		expectedReadable string
 	}{
 		{
-			name: "basic service name generation",
-			route: &gwtypes.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-route",
-					Namespace: "default",
-				},
-			},
-			cp: &commonv1alpha1.ControlPlaneRef{
-				Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
-				KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
-					Name: "test-cp",
-				},
-			},
+			name:  "basic service name generation",
+			route: testRoute("default", "test-route"),
+			cp:    testControlPlaneRef("test-cp"),
 			rule: gatewayv1.HTTPRouteRule{
 				BackendRefs: []gatewayv1.HTTPBackendRef{
-					{
-						BackendRef: gatewayv1.BackendRef{
-							BackendObjectReference: gatewayv1.BackendObjectReference{
-								Name: "service1",
-								Port: func() *gatewayv1.PortNumber { p := gatewayv1.PortNumber(8080); return &p }(),
-							},
-						},
-					},
+					testBackendRef("service1", nil, new(gatewayv1.PortNumber(8080))),
 				},
 			},
 			expectedReadable: "http.default-service1-8080.1",
 		},
 		{
-			name: "service with namespace",
-			route: &gwtypes.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-route",
-					Namespace: "default",
-				},
-			},
+			name:  "service with namespace",
+			route: testRoute("default", "test-route"),
 			cp: &commonv1alpha1.ControlPlaneRef{
 				Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
 				KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
@@ -198,14 +252,7 @@ func TestNewKongServiceName(t *testing.T) {
 			},
 			rule: gatewayv1.HTTPRouteRule{
 				BackendRefs: []gatewayv1.HTTPBackendRef{
-					{
-						BackendRef: gatewayv1.BackendRef{
-							BackendObjectReference: gatewayv1.BackendObjectReference{
-								Name:      "backend-service",
-								Namespace: func() *gatewayv1.Namespace { ns := gatewayv1.Namespace("backend-ns"); return &ns }(),
-							},
-						},
-					},
+					testBackendRef("backend-service", new(gatewayv1.Namespace("backend-ns")), nil),
 				},
 			},
 			expectedReadable: "http.backend-ns-backend-service.1",
@@ -217,6 +264,39 @@ func TestNewKongServiceName(t *testing.T) {
 			result := NewKongServiceName(tt.route, tt.cp, tt.rule)
 			expected := tt.expectedReadable + ".cp" + utils.Hash32(tt.cp) + "." + utils.Hash32(tt.rule.BackendRefs)
 			assert.Equal(t, expected, result)
+		})
+	}
+}
+
+func TestNewKongServiceName_Equality(t *testing.T) {
+	tests := []struct {
+		name  string
+		route *gwtypes.HTTPRoute
+		cp    *commonv1alpha1.ControlPlaneRef
+		ruleA gatewayv1.HTTPRouteRule
+		ruleB gatewayv1.HTTPRouteRule
+		equal bool
+	}{
+		{
+			name:  "different matches with no backends produce different results",
+			route: testRoute("gateway-conformance-infra", "redirect-host-and-status"),
+			cp:    testControlPlaneRef("same-namespace-rrfhd"),
+			ruleA: gatewayv1.HTTPRouteRule{Matches: testPathMatch("/hostname-redirect")},
+			ruleB: gatewayv1.HTTPRouteRule{Matches: testPathMatch("/host-and-status")},
+			equal: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nameA := NewKongServiceName(tt.route, tt.cp, tt.ruleA)
+			nameB := NewKongServiceName(tt.route, tt.cp, tt.ruleB)
+
+			if tt.equal {
+				assert.Equal(t, nameA, nameB)
+			} else {
+				assert.NotEqual(t, nameA, nameB)
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This change fixes a hybrid gateway naming collision for redirect-only HTTPRoute rules that do not define backend refs.

Previously, `name.go` generated KongUpstream and KongService names from the control plane ref plus backend refs only. That worked for backend-backed rules, but it caused different redirect-only rules to collapse onto the same generated names because they all had empty backend refs. In practice, that could lead to Konnect uniqueness conflicts and failed translation of multi-rule redirect-only routes. This happens for manifest like the one from [`HTTPRouteRedirectHostAndStatus` conformance test](https://github.com/kubernetes-sigs/gateway-api/blob/faba2585346ef0806585f8ce2ee458e9cd70ec7b/conformance/tests/httproute-redirect-host-and-status.yaml):

```
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: redirect-host-and-status
  namespace: gateway-conformance-infra
spec:
  parentRefs:
  - name: same-namespace
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /hostname-redirect
    filters:
    - type: RequestRedirect
      requestRedirect:
        hostname: example.org
  - matches:
    - path:
        type: PathPrefix
        value: /host-and-status
    filters:
    - type: RequestRedirect
      requestRedirect:
        statusCode: 301
        hostname: example.org
```

This could be observed in conformance tests operator logs as:

```
2026-03-12T11:59:05Z	ERROR	Reconciler error	{"controller": "KongUpstream", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongUpstream", "KongUpstream": {"name":"http.cp85fdd70a.76e902c7","namespace":"gateway-conformance-infra"}, "namespace": "gateway-conformance-infra", "name": "http.cp85fdd70a.76e902c7", "reconcileID": "152944e6-a246-453e-9a35-5c500b264e20", "error": "failed to create KongUpstream on Konnect: failed to create KongUpstream gateway-conformance-infra/http.cp85fdd70a.76e902c7: API error occurred: Status 400\n{\"code\":3,\"details\":[{\"@type\":\"type.googleapis.com/kong.admin.model.v1.ErrorDetail\",\"field\":\"name\",\"messages\":[\"name (type: unique) constraint failed\"],\"type\":\"ERROR_TYPE_REFERENCE\"}],\"message\":\"name (type: unique) constraint failed\"}"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:495
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:438
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:313
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

This fixes test flakiness of conformance hybrid suite.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
