### PR TITLE
chore(ci): Move linting of `x-konnect` APIs out of mise to fix CI

### DIFF
--- a/.golangci-kube-api.yaml
+++ b/.golangci-kube-api.yaml
@@ -1,4 +1,5 @@
 version: "2"
+go: "1.26"
 linters:
   default: none
   enable:

--- a/.mise.toml
+++ b/.mise.toml
@@ -108,12 +108,6 @@ description = "Generate DeepCopy methods for the API types"
 dir = "./{{env.DIR}}"
 run = "controller-gen object:headerFile='../hack/generators/boilerplate.go.txt' paths=../api/..."
 
-[tasks.lint-api]
-description = "Run golangci-lint"
-# TODO: This hardcodes the x-konnect API group. Removing this hardcode would cause the linter
-# to run against all the API groups which might create unwanted issues being reported here.
-run = "golangci-lint-kube-api-linter run -v --config .golangci-kube-api.yaml ./api/x-konnect/..."
-
 [tasks.test-crdsvalidation]
 description = "Run CRD validation tests"
 dir = "./{{env.DIR}}"
@@ -127,6 +121,6 @@ go test -v -count 1 ${GOTESTFLAGS} ./test/crdsvalidation/x-konnect.konghq.com/..
 description = "Generate API, CRDs, and run all tests and linters"
 run = [
        { task = "generate-api" },
-       { tasks = [ "lint-api", "test-unit", "gofix"] },
+       { tasks = ["test-unit", "gofix"] },
        { task = "test-crdsvalidation" },
 ]

--- a/Makefile
+++ b/Makefile
@@ -1139,11 +1139,11 @@ install.telepresence: download.telepresence
 uninstall.telepresence: download.telepresence
 	@$(PROJECT_DIR)/scripts/telepresence-manager.sh uninstall "$(TELEPRESENCE)"
 
-.PHONY: lint.api
+.PHONY: lint.api 
 lint.api: download.kube-api-linter
 	$(KUBE_API_LINTER) run --config $(PROJECT_DIR)/.golangci-kube-api.yaml -v \
 		./api/gateway-operator/v2beta1/... \
 		./api/konnect/v1alpha1/... \
 		./api/konnect/v1alpha2/... \
-		./api/common/v1alpha1/...
-	mise r lint-api
+		./api/common/v1alpha1/...  \
+		./api/x-konnect/...


### PR DESCRIPTION
**What this PR does / why we need it**:

The [kube-api-linter](https://github.com/kubernetes-sigs/kube-api-linter) uses different go version (1.24) with the go version(1.26) used in the project. This causes the `lint.api` action in the CI fail with
```
Error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.26.1)
Failed executing command with error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.26.1)
``` 
Here we specify the go version in the `.golangci-kube-api.yaml` to fix.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:
Could we maintain the go version here automatically? Like generating it from the `go.mod`.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
