### PR TITLE
fix: do not try to list `Gateway`s for not watched namespace (#3625)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- [v2.0.8](#v208)
 - [v2.0.7](#v207)
 - [v2.0.6](#v206)
 - [v2.0.5](#v205)
@@ -37,9 +38,18 @@
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
 
-## [v2.0.7]
+## [v2.0.8]
 
 > Release date: TBD
+
+### Fixed
+
+- Do not try to list `Gateway`s for namespaces that are not being watched by controller
+  [#3625](https://github.com/Kong/kong-operator/pull/3625)
+
+## [v2.0.7]
+
+> Release date: 2026-02-19
 
 ### Fixed
 

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -66,6 +66,7 @@ type Reconciler struct {
 	KonnectEnabled          bool
 	AnonymousReportsEnabled bool
 	LoggingMode             logging.Mode
+	WatchNamespaces         []string
 }
 
 // provisionDataPlaneFailRequeueAfter is the time duration after which we retry provisioning

--- a/controller/gateway/controller_watch.go
+++ b/controller/gateway/controller_watch.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
@@ -262,6 +263,11 @@ func (r *Reconciler) listManagedGatewaysInNamespace(ctx context.Context, obj cli
 		)
 		return nil
 	}
+	if len(r.WatchNamespaces) > 0 && !slices.Contains(r.WatchNamespaces, ns.Name) {
+		log.Trace(logger, "namespace is not configured to be watched by controller, skipping", "namespace", ns.Name)
+		return nil
+	}
+
 	gateways := &gatewayv1.GatewayList{}
 	if err := r.List(ctx, gateways, &client.ListOptions{
 		Namespace: ns.Name,

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -400,6 +400,7 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 				KonnectEnabled:          c.KonnectControllersEnabled,
 				AnonymousReportsEnabled: c.AnonymousReports,
 				LoggingMode:             c.LoggingMode,
+				WatchNamespaces:         c.WatchNamespaces,
 			},
 		},
 		// ControlPlane controller


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport of 

- #3625

and `CHANGELOG.md` adjustments
