### PR TITLE
ci: fix renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,12 @@
     "dependencies"
   ],
   "schedule": "before 5am every weekday",
+  "customDatasources": {
+    "gke-rapid": {
+      "defaultRegistryUrlTemplate": "https://raw.githubusercontent.com/kong/gke-renovate-datasource/main/static/rapid.json",
+      "format": "json"
+    }
+  },
   "customManagers": [
     {
       "description": "Match dependencies in config/samples/.*.yaml that are properly annotated with `# renovate: datasource={} versioning={}.`",
@@ -76,13 +82,14 @@
       "description": "Match versions in selected *.go files that are properly annotated with `// renovate: datasource={} depName={}.`",
       "customType": "regex",
       "datasourceTemplate": "docker",
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}",
       "fileMatch": [
         "^pkg/consts/dataplane\\.go$",
         "^internal/versions/controlplane\\.go$",
         "^test/e2e/helm_install_upgrade_test\\.go$"
       ],
       "matchStrings": [
-        ".+\\s?[=:]\\s+\"(?<currentValue>.+?)\",?\\s+//\\s+renovate:\\s+datasource=(?<datasource>.*?)\\s+(packageName=(?<packageName>.*)\\s+)?depName=(?<depName>.*)"
+        ".+\\s?[=:]\\s+\"(?<currentValue>.+?)\",?\\s+//\\s+renovate:\\s+datasource=(?<datasource>.*?)\\s+(packageName=(?<packageName>.*?)\\s+)?depName=(?<depName>.*?)(\\s+versioning=(?<versioning>.*?))?(?:\\r\\n|\\r|\\n|$)"
       ]
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -152,6 +152,13 @@
 
     // Latest release branch specific rules for updating patch versions of Go toolchain and Dockerfiles.
     {
+      "description": "Disable Go dependencies updates (still handled by dependabot)",
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "matchBaseBranches": ["$default", "release/2.1.x"],
+      "enabled": false
+    },
+    {
       "description": "Disable dependency updates on release/2.1.x by default",
       "matchBaseBranches": ["release/2.1.x"],
       "enabled": false


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix Renovate dependency lookups for test version annotations.

- This adds [the missing custom datasource for GKE rapid releases](https://github.com/Kong/kubernetes-ingress-controller/blob/59fadd5e714b70c7a96f06ae61168ed499f69ca2/renovate.json#L58-L63) (not ported from KIC)

- This also tightens the custom regex manager used for annotated Go version constants so depName and versioning are parsed correctly instead of being merged into a single invalid package name. As a result, Renovate can resolve the chart reference in the Helm upgrade test correctly and detect the available `kong/kong-operator-chart` update from 1.2.1 to 1.2.2, while also clearing the related lookup warning for the GKE test dependency.

    ```
               {
                 "deps": [
                   {
                     "depName": "kong/kong-operator-chart",
                     "currentValue": "1.2.1",
                     "datasource": "docker",
                     "versioning": "docker",
                     "replaceString": "\t\tlastReleasedChartVersion = \"1.2.1\" // renovate: datasource=docker depName=kong/kong-operator-chart versioning=docker\n",
                     "updates": [
                       {
                         "bucket": "patch",
                         "newVersion": "1.2.2",
                         "newValue": "1.2.2",
                         "releaseTimestamp": "2026-03-31T15:20:12.967Z",
                         "newVersionAgeInDays": 7,
                         "newMajor": 1,
                         "newMinor": 2,
                         "newPatch": 2,
                         "updateType": "patch",
                         "isBreaking": false,
                         "libYears": 0.0965336123160832,
                         "branchName": "renovate/kong-kong-operator-chart-1.2.x"
                       }
                     ],
                     "packageName": "kong/kong-operator-chart",
                     "warnings": [],
                     "sourceUrl": "https://github.com/Kong/kong-operator",
                     "registryUrl": "https://index.docker.io",
                     "homepage": "https://konghq.com/",
                     "mostRecentTimestamp": "2026-03-31T15:20:12.967Z",
                     "currentVersion": "1.2.1",
                     "currentVersionTimestamp": "2026-02-24T09:42:08.969Z",
                     "currentVersionAgeInDays": 43,
                     "isSingleVersion": true,
                     "fixedVersion": "1.2.1"
                   }
                 ],
                 "matchStrings": [
                   ".+\\s?[=:]\\s+\"(?<currentValue>.+?)\",?\\s+//\\s+renovate:\\s+datasource=(?<datasource>.*?)\\s+(packageName=(?<packageName>.*?)\\s+)?depName=(?<depName>.*?)(\\s+versioning=(?<versioning>.*?))?(?:\\r\\n|\\r|\\n|$)"
                 ],
                 "datasourceTemplate": "docker",
                 "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}",
                 "packageFile": "test/e2e/helm_install_upgrade_test.go"
               },
    ```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
