### PR TITLE
fix: fix TestGatewayHybridFull and stale Gateway address in status when DataPlane is not ready

### DIFF
--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -517,9 +517,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{}, errors.New("unexpected error, controlplane is nil. Returning to avoid panic")
 		}
 	}
-	// If the dataplane has not been marked as ready yet, return and wait for the next reconciliation loop.
+	// If the dataplane has not been marked as ready yet, clear any stale addresses
+	// and return to wait for the next reconciliation loop.
+	// Clearing addresses prevents the Gateway from advertising an IP for a service
+	// that may no longer exist (e.g. after DataPlane deletion and recreation).
 	if !k8sutils.HasConditionTrue(kcfggateway.DataPlaneReadyType, gwConditionAware) {
 		log.Debug(logger, "dataplane is not ready yet")
+		gateway.Status.Addresses = nil
+		if _, patchErr := patch.ApplyStatusPatchIfNotEmpty(ctx, r.Client, logger, &gateway, oldGateway); patchErr != nil {
+			return ctrl.Result{}, patchErr
+		}
 		return ctrl.Result{}, nil
 	}
 

--- a/test/integration/konnect/gateway_hybrid_test.go
+++ b/test/integration/konnect/gateway_hybrid_test.go
@@ -225,13 +225,20 @@ func TestGatewayHybridFull(t *testing.T) {
 	require.Eventually(t, testutils.GatewayIsProgrammed(t, ctx, gatewayNN, cl), testutils.GatewayReadyTimeLimit, time.Second)
 	require.Eventually(t, testutils.GatewayListenersAreProgrammed(t, ctx, gatewayNN, integration.GetClients()), testutils.GatewayReadyTimeLimit, time.Second)
 
-	t.Log("verifying Gateway gets an IP address again")
-	require.Eventually(t, testutils.GatewayIPAddressExist(t, ctx, gatewayNN, integration.GetClients()), testutils.SubresourceReadinessWait, time.Second)
-	gateway = testutils.MustGetGateway(t, ctx, gatewayNN, cl)
-	gatewayIPAddress = gateway.Status.Addresses[0].Value
-
 	t.Log("verifying connectivity to the Gateway")
-	require.Eventually(t, asserts.Expect404WithNoRouteFunc(t, ctx, "http://"+gatewayIPAddress), testutils.SubresourceReadinessWait, time.Second)
+	// We're using eventually because Gateway can still have the stale IP address
+	// from old DataPlane.
+	require.Eventually(t, func() bool {
+		gw := testutils.MustGetGateway(t, ctx, gatewayNN, cl)
+		addresses := gw.Status.Addresses
+		if len(addresses) == 0 ||
+			addresses[0].Type == nil ||
+			*addresses[0].Type != gatewayv1.IPAddressType {
+			return false
+		}
+		gatewayIPAddress = addresses[0].Value
+		return asserts.Expect404WithNoRouteFunc(t, ctx, "http://"+gatewayIPAddress)()
+	}, testutils.SubresourceReadinessWait, time.Second)
 
 	t.Log("verifying services managed by the dataplane")
 	var dataplaneService corev1.Service


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
