### PR TITLE
fix(hybrid): fix hybrid gateway route status

### DIFF
--- a/controller/hybridgateway/route/status.go
+++ b/controller/hybridgateway/route/status.go
@@ -389,6 +389,7 @@ func BuildAcceptedCondition(ctx context.Context, logger logr.Logger, cl client.C
 func BuildProgrammedCondition(ctx context.Context, logger logr.Logger, cl client.Client, route *gwtypes.HTTPRoute,
 	pRef gwtypes.ParentReference, expectedGVKs []schema.GroupVersionKind) ([]metav1.Condition, error) {
 	var conditions []metav1.Condition
+	am := metadata.NewAnnotationManager(logger)
 
 	// Skip setting programmed conditions for KongPlugins because they lack a status field.
 	expectedGVKs = FilterOutGVKByKind(expectedGVKs, "KongPlugin")
@@ -405,6 +406,14 @@ func BuildProgrammedCondition(ctx context.Context, logger logr.Logger, cl client
 		}
 
 		for _, item := range list.Items {
+			if !am.ContainsRoute(&item, route) {
+				log.Trace(logger, "Skipping resource not owned by route",
+					"gvk", gvk.String(),
+					"name", item.GetName(),
+					"namespace", item.GetNamespace())
+				continue
+			}
+
 			// Check if the item is programmed.
 			prog := isProgrammed(&item)
 			log.Debug(logger, "Resource programmed status", "gvk", gvk.String(), "name", item.GetName(), "namespace", item.GetNamespace(), "programmed", prog)

--- a/controller/hybridgateway/route/status_test.go
+++ b/controller/hybridgateway/route/status_test.go
@@ -20,7 +20,9 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
+	"github.com/kong/kong-operator/v2/pkg/consts"
 )
 
 // Test helpers for BuildProgrammedCondition.
@@ -754,11 +756,29 @@ func Test_BuildProgrammedCondition(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
 	}
 	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "FakeResource"}
+	kongServiceGVK := configurationv1alpha1.SchemeGroupVersion.WithKind("KongService")
 
 	// Helper to create unstructured with Programmed condition
 	makeUnstructured := func(programmed bool) *unstructured.Unstructured {
 		obj := &unstructured.Unstructured{}
 		obj.SetGroupVersionKind(gvk)
+		obj.SetAnnotations(map[string]string{
+			consts.GatewayOperatorHybridRoutesAnnotation: "default/route",
+		})
+		cond := map[string]any{"type": "Programmed", "status": "True"}
+		if !programmed {
+			cond["status"] = "False"
+		}
+		obj.Object["status"] = map[string]any{"conditions": []any{cond}}
+		return obj
+	}
+
+	makeAnnotatedUnstructured := func(gvk schema.GroupVersionKind, programmed bool, routeRef string) *unstructured.Unstructured {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(gvk)
+		obj.SetAnnotations(map[string]string{
+			consts.GatewayOperatorHybridRoutesAnnotation: routeRef,
+		})
 		cond := map[string]any{"type": "Programmed", "status": "True"}
 		if !programmed {
 			cond["status"] = "False"
@@ -802,6 +822,16 @@ func Test_BuildProgrammedCondition(t *testing.T) {
 			wantLen: 0,
 			wantErr: true,
 		},
+		{
+			name: "ignores resources owned by other routes",
+			client: &fakeListClient{items: []*unstructured.Unstructured{
+				makeAnnotatedUnstructured(kongServiceGVK, true, "default/route"),
+				makeAnnotatedUnstructured(kongServiceGVK, false, "default/other-route"),
+			}},
+			gvks:    []schema.GroupVersionKind{kongServiceGVK},
+			wantLen: 1,
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -816,6 +846,10 @@ func Test_BuildProgrammedCondition(t *testing.T) {
 		if tt.name == "one programmed, one not" && len(conds) == 1 {
 			// For unknown GVKs, GetProgrammedConditionForGVK returns an empty condition
 			require.Empty(t, conds[0].Type, "Type should be empty for unknown GVK")
+		}
+		if tt.name == "ignores resources owned by other routes" && len(conds) == 1 {
+			require.Equal(t, "KongServiceProgrammed", conds[0].Type)
+			require.Equal(t, metav1.ConditionTrue, conds[0].Status)
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Hybrid route status was using a broad managed-by label selector when building `Programmed` conditions, so an `HTTPRoute` could pick up Kong resources that actually belonged to a different route in the same namespace. In the intermittent `HTTPRouteWeight` failure, that let stale/unprogrammed resources from a neighboring route leak into the weighted route’s status and incorrectly report `KongServiceProgrammed=False`.

This mostly works around the fact that [label on routes is set only with GVK information](https://github.com/Kong/kong-operator/blob/5dce811c807ddb7a7da11ea65ee4e028ee2f094d/controller/hybridgateway/metadata/label.go#L17-L36).

This change keeps the existing list-by-label behavior, but filters the listed resources with the hybrid-routes ownership annotation before evaluating their Programmed state. That makes status computation consistent with orphan cleanup and prevents cross-route status contamination. A regression test was added to verify that unrelated route-owned resources are ignored.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

An alternative would be to add namespace and name information to route labels

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
