### PR TITLE
test(kongintegration): Set default protocol of routes in kongintegration test

### DIFF
--- a/ingress-controller/test/kongintegration/expression_router_test.go
+++ b/ingress-controller/test/kongintegration/expression_router_test.go
@@ -96,6 +96,7 @@ func TestExpressionsRouterMatchers_GenerateValidExpressions(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r := &kong.Route{
 				StripPath: new(true),
+				Protocols: kong.StringSlice("http", "https"),
 			}
 			atc.ApplyExpression(r, tc.matcher, 1)
 			req, err := kongClient.NewRequest(http.MethodPost, "/config", nil, marshalKongConfig(t, *s, *r))

--- a/test/test_dependencies.yaml
+++ b/test/test_dependencies.yaml
@@ -12,17 +12,17 @@ integration:
   # renovate: datasource=docker depName=kong versioning=docker
   kong-oss: '3.9.1'
   # renovate: datasource=docker depName=kong/kong-gateway versioning=docker
-  kong-ee: '3.13.0.2'
+  kong-ee: '3.14.0.1'
 
 kongintegration:
   # renovate: datasource=docker depName=kong versioning=docker
   kong-oss: '3.9.1'
   # renovate: datasource=docker depName=kong/kong-gateway versioning=docker
-  kong-ee: '3.13.0.2'
+  kong-ee: '3.14.0.1'
 
 envtests:
   # renovate: datasource=docker depName=kong/kong-gateway versioning=docker
-  kong-ee: '3.13.0.2'
+  kong-ee: '3.14.0.1'
   # This is a version of Kong Gateway that does not support sticky sessions,
   # all versions >= 3.11.0 support sticky sessions.
   kong-without-sticky-sessions: '3.9.1'


### PR DESCRIPTION
**What this PR does / why we need it**:
Set the default protocols of routes to `http,https` for expression router case in kongintegration tests to be compatible with Kong 3.14.
**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
