### PR TITLE
chore: remove obsolete TODOs

### DIFF
--- a/api/gateway-operator/v1beta1/shared_types.go
+++ b/api/gateway-operator/v1beta1/shared_types.go
@@ -107,8 +107,6 @@ type BlueGreenStrategy struct {
 // Promotion is a type that contains fields that define how the operator handles
 // promotion of resources during a blue/green rollout.
 type Promotion struct {
-	// TODO: implement AutomaticPromotion https://github.com/Kong/gateway-operator/issues/164
-
 	// Strategy indicates how you want the operator to handle the promotion of
 	// the preview (green) resources (Deployments and Services) after all workflows
 	// and tests succeed, OR if you even want it to break before performing
@@ -156,8 +154,6 @@ type RolloutResources struct {
 // RolloutResourcePlan is a type that holds rollout resource plan related fields
 // which control how the operator handles resources during and after a rollout.
 type RolloutResourcePlan struct {
-	// TODO: https://github.com/Kong/gateway-operator/issues/163
-
 	// Deployment describes how the operator manages Deployments during and after a rollout.
 	//
 	// +kubebuilder:validation:Enum=ScaleDownOnPromotionScaleUpOnRollout

--- a/api/gateway-operator/v2beta1/shared_types.go
+++ b/api/gateway-operator/v2beta1/shared_types.go
@@ -115,8 +115,6 @@ type BlueGreenStrategy struct {
 // Promotion is a type that contains fields that define how the operator handles
 // promotion of resources during a blue/green rollout.
 type Promotion struct {
-	// TODO: implement AutomaticPromotion https://github.com/Kong/gateway-operator/issues/164
-
 	// Strategy indicates how you want the operator to handle the promotion of
 	// the preview (green) resources (Deployments and Services) after all workflows
 	// and tests succeed, OR if you even want it to break before performing
@@ -165,8 +163,6 @@ type RolloutResources struct {
 // RolloutResourcePlan is a type that holds rollout resource plan related fields
 // which control how the operator handles resources during and after a rollout.
 type RolloutResourcePlan struct {
-	// TODO: https://github.com/Kong/gateway-operator/issues/163
-
 	// Deployment describes how the operator manages Deployments during and after a rollout.
 	//
 	// +kubebuilder:validation:Enum=ScaleDownOnPromotionScaleUpOnRollout

--- a/pkg/utils/test/config.go
+++ b/pkg/utils/test/config.go
@@ -38,7 +38,6 @@ func DefaultControllerConfigForTests(opts ...ControllerConfigOption) manager.Con
 	cfg.GatewayAPIExperimentalEnabled = true
 	cfg.EnforceConfig = true
 	cfg.ServiceAccountToImpersonate = ServiceAccountToImpersonate
-	// TODO: https://github.com/Kong/kong-operator/issues/1986
 	cfg.ConversionWebhookEnabled = false
 	cfg.ValidatingWebhookEnabled = true
 	cfg.APIServerQPS = -1

--- a/test/helpers/generators.go
+++ b/test/helpers/generators.go
@@ -74,9 +74,6 @@ func GenerateGatewayConfiguration(namespace string, opts ...gatewayConfiguration
 			Name:      uuid.NewString(),
 		},
 		Spec: operatorv2beta1.GatewayConfigurationSpec{
-			// TODO(pmalek): add support for ControlPlane optionns using GatewayConfiguration v2
-			// https://github.com/kong/kong-operator/issues/1728
-
 			DataPlaneOptions: &operatorv2beta1.GatewayConfigDataPlaneOptions{
 				Deployment: operatorv2beta1.DataPlaneDeploymentOptions{
 					DeploymentOptions: operatorv2beta1.DeploymentOptions{


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove TODOs that have been resolved or closed as no planned. This PR does it in a best effort manner. There are likely still many in the repo.

