### PR TITLE
refactor(hybrid gateway) Use generics for hybrid gateway controller

### DIFF
--- a/controller/hybridgateway/converter/common.go
+++ b/controller/hybridgateway/converter/common.go
@@ -1,0 +1,137 @@
+package converter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/samber/lo"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hybridgatewayerrors "github.com/kong/kong-operator/v2/controller/hybridgateway/errors"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/refs"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/utils"
+	"github.com/kong/kong-operator/v2/controller/pkg/log"
+	gwtypes "github.com/kong/kong-operator/v2/internal/types"
+)
+
+func getHybridGatewayParents[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRoutePtr[T]](
+	ctx context.Context, logger logr.Logger,
+	cl client.Client, route TPtr,
+) ([]hybridGatewayParent, error) {
+	parentRefs := gwtypes.GetSpecParentRefs(*route)
+	log.Debug(logger, "Getting hybrid gateway parents", "parentRefCount", len(parentRefs))
+
+	result := []hybridGatewayParent{}
+	for i, pRef := range parentRefs {
+		log.Debug(logger, "Processing parent reference", "index", i, "parentRef", pRef)
+
+		cp, err := refs.GetControlPlaneRefByParentRef[T](ctx, logger, cl, route, pRef)
+		if err != nil {
+			switch {
+			case errors.Is(err, hybridgatewayerrors.ErrNoGatewayFound),
+				errors.Is(err, hybridgatewayerrors.ErrNoGatewayClassFound),
+				errors.Is(err, hybridgatewayerrors.ErrNoGatewayController),
+				errors.Is(err, hybridgatewayerrors.ErrUnsupportedKind),
+				errors.Is(err, hybridgatewayerrors.ErrUnsupportedGroup):
+				// These are expected errors to be handled gracefully. Log and skip this ParentRef, continue with others.
+				log.Debug(logger, "Skipping ParentRef due to expected error", "parentRef", pRef, "error", err)
+				continue
+			default:
+				// Unexpected system error, fail the entire translation.
+				return nil, fmt.Errorf("failed to get ControlPlaneRef for ParentRef %s: %w", pRef.Name, err)
+			}
+		}
+
+		if cp == nil {
+			log.Debug(logger, "No ControlPlaneRef found for ParentRef, skipping", "parentRef", pRef)
+			continue
+		}
+
+		log.Debug(logger, "Found ControlPlaneRef for ParentRef", "parentRef", pRef, "controlPlane", cp.KonnectNamespacedRef)
+
+		hostnames, err := getHostnamesByParentRef[T](ctx, logger, cl, route, pRef)
+		if err != nil {
+			log.Error(logger, err, "Failed to get hostnames for ParentRef", "parentRef", pRef)
+			return nil, err
+		}
+		if hostnames == nil {
+			log.Debug(logger, "No hostnames found for ParentRef, skipping", "parentRef", pRef)
+			continue
+		}
+
+		log.Debug(logger, "Adding parent reference to result", "parentRef", pRef, "hostnames", hostnames)
+		result = append(result, hybridGatewayParent{
+			parentRef: pRef,
+			cpRef:     cp,
+			hostnames: hostnames,
+		})
+	}
+
+	log.Debug(logger, "Finished processing parent references", "supportedParents", len(result))
+	return result, nil
+}
+
+// getHostnamesByParentRef returns the hostnames that match between the route and the Gateway listeners.
+func getHostnamesByParentRef[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRoutePtr[T]](
+	ctx context.Context, logger logr.Logger, cl client.Client, route TPtr, pRef gwtypes.ParentReference,
+) ([]string, error) {
+	logger = logger.WithValues("parentRef", pRef.Name)
+	log.Debug(logger, "Getting hostnames for ParentRef")
+
+	var err error
+	var hostnames []string
+
+	listeners, err := refs.GetListenersByParentRef[T](ctx, cl, route, pRef)
+	if err != nil {
+		log.Error(logger, err, "Failed to get listeners for ParentRef")
+		return nil, err
+	}
+
+	log.Debug(logger, "Found listeners for ParentRef", "listenerCount", len(listeners))
+
+	for _, listener := range listeners {
+		// Check section reference if present
+		if pRef.SectionName != nil {
+			sectionName := string(*pRef.SectionName)
+			if string(listener.Name) != sectionName {
+				// This listener doesn't match the section reference, skip it
+				continue
+			}
+			if listener.Port != lo.FromPtr(pRef.Port) {
+				// This listener doesn't match the port reference, skip it
+				continue
+			}
+		}
+
+		// If the listener has no hostname, it means it accepts all HTTPRoute hostnames.
+		// No need to do further checks.
+		if listener.Hostname == nil || *listener.Hostname == "" {
+			log.Debug(logger, "Listener accepts all hostnames", "listener", listener.Name)
+			hostnames := routeHostNames[T](route)
+			return hostnames, nil
+		}
+
+		// Handle wildcard hostnames - get intersection
+		log.Debug(logger, "Processing listener with hostname", "listener", listener.Name, "listenerHostname", *listener.Hostname)
+		for _, host := range routeHostNames[T](route) {
+			if intersection := utils.HostnameIntersection(string(*listener.Hostname), host); intersection != "" {
+				log.Trace(logger, "Found hostname intersection", "listenerHostname", *listener.Hostname, "routeHostname", host, "intersection", intersection)
+				hostnames = append(hostnames, intersection)
+			}
+		}
+	}
+
+	log.Debug(logger, "Finished processing hostnames", "finalHostnames", hostnames)
+	return hostnames, nil
+}
+
+func routeHostNames[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRoutePtr[T]](route TPtr) []string {
+	switch r := any(route).(type) {
+	case *gwtypes.HTTPRoute:
+		return lo.Map(r.Spec.Hostnames, func(host gwtypes.Hostname, _ int) string { return string(host) })
+		// TODO: Add other routes that also supports hostnames (GRPCRoute) when we support them.
+	}
+	return []string{}
+}

--- a/controller/hybridgateway/converter/common.go
+++ b/controller/hybridgateway/converter/common.go
@@ -109,13 +109,13 @@ func getHostnamesByParentRef[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRou
 		// No need to do further checks.
 		if listener.Hostname == nil || *listener.Hostname == "" {
 			log.Debug(logger, "Listener accepts all hostnames", "listener", listener.Name)
-			hostnames := routeHostNames[T](route)
+			hostnames := routeHostNames(*route)
 			return hostnames, nil
 		}
 
 		// Handle wildcard hostnames - get intersection
 		log.Debug(logger, "Processing listener with hostname", "listener", listener.Name, "listenerHostname", *listener.Hostname)
-		for _, host := range routeHostNames[T](route) {
+		for _, host := range routeHostNames(*route) {
 			if intersection := utils.HostnameIntersection(string(*listener.Hostname), host); intersection != "" {
 				log.Trace(logger, "Found hostname intersection", "listenerHostname", *listener.Hostname, "routeHostname", host, "intersection", intersection)
 				hostnames = append(hostnames, intersection)
@@ -127,11 +127,9 @@ func getHostnamesByParentRef[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRou
 	return hostnames, nil
 }
 
-func routeHostNames[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRoutePtr[T]](route TPtr) []string {
-	switch r := any(route).(type) {
-	case *gwtypes.HTTPRoute:
+func routeHostNames[T gwtypes.SupportedRoute](route T) []string {
+	if r, ok := any(route).(gwtypes.HTTPRoute); ok {
 		return lo.Map(r.Spec.Hostnames, func(host gwtypes.Hostname, _ int) string { return string(host) })
-		// TODO: Add other routes that also supports hostnames (GRPCRoute) when we support them.
 	}
 	return []string{}
 }

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/samber/lo"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -368,7 +367,7 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 
 	var translationErrors []error
 
-	supportedParentRefs, err := c.getHybridGatewayParents(ctx, logger)
+	supportedParentRefs, err := getHybridGatewayParents(ctx, logger, c.Client, c.route)
 	if err != nil {
 		log.Error(logger, err, "Failed to get supported parent references")
 		return err
@@ -541,115 +540,4 @@ type hybridGatewayParent struct {
 	parentRef gwtypes.ParentReference
 	cpRef     *commonv1alpha1.ControlPlaneRef
 	hostnames []string
-}
-
-// getHybridGatewayParents returns parent references that are supported by this controller.
-func (c *httpRouteConverter) getHybridGatewayParents(ctx context.Context, logger logr.Logger) ([]hybridGatewayParent, error) {
-	log.Debug(logger, "Getting hybrid gateway parents", "parentRefCount", len(c.route.Spec.ParentRefs))
-
-	result := []hybridGatewayParent{}
-	for i, pRef := range c.route.Spec.ParentRefs {
-		log.Debug(logger, "Processing parent reference", "index", i, "parentRef", pRef)
-
-		cp, err := refs.GetControlPlaneRefByParentRef(ctx, logger, c.Client, c.route, pRef)
-		if err != nil {
-			switch {
-			case errors.Is(err, hybridgatewayerrors.ErrNoGatewayFound),
-				errors.Is(err, hybridgatewayerrors.ErrNoGatewayClassFound),
-				errors.Is(err, hybridgatewayerrors.ErrNoGatewayController),
-				errors.Is(err, hybridgatewayerrors.ErrUnsupportedKind),
-				errors.Is(err, hybridgatewayerrors.ErrUnsupportedGroup):
-				// These are expected errors to be handled gracefully. Log and skip this ParentRef, continue with others.
-				log.Debug(logger, "Skipping ParentRef due to expected error", "parentRef", pRef, "error", err)
-				continue
-			default:
-				// Unexpected system error, fail the entire translation.
-				return nil, fmt.Errorf("failed to get ControlPlaneRef for ParentRef %s: %w", pRef.Name, err)
-			}
-		}
-
-		if cp == nil {
-			log.Debug(logger, "No ControlPlaneRef found for ParentRef, skipping", "parentRef", pRef)
-			continue
-		}
-
-		log.Debug(logger, "Found ControlPlaneRef for ParentRef", "parentRef", pRef, "controlPlane", cp.KonnectNamespacedRef)
-
-		hostnames, err := c.getHostnamesByParentRef(ctx, logger, pRef)
-		if err != nil {
-			log.Error(logger, err, "Failed to get hostnames for ParentRef", "parentRef", pRef)
-			return nil, err
-		}
-		if hostnames == nil {
-			log.Debug(logger, "No hostnames found for ParentRef, skipping", "parentRef", pRef)
-			continue
-		}
-
-		log.Debug(logger, "Adding parent reference to result", "parentRef", pRef, "hostnames", hostnames)
-		result = append(result, hybridGatewayParent{
-			parentRef: pRef,
-			cpRef:     cp,
-			hostnames: hostnames,
-		})
-	}
-
-	log.Debug(logger, "Finished processing parent references", "supportedParents", len(result))
-	return result, nil
-}
-
-// getHostnamesByParentRef returns the hostnames that match between the HTTPRoute and the Gateway listeners.
-func (c *httpRouteConverter) getHostnamesByParentRef(ctx context.Context, logger logr.Logger, pRef gwtypes.ParentReference) ([]string, error) {
-	logger = logger.WithValues("parentRef", pRef.Name)
-	log.Debug(logger, "Getting hostnames for ParentRef")
-
-	var err error
-	var hostnames []string
-
-	listeners, err := refs.GetListenersByParentRef(ctx, c.Client, c.route, pRef)
-	if err != nil {
-		log.Error(logger, err, "Failed to get listeners for ParentRef")
-		return nil, err
-	}
-
-	log.Debug(logger, "Found listeners for ParentRef", "listenerCount", len(listeners))
-
-	for _, listener := range listeners {
-		// Check section reference if present
-		if pRef.SectionName != nil {
-			sectionName := string(*pRef.SectionName)
-			if string(listener.Name) != sectionName {
-				// This listener doesn't match the section reference, skip it
-				continue
-			}
-			if listener.Port != lo.FromPtr(pRef.Port) {
-				// This listener doesn't match the port reference, skip it
-				continue
-			}
-		}
-
-		// If the listener has no hostname, it means it accepts all HTTPRoute hostnames.
-		// No need to do further checks.
-		if listener.Hostname == nil || *listener.Hostname == "" {
-			log.Debug(logger, "Listener accepts all hostnames", "listener", listener.Name)
-			hostnames = []string{}
-			for _, host := range c.route.Spec.Hostnames {
-				hostnames = append(hostnames, string(host))
-			}
-			log.Debug(logger, "Returning all HTTPRoute hostnames", "hostnames", hostnames)
-			return hostnames, nil
-		}
-
-		// Handle wildcard hostnames - get intersection
-		log.Debug(logger, "Processing listener with hostname", "listener", listener.Name, "listenerHostname", *listener.Hostname)
-		for _, host := range c.route.Spec.Hostnames {
-			routeHostname := string(host)
-			if intersection := utils.HostnameIntersection(string(*listener.Hostname), routeHostname); intersection != "" {
-				log.Trace(logger, "Found hostname intersection", "listenerHostname", *listener.Hostname, "routeHostname", routeHostname, "intersection", intersection)
-				hostnames = append(hostnames, intersection)
-			}
-		}
-	}
-
-	log.Debug(logger, "Finished processing hostnames", "finalHostnames", hostnames)
-	return hostnames, nil
 }

--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -227,7 +227,7 @@ func TestHTTPRouteConverter_GetHybridGatewayParents(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			converter := tt.setup()
-			parents, err := converter.getHybridGatewayParents(ctx, logr.Discard())
+			parents, err := getHybridGatewayParents(ctx, logr.Discard(), converter.Client, converter.route)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errContains)
@@ -1153,7 +1153,7 @@ func TestHTTPRouteConverter_GetHostnamesByParentRef(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			converter, pRef := tt.setup()
-			hostnames, err := converter.getHostnamesByParentRef(ctx, logr.Discard(), pRef)
+			hostnames, err := getHostnamesByParentRef(ctx, logr.Discard(), converter.Client, converter.route, pRef)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errContains)

--- a/controller/hybridgateway/refs/by.go
+++ b/controller/hybridgateway/refs/by.go
@@ -35,11 +35,12 @@ func GetNamespacedRefs(ctx context.Context, cl client.Client, obj runtime.Object
 }
 
 // GetControlPlaneRefByParentRef retrieves the control plane reference for a given parent reference.
-func GetControlPlaneRefByParentRef(ctx context.Context, logger logr.Logger, cl client.Client, route *gwtypes.HTTPRoute,
+func GetControlPlaneRefByParentRef[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRoutePtr[T]](
+	ctx context.Context, logger logr.Logger, cl client.Client, route TPtr,
 	pRef gwtypes.ParentReference) (*commonv1alpha1.ControlPlaneRef, error) {
 
 	// Validate and get the supported Gateway for the ParentReference.
-	gw, found, err := GetSupportedGatewayForParentRef(ctx, logger, cl, pRef, route.Namespace)
+	gw, found, err := GetSupportedGatewayForParentRef(ctx, logger, cl, pRef, route.GetNamespace())
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +87,9 @@ func GetControlPlaneRefByGateway(ctx context.Context, cl client.Client, gateway 
 }
 
 // GetListenersByParentRef retrieves the listeners for a given parent reference.
-func GetListenersByParentRef(ctx context.Context, cl client.Client, route *gwtypes.HTTPRoute, pRef gwtypes.ParentReference) ([]gwtypes.Listener, error) {
+func GetListenersByParentRef[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRoutePtr[T]](
+	ctx context.Context, cl client.Client, route TPtr, pRef gwtypes.ParentReference,
+) ([]gwtypes.Listener, error) {
 	var namespace string
 	if pRef.Group == nil || *pRef.Group != gwtypes.GroupName {
 		return nil, nil
@@ -96,7 +99,7 @@ func GetListenersByParentRef(ctx context.Context, cl client.Client, route *gwtyp
 	}
 
 	if pRef.Namespace == nil || *pRef.Namespace == "" {
-		namespace = route.Namespace
+		namespace = route.GetNamespace()
 	} else {
 		namespace = string(*pRef.Namespace)
 	}

--- a/controller/hybridgateway/refs/by.go
+++ b/controller/hybridgateway/refs/by.go
@@ -28,7 +28,7 @@ func GetNamespacedRefs(ctx context.Context, cl client.Client, obj runtime.Object
 	switch o := obj.(type) {
 	// TODO: add other types here
 	case *gwtypes.HTTPRoute:
-		return byHTTPRoute(ctx, cl, *o)
+		return byRoute(ctx, cl, o)
 	default:
 		return nil, nil
 	}
@@ -116,10 +116,11 @@ func GetListenersByParentRef[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRou
 	return gw.Spec.Listeners, nil
 }
 
-// byHTTPRoute returns a slice of KonnectNamespacedRef associated with the given HTTPRoute, or an error if retrieval fails.
-func byHTTPRoute(ctx context.Context, cl client.Client, httpRoute gwtypes.HTTPRoute) (map[string]GatewaysByNamespacedRef, error) {
+// byRoute returns a slice of KonnectNamespacedRef associated with the given route, or an error if retrieval fails.
+func byRoute[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRoutePtr[T]](
+	ctx context.Context, cl client.Client, route TPtr) (map[string]GatewaysByNamespacedRef, error) {
 	namespacedRefs := map[string]GatewaysByNamespacedRef{}
-	gateways := GetGatewaysByHTTPRoute(ctx, cl, httpRoute)
+	gateways := GetGatewaysByRoute[T](ctx, cl, route)
 	for _, gw := range gateways {
 		ref, found, err := byGateway(ctx, cl, gw)
 		if err != nil {

--- a/controller/hybridgateway/refs/get.go
+++ b/controller/hybridgateway/refs/get.go
@@ -13,10 +13,13 @@ import (
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 )
 
-// GetGatewaysByHTTPRoute returns Gateways referenced by the given HTTPRoute.
-func GetGatewaysByHTTPRoute(ctx context.Context, cl client.Client, r gwtypes.HTTPRoute) []gwtypes.Gateway {
+// GetGatewaysByRoute returns Gateways referenced by the given route.
+func GetGatewaysByRoute[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRoutePtr[T]](
+	ctx context.Context, cl client.Client, route TPtr,
+) []gwtypes.Gateway {
 	gatewayRefs := []gwtypes.Gateway{}
-	for _, ref := range r.Spec.ParentRefs {
+	parentRefs := gwtypes.GetSpecParentRefs(*route)
+	for _, ref := range parentRefs {
 		var namespace string
 		if ref.Group == nil || *ref.Group != gwtypes.GroupName {
 			continue
@@ -27,7 +30,7 @@ func GetGatewaysByHTTPRoute(ctx context.Context, cl client.Client, r gwtypes.HTT
 		if ref.Namespace != nil && *ref.Namespace != "" {
 			namespace = string(*ref.Namespace)
 		} else {
-			namespace = r.Namespace
+			namespace = route.GetNamespace()
 		}
 		gw := &gwtypes.Gateway{}
 		err := cl.Get(ctx, client.ObjectKey{

--- a/internal/types/gatewaytypes_interfaces.go
+++ b/internal/types/gatewaytypes_interfaces.go
@@ -14,20 +14,9 @@ type SupportedRoutePtr[T SupportedRoute] interface {
 	client.Object
 }
 
-// SupportedRouteRule defines rules in supported routes.
-type SupportedRouteRule interface {
-	HTTPRouteRule
-}
-
-// SupportedRouteBackendRef defines backend references in supported routes.
-type SupportedRouteBackendRef interface {
-	BackendRef | HTTPBackendRef
-}
-
 // GetSpecParentRefs returns the parent references of a supported route.
 func GetSpecParentRefs[T SupportedRoute](route T) []ParentReference {
-	switch r := any(route).(type) {
-	case HTTPRoute:
+	if r, ok := any(route).(HTTPRoute); ok {
 		return r.Spec.ParentRefs
 	}
 	return []ParentReference{}

--- a/internal/types/gatewaytypes_interfaces.go
+++ b/internal/types/gatewaytypes_interfaces.go
@@ -1,0 +1,34 @@
+package types
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+// SupportedRoute defines a supported route type.
+type SupportedRoute interface {
+	HTTPRoute
+}
+
+// SupportedRoutePtr defines a pointer of a supported route type.
+// It includes the client.Object interface to extract metadata.
+type SupportedRoutePtr[T SupportedRoute] interface {
+	*T
+	client.Object
+}
+
+// SupportedRouteRule defines rules in supported routes.
+type SupportedRouteRule interface {
+	HTTPRouteRule
+}
+
+// SupportedRouteBackendRef defines backend references in supported routes.
+type SupportedRouteBackendRef interface {
+	BackendRef | HTTPBackendRef
+}
+
+// GetSpecParentRefs returns the parent references of a supported route.
+func GetSpecParentRefs[T SupportedRoute](route T) []ParentReference {
+	switch r := any(route).(type) {
+	case HTTPRoute:
+		return r.Spec.ParentRefs
+	}
+	return []ParentReference{}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

First PR of Reorganizing #3708.

Define interfaces for supported routes and extract some methods can be shared to uses type constraints insterad of fixed to  `HTTPRoute` to expand them to support `TLSRoute`.

**Which issue this PR fixes**


**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
