### PR TITLE
test(conformance): enable HTTPRouteReferenceGrant

### DIFF
--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -385,6 +385,65 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 			},
 		},
 		{
+			name: "translates cross-namespace backend without reference grant into request termination plugin",
+			setup: func() *httpRouteConverter {
+				route := newHTTPRouteForTranslation([]string{"api.example.com"}, []gwtypes.HTTPBackendRef{
+					newBackendRef("backend"),
+				}, nil)
+				gateway := baseGateway()
+				objects := append(newKonnectGatewayStandardObjects(gateway), newNamespace(), newService("backend"))
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(objects...).Build()
+				return newHTTPRouteConverter(route, fakeClient, false, "").(*httpRouteConverter)
+			},
+			wantCount: 5,
+			wantOutputs: outputCount{
+				upstreams: 1,
+				services:  1,
+				routes:    1,
+				targets:   0,
+				bindings:  1,
+				plugins:   1,
+			},
+			wantStoreLen: 5,
+			assertFn: func(t *testing.T, store []client.Object) {
+				t.Helper()
+
+				var (
+					serviceName string
+					pluginObj   *configurationv1.KongPlugin
+					bindingObj  *configurationv1alpha1.KongPluginBinding
+				)
+
+				for _, obj := range store {
+					switch typed := obj.(type) {
+					case *configurationv1alpha1.KongService:
+						serviceName = typed.Name
+					case *configurationv1.KongPlugin:
+						pluginObj = typed
+					case *configurationv1alpha1.KongPluginBinding:
+						bindingObj = typed
+					}
+				}
+
+				require.NotEmpty(t, serviceName)
+				require.NotNil(t, pluginObj)
+				require.NotNil(t, bindingObj)
+				assert.Equal(t, "request-termination", pluginObj.PluginName)
+
+				var config map[string]any
+				require.NoError(t, json.Unmarshal(pluginObj.Config.Raw, &config))
+				statusCode, ok := config["status_code"].(float64)
+				require.True(t, ok)
+				assert.InDelta(t, 500, statusCode, 0)
+				assert.Equal(t, "no existing backendRef provided", config["message"])
+
+				require.NotNil(t, bindingObj.Spec.Targets)
+				require.NotNil(t, bindingObj.Spec.Targets.ServiceReference)
+				assert.Equal(t, serviceName, bindingObj.Spec.Targets.ServiceReference.Name)
+				assert.Equal(t, pluginObj.Name, bindingObj.Spec.PluginReference.Name)
+			},
+		},
+		{
 			name: "translates multi rule redirect only route end to end",
 			setup: func() *httpRouteConverter {
 				route := newHTTPRouteWithRules(

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -44,7 +44,6 @@ var skippedTestsForHybrid = []string{
 	tests.HTTPRoutePartiallyInvalidViaInvalidReferenceGrant.ShortName,
 	tests.HTTPRoutePathMatchOrder.ShortName,
 	tests.HTTPRouteQueryParamMatching.ShortName,
-	tests.HTTPRouteReferenceGrant.ShortName,
 	tests.HTTPRouteExactPathMatching.ShortName,
 	tests.HTTPRouteHostnameIntersection.ShortName,
 	tests.HTTPRouteCrossNamespace.ShortName,


### PR DESCRIPTION
**What this PR does / why we need it**:

- enables the Hybrid Gateway `HTTPRouteReferenceGrant` conformance coverage by removing it from `test/conformance/skipped_tests_test.go`
- adds a regression test that verifies a cross-namespace backend without a `ReferenceGrant` still translates into a `request-termination` plugin path, which is the behavior needed after the conformance test deletes the grant and expects `500`

**Which issue this PR fixes**

Fixes #3450

**Special notes for your reviewer**:

- the core Hybrid behavior needed for this conformance case landed in #3603; this PR keeps the scope to unskipping the test and locking the behavior with unit coverage


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
