### PR TITLE
conformance(hybrid): enable HTTPRouteInvalidNonExistentBackendRef

### DIFF
--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -35,8 +35,7 @@ var skippedTestsForHybrid = []string{
 	// Core profile.
 	tests.HTTPRouteHTTPSListener.ShortName,
 	tests.HTTPRouteInvalidCrossNamespaceBackendRef.ShortName,
-	tests.HTTPRouteInvalidNonExistentBackendRef.ShortName,
-	tests.HTTPRouteInvalidReferenceGrant.ShortName,
+		tests.HTTPRouteInvalidReferenceGrant.ShortName,
 	tests.HTTPRouteListenerHostnameMatching.ShortName,
 	tests.HTTPRouteHeaderMatching.ShortName,
 	tests.HTTPRouteInvalidBackendRefUnknownKind.ShortName,


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable the core Gateway API conformance test `HTTPRouteInvalidNonExistentBackendRef` for Hybrid Gateway by removing it from the Hybrid skip list.

- Hybrid HTTPRoute status already sets `ResolvedRefs=False` with `Reason=BackendNotFound` when the backend `Service` is missing, while keeping `Accepted=True` if the parent `Gateway`/hostnames match.
- Reconciliation stops before translation when `ResolvedRefs` is `False`, so no Kong resources are created for invalid backends.

**Which issue this PR fixes**

Fixes #3453

**Special notes for your reviewer**:
- Change is test-only: remove a single skip entry in `test/conformance/skipped_tests_test.go`.
- Behavior is covered by unit tests in `controller/hybridgateway/route/status_test.go` ("service not found" case).
- Hybrid conformance in CI will validate once `KONG_TEST_KONNECT_ACCESS_TOKEN` is available.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes (N/A: test-only change)
