### PR TITLE
test(conformance): Skip conformance tests for hybrid-expressions combination

### DIFF
--- a/.github/workflows/__conformance_tests.yaml
+++ b/.github/workflows/__conformance_tests.yaml
@@ -24,6 +24,10 @@ jobs:
         gateway-type:
           - standard
           - hybrid
+        exclude:
+         - router-flavor: expressions
+           gateway-type: hybrid
+
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -68,6 +68,12 @@ func TestGatewayConformance(t *testing.T) {
 		t.Fatalf("unsupported KONG_TEST_CONFORMANCE_GATEWAY_TYPE: %s", gwType)
 	}
 
+	// hybrid gateway does not support expressions router flavor since we do not support expression routes in KongRoute:
+	// https://github.com/Kong/kong-operator/issues/2673
+	if gwType == hybridGateway && kongRouterFlavor == consts.RouterFlavorExpressions {
+		t.Skipf("hybrid gateway does not support expressions router flavor yet, skipping: https://github.com/Kong/kong-operator/issues/2673")
+	}
+
 	if gwType == hybridGateway && test.KonnectAccessToken() == "" {
 		t.Fatal("hybrid gateway type requires KONG_TEST_KONNECT_ACCESS_TOKEN to be set")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Skip the combination of hybrid gateway and expression router flavor in conformance tests since hybrid gateway does not support expression based route yet. It is meaningless to have such a combination and may waste resource of GH actions and Konnect APIs. 

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
