### PR TITLE
feat(translator): support multiple Gateway Listener certificateRefs (RSA + ECDSA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@
 
 ### Added
 
+- Support multiple `certificateRefs` per Gateway Listener (up to two): one RSA
+  and one ECDSA certificate. Kong stores the RSA cert in `cert`/`key` and the
+  ECDSA cert in `cert_alt`/`key_alt`, selecting the appropriate certificate at
+  TLS handshake time based on client algorithm support. Both certificates must
+  cover the same CN and DNS SANs.
+  [#3758](https://github.com/Kong/kong-operator/pull/3758)
 - TLSRoute support: Configure DataPlaneOption in created `DataPlane` to
   configure Kong DataPlane deployment and ingress service for listeners with
   `TLS` protocol.

--- a/ingress-controller/internal/dataplane/translator/translate_certs.go
+++ b/ingress-controller/internal/dataplane/translator/translate_certs.go
@@ -3,7 +3,11 @@ package translator
 import (
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -36,6 +40,55 @@ func getCertFromSecret(secret *corev1.Secret) (string, string, error) {
 	}
 
 	return string(cert), string(key), nil
+}
+
+// getCertAlgorithm returns the public key algorithm of a PEM-encoded certificate.
+func getCertAlgorithm(certPEM string) (x509.PublicKeyAlgorithm, error) {
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil {
+		return x509.UnknownPublicKeyAlgorithm, errors.New("failed to decode certificate PEM block")
+	}
+	parsed, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return x509.UnknownPublicKeyAlgorithm, fmt.Errorf("failed to parse certificate: %w", err)
+	}
+	return parsed.PublicKeyAlgorithm, nil
+}
+
+// verifyCertSANsMatch returns an error if the two PEM-encoded certificates do not share
+// the same Subject CN and DNS SANs.
+func verifyCertSANsMatch(cert1PEM, cert2PEM string) error {
+	cn1, dns1, err := parseCertCNAndDNSSANs(cert1PEM)
+	if err != nil {
+		return err
+	}
+	cn2, dns2, err := parseCertCNAndDNSSANs(cert2PEM)
+	if err != nil {
+		return err
+	}
+	if cn1 != cn2 {
+		return fmt.Errorf("CN mismatch: %q != %q", cn1, cn2)
+	}
+	sorted1 := slices.Clone(dns1)
+	sorted2 := slices.Clone(dns2)
+	slices.Sort(sorted1)
+	slices.Sort(sorted2)
+	if !slices.Equal(sorted1, sorted2) {
+		return fmt.Errorf("DNS SAN mismatch: %v != %v", sorted1, sorted2)
+	}
+	return nil
+}
+
+func parseCertCNAndDNSSANs(certPEM string) (string, []string, error) {
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil {
+		return "", nil, errors.New("failed to decode certificate PEM block")
+	}
+	parsed, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to parse certificate: %w", err)
+	}
+	return parsed.Subject.CommonName, parsed.DNSNames, nil
 }
 
 type certWrapper struct {
@@ -77,14 +130,115 @@ func (t *Translator) getGatewayCerts() []certWrapper {
 			// Ref: https://github.com/Kong/kong-operator/issues/1769
 
 			if listener.TLS != nil {
-				if len(listener.TLS.CertificateRefs) > 0 {
-					if len(listener.TLS.CertificateRefs) > 1 {
-						// TODO support cert_alt and key_alt if there are 2 SecretObjectReferences
-						// https://github.com/Kong/kubernetes-ingress-controller/issues/2604
-						t.registerTranslationFailure("listener '%s' has more than one certificateRef, it's not supported", gateway)
+				numRefs := len(listener.TLS.CertificateRefs)
+				if numRefs > 2 {
+					t.registerTranslationFailure("listener '%s' has more than two certificateRefs, at most two are supported", gateway)
+					continue
+				}
+
+				if numRefs == 2 {
+					// fetch both secrets
+					ref0, ref1 := listener.TLS.CertificateRefs[0], listener.TLS.CertificateRefs[1]
+					ns0, ns1 := gateway.Namespace, gateway.Namespace
+					if ref0.Namespace != nil {
+						ns0 = string(*ref0.Namespace)
+					}
+					if ref1.Namespace != nil {
+						ns1 = string(*ref1.Namespace)
+					}
+
+					secret0, err := s.GetSecret(ns0, string(ref0.Name))
+					if err != nil {
+						logger.Error(err, "Failed to fetch secret",
+							"gateway", gateway.Name,
+							"listener", listener.Name,
+							"secret_name", string(ref0.Name),
+							"secret_namespace", ns0,
+						)
+						continue
+					}
+					secret1, err := s.GetSecret(ns1, string(ref1.Name))
+					if err != nil {
+						logger.Error(err, "Failed to fetch secret",
+							"gateway", gateway.Name,
+							"listener", listener.Name,
+							"secret_name", string(ref1.Name),
+							"secret_namespace", ns1,
+						)
 						continue
 					}
 
+					cert0, key0, err := getCertFromSecret(secret0)
+					if err != nil {
+						t.registerTranslationFailure("failed to construct certificate from secret", secret0, gateway)
+						continue
+					}
+					cert1, key1, err := getCertFromSecret(secret1)
+					if err != nil {
+						t.registerTranslationFailure("failed to construct certificate from secret", secret1, gateway)
+						continue
+					}
+
+					// verify each certificate uses a supported algorithm (RSA or ECDSA)
+					algo0, err := getCertAlgorithm(cert0)
+					if err != nil {
+						t.registerTranslationFailure("failed to detect certificate algorithm", secret0, gateway)
+						continue
+					}
+					algo1, err := getCertAlgorithm(cert1)
+					if err != nil {
+						t.registerTranslationFailure("failed to detect certificate algorithm", secret1, gateway)
+						continue
+					}
+					if (algo0 != x509.RSA && algo0 != x509.ECDSA) || (algo1 != x509.RSA && algo1 != x509.ECDSA) {
+						t.registerTranslationFailure("listener '%s' has certificateRef with unsupported algorithm; only RSA and ECDSA are supported", gateway)
+						continue
+					}
+					// verify the two certificates use different algorithms so Kong can select by client support
+					if algo0 == algo1 {
+						t.registerTranslationFailure("listener '%s' has two certificateRefs with the same algorithm; one must be RSA and one ECDSA", gateway)
+						continue
+					}
+
+					// verify both certificates cover the same CN and DNS SANs so SNI selection remains unambiguous
+					if err := verifyCertSANsMatch(cert0, cert1); err != nil {
+						t.registerTranslationFailure(fmt.Sprintf("listener '%%s' has certificateRefs with mismatched CN/SANs: %v", err), gateway)
+						continue
+					}
+
+					// Kong stores RSA in cert/key and ECDSA in cert_alt/key_alt
+					var rsaCert, rsaKey, ecdsaCert, ecdsaKey string
+					var primarySecret *corev1.Secret
+					if algo0 == x509.RSA {
+						rsaCert, rsaKey = cert0, key0
+						ecdsaCert, ecdsaKey = cert1, key1
+						primarySecret = secret0
+					} else {
+						rsaCert, rsaKey = cert1, key1
+						ecdsaCert, ecdsaKey = cert0, key0
+						primarySecret = secret1
+					}
+
+					// determine the SNI
+					hostname := "*"
+					if listener.Hostname != nil {
+						hostname = string(*listener.Hostname)
+					}
+
+					certs = append(certs, certWrapper{
+						identifier: rsaCert + rsaKey + ecdsaCert + ecdsaKey,
+						cert: kong.Certificate{
+							ID:      new(string(primarySecret.UID)),
+							Cert:    new(rsaCert),
+							Key:     new(rsaKey),
+							CertAlt: new(ecdsaCert),
+							KeyAlt:  new(ecdsaKey),
+							Tags:    util.GenerateTagsForObject(primarySecret),
+						},
+						CreationTimestamp: primarySecret.CreationTimestamp,
+						snis:              []string{hostname},
+					})
+				} else if numRefs == 1 {
 					// determine the Secret Namespace
 					ref := listener.TLS.CertificateRefs[0]
 					namespace := gateway.Namespace

--- a/ingress-controller/internal/dataplane/translator/translate_certs_test.go
+++ b/ingress-controller/internal/dataplane/translator/translate_certs_test.go
@@ -12,6 +12,67 @@ import (
 	"github.com/kong/kong-operator/v2/test/helpers/certificate"
 )
 
+func TestGetCertAlgorithm(t *testing.T) {
+	rsaCert, _ := certificate.MustGenerateCertPEMFormat(certificate.WithCommonName("rsa.example.com"))
+	ecdsaCert, _ := certificate.MustGenerateCertPEMFormat(
+		certificate.WithCommonName("ecdsa.example.com"),
+		certificate.WithKeyType(certificate.ECDSA),
+	)
+
+	algo, err := getCertAlgorithm(string(rsaCert))
+	require.NoError(t, err)
+	require.Equal(t, "RSA", algo.String())
+
+	algo, err = getCertAlgorithm(string(ecdsaCert))
+	require.NoError(t, err)
+	require.Equal(t, "ECDSA", algo.String())
+
+	_, err = getCertAlgorithm("not a pem block")
+	require.Error(t, err)
+}
+
+func TestVerifyCertSANsMatch(t *testing.T) {
+	rsaCert, _ := certificate.MustGenerateCertPEMFormat(
+		certificate.WithCommonName("example.com"),
+		certificate.WithDNSNames("example.com", "www.example.com"),
+	)
+	ecdsaCert, _ := certificate.MustGenerateCertPEMFormat(
+		certificate.WithCommonName("example.com"),
+		certificate.WithDNSNames("example.com", "www.example.com"),
+		certificate.WithKeyType(certificate.ECDSA),
+	)
+
+	// same CN and SANs — should pass
+	require.NoError(t, verifyCertSANsMatch(string(rsaCert), string(ecdsaCert)))
+
+	// different CN — should fail
+	other, _ := certificate.MustGenerateCertPEMFormat(certificate.WithCommonName("other.com"))
+	require.Error(t, verifyCertSANsMatch(string(rsaCert), string(other)))
+
+	// different SANs — should fail
+	diffSAN, _ := certificate.MustGenerateCertPEMFormat(
+		certificate.WithCommonName("example.com"),
+		certificate.WithDNSNames("example.com"),
+	)
+	require.Error(t, verifyCertSANsMatch(string(rsaCert), string(diffSAN)))
+
+	// same SANs in different order — should pass (order must not matter)
+	ecdsaReversedSANs, _ := certificate.MustGenerateCertPEMFormat(
+		certificate.WithCommonName("example.com"),
+		certificate.WithDNSNames("www.example.com", "example.com"),
+		certificate.WithKeyType(certificate.ECDSA),
+	)
+	require.NoError(t, verifyCertSANsMatch(string(rsaCert), string(ecdsaReversedSANs)))
+
+	// both certs with no DNS SANs, only CN — should pass
+	rsaNoDNS, _ := certificate.MustGenerateCertPEMFormat(certificate.WithCommonName("nodns.com"))
+	ecdsaNoDNS, _ := certificate.MustGenerateCertPEMFormat(
+		certificate.WithCommonName("nodns.com"),
+		certificate.WithKeyType(certificate.ECDSA),
+	)
+	require.NoError(t, verifyCertSANsMatch(string(rsaNoDNS), string(ecdsaNoDNS)))
+}
+
 func TestMergeCerts(t *testing.T) {
 	crt1, key1 := certificate.MustGenerateCertPEMFormat(certificate.WithCommonName("foo.com"))
 	crt2, key2 := certificate.MustGenerateCertPEMFormat(certificate.WithCommonName("bar.com"))


### PR DESCRIPTION
**What this PR does / why we need it**:

The [Gateway API spec](https://gatewayapi.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GatewayTLSConfig) allows up to two `certificateRefs` per Listener one RSA and one ECDSA certificate. Kong natively supports dual-certificate TLS by storing RSA in `cert`/`key` and ECDSA in `cert_alt`/`key_alt`, selecting the appropriate certificate at TLS handshake time based on client algorithm support.

Previously, `getGatewayCerts` ignored any second `certificateRef` with a TODO comment. This PR implements the feature end-to-end:

- Validates that at most two `certificateRefs` are provided per Listener.
- Detects the public key algorithm of each certificate (RSA or ECDSA).
- Rejects unsupported algorithms and rejects two certs with the same algorithm.
- Verifies that both certificates cover identical CN and DNS SANs, so SNI-based selection remains unambiguous.
- Constructs a Kong `Certificate` with the RSA cert in `cert`/`key` and the ECDSA cert in `cert_alt`/`key_alt`.

**Which issue this PR fixes**:

Fixes Kong/kubernetes-ingress-controller#2604

This was originally submitted as Kong/kubernetes-ingress-controller#7870, but that repo no longer accepts new major/minor features. Porting to this repo as suggested.

**Special notes for your reviewer**:

This is my first contribution to this project. Happy to adjust anything to better match the project's conventions.

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
