### PR TITLE
chore: `ControlPlane` creation logged as error

### DIFF
--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -690,7 +690,7 @@ func (r *Reconciler) provisionControlPlane(
 	case count == 0:
 		err := r.createControlPlane(ctx, gateway, gatewayConfig)
 		if err != nil {
-			log.Debug(logger, fmt.Sprintf("controlplane creation failed - error: %v", err))
+			log.Error(logger, err, "controlplane creation failed")
 			k8sutils.SetCondition(
 				createControlPlaneCondition(metav1.ConditionFalse, kcfgdataplane.UnableToProvisionReason, err.Error(), gateway.Generation),
 				gatewayConditionsAndListenersAware(gateway),


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a valid case for being logged as an error. For a more holistic approach, there is a dedicated issue (#2344). 

**Which issue this PR fixes**

Fixes #153