### PR TITLE
chore: bump go 1.26.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Builder
 # ------------------------------------------------------------------------------
 
-FROM --platform=$BUILDPLATFORM golang:1.26.1@sha256:c42e4d75186af6a44eb4159dcfac758ef1c05a7011a0052fe8a8df016d8e8fb9 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2@sha256:2a2b4b5791cea8ae09caecba7bad0bd9631def96e5fe362e4a5e67009fe4ae61 AS builder
 
 WORKDIR /workspace
 ARG GOPATH

--- a/crd-from-oas/go.mod
+++ b/crd-from-oas/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kong-operator/v2/crd-from-oas
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/caarlos0/env/v11 v11.4.0

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -2,7 +2,7 @@
 # Debug image
 # ------------------------------------------------------------------------------
 
-FROM --platform=$BUILDPLATFORM golang:1.26.1@sha256:c42e4d75186af6a44eb4159dcfac758ef1c05a7011a0052fe8a8df016d8e8fb9 AS debug
+FROM --platform=$BUILDPLATFORM golang:1.26.2@sha256:2a2b4b5791cea8ae09caecba7bad0bd9631def96e5fe362e4a5e67009fe4ae61 AS debug
 
 ARG GOPATH
 ARG GOCACHE

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kong-operator/v2
 
-go 1.26.1
+go 1.26.2
 
 require (
 	cloud.google.com/go/container v1.47.0

--- a/hack/govulncheck-with-excludes.sh
+++ b/hack/govulncheck-with-excludes.sh
@@ -15,7 +15,13 @@ excludeVulns="$(jq -nc '[
   # Kubernetes GitRepo Volume Inadvertent Local Repository Access in k8s.io/kubernetes
   # We do not use the GitRepo volume type.
   # https://github.com/kubernetes/kubernetes/issues/130786
-  "GO-2025-3521"
+  "GO-2025-3521",
+
+  # Memory-safety vulnerability in github.com/jackc/pgx/v5.
+  # pgx is an indirect dependency (via terratest, testcontainers, certificate-transparency-go)
+  # and is not imported or used anywhere in our code.
+  "GO-2026-4771",
+  "GO-2026-4772"
 
 ]')"
 export excludeVulns


### PR DESCRIPTION
**What this PR does / why we need it**:

ref: https://groups.google.com/g/golang-announce/c/0uYbvbPZRWU

**Which issue this PR fixes**

Fixes https://github.com/Kong/kong-operator/actions/runs/24122677441/job/70380049126?pr=3777 

- GO-2026-4865 (aka CVE-2026-32289)

	Context was not properly tracked across template branches for JS template literals, leading to possibly incorrect escaping of content when branches were used. Additionally template actions within JS template literals did not properly track the brace depth, leading to incorrect escaping being applied.
	
	These issues could cause actions within JS template literals to be incorrectly or improperly escaped, leading to XSS vulnerabilities.

- GO-2026-4866 (aka CVE-2026-33810)

	When verifying a certificate chain containing excluded DNS constraints, these constraints are not correctly applied to wildcard DNS SANs which use a different case than the constraint.
	
	This only affects validation of otherwise trusted certificate chains, issued by a root CA in the VerifyOptions.Roots CertPool, or in the system certificate pool.

- GO-2026-4869 (aka CVE-2026-32288)

	tar.Reader can allocate an unbounded amount of memory when reading a maliciously-crafted archive containing a large number of sparse regions encoded in the "old GNU sparse map" format.

- GO-2026-4870 (aka CVE-2026-32283)

	If one side of the TLS connection sends multiple key update messages post-handshake in a single record, the connection can deadlock, causing uncontrolled consumption of resources. This can lead to a denial of service.
	
	This only affects TLS 1.3.

- GO-2026-4946 (aka CVE-2026-32281)

	Validating certificate chains which use policies is unexpectedly inefficient when certificates in the chain contain a very large number of policy mappings, possibly causing denial of service.
	
	This only affects validation of otherwise trusted certificate chains, issued by a root CA in the VerifyOptions.Roots CertPool, or in the system certificate pool.

- GO-2026-4947 (aka CVE-2026-32280)

	During chain building, the amount of work that is done is not correctly limited when a large number of intermediate certificates are passed in VerifyOptions.Intermediates, which can lead to a denial of service. This affects both direct users of crypto/x509 and users of crypto/tls.

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
