### PR TITLE
tests: create kpi eventually

### DIFF
--- a/test/integration/ko/kongplugininstallation_test.go
+++ b/test/integration/ko/kongplugininstallation_test.go
@@ -338,18 +338,20 @@ func attachKongPluginBasedOnKPIToRoute(
 	ctx := t.Context()
 
 	kongPluginName := kpiNN.Name + "-plugin"
-	// To have it in the same namespace as the HTTPRoute to which it is attached.
 	kongPluginNamespace := httpRouteNN.Namespace
-	kongPlugin := configurationv1.KongPlugin{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      kongPluginName,
-			Namespace: kongPluginNamespace,
-		},
-		PluginName: kpiNN.Name,
-	}
-	_, err := integration.GetClients().ConfigurationClient.ConfigurationV1().KongPlugins(kongPluginNamespace).Create(ctx, &kongPlugin, metav1.CreateOptions{})
-	require.NoError(t, err)
-	cleaner.Add(&kongPlugin)
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		// To have it in the same namespace as the HTTPRoute to which it is attached.
+		kongPlugin := configurationv1.KongPlugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kongPluginName,
+				Namespace: kongPluginNamespace,
+			},
+			PluginName: kpiNN.Name,
+		}
+		_, err := integration.GetClients().ConfigurationClient.ConfigurationV1().KongPlugins(kongPluginNamespace).Create(ctx, &kongPlugin, metav1.CreateOptions{})
+		require.NoError(t, err)
+		cleaner.Add(&kongPlugin)
+	}, time.Minute, 250*time.Millisecond)
 
 	t.Logf("attaching KongPlugin %s to HTTPRoute %s", kongPluginName, httpRouteNN)
 	require.Eventually(t,


### PR DESCRIPTION
Address the following flaky failure in tests:

```
Error Trace:	/home/runner/work/kong-operator/kong-operator/test/integration/ko/kongplugininstallation_test.go:351
            				/home/runner/work/kong-operator/kong-operator/test/integration/ko/kongplugininstallation_test.go:101
Error:      	Received unexpected error:
            	admission webhook "kong.validations.kong.konghq.com" denied the request: plugin failed schema validation: schema violation (name: plugin 'test-kpi' not enabled; add it to the 'plugins' configuration property)
Test:       	TestKongPluginInstallationEssentials
```

Found in https://github.com/Kong/kong-operator/actions/runs/23943209573/job/69833931196?pr=3778#step:15:11121

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
