### PR TITLE
chore(tests): do not ignore `controller-runtime` leaks in `TestManager_NoLeakedGoroutinesAfterContextCancellation`

### DIFF
--- a/test/envtest/manager_envtest_test.go
+++ b/test/envtest/manager_envtest_test.go
@@ -80,12 +80,7 @@ func TestManager_NoLeakedGoroutinesAfterContextCancellation(t *testing.T) {
 	t.Cleanup(func() {
 		ts.Stop(t)
 		t.Logf("Checking for goroutine leaks")
-		// Ignore leaks in controller-runtime/manager before the issue fixed:
-		// https://github.com/kubernetes-sigs/controller-runtime/issues/3218
-		ignoreManagerReconcile := goleak.IgnoreTopFunction("sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1")
-		ignoreManagerEnagageProcedure := goleak.IgnoreAnyFunction("sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).engageStopProcedure.func3.(*runnableGroup).StopAndWait.3.2")
-		ignorePriorityQueueHandleItems := goleak.IgnoreAnyFunction("sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue.(*priorityqueue[...]).handleReadyItems")
-		goleak.VerifyNone(t, ignoreManagerReconcile, ignoreManagerEnagageProcedure, ignorePriorityQueueHandleItems)
+		goleak.VerifyNone(t)
 	})
 
 	scheme := Scheme(t, WithKong)


### PR DESCRIPTION
**What this PR does / why we need it**:

Mentioned

- https://github.com/kubernetes-sigs/controller-runtime/issues/3218

has been resolved quite a while. Test now passes without skipping leaks related to `controller-runtime`, so let's not skip them.
