### PR TITLE
[Backport release/2.1.x]fix(ingress-controller): Add protocols in translated rotues (#3587)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@
   now include a hash of rule's other field to avoid naming collisions with other
   rules that also have no BackendRefs.
   [#3576](https://github.com/Kong/kong-operator/pull/3576)
+- Fix the on-prem translator to set `protocols` in translated Kong routes to
+  `http,https`.
+  [#3587](https://github.com/Kong/kong-operator/pull/3587)
 
 ## [v2.1.2]
 

--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,7 @@ API_DIR ?= api
 #   make generate && make manifests && make test.charts.golden.update
 # into a single command: make generate
 # Note: manifests is placed near the end to preserve the prior ordering (docs are generated from CRDs first).
-generate: generate.crds generate.crd-kustomize generate.k8sio-gomod-replace generate.mocks generate.deepcopy generate.apitypes-funcs generate.docs generate.lint-fix generate.format manifests test.charts.golden.update generate.cli-arguments-docs
+generate: generate.crds generate.crd-kustomize generate.k8sio-gomod-replace generate.deepcopy generate.apitypes-funcs generate.docs generate.lint-fix manifests test.charts.golden.update generate.cli-arguments-docs test.kongintegration.golden.update
 
 .PHONY: generate.crds
 generate.crds: controller-gen ## Generate WebhookConfiguration and CustomResourceDefinition objects.

--- a/ingress-controller/internal/dataplane/testdata/golden/grpcroute-example/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/grpcroute-example/expression-routes-on_golden.yaml
@@ -19,6 +19,9 @@ services:
     name: grpcroute.default.grpcbin.example.com.2.0
     preserve_host: true
     priority: 26766487871743
+    protocols:
+    - http
+    - https
     tags:
     - k8s-name:grpcbin
     - k8s-namespace:default
@@ -54,6 +57,9 @@ services:
     name: grpcroute.default.grpcbin.example.com.1.0
     preserve_host: true
     priority: 26766487904511
+    protocols:
+    - http
+    - https
     tags:
     - k8s-name:grpcbin
     - k8s-namespace:default
@@ -89,6 +95,9 @@ services:
     name: grpcroute.default.grpcbin.example.com.0.0
     preserve_host: true
     priority: 26766487929087
+    protocols:
+    - http
+    - https
     tags:
     - k8s-name:grpcbin
     - k8s-namespace:default

--- a/ingress-controller/internal/dataplane/testdata/golden/httproute-example/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/httproute-example/expression-routes-on_golden.yaml
@@ -15,6 +15,9 @@ services:
     name: httproute.default.httproute-testing._.3.0
     preserve_host: true
     priority: 35184414035967
+    protocols:
+    - http
+    - https
     strip_path: true
     tags:
     - k8s-name:httproute-testing
@@ -43,6 +46,9 @@ services:
     name: httproute.default.httproute-testing._.2.0
     preserve_host: true
     priority: 35184430813183
+    protocols:
+    - http
+    - https
     strip_path: true
     tags:
     - k8s-name:httproute-testing
@@ -57,6 +63,9 @@ services:
     name: httproute.default.httproute-testing._.1.0
     preserve_host: true
     priority: 35184405647359
+    protocols:
+    - http
+    - https
     strip_path: true
     tags:
     - k8s-name:httproute-testing
@@ -86,6 +95,9 @@ services:
     name: httproute.default.httproute-testing._.0.0
     preserve_host: true
     priority: 35184514699263
+    protocols:
+    - http
+    - https
     strip_path: true
     tags:
     - k8s-name:httproute-testing

--- a/ingress-controller/internal/dataplane/testdata/golden/httproute-url-rewrite-path-prefix/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/httproute-url-rewrite-path-prefix/expression-routes-on_golden.yaml
@@ -26,6 +26,9 @@ services:
       - k8s-version:v1
     preserve_host: true
     priority: 35184422424575
+    protocols:
+    - http
+    - https
     strip_path: false
     tags:
     - k8s-name:httproute-testing

--- a/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-empty-path/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-empty-path/expression-routes-on_golden.yaml
@@ -16,6 +16,9 @@ services:
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
     priority: 57178899611649
+    protocols:
+    - http
+    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-multiple-ports-for-one-service/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-multiple-ports-for-one-service/expression-routes-on_golden.yaml
@@ -16,6 +16,9 @@ services:
     name: foo-namespace.foo.foo-svc.example.net.8000
     preserve_host: true
     priority: 57178899611649
+    protocols:
+    - http
+    - https
     request_buffering: true
     response_buffering: true
     strip_path: false
@@ -49,6 +52,9 @@ services:
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
     priority: 57178899611649
+    protocols:
+    - http
+    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-ports-defined-by-name/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-ports-defined-by-name/expression-routes-on_golden.yaml
@@ -16,6 +16,9 @@ services:
     name: foo-namespace.regex-prefix.foo-svc.example.com.http
     preserve_host: true
     priority: 57178899611649
+    protocols:
+    - http
+    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-regex-prefix-exact-rule/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-regex-prefix-exact-rule/expression-routes-on_golden.yaml
@@ -16,6 +16,9 @@ services:
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
     priority: 57178899677193
+    protocols:
+    - http
+    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-regex-prefixed-path/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-regex-prefixed-path/expression-routes-on_golden.yaml
@@ -16,6 +16,9 @@ services:
     name: foo-namespace.regex-prefix.foo-svc.example.com.80
     preserve_host: true
     priority: 57178899677194
+    protocols:
+    - http
+    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer-ee/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer-ee/expression-routes-on_golden.yaml
@@ -67,6 +67,9 @@ services:
     name: bar-namespace.ing-with-tls.foo-svc.example.com.80
     preserve_host: true
     priority: 57178899677185
+    protocols:
+    - http
+    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_golden.yaml
@@ -83,6 +83,9 @@ services:
     name: bar-namespace.ing-with-tls.foo-svc.example.com.80
     preserve_host: true
     priority: 57178899677185
+    protocols:
+    - http
+    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/expression-routes-on_golden.yaml
@@ -16,6 +16,9 @@ services:
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
     priority: 57178899677185
+    protocols:
+    - http
+    - https
     request_buffering: true
     response_buffering: true
     strip_path: false
@@ -31,6 +34,9 @@ services:
     name: foo-namespace.foo-2.foo-svc.example.com.80
     preserve_host: true
     priority: 57178899677185
+    protocols:
+    - http
+    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-with-acme-like-path/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-with-acme-like-path/expression-routes-on_golden.yaml
@@ -16,6 +16,9 @@ services:
     name: foo-namespace.foo.cert-manager-solver-pod.example.com.80
     preserve_host: true
     priority: 57178899611680
+    protocols:
+    - http
+    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-with-default-backend/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-with-default-backend/expression-routes-on_golden.yaml
@@ -16,6 +16,9 @@ services:
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
     priority: 57178899677185
+    protocols:
+    - http
+    - https
     request_buffering: true
     response_buffering: true
     strip_path: false
@@ -47,6 +50,9 @@ services:
     name: bar-namespace.ing-with-default-backend
     preserve_host: true
     priority: 0
+    protocols:
+    - http
+    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/ingress-controller/internal/dataplane/testdata/golden/kong-service-facade/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/kong-service-facade/expression-routes-on_golden.yaml
@@ -35,6 +35,9 @@ services:
     name: default.beta
     preserve_host: true
     priority: 0
+    protocols:
+    - http
+    - https
     request_buffering: true
     response_buffering: true
     strip_path: false
@@ -67,6 +70,9 @@ services:
     name: default.beta..svc-facade-beta.svc.facade
     preserve_host: true
     priority: 54975581454341
+    protocols:
+    - http
+    - https
     request_buffering: true
     response_buffering: true
     strip_path: false
@@ -99,6 +105,9 @@ services:
     name: default.alpha..svc-facade-alpha.svc.facade
     preserve_host: true
     priority: 54975581454342
+    protocols:
+    - http
+    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/ingress-controller/internal/dataplane/translator/subtranslator/grpcroute_atc.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/grpcroute_atc.go
@@ -39,7 +39,8 @@ func GenerateKongExpressionRoutesFromGRPCRouteRule(grpcroute *gatewayapi.GRPCRou
 		r := kongstate.Route{
 			Ingress: ingressObjectInfo,
 			Route: kong.Route{
-				Name: kong.String(routeName),
+				Name:      kong.String(routeName),
+				Protocols: kong.StringSlice("http", "https"),
 			},
 			ExpressionRoutes: true,
 		}
@@ -62,7 +63,8 @@ func GenerateKongExpressionRoutesFromGRPCRouteRule(grpcroute *gatewayapi.GRPCRou
 		r := kongstate.Route{
 			Ingress: ingressObjectInfo,
 			Route: kong.Route{
-				Name: kong.String(routeName),
+				Name:      kong.String(routeName),
+				Protocols: kong.StringSlice("http", "https"),
 			},
 			ExpressionRoutes: true,
 		}
@@ -475,6 +477,7 @@ func KongExpressionRouteFromSplitGRPCRouteMatchWithPriority(
 	r := kongstate.Route{
 		Route: kong.Route{
 			Name:         kong.String(routeName),
+			Protocols:    kong.StringSlice("http", "https"),
 			PreserveHost: kong.Bool(true),
 			Tags:         tags,
 		},

--- a/ingress-controller/internal/dataplane/translator/subtranslator/grpcroute_atc_test.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/grpcroute_atc_test.go
@@ -57,6 +57,7 @@ func TestGenerateKongExpressionRoutesFromGRPCRouteRule(t *testing.T) {
 					ExpressionRoutes: true,
 					Route: kong.Route{
 						Name:       kong.String("grpcroute.default.single-match.0.0"),
+						Protocols:  kong.StringSlice("http", "https"),
 						Expression: kong.String(`(http.path ^= "/service0/") && (http.headers.x_foo == "Bar")`),
 						Priority:   kong.Uint64(1),
 					},
@@ -89,6 +90,7 @@ func TestGenerateKongExpressionRoutesFromGRPCRouteRule(t *testing.T) {
 					ExpressionRoutes: true,
 					Route: kong.Route{
 						Name:       kong.String("grpcroute.default.single-match-with-hostname.0.0"),
+						Protocols:  kong.StringSlice("http", "https"),
 						Expression: kong.String(`(http.path == "/service0/method0") && ((http.host == "foo.com") || (http.host =^ ".foo.com"))`),
 						Priority:   kong.Uint64(1),
 					},
@@ -134,6 +136,7 @@ func TestGenerateKongExpressionRoutesFromGRPCRouteRule(t *testing.T) {
 					ExpressionRoutes: true,
 					Route: kong.Route{
 						Name:       kong.String("grpcroute.default.multiple-matches.0.0"),
+						Protocols:  kong.StringSlice("http", "https"),
 						Expression: kong.String(`(http.path =^ "/method0") && ((http.headers.client == "kong-test") && (http.headers.version == "2"))`),
 						Priority:   kong.Uint64(1),
 					},
@@ -147,6 +150,7 @@ func TestGenerateKongExpressionRoutesFromGRPCRouteRule(t *testing.T) {
 					ExpressionRoutes: true,
 					Route: kong.Route{
 						Name:       kong.String("grpcroute.default.multiple-matches.0.1"),
+						Protocols:  kong.StringSlice("http", "https"),
 						Expression: kong.String(`http.path ~ "^/v[012]/.+"`),
 						Priority:   kong.Uint64(1),
 					},
@@ -186,6 +190,7 @@ func TestGenerateKongExpressionRoutesFromGRPCRouteRule(t *testing.T) {
 					ExpressionRoutes: true,
 					Route: kong.Route{
 						Name:       kong.String("grpcroute.default.single-match-with-annotations.0.0"),
+						Protocols:  kong.StringSlice("http", "https"),
 						Expression: kong.String(`(http.path == "/service0/method0") && (tls.sni == "kong.foo.com")`),
 						Priority:   kong.Uint64(1),
 					},
@@ -209,6 +214,7 @@ func TestGenerateKongExpressionRoutesFromGRPCRouteRule(t *testing.T) {
 					ExpressionRoutes: true,
 					Route: kong.Route{
 						Name:       kong.String("grpcroute.default.hostname-only.0.0"),
+						Protocols:  kong.StringSlice("http", "https"),
 						Expression: kong.String(`http.host == "foo.com"`),
 						Priority:   kong.Uint64(1),
 					},
@@ -1118,6 +1124,7 @@ func TestKongExpressionRouteFromSplitGRPCRouteWithPriority(t *testing.T) {
 			expectedRoute: kongstate.Route{
 				Route: kong.Route{
 					Name:         kong.String("grpcroute.default.no-hostname-exact-method._.0.0"),
+					Protocols:    kong.StringSlice("http", "https"),
 					PreserveHost: kong.Bool(true),
 					Expression:   kong.String(`http.path == "/pets/list"`),
 					Priority:     kong.Uint64(1 << 14),
@@ -1170,6 +1177,7 @@ func TestKongExpressionRouteFromSplitGRPCRouteWithPriority(t *testing.T) {
 			expectedRoute: kongstate.Route{
 				Route: kong.Route{
 					Name:         kong.String("grpcroute.default.precise-hostname-regex-method.foo.com.0.0"),
+					Protocols:    kong.StringSlice("http", "https"),
 					Expression:   kong.String(`(http.path ~ "^/name/[a-z0-9]+") && (http.host == "foo.com")`),
 					PreserveHost: kong.Bool(true),
 					Priority:     kong.Uint64((1 << 31) + 1),
@@ -1239,6 +1247,7 @@ func TestKongExpressionRouteFromSplitGRPCRouteWithPriority(t *testing.T) {
 			expectedRoute: kongstate.Route{
 				Route: kong.Route{
 					Name:         kong.String("grpcroute.default.wildcard-hostname-header-match._.foo.com.0.1"),
+					Protocols:    kong.StringSlice("http", "https"),
 					Expression:   kong.String(`(http.path ^= "/name/") && (http.headers.foo == "bar") && (http.host =^ ".foo.com")`),
 					PreserveHost: kong.Bool(true),
 					Priority:     kong.Uint64((1 << 42) + 1),

--- a/ingress-controller/internal/dataplane/translator/subtranslator/httproute_atc.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/httproute_atc.go
@@ -499,6 +499,7 @@ func kongExpressionRouteFromHTTPRouteMatchWithPriority(
 	r := &kongstate.Route{
 		Route: kong.Route{
 			Name:         kong.String(routeName),
+			Protocols:    kong.StringSlice("http", "https"),
 			PreserveHost: kong.Bool(true),
 			// stripPath needs to be disabled by default to be conformant with the Gateway API
 			StripPath: kong.Bool(false),

--- a/ingress-controller/internal/dataplane/translator/subtranslator/httproute_atc_test.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/httproute_atc_test.go
@@ -1218,6 +1218,7 @@ func TestKongExpressionRouteFromHTTPRouteMatchWithPriority(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, tc.routeName, *route.Name, "Should have expected route name")
+			require.ElementsMatch(t, []string{"http", "https"}, lo.FromSlicePtr(route.Protocols), "Protocols should be http,https")
 			require.True(t, route.ExpressionRoutes, "Should be expression route")
 			require.Equal(t, tc.routeExpression, *route.Expression, "Should translate to expected expression")
 			require.Equal(t, tc.priority, *route.Priority, "Should have expected priority")

--- a/ingress-controller/internal/dataplane/translator/subtranslator/ingress_atc.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/ingress_atc.go
@@ -42,6 +42,7 @@ func (m *ingressTranslationMeta) translateIntoKongExpressionRoute() *kongstate.R
 		Ingress: util.FromK8sObject(m.parentIngress),
 		Route: kong.Route{
 			Name:              kong.String(routeName),
+			Protocols:         kong.StringSlice("http", "https"),
 			StripPath:         kong.Bool(false),
 			PreserveHost:      kong.Bool(true),
 			RequestBuffering:  kong.Bool(true),

--- a/ingress-controller/internal/dataplane/translator/subtranslator/ingress_atc_test.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/ingress_atc_test.go
@@ -81,6 +81,7 @@ func TestTranslateIngressATC(t *testing.T) {
 						},
 						Route: kong.Route{
 							Name:       kong.String("default.test-ingress.test-service.konghq.com.80"),
+							Protocols:  kong.StringSlice("http", "https"),
 							Expression: kong.String(`(http.host == "konghq.com") && ((http.path == "/api") || (http.path ^= "/api/"))`),
 							Priority: kong.Uint64(IngressRoutePriorityTraits{
 								MatchFields:   2,
@@ -157,6 +158,7 @@ func TestTranslateIngressATC(t *testing.T) {
 						},
 						Route: kong.Route{
 							Name:       kong.String("default.test-ingress.test-service.konghq.com.80"),
+							Protocols:  kong.StringSlice("http", "https"),
 							Expression: kong.String(`(http.host == "konghq.com") && (http.path ^= "/api/")`),
 							Priority: kong.Uint64(IngressRoutePriorityTraits{
 								MatchFields:   2,
@@ -243,6 +245,7 @@ func TestTranslateIngressATC(t *testing.T) {
 						},
 						Route: kong.Route{
 							Name:       kong.String("default.test-ingress-annotations.test-service.konghq.com.80"),
+							Protocols:  kong.StringSlice("http", "https"),
 							Expression: kong.String(`(http.host == "konghq.com") && (http.path ^= "/api/") && (http.headers.foo == "bar") && (http.method == "GET")`),
 							Priority: kong.Uint64(IngressRoutePriorityTraits{
 								MatchFields:   4,
@@ -347,6 +350,7 @@ func TestTranslateIngressATC(t *testing.T) {
 						},
 						Route: kong.Route{
 							Name:       kong.String("default.test-ingress.konghq.com.svc-facade.svc.facade"),
+							Protocols:  kong.StringSlice("http", "https"),
 							Expression: kong.String(`(http.host == "konghq.com") && (http.path ^= "/api/")`),
 							Priority: kong.Uint64(IngressRoutePriorityTraits{
 								MatchFields:   2,

--- a/ingress-controller/internal/dataplane/translator/translate_ingress.go
+++ b/ingress-controller/internal/dataplane/translator/translate_ingress.go
@@ -245,6 +245,7 @@ func translateIngressDefaultBackendRoute(ingress *netv1.Ingress, tags []*string,
 		Ingress: util.FromK8sObject(ingress),
 		Route: kong.Route{
 			Name:              kong.String(ingress.Namespace + "." + ingress.Name),
+			Protocols:         kong.StringSlice("http", "https"),
 			StripPath:         kong.Bool(false),
 			PreserveHost:      kong.Bool(true),
 			RequestBuffering:  kong.Bool(true),


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport of #3587 to release/2.1.x.
**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
