### PR TITLE
feat(eventgateway): add KegDataPlane controller implementation

### DIFF
--- a/controller/eventgateway/dataplane/consts.go
+++ b/controller/eventgateway/dataplane/consts.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2025 Kong, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+const (
+	// FieldManager is the field manager name used for Server-Side Apply operations.
+	FieldManager = "gateway-operator"
+
+	// ControllerName is the name used for logging and event recording.
+	ControllerName = "keg-dataplane"
+
+	// DefaultKafkaPort is the default port exposed by the Kafka listener.
+	DefaultKafkaPort int32 = 9092
+
+	// DefaultHealthPort is the default port used for the keg health endpoint.
+	DefaultHealthPort int32 = 8080
+
+	// KonnectCertVolumeName is the name of the volume that holds the Konnect mTLS certificate.
+	KonnectCertVolumeName = "konnect-cert"
+
+	// KonnectCertMountPath is the path where the Konnect certificate Secret is mounted in the keg container.
+	KonnectCertMountPath = "/var/konnect-client-certificate/"
+)
+
+// -----------------------------------------------------------------------------
+// Consts - KEG environment variable names
+// Konnect settings use the KONG_KONNECT_ prefix; all other keg settings use
+// the KEG__ prefix with double underscores for nesting.
+// -----------------------------------------------------------------------------
+
+const (
+	// EnvKonnectRegion is the keg environment variable for the Konnect region.
+	EnvKonnectRegion = "KONG_KONNECT_REGION"
+	// EnvKonnectGatewayClusterID is the keg environment variable for the Konnect gateway cluster ID.
+	EnvKonnectGatewayClusterID = "KONG_KONNECT_GATEWAY_CLUSTER_ID"
+	// EnvKonnectClientCertPath is the keg environment variable for the Konnect mTLS client certificate path.
+	EnvKonnectClientCertPath = "KONG_KONNECT_CLIENT_CERT_PATH"
+	// EnvKonnectClientKeyPath is the keg environment variable for the Konnect mTLS client key path.
+	EnvKonnectClientKeyPath = "KONG_KONNECT_CLIENT_KEY_PATH"
+	// EnvKonnectDomain is the keg environment variable for the Konnect domain override.
+	EnvKonnectDomain = "KONG_KONNECT_DOMAIN"
+	// EnvKonnectAPIRequestTimeout is the keg environment variable for the Konnect API request timeout.
+	EnvKonnectAPIRequestTimeout = "KONG_KONNECT_API_REQUEST_TIMEOUT"
+	// EnvKonnectInsecureSkipVerify is the keg environment variable to skip TLS verification.
+	// For testing only.
+	EnvKonnectInsecureSkipVerify = "KONG_KONNECT_INSECURE_SKIP_VERIFY"
+
+	// EnvConfigPollInterval is the keg environment variable for the config poll interval.
+	EnvConfigPollInterval = "KEG__CONFIG_POLL_INTERVAL"
+	// EnvEnableDebugEndpoints is the keg environment variable to enable debug endpoints.
+	EnvEnableDebugEndpoints = "KEG__ENABLE_DEBUG_ENDPOINTS"
+
+	// EnvObsLogFlags is the keg environment variable for log level flags.
+	EnvObsLogFlags = "KEG__OBSERVABILITY__LOG_FLAGS"
+	// EnvObsLogFormat is the keg environment variable for the log output format.
+	EnvObsLogFormat = "KEG__OBSERVABILITY__LOG_FORMAT"
+	// EnvObsMetricsRollupAllowMap is the keg environment variable for the metrics rollup allow map.
+	EnvObsMetricsRollupAllowMap = "KEG__OBSERVABILITY__METRICS_ROLLUP_ALLOW_MAP"
+	// EnvObsPolicyErrorsInfoLogInterval is the keg environment variable for the policy errors info log interval.
+	EnvObsPolicyErrorsInfoLogInterval = "KEG__OBSERVABILITY__POLICY_ERRORS_INFO_LOG_INTERVAL"
+
+	// EnvRuntimeHealthAddr is the keg environment variable for the health listener address and port.
+	EnvRuntimeHealthAddr = "KEG__RUNTIME__HEALTH_LISTENER_ADDRESS_PORT"
+	// EnvRuntimeDrainDuration is the keg environment variable for the drain duration.
+	EnvRuntimeDrainDuration = "KEG__RUNTIME__DRAIN_DURATION"
+	// EnvRuntimeShutdownTimeout is the keg environment variable for the graceful shutdown timeout.
+	EnvRuntimeShutdownTimeout = "KEG__RUNTIME__SHUTDOWN_TIMEOUT"
+)

--- a/controller/eventgateway/dataplane/consts.go
+++ b/controller/eventgateway/dataplane/consts.go
@@ -40,6 +40,7 @@ const (
 // Consts - KEG environment variable names
 // Konnect settings use the KONG_KONNECT_ prefix; all other keg settings use
 // the KEG__ prefix with double underscores for nesting.
+// For more info see https://developer.konghq.com/event-gateway/configuration/.
 // -----------------------------------------------------------------------------
 
 const (

--- a/controller/eventgateway/dataplane/controller.go
+++ b/controller/eventgateway/dataplane/controller.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2025 Kong, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+
+	eventgatewayv1alpha1 "github.com/kong/kong-operator/v2/api/eventgateway/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	log "github.com/kong/kong-operator/v2/controller/pkg/log"
+	"github.com/kong/kong-operator/v2/controller/pkg/op"
+	"github.com/kong/kong-operator/v2/modules/manager/logging"
+)
+
+// Reconciler reconciles a KegDataPlane object.
+type Reconciler struct {
+	client.Client
+
+	// LoggingMode controls the format of log output.
+	LoggingMode logging.Mode
+
+	ClusterCASecretName      string
+	ClusterCASecretNamespace string
+	SecretLabelSelector      string
+	CertTTL                  time.Duration
+
+	// typeConverter is initialised once during SetupWithManager from the API
+	// server's OpenAPI v3 schemas. It supports all types (core K8s + CRDs) and
+	// is used for both diff-before-apply and SMD-based
+	// PodTemplateSpec merging.
+	typeConverter managedfields.TypeConverter
+
+	// eventRecorder records Kubernetes events on KegDataPlane objects.
+	eventRecorder events.EventRecorder
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	// Initialise the TypeConverter from API server OpenAPI v3 schemas.
+	// This is done once at startup.
+	tc, err := initTypeConverter(mgr)
+	if err != nil {
+		return fmt.Errorf("DataPlane controller: failed to initialize TypeConverter: %w", err)
+	}
+	r.typeConverter = tc
+	r.eventRecorder = mgr.GetEventRecorder(ControllerName)
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&eventgatewayv1alpha1.KegDataPlane{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
+		Owns(&corev1.Secret{}).
+		Watches(
+			&konnectv1alpha1.KonnectEventControlPlane{},
+			handler.EnqueueRequestsFromMapFunc(enqueueForKonnectEventGatewayRef(mgr.GetClient())),
+		).
+		Complete(r)
+}
+
+// Reconcile moves the current state of a KegDataPlane toward the desired state.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
+	logger := log.GetLogger(ctx, "keg-dataplane", r.LoggingMode)
+
+	log.Trace(logger, "reconciling KegDataPlane resource")
+
+	egdp := new(eventgatewayv1alpha1.KegDataPlane)
+	if err := r.Get(ctx, req.NamespacedName, egdp); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	defer r.applyStatus(ctx, logger, egdp, &err)
+
+	// Resolve referenced KonnectEventControlPlane and set resolution condition.
+	keg, err := r.resolveKonnectEventGateway(ctx, logger, egdp)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Ensure mTLS client certificate secret and set certificate condition.
+	certResult, certSecret, err := r.ensureCertificateSecret(ctx, egdp)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Requeue if the Secret was just created/updated so the Deployment
+	// picks up the correct Secret name on the next reconcile.
+	if certResult != op.Noop {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Reconcile the full Keg Deployment spec.
+	if err := r.ensureDeployment(ctx, logger, egdp, keg, certSecret.Name); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Ensure the Kafka Service.
+	if err := r.ensureKafkaService(ctx, logger, egdp); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Compute Ready condition; deferred applyStatus flushes status.
+	if err := ensureReadyStatus(ctx, r.Client, egdp); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	log.Debug(logger, "reconciliation complete for DataPlane resource")
+	return ctrl.Result{}, nil
+}

--- a/controller/eventgateway/dataplane/controller.go
+++ b/controller/eventgateway/dataplane/controller.go
@@ -106,10 +106,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 		return ctrl.Result{}, err
 	}
 
-	// Requeue if the Secret was just created/updated so the Deployment
-	// picks up the correct Secret name on the next reconcile.
+	// Return early if the Secret was just created/updated so the Deployment
+	// picks up the correct Secret name on the next reconcile. No explicit
+	// requeue is needed, the watch on the owned Secret triggers it.
 	if certResult != op.Noop {
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, nil
 	}
 
 	// Reconcile the full Keg Deployment spec.

--- a/controller/eventgateway/dataplane/controller.go
+++ b/controller/eventgateway/dataplane/controller.go
@@ -18,6 +18,7 @@ package dataplane
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -50,7 +51,7 @@ type Reconciler struct {
 
 	// typeConverter is initialised once during SetupWithManager from the API
 	// server's OpenAPI v3 schemas. It supports all types (core K8s + CRDs) and
-	// is used for both diff-before-apply and SMD-based
+	// is used for both diff-before-apply and structured-merge-diff based
 	// PodTemplateSpec merging.
 	typeConverter managedfields.TypeConverter
 
@@ -91,7 +92,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	defer r.applyStatus(ctx, logger, egdp, &err)
+	defer func() { err = errors.Join(err, r.applyStatus(ctx, logger, egdp)) }()
 
 	// Resolve referenced KonnectEventControlPlane and set resolution condition.
 	keg, err := r.resolveKonnectEventGateway(ctx, logger, egdp)

--- a/controller/eventgateway/dataplane/owned_deployment.go
+++ b/controller/eventgateway/dataplane/owned_deployment.go
@@ -1,0 +1,367 @@
+/*
+Copyright 2025 Kong, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+
+	eventgatewayv1alpha1 "github.com/kong/kong-operator/v2/api/eventgateway/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	"github.com/kong/kong-operator/v2/controller/konnect/server"
+	log "github.com/kong/kong-operator/v2/controller/pkg/log"
+	"github.com/kong/kong-operator/v2/controller/pkg/op"
+	controllerpkgssa "github.com/kong/kong-operator/v2/controller/pkg/ssa"
+	"github.com/kong/kong-operator/v2/pkg/consts"
+	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+)
+
+// ensureDeployment reconciles the keg Deployment for the given DataPlane.
+func (r *Reconciler) ensureDeployment(
+	ctx context.Context,
+	logger logr.Logger,
+	egdp *eventgatewayv1alpha1.KegDataPlane,
+	keg *konnectv1alpha1.KonnectEventControlPlane,
+	certSecretName string,
+) error {
+	image := resolveImage(egdp, consts.DefaultKEGImage)
+	desired, err := buildDeployment(r.typeConverter, egdp, keg, image, certSecretName)
+	if err != nil {
+		return fmt.Errorf("failed to build Deployment for DataPlane %s/%s: %w",
+			egdp.Namespace, egdp.Name, err)
+	}
+
+	result, err := controllerpkgssa.ApplyIfChanged(ctx, logger, r.Client, r.typeConverter, desired, FieldManager)
+	if err != nil {
+		r.eventRecorder.Eventf(egdp, nil, corev1.EventTypeWarning, "DeploymentFailed", "ApplyDeployment",
+			"Failed to apply Deployment: %v", err)
+		return fmt.Errorf("failed to apply Deployment for DataPlane %s/%s: %w",
+			egdp.Namespace, egdp.Name, err)
+	}
+	switch result {
+	case op.Created:
+		log.Debug(logger, "Deployment created", "name", desired.GetName())
+		r.eventRecorder.Eventf(egdp, nil, corev1.EventTypeNormal, "DeploymentCreated", "CreateDeployment",
+			"Deployment %s created", desired.GetName())
+	case op.Updated:
+		log.Debug(logger, "Deployment updated", "name", desired.GetName())
+		r.eventRecorder.Eventf(egdp, nil, corev1.EventTypeNormal, "DeploymentUpdated", "UpdateDeployment",
+			"Deployment %s updated", desired.GetName())
+	case op.Noop, op.Deleted:
+	}
+	return nil
+}
+
+// resolveImage determines the keg container image using the following priority:
+//  1. User-specified image in spec.deployment.podTemplateSpec (container named "keg")
+//  2. RELATED_IMAGE_KEG environment variable
+//  3. defaultImage
+func resolveImage(egdp *eventgatewayv1alpha1.KegDataPlane, defaultImage string) string {
+	if egdp.Spec.Deployment != nil && egdp.Spec.Deployment.PodTemplateSpec != nil {
+		if c := k8sutils.GetPodContainerByName(&egdp.Spec.Deployment.PodTemplateSpec.Spec, consts.KEGContainerName); c != nil && c.Image != "" {
+			return c.Image
+		}
+	}
+	if relatedImage := os.Getenv(consts.RelatedImageKEGEnvVar); relatedImage != "" {
+		return relatedImage
+	}
+	return defaultImage
+}
+
+// buildDeployment constructs the desired keg Deployment as *unstructured.Unstructured.
+// If the user has provided a PodTemplateSpec overlay in spec.deployment, it is
+// merged with the operator base via SMD. The result always has spec.strategy
+// removed so that SSA does not claim ownership of it, leaving the API server
+// (or admission webhooks) free to apply their own default.
+func buildDeployment(
+	tc managedfields.TypeConverter,
+	egdp *eventgatewayv1alpha1.KegDataPlane,
+	keg *konnectv1alpha1.KonnectEventControlPlane,
+	image string,
+	certSecretName string,
+) (*unstructured.Unstructured, error) {
+	base, err := generateBaseDeployment(egdp, keg, image, certSecretName)
+	if err != nil {
+		return nil, err
+	}
+
+	var u *unstructured.Unstructured
+	if egdp.Spec.Deployment == nil || egdp.Spec.Deployment.PodTemplateSpec == nil {
+		raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(base)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert Deployment to unstructured: %w", err)
+		}
+		u = &unstructured.Unstructured{Object: raw}
+	} else {
+		// Wrap the user PodTemplateSpec overlay into a Deployment skeleton.
+		userDeployment := &appsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      egdp.Name,
+				Namespace: egdp.Namespace,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						consts.GatewayOperatorManagedByLabel:     consts.DataPlaneManagedByLabelValue,
+						consts.GatewayOperatorManagedByNameLabel: egdp.Name,
+					},
+				},
+				Template: *egdp.Spec.Deployment.PodTemplateSpec,
+			},
+		}
+		var mergeErr error
+		u, mergeErr = controllerpkgssa.MergeObjects(tc, base, userDeployment)
+		if mergeErr != nil {
+			return nil, mergeErr
+		}
+	}
+
+	// Remove spec.strategy so we don't claim SSA ownership of it.
+	// The zero-value DeploymentStrategy{} serializes to "strategy: {}" which
+	// diverges from the server-defaulted rolling-update value every reconcile.
+	unstructured.RemoveNestedField(u.Object, "spec", "strategy")
+	return u, nil
+}
+
+// generateBaseDeployment creates the operator-managed keg Deployment without user overlays.
+func generateBaseDeployment(
+	egdp *eventgatewayv1alpha1.KegDataPlane,
+	keg *konnectv1alpha1.KonnectEventControlPlane,
+	image string,
+	certSecretName string,
+) (*appsv1.Deployment, error) {
+	labels := map[string]string{
+		"app.kubernetes.io/name":                      consts.KEGContainerName,
+		consts.GatewayOperatorManagedByLabel:          consts.DataPlaneManagedByLabelValue,
+		consts.GatewayOperatorManagedByNameLabel:      egdp.Name,
+		consts.GatewayOperatorManagedByNamespaceLabel: egdp.Namespace,
+	}
+	selector := map[string]string{
+		consts.GatewayOperatorManagedByLabel:          consts.DataPlaneManagedByLabelValue,
+		consts.GatewayOperatorManagedByNameLabel:      egdp.Name,
+		consts.GatewayOperatorManagedByNamespaceLabel: egdp.Namespace,
+	}
+
+	envVars, err := buildKEGEnvVars(egdp, keg)
+	if err != nil {
+		return nil, err
+	}
+
+	healthPort := intstr.FromInt32(DefaultHealthPort)
+
+	allowPrivilegeEscalation := false
+	readOnlyRootFilesystem := true
+	runAsUser := int64(65532)
+	runAsGroup := int64(65532)
+
+	container := corev1.Container{
+		Name:  consts.KEGContainerName,
+		Image: image,
+		Env:   envVars,
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+			ReadOnlyRootFilesystem:   &readOnlyRootFilesystem,
+			RunAsUser:                &runAsUser,
+			RunAsGroup:               &runAsGroup,
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"NET_RAW"},
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      KonnectCertVolumeName,
+				MountPath: KonnectCertMountPath,
+				ReadOnly:  true,
+			},
+			{
+				Name:      "tmp",
+				MountPath: "/tmp",
+			},
+		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/health/probes/readiness",
+					Port: healthPort,
+				},
+			},
+		},
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/health/probes/liveness",
+					Port: healthPort,
+				},
+			},
+		},
+	}
+
+	tmpSizeLimit := resource.MustParse("1Gi")
+	volumes := []corev1.Volume{
+		{
+			Name: KonnectCertVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: certSecretName,
+				},
+			},
+		},
+		{
+			Name: "tmp",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					SizeLimit: &tmpSizeLimit,
+				},
+			},
+		},
+	}
+
+	var replicas *int32
+	if egdp.Spec.Deployment != nil {
+		replicas = egdp.Spec.Deployment.Replicas
+	}
+
+	d := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      egdp.Name,
+			Namespace: egdp.Namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{Replicas: replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: selector,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: new(true),
+					},
+					Containers: []corev1.Container{container},
+					Volumes:    volumes,
+				},
+			},
+		},
+	}
+
+	k8sutils.SetOwnerForObject(d, egdp)
+	return d, nil
+}
+
+// buildKEGEnvVars builds the full list of keg environment variables from
+// KonnectEventGateway status and DataPlane spec.config.
+func buildKEGEnvVars(
+	egdp *eventgatewayv1alpha1.KegDataPlane,
+	keg *konnectv1alpha1.KonnectEventControlPlane,
+) ([]corev1.EnvVar, error) {
+	srv, err := server.NewServer[konnectv1alpha1.KonnectEventControlPlane](keg.Status.ServerURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse Konnect server URL %q: %w", keg.Status.ServerURL, err)
+	}
+	region := srv.Region().String()
+	domain := srv.Domain()
+	healthAddr := fmt.Sprintf("0.0.0.0:%d", DefaultHealthPort)
+
+	cfg := egdp.Spec.Config
+	if cfg != nil {
+		if cfg.Konnect != nil && cfg.Konnect.Domain != nil {
+			domain = *cfg.Konnect.Domain
+		}
+		if cfg.Runtime != nil && cfg.Runtime.HealthListenerAddressPort != nil {
+			healthAddr = *cfg.Runtime.HealthListenerAddressPort
+		}
+	}
+
+	envVars := []corev1.EnvVar{
+		{Name: EnvKonnectRegion, Value: region},
+		{Name: EnvKonnectGatewayClusterID, Value: keg.Status.ID},
+		{Name: EnvKonnectClientCertPath, Value: KonnectCertMountPath + "tls.crt"},
+		{Name: EnvKonnectClientKeyPath, Value: KonnectCertMountPath + "tls.key"},
+		{Name: EnvKonnectDomain, Value: domain},
+		// Bind the health endpoint to all interfaces so Kubernetes probes can reach it.
+		{Name: EnvRuntimeHealthAddr, Value: healthAddr},
+	}
+
+	if cfg == nil {
+		return envVars, nil
+	}
+
+	if cfg.Konnect != nil {
+		if cfg.Konnect.APIRequestTimeoutSeconds != nil {
+			envVars = append(envVars, corev1.EnvVar{Name: EnvKonnectAPIRequestTimeout, Value: fmt.Sprintf("%ds", *cfg.Konnect.APIRequestTimeoutSeconds)})
+		}
+		if cfg.Konnect.InsecureSkipVerify != nil {
+			envVars = append(envVars, corev1.EnvVar{Name: EnvKonnectInsecureSkipVerify, Value: strconv.FormatBool(*cfg.Konnect.InsecureSkipVerify == eventgatewayv1alpha1.TLSVerificationStateEnabled)})
+		}
+	}
+
+	if cfg.ConfigPollIntervalSeconds != nil {
+		envVars = append(envVars, corev1.EnvVar{Name: EnvConfigPollInterval, Value: fmt.Sprintf("%ds", *cfg.ConfigPollIntervalSeconds)})
+	}
+
+	if cfg.EnableDebugEndpoints != nil {
+		envVars = append(envVars, corev1.EnvVar{Name: EnvEnableDebugEndpoints, Value: strconv.FormatBool(*cfg.EnableDebugEndpoints == eventgatewayv1alpha1.DebugEndpointsStateEnabled)})
+	}
+
+	if obs := cfg.Observability; obs != nil { //nolint:gocritic
+		if obs.LogFlags != nil {
+			envVars = append(envVars, corev1.EnvVar{Name: EnvObsLogFlags, Value: *obs.LogFlags})
+		}
+		if obs.LogFormat != nil {
+			envVars = append(envVars, corev1.EnvVar{Name: EnvObsLogFormat, Value: *obs.LogFormat})
+		}
+		if obs.MetricsRollupAllowMap != nil {
+			envVars = append(envVars, corev1.EnvVar{Name: EnvObsMetricsRollupAllowMap, Value: *obs.MetricsRollupAllowMap})
+		}
+		if obs.PolicyErrorsInfoLogIntervalSeconds != nil {
+			envVars = append(envVars, corev1.EnvVar{Name: EnvObsPolicyErrorsInfoLogInterval, Value: fmt.Sprintf("%ds", *obs.PolicyErrorsInfoLogIntervalSeconds)})
+		}
+	}
+
+	if rt := cfg.Runtime; rt != nil {
+		if rt.DrainDurationSeconds != nil {
+			envVars = append(envVars, corev1.EnvVar{Name: EnvRuntimeDrainDuration, Value: fmt.Sprintf("%ds", *rt.DrainDurationSeconds)})
+		}
+		if rt.ShutdownTimeoutSeconds != nil {
+			envVars = append(envVars, corev1.EnvVar{Name: EnvRuntimeShutdownTimeout, Value: fmt.Sprintf("%ds", *rt.ShutdownTimeoutSeconds)})
+		}
+	}
+
+	return envVars, nil
+}

--- a/controller/eventgateway/dataplane/owned_deployment.go
+++ b/controller/eventgateway/dataplane/owned_deployment.go
@@ -139,10 +139,10 @@ func buildDeployment(
 				Template: *egdp.Spec.Deployment.PodTemplateSpec,
 			},
 		}
-		var mergeErr error
-		u, mergeErr = controllerpkgssa.MergeObjects(tc, base, userDeployment)
-		if mergeErr != nil {
-			return nil, mergeErr
+
+		u, err = controllerpkgssa.MergeObjects(tc, base, userDeployment)
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/controller/eventgateway/dataplane/owned_deployment.go
+++ b/controller/eventgateway/dataplane/owned_deployment.go
@@ -179,20 +179,15 @@ func generateBaseDeployment(
 
 	healthPort := intstr.FromInt32(DefaultHealthPort)
 
-	allowPrivilegeEscalation := false
-	readOnlyRootFilesystem := true
-	runAsUser := int64(65532)
-	runAsGroup := int64(65532)
-
 	container := corev1.Container{
 		Name:  consts.KEGContainerName,
 		Image: image,
 		Env:   envVars,
 		SecurityContext: &corev1.SecurityContext{
-			AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-			ReadOnlyRootFilesystem:   &readOnlyRootFilesystem,
-			RunAsUser:                &runAsUser,
-			RunAsGroup:               &runAsGroup,
+			AllowPrivilegeEscalation: new(false),
+			ReadOnlyRootFilesystem:   new(true),
+			RunAsUser:                new(int64(65532)),
+			RunAsGroup:               new(int64(65532)),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"NET_RAW"},
 			},

--- a/controller/eventgateway/dataplane/owned_secret.go
+++ b/controller/eventgateway/dataplane/owned_secret.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2025 Kong, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"context"
+	"fmt"
+
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	eventgatewayv1alpha1 "github.com/kong/kong-operator/v2/api/eventgateway/v1alpha1"
+	"github.com/kong/kong-operator/v2/controller/pkg/op"
+	"github.com/kong/kong-operator/v2/controller/pkg/secrets"
+	"github.com/kong/kong-operator/v2/pkg/consts"
+)
+
+// ensureCertificateSecret provisions (or finds) the mTLS client certificate Secret
+// for the given DataPlane, signed by the cluster CA.
+func (r *Reconciler) ensureCertificateSecret(
+	ctx context.Context,
+	egdp *eventgatewayv1alpha1.KegDataPlane,
+) (op.Result, *corev1.Secret, error) {
+	matchingLabels := client.MatchingLabels{
+		consts.SecretProvisioningLabelKey:         consts.SecretProvisioningAutomaticLabelValue,
+		consts.SecretKEGDataPlaneCertificateLabel: "true",
+	}
+	if r.SecretLabelSelector != "" {
+		matchingLabels[r.SecretLabelSelector] = "true"
+	}
+	res, secret, err := secrets.EnsureCertificate(
+		ctx,
+		egdp,
+		fmt.Sprintf("%s.%s", egdp.Name, egdp.Namespace),
+		types.NamespacedName{
+			Namespace: r.ClusterCASecretNamespace,
+			Name:      r.ClusterCASecretName,
+		},
+		[]certificatesv1.KeyUsage{
+			certificatesv1.UsageKeyEncipherment,
+			certificatesv1.UsageDigitalSignature,
+			certificatesv1.UsageClientAuth,
+		},
+		r.Client,
+		matchingLabels,
+		r.CertTTL,
+	)
+	if err != nil {
+		apimeta.SetStatusCondition(&egdp.Status.Conditions, metav1.Condition{
+			Type:               string(eventgatewayv1alpha1.CertificateProvisionedType),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(eventgatewayv1alpha1.UnableToProvisionReason),
+			Message:            fmt.Sprintf("failed to provision mTLS certificate Secret: %v", err),
+			ObservedGeneration: egdp.Generation,
+		})
+		return op.Noop, nil, err
+	}
+	apimeta.SetStatusCondition(&egdp.Status.Conditions, metav1.Condition{
+		Type:               string(eventgatewayv1alpha1.CertificateProvisionedType),
+		Status:             metav1.ConditionTrue,
+		Reason:             string(eventgatewayv1alpha1.CertificateProvisionedReason),
+		Message:            "mTLS certificate Secret provisioned",
+		ObservedGeneration: egdp.Generation,
+	})
+	return res, secret, nil
+}

--- a/controller/eventgateway/dataplane/owned_service.go
+++ b/controller/eventgateway/dataplane/owned_service.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2025 Kong, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	eventgatewayv1alpha1 "github.com/kong/kong-operator/v2/api/eventgateway/v1alpha1"
+	log "github.com/kong/kong-operator/v2/controller/pkg/log"
+	"github.com/kong/kong-operator/v2/controller/pkg/op"
+	controllerpkgssa "github.com/kong/kong-operator/v2/controller/pkg/ssa"
+	"github.com/kong/kong-operator/v2/pkg/consts"
+	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+)
+
+// ensureKafkaService reconciles the Kafka Service for the given DataPlane.
+func (r *Reconciler) ensureKafkaService(
+	ctx context.Context,
+	logger logr.Logger,
+	egdp *eventgatewayv1alpha1.KegDataPlane,
+) error {
+	desired, err := buildKafkaService(r.typeConverter, egdp)
+	if err != nil {
+		return fmt.Errorf("failed to build Kafka Service for DataPlane %s/%s: %w",
+			egdp.Namespace, egdp.Name, err)
+	}
+
+	result, err := controllerpkgssa.ApplyIfChanged(ctx, logger, r.Client, r.typeConverter, desired, FieldManager)
+	if err != nil {
+		r.eventRecorder.Eventf(egdp, nil, corev1.EventTypeWarning, "ServiceFailed", "ApplyService",
+			"Failed to apply Kafka Service: %v", err)
+		return fmt.Errorf("failed to apply Kafka Service for DataPlane %s/%s: %w",
+			egdp.Namespace, egdp.Name, err)
+	}
+	switch result {
+	case op.Created:
+		log.Debug(logger, "Kafka Service created", "name", desired.GetName())
+		r.eventRecorder.Eventf(egdp, nil, corev1.EventTypeNormal, "ServiceCreated", "CreateService",
+			"Kafka Service %s created", desired.GetName())
+	case op.Updated:
+		log.Debug(logger, "Kafka Service updated", "name", desired.GetName())
+		r.eventRecorder.Eventf(egdp, nil, corev1.EventTypeNormal, "ServiceUpdated", "UpdateService",
+			"Kafka Service %s updated", desired.GetName())
+	case op.Noop, op.Deleted:
+	}
+	return nil
+}
+
+// buildKafkaService constructs the desired Kafka Service. If the user has
+// provided ServiceOptions, they are merged with the operator base via SMD:
+// user-provided fields win on conflicts; the base supplies defaults (selector,
+// default port) only when the user has not specified them.
+func buildKafkaService(
+	tc managedfields.TypeConverter,
+	egdp *eventgatewayv1alpha1.KegDataPlane,
+) (client.Object, error) {
+	base := generateBaseKafkaService(egdp)
+
+	if egdp.Spec.Network == nil || egdp.Spec.Network.Services == nil || egdp.Spec.Network.Services.Kafka == nil {
+		return base, nil
+	}
+
+	userOverlay := generateKafkaServiceOverlay(egdp)
+	return controllerpkgssa.MergeObjects(tc, base, userOverlay)
+}
+
+// generateBaseKafkaService returns the operator defaults for the Kafka Service:
+// the pod selector and a default Kafka port. These are used only when the user
+// has not provided conflicting values in ServiceOptions.
+func generateBaseKafkaService(egdp *eventgatewayv1alpha1.KegDataPlane) *corev1.Service {
+	svc := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      egdp.Name + "-kafka",
+			Namespace: egdp.Namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				consts.GatewayOperatorManagedByLabel:     consts.DataPlaneManagedByLabelValue,
+				consts.GatewayOperatorManagedByNameLabel: egdp.Name,
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "kafka",
+					Port:       DefaultKafkaPort,
+					TargetPort: intstr.FromInt32(DefaultKafkaPort),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+	k8sutils.SetOwnerForObject(svc, egdp)
+	return svc
+}
+
+// generateKafkaServiceOverlay builds a Service skeleton from the user-provided
+// ServiceOptions. This is merged on top of the base by MergeObjects; base wins
+// on conflicts (e.g. selector, default port).
+func generateKafkaServiceOverlay(egdp *eventgatewayv1alpha1.KegDataPlane) *corev1.Service {
+	kafka := egdp.Spec.Network.Services.Kafka
+
+	var ports []corev1.ServicePort
+	for _, p := range kafka.Ports {
+		sp := corev1.ServicePort{
+			Port:     p.Port,
+			Protocol: corev1.ProtocolTCP,
+		}
+		if p.Name != nil {
+			sp.Name = *p.Name
+		}
+		if p.TargetPort != nil {
+			sp.TargetPort = *p.TargetPort
+		}
+		if p.NodePort != nil {
+			sp.NodePort = *p.NodePort
+		}
+		ports = append(ports, sp)
+	}
+
+	var extraLabels map[string]string
+	for k, v := range kafka.Labels {
+		if extraLabels == nil {
+			extraLabels = make(map[string]string)
+		}
+		extraLabels[string(k)] = string(v)
+	}
+
+	svc := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        egdp.Name + "-kafka",
+			Namespace:   egdp.Namespace,
+			Labels:      extraLabels,
+			Annotations: kafka.Annotations,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  kafka.Type,
+			Ports: ports,
+		},
+	}
+
+	if kafka.ExternalTrafficPolicy != "" {
+		svc.Spec.ExternalTrafficPolicy = kafka.ExternalTrafficPolicy
+	}
+
+	return svc
+}

--- a/controller/eventgateway/dataplane/owned_service.go
+++ b/controller/eventgateway/dataplane/owned_service.go
@@ -142,11 +142,8 @@ func generateKafkaServiceOverlay(egdp *eventgatewayv1alpha1.KegDataPlane) *corev
 		ports = append(ports, sp)
 	}
 
-	var extraLabels map[string]string
+	extraLabels := make(map[string]string)
 	for k, v := range kafka.Labels {
-		if extraLabels == nil {
-			extraLabels = make(map[string]string)
-		}
 		extraLabels[string(k)] = string(v)
 	}
 

--- a/controller/eventgateway/dataplane/resolve_konnect.go
+++ b/controller/eventgateway/dataplane/resolve_konnect.go
@@ -29,7 +29,6 @@ import (
 	eventgatewayv1alpha1 "github.com/kong/kong-operator/v2/api/eventgateway/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
 	log "github.com/kong/kong-operator/v2/controller/pkg/log"
-	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
 )
 
 // resolveKonnectEventGateway resolves the KonnectEventGateway referenced by the
@@ -50,14 +49,13 @@ func (r *Reconciler) resolveKonnectEventGateway(
 		log.Debug(logger, "referenced KonnectEventGateway not found",
 			"ref", egdp.Spec.ControlPlaneRef.KonnectNamespacedRef.Name)
 
-		k8sutils.SetCondition(metav1.Condition{
+		apimeta.SetStatusCondition(&egdp.Status.Conditions, metav1.Condition{
 			Type:               string(eventgatewayv1alpha1.KonnectEventGatewayResolvedType),
 			Status:             metav1.ConditionFalse,
 			Reason:             string(eventgatewayv1alpha1.KonnectEventGatewayNotFoundReason),
 			Message:            eventgatewayv1alpha1.KonnectEventGatewayNotFoundMessage,
 			ObservedGeneration: egdp.Generation,
-			LastTransitionTime: metav1.Now(),
-		}, egdp)
+		})
 
 		return nil, err
 	}
@@ -70,27 +68,25 @@ func (r *Reconciler) resolveKonnectEventGateway(
 		log.Debug(logger, "referenced KonnectEventGateway is not yet Programmed",
 			"ref", egdp.Spec.ControlPlaneRef.KonnectNamespacedRef.Name)
 
-		k8sutils.SetCondition(metav1.Condition{
+		apimeta.SetStatusCondition(&egdp.Status.Conditions, metav1.Condition{
 			Type:               string(eventgatewayv1alpha1.KonnectEventGatewayResolvedType),
 			Status:             metav1.ConditionFalse,
 			Reason:             string(eventgatewayv1alpha1.KonnectEventGatewayNotProgrammedReason),
 			Message:            eventgatewayv1alpha1.KonnectEventGatewayNotProgrammedMessage,
 			ObservedGeneration: egdp.Generation,
-			LastTransitionTime: metav1.Now(),
-		}, egdp)
+		})
 
 		return nil, fmt.Errorf("referenced KonnectEventControlPlane %q is not yet Programmed",
 			egdp.Spec.ControlPlaneRef.KonnectNamespacedRef.Name)
 	}
 
-	k8sutils.SetCondition(metav1.Condition{
+	apimeta.SetStatusCondition(&egdp.Status.Conditions, metav1.Condition{
 		Type:               string(eventgatewayv1alpha1.KonnectEventGatewayResolvedType),
 		Status:             metav1.ConditionTrue,
 		Reason:             string(eventgatewayv1alpha1.KonnectEventGatewayResolvedReason),
 		Message:            eventgatewayv1alpha1.KonnectEventGatewayResolvedMessage,
 		ObservedGeneration: egdp.Generation,
-		LastTransitionTime: metav1.Now(),
-	}, egdp)
+	})
 
 	return keg, nil
 }

--- a/controller/eventgateway/dataplane/resolve_konnect.go
+++ b/controller/eventgateway/dataplane/resolve_konnect.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2025 Kong, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	eventgatewayv1alpha1 "github.com/kong/kong-operator/v2/api/eventgateway/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	log "github.com/kong/kong-operator/v2/controller/pkg/log"
+	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+)
+
+// resolveKonnectEventGateway resolves the KonnectEventGateway referenced by the
+// DataPlane. It sets the KonnectEventGatewayResolved condition on the
+// EGDP and returns the resolved KonnectEventGateway if successful.
+func (r *Reconciler) resolveKonnectEventGateway(
+	ctx context.Context,
+	logger logr.Logger,
+	egdp *eventgatewayv1alpha1.KegDataPlane,
+) (*konnectv1alpha1.KonnectEventControlPlane, error) {
+	keg := &konnectv1alpha1.KonnectEventControlPlane{}
+	err := r.Get(ctx, types.NamespacedName{
+		Name:      egdp.Spec.ControlPlaneRef.KonnectNamespacedRef.Name,
+		Namespace: egdp.Namespace,
+	}, keg)
+
+	if apierrors.IsNotFound(err) {
+		log.Debug(logger, "referenced KonnectEventGateway not found",
+			"ref", egdp.Spec.ControlPlaneRef.KonnectNamespacedRef.Name)
+
+		k8sutils.SetCondition(metav1.Condition{
+			Type:               string(eventgatewayv1alpha1.KonnectEventGatewayResolvedType),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(eventgatewayv1alpha1.KonnectEventGatewayNotFoundReason),
+			Message:            eventgatewayv1alpha1.KonnectEventGatewayNotFoundMessage,
+			ObservedGeneration: egdp.Generation,
+			LastTransitionTime: metav1.Now(),
+		}, egdp)
+
+		return nil, err
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Check that the KonnectEventGateway is Programmed (i.e. exists in Konnect).
+	if !apimeta.IsStatusConditionTrue(keg.Status.Conditions, konnectv1alpha1.KonnectEntityProgrammedConditionType) {
+		log.Debug(logger, "referenced KonnectEventGateway is not yet Programmed",
+			"ref", egdp.Spec.ControlPlaneRef.KonnectNamespacedRef.Name)
+
+		k8sutils.SetCondition(metav1.Condition{
+			Type:               string(eventgatewayv1alpha1.KonnectEventGatewayResolvedType),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(eventgatewayv1alpha1.KonnectEventGatewayNotProgrammedReason),
+			Message:            eventgatewayv1alpha1.KonnectEventGatewayNotProgrammedMessage,
+			ObservedGeneration: egdp.Generation,
+			LastTransitionTime: metav1.Now(),
+		}, egdp)
+
+		return nil, fmt.Errorf("referenced KonnectEventControlPlane %q is not yet Programmed",
+			egdp.Spec.ControlPlaneRef.KonnectNamespacedRef.Name)
+	}
+
+	k8sutils.SetCondition(metav1.Condition{
+		Type:               string(eventgatewayv1alpha1.KonnectEventGatewayResolvedType),
+		Status:             metav1.ConditionTrue,
+		Reason:             string(eventgatewayv1alpha1.KonnectEventGatewayResolvedReason),
+		Message:            eventgatewayv1alpha1.KonnectEventGatewayResolvedMessage,
+		ObservedGeneration: egdp.Generation,
+		LastTransitionTime: metav1.Now(),
+	}, egdp)
+
+	return keg, nil
+}

--- a/controller/eventgateway/dataplane/ssa.go
+++ b/controller/eventgateway/dataplane/ssa.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2025 Kong, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	controllerpkgssa "github.com/kong/kong-operator/v2/controller/pkg/ssa"
+)
+
+// requiredSchemas lists the GroupVersions whose OpenAPI schemas are needed by
+// this controller for structured-merge-diff merging and diff-before-apply.
+var requiredSchemas = []schema.GroupVersion{
+	// core: Service, Secret, ConfigMap
+	{Group: "", Version: "v1"},
+	// Deployment
+	{Group: "apps", Version: "v1"},
+	// KegDataPlane (status apply)
+	{Group: "eventgateway.konghq.com", Version: "v1alpha1"},
+}
+
+// initTypeConverter creates a TypeConverter from the API server's OpenAPI v3 schemas.
+// Only the schemas needed by this controller are fetched.
+// Called once during SetupWithManager.
+func initTypeConverter(mgr ctrl.Manager) (managedfields.TypeConverter, error) {
+	return controllerpkgssa.NewTypeConverter(mgr, requiredSchemas)
+}

--- a/controller/eventgateway/dataplane/status.go
+++ b/controller/eventgateway/dataplane/status.go
@@ -18,7 +18,6 @@ package dataplane
 
 import (
 	"context"
-	"errors"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -83,23 +82,21 @@ func ensureReadyStatus(
 	return nil
 }
 
-// applyStatus patches the KegDataPlane status subresource via SSA and joins
-// any error into *err so the caller's named return reflects the failure.
+// applyStatus patches the KegDataPlane status subresource via SSA.
 func (r *Reconciler) applyStatus(
 	ctx context.Context,
 	logger logr.Logger,
 	egdp *eventgatewayv1alpha1.KegDataPlane,
-	err *error,
-) {
+) error {
 	result, statusErr := controllerpkgssa.ApplyStatusIfChanged(ctx, logger, r.Client, r.typeConverter, egdp, FieldManager)
 	if statusErr != nil {
 		log.Error(logger, statusErr, "failed to patch KegDataPlane status")
 		r.eventRecorder.Eventf(egdp, nil, corev1.EventTypeWarning, "StatusPatchFailed", "PatchStatus", "%s", statusErr.Error())
-		*err = errors.Join(*err, statusErr)
-		return
+		return statusErr
 	}
 	if result == op.Updated {
 		log.Debug(logger, "KegDataPlane status updated")
 		r.eventRecorder.Eventf(egdp, nil, corev1.EventTypeNormal, "StatusUpdated", "PatchStatus", "KegDataPlane status updated")
 	}
+	return nil
 }

--- a/controller/eventgateway/dataplane/status.go
+++ b/controller/eventgateway/dataplane/status.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2025 Kong, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	eventgatewayv1alpha1 "github.com/kong/kong-operator/v2/api/eventgateway/v1alpha1"
+	log "github.com/kong/kong-operator/v2/controller/pkg/log"
+	"github.com/kong/kong-operator/v2/controller/pkg/op"
+	controllerpkgssa "github.com/kong/kong-operator/v2/controller/pkg/ssa"
+	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+)
+
+// ensureReadyStatus reads the owned Deployment's replica counts, copies them to the
+// DataPlane status, and evaluates whether all conditions are True to set
+// the Ready condition accordingly. Status is not patched here, the caller
+// is responsible for flushing via patchStatus.
+func ensureReadyStatus(
+	ctx context.Context,
+	cl client.Client,
+	egdp *eventgatewayv1alpha1.KegDataPlane,
+) error {
+	deployment := &appsv1.Deployment{}
+	if err := cl.Get(ctx, client.ObjectKey{
+		Namespace: egdp.Namespace,
+		Name:      egdp.Name,
+	}, deployment); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			// Deployment not yet created, not ready.
+			apimeta.SetStatusCondition(&egdp.Status.Conditions, metav1.Condition{
+				Type:               string(eventgatewayv1alpha1.ReadyType),
+				Status:             metav1.ConditionFalse,
+				Reason:             string(eventgatewayv1alpha1.DependenciesNotReadyReason),
+				Message:            eventgatewayv1alpha1.DependenciesNotReadyMessage,
+				ObservedGeneration: egdp.Generation,
+			})
+			return nil
+		}
+		return err
+	}
+
+	egdp.Status.Replicas = deployment.Status.Replicas
+	egdp.Status.ReadyReplicas = deployment.Status.ReadyReplicas
+
+	// Mark Not Ready only when zero pods are serving traffic.
+	// During a rolling update some replicas are still ready, so we stay Ready
+	// throughout the rollout and only flip to False when there is nothing left to serve.
+	if deployment.Status.ReadyReplicas == 0 {
+		apimeta.SetStatusCondition(&egdp.Status.Conditions, metav1.Condition{
+			Type:               string(eventgatewayv1alpha1.ReadyType),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(eventgatewayv1alpha1.DependenciesNotReadyReason),
+			Message:            eventgatewayv1alpha1.DependenciesNotReadyMessage,
+			ObservedGeneration: egdp.Generation,
+		})
+	} else {
+		k8sutils.SetReadyWithGeneration(egdp, egdp.Generation)
+	}
+
+	return nil
+}
+
+// applyStatus patches the KegDataPlane status subresource via SSA and joins
+// any error into *err so the caller's named return reflects the failure.
+func (r *Reconciler) applyStatus(
+	ctx context.Context,
+	logger logr.Logger,
+	egdp *eventgatewayv1alpha1.KegDataPlane,
+	err *error,
+) {
+	result, statusErr := controllerpkgssa.ApplyStatusIfChanged(ctx, logger, r.Client, r.typeConverter, egdp, FieldManager)
+	if statusErr != nil {
+		log.Error(logger, statusErr, "failed to patch KegDataPlane status")
+		r.eventRecorder.Eventf(egdp, nil, corev1.EventTypeWarning, "StatusPatchFailed", "PatchStatus", "%s", statusErr.Error())
+		*err = errors.Join(*err, statusErr)
+		return
+	}
+	if result == op.Updated {
+		log.Debug(logger, "KegDataPlane status updated")
+		r.eventRecorder.Eventf(egdp, nil, corev1.EventTypeNormal, "StatusUpdated", "PatchStatus", "KegDataPlane status updated")
+	}
+}

--- a/controller/eventgateway/dataplane/watch.go
+++ b/controller/eventgateway/dataplane/watch.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2025 Kong, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	eventgatewayv1alpha1 "github.com/kong/kong-operator/v2/api/eventgateway/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	"github.com/kong/kong-operator/v2/internal/utils/index"
+)
+
+// enqueueForKonnectEventGatewayRef returns a MapFunc that enqueues reconcile requests
+// for all DataPlanes in the same namespace whose
+// spec.konnectEventGatewayRef.name matches the changed KonnectEventGateway.
+func enqueueForKonnectEventGatewayRef(cl client.Client) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		keg, ok := obj.(*konnectv1alpha1.KonnectEventControlPlane)
+		if !ok {
+			return nil
+		}
+
+		egdpList := &eventgatewayv1alpha1.KegDataPlaneList{}
+		if err := cl.List(ctx, egdpList,
+			client.MatchingFields{index.IndexFieldKegDataPlaneOnKonnectEventGateway: keg.Namespace + "/" + keg.Name},
+		); err != nil {
+			return nil
+		}
+
+		requests := make([]reconcile.Request, 0, len(egdpList.Items))
+		for _, egdp := range egdpList.Items {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: client.ObjectKeyFromObject(&egdp),
+			})
+		}
+		return requests
+	}
+}

--- a/controller/konnect/server/server.go
+++ b/controller/konnect/server/server.go
@@ -70,3 +70,14 @@ func (s Server) URL() string {
 func (s Server) Region() Region {
 	return s.region
 }
+
+// Domain returns the registrable domain of the server URL, i.e. the last two
+// DNS labels of the hostname (e.g. "konghq.com" from "us.api.konghq.com").
+// If the hostname has fewer than two labels it returns the full hostname.
+func (s Server) Domain() string {
+	parts := strings.Split(s.hostnameWithoutRegion, ".")
+	if len(parts) < 2 {
+		return s.hostnameWithoutRegion
+	}
+	return strings.Join(parts[len(parts)-2:], ".")
+}

--- a/controller/konnect/server/server_test.go
+++ b/controller/konnect/server/server_test.go
@@ -98,3 +98,45 @@ func TestServer(t *testing.T) {
 		}
 	})
 }
+
+func TestServer_Domain(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantDomain string
+	}{
+		{
+			name:       "standard Konnect URL",
+			input:      "https://us.api.konghq.com",
+			wantDomain: "konghq.com",
+		},
+		{
+			name:       "eu region",
+			input:      "https://eu.api.konghq.com",
+			wantDomain: "konghq.com",
+		},
+		{
+			name:       "bare hostname with region only",
+			input:      "us.konghq.com",
+			wantDomain: "konghq.com",
+		},
+		{
+			name:       "custom domain with many labels",
+			input:      "us.gateway.internal.example.com",
+			wantDomain: "example.com",
+		},
+		{
+			name:       "hostname with single label after region",
+			input:      "us.konghq",
+			wantDomain: "konghq",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := server.NewServer[konnectv1alpha2.KonnectGatewayControlPlane](tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantDomain, s.Domain())
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the reconciler for the KegDataPlane custom resource, which manages
the lifecycle of a Kong Event Gateway data plane deployment.

The controller:
- Reconciles KegDataPlane objects by ensuring a Deployment, a Kafka
  Service, and an mTLS client certificate Secret.
- Resolves the referenced KonnectEventControlPlane and surfaces the
  resolution result as a status condition.
- Uses Server-Side Apply (SSA) for all owned resource mutations, with a
  diff-before-apply guard to prevent spurious updates.
- Applies status conditions via the status subresource using SMD-based
  comparison (ApplyStatusIfChanged).
- Records Kubernetes events via the new events.EventRecorder API.
- Watches KonnectEventControlPlane objects and enqueues the owning
  KegDataPlane when they change.

**Which issue this PR fixes**

Fixes #

Part of: #3542 
**Special notes for your reviewer**:

Unit tests will be implemented in another PR. Wait for it.
This PR depends on: #3899 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
