### PR TITLE
tests: fix TestManager_NoLeakedGoroutinesAfterContextCancellation

### DIFF
--- a/test/envtest/manager_envtest_test.go
+++ b/test/envtest/manager_envtest_test.go
@@ -80,7 +80,9 @@ func TestManager_NoLeakedGoroutinesAfterContextCancellation(t *testing.T) {
 	t.Cleanup(func() {
 		ts.Stop(t)
 		t.Logf("Checking for goroutine leaks")
-		goleak.VerifyNone(t)
+		goleak.VerifyNone(t,
+			goleak.IgnoreTopFunction("sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue.(*priorityqueue[...]).handleReadyItems.func1.1"),
+		)
 	})
 
 	scheme := Scheme(t, WithKong)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix: https://github.com/Kong/kong-operator/actions/runs/24083832617/job/70251220927#step:14:2271

```
    manager_envtest_test.go:83: found unexpected goroutines:
        [Goroutine 6510 in state chan send, with sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue.(*priorityqueue[...]).handleReadyItems.func1.1 on top of the stack:
        sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue.(*priorityqueue[...]).handleReadyItems.func1.1()
        	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/controller/priorityqueue/priorityqueue.go:400 +0x5d3
        github.com/google/btree.(*node[...]).iterate(0x9436140, 0x1, {0x0, 0x90?}, {0x0?, 0x0?}, 0x0?, 0x0, 0xc000fa8a80)
        	/home/runner/go/pkg/mod/github.com/google/btree@v1.1.3/btree_generic.go:522 +0x60a
        github.com/google/btree.(*BTreeG[...]).Ascend(0x94350e0, 0xc000fa8a80)
        	/home/runner/go/pkg/mod/github.com/google/btree@v1.1.3/btree_generic.go:779 +0xe5
        sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue.(*priorityqueue[...]).handleReadyItems.func1(0x9434e20)
        	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/controller/priorityqueue/priorityqueue.go:389 +0x2ef
        sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue.(*priorityqueue[...]).handleReadyItems(0x9434e20)
        	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/controller/priorityqueue/priorityqueue.go:408 +0x46
        created by sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue.New[...] in goroutine 6507
        	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/controller/priorityqueue/priorityqueue.go:99 +0x1105
        ]
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
