### PR TITLE
chore(ci): Change stale issue timeout from 60 to 30 days

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -22,7 +22,7 @@ jobs:
         id: stale
         uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
-          days-before-stale: 60
+          days-before-stale: 30
           days-before-close: 700
           exempt-all-milestones: true
           stale-issue-label: 'stale'


### PR DESCRIPTION
Reduced the days before issues are marked as stale from 60 to 30.

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
