### PR TITLE
ci: fix charts nightly workflow

### DIFF
--- a/.github/workflows/charts-nightly.yaml
+++ b/.github/workflows/charts-nightly.yaml
@@ -7,6 +7,7 @@ on:
 
 env:
   NIGHTLY_CHART_NAME: nightly-kong-operator-chart
+  SEND_SLACK_NOTIFICATION: ${{ vars.CHARTS_NIGHTLY_SEND_SLACK_NOTIFICATION }}
 
 permissions:
   contents: read
@@ -38,10 +39,12 @@ jobs:
 
       - name: Install PyYAML
         run: |
-          python -m pip install --require-hashes --no-deps \
-            'pyyaml==6.0.2' \
+          cat > /tmp/charts-nightly-requirements.txt <<'REQ'
+          pyyaml==6.0.2 \
             --hash=sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5 \
             --hash=sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e
+          REQ
+          python -m pip install --require-hashes --no-deps -r /tmp/charts-nightly-requirements.txt
 
       - name: Compute nightly chart metadata
         id: metadata
@@ -113,3 +116,18 @@ jobs:
           PACKAGE: ${{ steps.package.outputs.package_path }}
         run: |
           helm push "${PACKAGE}" oci://registry-1.docker.io/kong
+
+      - name: Send slack notification if job fails.
+        if: failure() && env.SEND_SLACK_NOTIFICATION == 'true'
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.slack-webhook-url }}
+          SLACK_TEAM_ID: ${{ secrets.slack-team-id }}
+        with:
+          webhook: ${{ env.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            status: "failure"
+            option: "false"
+            fields: repo,message,commit,author,action,eventName,ref,workflow
+            text: ":red_circle: KO ${{ env.NIGHTLY_CHART_NAME }} push failed cc: <!subteam^${{ env.SLACK_TEAM_ID }}>"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes https://github.com/Kong/kong-operator/actions/runs/24173791303/job/70550833655#step:7:2

```
  python -m pip install --require-hashes --no-deps \
    'pyyaml==6.0.2' \
    --hash=sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5 \
    --hash=sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e
  shell: /usr/bin/bash -e {0}
  env:
    NIGHTLY_CHART_NAME: nightly-kong-operator-chart
    HELM_EXPERIMENTAL_OCI: 1
    pythonLocation: /opt/hostedtoolcache/Python/3.13.12/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.13.12/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.13.12/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.13.12/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.13.12/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.13.12/x64/lib
    MISE_LOG_LEVEL: info
    MISE_GITHUB_TOKEN: ***
    MISE_TRUSTED_CONFIG_PATHS: /home/runner/work/kong-operator/kong-operator
    MISE_YES: 1
    DIR: crd-from-oas
    PATH: /home/runner/.local/share/mise/installs/github-kubernetes-sigs-controller-tools/0.20.1:/home/runner/.local/share/mise/installs/github-golangci-golangci-lint/2.11.4:/home/runner/.local/share/mise/installs/github-kubernetes-sigs-controller-runtime/0.23.3:/home/runner/.local/share/mise/installs/github-kubernetes-sigs-kustomize/v5.8.1:/home/runner/.local/share/mise/installs/kind/v0.31.0:/home/runner/.local/share/mise/installs/github-kong-kubernetes-testing-framework/0.49.0:/home/runner/.local/share/mise/installs/github-telepresenceio-telepresence/2.27.3:/home/runner/.local/share/mise/installs/http-helm/4.1.3:/home/runner/.local/share/mise/installs/go-sigs-k8s-io-kube-api-linter-cmd-golangci-lint-kube-api-linter/c9b9b51b278a39c2d09b149df45196275919c23b/bin:/home/runner/.local/share/mise/shims:/home/runner/.local/share/mise/bin:/opt/hostedtoolcache/Python/3.13.12/x64/bin:/opt/hostedtoolcache/Python/3.13.12/x64:/snap/bin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin

[optparse.groups]Usage:[/]   
  /opt/hostedtoolcache/Python/3.13.12/x64/bin/python -m pip install \[options] <requirement specifier> \[package-index-options] ...
  /opt/hostedtoolcache/Python/3.13.12/x64/bin/python -m pip install \[options] -r <requirements file> \[package-index-options] ...
  /opt/hostedtoolcache/Python/3.13.12/x64/bin/python -m pip install \[options] [-e] <vcs project url> ...
  /opt/hostedtoolcache/Python/3.13.12/x64/bin/python -m pip install \[options] [-e] <local project path> ...
  /opt/hostedtoolcache/Python/3.13.12/x64/bin/python -m pip install \[options] <archive url/path> ...

no such option: --hash
```

and adds a slack notification when a failure occurs.

Sending is controlled via `CHARTS_NIGHTLY_SEND_SLACK_NOTIFICATION` GH variable.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
