### PR TITLE
chore(ci): use consistently `KONG_TEST_KONNECT_ACCESS_TOKEN` everywhere

### DIFF
--- a/.github/workflows/__kongintegration_tests.yaml
+++ b/.github/workflows/__kongintegration_tests.yaml
@@ -89,7 +89,7 @@ jobs:
         env:
           GOTESTSUM_JUNITFILE: ${{ env.GOTESTSUM_JUNITFILE }}
           KONG_CUSTOM_DOMAIN: konghq.tech
-          TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
+          KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
           TEST_KONG_ENTERPRISE: ${{ matrix.enterprise }}
 

--- a/ingress-controller/test/helpers/konnect/access.go
+++ b/ingress-controller/test/helpers/konnect/access.go
@@ -1,25 +1,10 @@
 package konnect
 
 import (
-	"os"
-	"testing"
-
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/test"
 )
-
-// SkipIfMissingRequiredKonnectEnvVariables skips the test if the required Konnect environment variables are missing.
-func SkipIfMissingRequiredKonnectEnvVariables(t *testing.T) {
-	if accessToken() == "" {
-		t.Skip("missing TEST_KONG_KONNECT_ACCESS_TOKEN")
-	}
-}
-
-// accessToken returns the access token to be used for Konnect API requests.
-func accessToken() string {
-	return os.Getenv("TEST_KONG_KONNECT_ACCESS_TOKEN")
-}
 
 // konnectControlPlaneAdminAPIBaseURL returns the base URL for Konnect Control Plane Admin API.
 // NOTE: This is a temporary solution until we migrate all the Konnect API calls to the new SDK.

--- a/ingress-controller/test/helpers/konnect/certificates.go
+++ b/ingress-controller/test/helpers/konnect/certificates.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/konnect/sdk"
+	"github.com/kong/kong-operator/v2/test"
 	"github.com/kong/kong-operator/v2/test/helpers/certificate"
 )
 
@@ -37,7 +38,7 @@ func CreateClientCertificate(ctx context.Context, t *testing.T, cpID string, tok
 
 	var s *sdkkonnectgo.SDK
 	if len(token) == 0 {
-		s = sdk.New(accessToken(), serverURLOpt(), retryConfig)
+		s = sdk.New(test.KonnectAccessToken(), serverURLOpt(), retryConfig)
 	} else {
 		s = sdk.New(token[0], serverURLOpt(), retryConfig)
 	}

--- a/ingress-controller/test/helpers/konnect/control_plane.go
+++ b/ingress-controller/test/helpers/konnect/control_plane.go
@@ -20,6 +20,7 @@ import (
 	managercfg "github.com/kong/kong-operator/v2/ingress-controller/pkg/manager/config"
 	"github.com/kong/kong-operator/v2/ingress-controller/test"
 	"github.com/kong/kong-operator/v2/ingress-controller/test/testenv"
+	testhelpers "github.com/kong/kong-operator/v2/test"
 	"github.com/kong/kong-operator/v2/test/helpers/deploy"
 )
 
@@ -32,7 +33,7 @@ func CreateTestControlPlane(ctx context.Context, t *testing.T, token ...string) 
 
 	var s *sdkkonnectgo.SDK
 	if len(token) == 0 {
-		s = sdk.New(accessToken(), serverURLOpt())
+		s = sdk.New(testhelpers.KonnectAccessToken(), serverURLOpt())
 	} else {
 		s = sdk.New(token[0], serverURLOpt())
 	}

--- a/ingress-controller/test/helpers/konnect/personal_access_tokens.go
+++ b/ingress-controller/test/helpers/konnect/personal_access_tokens.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/konnect/sdk"
+	testhelpers "github.com/kong/kong-operator/v2/test"
 )
 
 // CreateTestPersonalAccessToken creates a personal access token for the user
@@ -23,7 +24,7 @@ import (
 func CreateTestPersonalAccessToken(ctx context.Context, t *testing.T) string {
 	t.Helper()
 
-	s := sdk.New(accessToken(), serverURLOpt())
+	s := sdk.New(testhelpers.KonnectAccessToken(), serverURLOpt())
 
 	me, err := s.Me.GetUsersMe(ctx)
 	require.NoError(t, err)

--- a/ingress-controller/test/helpers/konnect/system_account_tokens.go
+++ b/ingress-controller/test/helpers/konnect/system_account_tokens.go
@@ -13,12 +13,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/konnect/sdk"
+	testhelpers "github.com/kong/kong-operator/v2/test"
 )
 
 func CreateTestSystemAccountToken(ctx context.Context, t *testing.T, systemAccountID string) (string, string) {
 	t.Helper()
 
-	s := sdk.New(accessToken(), serverURLOpt())
+	s := sdk.New(testhelpers.KonnectAccessToken(), serverURLOpt())
 
 	var (
 		systemAccountToken     string

--- a/ingress-controller/test/helpers/konnect/system_accounts.go
+++ b/ingress-controller/test/helpers/konnect/system_accounts.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/konnect/sdk"
 	"github.com/kong/kong-operator/v2/ingress-controller/test"
+	testhelpers "github.com/kong/kong-operator/v2/test"
 )
 
 // CreateTestSystemAccount creates a system account in Konnect for testing purposes and returns its ID.
@@ -22,7 +23,7 @@ import (
 func CreateTestSystemAccount(ctx context.Context, t *testing.T) string {
 	t.Helper()
 
-	s := sdk.New(accessToken(), serverURLOpt())
+	s := sdk.New(testhelpers.KonnectAccessToken(), serverURLOpt())
 
 	var (
 		systemAccountID   string

--- a/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
+++ b/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kong/kong-operator/v2/ingress-controller/test/helpers/konnect"
 	"github.com/kong/kong-operator/v2/ingress-controller/test/kongintegration/containers"
 	"github.com/kong/kong-operator/v2/ingress-controller/test/testenv"
+	"github.com/kong/kong-operator/v2/test"
 )
 
 const (
@@ -101,7 +102,9 @@ func TestKongClientGoldenTestsOutputs_Konnect(t *testing.T) {
 		timeout = 90 * time.Second
 	)
 
-	konnect.SkipIfMissingRequiredKonnectEnvVariables(t)
+	if test.KonnectAccessToken() == "" {
+		t.Skip("Konnect token is not available, skipping test")
+	}
 	t.Parallel()
 
 	ctx := t.Context()


### PR DESCRIPTION
**What this PR does / why we need it**:

Get rid of `TEST_KONG_KONNECT_ACCESS_TOKEN` entirely, because `KONG_TEST_KONNECT_ACCESS_TOKEN` is more popular in this repository.

