### PR TITLE
fix: reintroduce SNI certificate backref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,8 @@
 - Fix the hybrid gateway translator to set `protocols` in translated KongRoutes
   to `http,https` to avoid 426 errors from Konnect hybrid gateways.
   [#3753](https://github.com/Kong/kong-operator/pull/3753)
+- Revert change in configuring SNIs in ingress-controller when running with local controlplane.
+  [#3761](https://github.com/Kong/kong-operator/pull/3761)
 
 ## [v2.1.3]
 

--- a/ingress-controller/internal/dataplane/deckgen/deckgen.go
+++ b/ingress-controller/internal/dataplane/deckgen/deckgen.go
@@ -32,7 +32,7 @@ func GenerateSHA(targetContent *file.Content, customEntities map[string][]custom
 }
 
 // GetFCertificateFromKongCert converts a kong.Certificate to a file.FCertificate.
-func GetFCertificateFromKongCert(inmemory bool, kongCert kong.Certificate) file.FCertificate {
+func GetFCertificateFromKongCert(kongCert kong.Certificate) file.FCertificate {
 	var res file.FCertificate
 	if kongCert.ID != nil {
 		res.ID = new(*kongCert.ID)
@@ -44,17 +44,17 @@ func GetFCertificateFromKongCert(inmemory bool, kongCert kong.Certificate) file.
 		res.Cert = new(*kongCert.Cert)
 	}
 	res.Tags = kongCert.Tags
-	res.SNIs = getCertsSNIs(inmemory, kongCert)
+	res.SNIs = getCertsSNIs(kongCert)
 	return res
 }
 
-func getCertsSNIs(inmemory bool, kongCert kong.Certificate) []kong.SNI {
+func getCertsSNIs(kongCert kong.Certificate) []kong.SNI {
 	snis := make([]kong.SNI, 0, len(kongCert.SNIs))
 	for _, sni := range kongCert.SNIs {
 		kongSNI := kong.SNI{
 			Name: sni,
 		}
-		if !inmemory && kongCert.ID != nil {
+		if kongCert.ID != nil {
 			kongSNI.Certificate = &kong.Certificate{
 				ID: kongCert.ID,
 			}

--- a/ingress-controller/internal/dataplane/deckgen/deckgen_test.go
+++ b/ingress-controller/internal/dataplane/deckgen/deckgen_test.go
@@ -12,43 +12,19 @@ import (
 
 func TestGetFCertificateFromKongCert(t *testing.T) {
 	testCases := []struct {
-		name     string
-		inmemory bool
-		cert     kong.Certificate
-		want     file.FCertificate
+		name string
+		cert kong.Certificate
+		want file.FCertificate
 	}{
 		{
-			name:     "empty certificate",
-			inmemory: false,
-			cert:     kong.Certificate{},
+			name: "empty certificate",
+			cert: kong.Certificate{},
 			want: file.FCertificate{
 				SNIs: []kong.SNI{},
 			},
 		},
 		{
-			name:     "all fields set, inmemory=true, SNIs have no certificate ref",
-			inmemory: true,
-			cert: kong.Certificate{
-				ID:   new("cert-id"),
-				Key:  new("cert-key"),
-				Cert: new("cert-pem"),
-				Tags: kong.StringSlice("k8s-name:secret1", "k8s-namespace:default"),
-				SNIs: []*string{new("example.com"), new("other.com")},
-			},
-			want: file.FCertificate{
-				ID:   new("cert-id"),
-				Key:  new("cert-key"),
-				Cert: new("cert-pem"),
-				Tags: kong.StringSlice("k8s-name:secret1", "k8s-namespace:default"),
-				SNIs: []kong.SNI{
-					{Name: new("example.com")},
-					{Name: new("other.com")},
-				},
-			},
-		},
-		{
-			name:     "all fields set, inmemory=false, SNIs have certificate ref",
-			inmemory: false,
+			name: "all fields set, SNIs have certificate ref",
 			cert: kong.Certificate{
 				ID:   new("cert-id"),
 				Key:  new("cert-key"),
@@ -70,8 +46,7 @@ func TestGetFCertificateFromKongCert(t *testing.T) {
 			},
 		},
 		{
-			name:     "nil ID, inmemory=false, SNIs have no certificate ref",
-			inmemory: false,
+			name: "nil ID, SNIs have no certificate ref",
 			cert: kong.Certificate{
 				Key:  new("cert-key"),
 				Cert: new("cert-pem"),
@@ -86,8 +61,7 @@ func TestGetFCertificateFromKongCert(t *testing.T) {
 			},
 		},
 		{
-			name:     "no SNIs",
-			inmemory: false,
+			name: "no SNIs",
 			cert: kong.Certificate{
 				ID:   new("cert-id"),
 				Key:  new("cert-key"),
@@ -104,7 +78,7 @@ func TestGetFCertificateFromKongCert(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := deckgen.GetFCertificateFromKongCert(tc.inmemory, tc.cert)
+			got := deckgen.GetFCertificateFromKongCert(tc.cert)
 			require.Equal(t, tc.want, got)
 		})
 	}

--- a/ingress-controller/internal/dataplane/deckgen/generate.go
+++ b/ingress-controller/internal/dataplane/deckgen/generate.go
@@ -31,11 +31,6 @@ type GenerateDeckContentParams struct {
 	// the configuration is empty. It is used to workaround behavior in Kong where sending an empty configuration
 	// does not make its `GET /status/ready` endpoint return 200s.
 	AppendStubEntityWhenConfigEmpty bool
-
-	// InMemory indicates whether the generated deck content is intended to be used in-memory.
-	// This is used to determine whether to include certain fields in the generated content
-	// that are not relevant for in-memory use but are required for db based / konnect configurations.
-	InMemory bool
 }
 
 // ToDeckContent generates a decK configuration from `k8sState` and auxiliary parameters.
@@ -129,7 +124,7 @@ func ToDeckContent(
 	})
 
 	for _, c := range k8sState.Certificates {
-		cert := GetFCertificateFromKongCert(params.InMemory, c.Certificate)
+		cert := GetFCertificateFromKongCert(c.Certificate)
 		content.Certificates = append(content.Certificates, cert)
 	}
 	sort.SliceStable(content.Certificates, func(i, j int) bool {

--- a/ingress-controller/internal/dataplane/kong_client.go
+++ b/ingress-controller/internal/dataplane/kong_client.go
@@ -847,7 +847,6 @@ func (c *KongClient) sendToClient(
 		ExpressionRoutes:                config.ExpressionRoutes,
 		PluginSchemas:                   client.PluginSchemaStore(),
 		AppendStubEntityWhenConfigEmpty: config.InMemory,
-		InMemory:                        config.InMemory,
 	}
 	targetContent := deckgen.ToDeckContent(ctx, logger, s, deckGenParams)
 	customEntities := make(sendconfig.CustomEntitiesByType)

--- a/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer-ee/default_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer-ee/default_golden.yaml
@@ -31,8 +31,12 @@ certificates:
     5GTyl7XJmyY/
     -----END PRIVATE KEY-----
   snis:
-  - name: 1.example.com
-  - name: 2.example.com
+  - certificate:
+      id: c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+    name: 1.example.com
+  - certificate:
+      id: c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+    name: 2.example.com
   tags:
   - k8s-name:sooper-secret
   - k8s-namespace:bar-namespace

--- a/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer-ee/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer-ee/expression-routes-on_golden.yaml
@@ -31,8 +31,12 @@ certificates:
     5GTyl7XJmyY/
     -----END PRIVATE KEY-----
   snis:
-  - name: 1.example.com
-  - name: 2.example.com
+  - certificate:
+      id: c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+    name: 1.example.com
+  - certificate:
+      id: c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+    name: 2.example.com
   tags:
   - k8s-name:sooper-secret
   - k8s-namespace:bar-namespace

--- a/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls/default_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls/default_golden.yaml
@@ -31,8 +31,12 @@ certificates:
     7InkkRoDnTrU3Ro=
     -----END PRIVATE KEY-----
   snis:
-  - name: 3.example.com
-  - name: 4.example.com
+  - certificate:
+      id: 8aade13c-1470-46bd-9849-9a74e349214f
+    name: 3.example.com
+  - certificate:
+      id: 8aade13c-1470-46bd-9849-9a74e349214f
+    name: 4.example.com
   tags:
   - k8s-name:sooper-secret2
   - k8s-namespace:bar-namespace
@@ -70,8 +74,12 @@ certificates:
     5GTyl7XJmyY/
     -----END PRIVATE KEY-----
   snis:
-  - name: 1.example.com
-  - name: 2.example.com
+  - certificate:
+      id: c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+    name: 1.example.com
+  - certificate:
+      id: c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+    name: 2.example.com
   tags:
   - k8s-name:sooper-secret
   - k8s-namespace:bar-namespace

--- a/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_golden.yaml
@@ -31,8 +31,12 @@ certificates:
     7InkkRoDnTrU3Ro=
     -----END PRIVATE KEY-----
   snis:
-  - name: 3.example.com
-  - name: 4.example.com
+  - certificate:
+      id: 8aade13c-1470-46bd-9849-9a74e349214f
+    name: 3.example.com
+  - certificate:
+      id: 8aade13c-1470-46bd-9849-9a74e349214f
+    name: 4.example.com
   tags:
   - k8s-name:sooper-secret2
   - k8s-namespace:bar-namespace
@@ -70,8 +74,12 @@ certificates:
     5GTyl7XJmyY/
     -----END PRIVATE KEY-----
   snis:
-  - name: 1.example.com
-  - name: 2.example.com
+  - certificate:
+      id: c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+    name: 1.example.com
+  - certificate:
+      id: c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+    name: 2.example.com
   tags:
   - k8s-name:sooper-secret
   - k8s-namespace:bar-namespace


### PR DESCRIPTION
**What this PR does / why we need it**:

Revert https://github.com/Kong/kong-operator/issues/3554

More details in KIC PR: https://github.com/Kong/kubernetes-ingress-controller/pull/7872

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

Flaky conformance cleanup will be fixed with the context fix in https://github.com/Kong/kong-operator/pull/3762

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
