### PR TITLE
feat: rotate certificates issued by KO on expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,10 @@
   [#3850](https://github.com/Kong/kong-operator/pull/3850)
 - Hybridgateway: add support for `konghq.com/protocol` service annotation
   [#3847](https://github.com/Kong/kong-operator/pull/3847)
+- Automatic rotation of certificates issued by the operator and used internally,
+  configured via `--cert-ttl` and `--cert-expiration-margin` flags. The operator will
+  automatically renew certificates before they expire, ensuring secure communication. Short downtime during rotation is expected.
+  [#3745](https://github.com/Kong/kong-operator/pull/3745)
 
 ### Changed
 

--- a/controller/controlplane/controller.go
+++ b/controller/controlplane/controller.go
@@ -65,6 +65,7 @@ type Reconciler struct {
 	CacheSyncPeriod          time.Duration
 	ClusterCASecretName      string
 	ClusterCASecretNamespace string
+	CertTTL                  time.Duration
 
 	RestConfig              *rest.Config
 	KubeConfigPath          string

--- a/controller/controlplane/controller_reconciler_utils.go
+++ b/controller/controlplane/controller_reconciler_utils.go
@@ -126,6 +126,7 @@ func (r *Reconciler) ensureAdminMTLSCertificateSecret(
 		usages,
 		r.Client,
 		matchingLabels,
+		r.CertTTL,
 	)
 }
 

--- a/controller/cpextensions/metricsscraper/manager.go
+++ b/controller/cpextensions/metricsscraper/manager.go
@@ -30,9 +30,10 @@ import (
 )
 
 type certs struct {
-	Key  crypto.Signer
-	CA   *x509.Certificate
-	Cert *x509.Certificate
+	Key            crypto.Signer
+	CA             *x509.Certificate
+	Cert           *x509.Certificate
+	ExpirationDate time.Time
 }
 
 // MetricsScrapePipeline is a pipeline for scraping and enriching metrics.
@@ -50,9 +51,11 @@ type metricsPipeline struct {
 type Manager struct {
 	logger                   logr.Logger
 	scrapeInterval           time.Duration
+	certTTL                  time.Duration
+	certExpirationMargin     time.Duration
 	client                   client.Client
 	caSecretNN               types.NamespacedName
-	certs                    certs
+	certs                    *certs
 	pipelinesNotificationsCh chan scrapeUpdateNotification
 	pipelinesLock            sync.RWMutex
 	pipelines                map[types.UID]MetricsScrapePipeline
@@ -63,12 +66,16 @@ type Manager struct {
 func NewManager(
 	logger logr.Logger,
 	interval time.Duration,
+	certTTL time.Duration,
+	certExpirationMargin time.Duration,
 	cl client.Client,
 	caSecretNN types.NamespacedName,
 ) *Manager {
 	return &Manager{
 		logger:                   logger,
 		scrapeInterval:           interval,
+		certTTL:                  certTTL,
+		certExpirationMargin:     certExpirationMargin,
 		caSecretNN:               caSecretNN,
 		client:                   cl,
 		pipelinesNotificationsCh: make(chan scrapeUpdateNotification),
@@ -129,8 +136,7 @@ func (msm *Manager) initMTLSCerts(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	// Let's make this valid for 10 years.
-	expiration := int32(315400000)
+	expiration := int32(msm.certTTL.Seconds())
 	csr := certificatesv1.CertificateSigningRequestSpec{
 		Request: pem.EncodeToMemory(&pem.Block{
 			Type:  "CERTIFICATE REQUEST",
@@ -156,10 +162,11 @@ func (msm *Manager) initMTLSCerts(ctx context.Context) error {
 		return err
 	}
 
-	msm.certs = certs{
-		CA:   caCert,
-		Cert: cert,
-		Key:  csrKey,
+	msm.certs = &certs{
+		CA:             caCert,
+		Cert:           cert,
+		Key:            csrKey,
+		ExpirationDate: cert.NotAfter,
 	}
 	return nil
 }
@@ -206,10 +213,6 @@ func (msm *Manager) getCASecretAndKey(ctx context.Context) (*x509.Certificate, c
 // It spawns a goroutine that periodically scrapes metrics from the enabled scrapers.
 // This satisfies the Manager interface and can be used with controller-runtime Manager.
 func (msm *Manager) Start(ctx context.Context) error {
-	if err := msm.initMTLSCerts(ctx); err != nil {
-		return fmt.Errorf("failed to create mTLS certs: %w", err)
-	}
-
 	go func(ctx context.Context) {
 		ticker := time.NewTicker(msm.scrapeInterval)
 		defer ticker.Stop()
@@ -385,9 +388,17 @@ func (msm *Manager) enableMetricsScraperForControlPlanesDataPlane(
 	}
 
 	adminAPIAddressProvider := NewAdminAPIAddressProvider(msm.client)
-	httpClient := httpClientWithCerts(msm.certs)
 
-	enricher, err := NewEnricher(msm.logger, &dp, msm.client, msm.certs, adminAPIAddressProvider)
+	if msm.certs == nil || msm.certs.ExpirationDate.Sub(time.Now().UTC()) < msm.certExpirationMargin {
+		if err := msm.initMTLSCerts(ctx); err != nil {
+			return fmt.Errorf("failed to rotate mTLS certs: %w", err)
+		}
+		log.Debug(msm.logger, "new certificate for metrics provided", "expirationDate", msm.certs.ExpirationDate)
+	}
+
+	httpClient := httpClientWithCerts(*msm.certs)
+
+	enricher, err := NewEnricher(msm.logger, &dp, msm.client, *msm.certs, adminAPIAddressProvider)
 	if err != nil {
 		return fmt.Errorf("failed to create metrics enricher: %w", err)
 	}

--- a/controller/cpextensions/metricsscraper/manager_test.go
+++ b/controller/cpextensions/metricsscraper/manager_test.go
@@ -2,6 +2,7 @@ package metricsscraper
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"net/http"
 	"sync/atomic"
@@ -10,10 +11,10 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -247,15 +248,15 @@ func TestMetricsScrapeManagerAdd(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().Build()
-			msm := NewManager(logr.Discard(), interval, fakeClient, types.NamespacedName{})
+			msm := NewManager(logr.Discard(), interval, time.Hour, 10*time.Minute, fakeClient, types.NamespacedName{})
 			for _, pipeline := range tt.pairs {
 				msm.Add(pipeline.controlplane, pipeline.pipeline)
 			}
 
-			assert.Equal(t, tt.expectedCpNNToDPUID, msm.cpNNToDpUID)
-			assert.ElementsMatch(t, tt.expectedScrapersUIDs, lo.Keys(msm.pipelines))
+			require.Equal(t, tt.expectedCpNNToDPUID, msm.cpNNToDpUID)
+			require.ElementsMatch(t, tt.expectedScrapersUIDs, lo.Keys(msm.pipelines))
 			for uid, scraper := range msm.pipelines {
-				assert.Equal(t, uid, scraper.DataPlaneUID())
+				require.Equal(t, uid, scraper.DataPlaneUID())
 			}
 		})
 	}
@@ -356,7 +357,7 @@ func TestMetricsScrapeManager_RemoveForControlPlaneNN(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().Build()
-			msm := NewManager(logr.Discard(), interval, fakeClient, types.NamespacedName{})
+			msm := NewManager(logr.Discard(), interval, time.Hour, 10*time.Minute, fakeClient, types.NamespacedName{})
 			for _, pair := range tt.addPairs {
 				msm.Add(pair.controlplane, pair.pipeline)
 			}
@@ -365,10 +366,10 @@ func TestMetricsScrapeManager_RemoveForControlPlaneNN(t *testing.T) {
 				msm.RemoveForControlPlaneNN(*tt.removeCpNN)
 			}
 
-			assert.Equal(t, tt.expectedCpNNToDPUID, msm.cpNNToDpUID)
-			assert.Equal(t, tt.expectedScrapersUIDs, lo.Keys(msm.pipelines))
+			require.Equal(t, tt.expectedCpNNToDPUID, msm.cpNNToDpUID)
+			require.Equal(t, tt.expectedScrapersUIDs, lo.Keys(msm.pipelines))
 			for uid, scraper := range msm.pipelines {
-				assert.Equal(t, uid, scraper.DataPlaneUID())
+				require.Equal(t, uid, scraper.DataPlaneUID())
 			}
 		})
 	}
@@ -488,7 +489,7 @@ func TestMetricsScrapeManager_Start(t *testing.T) {
 			}
 			fakeClient := fake.NewClientBuilder().WithObjects(caSecret).Build()
 
-			msm := NewManager(logr.Discard(), intervalTime, fakeClient, client.ObjectKeyFromObject(caSecret))
+			msm := NewManager(logr.Discard(), intervalTime, time.Hour, 10*time.Minute, fakeClient, client.ObjectKeyFromObject(caSecret))
 			for _, pair := range tc.addPairs {
 				msm.Add(pair.controlplane, pair.pipeline)
 			}
@@ -496,7 +497,7 @@ func TestMetricsScrapeManager_Start(t *testing.T) {
 			for idx, pipeline := range msm.pipelines {
 				mp, ok := pipeline.(metricsPipeline)
 				require.True(t, ok)
-				assert.Zero(t, mp.MetricsScraper.(*mockScraper).CallCount(),
+				require.Zero(t, mp.MetricsScraper.(*mockScraper).CallCount(),
 					"scraper %d should not have been called yet", idx,
 				)
 			}
@@ -519,4 +520,122 @@ func TestMetricsScrapeManager_Start(t *testing.T) {
 			)
 		})
 	}
+}
+
+func TestMetricsScrapeManager_CertRotation(t *testing.T) {
+	const (
+		certTTL              = time.Hour
+		certExpirationMargin = 10 * time.Minute
+	)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, operatorv1beta1.AddToScheme(scheme))
+
+	certPEM, keyPEM := certificate.MustGenerateCertPEMFormat(certificate.WithCATrue())
+	caSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ca-secret",
+			Namespace: "kong-system",
+		},
+		Data: map[string][]byte{
+			"ca.crt":  certPEM,
+			"tls.crt": certPEM,
+			"tls.key": keyPEM,
+		},
+	}
+	dp := &operatorv1beta1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dp1",
+			Namespace: "ns1",
+			UID:       types.UID("dp-uid1"),
+		},
+	}
+	cp := &gwtypes.ControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cp1",
+			Namespace: "ns1",
+		},
+		Spec: gwtypes.ControlPlaneSpec{
+			DataPlane: gwtypes.ControlPlaneDataPlaneTarget{
+				Type: gwtypes.ControlPlaneDataPlaneTargetRefType,
+				Ref: &gwtypes.ControlPlaneDataPlaneTargetRef{
+					Name: "dp1",
+				},
+			},
+		},
+	}
+
+	t.Run("initializes certs when nil", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(caSecret, dp).
+			Build()
+		msm := NewManager(logr.Discard(), time.Second, certTTL, certExpirationMargin, fakeClient, client.ObjectKeyFromObject(caSecret))
+		require.Nil(t, msm.certs)
+
+		require.NoError(t, msm.enableMetricsScraperForControlPlanesDataPlane(t.Context(), cp))
+		require.NotNil(t, msm.certs)
+		require.False(t, msm.certs.ExpirationDate.IsZero(), "expiration date should be set")
+		require.WithinDuration(t, time.Now().Add(certTTL), msm.certs.ExpirationDate, certExpirationMargin)
+	})
+
+	t.Run("does not rotate certs when far from expiration", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(caSecret, dp).
+			Build()
+		msm := NewManager(logr.Discard(), time.Second, certTTL, certExpirationMargin, fakeClient, client.ObjectKeyFromObject(caSecret))
+
+		// Pre-populate certs with a far-future expiration.
+		msm.certs = &certs{
+			ExpirationDate: time.Now().Add(24 * time.Hour),
+			Cert:           &x509.Certificate{},
+			CA:             &x509.Certificate{},
+		}
+		originalExpiration := msm.certs.ExpirationDate
+
+		require.NoError(t, msm.enableMetricsScraperForControlPlanesDataPlane(t.Context(), cp))
+		require.Equal(t, originalExpiration, msm.certs.ExpirationDate, "certs should not have been rotated")
+	})
+
+	t.Run("rotates certs when near expiration", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(caSecret, dp).
+			Build()
+		msm := NewManager(logr.Discard(), time.Second, certTTL, certExpirationMargin, fakeClient, client.ObjectKeyFromObject(caSecret))
+
+		// Pre-populate certs with an expiration within the margin.
+		nearExpiration := time.Now().Add(certExpirationMargin / 2)
+		msm.certs = &certs{
+			ExpirationDate: nearExpiration,
+			Cert:           &x509.Certificate{},
+			CA:             &x509.Certificate{},
+		}
+
+		require.NoError(t, msm.enableMetricsScraperForControlPlanesDataPlane(t.Context(), cp))
+		require.NotEqual(t, nearExpiration, msm.certs.ExpirationDate, "certs should have been rotated")
+		require.True(t, msm.certs.ExpirationDate.After(time.Now()), "new cert should expire in the future")
+	})
+
+	t.Run("rotates certs when already expired", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(caSecret, dp).
+			Build()
+		msm := NewManager(logr.Discard(), time.Second, certTTL, certExpirationMargin, fakeClient, client.ObjectKeyFromObject(caSecret))
+
+		// Pre-populate certs with an expiration in the past.
+		expired := time.Now().Add(-time.Hour)
+		msm.certs = &certs{
+			ExpirationDate: expired,
+			Cert:           &x509.Certificate{},
+			CA:             &x509.Certificate{},
+		}
+
+		require.NoError(t, msm.enableMetricsScraperForControlPlanesDataPlane(t.Context(), cp))
+		require.NotEqual(t, expired, msm.certs.ExpirationDate, "certs should have been rotated")
+		require.True(t, msm.certs.ExpirationDate.After(time.Now()), "new cert should expire in the future")
+	})
 }

--- a/controller/dataplane/bluegreen_controller.go
+++ b/controller/dataplane/bluegreen_controller.go
@@ -75,6 +75,7 @@ type BlueGreenReconciler struct {
 	EnforceConfig          bool
 	ValidateDataPlaneImage bool
 	LoggingMode            logging.Mode
+	CertTTL                time.Duration
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -189,6 +190,7 @@ func (r *BlueGreenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			Name:      dataplaneAdminService.Name,
 		},
 		r.SecretLabelSelector,
+		r.CertTTL,
 	)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/controller/dataplane/controller.go
+++ b/controller/dataplane/controller.go
@@ -3,6 +3,7 @@ package dataplane
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
@@ -50,6 +51,7 @@ type Reconciler struct {
 	EnforceConfig          bool
 	LoggingMode            logging.Mode
 	ValidateDataPlaneImage bool
+	CertTTL                time.Duration
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -170,6 +172,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			Name:      dataplaneAdminService.Name,
 		},
 		r.SecretLabelSelector,
+		r.CertTTL,
 	)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/controller/dataplane/owned_resources.go
+++ b/controller/dataplane/owned_resources.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
@@ -37,7 +38,7 @@ func ensureDataPlaneCertificate(
 	clusterCASecretNN types.NamespacedName,
 	adminServiceNN types.NamespacedName,
 	secretLabelSelector string,
-
+	certTTL time.Duration,
 ) (op.Result, *corev1.Secret, error) {
 	usages := []certificatesv1.KeyUsage{
 		certificatesv1.UsageKeyEncipherment,
@@ -54,6 +55,7 @@ func ensureDataPlaneCertificate(
 		usages,
 		cl,
 		matchingLabels,
+		certTTL,
 	)
 }
 

--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -57,6 +57,7 @@ type KonnectExtensionReconciler struct {
 	ClusterCASecretName      string
 	ClusterCASecretNamespace string
 	SecretLabelSelector      string
+	CertTTL                  time.Duration
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controller/konnect/konnectextension_controller_utils.go
+++ b/controller/konnect/konnectextension_controller_utils.go
@@ -234,6 +234,7 @@ func (r *KonnectExtensionReconciler) ensureCertificateSecret(ctx context.Context
 		usages,
 		r.Client,
 		matchingLabels,
+		r.CertTTL,
 	)
 }
 

--- a/controller/pkg/secrets/cert.go
+++ b/controller/pkg/secrets/cert.go
@@ -192,6 +192,7 @@ func EnsureCertificate[
 	usages []certificatesv1.KeyUsage,
 	cl client.Client,
 	additionalMatchingLabels client.MatchingLabels,
+	certTTL time.Duration,
 ) (op.Result, *corev1.Secret, error) {
 	// Get the Secrets for the DataPlane using new labels.
 	matchingLabels := k8sresources.GetManagedLabelForOwner(owner)
@@ -215,7 +216,7 @@ func EnsureCertificate[
 	generatedSecret := k8sresources.GenerateNewTLSSecret(owner, secretOpts...)
 	// If there are no secrets yet, then create one.
 	if count == 0 {
-		return generateTLSDataSecret(ctx, generatedSecret, owner, subject, mtlsCASecretNN, usages, cl)
+		return generateTLSDataSecret(ctx, generatedSecret, owner, subject, mtlsCASecretNN, usages, cl, certTTL)
 	}
 
 	// Otherwise there is already 1 certificate matching specified selectors.
@@ -228,7 +229,7 @@ func EnsureCertificate[
 			return op.Noop, nil, err
 		}
 
-		return generateTLSDataSecret(ctx, generatedSecret, owner, subject, mtlsCASecretNN, usages, cl)
+		return generateTLSDataSecret(ctx, generatedSecret, owner, subject, mtlsCASecretNN, usages, cl, certTTL)
 	}
 
 	// Check if existing certificate is for a different subject.
@@ -242,7 +243,7 @@ func EnsureCertificate[
 			return op.Noop, nil, err
 		}
 
-		return generateTLSDataSecret(ctx, generatedSecret, owner, subject, mtlsCASecretNN, usages, cl)
+		return generateTLSDataSecret(ctx, generatedSecret, owner, subject, mtlsCASecretNN, usages, cl, certTTL)
 	}
 
 	var updated bool
@@ -310,6 +311,7 @@ func generateTLSDataSecret(
 	mtlsCASecret types.NamespacedName,
 	usages []certificatesv1.KeyUsage,
 	k8sClient client.Client,
+	certTTL time.Duration,
 ) (op.Result, *corev1.Secret, error) {
 
 	var ca corev1.Secret
@@ -344,12 +346,7 @@ func generateTLSDataSecret(
 	// This is effectively a placeholder so long as we handle signing internally. When actually creating CSR resources,
 	// this string is used by signers to filter which resources they pay attention to
 	signerName := "gateway-operator.konghq.com/mtls"
-	// TODO This creates certificates that last for 10 years as an arbitrarily long period for the alpha. A production-
-	// ready implementation should use a shorter lifetime and rotate certificates. Rotation requires some mechanism to
-	// recognize that certificates have expired (ideally without permissions to read Secrets across the cluster) and
-	// to get Deployments to acknowledge them. For Kong, this requires a restart, as there's no way to force a reload
-	// of updated files on disk.
-	expiration := int32(315400000) // 10 years in seconds.
+	expiration := int32(certTTL.Seconds())
 
 	csr := certificatesv1.CertificateSigningRequest{
 		ObjectMeta: metav1.ObjectMeta{
@@ -377,9 +374,18 @@ func generateTLSDataSecret(
 		"tls.crt": signed,
 		"tls.key": pem.EncodeToMemory(pemBlock),
 	}
+	// Preserve certificate expiration date as an annotation.
+	if generatedSecret.Annotations == nil {
+		generatedSecret.Annotations = make(map[string]string)
+	}
+	if certBlock, _ := pem.Decode(signed); certBlock != nil {
+		cert, err := x509.ParseCertificate(certBlock.Bytes)
+		if err == nil {
+			generatedSecret.Annotations[consts.CertExpiresAtAnnotation] = cert.NotAfter.UTC().Format(time.RFC3339)
+		}
+	}
 
-	err = k8sClient.Create(ctx, generatedSecret)
-	if err != nil {
+	if err = k8sClient.Create(ctx, generatedSecret); err != nil {
 		return op.Noop, nil, err
 	}
 

--- a/controller/pkg/secrets/cert_test.go
+++ b/controller/pkg/secrets/cert_test.go
@@ -28,6 +28,7 @@ import (
 	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
 	"github.com/kong/kong-operator/v2/controller/pkg/log"
 	"github.com/kong/kong-operator/v2/controller/pkg/op"
+	"github.com/kong/kong-operator/v2/pkg/consts"
 	k8sresources "github.com/kong/kong-operator/v2/pkg/utils/kubernetes/resources"
 	"github.com/kong/kong-operator/v2/test/helpers/certificate"
 )
@@ -371,6 +372,7 @@ func TestMaybeCreateCertificateSecret(t *testing.T) {
 						},
 						fakeClient,
 						tc.additionalMatchingLabels,
+						consts.DefaultCertTTL,
 					)
 
 					if tc.expectedError != nil {

--- a/controller/secret_cert/controller.go
+++ b/controller/secret_cert/controller.go
@@ -1,0 +1,114 @@
+package secretcert
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/kong/kong-operator/v2/controller/pkg/finalizer"
+	"github.com/kong/kong-operator/v2/controller/pkg/log"
+	"github.com/kong/kong-operator/v2/modules/manager/config"
+	"github.com/kong/kong-operator/v2/modules/manager/logging"
+	"github.com/kong/kong-operator/v2/pkg/consts"
+)
+
+// Reconciler reconciles TLS Secrets managed by DataPlane or ControlPlane.
+// Certs in these Secrets expires after a certain time, and the controller
+// is responsible for renewing them by deleting the expiring Secret,
+// which will trigger the creation of a new Secret with renewed certs by the
+// respective owner controllers (CP/DP).
+type Reconciler struct {
+	client.Client
+
+	ControllerOptions    controller.Options
+	LoggingMode          logging.Mode
+	CertExpirationMargin time.Duration
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(r.ControllerOptions).
+		For(&corev1.Secret{},
+			builder.WithPredicates(
+				predicate.NewPredicateFuncs(secretMatchesFilter),
+			),
+		).
+		Complete(r)
+}
+
+// secretMatchesFilter returns true if the Secret has the required labels and type.
+func secretMatchesFilter(obj client.Object) bool {
+	labels := obj.GetLabels()
+	if labels[config.DefaultSecretLabelSelector] != config.LabelValueForSelectorTrue {
+		return false
+	}
+	if managedBy := labels[consts.GatewayOperatorManagedByLabel]; managedBy != consts.DataPlaneManagedLabelValue && managedBy != consts.ControlPlaneManagedLabelValue {
+		return false
+	}
+
+	secret, ok := obj.(*corev1.Secret)
+	if !ok {
+		return false
+	}
+
+	return secret.Type == corev1.SecretTypeTLS
+}
+
+// Reconcile handles certificate Secret reconciliation.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var cert corev1.Secret
+	if err := r.Get(ctx, req.NamespacedName, &cert); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	logger := log.GetLogger(ctx, "secret_cert", r.LoggingMode).WithValues()
+
+	certExpirationAnnotation, ok := cert.Annotations[consts.CertExpiresAtAnnotation]
+	if !ok {
+		log.Debug(
+			logger,
+			"secret %s/%s created before introducing mechanism for autorotation, force rotation by deleting it manually",
+			cert.Namespace, cert.Name,
+		)
+		return ctrl.Result{}, nil
+	}
+	expiresAt, err := time.Parse(time.RFC3339, certExpirationAnnotation)
+	if err != nil {
+		log.Error(
+			logger,
+			err,
+			fmt.Sprintf("failed to parse %s annotation for secret %s/%s", consts.CertExpiresAtAnnotation, cert.Namespace, cert.Name),
+		)
+		return ctrl.Result{}, err
+	}
+	if timeUntilExpire := expiresAt.Sub(time.Now().UTC()); timeUntilExpire > r.CertExpirationMargin {
+		log.Debug(logger, "cert is still valid", "expires_at", expiresAt.String(), "time_until_expiry", timeUntilExpire.String())
+		return ctrl.Result{RequeueAfter: timeUntilExpire - r.CertExpirationMargin}, nil
+	}
+
+	log.Info(logger, "cert is expiring soon, renewing")
+
+	// Remove the wait-for-owner finalizer if present so that the secret can be deleted.
+	if controllerutil.RemoveFinalizer(&cert, consts.DataPlaneOwnedWaitForOwnerFinalizer) {
+		if err := r.Update(ctx, &cert); err != nil {
+			return finalizer.HandlePatchOrUpdateError(err, logger)
+		}
+		log.Debug(logger, "removed wait-for-owner finalizer from secret")
+	}
+	// Delete the expiring Secret, which will trigger the creation
+	// of a new secret with renewed certs by the respective owner controllers (CP/DP).
+	if err := r.Delete(ctx, &cert); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to delete secret %s/%s: %w", cert.Namespace, cert.Name, err)
+	}
+	log.Info(logger, "expiring cert secret has been deleted, new will be created immediately")
+
+	return ctrl.Result{}, nil
+}

--- a/docs/cli-arguments-for-developer-konghq-com.md
+++ b/docs/cli-arguments-for-developer-konghq-com.md
@@ -76,6 +76,14 @@ rows:
     type: '`string`'
     description: "Sets the time limit for syncing controller caches. Defaults to the controller-runtime value if set to `0`."
     default: '`0s`'
+  - flag: '`--cert-expiration-margin`'
+    type: '`duration`'
+    description: "Duration before certificate expiration at which the operator will trigger certificate renewal (specify it in hours in a format like '168h'). Must be lower than cert-ttl."
+    default: '`168h (7 days)`'
+  - flag: '`--cert-ttl`'
+    type: '`duration`'
+    description: "Time-to-live for certificates issued by the operator (specify it in hours in a format like '87600h')."
+    default: '`87600h (10 years)`'
   - flag: '`--cluster-ca-key-size`'
     type: '`int`'
     description: "WARN: DEPRECATED (it has no effect): Size (in bits) of the key used for the cluster CA certificate. Only used for RSA keys."

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -37,6 +37,14 @@ rows:
     type: '`string`'
     description: "Sets the time limit for syncing controller caches. Defaults to the controller-runtime value if set to `0`."
     default: '`0s`'
+  - flag: '`--cert-expiration-margin`'
+    type: '`duration`'
+    description: "Duration before certificate expiration at which the operator will trigger certificate renewal (specify it in hours in a format like '168h'). Must be lower than cert-ttl."
+    default: '`168h (7 days)`'
+  - flag: '`--cert-ttl`'
+    type: '`duration`'
+    description: "Time-to-live for certificates issued by the operator (specify it in hours in a format like '87600h')."
+    default: '`87600h (10 years)`'
   - flag: '`--cluster-ca-key-size`'
     type: '`int`'
     description: "WARN: DEPRECATED (it has no effect): Size (in bits) of the key used for the cluster CA certificate. Only used for RSA keys."

--- a/modules/cli/cli.go
+++ b/modules/cli/cli.go
@@ -92,6 +92,9 @@ func New(m metadata.Info) *CLI {
 	flagSet.UintVar(&cfg.MaxConcurrentReconcilesControlPlane, "max-concurrent-reconciles-controlplane-controller", consts.DefaultMaxConcurrentReconcilesControlPlane, "Maximum number of concurrent reconciles for ControlPlane controllers.")
 	flagSet.UintVar(&cfg.MaxConcurrentReconcilesGateway, "max-concurrent-reconciles-gateway-controller", consts.DefaultMaxConcurrentReconcilesGateway, "Maximum number of concurrent reconciles for Gateway controllers.")
 
+	flagSet.DurationVar(&cfg.CertTTL, "cert-ttl", consts.DefaultCertTTL, "Time-to-live for certificates issued by the operator (specify it in hours in a format like '87600h').")
+	flagSet.DurationVar(&cfg.CertExpirationMargin, "cert-expiration-margin", consts.DefaultCertExpirationMargin, "Duration before certificate expiration at which the operator will trigger certificate renewal (specify it in hours in a format like '168h'). Must be lower than cert-ttl.")
+
 	flagSet.BoolVar(&deferCfg.Version, "version", false, "Print version information.")
 
 	// webhook and validation options
@@ -265,6 +268,11 @@ func (c *CLI) Parse(arguments []string) manager.Config {
 
 		fmt.Println("WARN: --konnect-controller-max-concurrent-reconciles is deprecated, please use --max-concurrent-reconciles-konnect-controller instead")
 		c.cfg.MaxConcurrentReconcilesKonnect = c.cfg.KonnectControllerMaxConcurrentReconciles
+	}
+
+	if c.cfg.CertExpirationMargin >= c.cfg.CertTTL {
+		fmt.Printf("ERROR: --cert-expiration-margin (%s) must be lower than --cert-ttl (%s)\n", c.cfg.CertExpirationMargin, c.cfg.CertTTL)
+		os.Exit(1)
 	}
 
 	return *c.cfg

--- a/modules/cli/cli_test.go
+++ b/modules/cli/cli_test.go
@@ -404,5 +404,7 @@ func expectedDefaultCfg() manager.Config {
 		ConversionWebhookEnabled:                 true,
 		ValidatingWebhookEnabled:                 true,
 		FQDNModeEnabled:                          false,
+		CertTTL:                                  consts.DefaultCertTTL,
+		CertExpirationMargin:                     consts.DefaultCertExpirationMargin,
 	}
 }

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -40,6 +40,7 @@ import (
 	"github.com/kong/kong-operator/v2/controller/konnect/constraints"
 	sdkops "github.com/kong/kong-operator/v2/controller/konnect/ops/sdk"
 	"github.com/kong/kong-operator/v2/controller/mcpserver"
+	secretcert "github.com/kong/kong-operator/v2/controller/secret_cert"
 	"github.com/kong/kong-operator/v2/controller/specialized"
 	"github.com/kong/kong-operator/v2/ingress-controller/pkg/manager/multiinstance"
 	"github.com/kong/kong-operator/v2/internal/metrics"
@@ -462,6 +463,8 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 	scrapersMgr := metricsscraper.NewManager(
 		mgr.GetLogger(),
 		metricsScrapeInterval,
+		c.CertTTL,
+		c.CertExpirationMargin,
 		mgr.GetClient(),
 		k8stypes.NamespacedName{
 			Name:      c.ClusterCASecretName,
@@ -530,6 +533,7 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 				ClusterDomain:            c.ClusterDomain,
 				EmitKubernetesEvents:     c.EmitKubernetesEvents,
 				WatchNamespaces:          c.WatchNamespaces,
+				CertTTL:                  c.CertTTL,
 			},
 		},
 		// DataPlane controller
@@ -547,6 +551,7 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 				EnforceConfig:            c.EnforceConfig,
 				LoggingMode:              c.LoggingMode,
 				ValidateDataPlaneImage:   c.ValidateImages,
+				CertTTL:                  c.CertTTL,
 			},
 		},
 		// DataPlaneBlueGreen controller
@@ -571,12 +576,14 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 					EnforceConfig:            c.EnforceConfig,
 					ValidateDataPlaneImage:   c.ValidateImages,
 					LoggingMode:              c.LoggingMode,
+					CertTTL:                  c.CertTTL,
 				},
 				DefaultImage:           consts.DefaultDataPlaneImage,
 				KonnectEnabled:         c.KonnectControllersEnabled,
 				EnforceConfig:          c.EnforceConfig,
 				ValidateDataPlaneImage: c.ValidateImages,
 				LoggingMode:            c.LoggingMode,
+				CertTTL:                c.CertTTL,
 			},
 		},
 		// DataPlaneOwnedServiceFinalizer controller
@@ -605,6 +612,16 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 				c.LoggingMode,
 				ctrlOpts,
 			),
+		},
+		// SecretCert controller
+		{
+			Enabled: c.DataPlaneControllerEnabled || c.DataPlaneBlueGreenControllerEnabled || c.ControlPlaneControllerEnabled,
+			Controller: &secretcert.Reconciler{
+				ControllerOptions:    ctrlOpts,
+				Client:               mgr.GetClient(),
+				LoggingMode:          c.LoggingMode,
+				CertExpirationMargin: c.CertExpirationMargin,
+			},
 		},
 		// AIGateway Controller
 		{
@@ -714,6 +731,7 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 					ClusterCASecretName:      c.ClusterCASecretName,
 					ClusterCASecretNamespace: c.ClusterCASecretNamespace,
 					SecretLabelSelector:      c.SecretLabelSelector,
+					CertTTL:                  c.CertTTL,
 				},
 			},
 		)

--- a/modules/manager/controller_setup_test.go
+++ b/modules/manager/controller_setup_test.go
@@ -23,7 +23,7 @@ func TestSetupControllers(t *testing.T) {
 	controllerDefs, err := manager.SetupControllers(mgr, &cfg, nil)
 	require.NoError(t, err)
 
-	const expectedControllerCount = 47
+	const expectedControllerCount = 48
 	require.Len(t, controllerDefs, expectedControllerCount)
 
 	seenControllerTypes := make(map[string]int, expectedControllerCount)

--- a/modules/manager/run.go
+++ b/modules/manager/run.go
@@ -132,6 +132,12 @@ type Config struct {
 	// Webhook options.
 	ConversionWebhookEnabled bool
 	ValidatingWebhookEnabled bool
+
+	// CertTTL is the time-to-live for certificates issued by the operator.
+	CertTTL time.Duration
+	// CertExpirationMargin is the duration before certificate expiration at which
+	// the secret_cert controller will trigger certificate renewal.
+	CertExpirationMargin time.Duration
 }
 
 const (
@@ -172,6 +178,8 @@ func DefaultConfig() Config {
 		ValidatingWebhookEnabled:      true,
 		KonnectSyncPeriod:             consts.DefaultKonnectSyncPeriod,
 		KonnectRequestTimeout:         consts.DefaultKonnectRequestTimeout,
+		CertTTL:                       consts.DefaultCertTTL,
+		CertExpirationMargin:          consts.DefaultCertExpirationMargin,
 	}
 }
 

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -96,6 +96,10 @@ const (
 	// This means that the DataPlane, ControlPlane and KonnectGatewayControlPlane resources
 	// are named as the Gateway resource.
 	GatewayStaticNamingAnnotation = OperatorAnnotationPrefix + "static-naming"
+
+	// CertExpiresAtAnnotation is the annotation used to store the certificate expiration time
+	// in RFC3339 format as an annotation on the Secret containing the certificate.
+	CertExpiresAtAnnotation = "konghq.com/cert-expires-at"
 )
 
 // -----------------------------------------------------------------------------
@@ -186,6 +190,16 @@ const (
 	// DefaultMaxConcurrentReconcilesGateway is the default max concurrent
 	// reconciles for the Gateway controllers.
 	DefaultMaxConcurrentReconcilesGateway = uint(1)
+)
+
+const (
+	// DefaultCertTTL is the default time-to-live for certificates issued by the operator.
+	// Set to 10 years to be as it used to be in the past, but it can be overridden by user.
+	DefaultCertTTL = 10 * 365 * 24 * time.Hour
+	// DefaultCertExpirationMargin is the default duration before certificate
+	// expiration at which the operator will trigger certificate renewal.
+	// Set to 7 days to ensure certificates are renewed well before they expire.
+	DefaultCertExpirationMargin = 7 * 24 * time.Hour
 )
 
 const (

--- a/scripts/cli-arguments-docs-gen/main.go
+++ b/scripts/cli-arguments-docs-gen/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
+	"math"
 	"strings"
+	"time"
 
 	"github.com/kong/kong-operator/v2/modules/cli"
 	"github.com/kong/kong-operator/v2/modules/manager"
@@ -51,6 +53,18 @@ func visit(markdown *strings.Builder) func(*flag.Flag) {
 		defaultValue := "\"\""
 		if flag.DefValue != "" {
 			defaultValue = fmt.Sprintf("'`%s`'", flag.DefValue)
+			// Try to parse as duration and convert to human-readable format.
+			if d, err := time.ParseDuration(flag.DefValue); err == nil {
+				hours := d.Hours()
+				switch {
+				case hours >= 24*365 && math.Mod(hours, 24*365) == 0:
+					defaultValue = fmt.Sprintf("'`%dh (%d years)`'", int(hours), int(hours/(24*365)))
+				case hours >= 24 && math.Mod(hours, 24) == 0:
+					defaultValue = fmt.Sprintf("'`%dh (%d days)`'", int(hours), int(hours/24))
+				default:
+					defaultValue = fmt.Sprintf("'`%s`'", flag.DefValue)
+				}
+			}
 		}
 
 		mustWrite(markdown, fmt.Sprintf("  - flag: '%s'\n", name))

--- a/test/envtest/dataplane_bluegreen_test.go
+++ b/test/envtest/dataplane_bluegreen_test.go
@@ -13,6 +13,7 @@ import (
 	kcfgdataplane "github.com/kong/kong-operator/v2/api/gateway-operator/dataplane"
 	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
 	"github.com/kong/kong-operator/v2/controller/dataplane"
+	secretcert "github.com/kong/kong-operator/v2/controller/secret_cert"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	"github.com/kong/kong-operator/v2/pkg/consts"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
@@ -31,15 +32,24 @@ func TestDataPlaneBlueGreen(t *testing.T) {
 		ClusterCASecretNamespace: clusterCA.Namespace,
 		DefaultImage:             consts.DefaultDataPlaneImage,
 		ValidateDataPlaneImage:   true,
+		CertTTL:                  consts.DefaultCertTTL,
 		DataPlaneController: &dataplane.Reconciler{
 			Client:                   mgr.GetClient(),
 			ClusterCASecretName:      clusterCA.Name,
 			ClusterCASecretNamespace: clusterCA.Namespace,
 			DefaultImage:             consts.DefaultDataPlaneImage,
 			ValidateDataPlaneImage:   true,
+			CertTTL:                  consts.DefaultCertTTL,
 		},
 	}
-	StartReconcilers(ctx, t, mgr, logs, bgReconciler)
+	secretCertReconciler := &secretcert.Reconciler{
+		Client:               mgr.GetClient(),
+		CertExpirationMargin: consts.DefaultCertExpirationMargin,
+	}
+	StartReconcilers(ctx, t, mgr, logs,
+		bgReconciler,
+		secretCertReconciler,
+	)
 
 	dp := &operatorv1beta1.DataPlane{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/envtest/dataplane_konnectextensions_test.go
+++ b/test/envtest/dataplane_konnectextensions_test.go
@@ -26,6 +26,7 @@ import (
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	"github.com/kong/kong-operator/v2/controller/dataplane"
 	"github.com/kong/kong-operator/v2/controller/konnect"
+	secretcert "github.com/kong/kong-operator/v2/controller/secret_cert"
 	"github.com/kong/kong-operator/v2/modules/manager/logging"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	"github.com/kong/kong-operator/v2/pkg/consts"
@@ -82,6 +83,7 @@ func TestDataPlaneKonnectExtension(t *testing.T) {
 				ClusterCASecretName:      clusterCASecretNN.Name,
 				ClusterCASecretNamespace: clusterCASecretNN.Namespace,
 				DefaultImage:             consts.DefaultDataPlaneImage,
+				CertTTL:                  consts.DefaultCertTTL,
 				ValidateDataPlaneImage:   true,
 				KonnectEnabled:           true,
 				EnforceConfig:            true,
@@ -93,10 +95,16 @@ func TestDataPlaneKonnectExtension(t *testing.T) {
 				SyncPeriod:               konnectInfiniteSyncTime,
 				ClusterCASecretName:      clusterCASecretNN.Name,
 				ClusterCASecretNamespace: clusterCASecretNN.Namespace,
+				CertTTL:                  consts.DefaultCertTTL,
+			}
+			secretCertReconciler := &secretcert.Reconciler{
+				Client:               mgr.GetClient(),
+				CertExpirationMargin: consts.DefaultCertExpirationMargin,
 			}
 
 			StartReconcilers(ctx, t, mgr, logs,
 				dpReconciler,
+				secretCertReconciler,
 				konnectExtensionReconciler,
 				konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
 					konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongDataPlaneClientCertificate](konnectInfiniteSyncTime),

--- a/test/envtest/dataplane_test.go
+++ b/test/envtest/dataplane_test.go
@@ -17,6 +17,7 @@ import (
 	kcfgdataplane "github.com/kong/kong-operator/v2/api/gateway-operator/dataplane"
 	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
 	"github.com/kong/kong-operator/v2/controller/dataplane"
+	secretcert "github.com/kong/kong-operator/v2/controller/secret_cert"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	"github.com/kong/kong-operator/v2/pkg/consts"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
@@ -351,9 +352,17 @@ func setupDataPlaneTest(t *testing.T, ctx context.Context, caSecretName string) 
 		ClusterCASecretName:      clusterCA.Name,
 		ClusterCASecretNamespace: clusterCA.Namespace,
 		DefaultImage:             consts.DefaultDataPlaneImage,
+		CertTTL:                  consts.DefaultCertTTL,
 		ValidateDataPlaneImage:   true,
 	}
-	StartReconcilers(ctx, t, mgr, logs, dpReconciler)
+	secretCertReconciler := &secretcert.Reconciler{
+		Client:               mgr.GetClient(),
+		CertExpirationMargin: consts.DefaultCertExpirationMargin,
+	}
+	StartReconcilers(ctx, t, mgr, logs,
+		dpReconciler,
+		secretCertReconciler,
+	)
 
 	return mgr.GetClient(), ns
 }

--- a/test/envtest/gateway_envtest_test.go
+++ b/test/envtest/gateway_envtest_test.go
@@ -19,6 +19,7 @@ import (
 	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
 	dpreconciler "github.com/kong/kong-operator/v2/controller/dataplane"
 	kogateway "github.com/kong/kong-operator/v2/controller/gateway"
+	secretcert "github.com/kong/kong-operator/v2/controller/secret_cert"
 	"github.com/kong/kong-operator/v2/ingress-controller/test/gatewayapi"
 	"github.com/kong/kong-operator/v2/ingress-controller/test/util"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
@@ -249,6 +250,11 @@ func TestGatewayInfrastructureLabels(t *testing.T) {
 			ClusterCASecretName:      caSecretName,
 			ClusterCASecretNamespace: ns.Name,
 			DefaultImage:             consts.DefaultDataPlaneImage,
+			CertTTL:                  consts.DefaultCertTTL,
+		},
+		&secretcert.Reconciler{
+			Client:               c,
+			CertExpirationMargin: consts.DefaultCertExpirationMargin,
 		},
 	)
 

--- a/test/envtest/secret_cert_controller_test.go
+++ b/test/envtest/secret_cert_controller_test.go
@@ -1,0 +1,136 @@
+package envtest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	secretcert "github.com/kong/kong-operator/v2/controller/secret_cert"
+	"github.com/kong/kong-operator/v2/modules/manager/config"
+	"github.com/kong/kong-operator/v2/modules/manager/logging"
+	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+	"github.com/kong/kong-operator/v2/pkg/consts"
+)
+
+func TestSecretCertReconciler(t *testing.T) {
+	baseTLSSecret := func(namespace string) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "secret-for-test",
+				Namespace:    namespace,
+				Labels:       map[string]string{},
+				Annotations:  map[string]string{},
+			},
+			Type: corev1.SecretTypeTLS,
+			Data: map[string][]byte{
+				"tls.crt": []byte("not-important-for-this-test"),
+				"tls.key": []byte("not-important-for-this-test"),
+			},
+		}
+	}
+	expiredAnnotationValue := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+
+	tests := []struct {
+		name                   string
+		adjust                 func(*corev1.Secret)
+		expectDeletion         bool
+		customExpirationMargin time.Duration
+	}{
+		{
+			name: "actual requeue for short term valid DataPlane managed cert and delete it",
+			adjust: func(s *corev1.Secret) {
+				s.Annotations[consts.CertExpiresAtAnnotation] = time.Now().Add(20 * time.Second).UTC().Format(time.RFC3339)
+				s.Labels[config.DefaultSecretLabelSelector] = config.LabelValueForSelectorTrue
+				s.Labels[consts.GatewayOperatorManagedByLabel] = consts.DataPlaneManagedLabelValue
+				s.Finalizers = []string{consts.DataPlaneOwnedWaitForOwnerFinalizer}
+			},
+			customExpirationMargin: 5 * time.Second,
+			expectDeletion:         true,
+		},
+		{
+			name: "expired cert with DataPlane managed is deleted",
+			adjust: func(s *corev1.Secret) {
+				s.Annotations[consts.CertExpiresAtAnnotation] = expiredAnnotationValue
+				s.Labels[config.DefaultSecretLabelSelector] = config.LabelValueForSelectorTrue
+				s.Labels[consts.GatewayOperatorManagedByLabel] = consts.DataPlaneManagedLabelValue
+				s.Finalizers = []string{consts.DataPlaneOwnedWaitForOwnerFinalizer}
+
+			},
+			expectDeletion: false,
+		},
+		{
+			name: "expired cert with ControlPlane managed is deleted",
+			adjust: func(s *corev1.Secret) {
+				s.Annotations[consts.CertExpiresAtAnnotation] = expiredAnnotationValue
+				s.Labels[config.DefaultSecretLabelSelector] = config.LabelValueForSelectorTrue
+				s.Labels[consts.GatewayOperatorManagedByLabel] = consts.ControlPlaneManagedLabelValue
+			},
+			expectDeletion: true,
+		},
+		{
+			name: "valid cert secret is not deleted",
+			adjust: func(s *corev1.Secret) {
+				s.Labels[config.DefaultSecretLabelSelector] = config.LabelValueForSelectorTrue
+				s.Labels[consts.GatewayOperatorManagedByLabel] = consts.ControlPlaneManagedLabelValue
+			},
+			expectDeletion: false,
+		},
+		{
+			name: "secret without matching labels is ignored",
+			adjust: func(s *corev1.Secret) {
+				s.Labels = nil
+			},
+			expectDeletion: false,
+		},
+		{
+			name: "non-TLS secret with matching labels is ignored",
+			adjust: func(s *corev1.Secret) {
+				s.Labels[config.DefaultSecretLabelSelector] = config.LabelValueForSelectorTrue
+				s.Labels[consts.GatewayOperatorManagedByLabel] = consts.ControlPlaneManagedLabelValue
+				s.Type = corev1.SecretTypeOpaque
+				s.Data = map[string][]byte{"data": []byte("not-a-cert")}
+			},
+			expectDeletion: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
+			mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+
+			reconciler := &secretcert.Reconciler{
+				Client:      mgr.GetClient(),
+				LoggingMode: logging.DevelopmentMode,
+			}
+			if tt.customExpirationMargin != 0 {
+				reconciler.CertExpirationMargin = tt.customExpirationMargin
+			}
+			StartReconcilers(ctx, t, mgr, logs, reconciler)
+
+			secret := baseTLSSecret(ns.Name)
+			tt.adjust(secret)
+			require.NoError(t, mgr.GetClient().Create(ctx, secret))
+
+			nn := k8stypes.NamespacedName{Name: secret.Name, Namespace: ns.Name}
+			if tt.expectDeletion {
+				require.EventuallyWithT(t, func(ct *assert.CollectT) {
+					s := &corev1.Secret{}
+					err := mgr.GetClient().Get(ctx, nn, s)
+					require.True(ct, apierrors.IsNotFound(err), "secret should be deleted, got: %v", err)
+				}, 3*waitTime, tickTime, "secret should be deleted by the reconciler")
+			} else {
+				var existing corev1.Secret
+				err := mgr.GetClient().Get(ctx, nn, &existing)
+				require.NoError(t, err, "secret should not be deleted")
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Preserve old defaults regarding the validity of certificates issued by KO for internal purposes, and introduce a mechanism to rotate them near expiration that leverages the graceful recreation of a missing certificate secret (a new one is issued).

**Which issue this PR fixes**

Fixes #199, #1666

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
