### PR TITLE
[Backport release/2.0.x] fix: fix requeue of KonnectAPIAuthConfiguration when there was an error calling organizations endpoint (#3611)

### DIFF
--- a/controller/consts/requeue.go
+++ b/controller/consts/requeue.go
@@ -5,4 +5,9 @@ import "time"
 const (
 	// RequeueWithoutBackoff is the time after which the controller should requeue the request.
 	RequeueWithoutBackoff = time.Millisecond * 200
+
+	// RequeueWithBackoff is the time after which the controller should requeue the request with backoff.
+	// This is useful to avoid requeuing the request too frequently in case of
+	// e.g. external system errors.
+	RequeueWithBackoff = time.Second * 3
 )

--- a/controller/konnect/reconciler_konnectapiauth.go
+++ b/controller/konnect/reconciler_konnectapiauth.go
@@ -19,6 +19,7 @@ import (
 
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/v2/api/konnect/v1alpha1"
 
+	ctrlconsts "github.com/kong/kong-operator/v2/controller/consts"
 	sdkops "github.com/kong/kong-operator/v2/controller/konnect/ops/sdk"
 	"github.com/kong/kong-operator/v2/controller/konnect/server"
 	"github.com/kong/kong-operator/v2/controller/pkg/log"
@@ -186,9 +187,14 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 				return ctrl.Result{}, errUpdate
 			}
 
-			return ctrl.Result{}, nil
+			// Requeue with backoff to avoid spamming the API if there is
+			// a persistent issue with the token, server URL or connectivity.
+			return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithBackoff}, nil
 		}
-		return ctrl.Result{}, nil
+
+		// Requeue with backoff to avoid spamming the API if there is
+		// a persistent issue with the token, server URL or connectivity.
+		return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithBackoff}, nil
 	}
 
 	// Update the status only if it would change to prevent unnecessary updates.

--- a/test/envtest/konnect_entities_konnectapiauthconfiguration_test.go
+++ b/test/envtest/konnect_entities_konnectapiauthconfiguration_test.go
@@ -17,12 +17,10 @@ import (
 
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/v2/api/konnect/v1alpha1"
 
-	ctrlconsts "github.com/kong/kong-operator/v2/controller/consts"
 	"github.com/kong/kong-operator/v2/controller/konnect"
 	"github.com/kong/kong-operator/v2/modules/manager/logging"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
-	"github.com/kong/kong-operator/v2/test/helpers"
 	"github.com/kong/kong-operator/v2/test/helpers/deploy"
 	"github.com/kong/kong-operator/v2/test/mocks/sdkmocks"
 )
@@ -186,14 +184,14 @@ func TestKonnectAPIAuthConfiguration(t *testing.T) {
 			Return(
 				&sdkkonnectops.GetOrganizationsMeResponse{
 					MeOrganization: &sdkkonnectcomp.MeOrganization{
-						ID:   new("12345"),
-						Name: new("org-12345"),
+						ID:   lo.ToPtr("12345"),
+						Name: lo.ToPtr("org-12345"),
 					},
 				},
 				nil,
 			)
 		t.Log("Waiting for KonnectAPIAuthConfiguration to be APIAuthValid=true after no error is returned now")
-		helpers.WatchFor(t, ctx, w.WatchI(), apiwatch.Modified, 2*ctrlconsts.RequeueWithBackoff,
+		watchFor(t, ctx, w, apiwatch.Modified,
 			func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
 				return client.ObjectKeyFromObject(r) == client.ObjectKeyFromObject(apiAuth) &&
 					k8sutils.HasConditionTrue("APIAuthValid", r)

--- a/test/envtest/konnect_entities_konnectapiauthconfiguration_test.go
+++ b/test/envtest/konnect_entities_konnectapiauthconfiguration_test.go
@@ -1,7 +1,9 @@
 package envtest
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
@@ -15,10 +17,12 @@ import (
 
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/v2/api/konnect/v1alpha1"
 
+	ctrlconsts "github.com/kong/kong-operator/v2/controller/consts"
 	"github.com/kong/kong-operator/v2/controller/konnect"
 	"github.com/kong/kong-operator/v2/modules/manager/logging"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+	"github.com/kong/kong-operator/v2/test/helpers"
 	"github.com/kong/kong-operator/v2/test/helpers/deploy"
 	"github.com/kong/kong-operator/v2/test/mocks/sdkmocks"
 )
@@ -149,5 +153,52 @@ func TestKonnectAPIAuthConfiguration(t *testing.T) {
 			return client.ObjectKeyFromObject(r) == client.ObjectKeyFromObject(apiAuth) &&
 				k8sutils.HasConditionFalse("APIAuthValid", r)
 		}, "KonnectAPIAuthConfiguration didn't get APIAuthValid status condition set to false")
+	})
+
+	t.Run("when calling Konnect API fails, reconciliation is requeued and status is updated", func(t *testing.T) {
+		call = call.
+			Return(
+				nil,
+				errors.New("some error"),
+			)
+
+		w := setupWatch[konnectv1alpha1.KonnectAPIAuthConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
+		apiAuth := deploy.KonnectAPIAuthConfiguration(t, ctx, clientNamespaced)
+		t.Cleanup(func() { assert.NoError(t, cl.Delete(ctx, apiAuth)) })
+
+		t.Log("Waiting for KonnectAPIAuthConfiguration to be APIAuthValid=false")
+		watchFor(t, ctx, w, apiwatch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
+			return client.ObjectKeyFromObject(r) == client.ObjectKeyFromObject(apiAuth) &&
+				k8sutils.HasConditionFalse("APIAuthValid", r)
+		}, "KonnectAPIAuthConfiguration didn't get APIAuthValid status condition set to false")
+
+		// Wait for a bit to allow the controller to requeue the reconciliation after
+		// the status update. Otherwise we'd pass the test because the status update
+		// would triggered another reconciliation.
+		// This is not what we want to test here.
+		// We want a time based requeue to happen and to verify it here.
+		select {
+		case <-t.Context().Done():
+		case <-time.After(500 * time.Millisecond):
+		}
+
+		call = call.
+			Return(
+				&sdkkonnectops.GetOrganizationsMeResponse{
+					MeOrganization: &sdkkonnectcomp.MeOrganization{
+						ID:   new("12345"),
+						Name: new("org-12345"),
+					},
+				},
+				nil,
+			)
+		t.Log("Waiting for KonnectAPIAuthConfiguration to be APIAuthValid=true after no error is returned now")
+		helpers.WatchFor(t, ctx, w.WatchI(), apiwatch.Modified, 2*ctrlconsts.RequeueWithBackoff,
+			func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
+				return client.ObjectKeyFromObject(r) == client.ObjectKeyFromObject(apiAuth) &&
+					k8sutils.HasConditionTrue("APIAuthValid", r)
+			},
+			"KonnectAPIAuthConfiguration didn't get APIAuthValid status condition set to true",
+		)
 	})
 }


### PR DESCRIPTION
Backport e6534dd5d1a8650c387e8f7ff650d768edbb7631 from #3611.