### PR TITLE
tests: use GITHUB_TOKEN for API requests in e2e tests suite

### DIFF
--- a/.github/workflows/__e2e_tests.yaml
+++ b/.github/workflows/__e2e_tests.yaml
@@ -1,0 +1,95 @@
+name: E2E tests
+
+on:
+  workflow_call: {}
+
+permissions:
+  contents: read
+
+env:
+  MISE_VERBOSE: 1
+  MISE_DEBUG: 1
+
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
+      with:
+        egress-policy: audit
+    - name: checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 0
+
+    - name: setup golang
+      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+      with:
+        go-version-file: go.mod
+        cache: false
+
+    - name: build docker image
+      env:
+        IMG: kong-operator
+        TAG: e2e-${{ github.sha }}
+      run: make docker.build
+
+    - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
+      with:
+        install: false
+
+    - run: echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
+    - run: echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
+    - run: echo "GO_CACHE_KEY=go-e2e-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
+    - run: echo "GO_CACHE_KEY_2=go-e2e-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
+
+    - name: Go cache main branch
+      if: ${{ github.ref == 'refs/heads/main' }}
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+      with:
+        path: |
+          ${{ env.GO_MOD_CACHE }}
+          ${{ env.GO_BUILD_CACHE }}
+        key: ${{ env.GO_CACHE_KEY }}
+        restore-keys: |
+          ${{ env.GO_CACHE_KEY }}
+          ${{ env.GO_CACHE_KEY_2 }}
+
+    - name: Go cache (restore only for non-main branches)
+      if: ${{ github.ref != 'refs/heads/main' }}
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+      with:
+        path: |
+          ${{ env.GO_MOD_CACHE }}
+          ${{ env.GO_BUILD_CACHE }}
+        key: ${{ env.GO_CACHE_KEY }}
+        restore-keys: |
+          ${{ env.GO_CACHE_KEY }}
+          ${{ env.GO_CACHE_KEY_2 }}
+
+    - name: run e2e tests
+      run: make test.e2e
+      env:
+        KONG_TEST_KONG_OPERATOR_IMAGE_LOAD: kong-operator:e2e-${{ github.sha }}
+        GOTESTSUM_JUNITFILE: "e2e-tests.xml"
+        # This is needed for ktf to find latest releases of addons.
+        # This could be changed so that ktf addons have their versions pinned
+        # in the test Makefile instead.
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: upload diagnostics
+      if: always()
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: diagnostics-e2e
+        path: /tmp/ktf-diag*
+        if-no-files-found: ignore
+
+    - name: collect test report
+      if: ${{ always() }}
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: tests-report-e2e
+        path: e2e-tests.xml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -397,54 +397,12 @@ jobs:
       cluster_version: ${{ needs.matrix_k8s_node_versions.outputs.latest }}
 
   e2e-tests:
-    runs-on: ubuntu-latest
-    needs: [check-docs-only]
+    needs:
+      - check-docs-only
+      - matrix_k8s_node_versions
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
-    steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-      with:
-        egress-policy: audit
-    - name: checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        fetch-depth: 0
-
-    - name: setup golang
-      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-      with:
-        go-version-file: go.mod
-
-    - name: build docker image
-      env:
-        IMG: kong-operator
-        TAG: e2e-${{ github.sha }}
-      run: make docker.build
-
-    - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
-      with:
-        install: false
-
-    - name: run e2e tests
-      run: make test.e2e
-      env:
-        KONG_TEST_KONG_OPERATOR_IMAGE_LOAD: kong-operator:e2e-${{ github.sha }}
-        GOTESTSUM_JUNITFILE: "e2e-tests.xml"
-
-    - name: upload diagnostics
-      if: always()
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-      with:
-        name: diagnostics-e2e
-        path: /tmp/ktf-diag*
-        if-no-files-found: ignore
-
-    - name: collect test report
-      if: ${{ always() }}
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-      with:
-        name: tests-report-e2e
-        path: e2e-tests.xml
+    uses: ./.github/workflows/__e2e_tests.yaml
+    secrets: inherit
 
   e2e-tests-chainsaw:
     needs:


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent failures like:

```
=== FAIL: test/e2e TestHelmUpgrade (32.15s)
    helm_install_upgrade_test.go:55: KONG_TEST_KONG_OPERATOR_IMAGE_LOAD set to "kong-operator:e2e-02de3b80113a2f14e0f270c9c4e21e663d2f09d5"
    helm_install_upgrade_test.go:60: configuring cluster for testing environment
    helm_install_upgrade_test.go:60: no existing cluster found, deploying using Kubernetes In Docker (KIND)
INFO: CertManager plugin is enabled
INFO: MetalLB plugin is enabled
    helm_install_upgrade_test.go:60: loading image: kong-operator:e2e-02de3b80113a2f14e0f270c9c4e21e663d2f09d5
    helm_install_upgrade_test.go:60: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/e2e/environment.go:134
        	            				/home/runner/work/kong-operator/kong-operator/test/e2e/helm_install_upgrade_test.go:60
        	Error:      	Received unexpected error:
        	            	failed to deploy addon cert-manager: couldn't fetch latest jetstack/cert-manager release: GET https://api.github.com/repos/jetstack/cert-manager/releases/latest: 403 API rate limit exceeded for 135.232.176.179. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 10m03s]
```

https://github.com/Kong/kong-operator/actions/runs/23214745291/job/67472716865?pr=3630#step:8:293

by using `GITHUB_TOKEN` (this will be automatically used by ktf in https://github.com/Kong/kubernetes-testing-framework/blob/966b6b05418550b95fc6285d9d63205bed31b8cf/pkg/utils/github/release.go#L36-L44 for API requests).

While at it move e2e tests to a separate workflow file.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
