### PR TITLE
[backport 2.1.x] fix(hybridgateway): set default http/https protocols for KongRoute (#3753)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
 
+## Unreleased
+
+### Fixes
+
+- Fix the hybrid gateway translator to set `protocols` in translated KongRoutes
+  to `http,https` to avoid 426 errors from Konnect hybrid gateways.
+  [#3753](https://github.com/Kong/kong-operator/pull/3753)
+
 ## [v2.1.3]
 
 > Release date: 2026-03-25

--- a/controller/hybridgateway/builder/kongroute.go
+++ b/controller/hybridgateway/builder/kongroute.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"strings"
 
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -42,6 +43,12 @@ func NewKongRoute() *KongRouteBuilder {
 // WithHosts sets the hosts for the KongRoute being built.
 func (b *KongRouteBuilder) WithHosts(hosts []string) *KongRouteBuilder {
 	b.route.Spec.Hosts = append(b.route.Spec.Hosts, hosts...)
+	return b
+}
+
+// WithProtocols sets the allowed protocols for the KongRoute being built.
+func (b *KongRouteBuilder) WithProtocols(protocols ...sdkkonnectcomp.RouteJSONProtocols) *KongRouteBuilder {
+	b.route.Spec.Protocols = append(b.route.Spec.Protocols, protocols...)
 	return b
 }
 

--- a/controller/hybridgateway/kongroute/route.go
+++ b/controller/hybridgateway/kongroute/route.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -70,6 +71,11 @@ func RouteForRule(
 	// Check if the rule contains a URLRewrite or RequestRedirect filter with ReplacePrefixMatch:
 	// if so, we need to set a capture group on the KongRoute paths.
 	setCaptureGroup := needsCaptureGroup(rule)
+
+	routeBuilder = routeBuilder.WithProtocols(
+		sdkkonnectcomp.RouteJSONProtocols("http"),
+		sdkkonnectcomp.RouteJSONProtocols("https"),
+	)
 
 	// Add HTTPRoute matches
 	for _, match := range rule.Matches {

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -109,6 +110,13 @@ func TestRouteForRule(t *testing.T) {
 			assert.Equal(t, "test-namespace", result.Namespace)
 			assert.NotEmpty(t, result.Name)
 			assert.Equal(t, tt.hostnames, result.Spec.Hosts)
+			assert.Equal(t,
+				[]sdkkonnectcomp.RouteJSONProtocols{
+					sdkkonnectcomp.RouteJSONProtocols("http"),
+					sdkkonnectcomp.RouteJSONProtocols("https"),
+				},
+				result.Spec.Protocols,
+			)
 
 			// Verify service reference
 			if tt.serviceName != "" {

--- a/test/helpers/deploy/deploy_resources.go
+++ b/test/helpers/deploy/deploy_resources.go
@@ -528,6 +528,11 @@ func KongRoute(
 		Spec: configurationv1alpha1.KongRouteSpec{
 			KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
 				Name: lo.ToPtr(name),
+				Protocols: []sdkkonnectcomp.RouteJSONProtocols{
+					sdkkonnectcomp.RouteJSONProtocolsHTTP,
+					sdkkonnectcomp.RouteJSONProtocolsHTTPS,
+				},
+				Methods: []string{"GET"},
 			},
 		},
 	}


### PR DESCRIPTION
…
(cherry picked from commit 87ec939778bc690f04ebd27fcc4b498ba360297c)

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
