### PR TITLE
fix: fix deckgen not generating certificate tags

### DIFF
--- a/ingress-controller/internal/dataplane/deckgen/deckgen.go
+++ b/ingress-controller/internal/dataplane/deckgen/deckgen.go
@@ -43,6 +43,7 @@ func GetFCertificateFromKongCert(inmemory bool, kongCert kong.Certificate) file.
 	if kongCert.Cert != nil {
 		res.Cert = new(*kongCert.Cert)
 	}
+	res.Tags = kongCert.Tags
 	res.SNIs = getCertsSNIs(inmemory, kongCert)
 	return res
 }

--- a/ingress-controller/internal/dataplane/deckgen/deckgen_test.go
+++ b/ingress-controller/internal/dataplane/deckgen/deckgen_test.go
@@ -32,12 +32,14 @@ func TestGetFCertificateFromKongCert(t *testing.T) {
 				ID:   new("cert-id"),
 				Key:  new("cert-key"),
 				Cert: new("cert-pem"),
+				Tags: kong.StringSlice("k8s-name:secret1", "k8s-namespace:default"),
 				SNIs: []*string{new("example.com"), new("other.com")},
 			},
 			want: file.FCertificate{
 				ID:   new("cert-id"),
 				Key:  new("cert-key"),
 				Cert: new("cert-pem"),
+				Tags: kong.StringSlice("k8s-name:secret1", "k8s-namespace:default"),
 				SNIs: []kong.SNI{
 					{Name: new("example.com")},
 					{Name: new("other.com")},
@@ -51,12 +53,14 @@ func TestGetFCertificateFromKongCert(t *testing.T) {
 				ID:   new("cert-id"),
 				Key:  new("cert-key"),
 				Cert: new("cert-pem"),
+				Tags: kong.StringSlice("k8s-name:secret1", "k8s-namespace:default"),
 				SNIs: []*string{new("example.com")},
 			},
 			want: file.FCertificate{
 				ID:   new("cert-id"),
 				Key:  new("cert-key"),
 				Cert: new("cert-pem"),
+				Tags: kong.StringSlice("k8s-name:secret1", "k8s-namespace:default"),
 				SNIs: []kong.SNI{
 					{
 						Name:        new("example.com"),

--- a/ingress-controller/internal/dataplane/deckgen/generate_test.go
+++ b/ingress-controller/internal/dataplane/deckgen/generate_test.go
@@ -46,6 +46,38 @@ func TestToDeckContent(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:   "certificate tags are preserved in rendered content",
+			params: GenerateDeckContentParams{},
+			input: &kongstate.KongState{
+				Certificates: []kongstate.Certificate{
+					{
+						Certificate: kong.Certificate{
+							ID:   new("cert-id"),
+							Cert: new("cert-pem"),
+							Key:  new("cert-key"),
+							Tags: kong.StringSlice("k8s-name:secret1", "k8s-namespace:default", "k8s-uid:uid-1"),
+							SNIs: kong.StringSlice("example.com"),
+						},
+					},
+				},
+			},
+			expected: &file.Content{
+				FormatVersion: versions.DeckFileFormatVersion,
+				Certificates: []file.FCertificate{
+					{
+						ID:   new("cert-id"),
+						Cert: new("cert-pem"),
+						Key:  new("cert-key"),
+						Tags: kong.StringSlice("k8s-name:secret1", "k8s-namespace:default", "k8s-uid:uid-1"),
+						SNIs: []kong.SNI{{
+							Name:        new("example.com"),
+							Certificate: &kong.Certificate{ID: new("cert-id")},
+						}},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer-ee/default_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer-ee/default_golden.yaml
@@ -33,6 +33,12 @@ certificates:
   snis:
   - name: 1.example.com
   - name: 2.example.com
+  tags:
+  - k8s-name:sooper-secret
+  - k8s-namespace:bar-namespace
+  - k8s-kind:Secret
+  - k8s-uid:c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+  - k8s-version:v1
 consumers:
 - basicauth_credentials:
   - password: consumer-1-password

--- a/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer-ee/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer-ee/expression-routes-on_golden.yaml
@@ -33,6 +33,12 @@ certificates:
   snis:
   - name: 1.example.com
   - name: 2.example.com
+  tags:
+  - k8s-name:sooper-secret
+  - k8s-namespace:bar-namespace
+  - k8s-kind:Secret
+  - k8s-uid:c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+  - k8s-version:v1
 consumers:
 - basicauth_credentials:
   - password: consumer-1-password

--- a/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls/default_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls/default_golden.yaml
@@ -33,6 +33,12 @@ certificates:
   snis:
   - name: 3.example.com
   - name: 4.example.com
+  tags:
+  - k8s-name:sooper-secret2
+  - k8s-namespace:bar-namespace
+  - k8s-kind:Secret
+  - k8s-uid:8aade13c-1470-46bd-9849-9a74e349214f
+  - k8s-version:v1
 - cert: |-
     -----BEGIN CERTIFICATE-----
     MIIBoTCCAQoCCQC/V5OfTXu7xDANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApr
@@ -66,6 +72,12 @@ certificates:
   snis:
   - name: 1.example.com
   - name: 2.example.com
+  tags:
+  - k8s-name:sooper-secret
+  - k8s-namespace:bar-namespace
+  - k8s-kind:Secret
+  - k8s-uid:c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+  - k8s-version:v1
 services:
 - connect_timeout: 60000
   host: foo-svc.bar-namespace.80.svc

--- a/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_golden.yaml
@@ -33,6 +33,12 @@ certificates:
   snis:
   - name: 3.example.com
   - name: 4.example.com
+  tags:
+  - k8s-name:sooper-secret2
+  - k8s-namespace:bar-namespace
+  - k8s-kind:Secret
+  - k8s-uid:8aade13c-1470-46bd-9849-9a74e349214f
+  - k8s-version:v1
 - cert: |-
     -----BEGIN CERTIFICATE-----
     MIIBoTCCAQoCCQC/V5OfTXu7xDANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApr
@@ -66,6 +72,12 @@ certificates:
   snis:
   - name: 1.example.com
   - name: 2.example.com
+  tags:
+  - k8s-name:sooper-secret
+  - k8s-namespace:bar-namespace
+  - k8s-kind:Secret
+  - k8s-uid:c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+  - k8s-version:v1
 services:
 - connect_timeout: 60000
   host: foo-svc.bar-namespace.80.svc


### PR DESCRIPTION
**What this PR does / why we need it**:

Failures noticed in integration tests:

```
2026-03-17T11:52:01.4703341Z 2026-03-17T11:52:01Z	error	API error returned from the gateway for an entity is missing Kubernetes metadata in tags, Kubernetes Event won't be created	{"name": "", "id": "b579b7d4-75aa-4975-98bb-88ff5e804b17", "tags": [], "type": "certificate", "raw_error": {"entity_id":"b579b7d4-75aa-4975-98bb-88ff5e804b17","entity_type":"certificate","errors":[{"message":"required field missing","type":"entity"}]}, "error": "resource error has no name tag"}
2026-03-17T11:52:01.4708784Z 2026-03-17T11:52:01Z	error	API error returned from the gateway for an entity is missing Kubernetes metadata in tags, Kubernetes Event won't be created	{"name": "", "id": "b579b7d4-75aa-4975-98bb-88ff5e804b17", "tags": [], "type": "certificate", "raw_error": {"entity_id":"b579b7d4-75aa-4975-98bb-88ff5e804b17","entity_type":"certificate","errors":[{"message":"required field missing","type":"entity"}]}, "error": "resource error has no name tag"}
2026-03-17T11:52:01.4714483Z 2026-03-17T11:52:01Z	error	API error returned from the gateway for an entity is missing Kubernetes metadata in tags, Kubernetes Event won't be created	{"name": "", "id": "8170113e-d1af-4cae-bbd0-a6f159b1111e", "tags": [], "type": "certificate", "raw_error": {"entity_id":"8170113e-d1af-4cae-bbd0-a6f159b1111e","entity_type":"certificate","errors":[{"message":"required field missing","type":"entity"}]}, "error": "resource error has no name tag"}
2026-03-17T11:52:01.4718025Z 2026-03-17T11:52:01Z	debug	Shipping config to diagnostic server	{"url": "http://172.18.128.1:8001", "v": 1}
2026-03-17T11:52:01.4719460Z 2026-03-17T11:52:01Z	debug	controllers.KongLicense	No KongLicense available	{"v": 1}
2026-03-17T11:52:01.4720722Z 2026-03-17T11:52:01Z	debug	Sending configuration to gateway clients	{"v": 1, "urls": ["http://172.18.128.1:8001"]}
2026-03-17T11:52:01.4785694Z 2026-03-17T11:52:01Z	debug	No configuration change, skipping sync to Kong	{"url": "http://172.18.128.1:8001", "v": 1}
2026-03-17T11:52:01.4787209Z 2026-03-17T11:52:01Z	debug	Shipping config to diagnostic server	{"url": "http://172.18.128.1:8001", "v": 1}
2026-03-17T11:52:01.4788722Z 2026-03-17T11:52:01Z	debug	Due to errors in the current config, the last valid config has been pushed to Gateways	{"v": 1}
2026-03-17T11:52:01.4790209Z 2026-03-17T11:52:01Z	error	dataplane-synchronizer	Could not update kong admin	{"error": "performing update for http://172.18.128.1:8001 failed: HTTP status 400 (message: \"failed posting new config to /config\")"}
2026-03-17T11:52:01.6935368Z === NAME  TestHTTPSIngress
2026-03-17T11:52:01.6936391Z     ingress_https_test.go:281: 
2026-03-17T11:52:01.6938972Z         	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/integration/kic/ingress_https_test.go:281
2026-03-17T11:52:01.6940392Z         	Error:      	Condition never satisfied
2026-03-17T11:52:01.6941523Z         	Test:       	TestHTTPSIngress
2026-03-17T11:52:01.6943665Z     ingress_https_test.go:292: confirm Ingress still routes with matching SNI
2026-03-17T11:52:01.7027970Z     setup.go:34: Start cleanup for test TestHTTPSIngress
2026-03-17T11:52:01.7079957Z === NAME  TestIngressEssentials
2026-03-17T11:52:01.7082117Z     http.go:186: 
2026-03-17T11:52:01.7084481Z         	Error Trace:	/home/runner/work/kong-operator/kong-operator/ingress-controller/test/helpers/http.go:153
2026-03-17T11:52:01.7086547Z         	            				/opt/hostedtoolcache/go/1.26.1/x64/src/runtime/asm_amd64.s:1771
2026-03-17T11:52:01.7087501Z         	Error:      	Not equal: 
2026-03-17T11:52:01.7088211Z         	            	expected: 404
2026-03-17T11:52:01.7088644Z         	            	actual  : 200
2026-03-17T11:52:01.7089166Z     http.go:186: 
2026-03-17T11:52:01.7090286Z         	Error Trace:	/home/runner/work/kong-operator/kong-operator/ingress-controller/test/helpers/http.go:146
2026-03-17T11:52:01.7092153Z         	            				/home/runner/work/kong-operator/kong-operator/ingress-controller/test/helpers/http.go:186
2026-03-17T11:52:01.7094683Z         	            				/home/runner/work/kong-operator/kong-operator/test/helpers/kic_wrappers.go:102
2026-03-17T11:52:01.7098760Z         	            				/home/runner/work/kong-operator/kong-operator/test/integration/kic/ingress_test.go:114
2026-03-17T11:52:01.7100922Z         	Error:      	Condition never satisfied
2026-03-17T11:52:01.7101628Z         	Test:       	TestIngressEssentials
2026-03-17T11:52:01.7102890Z     setup.go:34: Start cleanup for test TestIngressEssentials
2026-03-17T11:52:01.7346377Z === NAME  TestConsumerCredential
2026-03-17T11:52:01.7347038Z     consumer_test.go:143: 
2026-03-17T11:52:01.7348392Z         	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/integration/kic/consumer_test.go:143
2026-03-17T11:52:01.7349449Z         	Error:      	Condition never satisfied
2026-03-17T11:52:01.7350177Z         	Test:       	TestConsumerCredential
2026-03-17T11:52:01.7354887Z     consumer_test.go:154: updating credential to confirm references update store copy
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
