### PR TITLE
ci: renovate config to automatically bump Go patch versions in Dockerfile for release/2.1.x branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/---release.md
+++ b/.github/ISSUE_TEMPLATE/---release.md
@@ -32,6 +32,7 @@ If the troubleshooting section does not contain the answer to the problem you en
 - [ ] Update the official documentation at [https://github.com/Kong/developer.konghq.com/][docs_repo]
   - [ ] **Changelog, CLI configuration options, and CRD reference**: Automatically synced by the release workflow (when `latest=true`). A docs PR will be created in the [docs repo][docs_repo] and a comment will be posted in this issue. Review and merge the PR when ready.
   - [ ] Update supported releases table at <https://github.com/Kong/developer.konghq.com/blob/main/app/_data/products/operator.yml>
+- [ ] Major/Minor only: update `renovate.json` config which targets the latest release branch (e.g. `release/2.1.x`) to update the `matchBaseBranches` field to the new release branch (e.g. `release/2.2.x`).
 
 ## Conformance tests report
 

--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,17 @@
   "extends": [
     "config:recommended"
   ],
+  "baseBranchPatterns": [
+    "$default",
+    "release/2.1.x"
+  ],
   "ignorePaths": [],
   "enabledManagers": [
     "custom.regex",
-    "kustomize"
+    "kustomize",
+    // Only for Go toolchain updates, not module updates. Modules are still update via dependabot.
+     "gomod",
+     "dockerfile"
   ],
   "automerge": false,
   "separateMinorPatch": true,
@@ -120,11 +127,13 @@
   "packageRules": [
     {
       "description": "Strip kustomize/ version prefix",
+      "matchBaseBranches": ["$default"],
       "matchPackageNames": ["kubernetes-sigs/kustomize"],
       "extractVersion": "^kustomize/(?<version>.*)$"
     },
     {
       "description": "Ignore minor updates if depName has `@only-patch` suffix.",
+      "matchBaseBranches": ["$default"],
       "matchUpdateTypes": [
         "minor"
       ],
@@ -132,6 +141,46 @@
       "matchDepNames": [
         "/.*@only-patch/"
       ]
+    },
+
+    // Latest release branch specific rules for updating patch versions of Go toolchain and Dockerfiles.
+    {
+      "description": "Disable dependency updates on release/2.1.x by default",
+      "matchBaseBranches": ["release/2.1.x"],
+      "enabled": false
+    },
+    {
+      "description": "Go toolchain patch updates only on release/2.1.x",
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "matchBaseBranches": ["release/2.1.x"],
+      "rangeStrategy": "bump",
+      "enabled": true
+    },
+    {
+      "description": "Disable Go toolchain major and minor updates on release/2.1.x",
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "matchBaseBranches": ["release/2.1.x"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
+      "description": "Go modules patch updates only on release/2.1.x",
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["!go"],
+      "matchBaseBranches": ["release/2.1.x"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": true
+    },
+    {
+      "description": "Dockerfile golang patch updates only on release/2.1.x",
+      "matchManagers": ["dockerfile"],
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["golang"],
+      "matchBaseBranches": ["release/2.1.x"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
