### PR TITLE
Fix/reconcile compare bugs

### DIFF
--- a/controller/cpextensions/controller.go
+++ b/controller/cpextensions/controller.go
@@ -355,14 +355,14 @@ func (r *Reconciler) ensurePrometheusPlugin(
 	}
 
 	// If it exists, ensure it's up to date.
-	if !cmp.Equal(generatedPlugin.Config, &prometheusPluginActual.Config) ||
-		!cmp.Equal(generatedPlugin.Annotations, &prometheusPluginActual.Annotations) ||
-		!cmp.Equal(generatedPlugin.OwnerReferences, &prometheusPluginActual.OwnerReferences) ||
-		!cmp.Equal(generatedPlugin.Labels, &prometheusPluginActual.Labels) ||
-		!cmp.Equal(generatedPlugin.Finalizers, &prometheusPluginActual.Finalizers) ||
-		!cmp.Equal(generatedPlugin.InstanceName, &prometheusPluginActual.InstanceName) ||
-		!cmp.Equal(generatedPlugin.PluginName, &prometheusPluginActual.PluginName) ||
-		!cmp.Equal(generatedPlugin.Disabled, &prometheusPluginActual.Disabled) {
+	if !cmp.Equal(generatedPlugin.Config, prometheusPluginActual.Config) ||
+		!cmp.Equal(generatedPlugin.Annotations, prometheusPluginActual.Annotations) ||
+		!cmp.Equal(generatedPlugin.OwnerReferences, prometheusPluginActual.OwnerReferences) ||
+		!cmp.Equal(generatedPlugin.Labels, prometheusPluginActual.Labels) ||
+		!cmp.Equal(generatedPlugin.Finalizers, prometheusPluginActual.Finalizers) ||
+		!cmp.Equal(generatedPlugin.InstanceName, prometheusPluginActual.InstanceName) ||
+		!cmp.Equal(generatedPlugin.PluginName, prometheusPluginActual.PluginName) ||
+		!cmp.Equal(generatedPlugin.Disabled, prometheusPluginActual.Disabled) {
 		prometheusPluginActual.Config = generatedPlugin.Config
 		prometheusPluginActual.Disabled = generatedPlugin.Disabled
 		prometheusPluginActual.Annotations = generatedPlugin.Annotations

--- a/controller/cpextensions/controller_test.go
+++ b/controller/cpextensions/controller_test.go
@@ -1,0 +1,137 @@
+package cpextensions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	operatorv1alpha1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1alpha1"
+	gwtypes "github.com/kong/kong-operator/v2/internal/types"
+	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+)
+
+type countingUpdateClient struct {
+	client.Client
+	updateCalls int
+}
+
+func (c *countingUpdateClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	c.updateCalls++
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+func TestEnsurePrometheusPlugin_DoesNotUpdateWhenPluginIsAlreadyUpToDate(t *testing.T) {
+	ctx := t.Context()
+	testScheme := scheme.Get()
+
+	cp := &gwtypes.ControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cp",
+			Namespace: "default",
+			UID:       types.UID("cp-uid"),
+		},
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc",
+			Namespace: "default",
+		},
+	}
+	ext := &operatorv1alpha1.DataPlaneMetricsExtension{
+		Spec: operatorv1alpha1.DataPlaneMetricsExtensionSpec{
+			Config: operatorv1alpha1.MetricsConfig{
+				Latency:        true,
+				Bandwidth:      true,
+				UpstreamHealth: false,
+				StatusCode:     true,
+			},
+		},
+	}
+
+	generated, err := prometheusPluginForSvc(svc, cp, ext)
+	require.NoError(t, err)
+	require.NoError(t, controllerutil.SetControllerReference(cp, generated, testScheme))
+
+	baseClient := fakectrlruntimeclient.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(cp, svc, generated).
+		Build()
+	wrappedClient := &countingUpdateClient{Client: baseClient}
+
+	r := &Reconciler{
+		Client: wrappedClient,
+	}
+
+	_, err = r.ensurePrometheusPlugin(ctx, svc, cp, ext)
+	require.NoError(t, err)
+	require.Equal(t, 0, wrappedClient.updateCalls, "expected no Update() when plugin is already up to date")
+}
+
+func TestEnsurePrometheusPlugin_UpdatesWhenPluginDiffers(t *testing.T) {
+	ctx := t.Context()
+	testScheme := scheme.Get()
+
+	cp := &gwtypes.ControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cp",
+			Namespace: "default",
+			UID:       types.UID("cp-uid"),
+		},
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc",
+			Namespace: "default",
+		},
+	}
+	oldExt := &operatorv1alpha1.DataPlaneMetricsExtension{
+		Spec: operatorv1alpha1.DataPlaneMetricsExtensionSpec{
+			Config: operatorv1alpha1.MetricsConfig{
+				Latency:        false,
+				Bandwidth:      false,
+				UpstreamHealth: false,
+				StatusCode:     false,
+			},
+		},
+	}
+	newExt := &operatorv1alpha1.DataPlaneMetricsExtension{
+		Spec: operatorv1alpha1.DataPlaneMetricsExtensionSpec{
+			Config: operatorv1alpha1.MetricsConfig{
+				Latency:        true,
+				Bandwidth:      true,
+				UpstreamHealth: true,
+				StatusCode:     true,
+			},
+		},
+	}
+
+	oldPlugin, err := prometheusPluginForSvc(svc, cp, oldExt)
+	require.NoError(t, err)
+	require.NoError(t, controllerutil.SetControllerReference(cp, oldPlugin, testScheme))
+
+	baseClient := fakectrlruntimeclient.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(cp, svc, oldPlugin).
+		Build()
+	wrappedClient := &countingUpdateClient{Client: baseClient}
+
+	r := &Reconciler{
+		Client: wrappedClient,
+	}
+
+	updatedPlugin, err := r.ensurePrometheusPlugin(ctx, svc, cp, newExt)
+	require.NoError(t, err)
+	require.Equal(t, 1, wrappedClient.updateCalls, "expected Update() when plugin differs")
+
+	expectedPlugin, err := prometheusPluginForSvc(svc, cp, newExt)
+	require.NoError(t, err)
+	require.Equal(t, string(expectedPlugin.Config.Raw), string(updatedPlugin.Config.Raw))
+}
+

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -1010,18 +1010,22 @@ func (r *Reconciler) patchStatus(ctx context.Context, gateway, oldGateway *gwtyp
 
 func dataPlaneSpecDeepEqual(specCurrent, specExpected *operatorv1beta1.DataPlaneOptions, isHybrid bool) bool {
 	specCurrentExtensions := specCurrent.Extensions
+	specExpectedExtensions := specExpected.Extensions
 	// For Hybrid gateways ignore KonnectExtension in the comparison,
 	// it's managed later (separately) by the Gateway controller.
 	if isHybrid {
 		specCurrentExtensions = lo.Filter(specCurrentExtensions, func(e commonv1alpha1.ExtensionRef, _ int) bool {
 			return e.Group != konnectv1alpha2.SchemeGroupVersion.Group || e.Kind != konnectv1alpha2.KonnectExtensionKind
 		})
+		specExpectedExtensions = lo.Filter(specExpectedExtensions, func(e commonv1alpha1.ExtensionRef, _ int) bool {
+			return e.Group != konnectv1alpha2.SchemeGroupVersion.Group || e.Kind != konnectv1alpha2.KonnectExtensionKind
+		})
 	}
 	// Consider slices equal if both are empty or nil, or if they are deeply equal.
 	// This is to avoid infinite reconciliation loops when one of the specs has nil value
 	// and the other has an empty slice.
-	extensionsEqual := len(specCurrentExtensions) == 0 && len(specExpected.Extensions) == 0 ||
-		reflect.DeepEqual(specCurrentExtensions, specExpected.Extensions)
+	extensionsEqual := len(specCurrentExtensions) == 0 && len(specExpectedExtensions) == 0 ||
+		reflect.DeepEqual(specCurrentExtensions, specExpectedExtensions)
 	pluginsToInstallEqual := len(specCurrent.PluginsToInstall) == 0 && len(specExpected.PluginsToInstall) == 0 ||
 		reflect.DeepEqual(specCurrent.PluginsToInstall, specExpected.PluginsToInstall)
 

--- a/controller/gateway/controller_test.go
+++ b/controller/gateway/controller_test.go
@@ -429,6 +429,117 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 	}
 }
 
+func TestProvisionControlPlane_UpdatesExtensionsWhenOnlyExtensionsDiffer(t *testing.T) {
+	ctx := t.Context()
+
+	gateway := &gwtypes.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gateway",
+			Namespace: "test-namespace",
+			UID:       types.UID(uuid.NewString()),
+		},
+	}
+
+	controlPlane := &gwtypes.ControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-controlplane",
+			Namespace: "test-namespace",
+		},
+		Spec: gwtypes.ControlPlaneSpec{
+			ControlPlaneOptions: gwtypes.ControlPlaneOptions{},
+			Extensions: []commonv1alpha1.ExtensionRef{
+				{
+					Group: "sample.group",
+					Kind:  "SampleExtension",
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "old-extension",
+					},
+				},
+			},
+		},
+	}
+	k8sutils.SetOwnerForObject(controlPlane, gateway)
+	gatewayutils.LabelObjectAsGatewayManaged(controlPlane, gateway.Name)
+
+	fakeClient := fakectrlruntimeclient.
+		NewClientBuilder().
+		WithScheme(scheme.Get()).
+		WithObjects(controlPlane).
+		Build()
+
+	reconciler := Reconciler{
+		Client: fakeClient,
+	}
+
+	gatewayConfig := &GatewayConfiguration{
+		Spec: GatewayConfigurationSpec{
+			Extensions: []commonv1alpha1.ExtensionRef{
+				{
+					Group: "sample.group",
+					Kind:  "SampleExtension",
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "new-extension",
+					},
+				},
+			},
+		},
+	}
+
+	reconciler.provisionControlPlane(ctx, logr.Discard(), gateway, gatewayConfig)
+
+	var updatedControlPlane gwtypes.ControlPlane
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{
+		Name:      controlPlane.Name,
+		Namespace: controlPlane.Namespace,
+	}, &updatedControlPlane))
+	require.Equal(t, gatewayConfig.Spec.Extensions, updatedControlPlane.Spec.Extensions)
+}
+
+func TestDataPlaneSpecDeepEqual_HybridIgnoresKonnectExtensionOnBothSides(t *testing.T) {
+	specCurrent := &operatorv1beta1.DataPlaneOptions{
+		Extensions: []commonv1alpha1.ExtensionRef{
+			{
+				Group: konnectv1alpha2.SchemeGroupVersion.Group,
+				Kind:  konnectv1alpha2.KonnectExtensionKind,
+				NamespacedRef: commonv1alpha1.NamespacedRef{
+					Name: "konnect-ext",
+				},
+			},
+		},
+	}
+	specExpected := &operatorv1beta1.DataPlaneOptions{
+		Extensions: []commonv1alpha1.ExtensionRef{},
+	}
+
+	require.True(t, dataPlaneSpecDeepEqual(specCurrent, specExpected, true))
+}
+
+func TestDataPlaneSpecDeepEqual_HybridStillComparesNonKonnectExtensions(t *testing.T) {
+	specCurrent := &operatorv1beta1.DataPlaneOptions{
+		Extensions: []commonv1alpha1.ExtensionRef{
+			{
+				Group: "example.konghq.com",
+				Kind:  "SomeExtension",
+				NamespacedRef: commonv1alpha1.NamespacedRef{
+					Name: "ext-a",
+				},
+			},
+		},
+	}
+	specExpected := &operatorv1beta1.DataPlaneOptions{
+		Extensions: []commonv1alpha1.ExtensionRef{
+			{
+				Group: "example.konghq.com",
+				Kind:  "SomeExtension",
+				NamespacedRef: commonv1alpha1.NamespacedRef{
+					Name: "ext-b",
+				},
+			},
+		},
+	}
+
+	require.False(t, dataPlaneSpecDeepEqual(specCurrent, specExpected, true))
+}
 func Test_setDataPlaneOptionsDefaults(t *testing.T) {
 	testcases := []struct {
 		name     string

--- a/ingress-controller/internal/controllers/gateway/gateway_controller.go
+++ b/ingress-controller/internal/controllers/gateway/gateway_controller.go
@@ -889,9 +889,9 @@ func (r *GatewayReconciler) determineListenersFromDataPlane(
 // Gateway Controller - Private Object Update Methods
 // -----------------------------------------------------------------------------
 
-// updateAddressesAndListenersStatus updates a unmanaged gateway's status with new addresses and listeners.
-// If the addresses and listeners provided are the same as what exists,
-// it is assumed that reconciliation is complete and a Programmed condition is posted.
+// updateAddressesAndListenersStatus updates an unmanaged Gateway status with
+// the provided listener statuses and addresses when status changes are detected.
+// If the Gateway is not yet programmed, it also sets the Programmed condition.
 func (r *GatewayReconciler) updateAddressesAndListenersStatus(
 	ctx context.Context,
 	log logr.Logger,
@@ -899,26 +899,29 @@ func (r *GatewayReconciler) updateAddressesAndListenersStatus(
 	listenerStatuses []gatewayapi.ListenerStatus,
 	addresses []gatewayapi.GatewayStatusAddress,
 ) (ctrl.Result, error) {
-	if !isGatewayProgrammed(gateway) {
+	programmed := isGatewayProgrammed(gateway)
+	listenersChanged := !isEqualListenersStatus(gateway.Status.Listeners, listenerStatuses)
+	addressesChanged := !reflect.DeepEqual(gateway.Status.Addresses, addresses)
+
+	if !programmed || listenersChanged || addressesChanged {
 		gateway.Status.Listeners = listenerStatuses
 		gateway.Status.Addresses = addresses
-		programmedCondition := metav1.Condition{
-			Type:               string(gatewayapi.GatewayConditionProgrammed),
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: gateway.Generation,
-			LastTransitionTime: metav1.Now(),
-			Reason:             string(gatewayapi.GatewayReasonProgrammed),
+
+		if !programmed {
+			programmedCondition := metav1.Condition{
+				Type:               string(gatewayapi.GatewayConditionProgrammed),
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: gateway.Generation,
+				LastTransitionTime: metav1.Now(),
+				Reason:             string(gatewayapi.GatewayReasonProgrammed),
+			}
+			setGatewayCondition(gateway, programmedCondition)
+			info(log, gateway, "Gateway programmed status updated")
+			return handleUpdateError(r.Status().Update(ctx, pruneGatewayStatusConds(gateway)), r.Log, gateway)
 		}
-		setGatewayCondition(gateway, programmedCondition)
-		info(log, gateway, "Gateway Programmed status updated")
-		err := r.Status().Update(ctx, pruneGatewayStatusConds(gateway))
-		return handleUpdateError(err, r.Log, gateway)
-	}
-	if !isEqualListenersStatus(gateway.Status.Listeners, listenerStatuses) {
-		gateway.Status.Listeners = listenerStatuses
-		info(log, gateway, "Gateway listener status updated")
-		err := r.Status().Update(ctx, gateway)
-		return handleUpdateError(err, r.Log, gateway)
+
+		info(log, gateway, "Gateway status updated")
+		return handleUpdateError(r.Status().Update(ctx, gateway), r.Log, gateway)
 	}
 
 	debug(log, gateway, "Gateway status not updated")

--- a/ingress-controller/internal/controllers/gateway/gateway_controller_test.go
+++ b/ingress-controller/internal/controllers/gateway/gateway_controller_test.go
@@ -1,16 +1,22 @@
 package gateway
 
 import (
+	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/annotations"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/gatewayapi"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/util"
+	"github.com/kong/kong-operator/v2/ingress-controller/pkg/manager/scheme"
 )
 
 func TestReadyConditionExistsForObservedGeneration(t *testing.T) {
@@ -521,4 +527,56 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 			tc.referenceGrants,
 		))
 	}
+}
+
+func TestUpdateAddressesAndListenersStatus_UpdatesAddressesWhenProgrammed(t *testing.T) {
+	ctx := context.Background()
+	sch := scheme.Get()
+
+	ipType := gatewayapi.IPAddressType
+	gateway := &gatewayapi.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "gw",
+			Namespace:  "default",
+			Generation: 1,
+		},
+		Status: gatewayapi.GatewayStatus{
+			Addresses: []gatewayapi.GatewayStatusAddress{
+				{Type: &ipType, Value: "10.0.0.1"},
+			},
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(gatewayapi.GatewayConditionProgrammed),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+					Reason:             string(gatewayapi.GatewayReasonProgrammed),
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(sch).
+		WithObjects(gateway).
+		WithStatusSubresource(gateway).
+		Build()
+
+	r := &GatewayReconciler{
+		Client: cl,
+		Log:    logr.Discard(),
+	}
+
+	listenerStatuses := []gatewayapi.ListenerStatus{}
+	newAddresses := []gatewayapi.GatewayStatusAddress{
+		{Type: &ipType, Value: "10.0.0.2"},
+	}
+
+	res, err := r.updateAddressesAndListenersStatus(ctx, logr.Discard(), gateway, listenerStatuses, newAddresses)
+	require.NoError(t, err)
+	require.True(t, res.IsZero())
+
+	updated := &gatewayapi.Gateway{}
+	require.NoError(t, cl.Get(ctx, ctrlclient.ObjectKeyFromObject(gateway), updated))
+	require.Equal(t, newAddresses, updated.Status.Addresses)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes three reconcile compare/update guard issues tracked in #3770:

- `controller/cpextensions`:
  fix Prometheus `KongPlugin` drift checks to compare value-to-value fields (instead of value-to-pointer), so updates happen only on real drift.
- `controller/gateway`:
  fix hybrid `dataPlaneSpecDeepEqual()` to ignore `KonnectExtension` symmetrically on both current and expected spec sides.
- `ingress-controller/internal/controllers/gateway`:
  update unmanaged Gateway status when addresses change after `Programmed=True` (listeners-only check was insufficient before).

The changes include focused regression tests for all three paths.

**Which issue this PR fixes**

Fixes #3770  
Issue: [Reconcile compare guards trigger redundant updates and can miss Gateway address-only status changes](https://github.com/Kong/kong-operator/issues/3770)

**Special notes for your reviewer**:

- Commits are split by logical area:
  1. `fix(cpextensions): avoid redundant Prometheus plugin updates`
  2. `fix(gateway): ignore KonnectExtension on both hybrid compare sides`
  3. `fix(ingress-controller): update Gateway addresses after programming`
- The ingress-controller change also simplifies `updateAddressesAndListenersStatus()`:
  - computes `programmed`, `listenersChanged`, `addressesChanged`
  - performs status update when any of these require it
  - sets `Programmed` only when transitioning from not programmed state
- Behavior is unchanged except for the bugfixes above.

Validation performed locally:

- `go test ./controller/cpextensions -run TestEnsurePrometheusPlugin -count=1`
- `go test ./controller/gateway -run "TestProvisionControlPlane_UpdatesExtensionsWhenOnlyExtensionsDiffer|TestDataPlaneSpecDeepEqual" -count=1`
- `go test ./ingress-controller/internal/controllers/gateway -run TestUpdateAddressesAndListenersStatus_UpdatesAddressesWhenProgrammed -count=1`

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes