### PR TITLE
[Backport release/2.1.x] fix(hybrid): fix hybrid gateway upstream and service name collisions for backendless HTTPRoute rules (#3576)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@
   [#3554](https://github.com/Kong/kong-operator/pull/3554)
 - Fix reducing `Secret`s with in use finalizers.
   [#3506](https://github.com/Kong/kong-operator/pull/3506)
+- Fix KongUpstream and KongService names in hybrid mode not taking into account
+  backendless rules. When a rule has no BackendRefs, the generated KongUpsteam and KongService names
+  now include a hash of rule's other field to avoid naming collisions with other
+  rules that also have no BackendRefs.
+  [#3576](https://github.com/Kong/kong-operator/pull/3576)
 
 ## [v2.1.2]
 

--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -297,6 +298,7 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 		wantErrSub   string
 		wantOutputs  outputCount
 		wantStoreLen int
+		assertFn     func(t *testing.T, store []client.Object)
 	}{
 		{
 			name: "translates route with plugins and targets",
@@ -325,6 +327,109 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 				plugins:   2,
 			},
 			wantStoreLen: 8,
+		},
+		{
+			name: "translates multi rule redirect only route end to end",
+			setup: func() *httpRouteConverter {
+				route := newHTTPRouteWithRules(
+					[]string{"api.example.com"},
+					[]gwtypes.HTTPRouteRule{
+						{
+							Matches: []gwtypes.HTTPRouteMatch{{
+								Path: &gatewayv1.HTTPPathMatch{
+									Type:  lo.ToPtr(gatewayv1.PathMatchPathPrefix),
+									Value: lo.ToPtr("/hostname-redirect"),
+								},
+							}},
+							Filters: []gwtypes.HTTPRouteFilter{
+								newRequestRedirectFilter("example.org", nil),
+							},
+						},
+						{
+							Matches: []gwtypes.HTTPRouteMatch{{
+								Path: &gatewayv1.HTTPPathMatch{
+									Type:  lo.ToPtr(gatewayv1.PathMatchPathPrefix),
+									Value: lo.ToPtr("/host-and-status"),
+								},
+							}},
+							Filters: []gwtypes.HTTPRouteFilter{
+								newRequestRedirectFilter("example.org", lo.ToPtr(301)),
+							},
+						},
+					},
+				)
+				gateway := baseGateway()
+				objects := append(newKonnectGatewayStandardObjects(gateway), newNamespace())
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(objects...).Build()
+				return newHTTPRouteConverter(route, fakeClient, false, "").(*httpRouteConverter)
+			},
+			wantCount: 10,
+			wantOutputs: outputCount{
+				upstreams: 2,
+				services:  2,
+				routes:    2,
+				targets:   0,
+				bindings:  2,
+				plugins:   2,
+			},
+			wantStoreLen: 10,
+			assertFn: func(t *testing.T, store []client.Object) {
+				t.Helper()
+
+				upstreamNames := map[string]struct{}{}
+				serviceNames := map[string]struct{}{}
+				routeNames := map[string]struct{}{}
+				pluginNames := map[string]struct{}{}
+				bindingNames := map[string]struct{}{}
+
+				pluginConfigs := map[string]map[string]any{}
+
+				for _, obj := range store {
+					switch typed := obj.(type) {
+					case *configurationv1alpha1.KongUpstream:
+						upstreamNames[typed.Name] = struct{}{}
+					case *configurationv1alpha1.KongService:
+						serviceNames[typed.Name] = struct{}{}
+					case *configurationv1alpha1.KongRoute:
+						routeNames[typed.Name] = struct{}{}
+					case *configurationv1.KongPlugin:
+						pluginNames[typed.Name] = struct{}{}
+						var config map[string]any
+						require.NoError(t, json.Unmarshal(typed.Config.Raw, &config))
+						pluginConfigs[typed.Name] = config
+					case *configurationv1alpha1.KongPluginBinding:
+						bindingNames[typed.Name] = struct{}{}
+						require.NotNil(t, typed.Spec.Targets)
+						require.NotNil(t, typed.Spec.Targets.RouteReference)
+						assert.Contains(t, routeNames, typed.Spec.Targets.RouteReference.Name)
+						require.NotNil(t, typed.Spec.PluginReference)
+						assert.Contains(t, pluginNames, typed.Spec.PluginReference.Name)
+					}
+				}
+
+				assert.Len(t, upstreamNames, 2)
+				assert.Len(t, serviceNames, 2)
+				assert.Len(t, routeNames, 2)
+				assert.Len(t, pluginNames, 2)
+				assert.Len(t, bindingNames, 2)
+
+				var sawDefaultStatus bool
+				var sawCustomStatus bool
+				for _, config := range pluginConfigs {
+					assert.Equal(t, "http://example.org/", config["location"])
+					assert.Equal(t, true, config["keep_incoming_path"])
+					statusCode, ok := config["status_code"].(float64)
+					require.True(t, ok)
+					switch int(statusCode) {
+					case 301:
+						sawCustomStatus = true
+					case 302:
+						sawDefaultStatus = true
+					}
+				}
+				assert.True(t, sawDefaultStatus)
+				assert.True(t, sawCustomStatus)
+			},
 		},
 		{
 			name: "returns error when filter translation fails",
@@ -539,6 +644,9 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 			}
 			if (tt.wantOutputs != outputCount{}) {
 				assert.Equal(t, tt.wantOutputs, countOutputs(converter.outputStore))
+			}
+			if tt.assertFn != nil {
+				tt.assertFn(t, converter.outputStore)
 			}
 		})
 	}
@@ -1101,6 +1209,19 @@ func assertConditionStatus(t *testing.T, conditions []metav1.Condition, conditio
 }
 
 func newHTTPRouteForTranslation(hostnames []string, backendRefs []gwtypes.HTTPBackendRef, filters []gwtypes.HTTPRouteFilter) *gwtypes.HTTPRoute {
+	return newHTTPRouteWithRules(hostnames, []gwtypes.HTTPRouteRule{{
+		Matches: []gwtypes.HTTPRouteMatch{{
+			Path: &gatewayv1.HTTPPathMatch{
+				Type:  ptr.To(gatewayv1.PathMatchPathPrefix),
+				Value: ptr.To("/"),
+			},
+		}},
+		BackendRefs: backendRefs,
+		Filters:     filters,
+	}})
+}
+
+func newHTTPRouteWithRules(hostnames []string, rules []gwtypes.HTTPRouteRule) *gwtypes.HTTPRoute {
 	var gwHostnames []gatewayv1.Hostname
 	for _, hostname := range hostnames {
 		gwHostnames = append(gwHostnames, gatewayv1.Hostname(hostname))
@@ -1113,20 +1234,7 @@ func newHTTPRouteForTranslation(hostnames []string, backendRefs []gwtypes.HTTPBa
 		},
 		Spec: gwtypes.HTTPRouteSpec{
 			Hostnames: gwHostnames,
-			Rules: []gwtypes.HTTPRouteRule{
-				{
-					Matches: []gwtypes.HTTPRouteMatch{
-						{
-							Path: &gatewayv1.HTTPPathMatch{
-								Type:  lo.ToPtr(gatewayv1.PathMatchPathPrefix),
-								Value: lo.ToPtr("/"),
-							},
-						},
-					},
-					BackendRefs: backendRefs,
-					Filters:     filters,
-				},
-			},
+			Rules:     rules,
 			CommonRouteSpec: gwtypes.CommonRouteSpec{
 				ParentRefs: []gwtypes.ParentReference{
 					{
@@ -1138,6 +1246,19 @@ func newHTTPRouteForTranslation(hostnames []string, backendRefs []gwtypes.HTTPBa
 			},
 		},
 	}
+}
+
+func newRequestRedirectFilter(hostname string, statusCode *int) gwtypes.HTTPRouteFilter {
+	filter := gwtypes.HTTPRouteFilter{
+		Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+		RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+			Hostname: ptr.To(gatewayv1.PreciseHostname(hostname)),
+		},
+	}
+	if statusCode != nil {
+		filter.RequestRedirect.StatusCode = statusCode
+	}
+	return filter
 }
 
 func newBackendRef(namespace string) gwtypes.HTTPBackendRef {

--- a/controller/hybridgateway/namegen/name.go
+++ b/controller/hybridgateway/namegen/name.go
@@ -79,10 +79,7 @@ func NewKongUpstreamName(route *gwtypes.HTTPRoute, cp *commonv1alpha1.ControlPla
 		[]string{httpProcolPrefix},
 		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
 	)
-	hashElements := []string{
-		defaultCPPrefix + utils.Hash32(cp),
-		utils.Hash32(rule.BackendRefs),
-	}
+	hashElements := hashElementsForServiceLikeName(route, cp, rule)
 	return newNameWithHashSuffix(readableElements, hashElements)
 }
 
@@ -92,11 +89,37 @@ func NewKongServiceName(route *gwtypes.HTTPRoute, cp *commonv1alpha1.ControlPlan
 		[]string{httpProcolPrefix},
 		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
 	)
-	hashElements := []string{
-		defaultCPPrefix + utils.Hash32(cp),
-		utils.Hash32(rule.BackendRefs),
-	}
+	hashElements := hashElementsForServiceLikeName(route, cp, rule)
 	return newNameWithHashSuffix(readableElements, hashElements)
+}
+
+func hashElementsForServiceLikeName(
+	route *gwtypes.HTTPRoute,
+	cp *commonv1alpha1.ControlPlaneRef,
+	rule gatewayv1.HTTPRouteRule,
+) []string {
+	var hash string
+	if len(rule.BackendRefs) > 0 {
+		hash = utils.Hash32(rule.BackendRefs)
+	} else {
+		zeroBackendRuleIdentity := struct {
+			RouteNamespace string
+			RouteName      string
+			Matches        []gatewayv1.HTTPRouteMatch
+			Filters        []gatewayv1.HTTPRouteFilter
+		}{
+			RouteNamespace: route.Namespace,
+			RouteName:      route.Name,
+			Matches:        rule.Matches,
+			Filters:        rule.Filters,
+		}
+		hash = utils.Hash32(zeroBackendRuleIdentity)
+	}
+
+	return []string{
+		defaultCPPrefix + utils.Hash32(cp),
+		hash,
+	}
 }
 
 // NewKongRouteName generates a KongRoute name based on the HTTPRoute, ControlPlaneRef, and HTTPRouteRule passed as arguments.

--- a/controller/hybridgateway/namegen/name_test.go
+++ b/controller/hybridgateway/namegen/name_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,6 +14,50 @@ import (
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/utils"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 )
+
+func testRoute(namespace, name string) *gwtypes.HTTPRoute {
+	return &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+func testControlPlaneRef(name string) *commonv1alpha1.ControlPlaneRef {
+	return &commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: name,
+		},
+	}
+}
+
+func testPathMatch(path string) []gatewayv1.HTTPRouteMatch {
+	matchType := gatewayv1.PathMatchPathPrefix
+	return []gatewayv1.HTTPRouteMatch{
+		{
+			Path: &gatewayv1.HTTPPathMatch{
+				Type:  &matchType,
+				Value: &path,
+			},
+		},
+	}
+}
+
+func testBackendRef(
+	name string, namespace *gatewayv1.Namespace, port *gatewayv1.PortNumber,
+) gatewayv1.HTTPBackendRef {
+	return gatewayv1.HTTPBackendRef{
+		BackendRef: gatewayv1.BackendRef{
+			BackendObjectReference: gatewayv1.BackendObjectReference{
+				Name:      gatewayv1.ObjectName(name),
+				Namespace: namespace,
+				Port:      port,
+			},
+		},
+	}
+}
 
 func TestNewName(t *testing.T) {
 	tests := []struct {
@@ -64,83 +109,115 @@ func TestNewName(t *testing.T) {
 
 func TestNewKongUpstreamName(t *testing.T) {
 	tests := []struct {
-		name             string
-		route            *gwtypes.HTTPRoute
-		cp               *commonv1alpha1.ControlPlaneRef
-		rule             gatewayv1.HTTPRouteRule
-		expectedReadable string
+		name     string
+		route    *gwtypes.HTTPRoute
+		cp       *commonv1alpha1.ControlPlaneRef
+		rule     gatewayv1.HTTPRouteRule
+		expected string
 	}{
 		{
-			name: "basic upstream name generation",
-			route: &gwtypes.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-route",
-					Namespace: "default",
-				},
-			},
-			cp: &commonv1alpha1.ControlPlaneRef{
-				Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
-				KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
-					Name: "test-cp",
-				},
-			},
+			name:  "basic upstream name generation",
+			route: testRoute("default", "test-route"),
+			cp:    testControlPlaneRef("test-cp"),
 			rule: gatewayv1.HTTPRouteRule{
 				BackendRefs: []gatewayv1.HTTPBackendRef{
-					{
-						BackendRef: gatewayv1.BackendRef{
-							BackendObjectReference: gatewayv1.BackendObjectReference{
-								Name: "service1",
-								Port: func() *gatewayv1.PortNumber { p := gatewayv1.PortNumber(8080); return &p }(),
-							},
-						},
-					},
+					testBackendRef("service1", nil, lo.ToPtr(gatewayv1.PortNumber(8080))),
 				},
 			},
-			expectedReadable: "http.default-service1-8080.1",
+			expected: "http.default-service1-8080.1.cp1fbfa93f.e25441d7",
 		},
 		{
-			name: "multiple backend refs",
-			route: &gwtypes.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-route",
-					Namespace: "default",
-				},
-			},
-			cp: &commonv1alpha1.ControlPlaneRef{
-				Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
-				KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
-					Name: "multi-cp",
-				},
-			},
+			name:  "multiple backend refs use lowest lexical backend in readable prefix",
+			route: testRoute("default", "test-route"),
+			cp:    testControlPlaneRef("multi-cp"),
 			rule: gatewayv1.HTTPRouteRule{
 				BackendRefs: []gatewayv1.HTTPBackendRef{
+					testBackendRef("service2", nil, lo.ToPtr(gatewayv1.PortNumber(9090))),
+					testBackendRef("service1", nil, lo.ToPtr(gatewayv1.PortNumber(8080))),
+				},
+			},
+			expected: "http.default-service1-8080.2.cp918460a.2c5d1acf",
+		},
+		{
+			name:  "cross namespace backend is reflected in readable prefix",
+			route: testRoute("default", "test-route"),
+			cp:    testControlPlaneRef("namespaced-cp"),
+			rule: gatewayv1.HTTPRouteRule{
+				BackendRefs: []gatewayv1.HTTPBackendRef{
+					testBackendRef("backend-service", lo.ToPtr(gatewayv1.Namespace("backend-ns")), nil),
+				},
+			},
+			expected: "http.backend-ns-backend-service.1.cpba78230e.1f2a8c5",
+		},
+		{
+			name:  "backendless rule produces readable prefix with just http and cp hash",
+			route: testRoute("default", "test-route"),
+			cp:    testControlPlaneRef("namespaced-cp"),
+			rule: gatewayv1.HTTPRouteRule{
+				BackendRefs: []gatewayv1.HTTPBackendRef{},
+				Filters: []gatewayv1.HTTPRouteFilter{
 					{
-						BackendRef: gatewayv1.BackendRef{
-							BackendObjectReference: gatewayv1.BackendObjectReference{
-								Name: "service1",
-								Port: func() *gatewayv1.PortNumber { p := gatewayv1.PortNumber(8080); return &p }(),
-							},
-						},
-					},
-					{
-						BackendRef: gatewayv1.BackendRef{
-							BackendObjectReference: gatewayv1.BackendObjectReference{
-								Name: "service2",
-								Port: func() *gatewayv1.PortNumber { p := gatewayv1.PortNumber(9090); return &p }(),
+						Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+							Set: []gatewayv1.HTTPHeader{
+								{
+									Name:  "header",
+									Value: "value",
+								},
 							},
 						},
 					},
 				},
+				Matches: []gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  lo.ToPtr(gatewayv1.PathMatchPathPrefix),
+							Value: lo.ToPtr("/prefix"),
+						},
+					},
+				},
 			},
-			expectedReadable: "http.default-service1-8080.2",
+			expected: "http.cpba78230e.7f99a851",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := NewKongUpstreamName(tt.route, tt.cp, tt.rule)
-			expected := tt.expectedReadable + ".cp" + utils.Hash32(tt.cp) + "." + utils.Hash32(tt.rule.BackendRefs)
-			assert.Equal(t, expected, result)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewKongUpstreamName_Equality(t *testing.T) {
+	tests := []struct {
+		name  string
+		route *gwtypes.HTTPRoute
+		cp    *commonv1alpha1.ControlPlaneRef
+		ruleA gatewayv1.HTTPRouteRule
+		ruleB gatewayv1.HTTPRouteRule
+		equal bool
+	}{
+		{
+			name:  "different matches with no backends produce different results",
+			route: testRoute("gateway-conformance-infra", "redirect-host-and-status"),
+			cp:    testControlPlaneRef("same-namespace-rrfhd"),
+			ruleA: gatewayv1.HTTPRouteRule{Matches: testPathMatch("/hostname-redirect")},
+			ruleB: gatewayv1.HTTPRouteRule{Matches: testPathMatch("/host-and-status")},
+			equal: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nameA := NewKongUpstreamName(tt.route, tt.cp, tt.ruleA)
+			nameB := NewKongUpstreamName(tt.route, tt.cp, tt.ruleB)
+
+			if tt.equal {
+				assert.Equal(t, nameA, nameB)
+			} else {
+				assert.NotEqual(t, nameA, nameB)
+			}
 		})
 	}
 }
@@ -154,41 +231,19 @@ func TestNewKongServiceName(t *testing.T) {
 		expectedReadable string
 	}{
 		{
-			name: "basic service name generation",
-			route: &gwtypes.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-route",
-					Namespace: "default",
-				},
-			},
-			cp: &commonv1alpha1.ControlPlaneRef{
-				Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
-				KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
-					Name: "test-cp",
-				},
-			},
+			name:  "basic service name generation",
+			route: testRoute("default", "test-route"),
+			cp:    testControlPlaneRef("test-cp"),
 			rule: gatewayv1.HTTPRouteRule{
 				BackendRefs: []gatewayv1.HTTPBackendRef{
-					{
-						BackendRef: gatewayv1.BackendRef{
-							BackendObjectReference: gatewayv1.BackendObjectReference{
-								Name: "service1",
-								Port: func() *gatewayv1.PortNumber { p := gatewayv1.PortNumber(8080); return &p }(),
-							},
-						},
-					},
+					testBackendRef("service1", nil, lo.ToPtr(gatewayv1.PortNumber(8080))),
 				},
 			},
 			expectedReadable: "http.default-service1-8080.1",
 		},
 		{
-			name: "service with namespace",
-			route: &gwtypes.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-route",
-					Namespace: "default",
-				},
-			},
+			name:  "service with namespace",
+			route: testRoute("default", "test-route"),
 			cp: &commonv1alpha1.ControlPlaneRef{
 				Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
 				KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
@@ -198,14 +253,7 @@ func TestNewKongServiceName(t *testing.T) {
 			},
 			rule: gatewayv1.HTTPRouteRule{
 				BackendRefs: []gatewayv1.HTTPBackendRef{
-					{
-						BackendRef: gatewayv1.BackendRef{
-							BackendObjectReference: gatewayv1.BackendObjectReference{
-								Name:      "backend-service",
-								Namespace: func() *gatewayv1.Namespace { ns := gatewayv1.Namespace("backend-ns"); return &ns }(),
-							},
-						},
-					},
+					testBackendRef("backend-service", lo.ToPtr(gatewayv1.Namespace("backend-ns")), nil),
 				},
 			},
 			expectedReadable: "http.backend-ns-backend-service.1",
@@ -217,6 +265,39 @@ func TestNewKongServiceName(t *testing.T) {
 			result := NewKongServiceName(tt.route, tt.cp, tt.rule)
 			expected := tt.expectedReadable + ".cp" + utils.Hash32(tt.cp) + "." + utils.Hash32(tt.rule.BackendRefs)
 			assert.Equal(t, expected, result)
+		})
+	}
+}
+
+func TestNewKongServiceName_Equality(t *testing.T) {
+	tests := []struct {
+		name  string
+		route *gwtypes.HTTPRoute
+		cp    *commonv1alpha1.ControlPlaneRef
+		ruleA gatewayv1.HTTPRouteRule
+		ruleB gatewayv1.HTTPRouteRule
+		equal bool
+	}{
+		{
+			name:  "different matches with no backends produce different results",
+			route: testRoute("gateway-conformance-infra", "redirect-host-and-status"),
+			cp:    testControlPlaneRef("same-namespace-rrfhd"),
+			ruleA: gatewayv1.HTTPRouteRule{Matches: testPathMatch("/hostname-redirect")},
+			ruleB: gatewayv1.HTTPRouteRule{Matches: testPathMatch("/host-and-status")},
+			equal: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nameA := NewKongServiceName(tt.route, tt.cp, tt.ruleA)
+			nameB := NewKongServiceName(tt.route, tt.cp, tt.ruleB)
+
+			if tt.equal {
+				assert.Equal(t, nameA, nameB)
+			} else {
+				assert.NotEqual(t, nameA, nameB)
+			}
 		})
 	}
 }


### PR DESCRIPTION
(cherry picked from commit 7e43c87684be71f082419c932d0676ffc2582e5d)

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
