### PR TITLE
fix: fix translator for invalid backendRefs

### DIFF
--- a/ingress-controller/internal/dataplane/testdata/golden/grpcroute-example/default_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/grpcroute-example/default_golden.yaml
@@ -1,7 +1,7 @@
 _format_version: "3.0"
 services:
 - connect_timeout: 60000
-  host: grpcroute.default.grpcbin.2
+  host: grpcroute.default.grpcbin.2.invalid
   id: 20d53c70-e92e-57d7-85a4-265209989fd2
   name: grpcroute.default.grpcbin.2
   plugins:
@@ -41,7 +41,7 @@ services:
   - k8s-version:v1
   write_timeout: 60000
 - connect_timeout: 60000
-  host: grpcroute.default.grpcbin.1
+  host: grpcroute.default.grpcbin.1.invalid
   id: 5a5c3a90-aad9-5e89-93e6-53741e27b8fa
   name: grpcroute.default.grpcbin.1
   plugins:
@@ -81,7 +81,7 @@ services:
   - k8s-version:v1
   write_timeout: 60000
 - connect_timeout: 60000
-  host: grpcroute.default.grpcbin.0
+  host: grpcroute.default.grpcbin.0.invalid
   id: 21a5e729-c47e-5086-a236-0551b9a11bda
   name: grpcroute.default.grpcbin.0
   plugins:
@@ -122,7 +122,7 @@ services:
   write_timeout: 60000
 upstreams:
 - algorithm: round-robin
-  name: grpcroute.default.grpcbin.2
+  name: grpcroute.default.grpcbin.2.invalid
   tags:
   - k8s-name:UNKNOWN
   - k8s-namespace:UNKNOWN
@@ -131,7 +131,7 @@ upstreams:
   - k8s-group:core
   - k8s-version:v1
 - algorithm: round-robin
-  name: grpcroute.default.grpcbin.1
+  name: grpcroute.default.grpcbin.1.invalid
   tags:
   - k8s-name:UNKNOWN
   - k8s-namespace:UNKNOWN
@@ -140,7 +140,7 @@ upstreams:
   - k8s-group:core
   - k8s-version:v1
 - algorithm: round-robin
-  name: grpcroute.default.grpcbin.0
+  name: grpcroute.default.grpcbin.0.invalid
   tags:
   - k8s-name:UNKNOWN
   - k8s-namespace:UNKNOWN

--- a/ingress-controller/internal/dataplane/testdata/golden/grpcroute-example/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/grpcroute-example/expression-routes-on_golden.yaml
@@ -1,7 +1,7 @@
 _format_version: "3.0"
 services:
 - connect_timeout: 60000
-  host: grpcroute.default.grpcbin.example.com.2
+  host: grpcroute.default.grpcbin.example.com.2.invalid
   id: 3ffe4b8d-2338-5124-ae9f-8dccbb3af27b
   name: grpcroute.default.grpcbin.example.com.2
   plugins:
@@ -39,7 +39,7 @@ services:
   - k8s-version:v1
   write_timeout: 60000
 - connect_timeout: 60000
-  host: grpcroute.default.grpcbin.example.com.1
+  host: grpcroute.default.grpcbin.example.com.1.invalid
   id: 4d9f08e3-4be4-5155-85df-879454f38400
   name: grpcroute.default.grpcbin.example.com.1
   plugins:
@@ -77,7 +77,7 @@ services:
   - k8s-version:v1
   write_timeout: 60000
 - connect_timeout: 60000
-  host: grpcroute.default.grpcbin.example.com.0
+  host: grpcroute.default.grpcbin.example.com.0.invalid
   id: e3750232-74d7-5496-bf14-1c266ec17184
   name: grpcroute.default.grpcbin.example.com.0
   plugins:
@@ -116,7 +116,7 @@ services:
   write_timeout: 60000
 upstreams:
 - algorithm: round-robin
-  name: grpcroute.default.grpcbin.example.com.2
+  name: grpcroute.default.grpcbin.example.com.2.invalid
   tags:
   - k8s-name:UNKNOWN
   - k8s-namespace:UNKNOWN
@@ -125,7 +125,7 @@ upstreams:
   - k8s-group:core
   - k8s-version:v1
 - algorithm: round-robin
-  name: grpcroute.default.grpcbin.example.com.1
+  name: grpcroute.default.grpcbin.example.com.1.invalid
   tags:
   - k8s-name:UNKNOWN
   - k8s-namespace:UNKNOWN
@@ -134,7 +134,7 @@ upstreams:
   - k8s-group:core
   - k8s-version:v1
 - algorithm: round-robin
-  name: grpcroute.default.grpcbin.example.com.0
+  name: grpcroute.default.grpcbin.example.com.0.invalid
   tags:
   - k8s-name:UNKNOWN
   - k8s-namespace:UNKNOWN

--- a/ingress-controller/internal/dataplane/testdata/golden/tcproute-example/default_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/tcproute-example/default_golden.yaml
@@ -1,7 +1,7 @@
 _format_version: "3.0"
 services:
 - connect_timeout: 60000
-  host: tcproute.tcp-namespace.echo-plaintext.0
+  host: tcproute.tcp-namespace.echo-plaintext.0.invalid
   id: e2302e1e-0a75-5174-82f3-c0bc379a108a
   name: tcproute.tcp-namespace.echo-plaintext.0
   plugins:
@@ -37,7 +37,7 @@ services:
   write_timeout: 60000
 upstreams:
 - algorithm: round-robin
-  name: tcproute.tcp-namespace.echo-plaintext.0
+  name: tcproute.tcp-namespace.echo-plaintext.0.invalid
   tags:
   - k8s-name:UNKNOWN
   - k8s-namespace:UNKNOWN

--- a/ingress-controller/internal/dataplane/testdata/golden/tcproute-example/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/tcproute-example/expression-routes-on_golden.yaml
@@ -1,7 +1,7 @@
 _format_version: "3.0"
 services:
 - connect_timeout: 60000
-  host: tcproute.tcp-namespace.echo-plaintext.0
+  host: tcproute.tcp-namespace.echo-plaintext.0.invalid
   id: e2302e1e-0a75-5174-82f3-c0bc379a108a
   name: tcproute.tcp-namespace.echo-plaintext.0
   plugins:
@@ -36,7 +36,7 @@ services:
   write_timeout: 60000
 upstreams:
 - algorithm: round-robin
-  name: tcproute.tcp-namespace.echo-plaintext.0
+  name: tcproute.tcp-namespace.echo-plaintext.0.invalid
   tags:
   - k8s-name:UNKNOWN
   - k8s-namespace:UNKNOWN

--- a/ingress-controller/internal/dataplane/testdata/golden/tlsroute-example/default_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/tlsroute-example/default_golden.yaml
@@ -1,7 +1,7 @@
 _format_version: "3.0"
 services:
 - connect_timeout: 60000
-  host: tlsroute.tls-namespace.echo-tls.0
+  host: tlsroute.tls-namespace.echo-tls.0.invalid
   id: 2a2aad7c-6331-5bcf-bd7c-d9516639f65d
   name: tlsroute.tls-namespace.echo-tls.0
   plugins:
@@ -38,7 +38,7 @@ services:
   write_timeout: 60000
 upstreams:
 - algorithm: round-robin
-  name: tlsroute.tls-namespace.echo-tls.0
+  name: tlsroute.tls-namespace.echo-tls.0.invalid
   tags:
   - k8s-name:UNKNOWN
   - k8s-namespace:UNKNOWN

--- a/ingress-controller/internal/dataplane/testdata/golden/tlsroute-example/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/tlsroute-example/expression-routes-on_golden.yaml
@@ -1,7 +1,7 @@
 _format_version: "3.0"
 services:
 - connect_timeout: 60000
-  host: tlsroute.tls-namespace.echo-tls.0
+  host: tlsroute.tls-namespace.echo-tls.0.invalid
   id: 2a2aad7c-6331-5bcf-bd7c-d9516639f65d
   name: tlsroute.tls-namespace.echo-tls.0
   plugins:
@@ -37,7 +37,7 @@ services:
   write_timeout: 60000
 upstreams:
 - algorithm: round-robin
-  name: tlsroute.tls-namespace.echo-tls.0
+  name: tlsroute.tls-namespace.echo-tls.0.invalid
   tags:
   - k8s-name:UNKNOWN
   - k8s-namespace:UNKNOWN

--- a/ingress-controller/internal/dataplane/testdata/golden/udproute-example/default_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/udproute-example/default_golden.yaml
@@ -1,7 +1,7 @@
 _format_version: "3.0"
 services:
 - connect_timeout: 60000
-  host: udproute.udp-example.tftp.0
+  host: udproute.udp-example.tftp.0.invalid
   id: 439fc57a-baff-51a3-9e1f-4e6af6b9dcae
   name: udproute.udp-example.tftp.0
   plugins:
@@ -38,7 +38,7 @@ services:
   write_timeout: 60000
 upstreams:
 - algorithm: round-robin
-  name: udproute.udp-example.tftp.0
+  name: udproute.udp-example.tftp.0.invalid
   tags:
   - k8s-name:UNKNOWN
   - k8s-namespace:UNKNOWN

--- a/ingress-controller/internal/dataplane/testdata/golden/udproute-example/expression-routes-on_golden.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/udproute-example/expression-routes-on_golden.yaml
@@ -1,7 +1,7 @@
 _format_version: "3.0"
 services:
 - connect_timeout: 60000
-  host: udproute.udp-example.tftp.0
+  host: udproute.udp-example.tftp.0.invalid
   id: 439fc57a-baff-51a3-9e1f-4e6af6b9dcae
   name: udproute.udp-example.tftp.0
   plugins:
@@ -37,7 +37,7 @@ services:
   write_timeout: 60000
 upstreams:
 - algorithm: round-robin
-  name: udproute.udp-example.tftp.0
+  name: udproute.udp-example.tftp.0.invalid
   tags:
   - k8s-name:UNKNOWN
   - k8s-namespace:UNKNOWN

--- a/ingress-controller/internal/dataplane/translator/subtranslator/httproute.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/httproute.go
@@ -41,6 +41,18 @@ type TranslateHTTPRouteToKongstateServiceOptions struct {
 	SupportRedirectPlugin                   bool
 }
 
+const invalidBackendRefsServiceHostSuffix = ".invalid"
+
+// HostForKongService returns the upstream host for a translated Kong service.
+// Services created from invalid backendRefs use a distinct host to avoid
+// reusing Kong balancer state when the same logical service later becomes valid.
+func HostForKongService(serviceName string, backendCount, backendRefCount int) string {
+	if backendCount == 0 && backendRefCount != 0 {
+		return serviceName + invalidBackendRefsServiceHostSuffix
+	}
+	return serviceName
+}
+
 // TranslateHTTPRoutesToKongstateServices translates a set of HTTPRoutes to kongstate services,
 // and collect the translation errors in the process of translating.
 func TranslateHTTPRoutesToKongstateServices(
@@ -232,6 +244,7 @@ func translateHTTPRouteRulesMetaToKongstateService(
 		allowed,
 	)
 	service.Backends = kongstateBackends
+	service.Host = new(HostForKongService(serviceName, len(service.Backends), len(backendRefs)))
 	// set the metadata of the kong state service to point to the first HTTPRoute.
 	service.Namespace = firstHTTPRoute.GetNamespace()
 	service.Parent = firstHTTPRoute

--- a/ingress-controller/internal/dataplane/translator/subtranslator/httproute_test.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/httproute_test.go
@@ -1366,7 +1366,7 @@ func TestTranslateHTTPRoutesToKongstateServices(t *testing.T) {
 				"httproute.another-namespace.svc.default.service-1.80": {
 					Service: kong.Service{
 						Name: new("httproute.another-namespace.svc.default.service-1.80"),
-						Host: new("httproute.another-namespace.svc.default.service-1.80"),
+						Host: new("httproute.another-namespace.svc.default.service-1.80.invalid"),
 					},
 					Backends: []kongstate.ServiceBackend{},
 				},

--- a/ingress-controller/internal/dataplane/translator/translate_utils.go
+++ b/ingress-controller/internal/dataplane/translator/translate_utils.go
@@ -50,7 +50,7 @@ func generateKongServiceFromBackendRefWithName(
 
 	// the service host needs to be a resolvable name due to legacy logic so we'll
 	// use the anchor backendRef as the basis for the name
-	serviceHost := serviceName
+	serviceHost := subtranslator.HostForKongService(serviceName, len(backends), len(backendRefs))
 
 	// check if the service is already known, and if not create it
 	service, ok := rules.ServiceNameToServices[serviceName]
@@ -70,6 +70,7 @@ func generateKongServiceFromBackendRefWithName(
 			Parent:    route,
 		}
 	}
+	service.Host = new(serviceHost)
 
 	// In the context of the gateway API conformance tests, if there is no service for the backend,
 	// the response must have a status code of 500. Since The default behavior of Kong is returning 503

--- a/ingress-controller/internal/dataplane/translator/translate_utils_test.go
+++ b/ingress-controller/internal/dataplane/translator/translate_utils_test.go
@@ -281,7 +281,7 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 			result: kongstate.Service{
 				Service: kong.Service{
 					Name:           new("tcproute.behbudiy.kitab-ul-atfol.999"),
-					Host:           new("tcproute.behbudiy.kitab-ul-atfol.999"),
+					Host:           new("tcproute.behbudiy.kitab-ul-atfol.999.invalid"),
 					Protocol:       new(protocol),
 					ConnectTimeout: new(DefaultServiceTimeout),
 					ReadTimeout:    new(DefaultServiceTimeout),


### PR DESCRIPTION
**What this PR does / why we need it**:

Attempt to fix conformance test failures:

Only one test failed: HTTPRouteReferenceGrant/Simple HTTP request should reach web-backend

The test sends HTTP requests expecting 200, but gets 404 initially, then 503 continuously for 30 seconds until timeout. Notably, Kong is responding (the Server: kong/3.13.0.3-enterprise-edition header is present), so the DataPlane+ControlPlane are fully up and running.

Root Cause: Kong Balancer State Poisoning
The test order matters:

HTTPRouteInvalidReferenceGrant runs first (newly enabled by 3f92a47f3 on main). It creates an HTTPRoute with a backendRef to a cross-namespace service without a valid ReferenceGrant. The translator correctly determines there are no valid backends (`len(backends) == 0`) and injects a request-termination plugin returning 500. But it creates a Kong service with `Host: "servicename"` (the same logical host name).

HTTPRouteReferenceGrant runs afterward. It creates a similar HTTPRoute with a valid ReferenceGrant. The translator should now produce a Kong service with actual backend targets. The Kong service name/host is the same as in step 1.

The problem: Kong internally caches balancer state keyed by the service Host. When the valid service reuses the same host name, Kong's balancer still has the "poisoned" state from the invalid test — no healthy targets. The request-termination plugin is gone, so instead of returning 500, Kong tries to proxy to the upstream, finds no healthy targets in the cached balancer, and returns 503.

How Commit 9dd596cc Fixes It
The fix in translate_utils.go:53 and httproute.go:47-55 introduces `HostForKongService()`:

When backendRefs are invalid (no valid backends), the service host becomes servicename.invalid. When they're valid, it's servicename. Because the hosts differ, Kong uses separate balancer instances — the poisoned balancer from the invalid-ReferenceGrant test doesn't interfere with the valid-ReferenceGrant test.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

Exemplar logs: https://github.com/Kong/kong-operator/actions/runs/24411131683/job/71308056599#step:13:17205

```
=== FAIL: test/conformance TestGatewayConformance/HTTPRouteReferenceGrant/Simple_HTTP_request_should_reach_web-backend (30.00s)
    httproute-reference-grant.go:54: 2026-04-14T16:45:19.400005017Z: Making GET request to host  via http://172.18.128.1/
    http.go:285: 2026-04-14T16:45:19.401636176Z: Response expectation failed for request: {URL: {Scheme:http Opaque: User: Host:172.18.128.1 Path:/ Fragment: RawQuery: RawPath: RawFragment: ForceQuery:false OmitHost:false}, Host: , Protocol: HTTP, Method: GET, Headers: map[X-Echo-Set-Header:[]], UnfollowRedirect: false, ServerName: , ServerCertificate: <truncated>, ClientCertificate: <truncated>, ClientCertificateKey: <truncated>}  not ready yet: expected status code to be one of [200], got 404. CRes: &{404 103 HTTP/1.1 map[Content-Length:[103] Content-Type:[application/json; charset=utf-8] Date:[Tue, 14 Apr 2026 16:45:19 GMT] Server:[kong/3.13.0.3-enterprise-edition] X-Kong-Request-Id:[c4fa8328bca80109c2a1e12f7fd9ee47] X-Kong-Response-Latency:[0]] <nil> []} (after 4.378µs)
    http.go:285: 2026-04-14T16:45:20.403144277Z: Response expectation failed for request: {URL: {Scheme:http Opaque: User: Host:172.18.128.1 Path:/ Fragment: RawQuery: RawPath: RawFragment: ForceQuery:false OmitHost:false}, Host: , Protocol: HTTP, Method: GET, Headers: map[X-Echo-Set-Header:[]], UnfollowRedirect: false, ServerName: , ServerCertificate: <truncated>, ClientCertificate: <truncated>, ClientCertificateKey: <truncated>}  not ready yet: expected status code to be one of [200], got 404. CRes: &{404 103 HTTP/1.1 map[Content-Length:[103] Content-Type:[application/json; charset=utf-8] Date:[Tue, 14 Apr 2026 16:45:20 GMT] Server:[kong/3.13.0.3-enterprise-edition] X-Kong-Request-Id:[5480bb0a70ce9504800b9375759b7025] X-Kong-Response-Latency:[0]] <nil> []} (after 1.001763678s)
    http.go:285: 2026-04-14T16:45:21.405122879Z: Response expectation failed for request: {URL: {Scheme:http Opaque: User: Host:172.18.128.1 Path:/ Fragment: RawQuery: RawPath: RawFragment: ForceQuery:false OmitHost:false}, Host: , Protocol: HTTP, Method: GET, Headers: map[X-Echo-Set-Header:[]], UnfollowRedirect: false, ServerName: , ServerCertificate: <truncated>, ClientCertificate: <truncated>, ClientCertificateKey: <truncated>}  not ready yet: expected status code to be one of [200], got 503. CRes: &{503 113 HTTP/1.1 map[Content-Length:[113] Content-Type:[application/json; charset=utf-8] Date:[Tue, 14 Apr 2026 16:45:21 GMT] Server:[kong/3.13.0.3-enterprise-edition] X-Kong-Request-Id:[c3beb13c377ae850bd282a2a9158e871] X-Kong-Response-Latency:[0]] <nil> []} (after 2.003772215s)
    http.go:285: 2026-04-14T16:45:22.407645526Z: Response expectation failed for request: {URL: {Scheme:http Opaque: User: Host:172.18.128.1 Path:/ Fragment: RawQuery: RawPath: RawFragment: ForceQuery:false OmitHost:false}, Host: , Protocol: HTTP, Method: GET, Headers: map[X-Echo-Set-Header:[]], UnfollowRedirect: false, ServerName: , ServerCertificate: <truncated>, ClientCertificate: <truncated>, ClientCertificateKey: <truncated>}  not ready yet: expected status code to be one of [200], got 503. CRes: &{503 113 HTTP/1.1 map[Content-Length:[113] Content-Type:[application/json; charset=utf-8] Date:[Tue, 14 Apr 2026 16:45:22 GMT] Server:[kong/3.13.0.3-enterprise-edition] X-Kong-Request-Id:[760e1b009561e031383690244de4805e] X-Kong-Response-Latency:[1]] <nil> []} (after 3.006151657s)
    http.go:285: 2026-04-14T16:45:23.409850618Z: Response expectation failed for request: {URL: {Scheme:http Opaque: User: Host:172.18.128.1 Path:/ Fragment: RawQuery: RawPath: RawFragment: ForceQuery:false OmitHost:false}, Host: , Protocol: HTTP, Method: GET, Headers: map[X-Echo-Set-Header:[]], UnfollowRedirect: false, ServerName: , ServerCertificate: <truncated>, ClientCertificate: <truncated>, ClientCertificateKey: <truncated>}  not ready yet: expected status code to be one of [200], got 503. CRes: &{503 113 HTTP/1.1 map[Content-Length:[113] Content-Type:[application/json; charset=utf-8] Date:[Tue, 14 Apr 2026 16:45:23 GMT] Server:[kong/3.13.0.3-enterprise-edition] X-Kong-Request-Id:[4233c73eed9f8d1dbf1ac906dabb6464] X-Kong-Response-Latency:[0]] <nil> []} (after 4.008383218s)
    http.go:285: 2026-04-14T16:45:24.412271596Z: Response expectation failed for request: {URL: {Scheme:http Opaque: User: Host:172.18.128.1 Path:/ Fragment: RawQuery: RawPath: RawFragment: ForceQuery:false OmitHost:false}, Host: , Protocol: HTTP, Method: GET, Headers: map[X-Echo-Set-Header:[]], UnfollowRedirect: false, ServerName: , ServerCertificate: <truncated>, ClientCertificate: <truncated>, ClientCertificateKey: <truncated>}  not ready yet: expected status code to be one of [200], got 503. CRes: &{503 113 HTTP/1.1 map[Content-Length:[113] Content-Type:[application/json; charset=utf-8] Date:[Tue, 14 Apr 2026 16:45:24 GMT] Server:[kong/3.13.0.3-enterprise-edition] X-Kong-Request-Id:[0f8eab52b5f15148f4e39615d3882f7b] X-Kong-Response-Latency:[0]] <nil> []} (after 5.010871248s)
```

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
