### PR TITLE
chore(ci): adjust automatic GitHub secret scanning

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,9 @@
+# Customize GitHub secret scanning to automatically close alerts for secrets found in specific directories
+# that are used for testing or examples, as these are not actual secrets and do not pose a security risk.
+# Read more:
+# https://docs.github.com/en/code-security/how-tos/secure-your-secrets/customize-leak-detection/excluding-folders-and-files-from-secret-scanning
+paths-ignore:
+  - "charts/kong-operator/ci/__snapshots__/**"
+  - "ingress-controller/examples/**"
+  - "config/samples/**"
+  - "ingress-controller/internal/dataplane/testdata/golden/**"


### PR DESCRIPTION
**What this PR does / why we need it**:

As discussed during team sync 8.04.2026, avoid false positives with proper configuration as described in https://docs.github.com/en/code-security/how-tos/secure-your-secrets/customize-leak-detection/excluding-folders-and-files-from-secret-scanning
