### PR TITLE
test(conformance): enable HTTPRouteInvalidCrossNamespaceBackendRef for Hybrid Gateway

### DIFF
--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -34,7 +34,7 @@ var skippedTestsForHybrid = []string{
 
 	// Core profile.
 	tests.HTTPRouteHTTPSListener.ShortName,
-	tests.HTTPRouteInvalidCrossNamespaceBackendRef.ShortName,
+	tests.HTTPRouteInvalidNonExistentBackendRef.ShortName,
 	tests.HTTPRouteInvalidReferenceGrant.ShortName,
 	tests.HTTPRouteListenerHostnameMatching.ShortName,
 	tests.HTTPRouteHeaderMatching.ShortName,


### PR DESCRIPTION


**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes https://github.com/Kong/kong-operator/issues/3452

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
