### PR TITLE
ci: fix yq installation on darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,9 @@ ARCH := $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
 # renovate: datasource=github-releases depName=mikefarah/yq
 YQ_VERSION = 4.52.5
 YQ = $(PROJECT_DIR)/bin/installs/github-mikefarah-yq/$(YQ_VERSION)/yq_$(OS)_$(ARCH)
+ifeq ($(OS),darwin)
+YQ = $(PROJECT_DIR)/bin/installs/github-mikefarah-yq/$(YQ_VERSION)/yq
+endif
 .PHONY: yq
 yq: mise # Download yq locally if necessary.
 	$(MAKE) mise-install DEP_VER=github:mikefarah/yq@$(YQ_VERSION)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix:

```
bash: line 1: /Users/USER/code_/kong-operator/bin/installs/github-mikefarah-yq/4.52.5/yq_darwin_arm64: No such file or directory
/Library/Developer/CommandLineTools/usr/bin/make mise-install DEP_VER=github:golangci/golangci-lint@
MISE_DATA_DIR=/Users/USER/code_/kong-operator/bin/ /opt/homebrew/bin/mise install -q github:golangci/golangci-lint@
bash: line 1: /Users/USER/code_/kong-operator/bin/installs/github-mikefarah-yq/4.52.5/yq_darwin_arm64: No such file or directory
bash: line 1: /Users/USER/code_/kong-operator/bin/installs/github-mikefarah-yq/4.52.5/yq_darwin_arm64: No such file or directory
/Users/USER/code_/kong-operator/bin/installs/github-golangci-golangci-lint//golangci-lint run -v --config /Users/USER/code_/kong-operator/.golangci.yaml
bash: line 1: /Users/USER/code_/kong-operator/bin/installs/github-golangci-golangci-lint//golangci-lint: No such file or directory
make: *** [lint.golangci-lint] Error 127
```

on darwin.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
