### PR TITLE
[Backport release/2.1.x] fix(konnect): handle Programmed=False condition in case of APIAuthCofiguration missing reference (#3526)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@
 
 - Do not try to list `Gateway`s for namespaces that are not being watched by controller
   [#3625](https://github.com/Kong/kong-operator/pull/3625)
+- Fix `KonnectGatewayControlPlane` not setting `Programmed=False` when its
+  `KonnectAPIAuthConfiguration` reference cannot be resolved (e.g. the auth
+  config does not exist, or a cross-namespace reference lacks a
+  `KongReferenceGrant`). Both `APIAuthResolvedRef` and `Programmed` conditions
+  are now set to `False` atomically.
+  [#3526](https://github.com/Kong/kong-operator/pull/3526)
 
 ## [v2.1.2]
 

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -400,11 +400,18 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		return patchWithProgrammedStatusConditionBasedOnOtherConditions(ctx, r.Client, ent)
 	}
 
+	programmedFalseCondition := metav1.Condition{
+		Type:    konnectv1alpha1.KonnectEntityProgrammedConditionType,
+		Status:  metav1.ConditionFalse,
+		Reason:  konnectv1alpha1.KonnectEntityProgrammedReasonConditionWithStatusFalseExists,
+		Message: "Some conditions have status set to False",
+	}
+
 	apiAuthRef, err := getAPIAuthRefNN(ctx, r.Client, ent)
 	if err != nil {
 		if crossnamespace.IsReferenceNotGranted(err) {
 			log.Info(logger, "cross-namespace reference to KonnectAPIAuthConfiguration is not granted", "error", err.Error())
-			if requeue, res, retErr := handleAPIAuthStatusCondition(ctx, r.Client, ent, konnectv1alpha1.KonnectAPIAuthConfiguration{}, apiAuthRef, err); requeue {
+			if requeue, res, retErr := handleAPIAuthStatusCondition(ctx, r.Client, ent, konnectv1alpha1.KonnectAPIAuthConfiguration{}, apiAuthRef, err, programmedFalseCondition); requeue {
 				return res, retErr
 			}
 		}
@@ -414,7 +421,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 
 	var apiAuth konnectv1alpha1.KonnectAPIAuthConfiguration
 	err = r.Client.Get(ctx, apiAuthRef, &apiAuth)
-	if requeue, res, retErr := handleAPIAuthStatusCondition(ctx, r.Client, ent, apiAuth, apiAuthRef, err); requeue {
+	if requeue, res, retErr := handleAPIAuthStatusCondition(ctx, r.Client, ent, apiAuth, apiAuthRef, err, programmedFalseCondition); requeue {
 		return res, retErr
 	}
 

--- a/test/envtest/konnect_entities_gatewaycontrolplane_test.go
+++ b/test/envtest/konnect_entities_gatewaycontrolplane_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/url"
 	"testing"
+	"time"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
@@ -23,7 +24,10 @@ import (
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	"github.com/kong/kong-operator/v2/controller/konnect"
 	"github.com/kong/kong-operator/v2/controller/konnect/ops"
+	"github.com/kong/kong-operator/v2/modules/manager/logging"
+	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	"github.com/kong/kong-operator/v2/test/helpers/deploy"
+	"github.com/kong/kong-operator/v2/test/mocks/metricsmocks"
 	"github.com/kong/kong-operator/v2/test/mocks/sdkmocks"
 )
 
@@ -863,6 +867,55 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 			)
 		},
 	},
+	{
+		enabled: true,
+		name:    "unresolved APIAuth ref sets both APIAuthResolvedRef and Programmed conditions to False",
+		objectOps: func(ctx context.Context, t *testing.T, cl client.Client, ns *corev1.Namespace) {
+			// Reference a KonnectAPIAuthConfiguration that does not exist.
+			fakeAuth := &konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "nonexistent-auth"},
+			}
+			deploy.KonnectGatewayControlPlane(t, ctx, cl, fakeAuth,
+				func(obj client.Object) {
+					cp := obj.(*konnectv1alpha2.KonnectGatewayControlPlane)
+					cp.Name = "cp-unresolved-auth"
+					cp.Spec.CreateControlPlaneRequest.Name = "cp-unresolved-auth"
+				},
+			)
+		},
+		mockExpectations: func(t *testing.T, sdk *sdkmocks.MockSDKWrapper, cl client.Client, ns *corev1.Namespace) {
+			// No SDK calls expected — reconciler returns early when auth ref is not found.
+		},
+		eventuallyPredicate: func(ctx context.Context, t *assert.CollectT, cl client.Client, ns *corev1.Namespace) {
+			cp := &konnectv1alpha2.KonnectGatewayControlPlane{}
+			require.NoError(t,
+				cl.Get(ctx,
+					k8stypes.NamespacedName{
+						Namespace: ns.Name,
+						Name:      "cp-unresolved-auth",
+					},
+					cp,
+				),
+			)
+
+			assert.True(t, lo.ContainsBy(cp.Status.Conditions, func(c metav1.Condition) bool {
+				return c.Type == konnectv1alpha1.KonnectEntityAPIAuthConfigurationResolvedRefConditionType &&
+					c.Status == metav1.ConditionFalse &&
+					c.Reason == konnectv1alpha1.KonnectEntityAPIAuthConfigurationResolvedRefReasonRefNotFound
+			}), "APIAuthResolvedRef condition should be False with RefNotFound reason")
+
+			assert.True(t, conditionsContainProgrammedFalse(cp.Status.Conditions),
+				"Programmed condition should be set to False when APIAuth ref is not found",
+			)
+			assert.True(t,
+				conditionsContainProgrammedWithReason(
+					cp.Status.Conditions,
+					konnectv1alpha1.KonnectEntityProgrammedReasonConditionWithStatusFalseExists,
+				),
+				"Programmed condition reason should indicate ConditionWithStatusFalseExists",
+			)
+		},
+	},
 }
 
 func conditionsContainProgrammed(conds []metav1.Condition, status metav1.ConditionStatus) bool {
@@ -909,4 +962,81 @@ func conditionsContainMembersRefResolvedFalse(conds []metav1.Condition) bool {
 
 func conditionsContainMembersRefResolvedTrue(conds []metav1.Condition) bool {
 	return conditionsContainMembersRefResolved(conds, metav1.ConditionTrue)
+}
+
+// TestKonnectGatewayControlPlane_CrossNamespaceRefNotPermitted verifies that when a
+// KonnectGatewayControlPlane in one namespace references a KonnectAPIAuthConfiguration
+// in another namespace without a KongReferenceGrant, both APIAuthResolvedRef=False
+// (RefNotPermitted) and Programmed=False are set.
+//
+// This is a standalone test (not in the test table) because the table-driven suite
+// uses a namespaced client that cannot perform cross-namespace operations.
+func TestKonnectGatewayControlPlane_CrossNamespaceRefNotPermitted(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cfg, _ := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
+	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+
+	cl := mgr.GetClient()
+	factory := sdkmocks.NewMockSDKFactory(t)
+
+	StartReconcilers(ctx, t, mgr, logs,
+		konnect.NewKonnectEntityReconciler[
+			konnectv1alpha2.KonnectGatewayControlPlane,
+			*konnectv1alpha2.KonnectGatewayControlPlane,
+		](factory, logging.DevelopmentMode, cl,
+			konnect.WithMetricRecorder[
+				konnectv1alpha2.KonnectGatewayControlPlane,
+				*konnectv1alpha2.KonnectGatewayControlPlane,
+			](&metricsmocks.MockRecorder{})))
+
+	// Create two namespaces: one for the CP, one for the auth config target.
+	cpNs := deploy.Namespace(t, ctx, cl)
+	authNs := deploy.Namespace(t, ctx, cl)
+
+	// Reference a KonnectAPIAuthConfiguration in the auth namespace.
+	// It doesn't need to exist — the cross-namespace grant check runs first.
+	fakeAuth := &konnectv1alpha1.KonnectAPIAuthConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "auth-in-other-ns"},
+	}
+	deploy.KonnectGatewayControlPlane(t, ctx, cl, fakeAuth,
+		func(obj client.Object) {
+			cp := obj.(*konnectv1alpha2.KonnectGatewayControlPlane)
+			cp.Name = "cp-xns-no-grant"
+			cp.Namespace = cpNs.Name
+			cp.Spec.CreateControlPlaneRequest.Name = "cp-xns-no-grant"
+			cp.Spec.KonnectConfiguration.APIAuthConfigurationRef.Namespace = new(authNs.Name)
+		},
+	)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		cp := &konnectv1alpha2.KonnectGatewayControlPlane{}
+		require.NoError(collect,
+			cl.Get(ctx,
+				k8stypes.NamespacedName{
+					Namespace: cpNs.Name,
+					Name:      "cp-xns-no-grant",
+				},
+				cp,
+			),
+		)
+
+		assert.True(collect, lo.ContainsBy(cp.Status.Conditions, func(c metav1.Condition) bool {
+			return c.Type == konnectv1alpha1.KonnectEntityAPIAuthConfigurationResolvedRefConditionType &&
+				c.Status == metav1.ConditionFalse &&
+				c.Reason == konnectv1alpha1.KonnectEntityAPIAuthConfigurationResolvedRefReasonRefNotPermitted
+		}), "APIAuthResolvedRef condition should be False with RefNotPermitted reason")
+
+		assert.True(collect, conditionsContainProgrammedFalse(cp.Status.Conditions),
+			"Programmed condition should be set to False when cross-namespace ref is not permitted",
+		)
+		assert.True(collect,
+			conditionsContainProgrammedWithReason(
+				cp.Status.Conditions,
+				konnectv1alpha1.KonnectEntityProgrammedReasonConditionWithStatusFalseExists,
+			),
+			"Programmed condition reason should indicate ConditionWithStatusFalseExists",
+		)
+	}, 10*time.Second, 200*time.Millisecond)
 }

--- a/test/envtest/konnect_entities_gatewaycontrolplane_test.go
+++ b/test/envtest/konnect_entities_gatewaycontrolplane_test.go
@@ -1006,7 +1006,7 @@ func TestKonnectGatewayControlPlane_CrossNamespaceRefNotPermitted(t *testing.T) 
 			cp.Name = "cp-xns-no-grant"
 			cp.Namespace = cpNs.Name
 			cp.Spec.CreateControlPlaneRequest.Name = "cp-xns-no-grant"
-			cp.Spec.KonnectConfiguration.APIAuthConfigurationRef.Namespace = new(authNs.Name)
+			cp.Spec.KonnectConfiguration.APIAuthConfigurationRef.Namespace = &authNs.Name
 		},
 	)
 


### PR DESCRIPTION
(cherry picked from commit 9414cf9ef01c63379adbb0ee840a6303c417b61a)

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
