### PR TITLE
ci: dependabot group updates for github.com/aws/aws-sdk-go-v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,12 @@ updates:
         applies-to: version-updates # Applies the group rule to version updates.
         patterns:
           - "actions/*"
+     # Specify a name for the group, which will be used in pull request titles and branch names.
+     aws-sdk-go-v2:
+        # Define patterns to include dependencies in the group (based on dependency name).
+        applies-to: version-updates # Applies the group rule to version updates.
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2/*"
 - package-ecosystem: github-actions
   directory: /
   schedule:


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent 
<img width="1524" height="459" alt="image" src="https://github.com/user-attachments/assets/cff926cc-84eb-497e-88dd-a2b971d4e7e2" />

by grouping them into 1 PR.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
