### PR TITLE
Fix(mcpserver): `KonnectGatewayControlPlane` version

### DIFF
--- a/controller/mcpserver/controlplane_controller.go
+++ b/controller/mcpserver/controlplane_controller.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	"github.com/kong/kong-operator/v2/controller/konnect"
 	sdkops "github.com/kong/kong-operator/v2/controller/konnect/ops/sdk"
 	"github.com/kong/kong-operator/v2/controller/konnect/server"
@@ -35,7 +36,7 @@ func (r *MCPServerCPReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 	r.SignalManager.run(ctx)
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(r.ControllerOptions).
-		For(&konnectv1alpha1.KonnectGatewayControlPlane{}).
+		For(&konnectv1alpha2.KonnectGatewayControlPlane{}).
 		Complete(r)
 }
 
@@ -43,12 +44,12 @@ func (r *MCPServerCPReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 func (r *MCPServerCPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.GetLogger(ctx, "mcp-cp", r.LoggingMode)
 
-	var controlPlane konnectv1alpha1.KonnectGatewayControlPlane
+	var controlPlane konnectv1alpha2.KonnectGatewayControlPlane
 	if err := r.Get(ctx, req.NamespacedName, &controlPlane); err != nil {
 		if apierrors.IsNotFound(err) {
 			r.SignalManager.EmitControlPlaneEvent(ctx, CPEvent{
 				Type: EventTypeDeregister,
-				ControlPlane: &konnectv1alpha1.KonnectGatewayControlPlane{
+				ControlPlane: &konnectv1alpha2.KonnectGatewayControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      req.Name,
 						Namespace: req.Namespace,
@@ -91,7 +92,7 @@ func (r *MCPServerCPReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 		return ctrl.Result{}, err
 	}
-	srv, err := server.NewServer[konnectv1alpha1.KonnectGatewayControlPlane](apiAuth.Status.ServerURL)
+	srv, err := server.NewServer[konnectv1alpha2.KonnectGatewayControlPlane](apiAuth.Status.ServerURL)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to parse server URL %q: %w", apiAuth.Status.ServerURL, err)
 	}

--- a/controller/mcpserver/mcpserver_controller_utils.go
+++ b/controller/mcpserver/mcpserver_controller_utils.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	konnectcontroller "github.com/kong/kong-operator/v2/controller/konnect"
 	sdkops "github.com/kong/kong-operator/v2/controller/konnect/ops/sdk"
 	"github.com/kong/kong-operator/v2/controller/konnect/server"
@@ -43,7 +44,7 @@ func generateHashedName(namespace, prefix, hashKey string) types.NamespacedName 
 // owns the given MCPServer, or an empty string if no such owner is found.
 func ownerControlPlaneName(mcpServer *konnectv1alpha1.MCPServer) string {
 	for _, ref := range mcpServer.OwnerReferences {
-		if ref.APIVersion == konnectv1alpha1.GroupVersion.String() && ref.Kind == "KonnectGatewayControlPlane" {
+		if ref.APIVersion == konnectv1alpha2.GroupVersion.String() && ref.Kind == "KonnectGatewayControlPlane" {
 			return ref.Name
 		}
 	}

--- a/controller/mcpserver/mcpserver_controller_utils_test.go
+++ b/controller/mcpserver/mcpserver_controller_utils_test.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 )
 
 func TestOwnerControlPlaneName(t *testing.T) {
@@ -21,7 +22,7 @@ func TestOwnerControlPlaneName(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							APIVersion: konnectv1alpha1.GroupVersion.String(),
+							APIVersion: konnectv1alpha2.GroupVersion.String(),
 							Kind:       "KonnectGatewayControlPlane",
 							Name:       "my-cp",
 						},
@@ -41,7 +42,7 @@ func TestOwnerControlPlaneName(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							APIVersion: konnectv1alpha1.GroupVersion.String(),
+							APIVersion: konnectv1alpha2.GroupVersion.String(),
 							Kind:       "SomethingElse",
 							Name:       "my-cp",
 						},
@@ -76,7 +77,7 @@ func TestOwnerControlPlaneName(t *testing.T) {
 							Name:       "other",
 						},
 						{
-							APIVersion: konnectv1alpha1.GroupVersion.String(),
+							APIVersion: konnectv1alpha2.GroupVersion.String(),
 							Kind:       "KonnectGatewayControlPlane",
 							Name:       "my-cp",
 						},

--- a/controller/mcpserver/mcpserverfetcher.go
+++ b/controller/mcpserver/mcpserverfetcher.go
@@ -20,6 +20,7 @@ import (
 
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	sdkops "github.com/kong/kong-operator/v2/controller/konnect/ops/sdk"
 	"github.com/kong/kong-operator/v2/controller/pkg/log"
 	"github.com/kong/kong-operator/v2/internal/utils/index"
@@ -38,7 +39,7 @@ type MCPServersFetcher struct {
 	scheme        *runtime.Scheme
 	konnectClient sdkops.SDKWrapper
 
-	controlPlane *konnectv1alpha1.KonnectGatewayControlPlane
+	controlPlane *konnectv1alpha2.KonnectGatewayControlPlane
 
 	fetchEventCh     chan struct{}
 	reconcileEventCh chan<- event.GenericEvent
@@ -51,7 +52,7 @@ func NewMCPServersFetcher(
 	konnectClient sdkops.SDKWrapper,
 	fetchEventCh chan struct{},
 	reconcileEventCh chan<- event.GenericEvent,
-	controlPlane *konnectv1alpha1.KonnectGatewayControlPlane,
+	controlPlane *konnectv1alpha2.KonnectGatewayControlPlane,
 	scheme *runtime.Scheme,
 ) *MCPServersFetcher {
 	return &MCPServersFetcher{

--- a/controller/mcpserver/mcpserverfetcher_test.go
+++ b/controller/mcpserver/mcpserverfetcher_test.go
@@ -101,12 +101,12 @@ func TestSyncMCPServers(t *testing.T) {
 	)
 
 	// controlPlane is the owner KonnectGatewayControlPlane used in all tests.
-	controlPlane := &konnectv1alpha1.KonnectGatewayControlPlane{
+	controlPlane := &konnectv1alpha2.KonnectGatewayControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cpName,
 			Namespace: namespace,
 		},
-		Status: konnectv1alpha1.KonnectGatewayControlPlaneStatus{
+		Status: konnectv1alpha2.KonnectGatewayControlPlaneStatus{
 			KonnectEntityStatus: konnectv1alpha2.KonnectEntityStatus{
 				ID: cpID,
 			},

--- a/controller/mcpserver/signal.go
+++ b/controller/mcpserver/signal.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
-	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	sdkops "github.com/kong/kong-operator/v2/controller/konnect/ops/sdk"
 	"github.com/kong/kong-operator/v2/controller/pkg/log"
 	"github.com/kong/kong-operator/v2/modules/manager/logging"
@@ -43,7 +43,7 @@ const (
 type CPEvent struct {
 	Type          EventType
 	KonnectClient sdkops.SDKWrapper
-	ControlPlane  *konnectv1alpha1.KonnectGatewayControlPlane
+	ControlPlane  *konnectv1alpha2.KonnectGatewayControlPlane
 }
 
 // SignalManager manages a set of per-UUID background goroutines that periodically
@@ -127,7 +127,7 @@ func (s *SignalManager) NotifyMCPServerDeleted(namespace, cpName string) {
 
 // registerControlPlane registers the control plane and starts a dedicated goroutine for it.
 // If the control plane is already registered, registerControlPlane is a no-op.
-func (s *SignalManager) registerControlPlane(konnectClient sdkops.SDKWrapper, cp *konnectv1alpha1.KonnectGatewayControlPlane) {
+func (s *SignalManager) registerControlPlane(konnectClient sdkops.SDKWrapper, cp *konnectv1alpha2.KonnectGatewayControlPlane) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -164,7 +164,7 @@ func (s *SignalManager) CPEvents() <-chan CPEvent {
 
 // deregisterControlPlane cancels and unregisters the goroutine for the given control plane.
 // If the control plane is not registered, deregisterControlPlane is a no-op.
-func (s *SignalManager) deregisterControlPlane(cp *konnectv1alpha1.KonnectGatewayControlPlane) {
+func (s *SignalManager) deregisterControlPlane(cp *konnectv1alpha2.KonnectGatewayControlPlane) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -178,7 +178,7 @@ func (s *SignalManager) deregisterControlPlane(cp *konnectv1alpha1.KonnectGatewa
 	delete(s.resetChs, key)
 }
 
-func (s *SignalManager) mcpCPSignalRoutine(ctx context.Context, cp *konnectv1alpha1.KonnectGatewayControlPlane, konnectClient sdkops.SDKWrapper, fetchEventCh chan<- struct{}, resetCh <-chan struct{}) {
+func (s *SignalManager) mcpCPSignalRoutine(ctx context.Context, cp *konnectv1alpha2.KonnectGatewayControlPlane, konnectClient sdkops.SDKWrapper, fetchEventCh chan<- struct{}, resetCh <-chan struct{}) {
 	logger := log.GetLogger(ctx, "mcpserver-signal", s.loggingMode)
 	offset := new(initialOffset)
 

--- a/controller/mcpserver/signal_test.go
+++ b/controller/mcpserver/signal_test.go
@@ -9,7 +9,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
-	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	"github.com/kong/kong-operator/v2/modules/manager/logging"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
@@ -78,10 +77,10 @@ func TestSignalManager_NotifyMCPServerDeleted(t *testing.T) {
 }
 
 func TestSignalManager_DeregisterControlPlane(t *testing.T) {
-	makeCP := func(name, namespace string) *konnectv1alpha1.KonnectGatewayControlPlane {
-		return &konnectv1alpha1.KonnectGatewayControlPlane{
+	makeCP := func(name, namespace string) *konnectv1alpha2.KonnectGatewayControlPlane {
+		return &konnectv1alpha2.KonnectGatewayControlPlane{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-			Status: konnectv1alpha1.KonnectGatewayControlPlaneStatus{
+			Status: konnectv1alpha2.KonnectGatewayControlPlaneStatus{
 				KonnectEntityStatus: konnectv1alpha2.KonnectEntityStatus{ID: "konnect-id"},
 			},
 		}
@@ -129,10 +128,10 @@ func TestSignalManager_DeregisterControlPlane(t *testing.T) {
 }
 
 func TestSignalManager_RegisterControlPlane(t *testing.T) {
-	makeCP := func(name, namespace string) *konnectv1alpha1.KonnectGatewayControlPlane {
-		return &konnectv1alpha1.KonnectGatewayControlPlane{
+	makeCP := func(name, namespace string) *konnectv1alpha2.KonnectGatewayControlPlane {
+		return &konnectv1alpha2.KonnectGatewayControlPlane{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-			Status: konnectv1alpha1.KonnectGatewayControlPlaneStatus{
+			Status: konnectv1alpha2.KonnectGatewayControlPlaneStatus{
 				KonnectEntityStatus: konnectv1alpha2.KonnectEntityStatus{ID: "konnect-id"},
 			},
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

KonnectGatewayControlPlane watched by the `MCPServer` controllers must be `v1alpha2`, not `v1alpha1`

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
