### PR TITLE
[Backport release/2.1.x] tests(kongintegration): fix TestUpdateStrategyInMemory_PropagatesResourcesErrors

### DIFF
--- a/ingress-controller/test/kongintegration/inmemory_update_strategy_test.go
+++ b/ingress-controller/test/kongintegration/inmemory_update_strategy_test.go
@@ -135,14 +135,12 @@ func TestUpdateStrategyInMemory_PropagatesResourcesErrors(t *testing.T) {
 			fmt.Printf("DEBUG: resource failure [%d]: message=%q, causingObjects=%v\n", i, rf.Message(), rf.CausingObjects())
 		}
 		resourceErr, found := lo.Find(updateError.ResourceFailures(), func(r failures.ResourceFailure) bool {
-			return lo.ContainsBy(r.CausingObjects(), func(obj client.Object) bool {
-				return obj.GetName() == "test-service"
-			})
+			return r.Message() == expectedMessage &&
+				lo.ContainsBy(r.CausingObjects(), func(obj client.Object) bool {
+					return obj.GetName() == "test-service"
+				})
 		})
-		if !assert.Truef(t, found, "expected resource error for test-service, got: %+v", updateError.ResourceFailures()) {
-			return
-		}
-		if !assert.Equal(t, resourceErr.Message(), expectedMessage) {
+		if !assert.Truef(t, found, "expected resource error for test-service with message %q, got: %+v", expectedMessage, updateError.ResourceFailures()) {
 			return
 		}
 		if diff := cmp.Diff(expectedCausingObjects, resourceErr.CausingObjects()); !assert.Empty(t, diff) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Backports #3310 to `release/2.1.x`.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
