### PR TITLE
fix: do not try to list `Gateway`s for not watched namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,8 @@
   now include a hash of rule's other field to avoid naming collisions with other
   rules that also have no BackendRefs.
   [#3576](https://github.com/Kong/kong-operator/pull/3576)
+- Do not try to list `Gateway`s for namespaces that are not being watched by controller
+  [#3625](https://github.com/Kong/kong-operator/pull/3625)
 
 ## [v2.1.2]
 

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -73,6 +73,7 @@ type Reconciler struct {
 	KonnectEnabled          bool
 	AnonymousReportsEnabled bool
 	LoggingMode             logging.Mode
+	WatchNamespaces         []string
 }
 
 // provisionDataPlaneFailRequeueAfter is the time duration after which we retry provisioning

--- a/controller/gateway/controller_watch.go
+++ b/controller/gateway/controller_watch.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
@@ -350,6 +351,11 @@ func (r *Reconciler) listManagedGatewaysInNamespace(ctx context.Context, obj cli
 		)
 		return nil
 	}
+	if len(r.WatchNamespaces) > 0 && !slices.Contains(r.WatchNamespaces, ns.Name) {
+		log.Trace(logger, "namespace is not configured to be watched by controller, skipping", "namespace", ns.Name)
+		return nil
+	}
+
 	gateways := &gatewayv1.GatewayList{}
 	if err := r.List(ctx, gateways, &client.ListOptions{
 		Namespace: ns.Name,

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -397,6 +397,7 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 				KonnectEnabled:          c.KonnectControllersEnabled,
 				AnonymousReportsEnabled: c.AnonymousReports,
 				LoggingMode:             c.LoggingMode,
+				WatchNamespaces:         c.WatchNamespaces,
 			},
 		},
 		// ControlPlane controller


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the issue reported by @bcollard (thank you!), below description provided by him

>KO v2.1 deployed with
>```
>helm --kube-context $CTX_CLUSTER1 upgrade --install kong-operator kong/kong-operator -n ${KO_NAMESPACE} \
>  --create-namespace \
>  --set image.tag=${KONG_KO_VERSION} \
>  --set env.ENABLE_FQDN_MODE=true \
>  --set "env.WATCH_NAMESPACES=${KO_NAMESPACE}\,${BU1_GW_NAMESPACE}\,${BU2_GW_NAMESPACE}"
>```
>
>Startup logs show
>
>```
>{"level":"info","ts":"2026-03-17T15:24:32Z","logger":"setup","msg":"Manager set up with multiple namespaces","namespaces":["kong-system","kong-gw-bu1","kong-gw-bu2"]}
>so, watch namespaces is well parsed, but down the logs, I can see one error like the following for each namespace not in the list above:
>{"level":"error","ts":"2026-03-17T15:24:33Z","msg":"Failed to list gateways in watch","namespace":"default","error":"unable to list: default because of unknown namespace for the cache","stacktrace":"github.com/kong/kong-operator/v2/controller/gateway.(*Reconciler).listManagedGatewaysInNamespace\n\t/workspace/controller/gateway/controller_watch.go:268\nsigs.k8s.io/controller-runtime/pkg/handler.(*enqueueRequestsFromMapFunc[...]).mapAndEnqueue\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/handler/enqueue_mapped.go:140\nsigs.k8s.io/controller-runtime/pkg/handler.(*enqueueRequestsFromMapFunc[...]).Create\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/handler/enqueue_mapped.go:95\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*EventHandler[...]).OnAdd\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/source/event_handler.go:86\nk8s.io/client-go/tools/cache.(*processorListener).run.func1\n\t/home/runner/go/pkg/mod/k8s.io/client-go@v0.35.2/tools/cache/shared_informer.go:1074\nk8s.io/client-go/tools/cache.(*processorListener).run\n\t/home/runner/go/pkg/mod/k8s.io/client-go@v0.35.2/tools/cache/shared_informer.go:1084\nk8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1\n\t/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.35.2/pkg/util/wait/wait.go:72"}
>```
>
>Is this a known bug or a misconfig?
>I want KO to only watch the namespaces listed in the helm values.


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
