### PR TITLE
fix: fix operator restart sending empty config to `DataPlane` pods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@
   upstreams synced to Konnect. A CEL validation rule enforces that
   `sticky_sessions_cookie` is set when `algorithm` is `sticky-sessions`.
   [#3555](https://github.com/Kong/kong-operator/pull/3555)
+- Fix license storage not being enabled for `ControlPlane`s, license decoding
+  from `Secret`s and not setting the `Secret` label selector labels on license `Secret`s.
+  [#3610](https://github.com/Kong/kong-operator/pull/3610)
 
 ### Changed
 

--- a/controller/pkg/extensions/konnect/controlplane.go
+++ b/controller/pkg/extensions/konnect/controlplane.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
@@ -95,20 +94,17 @@ func kicInKonnectDefaults(ctx context.Context, cl client.Client, konnectExtensio
 		}
 
 		// Build the configuration and return it.
+		konnectConfig := managercfg.DefaultKonnectConfig()
+		konnectConfig.Address = buildKonnectAddress(konnectExtension.Status.Konnect.Endpoints.ControlPlaneEndpoint)
+		konnectConfig.ControlPlaneID = konnectExtension.Status.Konnect.ControlPlaneID
+		konnectConfig.TLSClient = managercfg.TLSClientConfig{
+			Cert: TLSClientCert,
+			Key:  TLSClientKey,
+		}
+		konnectConfig.LicenseSynchronizationEnabled = true
+		konnectConfig.ConfigSynchronizationEnabled = true
 		return &KonnectExtensionConfig{
-			KonnectConfig: &managercfg.KonnectConfig{
-				Address:        buildKonnectAddress(konnectExtension.Status.Konnect.Endpoints.ControlPlaneEndpoint),
-				ControlPlaneID: konnectExtension.Status.Konnect.ControlPlaneID,
-				TLSClient: managercfg.TLSClientConfig{
-					Cert: TLSClientCert,
-					Key:  TLSClientKey,
-				},
-				LicenseSynchronizationEnabled: true,
-				ConfigSynchronizationEnabled:  true,
-				UploadConfigPeriod:            time.Second * 10,
-				InitialLicensePollingPeriod:   time.Second * 10,
-				LicensePollingPeriod:          time.Second * 10,
-			},
+			KonnectConfig: &konnectConfig,
 		}, nil
 
 	case konnectv1alpha2.ClusterTypeControlPlane:

--- a/ingress-controller/internal/dataplane/configfetcher/config_fetcher.go
+++ b/ingress-controller/internal/dataplane/configfetcher/config_fetcher.go
@@ -101,6 +101,12 @@ func (cf *DefaultKongLastGoodConfigFetcher) LastValidConfig() (*kongstate.KongSt
 }
 
 func (cf *DefaultKongLastGoodConfigFetcher) StoreLastValidConfig(s *kongstate.KongState) {
+	// Do not overwrite a non-empty last valid config with an empty one.
+	// This protects against startup races where the K8s informer cache hasn't
+	// been fully populated yet and BuildKongConfig() produces an empty state.
+	if s.IsEmpty() && cf.lastValidState != nil && !cf.lastValidState.IsEmpty() {
+		return
+	}
 	cf.lastValidState = s
 }
 

--- a/ingress-controller/internal/dataplane/configfetcher/config_fetcher.go
+++ b/ingress-controller/internal/dataplane/configfetcher/config_fetcher.go
@@ -101,12 +101,6 @@ func (cf *DefaultKongLastGoodConfigFetcher) LastValidConfig() (*kongstate.KongSt
 }
 
 func (cf *DefaultKongLastGoodConfigFetcher) StoreLastValidConfig(s *kongstate.KongState) {
-	// Do not overwrite a non-empty last valid config with an empty one.
-	// This protects against startup races where the K8s informer cache hasn't
-	// been fully populated yet and BuildKongConfig() produces an empty state.
-	if s.IsEmpty() && cf.lastValidState != nil && !cf.lastValidState.IsEmpty() {
-		return
-	}
 	cf.lastValidState = s
 }
 

--- a/ingress-controller/internal/dataplane/configfetcher/config_fetcher_test.go
+++ b/ingress-controller/internal/dataplane/configfetcher/config_fetcher_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/adminapi"
+	"github.com/kong/kong-operator/v2/ingress-controller/internal/dataplane/kongstate"
 	managercfg "github.com/kong/kong-operator/v2/ingress-controller/pkg/manager/config"
 	"github.com/kong/kong-operator/v2/ingress-controller/test/mocks"
 )
@@ -124,4 +125,25 @@ func TestTryFetchingValidConfigFromGateways(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStoreLastValidConfig_AllowsReplacingNonEmptyWithEmpty(t *testing.T) {
+	fetcher := NewDefaultKongLastGoodConfigFetcher(false, "")
+
+	nonEmpty := &kongstate.KongState{
+		Services: []kongstate.Service{{}},
+	}
+	fetcher.StoreLastValidConfig(nonEmpty)
+
+	state, ok := fetcher.LastValidConfig()
+	require.True(t, ok)
+	require.Same(t, nonEmpty, state)
+
+	empty := &kongstate.KongState{}
+	fetcher.StoreLastValidConfig(empty)
+
+	state, ok = fetcher.LastValidConfig()
+	require.True(t, ok)
+	require.Same(t, empty, state)
+	require.True(t, state.IsEmpty())
 }

--- a/ingress-controller/internal/dataplane/kong_client.go
+++ b/ingress-controller/internal/dataplane/kong_client.go
@@ -523,23 +523,24 @@ func (c *KongClient) Update(ctx context.Context) error {
 	parsingResult := c.kongConfigBuilder.BuildKongConfig()
 	translationDuration := time.Since(translationStart)
 
-	if failuresCount := len(parsingResult.TranslationFailures); failuresCount > 0 {
-		c.metricsRecorder.RecordTranslationFailure(translationDuration)
-		c.metricsRecorder.RecordTranslationBrokenResources(failuresCount)
-		c.recordResourceFailureEvents(parsingResult.TranslationFailures, KongConfigurationTranslationFailedEventReason)
-		c.logger.V(logging.DebugLevel).Info("Translation failures occurred when building data-plane configuration", "count", failuresCount)
+	kongState := parsingResult.KongState
+	if newKongState, skip := c.shouldSkipInitialEmptyConfigPush(parsingResult.KongState); skip {
+		kongState = newKongState
 	} else {
-		c.metricsRecorder.RecordTranslationSuccess(translationDuration)
-		c.metricsRecorder.RecordTranslationBrokenResources(0)
-		c.logger.V(logging.DebugLevel).Info("Successfully built data-plane configuration", "duration", translationDuration.String())
-	}
-
-	if c.shouldSkipInitialEmptyConfigPush(parsingResult.KongState) {
-		return nil
+		if failuresCount := len(parsingResult.TranslationFailures); failuresCount > 0 {
+			c.metricsRecorder.RecordTranslationFailure(translationDuration)
+			c.metricsRecorder.RecordTranslationBrokenResources(failuresCount)
+			c.recordResourceFailureEvents(parsingResult.TranslationFailures, KongConfigurationTranslationFailedEventReason)
+			c.logger.V(logging.DebugLevel).Info("Translation failures occurred when building data-plane configuration", "count", failuresCount)
+		} else {
+			c.metricsRecorder.RecordTranslationSuccess(translationDuration)
+			c.metricsRecorder.RecordTranslationBrokenResources(0)
+			c.logger.V(logging.DebugLevel).Info("Successfully built data-plane configuration", "duration", translationDuration.String())
+		}
 	}
 
 	const isFallback = false
-	shas, gatewaysSyncErr := c.sendOutToGatewayClients(ctx, parsingResult.KongState, c.kongConfig, isFallback)
+	shas, gatewaysSyncErr := c.sendOutToGatewayClients(ctx, kongState, c.kongConfig, isFallback)
 
 	// Taking into account the results of syncing configuration with Gateways and potential translation
 	// failures, calculate the config status and update it.
@@ -563,7 +564,7 @@ func (c *KongClient) Update(ctx context.Context) error {
 	}
 
 	// Send configuration to Konnect only when successfully applied configuration to Kong Gateways run in cluster.
-	c.maybeUpdateKonnectKongState(parsingResult.KongState, isFallback)
+	c.maybeUpdateKonnectKongState(kongState, isFallback)
 	// Gateways were successfully synced with the current configuration, so we can update the last valid cache snapshot.
 	c.maybePreserveTheLastValidConfigCache(cacheSnapshot)
 
@@ -591,24 +592,33 @@ func (c *KongClient) maybePreserveTheLastValidConfigCache(lastValidCache store.C
 	}
 }
 
-func (c *KongClient) shouldSkipInitialEmptyConfigPush(s *kongstate.KongState) bool {
+// shouldSkipInitialEmptyConfigPush returns true if the client should skip pushing
+// an initial empty configuration to the gateways, which can happen during startup
+// when the informer cache has not yet been fully populated and the client has
+// not yet successfully pushed any configuration.
+// In this case, if there is a last valid configuration available,
+// we can skip pushing an empty configuration and instead use the last valid
+// configuration as the one to be pushed, which can help avoid unnecessary downtime
+// due to pushing an empty configuration.
+// Last valid configuration is returned when function returns true.
+func (c *KongClient) shouldSkipInitialEmptyConfigPush(s *kongstate.KongState) (*kongstate.KongState, bool) {
 	if c.hasSuccessfullyPushedConfig {
-		return false
+		return nil, false
 	}
 
 	if !s.IsEmpty() {
-		return false
+		return nil, false
 	}
 
 	lastValidConfig, ok := c.kongConfigFetcher.LastValidConfig()
 	if !ok || lastValidConfig == nil || lastValidConfig.IsEmpty() {
-		return false
+		return nil, false
 	}
 
 	c.logger.V(logging.DebugLevel).Info(
 		"Skipping empty config push before first successful update because a last valid config is already available",
 	)
-	return true
+	return lastValidConfig, true
 }
 
 // maybeTryRecoveringFromGatewaysSyncError tries to recover from a configuration rejection if the error is of the expected

--- a/ingress-controller/internal/dataplane/kong_client.go
+++ b/ingress-controller/internal/dataplane/kong_client.go
@@ -198,6 +198,14 @@ type KongClient struct {
 	// konnectKongStateUpdater is used to update the current state seen by Konnect that will be picked asynchronously
 	// by the Konnect config synchronization loop.
 	konnectKongStateUpdater KonnectKongStateUpdater
+
+	// hasSuccessfullyPushedConfig indicates whether this client instance has already
+	// successfully pushed a configuration to a gateway during its lifetime.
+	// It is used to prevent an initial empty config push from replacing a known
+	// last valid configuration during startup race between last valid config fetching
+	// and syncing informer cache.
+	hasSuccessfullyPushedConfig     bool
+	hasSuccessfullyPushedConfigOnce sync.Once
 }
 
 // KongClientOption is a functional option for configuring a KongClient.
@@ -526,18 +534,8 @@ func (c *KongClient) Update(ctx context.Context) error {
 		c.logger.V(logging.DebugLevel).Info("Successfully built data-plane configuration", "duration", translationDuration.String())
 	}
 
-	// Guard against pushing an empty config when we have a known valid config from the gateway.
-	// This can happen during startup when the K8s informer cache hasn't been fully populated yet
-	// (e.g., HTTPRoute controller hasn't processed routes because Gateway isn't Programmed).
-	if lastValid, ok := c.kongConfigFetcher.LastValidConfig(); ok {
-		if parsingResult.KongState.IsEmpty() && !lastValid.IsEmpty() {
-			c.logger.Info(
-				"Skipping config push: new config is empty but a previously valid config exists, likely a startup race",
-				"last_valid_services", len(lastValid.Services),
-				"last_valid_routes", lo.SumBy(lastValid.Services, func(s kongstate.Service) int { return len(s.Routes) }),
-			)
-			return nil
-		}
+	if c.shouldSkipInitialEmptyConfigPush(parsingResult.KongState) {
+		return nil
 	}
 
 	const isFallback = false
@@ -591,6 +589,26 @@ func (c *KongClient) maybePreserveTheLastValidConfigCache(lastValidCache store.C
 		c.logger.V(logging.DebugLevel).Info("Preserving the last valid configuration cache")
 		c.lastValidCacheSnapshot = &lastValidCache
 	}
+}
+
+func (c *KongClient) shouldSkipInitialEmptyConfigPush(s *kongstate.KongState) bool {
+	if c.hasSuccessfullyPushedConfig {
+		return false
+	}
+
+	if !s.IsEmpty() {
+		return false
+	}
+
+	lastValidConfig, ok := c.kongConfigFetcher.LastValidConfig()
+	if !ok || lastValidConfig == nil || lastValidConfig.IsEmpty() {
+		return false
+	}
+
+	c.logger.V(logging.DebugLevel).Info(
+		"Skipping empty config push before first successful update because a last valid config is already available",
+	)
+	return true
 }
 
 // maybeTryRecoveringFromGatewaysSyncError tries to recover from a configuration rejection if the error is of the expected
@@ -785,6 +803,9 @@ func (c *KongClient) sendOutToGatewayClients(
 	previousSHAs := c.SHAs
 	sort.Strings(shas)
 	c.SHAs = shas
+	c.hasSuccessfullyPushedConfigOnce.Do(func() {
+		c.hasSuccessfullyPushedConfig = true
+	})
 
 	c.kongConfigFetcher.StoreLastValidConfig(s)
 

--- a/ingress-controller/internal/dataplane/kong_client.go
+++ b/ingress-controller/internal/dataplane/kong_client.go
@@ -525,8 +525,11 @@ func (c *KongClient) Update(ctx context.Context) error {
 
 	kongState := parsingResult.KongState
 	if newKongState, skip := c.shouldSkipInitialEmptyConfigPush(parsingResult.KongState); skip {
+		// Use last valid state if we should skip the initial empty config.
 		kongState = newKongState
 	} else {
+		// Otherwise, the translated Kong state is used so we should record
+		// the statistics of the translation.
 		if failuresCount := len(parsingResult.TranslationFailures); failuresCount > 0 {
 			c.metricsRecorder.RecordTranslationFailure(translationDuration)
 			c.metricsRecorder.RecordTranslationBrokenResources(failuresCount)

--- a/ingress-controller/internal/dataplane/kong_client.go
+++ b/ingress-controller/internal/dataplane/kong_client.go
@@ -526,6 +526,20 @@ func (c *KongClient) Update(ctx context.Context) error {
 		c.logger.V(logging.DebugLevel).Info("Successfully built data-plane configuration", "duration", translationDuration.String())
 	}
 
+	// Guard against pushing an empty config when we have a known valid config from the gateway.
+	// This can happen during startup when the K8s informer cache hasn't been fully populated yet
+	// (e.g., HTTPRoute controller hasn't processed routes because Gateway isn't Programmed).
+	if lastValid, ok := c.kongConfigFetcher.LastValidConfig(); ok {
+		if parsingResult.KongState.IsEmpty() && !lastValid.IsEmpty() {
+			c.logger.Info(
+				"Skipping config push: new config is empty but a previously valid config exists, likely a startup race",
+				"last_valid_services", len(lastValid.Services),
+				"last_valid_routes", lo.SumBy(lastValid.Services, func(s kongstate.Service) int { return len(s.Routes) }),
+			)
+			return nil
+		}
+	}
+
 	const isFallback = false
 	shas, gatewaysSyncErr := c.sendOutToGatewayClients(ctx, parsingResult.KongState, c.kongConfig, isFallback)
 

--- a/ingress-controller/internal/dataplane/kong_client_test.go
+++ b/ingress-controller/internal/dataplane/kong_client_test.go
@@ -776,7 +776,7 @@ func TestKongClient_EmptyConfigUpdate(t *testing.T) {
 	})
 }
 
-func TestKongClient_EmptyConfigUpdate_IsSkippedOnStartupWhenLastValidConfigExists(t *testing.T) {
+func TestKongClient_EmptyConfigUpdate_UsesLastValidConfigOnStartupWhenLastValidConfigExistsOnStartup(t *testing.T) {
 	var (
 		ctx               = t.Context()
 		testGatewayClient = mustSampleGatewayClient(t)
@@ -802,12 +802,12 @@ func TestKongClient_EmptyConfigUpdate_IsSkippedOnStartupWhenLastValidConfigExist
 	require.NoError(t, err)
 
 	_, ok := updateStrategyResolver.LastUpdatedContentForURL(testGatewayClient.BaseRootURL())
-	require.False(t, ok)
+	require.True(t, ok)
 
 	lastValidConfig, ok := kongRawStateGetter.LastValidConfig()
 	require.True(t, ok)
 	require.False(t, lastValidConfig.IsEmpty())
-	require.False(t, kongClient.hasSuccessfullyPushedConfig)
+	require.True(t, kongClient.hasSuccessfullyPushedConfig)
 }
 
 func TestKongClient_EmptyConfigUpdate_ReplacesPreviousValidConfigAfterSuccessfulPush(t *testing.T) {

--- a/ingress-controller/internal/dataplane/kong_client_test.go
+++ b/ingress-controller/internal/dataplane/kong_client_test.go
@@ -776,6 +776,134 @@ func TestKongClient_EmptyConfigUpdate(t *testing.T) {
 	})
 }
 
+func TestKongClient_EmptyConfigUpdate_IsSkippedOnStartupWhenLastValidConfigExists(t *testing.T) {
+	var (
+		ctx               = t.Context()
+		testGatewayClient = mustSampleGatewayClient(t)
+
+		clientsProvider = &mockGatewayClientsProvider{
+			gatewayClients: []*adminapi.Client{testGatewayClient},
+		}
+
+		updateStrategyResolver = mocks.NewUpdateStrategyResolver()
+		configChangeDetector   = mocks.ConfigurationChangeDetector{ConfigurationChanged: true}
+		configBuilder          = newMockKongConfigBuilder()
+		kongRawStateGetter     = &mockKongLastValidConfigFetcher{
+			lastKongState: &kongstate.KongState{
+				Services: []kongstate.Service{{
+					Routes: []kongstate.Route{{}},
+				}},
+			},
+		}
+		kongClient = setupTestKongClient(t, updateStrategyResolver, clientsProvider, configChangeDetector, configBuilder, nil, kongRawStateGetter)
+	)
+
+	err := kongClient.Update(ctx)
+	require.NoError(t, err)
+
+	_, ok := updateStrategyResolver.LastUpdatedContentForURL(testGatewayClient.BaseRootURL())
+	require.False(t, ok)
+
+	lastValidConfig, ok := kongRawStateGetter.LastValidConfig()
+	require.True(t, ok)
+	require.False(t, lastValidConfig.IsEmpty())
+	require.False(t, kongClient.hasSuccessfullyPushedConfig)
+}
+
+func TestKongClient_EmptyConfigUpdate_ReplacesPreviousValidConfigAfterSuccessfulPush(t *testing.T) {
+	var (
+		ctx               = t.Context()
+		testGatewayClient = mustSampleGatewayClient(t)
+
+		clientsProvider = &mockGatewayClientsProvider{
+			gatewayClients: []*adminapi.Client{testGatewayClient},
+		}
+
+		configChangeDetector = mocks.ConfigurationChangeDetector{ConfigurationChanged: true}
+	)
+
+	t.Run("dbless", func(t *testing.T) {
+		updateStrategyResolver := mocks.NewUpdateStrategyResolver()
+		configBuilder := newMockKongConfigBuilder()
+		configBuilder.kongState = &kongstate.KongState{
+			Services: []kongstate.Service{{
+				Routes: []kongstate.Route{{}},
+			}},
+		}
+		kongRawStateGetter := &mockKongLastValidConfigFetcher{
+			lastKongState: &kongstate.KongState{
+				Services: []kongstate.Service{{
+					Routes: []kongstate.Route{{}},
+				}},
+			},
+		}
+		kongClient := setupTestKongClient(t, updateStrategyResolver, clientsProvider, configChangeDetector, configBuilder, nil, kongRawStateGetter)
+		konnectKongStateUpdater := &mocks.KonnectKongStateUpdater{}
+		kongClient.SetKonnectKongStateUpdater(konnectKongStateUpdater)
+		kongClient.kongConfig.InMemory = true
+
+		err := kongClient.Update(ctx)
+		require.NoError(t, err)
+		require.True(t, kongClient.hasSuccessfullyPushedConfig)
+
+		configBuilder.kongState = &kongstate.KongState{}
+		err = kongClient.Update(ctx)
+		require.NoError(t, err)
+
+		gwContent, ok := updateStrategyResolver.LastUpdatedContentForURL(testGatewayClient.BaseRootURL())
+		require.True(t, ok)
+		assert.Equal(t, &file.Content{
+			FormatVersion: versions.DeckFileFormatVersion,
+			Upstreams: []file.FUpstream{{
+				Upstream: kong.Upstream{
+					Name: new(deckgen.StubUpstreamName),
+				},
+			}},
+		}, gwContent.Content, "gateway content should have appended stub upstream")
+
+		lastValidConfig, ok := kongRawStateGetter.LastValidConfig()
+		require.True(t, ok)
+		require.True(t, lastValidConfig.IsEmpty())
+	})
+
+	t.Run("db", func(t *testing.T) {
+		updateStrategyResolver := mocks.NewUpdateStrategyResolver()
+		configBuilder := newMockKongConfigBuilder()
+		configBuilder.kongState = &kongstate.KongState{
+			Services: []kongstate.Service{{
+				Routes: []kongstate.Route{{}},
+			}},
+		}
+		kongRawStateGetter := &mockKongLastValidConfigFetcher{
+			lastKongState: &kongstate.KongState{
+				Services: []kongstate.Service{{
+					Routes: []kongstate.Route{{}},
+				}},
+			},
+		}
+		kongClient := setupTestKongClient(t, updateStrategyResolver, clientsProvider, configChangeDetector, configBuilder, nil, kongRawStateGetter)
+		konnectKongStateUpdater := &mocks.KonnectKongStateUpdater{}
+		kongClient.SetKonnectKongStateUpdater(konnectKongStateUpdater)
+		kongClient.kongConfig.InMemory = false
+
+		err := kongClient.Update(ctx)
+		require.NoError(t, err)
+		require.True(t, kongClient.hasSuccessfullyPushedConfig)
+
+		configBuilder.kongState = &kongstate.KongState{}
+		err = kongClient.Update(ctx)
+		require.NoError(t, err)
+
+		gwContent, ok := updateStrategyResolver.LastUpdatedContentForURL(testGatewayClient.BaseRootURL())
+		require.True(t, ok)
+		require.True(t, deckgen.IsContentEmpty(gwContent.Content), "gateway content should be empty")
+
+		lastValidConfig, ok := kongRawStateGetter.LastValidConfig()
+		require.True(t, ok)
+		require.True(t, lastValidConfig.IsEmpty())
+	})
+}
+
 // setupTestKongClient creates a KongClient with mocked dependencies.
 func setupTestKongClient(
 	t *testing.T,

--- a/ingress-controller/internal/dataplane/kongstate/kongstate.go
+++ b/ingress-controller/internal/dataplane/kongstate/kongstate.go
@@ -50,6 +50,9 @@ type KongState struct {
 // Licenses are excluded because a state with only a license is still "empty" from
 // a routing perspective and would cause 404s.
 func (ks *KongState) IsEmpty() bool {
+	if ks == nil {
+		return true
+	}
 	return len(ks.Services) == 0 &&
 		len(ks.Upstreams) == 0 &&
 		len(ks.Certificates) == 0 &&

--- a/ingress-controller/internal/dataplane/kongstate/kongstate.go
+++ b/ingress-controller/internal/dataplane/kongstate/kongstate.go
@@ -46,6 +46,21 @@ type KongState struct {
 	CustomEntities map[string]*KongCustomEntityCollection
 }
 
+// IsEmpty returns true if the KongState has no meaningful configuration entities.
+// Licenses are excluded because a state with only a license is still "empty" from
+// a routing perspective and would cause 404s.
+func (ks *KongState) IsEmpty() bool {
+	return len(ks.Services) == 0 &&
+		len(ks.Upstreams) == 0 &&
+		len(ks.Certificates) == 0 &&
+		len(ks.CACertificates) == 0 &&
+		len(ks.Plugins) == 0 &&
+		len(ks.Consumers) == 0 &&
+		len(ks.ConsumerGroups) == 0 &&
+		len(ks.Vaults) == 0 &&
+		len(ks.CustomEntities) == 0
+}
+
 // SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.
 func (ks *KongState) SanitizedCopy(uuidGenerator util.UUIDGenerator) *KongState {
 	return &KongState{

--- a/ingress-controller/internal/konnect/license/storage.go
+++ b/ingress-controller/internal/konnect/license/storage.go
@@ -2,14 +2,14 @@ package license
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -38,9 +38,10 @@ type Storer interface {
 // the CP ID, a predefined prefix and the provided namespace to designate the target Secret
 // which will be used for storage.
 type SecretLicenseStore struct {
-	cl             client.Client
-	namespace      string
-	controlPlaneID string
+	cl                  client.Client
+	namespace           string
+	controlPlaneID      string
+	secretLabelSelector map[string]string
 }
 
 var _ Storer = &SecretLicenseStore{}
@@ -48,21 +49,26 @@ var _ Storer = &SecretLicenseStore{}
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=create;get;update
 
 // NewSecretLicenseStore creates a storage to store Konnect license to a secret.
-func NewSecretLicenseStore(cl client.Client, namespace, controlPlaneID string) *SecretLicenseStore {
+func NewSecretLicenseStore(
+	cl client.Client,
+	namespace, controlPlaneID string,
+	secretLabelSelector map[string]string,
+) *SecretLicenseStore {
 	return &SecretLicenseStore{
-		cl:             cl,
-		namespace:      namespace,
-		controlPlaneID: controlPlaneID,
+		cl:                  cl,
+		namespace:           namespace,
+		controlPlaneID:      controlPlaneID,
+		secretLabelSelector: secretLabelSelector,
 	}
 }
 
 // Store stores license to the secret `konnect-license-<cpid>`.
 func (s *SecretLicenseStore) Store(ctx context.Context, l license.KonnectLicense) error {
-	secret := &corev1.Secret{}
+	var secret corev1.Secret
 	err := s.cl.Get(ctx, k8stypes.NamespacedName{
 		Namespace: s.namespace,
 		Name:      licenseResourceNamePrefix + s.controlPlaneID,
-	}, secret)
+	}, &secret)
 	if err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			return err
@@ -70,27 +76,31 @@ func (s *SecretLicenseStore) Store(ctx context.Context, l license.KonnectLicense
 		// Create the secret in case that the secret is not found.
 		secret.Name = licenseResourceNamePrefix + s.controlPlaneID
 		secret.Namespace = s.namespace
-		secret.Labels = map[string]string{labels.ManagedByLabel: labels.ManagedByLabelValueIngressController}
-		secret.StringData = map[string]string{
-			secretKeyPayload:   l.Payload,
-			secretKeyUpdatedAt: strconv.FormatInt(l.UpdatedAt.Unix(), 10),
-			secretKeyID:        l.ID,
+		s.setSecretLabels(&secret)
+		secret.StringData = licenseToSecretData(l)
+
+		if err := s.cl.Create(ctx, &secret); err != nil {
+			if !apierrors.IsAlreadyExists(err) {
+				return err
+			}
+			toDelete := secret.DeepCopy()
+			// Attempt to delete the existing secret.
+			// This is a fallback mechanism to enforce for example the secret label
+			// selector in the Secret. When selector is configured operator can't
+			// perform an update on the Secret because the existing Secret doesn't
+			// match the selector, but after deletion and creation it will be
+			// recreated with the correct labels.
+			if err := s.cl.Delete(ctx, toDelete); err != nil {
+				return fmt.Errorf("failed to delete existing secret when creating license secret: %w", err)
+			}
+			return s.cl.Create(ctx, &secret)
 		}
-		return s.cl.Create(ctx, secret)
+		return nil
 	}
 
-	// Add label to mark that the secret is managed by KIC.
-	if secret.Labels == nil {
-		secret.Labels = map[string]string{}
-	}
-	secret.Labels[labels.ManagedByLabel] = labels.ManagedByLabelValueIngressController
-
-	secret.StringData = map[string]string{
-		secretKeyPayload:   l.Payload,
-		secretKeyUpdatedAt: strconv.FormatInt(l.UpdatedAt.Unix(), 10),
-		secretKeyID:        l.ID,
-	}
-	return s.cl.Update(ctx, secret)
+	s.setSecretLabels(&secret)
+	secret.StringData = licenseToSecretData(l)
+	return s.cl.Update(ctx, &secret)
 }
 
 // Load loads the license from the secret from secret `konnect-license-<cpid>`.
@@ -106,36 +116,66 @@ func (s *SecretLicenseStore) Load(
 		return license.KonnectLicense{}, err
 	}
 
-	requiredKeys := []string{secretKeyPayload, secretKeyID, secretKeyUpdatedAt}
+	return konnectLicenseFromSecret(secret)
+}
+
+func (s *SecretLicenseStore) setSecretLabels(secret *corev1.Secret) {
+	if secret == nil {
+		return
+	}
+
+	if secret.Labels == nil {
+		secret.Labels = map[string]string{}
+	}
+	// Add label to mark that the secret is managed by KIC.
+	secret.Labels[labels.ManagedByLabel] = labels.ManagedByLabelValueIngressController
+	maps.Copy(secret.Labels, s.secretLabelSelector)
+}
+
+var requiredSecretKeys = []string{secretKeyPayload, secretKeyID, secretKeyUpdatedAt}
+
+func konnectLicenseFromSecret(secret *corev1.Secret) (license.KonnectLicense, error) {
+	if secret == nil || secret.Data == nil {
+		return license.KonnectLicense{},
+			fmt.Errorf("secret %s doesn't contain data", secret.Name)
+	}
+
 	missingKeys := []string{}
-	for _, key := range requiredKeys {
-		if !lo.HasKey(secret.Data, key) {
+	for _, key := range requiredSecretKeys {
+		if v, ok := secret.Data[key]; !ok || len(v) == 0 {
 			missingKeys = append(missingKeys, key)
 		}
 	}
 	if len(missingKeys) > 0 {
-		return license.KonnectLicense{}, fmt.Errorf("missing required key(s): %s in secret %s", strings.Join(missingKeys, ","), secret.Name)
+		return license.KonnectLicense{},
+			fmt.Errorf(
+				"missing required key(s): %s in secret %s",
+				strings.Join(missingKeys, ", "), secret.Name,
+			)
 	}
 
-	decodedPayload, err := base64.StdEncoding.DecodeString(string(secret.Data[secretKeyPayload]))
+	payload := string(secret.Data[secretKeyPayload])
+	decodedID := string(secret.Data[secretKeyID])
+	decodedUpdateAt := string(secret.Data[secretKeyUpdatedAt])
+	updateAt, err := strconv.ParseInt(decodedUpdateAt, 10, 64)
 	if err != nil {
-		return license.KonnectLicense{}, fmt.Errorf("failed to decode payload of license stored in secret %s: %w", secret.Name, err)
-	}
-	decodedID, err := base64.StdEncoding.DecodeString(string(secret.Data[secretKeyID]))
-	if err != nil {
-		return license.KonnectLicense{}, fmt.Errorf("failed to decode id of license stored in secret %s: %w", secret.Name, err)
-	}
-	decodedUpdateAt, err := base64.StdEncoding.DecodeString(string(secret.Data[secretKeyUpdatedAt]))
-	if err != nil {
-		return license.KonnectLicense{}, fmt.Errorf("failed to decode updated_at of license stored in secret %s: %w", secret.Name, err)
-	}
-	updateAt, err := strconv.ParseInt(string(decodedUpdateAt), 10, 64)
-	if err != nil {
-		return license.KonnectLicense{}, fmt.Errorf("failed to parse updated_at as timestamp of license stored in secret %s: %w", secret.Name, err)
+		return license.KonnectLicense{},
+			fmt.Errorf(
+				"failed to parse updated_at as timestamp of license stored in secret %s: %w",
+				secret.Name, err,
+			)
 	}
 	return license.KonnectLicense{
-		Payload:   string(decodedPayload),
+		Payload:   payload,
 		UpdatedAt: time.Unix(updateAt, 0),
-		ID:        string(decodedID),
+		ID:        decodedID,
 	}, nil
+}
+
+func licenseToSecretData(l license.KonnectLicense) map[string]string {
+	return map[string]string{
+		secretKeyPayload:   l.Payload,
+		secretKeyUpdatedAt: strconv.FormatInt(l.UpdatedAt.Unix(), 10),
+		secretKeyID:        l.ID,
+	}
 }

--- a/ingress-controller/internal/konnect/license/storage_internal_test.go
+++ b/ingress-controller/internal/konnect/license/storage_internal_test.go
@@ -1,0 +1,165 @@
+package license
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kong-operator/v2/ingress-controller/internal/license"
+)
+
+func TestKonnectLicenseFromSecret(t *testing.T) {
+	timeNowUnix := time.Now().Unix()
+
+	testCases := []struct {
+		name            string
+		secret          *corev1.Secret
+		expectedLicense license.KonnectLicense
+		expectError     bool
+		expectedErrMsg  string
+	}{
+		{
+			name: "nil secret Data returns error",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-secret",
+				},
+			},
+			expectError:    true,
+			expectedErrMsg: "secret test-secret doesn't contain data",
+		},
+		{
+			name: "empty Data map returns error with all missing keys",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-secret",
+				},
+				Data: map[string][]byte{},
+			},
+			expectError:    true,
+			expectedErrMsg: "missing required key(s): payload, id, updated_at in secret test-secret",
+		},
+		{
+			name: "missing payload key",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-secret",
+				},
+				Data: map[string][]byte{
+					"id":         []byte("some-id"),
+					"updated_at": []byte(strconv.FormatInt(timeNowUnix, 10)),
+				},
+			},
+			expectError:    true,
+			expectedErrMsg: "missing required key(s): payload in secret test-secret",
+		},
+		{
+			name: "missing id key",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-secret",
+				},
+				Data: map[string][]byte{
+					"payload":    []byte("some-payload"),
+					"updated_at": []byte(strconv.FormatInt(timeNowUnix, 10)),
+				},
+			},
+			expectError:    true,
+			expectedErrMsg: "missing required key(s): id in secret test-secret",
+		},
+		{
+			name: "missing updated_at key",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-secret",
+				},
+				Data: map[string][]byte{
+					"payload": []byte("some-payload"),
+					"id":      []byte("some-id"),
+				},
+			},
+			expectError:    true,
+			expectedErrMsg: "missing required key(s): updated_at in secret test-secret",
+		},
+		{
+			name: "missing multiple keys",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-secret",
+				},
+				Data: map[string][]byte{
+					"payload": []byte("some-payload"),
+				},
+			},
+			expectError:    true,
+			expectedErrMsg: "missing required key(s): id, updated_at in secret test-secret",
+		},
+		{
+			name: "invalid updated_at value",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-secret",
+				},
+				Data: map[string][]byte{
+					"payload":    []byte("some-payload"),
+					"id":         []byte("some-id"),
+					"updated_at": []byte("not-a-number"),
+				},
+			},
+			expectError:    true,
+			expectedErrMsg: "failed to parse updated_at as timestamp of license stored in secret test-secret",
+		},
+		{
+			name: "valid secret returns license",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-secret",
+				},
+				Data: map[string][]byte{
+					"payload":    []byte("some-license-payload"),
+					"id":         []byte("some-license-id"),
+					"updated_at": []byte(strconv.FormatInt(timeNowUnix, 10)),
+				},
+			},
+			expectedLicense: license.KonnectLicense{
+				Payload:   "some-license-payload",
+				ID:        "some-license-id",
+				UpdatedAt: time.Unix(timeNowUnix, 0),
+			},
+		},
+		{
+			name: "secret with empty payload is invalid",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-secret",
+				},
+				Data: map[string][]byte{
+					"payload":    []byte(""),
+					"id":         []byte(""),
+					"updated_at": []byte("0"),
+				},
+			},
+			expectError:    true,
+			expectedErrMsg: "missing required key(s): payload, id in secret test-secret",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			l, err := konnectLicenseFromSecret(tc.secret)
+			if tc.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErrMsg)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedLicense, l)
+		})
+	}
+}

--- a/ingress-controller/internal/konnect/license/storage_test.go
+++ b/ingress-controller/internal/konnect/license/storage_test.go
@@ -13,8 +13,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	konnectlicense "github.com/kong/kong-operator/v2/ingress-controller/internal/konnect/license"
+	"github.com/kong/kong-operator/v2/ingress-controller/internal/labels"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/license"
 )
+
+var testLabelSelector = map[string]string{
+	"app": "konnect-license",
+}
 
 func TestSecretLicenseStore_Store(t *testing.T) {
 	testCases := []struct {
@@ -55,18 +60,19 @@ func TestSecretLicenseStore_Store(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cl := fake.NewClientBuilder().WithObjects(tc.secret).Build()
-			s := konnectlicense.NewSecretLicenseStore(cl, "default", "test-cp")
-			err := s.Store(t.Context(), tc.license)
-
-			require.NoError(t, err)
+			s := konnectlicense.NewSecretLicenseStore(cl, "default", "test-cp", testLabelSelector)
+			require.NoError(t, s.Store(t.Context(), tc.license))
 			secret := &corev1.Secret{}
-			err = cl.Get(t.Context(), client.ObjectKey{
+
+			err := cl.Get(t.Context(), client.ObjectKey{
 				Namespace: "default",
 				Name:      "konnect-license-test-cp",
 			}, secret)
 			require.NoError(t, err)
 			// fake client stores stringData of secret as-is.
 			require.Equal(t, tc.license.Payload, secret.StringData["payload"])
+			require.Equal(t, labels.ManagedByLabelValueIngressController, secret.Labels[labels.ManagedByLabel])
+			require.Equal(t, "konnect-license", secret.Labels["app"])
 		})
 	}
 }
@@ -87,9 +93,9 @@ func TestSecretLicenseStore_Load(t *testing.T) {
 					Namespace: "default",
 				},
 				Data: map[string][]byte{
-					"payload":    []byte(base64.StdEncoding.EncodeToString([]byte("some-license-payload"))),
-					"id":         []byte(base64.StdEncoding.EncodeToString([]byte("some-license-id"))),
-					"updated_at": []byte(base64.StdEncoding.EncodeToString([]byte(strconv.FormatInt(timeNowUnix, 10)))),
+					"payload":    []byte("some-license-payload"),
+					"id":         []byte("some-license-id"),
+					"updated_at": []byte(strconv.FormatInt(timeNowUnix, 10)),
 				},
 			},
 			license: license.KonnectLicense{
@@ -142,7 +148,7 @@ func TestSecretLicenseStore_Load(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cl := fake.NewClientBuilder().WithObjects(tc.secret).Build()
-			s := konnectlicense.NewSecretLicenseStore(cl, "default", "test-cp")
+			s := konnectlicense.NewSecretLicenseStore(cl, "default", "test-cp", testLabelSelector)
 
 			l, err := s.Load(t.Context())
 			if tc.expectError {

--- a/ingress-controller/internal/konnect/node_agent.go
+++ b/ingress-controller/internal/konnect/node_agent.go
@@ -17,8 +17,7 @@ import (
 )
 
 const (
-	MinRefreshNodePeriod     = 30 * time.Second
-	DefaultRefreshNodePeriod = 60 * time.Second
+	MinRefreshNodePeriod = 30 * time.Second
 )
 
 // GatewayInstance is a controlled kong gateway instance.

--- a/ingress-controller/internal/konnect/node_agent_test.go
+++ b/ingress-controller/internal/konnect/node_agent_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	testHostname = "ingress-0"
+	testHostname             = "ingress-0"
+	defaultRefreshNodePeriod = 60 * time.Second
 )
 
 var (
@@ -274,7 +275,7 @@ func TestNodeAgentUpdateNodes(t *testing.T) {
 			nodeAgent := konnect.NewNodeAgent(
 				testHostname,
 				testKOUserAgent,
-				konnect.DefaultRefreshNodePeriod,
+				defaultRefreshNodePeriod,
 				logr.Discard(),
 				nodeClient,
 				configStatusQueue,
@@ -342,7 +343,7 @@ func TestNodeAgent_StartDoesntReturnUntilContextGetsCancelled(t *testing.T) {
 	nodeAgent := konnect.NewNodeAgent(
 		testHostname,
 		testKOUserAgent,
-		konnect.DefaultRefreshNodePeriod,
+		defaultRefreshNodePeriod,
 		logr.Discard(),
 		nodeClient,
 		newMockConfigStatusNotifier(),
@@ -387,7 +388,7 @@ func TestNodeAgent_ControllerNodeStatusGetsUpdatedOnStatusNotification(t *testin
 	nodeAgent := konnect.NewNodeAgent(
 		testHostname,
 		testKOUserAgent,
-		konnect.DefaultRefreshNodePeriod,
+		defaultRefreshNodePeriod,
 		logr.Discard(),
 		nodeClient,
 		configStatusQueue,
@@ -489,7 +490,7 @@ func TestNodeAgent_ControllerNodeStatusGetsUpdatedOnlyWhenItChanges(t *testing.T
 	nodeAgent := konnect.NewNodeAgent(
 		testHostname,
 		testKOUserAgent,
-		konnect.DefaultRefreshNodePeriod,
+		defaultRefreshNodePeriod,
 		logr.Discard(),
 		nodeClient,
 		configStatusQueue,
@@ -528,7 +529,7 @@ func TestNodeAgent_ControllerNodeStatusGetsUpdatedOnlyWhenItChanges(t *testing.T
 }
 
 func TestNodeAgent_TickerResetsOnEveryNodesUpdate(t *testing.T) {
-	const halfOfRefreshPeriod = konnect.DefaultRefreshNodePeriod / 2
+	const halfOfRefreshPeriod = defaultRefreshNodePeriod / 2
 
 	t.Run("config status notification", func(t *testing.T) {
 		nodeClient := newMockNodeClient(nil)
@@ -539,7 +540,7 @@ func TestNodeAgent_TickerResetsOnEveryNodesUpdate(t *testing.T) {
 		nodeAgent := konnect.NewNodeAgent(
 			testHostname,
 			testKOUserAgent,
-			konnect.DefaultRefreshNodePeriod,
+			defaultRefreshNodePeriod,
 			logr.Discard(),
 			nodeClient,
 			configStatusQueue,
@@ -563,7 +564,7 @@ func TestNodeAgent_TickerResetsOnEveryNodesUpdate(t *testing.T) {
 		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() == 2 }, time.Second, time.Microsecond)
 
 		t.Log("trigger update with ticker")
-		ticker.Add(konnect.DefaultRefreshNodePeriod)
+		ticker.Add(defaultRefreshNodePeriod)
 		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() > 2 }, time.Second, time.Microsecond)
 	})
 
@@ -576,7 +577,7 @@ func TestNodeAgent_TickerResetsOnEveryNodesUpdate(t *testing.T) {
 		nodeAgent := konnect.NewNodeAgent(
 			testHostname,
 			testKOUserAgent,
-			konnect.DefaultRefreshNodePeriod,
+			defaultRefreshNodePeriod,
 			logr.Discard(),
 			nodeClient,
 			configStatusQueue,
@@ -599,7 +600,7 @@ func TestNodeAgent_TickerResetsOnEveryNodesUpdate(t *testing.T) {
 		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() == 2 }, time.Second, time.Microsecond)
 
 		t.Log("trigger update with ticker")
-		ticker.Add(konnect.DefaultRefreshNodePeriod)
+		ticker.Add(defaultRefreshNodePeriod)
 		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() == 3 }, time.Second, time.Microsecond)
 	})
 }

--- a/ingress-controller/internal/logging/setup.go
+++ b/ingress-controller/internal/logging/setup.go
@@ -8,20 +8,18 @@ import (
 	"github.com/go-logr/zapr"
 	kongdbreconciler "github.com/kong/go-database-reconciler/pkg/cprint"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
-
-	managercfg "github.com/kong/kong-operator/v2/ingress-controller/pkg/manager/config"
 )
 
 // SetupLoggers sets up the loggers for the controller manager.
-func SetupLoggers(c managercfg.Config, output io.Writer) (logr.Logger, error) {
-	zapBase, err := makeLogger(c.LogLevel, c.LogFormat, output)
+func SetupLoggers(logLevel string, logFormat string, output io.Writer) (logr.Logger, error) {
+	zapBase, err := makeLogger(logLevel, logFormat, output)
 	if err != nil {
 		return logr.Logger{}, fmt.Errorf("failed to make logger: %w", err)
 	}
 	logger := zapr.NewLoggerWithOptions(zapBase, zapr.LogInfoLevel("v"))
 
 	// It's specific for the Kong Ingress Controller.
-	if c.LogLevel != "trace" && c.LogLevel != "debug" {
+	if logLevel != "trace" && logLevel != "debug" {
 		// Disable deck's per-change diff output
 		kongdbreconciler.DisableOutput = true
 	}

--- a/ingress-controller/internal/manager/setup.go
+++ b/ingress-controller/internal/manager/setup.go
@@ -444,7 +444,7 @@ func setupLicenseGetter(
 				return nil, err
 			}
 			licenseStore := konnectLicense.NewSecretLicenseStore(
-				mgr.GetClient(), nn.Namespace, c.Konnect.ControlPlaneID,
+				mgr.GetClient(), nn.Namespace, c.Konnect.ControlPlaneID, c.SecretLabelSelector,
 			)
 			konnectLicenseAPIClient.WithLicenseStore(licenseStore)
 			konnectLicenseAPIClient = konnectLicenseAPIClient.WithLicenseStore(licenseStore)

--- a/ingress-controller/pkg/manager/config/config.go
+++ b/ingress-controller/pkg/manager/config/config.go
@@ -140,25 +140,7 @@ func NewConfig(opts ...Opt) Config {
 		// SIGTERM or SIGINT signal delay
 		TermDelay: 0,
 
-		// Konnect - all disabled by default
-		Konnect: KonnectConfig{
-			ConfigSynchronizationEnabled:  false,
-			LicenseSynchronizationEnabled: false,
-			LicenseStorageEnabled:         true,
-			InitialLicensePollingPeriod:   time.Minute,    // license.DefaultInitialPollingPeriod,
-			LicensePollingPeriod:          12 * time.Hour, // license.DefaultPollingPeriod
-			ControlPlaneID:                "",
-			Address:                       "https://us.kic.api.konghq.com",
-			TLSClient: TLSClientConfig{
-				Cert:     "",
-				CertFile: "",
-				Key:      "",
-				KeyFile:  "",
-			},
-			UploadConfigPeriod:    DefaultKonnectConfigUploadPeriod,
-			RefreshNodePeriod:     60 * time.Second, // konnect.DefaultRefreshNodePeriod
-			ConsumersSyncDisabled: false,
-		},
+		Konnect: DefaultKonnectConfig(),
 
 		// Telemetry settings - defaults
 		SplunkEndpoint:                   "",

--- a/ingress-controller/pkg/manager/config/config_test.go
+++ b/ingress-controller/pkg/manager/config/config_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/annotations"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/controllers/gateway"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/dataplane"
-	"github.com/kong/kong-operator/v2/ingress-controller/internal/konnect"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/license"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/manager/consts"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/util/kubernetes/object/status"
@@ -111,7 +110,7 @@ func TestNewConfig(t *testing.T) {
 				LicensePollingPeriod:        license.DefaultPollingPeriod,
 				LicenseStorageEnabled:       true,
 				UploadConfigPeriod:          managercfg.DefaultKonnectConfigUploadPeriod,
-				RefreshNodePeriod:           konnect.DefaultRefreshNodePeriod,
+				RefreshNodePeriod:           managercfg.DefaultKonnectNodeRefreshPeriod,
 			},
 			SplunkEndpoint:                   "",
 			SplunkEndpointInsecureSkipVerify: false,

--- a/ingress-controller/pkg/manager/config/consts.go
+++ b/ingress-controller/pkg/manager/config/consts.go
@@ -25,6 +25,8 @@ const (
 	MinKonnectConfigUploadPeriod = 10 * time.Second
 	// DefaultKonnectConfigUploadPeriod is the default period between operations to upload Kong configuration to Konnect.
 	DefaultKonnectConfigUploadPeriod = 30 * time.Second
+	// DefaultKonnectNodeRefreshPeriod is the default period between operations to refresh node in Konnect.
+	DefaultKonnectNodeRefreshPeriod = 60 * time.Second
 )
 
 const (

--- a/ingress-controller/pkg/manager/config/konnect.go
+++ b/ingress-controller/pkg/manager/config/konnect.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"time"
+
+	"github.com/kong/kong-operator/v2/ingress-controller/internal/license"
 )
 
 type KonnectConfig struct {
@@ -20,4 +22,26 @@ type KonnectConfig struct {
 	LicensePollingPeriod          time.Duration
 	LicenseStorageEnabled         bool
 	ConsumersSyncDisabled         bool
+}
+
+// DefaultKonnectConfig returns a KonnectConfig with default values for all fields.
+func DefaultKonnectConfig() KonnectConfig {
+	return KonnectConfig{
+		ConfigSynchronizationEnabled:  false,
+		LicenseSynchronizationEnabled: false,
+		LicenseStorageEnabled:         true,
+		InitialLicensePollingPeriod:   license.DefaultInitialPollingPeriod,
+		LicensePollingPeriod:          license.DefaultPollingPeriod,
+		ControlPlaneID:                "",
+		Address:                       "https://us.kic.api.konghq.com",
+		TLSClient: TLSClientConfig{
+			Cert:     "",
+			CertFile: "",
+			Key:      "",
+			KeyFile:  "",
+		},
+		UploadConfigPeriod:    DefaultKonnectConfigUploadPeriod,
+		RefreshNodePeriod:     DefaultKonnectNodeRefreshPeriod,
+		ConsumersSyncDisabled: false,
+	}
 }

--- a/ingress-controller/test/util/controller_manager.go
+++ b/ingress-controller/test/util/controller_manager.go
@@ -166,12 +166,8 @@ func SetupLoggers(logLevel string, logFormat string) (logr.Logger, string, error
 			return logr.Logger{}, logOutput, err
 		}
 	}
-	config := managercfg.Config{
-		LogLevel:  logLevel,
-		LogFormat: logFormat,
-	}
 
-	logger, err := logging.SetupLoggers(config, output)
+	logger, err := logging.SetupLoggers(logLevel, logFormat, output)
 	// Prevents controller-runtime from logging
 	// [controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
 	return logger, "", err


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix operator restart (after or during no Konnect connectivity) causing `ControlPlane` to send an empty config to `DataPlane` pods, causing them to return 404 responses for several seconds until the K8s informer cache fully populates.

This PR addresses several distinct issues discovered during investigation:

### 1. Empty config push on restart (main fix)

**Root cause:** On the first synchronizer tick after operator restart, `Update()` calls
`TryFetchingValidConfigFromGateways` which successfully fetches the existing valid config
from the gateway (services, routes, upstreams), then proceeds unconditionally to
`BuildKongConfig()` which produces an empty KongState because the K8s informer cache
hasn't synced HTTPRoute objects yet. This empty config is pushed via `POST /config`,
wiping all routes and causing 404s for ~3 seconds until the next tick pushes the real
config.

**Fix:**

- Added `KongState.IsEmpty()` method that checks whether the state has any meaningful
  routing entities (services, upstreams, certificates, plugins, consumers, etc.).
  Licenses are deliberately excluded — a state with only a license is still "empty"
  from a routing perspective.
- Added a guard in `KongClient.Update()` between `BuildKongConfig()` and
  `sendOutToGatewayClients()`: if the new config is empty but a previously fetched
  valid config exists with real entities, the push is skipped. This is checked only once to allow sending empty configs afterwards.

### 2. Double base64 decode bug in license storage

**Root cause:** `Store()` uses `StringData` (Kubernetes auto-base64-encodes for storage),
but `Load()` reads from `secret.Data` (Kubernetes client auto-decodes) and then tries
`base64.StdEncoding.DecodeString()` again, causing `"illegal base64 data at input byte 0"`.
The existing test masked this by manually pre-encoding `Data` values.

**Fix:** Removed the redundant `base64.StdEncoding.DecodeString()` calls in `Load()`.
Fixed the test to use raw (non-encoded) values in `Data`, matching real Kubernetes
behavior. Added comprehensive `storage_internal_test.go` covering edge cases.

### 3. Hardcoded Konnect config in `ControlPlane`'s config

**Root cause:** `kicInKonnectDefaults()` in `controlplane.go` hardcoded its own polling
periods instead of using the shared defaults:

| Setting | Was (hardcoded) | Now (from defaults) |
|---|---|---|
| `UploadConfigPeriod` | 10s | 30s (`DefaultKonnectConfigUploadPeriod`) |
| `InitialLicensePollingPeriod` | 10s | 1m (`license.DefaultInitialPollingPeriod`) |
| `LicensePollingPeriod` | 10s | 12h (`license.DefaultPollingPeriod`) |
| `RefreshNodePeriod` | *(was missing)* | 60s (`DefaultKonnectNodeRefreshPeriod`) |

**Fix:** Extracted `DefaultKonnectConfig()` constructor in the config package and use it
in both `NewConfig()` and `kicInKonnectDefaults()`, ensuring a single source of truth
for all default values. Moved `DefaultRefreshNodePeriod` from the `konnect` package to
`config.DefaultKonnectNodeRefreshPeriod` for consistency.

### 4. Adding missing `Secret` label selector `SecretLicenseStore`

`SecretLicenseStore` now accepts a `secretLabelSelector` parameter, allowing the
operator to set custom labels on the license `Secret`.
The `Secret` label selector has been set to non empty value in KO 2.0 but `SecretLicenseStore` has not accounted for that change. This resulted in it not seeing the license `Secret`s.

This prevented it from creating or getting the license `Secret` from the cluster (when license storage was enabled).

License storage `Store()` handles `AlreadyExists` on create by deleting and
recreating the Secret (to enforce correct label selectors on pre-existing Secrets).

### 5. License storage was not enabled by default for `ControlPlane`s

Default config for `ControlPlane` [did include license storage set to `true`](https://github.com/Kong/kong-operator/blob/32fde06a1e38e90f7ba13d82b4fa72178da3cb9c/ingress-controller/pkg/manager/config/config.go#L147) but options for this config (based on `ControlPlane` spec) constructed with `constructControlPlaneManagerConfigOptions` where completely overriding it in https://github.com/Kong/kong-operator/blob/5dce811c807ddb7a7da11ea65ee4e028ee2f094d/controller/controlplane/manager_options.go#L565-L567 from options set by the extension processor (which did not include the license storage option enabled): https://github.com/Kong/kong-operator/blob/5dce811c807ddb7a7da11ea65ee4e028ee2f094d/controller/pkg/extensions/konnect/controlplane.go#L84-L112

Extracting the defaults `DefaultKonnectConfig` (as mentioned above) fixes that issue.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

FTI-7364.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
