### PR TITLE
chore(lint): improve `.golangci.yaml`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -320,11 +320,6 @@ linters:
           - forbidigo
         text: use of `errors.As` forbidden because
         path: ".*_test.go|test/.*|ingress-controller/.*"
-      # TODO: remove when https://github.com/golangci/golangci-lint/issues/6363
-      # is resolved and we can use new(expression) instead of ToPtr.
-      - linters:
-          - modernize
-        text: call of .+\(x\) can be simplified to new\(x\)
       - linters:
           - modernize
         text: .+ can be an inlinable wrapper around new


### PR DESCRIPTION
**What this PR does / why we need it**:

Linked issue 

- https://github.com/golangci/golangci-lint/issues/6363

has been resolved some time ago. Removing specific config does not break anything, so this PR removes it. 
