### PR TITLE
fix(admission): validate KongPlugin against gateways that expose the plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,10 +147,11 @@
   `http,https`.
   [#3587](https://github.com/Kong/kong-operator/pull/3587)
 - Fix `KongPlugin` admission validation when multiple Kong Gateway Admin API
-  clients are discovered: probe plugin schema per gateway and validate only on
-  gateways that expose the plugin, falling back to the previous single-client
-  behavior when none match. Avoids false rejections when plugin bundles differ
-  across gateways.
+  clients are discovered: probe plugin schema on every gateway (order-independent),
+  validate only on gateways that expose the plugin, and fall back to the previous
+  single-client behavior when none match. Partial probe failures on one gateway do
+  not reject admission if another gateway exposes the plugin. Avoids false rejections
+  when plugin bundles differ across gateways.
   [#3737](https://github.com/Kong/kong-operator/issues/3737)
 
 ## [v2.1.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,12 @@
 - Fix the on-prem translator to set `protocols` in translated Kong routes to
   `http,https`.
   [#3587](https://github.com/Kong/kong-operator/pull/3587)
+- Fix `KongPlugin` admission validation when multiple Kong Gateway Admin API
+  clients are discovered: probe plugin schema per gateway and validate only on
+  gateways that expose the plugin, falling back to the previous single-client
+  behavior when none match. Avoids false rejections when plugin bundles differ
+  across gateways.
+  [#3737](https://github.com/Kong/kong-operator/issues/3737)
 
 ## [v2.1.3]
 

--- a/ingress-controller/internal/admission/adminapi_provider.go
+++ b/ingress-controller/internal/admission/adminapi_provider.go
@@ -37,6 +37,15 @@ func (p DefaultAdminAPIServicesProvider) GetPluginsService() (kong.AbstractPlugi
 	return c.Plugins, true
 }
 
+func (p DefaultAdminAPIServicesProvider) GetPluginsServices() []kong.AbstractPluginService {
+	gwClients := p.gatewayClientsProvider.GatewayClients()
+	services := make([]kong.AbstractPluginService, 0, len(gwClients))
+	for _, c := range gwClients {
+		services = append(services, c.AdminAPIClient().Plugins)
+	}
+	return services
+}
+
 func (p DefaultAdminAPIServicesProvider) GetConsumerGroupsService() (kong.AbstractConsumerGroupService, bool) {
 	c, ok := p.designatedAdminAPIClient()
 	if !ok {
@@ -83,13 +92,10 @@ func (p DefaultAdminAPIServicesProvider) designatedAdminAPIClient() (*kong.Clien
 		return nil, false
 	}
 
-	// For now using first client is kind of OK. Using Consumer and Plugin
-	// services from first kong client should theoretically return the same
-	// results as for all other clients. There might be instances where
-	// configurations in different Kong Gateways are ever so slightly
-	// different but that shouldn't cause a fatal failure.
+	// Uses the first discovered gateway for Admin API calls (consumers, routes, etc.).
+	// KongPlugin admission can opt into multi-gateway plugin service selection through
+	// the optional GetPluginsServices() extension.
 	//
-	// TODO: We should take a look at this sooner rather than later.
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/3363
 	return gwClients[0].AdminAPIClient(), true
 }

--- a/ingress-controller/internal/admission/validator.go
+++ b/ingress-controller/internal/admission/validator.go
@@ -594,15 +594,19 @@ func (validator KongHTTPValidator) validatePluginAgainstGatewaySchema(ctx contex
 	return "", nil
 }
 
-// pluginServicesForAvailablePlugin returns plugin services for gateways that expose the plugin schema.
-// A 404 from GetFullSchema means the plugin is not available on that gateway and that client is skipped.
-// Any other error is returned immediately so transient Admin API failures are not mistaken for "plugin absent".
+// pluginServicesForAvailablePlugin returns plugin services for gateways that expose the plugin schema
+// (GetFullSchema succeeds). A 404 means the plugin is not available on that gateway and is skipped.
+// Other probe errors are remembered but do not stop the scan: if any gateway exposes the schema,
+// those services are returned and probe failures on other gateways are ignored. If no gateway
+// exposes the schema, the first non-404 probe error is returned (when present); otherwise an empty
+// slice and nil error (all 404), so callers can fall back to legacy validation.
 func pluginServicesForAvailablePlugin(
 	ctx context.Context,
 	pluginServices []kong.AbstractPluginService,
 	pluginName string,
 ) ([]kong.AbstractPluginService, error) {
 	available := make([]kong.AbstractPluginService, 0, len(pluginServices))
+	var firstProbeErr error
 	for _, ps := range pluginServices {
 		_, err := ps.GetFullSchema(ctx, &pluginName)
 		switch {
@@ -611,8 +615,16 @@ func pluginServicesForAvailablePlugin(
 		case kong.IsNotFoundErr(err):
 			// Plugin not installed / not exposed on this gateway.
 		default:
-			return nil, err
+			if firstProbeErr == nil {
+				firstProbeErr = err
+			}
 		}
+	}
+	if len(available) > 0 {
+		return available, nil
+	}
+	if firstProbeErr != nil {
+		return nil, firstProbeErr
 	}
 	return available, nil
 }

--- a/ingress-controller/internal/admission/validator.go
+++ b/ingress-controller/internal/admission/validator.go
@@ -61,6 +61,12 @@ type AdminAPIServicesProvider interface {
 	GetSchemasService() (kong.AbstractSchemaService, bool)
 }
 
+// MultiGatewayAdminAPIServicesProvider is an optional extension for providers that
+// can expose services for all discovered gateways.
+type MultiGatewayAdminAPIServicesProvider interface {
+	GetPluginsServices() []kong.AbstractPluginService
+}
+
 // ConsumerGetter is an interface for retrieving KongConsumers.
 type ConsumerGetter interface {
 	ListAllConsumers(ctx context.Context) ([]configurationv1.KongConsumer, error)
@@ -560,6 +566,16 @@ func (validator KongHTTPValidator) ensureConsumerDoesNotExistInGateway(ctx conte
 }
 
 func (validator KongHTTPValidator) validatePluginAgainstGatewaySchema(ctx context.Context, plugin kong.Plugin) (string, error) {
+	if multiGatewayProvider, ok := validator.AdminAPIServicesProvider.(MultiGatewayAdminAPIServicesProvider); ok {
+		pluginServices := multiGatewayProvider.GetPluginsServices()
+		if len(pluginServices) > 0 && plugin.Name != nil {
+			availablePluginServices := pluginServicesForAvailablePlugin(ctx, pluginServices, *plugin.Name)
+			if len(availablePluginServices) > 0 {
+				return validatePluginAcrossPluginServices(ctx, availablePluginServices, plugin)
+			}
+		}
+	}
+
 	pluginService, hasClient := validator.AdminAPIServicesProvider.GetPluginsService()
 	if hasClient {
 		isValid, msg, err := pluginService.Validate(ctx, &plugin)
@@ -572,6 +588,45 @@ func (validator KongHTTPValidator) validatePluginAgainstGatewaySchema(ctx contex
 	}
 
 	// if there's no client, do not verify with data-plane as there's none available
+	return "", nil
+}
+
+func pluginServicesForAvailablePlugin(
+	ctx context.Context,
+	pluginServices []kong.AbstractPluginService,
+	pluginName string,
+) []kong.AbstractPluginService {
+	available := make([]kong.AbstractPluginService, 0, len(pluginServices))
+	for _, ps := range pluginServices {
+		if _, err := ps.GetFullSchema(ctx, &pluginName); err == nil {
+			available = append(available, ps)
+		}
+	}
+	return available
+}
+
+// validatePluginAcrossPluginServices returns success if any gateway validates the plugin.
+// This matches multi-gateway deployments where plugin bundles differ between data planes.
+func validatePluginAcrossPluginServices(ctx context.Context, pluginServices []kong.AbstractPluginService, plugin kong.Plugin) (string, error) {
+	var lastErr error
+	var lastInvalidMsg string
+	for _, ps := range pluginServices {
+		isValid, msg, err := ps.Validate(ctx, &plugin)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if isValid {
+			return "", nil
+		}
+		lastInvalidMsg = msg
+	}
+	if lastErr != nil {
+		return ErrTextPluginConfigValidationFailed, lastErr
+	}
+	if lastInvalidMsg != "" {
+		return fmt.Sprintf(ErrTextPluginConfigViolatesSchema, lastInvalidMsg), nil
+	}
 	return "", nil
 }
 

--- a/ingress-controller/internal/admission/validator.go
+++ b/ingress-controller/internal/admission/validator.go
@@ -569,7 +569,10 @@ func (validator KongHTTPValidator) validatePluginAgainstGatewaySchema(ctx contex
 	if multiGatewayProvider, ok := validator.AdminAPIServicesProvider.(MultiGatewayAdminAPIServicesProvider); ok {
 		pluginServices := multiGatewayProvider.GetPluginsServices()
 		if len(pluginServices) > 0 && plugin.Name != nil {
-			availablePluginServices := pluginServicesForAvailablePlugin(ctx, pluginServices, *plugin.Name)
+			availablePluginServices, err := pluginServicesForAvailablePlugin(ctx, pluginServices, *plugin.Name)
+			if err != nil {
+				return ErrTextPluginConfigValidationFailed, err
+			}
 			if len(availablePluginServices) > 0 {
 				return validatePluginAcrossPluginServices(ctx, availablePluginServices, plugin)
 			}
@@ -591,18 +594,27 @@ func (validator KongHTTPValidator) validatePluginAgainstGatewaySchema(ctx contex
 	return "", nil
 }
 
+// pluginServicesForAvailablePlugin returns plugin services for gateways that expose the plugin schema.
+// A 404 from GetFullSchema means the plugin is not available on that gateway and that client is skipped.
+// Any other error is returned immediately so transient Admin API failures are not mistaken for "plugin absent".
 func pluginServicesForAvailablePlugin(
 	ctx context.Context,
 	pluginServices []kong.AbstractPluginService,
 	pluginName string,
-) []kong.AbstractPluginService {
+) ([]kong.AbstractPluginService, error) {
 	available := make([]kong.AbstractPluginService, 0, len(pluginServices))
 	for _, ps := range pluginServices {
-		if _, err := ps.GetFullSchema(ctx, &pluginName); err == nil {
+		_, err := ps.GetFullSchema(ctx, &pluginName)
+		switch {
+		case err == nil:
 			available = append(available, ps)
+		case kong.IsNotFoundErr(err):
+			// Plugin not installed / not exposed on this gateway.
+		default:
+			return nil, err
 		}
 	}
-	return available
+	return available, nil
 }
 
 // validatePluginAcrossPluginServices returns success if any gateway validates the plugin.

--- a/ingress-controller/internal/admission/validator_test.go
+++ b/ingress-controller/internal/admission/validator_test.go
@@ -41,10 +41,19 @@ type fakePluginSvc struct {
 	err   error
 	msg   string
 	valid bool
+	// If non-nil, GetFullSchema returns this error (e.g. 404 = plugin not on gateway).
+	getFullSchemaErr error
 }
 
 func (f *fakePluginSvc) Validate(context.Context, *kong.Plugin) (bool, string, error) {
 	return f.valid, f.msg, f.err
+}
+
+func (f *fakePluginSvc) GetFullSchema(context.Context, *string) (kong.Schema, error) {
+	if f.getFullSchemaErr != nil {
+		return nil, f.getFullSchemaErr
+	}
+	return kong.Schema{}, nil
 }
 
 type fakeConsumersSvc struct {
@@ -1385,6 +1394,46 @@ func (s fakeVaultSvc) Validate(_ context.Context, _ *kong.Vault) (bool, string, 
 		return false, "something is wrong with the vault", nil
 	}
 	return true, "", nil
+}
+
+func TestPluginServicesForAvailablePlugin(t *testing.T) {
+	ctx := t.Context()
+	svcs := []kong.AbstractPluginService{
+		&fakePluginSvc{getFullSchemaErr: kong.NewAPIError(http.StatusNotFound, "unknown plugin")},
+		&fakePluginSvc{},
+	}
+
+	t.Run("404 skipped others kept", func(t *testing.T) {
+		got, err := pluginServicesForAvailablePlugin(ctx, svcs, "my-plugin")
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+	})
+
+	t.Run("non-404 error returned", func(t *testing.T) {
+		e := kong.NewAPIError(http.StatusServiceUnavailable, "upstream")
+		_, err := pluginServicesForAvailablePlugin(ctx, []kong.AbstractPluginService{
+			&fakePluginSvc{getFullSchemaErr: e},
+		}, "my-plugin")
+		require.ErrorIs(t, err, e)
+	})
+
+	t.Run("404 then non-404 returns non-404", func(t *testing.T) {
+		e := kong.NewAPIError(http.StatusBadGateway, "bad")
+		_, err := pluginServicesForAvailablePlugin(ctx, []kong.AbstractPluginService{
+			&fakePluginSvc{getFullSchemaErr: kong.NewAPIError(http.StatusNotFound, "nope")},
+			&fakePluginSvc{getFullSchemaErr: e},
+		}, "my-plugin")
+		require.ErrorIs(t, err, e)
+	})
+
+	t.Run("all 404 yields empty", func(t *testing.T) {
+		got, err := pluginServicesForAvailablePlugin(ctx, []kong.AbstractPluginService{
+			&fakePluginSvc{getFullSchemaErr: kong.NewAPIError(http.StatusNotFound, "a")},
+			&fakePluginSvc{getFullSchemaErr: kong.NewAPIError(http.StatusNotFound, "b")},
+		}, "my-plugin")
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
 }
 
 func TestValidatePluginAcrossPluginServices(t *testing.T) {

--- a/ingress-controller/internal/admission/validator_test.go
+++ b/ingress-controller/internal/admission/validator_test.go
@@ -1387,6 +1387,48 @@ func (s fakeVaultSvc) Validate(_ context.Context, _ *kong.Vault) (bool, string, 
 	return true, "", nil
 }
 
+func TestValidatePluginAcrossPluginServices(t *testing.T) {
+	ctx := t.Context()
+	plugin := kong.Plugin{Name: kong.String("test")}
+
+	t.Run("first invalid second valid", func(t *testing.T) {
+		msg, err := validatePluginAcrossPluginServices(ctx, []kong.AbstractPluginService{
+			&fakePluginSvc{valid: false, msg: "unknown plugin"},
+			&fakePluginSvc{valid: true},
+		}, plugin)
+		require.NoError(t, err)
+		assert.Empty(t, msg)
+	})
+
+	t.Run("first error second valid", func(t *testing.T) {
+		msg, err := validatePluginAcrossPluginServices(ctx, []kong.AbstractPluginService{
+			&fakePluginSvc{err: errors.New("connection refused")},
+			&fakePluginSvc{valid: true},
+		}, plugin)
+		require.NoError(t, err)
+		assert.Empty(t, msg)
+	})
+
+	t.Run("all invalid uses last message", func(t *testing.T) {
+		msg, err := validatePluginAcrossPluginServices(ctx, []kong.AbstractPluginService{
+			&fakePluginSvc{valid: false, msg: "bad"},
+			&fakePluginSvc{valid: false, msg: "worse"},
+		}, plugin)
+		require.NoError(t, err)
+		assert.Contains(t, msg, "worse")
+	})
+
+	t.Run("all errors", func(t *testing.T) {
+		e := errors.New("upstream failure")
+		msg, err := validatePluginAcrossPluginServices(ctx, []kong.AbstractPluginService{
+			&fakePluginSvc{err: e},
+			&fakePluginSvc{err: e},
+		}, plugin)
+		require.ErrorIs(t, err, e)
+		assert.Equal(t, ErrTextPluginConfigValidationFailed, msg)
+	})
+}
+
 func TestValidator_ValidateCustomEntity(t *testing.T) {
 	testCases := []struct {
 		name            string

--- a/ingress-controller/internal/admission/validator_test.go
+++ b/ingress-controller/internal/admission/validator_test.go
@@ -1398,18 +1398,30 @@ func (s fakeVaultSvc) Validate(_ context.Context, _ *kong.Vault) (bool, string, 
 
 func TestPluginServicesForAvailablePlugin(t *testing.T) {
 	ctx := t.Context()
-	svcs := []kong.AbstractPluginService{
-		&fakePluginSvc{getFullSchemaErr: kong.NewAPIError(http.StatusNotFound, "unknown plugin")},
-		&fakePluginSvc{},
-	}
 
 	t.Run("404 skipped others kept", func(t *testing.T) {
+		svcs := []kong.AbstractPluginService{
+			&fakePluginSvc{getFullSchemaErr: kong.NewAPIError(http.StatusNotFound, "unknown plugin")},
+			&fakePluginSvc{},
+		}
 		got, err := pluginServicesForAvailablePlugin(ctx, svcs, "my-plugin")
 		require.NoError(t, err)
 		require.Len(t, got, 1)
 	})
 
-	t.Run("non-404 error returned", func(t *testing.T) {
+	t.Run("first non-404 second schema ok is order-independent", func(t *testing.T) {
+		e503 := kong.NewAPIError(http.StatusServiceUnavailable, "upstream")
+		ok := &fakePluginSvc{}
+		got, err := pluginServicesForAvailablePlugin(ctx, []kong.AbstractPluginService{
+			&fakePluginSvc{getFullSchemaErr: e503},
+			ok,
+		}, "my-plugin")
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Same(t, ok, got[0])
+	})
+
+	t.Run("single gateway non-404 only returns that error", func(t *testing.T) {
 		e := kong.NewAPIError(http.StatusServiceUnavailable, "upstream")
 		_, err := pluginServicesForAvailablePlugin(ctx, []kong.AbstractPluginService{
 			&fakePluginSvc{getFullSchemaErr: e},
@@ -1417,13 +1429,32 @@ func TestPluginServicesForAvailablePlugin(t *testing.T) {
 		require.ErrorIs(t, err, e)
 	})
 
-	t.Run("404 then non-404 returns non-404", func(t *testing.T) {
+	t.Run("404 then non-404 when no gateway exposes schema returns non-404", func(t *testing.T) {
 		e := kong.NewAPIError(http.StatusBadGateway, "bad")
 		_, err := pluginServicesForAvailablePlugin(ctx, []kong.AbstractPluginService{
 			&fakePluginSvc{getFullSchemaErr: kong.NewAPIError(http.StatusNotFound, "nope")},
 			&fakePluginSvc{getFullSchemaErr: e},
 		}, "my-plugin")
 		require.ErrorIs(t, err, e)
+	})
+
+	t.Run("non-404 then 404 when no gateway exposes schema returns first error", func(t *testing.T) {
+		e := kong.NewAPIError(http.StatusServiceUnavailable, "first")
+		_, err := pluginServicesForAvailablePlugin(ctx, []kong.AbstractPluginService{
+			&fakePluginSvc{getFullSchemaErr: e},
+			&fakePluginSvc{getFullSchemaErr: kong.NewAPIError(http.StatusNotFound, "nope")},
+		}, "my-plugin")
+		require.ErrorIs(t, err, e)
+	})
+
+	t.Run("multiple non-404 no success returns first probe error", func(t *testing.T) {
+		first := kong.NewAPIError(http.StatusBadGateway, "first")
+		second := kong.NewAPIError(http.StatusGatewayTimeout, "second")
+		_, err := pluginServicesForAvailablePlugin(ctx, []kong.AbstractPluginService{
+			&fakePluginSvc{getFullSchemaErr: first},
+			&fakePluginSvc{getFullSchemaErr: second},
+		}, "my-plugin")
+		require.ErrorIs(t, err, first)
 	})
 
 	t.Run("all 404 yields empty", func(t *testing.T) {


### PR DESCRIPTION
# PR: Multi-gateway KongPlugin admission validation (#3737)

## What this PR does

When several Kong Gateway Admin API clients are discovered, `KongPlugin` admission used to validate through a single chosen client (`GatewayClients()[0]` via `DefaultAdminAPIServicesProvider`). That order is not stable, so validation could hit a gateway that does not expose a plugin/schema even when another discovered gateway does—causing false rejections or flaky behavior in multi-gateway setups with different plugin bundles.

This PR makes `KongPlugin` admission validation **gateway-aware**:

- Extends `DefaultAdminAPIServicesProvider` with an optional **`GetPluginsServices()`** path via **`MultiGatewayAdminAPIServicesProvider`**.
- Probes **`GetFullSchema(pluginName)`** on each discovered gateway.
- Validates only against gateways that expose the plugin schema.
- **Accepts** the resource if **any** matching gateway validates the plugin successfully.
- **Preserves** the legacy single-client path when **no** gateway exposes the plugin schema.

**Schema probing is order-independent:**

- **404 Not Found** → plugin not available on that gateway (skip).
- **Non-404** probe errors are recorded but **do not** abort early if another gateway exposes the schema.
- If **no** gateway exposes the schema: return the **first** non-404 probe error when present; otherwise fall back to the legacy single-client validation.

**Fixes #3737**

Related upstream discussion: [kubernetes-ingress-controller#3363](https://github.com/Kong/kubernetes-ingress-controller/issues/3363)

## Notes for reviewers

### Trade-offs

1. **First successful validation wins** — If several gateways expose the plugin, admission succeeds as soon as one validates the plugin. This favors availability in mixed multi-gateway deployments.

2. **Extra Admin API work at admission** — Probing `GetFullSchema()` per gateway and validating the matching subset adds some overhead vs. a single client, bounded by the number of discovered gateways.

3. **Scope** — Only **`KongPlugin` admission validation** is changed. Other admission paths that still use the single designated client are unchanged.

### Changelog

Release notes are under **Unreleased → Fixes** in `CHANGELOG.md`.

## PR readiness

- [x] `CHANGELOG.md` updated for significant changes
