### PR TITLE
ci: fix renovate Dockerfile config for 2.1 branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -188,13 +188,21 @@
       "enabled": true
     },
     {
-      "description": "Dockerfile golang patch updates only on release/2.1.x",
+      "description": "Enable Dockerfile golang updates on release/2.1.x",
       "matchManagers": ["dockerfile"],
       "matchDatasources": ["docker"],
       "matchDepNames": ["golang"],
       "matchBaseBranches": ["release/2.1.x"],
-      "matchUpdateTypes": ["patch"],
       "enabled": true
+    },
+    {
+      "description": "Disable Dockerfile golang major and minor updates on release/2.1.x",
+      "matchManagers": ["dockerfile"],
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["golang"],
+      "matchBaseBranches": ["release/2.1.x"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The golang Dockerfile dependency was not receiving patch updates on the release/2.1.x branch because the "disable all deps on release/2.1.x" rule operates at the dependency level (preventing update lookup entirely), while the re-enable rule used matchUpdateTypes: ["patch"] which operates at the update level — never matching since no updates were computed.

Split the single rule into two, following the same pattern as the working Go toolchain rules: first re-enable the dependency unconditionally, then disable major/minor update types.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
