### PR TITLE
fix(hybrid_gateway): Include kind of route in annotation `konghq.com/hybrid-route`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,12 @@
 
 ### Changed
 
+- HybridGateway: Changed the annotation on generate Kubernetes resources
+  (Konnect entities) to mark the parent route. Now the format of the annotation
+  key is changed to `konghq.com/hybrid-route-<routeKind>` to support multiple
+  kinds of routes. If the route kind is `HTTPRoute`, the key format remains
+  unchanged.
+  [#3905](https://github.com/Kong/kong-operator/pull/3905)
 - Increase default interval of uploading configuration and node status to the
   read-only Konnect control plane (The legacy KIC type CP) to 3 minutes to
   decrease the API calls to Konnect.

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -321,7 +321,7 @@ func (c *httpRouteConverter) HandleOrphanedResource(ctx context.Context, logger 
 	am.RemoveRouteFromAnnotation(resource, c.route)
 
 	// If other Routes are still present in the annotation, we just need to update the resource.
-	if len(am.GetRoutes(resource)) > 0 {
+	if len(am.GetRoutesWithKind(resource, "HTTPRoute")) > 0 {
 		log.Debug(logger, "Updating hybrid-routes annotation", "kind", resource.GetKind(), "obj", client.ObjectKeyFromObject(resource))
 		if err := c.Patch(ctx, resource, client.MergeFrom(oldResource)); err != nil && !apierrors.IsNotFound(err) {
 			return true, fmt.Errorf("failed to update resource: %w", err)

--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -1290,7 +1290,7 @@ func TestHTTPRouteConverter_HandleOrphanedResource(t *testing.T) {
 			},
 			wantSkip: true,
 			assertFn: func(t *testing.T, resource *unstructured.Unstructured) {
-				assert.Equal(t, "other-ns/other-route", resource.GetAnnotations()[consts.GatewayOperatorHybridRoutesAnnotation])
+				assert.Equal(t, "other-ns/other-route", resource.GetAnnotations()[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation])
 			},
 		},
 		{
@@ -1302,7 +1302,7 @@ func TestHTTPRouteConverter_HandleOrphanedResource(t *testing.T) {
 				return newHTTPRouteConverter(route, fakeClient, false, "").(*httpRouteConverter), resource
 			},
 			assertFn: func(t *testing.T, resource *unstructured.Unstructured) {
-				_, exists := resource.GetAnnotations()[consts.GatewayOperatorHybridRoutesAnnotation]
+				_, exists := resource.GetAnnotations()[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation]
 				assert.False(t, exists)
 			},
 		},
@@ -1715,7 +1715,7 @@ func newUnstructuredResource(routesAnnotation string) *unstructured.Unstructured
 	resource.SetNamespace("default")
 	if routesAnnotation != "" {
 		resource.SetAnnotations(map[string]string{
-			consts.GatewayOperatorHybridRoutesAnnotation: routesAnnotation,
+			consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: routesAnnotation,
 		})
 	}
 	return resource

--- a/controller/hybridgateway/converter/tls_route.go
+++ b/controller/hybridgateway/converter/tls_route.go
@@ -228,7 +228,7 @@ func (c *tlsRouteConverter) HandleOrphanedResource(ctx context.Context, logger l
 	am.RemoveRouteFromAnnotation(resource, c.route)
 
 	// If other Routes are still present in the annotation, we just need to update the resource.
-	if len(am.GetRoutes(resource)) > 0 {
+	if len(am.GetRoutesWithKind(resource, "TLSRoute")) > 0 {
 		log.Debug(logger, "Updating hybrid-routes annotation", "kind", resource.GetKind(), "obj", client.ObjectKeyFromObject(resource))
 		if err := c.Patch(ctx, resource, client.MergeFrom(oldResource)); err != nil && !apierrors.IsNotFound(err) {
 			return true, fmt.Errorf("failed to update resource: %w", err)

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -141,8 +141,8 @@ func TestRoutesForRule(t *testing.T) {
 				}
 
 				// Verify HTTPRoute annotation
-				expectedAnnotation := "HTTPRoute/" + httpRoute.Namespace + "/" + httpRoute.Name
-				assert.Contains(t, result.Annotations[consts.GatewayOperatorHybridRoutesAnnotation], expectedAnnotation)
+				expectedAnnotation := httpRoute.Namespace + "/" + httpRoute.Name
+				assert.Contains(t, result.Annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation], expectedAnnotation)
 
 				// Verify at least one path/header/method is set based on the match.
 				// For the first match with path, we expect Paths to be non-empty.

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -20,6 +20,11 @@ import (
 	"github.com/kong/kong-operator/v2/pkg/consts"
 )
 
+var httpRouteTypeMeta = metav1.TypeMeta{
+	Kind:       "HTTPRoute",
+	APIVersion: "gateway.networking.k8s.io/v1",
+}
+
 func TestRoutesForRule(t *testing.T) {
 	ctx := context.Background()
 	logger := logr.Discard()
@@ -30,6 +35,7 @@ func TestRoutesForRule(t *testing.T) {
 
 	// Create test HTTPRoute
 	httpRoute := &gwtypes.HTTPRoute{
+		TypeMeta: httpRouteTypeMeta,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
 			Namespace: "test-namespace",
@@ -135,7 +141,7 @@ func TestRoutesForRule(t *testing.T) {
 				}
 
 				// Verify HTTPRoute annotation
-				expectedAnnotation := httpRoute.Namespace + "/" + httpRoute.Name
+				expectedAnnotation := "HTTPRoute/" + httpRoute.Namespace + "/" + httpRoute.Name
 				assert.Contains(t, result.Annotations[consts.GatewayOperatorHybridRoutesAnnotation], expectedAnnotation)
 
 				// Verify at least one path/header/method is set based on the match.

--- a/controller/hybridgateway/metadata/annotation.go
+++ b/controller/hybridgateway/metadata/annotation.go
@@ -161,8 +161,9 @@ func NameStringToObjectKey(s string) client.ObjectKey {
 //   - bool: true if the hybrid-routes annotation was modified, false if the annotation was already
 //     there and no changes were made
 func (am *AnnotationManager) AppendRouteToAnnotation(obj metav1.Object, route client.Object) bool {
-	currentRouteKey := ObjectToNameString(route)
-	currentRouteAnnotation := currentRouteKey
+	currentRouteKind := route.GetObjectKind().GroupVersionKind().Kind
+	currentRouteObjectKey := ObjectToNameString(route)
+	currentRouteAnnotation := currentRouteKind + "/" + currentRouteObjectKey
 
 	log.Debug(am.logger, "Processing route annotation",
 		"currentRoute", currentRouteAnnotation,

--- a/controller/hybridgateway/metadata/annotation.go
+++ b/controller/hybridgateway/metadata/annotation.go
@@ -188,9 +188,9 @@ func (am *AnnotationManager) AppendRouteToAnnotation(obj metav1.Object, route cl
 		return true
 	}
 
-	for route := range strings.SplitSeq(hybridRouteAnnotation, ",") {
-		route = strings.TrimSpace(route)
-		if route == currentRouteAnnotation {
+	for routeAnnotation := range strings.SplitSeq(hybridRouteAnnotation, ",") {
+		routeAnnotation = strings.TrimSpace(routeAnnotation)
+		if RouteAnnotationMatch(routeAnnotation, route) {
 			log.Debug(am.logger, "Route already exists in annotation, no update needed",
 				"currentRoute", currentRouteAnnotation,
 				"objectName", obj.GetName())
@@ -255,9 +255,7 @@ func (am *AnnotationManager) RemoveRouteFromAnnotation(obj metav1.Object, route 
 	found := false
 	for _, routeAnnotation := range existingRoutes {
 		routeAnnotation = strings.TrimSpace(routeAnnotation)
-		if routeAnnotation == currentRouteAnnotation ||
-			// For HTTPRoute, KO 2.1 was using namespace/name format so match the format if the kind is HTTPRoute.
-			currentRouteKind == kindHTTPRoute && routeAnnotation == currentRouteObjectKey {
+		if RouteAnnotationMatch(routeAnnotation, route) {
 			found = true
 			continue
 		}
@@ -354,8 +352,7 @@ func (am *AnnotationManager) GetRoutes(obj metav1.Object) []string {
 			continue
 		}
 		// For route keys with only 2 parts, treat them as the annotation created by KO 2.1 so set kind to "HTTPRoute".
-		parts := strings.Split(route, "/")
-		if len(parts) == 2 {
+		if strings.Count(route, "/") == 1 {
 			route = kindHTTPRoute + "/" + route
 		}
 		// Format is now just "kind/namespace/name"
@@ -388,9 +385,8 @@ func (am *AnnotationManager) SetRoutes(obj metav1.Object, routes []string) bool 
 
 	same := lo.ElementsMatchBy(existingRoutes, routes, func(routeKey string) string {
 		routeKey = strings.TrimSpace(routeKey)
-		parts := strings.Split(routeKey, "/")
-		// For route keys with only 2 parts, treat them as the annotation created by KO 2.1 so set kind to "HTTPRoute".
-		if len(parts) == 2 {
+		// For route keys with the namespace/name format, treat them as the annotation created by KO 2.1 so set kind to "HTTPRoute".
+		if strings.Count(routeKey, "/") == 1 {
 			return kindHTTPRoute + "/" + routeKey
 		}
 		return routeKey
@@ -412,4 +408,26 @@ func (am *AnnotationManager) SetRoutes(obj metav1.Object, routes []string) bool 
 		consts.GatewayOperatorHybridRoutesAnnotation, newAnnotation,
 		"objectName", obj.GetName())
 	return true
+}
+
+// RouteAnnotationMatch returns true if the hybrid route annotation matches the given route by kind, namespace and name.
+func RouteAnnotationMatch(routeAnnotation string, route client.Object) bool {
+	var kind, namespace, name string
+	parts := strings.Split(routeAnnotation, "/")
+	switch len(parts) {
+	// The annotation kind/namespace/name format.
+	case 3:
+		kind = parts[0]
+		namespace = parts[1]
+		name = parts[2]
+	// The annotation in namespace/name format implies that the kind is HTTPRoute.
+	case 2:
+		kind = kindHTTPRoute
+		namespace = parts[0]
+		name = parts[1]
+	// malformed annotation. Should be unreachable.
+	default:
+		return false
+	}
+	return kind == route.GetObjectKind().GroupVersionKind().Kind && namespace == route.GetNamespace() && name == route.GetName()
 }

--- a/controller/hybridgateway/metadata/annotation.go
+++ b/controller/hybridgateway/metadata/annotation.go
@@ -359,7 +359,7 @@ func (am *AnnotationManager) GetRoutesWithKind(obj metav1.Object, routeKind stri
 		if route == "" {
 			continue
 		}
-		// Format is now just "kind/namespace/name"
+		// Format is now just "namespace/name"
 		routes = append(routes, route)
 	}
 
@@ -429,5 +429,5 @@ func (am *AnnotationManager) RouteAnnotationKeyForKind(routeKind string) string 
 // RouteAnnotationMatch returns true if the hybrid route annotation matches the given route by its namespace and name.
 func RouteAnnotationMatch(routeAnnotation string, route client.Object) bool {
 	routeObjectKey := client.ObjectKeyFromObject(route)
-	return routeAnnotation == routeObjectKey.String()
+	return strings.TrimSpace(routeAnnotation) == routeObjectKey.String()
 }

--- a/controller/hybridgateway/metadata/annotation.go
+++ b/controller/hybridgateway/metadata/annotation.go
@@ -21,6 +21,7 @@ const (
 	preserveHostKey  = "/preserve-host"
 	protocolKey      = "/protocol"
 	kindHTTPRoute    = "HTTPRoute"
+	kindTLSRoute     = "TLSRoute"
 )
 
 // Defaults for the annotations when not specified that match the behavior of on-prem.
@@ -105,15 +106,13 @@ func BuildAnnotations(obj client.Object, parentRef *gwtypes.ParentReference) map
 		consts.GatewayOperatorHybridGatewaysAnnotation: gwObjKey.String(),
 	}
 
-	// Add route annotation for TLSRoute and HTTPRoute objects
-	// Include kind of the parent route to prevent conflicts between different kind of routes.
-	// REVIEW: Should we provide the options to generate the KO 2.1 compatible format (namespace/name) for HTTPRoute for backward compatibility?
-	objectKind := obj.GetObjectKind().GroupVersionKind().Kind
+	// Add route annotation for TLSRoute and HTTPRoute objects.
+	// Use different annotation keys for each type to distinguish the routes with same namespace/name but different kinds.
 	switch obj.(type) {
 	case *gwtypes.HTTPRoute:
-		annotations[consts.GatewayOperatorHybridRoutesAnnotation] = objectKind + "/" + client.ObjectKeyFromObject(obj).String()
+		annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation] = client.ObjectKeyFromObject(obj).String()
 	case *gwtypes.TLSRoute:
-		annotations[consts.GatewayOperatorHybridRoutesAnnotation] = objectKind + "/" + client.ObjectKeyFromObject(obj).String()
+		annotations[consts.GatewayOperatorHybridRoutesTLSRouteAnnotation] = client.ObjectKeyFromObject(obj).String()
 	}
 
 	return annotations
@@ -163,10 +162,10 @@ func NameStringToObjectKey(s string) client.ObjectKey {
 func (am *AnnotationManager) AppendRouteToAnnotation(obj metav1.Object, route client.Object) bool {
 	currentRouteKind := route.GetObjectKind().GroupVersionKind().Kind
 	currentRouteObjectKey := ObjectToNameString(route)
-	currentRouteAnnotation := currentRouteKind + "/" + currentRouteObjectKey
 
 	log.Debug(am.logger, "Processing route annotation",
-		"currentRoute", currentRouteAnnotation,
+		"routeKind", currentRouteKind,
+		"currentRoute", currentRouteObjectKey,
 		"objectName", obj.GetName(),
 		"objectNamespace", obj.GetNamespace())
 
@@ -176,14 +175,19 @@ func (am *AnnotationManager) AppendRouteToAnnotation(obj metav1.Object, route cl
 	}
 
 	// Get existing hybrid-routes annotation
-	hybridRouteAnnotation, exists := annotations[consts.GatewayOperatorHybridRoutesAnnotation]
+	routeAnnotationKey := am.RouteAnnotationKeyForKind(currentRouteKind)
+	if routeAnnotationKey == "" {
+		log.Debug(am.logger, "Unsupported route kind for setting annotation", "routeKind", currentRouteKind)
+		return false
+	}
+	hybridRouteAnnotation, exists := annotations[routeAnnotationKey]
 
 	if !exists || hybridRouteAnnotation == "" {
 		// No existing hybrid-routes annotation, set it to the current route
-		annotations[consts.GatewayOperatorHybridRoutesAnnotation] = currentRouteAnnotation
+		annotations[routeAnnotationKey] = currentRouteObjectKey
 		obj.SetAnnotations(annotations)
 		log.Debug(am.logger, "Set new hybrid-routes annotation",
-			"annotation", currentRouteAnnotation,
+			"annotation", currentRouteObjectKey,
 			"objectName", obj.GetName())
 		return true
 	}
@@ -191,15 +195,15 @@ func (am *AnnotationManager) AppendRouteToAnnotation(obj metav1.Object, route cl
 	for routeAnnotation := range strings.SplitSeq(hybridRouteAnnotation, ",") {
 		if RouteAnnotationMatch(routeAnnotation, route) {
 			log.Debug(am.logger, "Route already exists in annotation, no update needed",
-				"currentRoute", currentRouteAnnotation,
+				"currentRoute", currentRouteObjectKey,
 				"objectName", obj.GetName())
 			return false
 		}
 	}
 
 	// Append current route to existing list
-	updatedAnnotation := hybridRouteAnnotation + "," + currentRouteAnnotation
-	annotations[consts.GatewayOperatorHybridRoutesAnnotation] = updatedAnnotation
+	updatedAnnotation := hybridRouteAnnotation + "," + currentRouteObjectKey
+	annotations[routeAnnotationKey] = updatedAnnotation
 	obj.SetAnnotations(annotations)
 
 	log.Debug(am.logger, "Appended Route to existing annotation",
@@ -222,27 +226,32 @@ func (am *AnnotationManager) AppendRouteToAnnotation(obj metav1.Object, route cl
 func (am *AnnotationManager) RemoveRouteFromAnnotation(obj metav1.Object, route client.Object) bool {
 	currentRouteKind := route.GetObjectKind().GroupVersionKind().Kind
 	currentRouteObjectKey := client.ObjectKeyFromObject(route).String()
-	// The annotation is in kind/namespace/name format.
-	currentRouteAnnotation := currentRouteKind + "/" + currentRouteObjectKey
 
 	log.Debug(am.logger, "Removing route from annotation",
-		"routeToRemove", currentRouteAnnotation,
+		"routeKind", currentRouteKind,
+		"routeToRemove", currentRouteObjectKey,
 		"objectName", obj.GetName())
 
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		log.Debug(am.logger, "No annotations present, nothing to remove",
-			"routeToRemove", currentRouteAnnotation,
+			"routeKind", currentRouteKind,
+			"routeToRemove", currentRouteObjectKey,
 			"objectName", obj.GetName())
 		return false
 	}
 
-	// Get existing hybrid-routes annotation
-	existingAnnotation, exists := annotations[consts.GatewayOperatorHybridRoutesAnnotation]
+	// Get existing hybrid-routes annotation fir the route kind.
+	routeAnnotationKey := am.RouteAnnotationKeyForKind(currentRouteKind)
+	if routeAnnotationKey == "" {
+		return false
+	}
+	existingAnnotation, exists := annotations[routeAnnotationKey]
 
 	if !exists || existingAnnotation == "" {
 		log.Debug(am.logger, "No hybrid-routes annotation exists, nothing to remove",
-			"routeToRemove", currentRouteAnnotation,
+			"routeKind", currentRouteKind,
+			"routeToRemove", currentRouteObjectKey,
 			"objectName", obj.GetName())
 		return false
 	}
@@ -262,7 +271,8 @@ func (am *AnnotationManager) RemoveRouteFromAnnotation(obj metav1.Object, route 
 
 	if !found {
 		log.Debug(am.logger, "Route not found in annotation, no changes made",
-			"routeToRemove", currentRouteAnnotation,
+			"routeKind", currentRouteKind,
+			"routeToRemove", currentRouteObjectKey,
 			"objectName", obj.GetName())
 		return false
 	}
@@ -270,13 +280,13 @@ func (am *AnnotationManager) RemoveRouteFromAnnotation(obj metav1.Object, route 
 	// Update annotation
 	if len(remainingRoutes) == 0 {
 		// No routes left, remove the annotation entirely
-		delete(annotations, consts.GatewayOperatorHybridRoutesAnnotation)
+		delete(annotations, routeAnnotationKey)
 		log.Debug(am.logger, "Removed hybrid-routes annotation completely as no routes remain",
 			"objectName", obj.GetName())
 	} else {
 		// Update with remaining routes
 		updatedAnnotation := strings.Join(remainingRoutes, ",")
-		annotations[consts.GatewayOperatorHybridRoutesAnnotation] = updatedAnnotation
+		annotations[routeAnnotationKey] = updatedAnnotation
 		log.Debug(am.logger, "Updated hybrid-routes annotation",
 			"previousAnnotation", existingAnnotation,
 			"updatedAnnotation", updatedAnnotation,
@@ -301,7 +311,12 @@ func (am *AnnotationManager) ContainsRoute(obj metav1.Object, route client.Objec
 		return false
 	}
 
-	existingAnnotation, exists := annotations[consts.GatewayOperatorHybridRoutesAnnotation]
+	currentRouteKind := route.GetObjectKind().GroupVersionKind().Kind
+	routeAnnotationKey := am.RouteAnnotationKeyForKind(currentRouteKind)
+	if routeAnnotationKey == "" {
+		return false
+	}
+	existingAnnotation, exists := annotations[routeAnnotationKey]
 	if !exists || existingAnnotation == "" {
 		return false
 	}
@@ -311,21 +326,27 @@ func (am *AnnotationManager) ContainsRoute(obj metav1.Object, route client.Objec
 	})
 }
 
-// GetRoutes returns all Route references from the hybrid-routes annotation
-// of the provided Kubernetes object.
+// GetRoutesWithKind returns all Route references having the given route kind
+// from the hybrid-routes annotation of the provided Kubernetes object.
 //
 // Parameters:
 //   - obj: Any Kubernetes object that implements metav1.Object
+//   - routeKind: The kind of the route reference
 //
 // Returns:
-//   - []string: List of route references in "kind/namespace/name" format
-func (am *AnnotationManager) GetRoutes(obj metav1.Object) []string {
+//   - []string: List of route references in "namespace/name" format
+func (am *AnnotationManager) GetRoutesWithKind(obj metav1.Object, routeKind string) []string {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		return []string{}
 	}
 
-	existingAnnotation, exists := annotations[consts.GatewayOperatorHybridRoutesAnnotation]
+	routeAnnotationKey := am.RouteAnnotationKeyForKind(routeKind)
+	if routeAnnotationKey == "" {
+		return []string{}
+	}
+	existingAnnotation, exists := annotations[routeAnnotationKey]
+
 	if !exists || existingAnnotation == "" {
 		return []string{}
 	}
@@ -338,10 +359,6 @@ func (am *AnnotationManager) GetRoutes(obj metav1.Object) []string {
 		if route == "" {
 			continue
 		}
-		// For route keys with only 2 parts, treat them as the annotation created by KO 2.1 so set kind to "HTTPRoute".
-		if strings.Count(route, "/") == 1 {
-			route = kindHTTPRoute + "/" + route
-		}
 		// Format is now just "kind/namespace/name"
 		routes = append(routes, route)
 	}
@@ -349,35 +366,34 @@ func (am *AnnotationManager) GetRoutes(obj metav1.Object) []string {
 	return routes
 }
 
-// SetRoutes sets the hybrid-routes annotation to contain exactly the provided route references.
+// SetRoutesWithKind sets the hybrid-routes annotation to contain exactly the provided route references with given kind.
 //
 // Parameters:
 //   - obj: Any Kubernetes object that implements metav1.Object
-//   - routes: List of route references (kind/namespace/name) to set in the annotation
+//   - routeKind: The kind of the route references
+//   - routes: List of route references (namespace/name) to set in the annotation
 //
 // Returns:
 //   - bool: true if the annotation was modified, false if no changes were made
-func (am *AnnotationManager) SetRoutes(obj metav1.Object, routes []string) bool {
+func (am *AnnotationManager) SetRoutesWithKind(obj metav1.Object, routeKind string, routes []string) bool {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)
 		obj.SetAnnotations(annotations)
 	}
 
+	routeAnnotationKey := am.RouteAnnotationKeyForKind(routeKind)
+	if routeAnnotationKey == "" {
+		return false
+	}
+
 	newAnnotation := strings.Join(routes, ",")
 
 	// Check if annotation needs to be updated
-	existingAnnotation := annotations[consts.GatewayOperatorHybridRoutesAnnotation]
+	existingAnnotation := annotations[routeAnnotationKey]
 	existingRoutes := strings.Split(existingAnnotation, ",")
 
-	same := lo.ElementsMatchBy(existingRoutes, routes, func(routeKey string) string {
-		routeKey = strings.TrimSpace(routeKey)
-		// For route keys with the namespace/name format, treat them as the annotation created by KO 2.1 so set kind to "HTTPRoute".
-		if strings.Count(routeKey, "/") == 1 {
-			return kindHTTPRoute + "/" + routeKey
-		}
-		return routeKey
-	})
+	same := lo.ElementsMatchBy(existingRoutes, routes, strings.TrimSpace)
 
 	if same {
 		log.Debug(am.logger, "Hybrid-routes annotation already up to date",
@@ -386,36 +402,32 @@ func (am *AnnotationManager) SetRoutes(obj metav1.Object, routes []string) bool 
 	}
 
 	if newAnnotation == "" {
-		delete(annotations, consts.GatewayOperatorHybridRoutesAnnotation)
+		delete(annotations, routeAnnotationKey)
 	} else {
-		annotations[consts.GatewayOperatorHybridRoutesAnnotation] = newAnnotation
+		annotations[routeAnnotationKey] = newAnnotation
 	}
 	obj.SetAnnotations(annotations)
 	log.Debug(am.logger, "Set hybrid-routes annotation",
-		consts.GatewayOperatorHybridRoutesAnnotation, newAnnotation,
+		routeAnnotationKey, newAnnotation,
 		"objectName", obj.GetName())
 	return true
 }
 
-// RouteAnnotationMatch returns true if the hybrid route annotation matches the given route by kind, namespace and name.
-func RouteAnnotationMatch(routeAnnotation string, route client.Object) bool {
-	var kind, namespace, name string
-	routeAnnotation = strings.TrimSpace(routeAnnotation)
-	parts := strings.Split(routeAnnotation, "/")
-	switch len(parts) {
-	// The annotation in kind/namespace/name format.
-	case 3:
-		kind = parts[0]
-		namespace = parts[1]
-		name = parts[2]
-	// The annotation in namespace/name format implies that the kind is HTTPRoute.
-	case 2:
-		kind = kindHTTPRoute
-		namespace = parts[0]
-		name = parts[1]
-	// malformed annotation. Should be unreachable.
-	default:
-		return false
+// RouteAnnotationKeyForKind returns the annotation key for the route kind to
+// mark the namespace and name of the route with given kind that owns the object.
+func (am *AnnotationManager) RouteAnnotationKeyForKind(routeKind string) string {
+	switch routeKind {
+	case kindHTTPRoute:
+		return consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation
+	case kindTLSRoute:
+		return consts.GatewayOperatorHybridRoutesTLSRouteAnnotation
 	}
-	return kind == route.GetObjectKind().GroupVersionKind().Kind && namespace == route.GetNamespace() && name == route.GetName()
+	// Not supported route kind. Should be unreachable.
+	return ""
+}
+
+// RouteAnnotationMatch returns true if the hybrid route annotation matches the given route by its namespace and name.
+func RouteAnnotationMatch(routeAnnotation string, route client.Object) bool {
+	routeObjectKey := client.ObjectKeyFromObject(route)
+	return routeAnnotation == routeObjectKey.String()
 }

--- a/controller/hybridgateway/metadata/annotation.go
+++ b/controller/hybridgateway/metadata/annotation.go
@@ -189,7 +189,6 @@ func (am *AnnotationManager) AppendRouteToAnnotation(obj metav1.Object, route cl
 	}
 
 	for routeAnnotation := range strings.SplitSeq(hybridRouteAnnotation, ",") {
-		routeAnnotation = strings.TrimSpace(routeAnnotation)
 		if RouteAnnotationMatch(routeAnnotation, route) {
 			log.Debug(am.logger, "Route already exists in annotation, no update needed",
 				"currentRoute", currentRouteAnnotation,
@@ -254,7 +253,6 @@ func (am *AnnotationManager) RemoveRouteFromAnnotation(obj metav1.Object, route 
 	// Filter out the route to remove
 	found := false
 	for _, routeAnnotation := range existingRoutes {
-		routeAnnotation = strings.TrimSpace(routeAnnotation)
 		if RouteAnnotationMatch(routeAnnotation, route) {
 			found = true
 			continue
@@ -303,25 +301,14 @@ func (am *AnnotationManager) ContainsRoute(obj metav1.Object, route client.Objec
 		return false
 	}
 
-	currentRouteKind := route.GetObjectKind().GroupVersionKind().Kind
-	currentRouteObjectKey := client.ObjectKeyFromObject(route).String()
-	currentRouteAnnotation := currentRouteKind + "/" + currentRouteObjectKey
-
 	existingAnnotation, exists := annotations[consts.GatewayOperatorHybridRoutesAnnotation]
 	if !exists || existingAnnotation == "" {
 		return false
 	}
 
-	for routeAnnotation := range strings.SplitSeq(existingAnnotation, ",") {
-		routeAnnotation = strings.TrimSpace(routeAnnotation)
-		if routeAnnotation == currentRouteAnnotation ||
-			// For HTTPRoute, KO 2.1 was using namespace/name format so match the format if the kind is HTTPRoute.
-			currentRouteKind == kindHTTPRoute && routeAnnotation == currentRouteObjectKey {
-			return true
-		}
-	}
-
-	return false
+	return lo.ContainsBy(strings.Split(existingAnnotation, ","), func(routeAnnotation string) bool {
+		return RouteAnnotationMatch(routeAnnotation, route)
+	})
 }
 
 // GetRoutes returns all Route references from the hybrid-routes annotation
@@ -413,9 +400,10 @@ func (am *AnnotationManager) SetRoutes(obj metav1.Object, routes []string) bool 
 // RouteAnnotationMatch returns true if the hybrid route annotation matches the given route by kind, namespace and name.
 func RouteAnnotationMatch(routeAnnotation string, route client.Object) bool {
 	var kind, namespace, name string
+	routeAnnotation = strings.TrimSpace(routeAnnotation)
 	parts := strings.Split(routeAnnotation, "/")
 	switch len(parts) {
-	// The annotation kind/namespace/name format.
+	// The annotation in kind/namespace/name format.
 	case 3:
 		kind = parts[0]
 		namespace = parts[1]

--- a/controller/hybridgateway/metadata/annotation.go
+++ b/controller/hybridgateway/metadata/annotation.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -19,6 +20,7 @@ const (
 	stripPathKey     = "/strip-path"
 	preserveHostKey  = "/preserve-host"
 	protocolKey      = "/protocol"
+	kindHTTPRoute    = "HTTPRoute"
 )
 
 // Defaults for the annotations when not specified that match the behavior of on-prem.
@@ -104,13 +106,14 @@ func BuildAnnotations(obj client.Object, parentRef *gwtypes.ParentReference) map
 	}
 
 	// Add route annotation for TLSRoute and HTTPRoute objects
-	// TODO: include kind of the parent route to prevent conflicts:
-	// https://github.com/Kong/kong-operator/issues/3747
+	// Include kind of the parent route to prevent conflicts between different kind of routes.
+	// REVIEW: Should we provide the options to generate the KO 2.1 compatible format (namespace/name) for HTTPRoute for backward compatibility?
+	objectKind := obj.GetObjectKind().GroupVersionKind().Kind
 	switch obj.(type) {
 	case *gwtypes.HTTPRoute:
-		annotations[consts.GatewayOperatorHybridRoutesAnnotation] = client.ObjectKeyFromObject(obj).String()
+		annotations[consts.GatewayOperatorHybridRoutesAnnotation] = objectKind + "/" + client.ObjectKeyFromObject(obj).String()
 	case *gwtypes.TLSRoute:
-		annotations[consts.GatewayOperatorHybridRoutesAnnotation] = client.ObjectKeyFromObject(obj).String()
+		annotations[consts.GatewayOperatorHybridRoutesAnnotation] = objectKind + "/" + client.ObjectKeyFromObject(obj).String()
 	}
 
 	return annotations
@@ -217,8 +220,10 @@ func (am *AnnotationManager) AppendRouteToAnnotation(obj metav1.Object, route cl
 // Returns:
 //   - bool: true if the annotation was modified, false if no changes were made
 func (am *AnnotationManager) RemoveRouteFromAnnotation(obj metav1.Object, route client.Object) bool {
-	currentRouteKey := client.ObjectKeyFromObject(route).String()
-	currentRouteAnnotation := currentRouteKey
+	currentRouteKind := route.GetObjectKind().GroupVersionKind().Kind
+	currentRouteObjectKey := client.ObjectKeyFromObject(route).String()
+	// The annotation is in kind/namespace/name format.
+	currentRouteAnnotation := currentRouteKind + "/" + currentRouteObjectKey
 
 	log.Debug(am.logger, "Removing route from annotation",
 		"routeToRemove", currentRouteAnnotation,
@@ -247,13 +252,15 @@ func (am *AnnotationManager) RemoveRouteFromAnnotation(obj metav1.Object, route 
 
 	// Filter out the route to remove
 	found := false
-	for _, route := range existingRoutes {
-		route = strings.TrimSpace(route)
-		if route != currentRouteAnnotation {
-			remainingRoutes = append(remainingRoutes, route)
-		} else {
+	for _, routeAnnotation := range existingRoutes {
+		routeAnnotation = strings.TrimSpace(routeAnnotation)
+		if routeAnnotation == currentRouteAnnotation ||
+			// For HTTPRoute, KO 2.1 was using namespace/name format so match the format if the kind is HTTPRoute.
+			currentRouteKind == kindHTTPRoute && routeAnnotation == currentRouteObjectKey {
 			found = true
+			continue
 		}
+		remainingRoutes = append(remainingRoutes, routeAnnotation)
 	}
 
 	if !found {
@@ -297,17 +304,20 @@ func (am *AnnotationManager) ContainsRoute(obj metav1.Object, route client.Objec
 		return false
 	}
 
-	currentRouteKey := client.ObjectKeyFromObject(route).String()
-	currentRouteAnnotation := currentRouteKey
+	currentRouteKind := route.GetObjectKind().GroupVersionKind().Kind
+	currentRouteObjectKey := client.ObjectKeyFromObject(route).String()
+	currentRouteAnnotation := currentRouteKind + "/" + currentRouteObjectKey
 
 	existingAnnotation, exists := annotations[consts.GatewayOperatorHybridRoutesAnnotation]
 	if !exists || existingAnnotation == "" {
 		return false
 	}
 
-	for route := range strings.SplitSeq(existingAnnotation, ",") {
-		route = strings.TrimSpace(route)
-		if route == currentRouteAnnotation {
+	for routeAnnotation := range strings.SplitSeq(existingAnnotation, ",") {
+		routeAnnotation = strings.TrimSpace(routeAnnotation)
+		if routeAnnotation == currentRouteAnnotation ||
+			// For HTTPRoute, KO 2.1 was using namespace/name format so match the format if the kind is HTTPRoute.
+			currentRouteKind == kindHTTPRoute && routeAnnotation == currentRouteObjectKey {
 			return true
 		}
 	}
@@ -322,7 +332,7 @@ func (am *AnnotationManager) ContainsRoute(obj metav1.Object, route client.Objec
 //   - obj: Any Kubernetes object that implements metav1.Object
 //
 // Returns:
-//   - []string: List of route references in "namespace/name" format
+//   - []string: List of route references in "kind/namespace/name" format
 func (am *AnnotationManager) GetRoutes(obj metav1.Object) []string {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
@@ -342,8 +352,12 @@ func (am *AnnotationManager) GetRoutes(obj metav1.Object) []string {
 		if route == "" {
 			continue
 		}
-
-		// Format is now just "namespace/name"
+		// For route keys with only 2 parts, treat them as the annotation created by KO 2.1 so set kind to "HTTPRoute".
+		parts := strings.Split(route, "/")
+		if len(parts) == 2 {
+			route = kindHTTPRoute + "/" + route
+		}
+		// Format is now just "kind/namespace/name"
 		routes = append(routes, route)
 	}
 
@@ -354,7 +368,7 @@ func (am *AnnotationManager) GetRoutes(obj metav1.Object) []string {
 //
 // Parameters:
 //   - obj: Any Kubernetes object that implements metav1.Object
-//   - routes: List of route references to set in the annotation
+//   - routes: List of route references (kind/namespace/name) to set in the annotation
 //
 // Returns:
 //   - bool: true if the annotation was modified, false if no changes were made
@@ -370,28 +384,21 @@ func (am *AnnotationManager) SetRoutes(obj metav1.Object, routes []string) bool 
 	// Check if annotation needs to be updated
 	existingAnnotation := annotations[consts.GatewayOperatorHybridRoutesAnnotation]
 	existingRoutes := strings.Split(existingAnnotation, ",")
-	if len(existingRoutes) == len(routes) {
-		same := true
-		for _, er := range existingRoutes {
-			er = strings.TrimSpace(er)
-			found := false
-			for _, r := range routes {
-				r = strings.TrimSpace(r)
-				if er == r {
-					found = true
-					break
-				}
-			}
-			if !found {
-				same = false
-				break
-			}
+
+	same := lo.ElementsMatchBy(existingRoutes, routes, func(routeKey string) string {
+		routeKey = strings.TrimSpace(routeKey)
+		parts := strings.Split(routeKey, "/")
+		// For route keys with only 2 parts, treat them as the annotation created by KO 2.1 so set kind to "HTTPRoute".
+		if len(parts) == 2 {
+			return kindHTTPRoute + "/" + routeKey
 		}
-		if same {
-			log.Debug(am.logger, "Hybrid-routes annotation already up to date",
-				"objectName", obj.GetName())
-			return false
-		}
+		return routeKey
+	})
+
+	if same {
+		log.Debug(am.logger, "Hybrid-routes annotation already up to date",
+			"objectName", obj.GetName())
+		return false
 	}
 
 	if newAnnotation == "" {

--- a/controller/hybridgateway/metadata/annotation_test.go
+++ b/controller/hybridgateway/metadata/annotation_test.go
@@ -172,8 +172,8 @@ func TestBuildAnnotations(t *testing.T) {
 				Namespace: func() *gwtypes.Namespace { ns := gwtypes.Namespace("gateway-namespace"); return &ns }(),
 			},
 			expected: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation:   "HTTPRoute/test-namespace/test-route",
-				consts.GatewayOperatorHybridGatewaysAnnotation: "gateway-namespace/test-gateway",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "test-namespace/test-route",
+				consts.GatewayOperatorHybridGatewaysAnnotation:        "gateway-namespace/test-gateway",
 			},
 			description: "should use explicit parent namespace when provided",
 		},
@@ -191,8 +191,8 @@ func TestBuildAnnotations(t *testing.T) {
 				Namespace: nil,
 			},
 			expected: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation:   "HTTPRoute/test-namespace/test-route",
-				consts.GatewayOperatorHybridGatewaysAnnotation: "test-namespace/test-gateway",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "test-namespace/test-route",
+				consts.GatewayOperatorHybridGatewaysAnnotation:        "test-namespace/test-gateway",
 			},
 			description: "should use HTTPRoute namespace when parent namespace is nil",
 		},
@@ -210,8 +210,8 @@ func TestBuildAnnotations(t *testing.T) {
 				Namespace: func() *gwtypes.Namespace { ns := gwtypes.Namespace(""); return &ns }(),
 			},
 			expected: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation:   "HTTPRoute/test-namespace/test-route",
-				consts.GatewayOperatorHybridGatewaysAnnotation: "test-namespace/test-gateway",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "test-namespace/test-route",
+				consts.GatewayOperatorHybridGatewaysAnnotation:        "test-namespace/test-gateway",
 			},
 			description: "should use HTTPRoute namespace when parent namespace is empty",
 		},
@@ -229,8 +229,8 @@ func TestBuildAnnotations(t *testing.T) {
 				Namespace: func() *gwtypes.Namespace { ns := gwtypes.Namespace("infrastructure"); return &ns }(),
 			},
 			expected: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation:   "HTTPRoute/apps/my-route",
-				consts.GatewayOperatorHybridGatewaysAnnotation: "infrastructure/my-gateway",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "apps/my-route",
+				consts.GatewayOperatorHybridGatewaysAnnotation:        "infrastructure/my-gateway",
 			},
 			description: "should handle different namespaces correctly",
 		},
@@ -276,10 +276,10 @@ func TestBuildAnnotationsObjectKeyCreation(t *testing.T) {
 		}
 
 		result := BuildAnnotations(httpRoute, parentRef)
-		routeAnnotation := result[consts.GatewayOperatorHybridRoutesAnnotation]
+		routeAnnotation := result[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation]
 
 		expectedRouteKey := client.ObjectKeyFromObject(httpRoute)
-		assert.Equal(t, kindHTTPRoute+"/"+expectedRouteKey.String(), routeAnnotation)
+		assert.Equal(t, expectedRouteKey.String(), routeAnnotation)
 	})
 }
 
@@ -304,13 +304,13 @@ func TestAppendRouteToAnnotation(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
+			expectedAnnotation: "test-namespace/test-route",
 			expectModification: true,
 		},
 		{
 			name: "empty hybrid-route annotation",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -319,13 +319,13 @@ func TestAppendRouteToAnnotation(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
+			expectedAnnotation: "test-namespace/test-route",
 			expectModification: true,
 		},
 		{
 			name: "existing different route in annotation",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/other-namespace/other-route",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "other-namespace/other-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -334,13 +334,13 @@ func TestAppendRouteToAnnotation(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "HTTPRoute/other-namespace/other-route,HTTPRoute/test-namespace/test-route",
+			expectedAnnotation: "other-namespace/other-route,test-namespace/test-route",
 			expectModification: true,
 		},
 		{
 			name: "route already exists in annotation without kind",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "test-namespace/test-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -353,24 +353,9 @@ func TestAppendRouteToAnnotation(t *testing.T) {
 			expectModification: false,
 		},
 		{
-			name: "route already exists in annotation with kind",
-			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/test-namespace/test-route",
-			},
-			httpRoute: &gwtypes.HTTPRoute{
-				TypeMeta: httpRouteTypeMeta,
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-route",
-					Namespace: "test-namespace",
-				},
-			},
-			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
-			expectModification: false,
-		},
-		{
 			name: "multiple existing routes, adding new one",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/ns1/route1,HTTPRoute/ns2/route2",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route1,ns2/route2",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -379,13 +364,13 @@ func TestAppendRouteToAnnotation(t *testing.T) {
 					Namespace: "ns3",
 				},
 			},
-			expectedAnnotation: "HTTPRoute/ns1/route1,HTTPRoute/ns2/route2,HTTPRoute/ns3/route3",
+			expectedAnnotation: "ns1/route1,ns2/route2,ns3/route3",
 			expectModification: true,
 		},
 		{
 			name: "same namespace and name but different kinds",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "TLSRoute/test-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesTLSRouteAnnotation: "test-namespace/test-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -394,7 +379,7 @@ func TestAppendRouteToAnnotation(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "TLSRoute/test-namespace/test-route,HTTPRoute/test-namespace/test-route",
+			expectedAnnotation: "test-namespace/test-route",
 			expectModification: true,
 		},
 	}
@@ -417,13 +402,13 @@ func TestAppendRouteToAnnotation(t *testing.T) {
 			modified := am.AppendRouteToAnnotation(obj, tt.httpRoute)
 
 			assert.Equal(t, tt.expectModification, modified)
-			actualAnnotation := obj.Annotations[consts.GatewayOperatorHybridRoutesAnnotation]
+			actualAnnotation := obj.Annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation]
 			assert.Equal(t, tt.expectedAnnotation, actualAnnotation)
 		})
 	}
 }
 
-func TestRemoveRouteFromAnnotation_LegacyFormat(t *testing.T) {
+func TestRemoveRouteFromAnnotation(t *testing.T) {
 	logger := logr.Discard()
 	am := NewAnnotationManager(logger)
 
@@ -451,7 +436,7 @@ func TestRemoveRouteFromAnnotation_LegacyFormat(t *testing.T) {
 		{
 			name: "route not in annotation",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "other-namespace/other-route",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "other-namespace/other-route",
 			},
 			route: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -466,7 +451,7 @@ func TestRemoveRouteFromAnnotation_LegacyFormat(t *testing.T) {
 		{
 			name: "remove only route - annotation should be deleted",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "test-namespace/test-route",
 			},
 			route: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -482,7 +467,7 @@ func TestRemoveRouteFromAnnotation_LegacyFormat(t *testing.T) {
 		{
 			name: "remove first route from multiple",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route,ns2/route2",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "test-namespace/test-route,ns2/route2",
 			},
 			route: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -497,7 +482,7 @@ func TestRemoveRouteFromAnnotation_LegacyFormat(t *testing.T) {
 		{
 			name: "remove middle route from multiple",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1,test-namespace/test-route,ns3/route3",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route1,test-namespace/test-route,ns3/route3",
 			},
 			route: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -510,10 +495,10 @@ func TestRemoveRouteFromAnnotation_LegacyFormat(t *testing.T) {
 			expectModification: true,
 		},
 		{
-			// No kind implies that the kind of parent route is HTTPRoute so TLSRoute with the same namespace and name should not trigger the removal.
 			name: "does not remove if kind does not match",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "test-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesTLSRouteAnnotation:  "other-namespace/other-route",
 			},
 			route: &gwtypes.TLSRoute{
 				TypeMeta: tlsRouteTypeMeta,
@@ -522,8 +507,23 @@ func TestRemoveRouteFromAnnotation_LegacyFormat(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "test-namespace/test-route",
+			expectedAnnotation: "other-namespace/other-route",
 			expectModification: false,
+		},
+		{
+			name: "remove middle route from multiple - TLSRoute",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesTLSRouteAnnotation: "ns1/route1,test-namespace/test-route,ns3/route3",
+			},
+			route: &gwtypes.TLSRoute{
+				TypeMeta: tlsRouteTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			expectedAnnotation: "ns1/route1,ns3/route3",
+			expectModification: true,
 		},
 	}
 
@@ -546,11 +546,13 @@ func TestRemoveRouteFromAnnotation_LegacyFormat(t *testing.T) {
 
 			assert.Equal(t, tt.expectModification, modified)
 
+			routeAnnotaionKey := am.RouteAnnotationKeyForKind(tt.route.GetObjectKind().GroupVersionKind().Kind)
+
 			if tt.expectAnnotationDeleted {
-				_, exists := obj.Annotations[consts.GatewayOperatorHybridRoutesAnnotation]
+				_, exists := obj.Annotations[routeAnnotaionKey]
 				assert.False(t, exists, "annotation should be deleted")
 			} else if tt.expectedAnnotation != "" {
-				actualAnnotation := obj.Annotations[consts.GatewayOperatorHybridRoutesAnnotation]
+				actualAnnotation := obj.Annotations[routeAnnotaionKey]
 				assert.Equal(t, tt.expectedAnnotation, actualAnnotation)
 			}
 		})
@@ -590,49 +592,35 @@ func TestContainsRoute(t *testing.T) {
 		{
 			name: "empty annotation",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "",
 			},
 			expected: false,
 		},
 		{
 			name: "route exists",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "test-namespace/test-route",
 			},
 			expected: true,
 		},
 		{
 			name: "route exists among others",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1,test-namespace/test-route,ns3/route3",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route1,test-namespace/test-route,ns3/route3",
 			},
 			expected: true,
 		},
 		{
 			name: "different route",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "other-namespace/other-route",
-			},
-			expected: false,
-		},
-		{
-			name: "annotation with kind",
-			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/test-namespace/test-route",
-			},
-			expected: true,
-		},
-		{
-			name: "annotation with kind but other route",
-			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/other-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "other-namespace/other-route",
 			},
 			expected: false,
 		},
 		{
 			name: "annotation with kind but the kind is different",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "TLSRoute/test-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesTLSRouteAnnotation: "test-namespace/test-route",
 			},
 			expected: false,
 		},
@@ -651,35 +639,28 @@ func TestContainsRoute(t *testing.T) {
 		{
 			name: "empty annotation",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "",
+				consts.GatewayOperatorHybridRoutesTLSRouteAnnotation: "",
 			},
 			expected: false,
 		},
 		{
 			name: "route exists",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "TLSRoute/test-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesTLSRouteAnnotation: "test-namespace/test-route",
 			},
 			expected: true,
 		},
 		{
 			name: "route exists among others",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "TLSRoute/ns1/route1,TLSRoute/test-namespace/test-route,HTTPRoute/ns3/route3",
+				consts.GatewayOperatorHybridRoutesTLSRouteAnnotation: "ns1/route1,test-namespace/test-route,ns3/route3",
 			},
 			expected: true,
 		},
 		{
 			name: "different route",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "TLSRoute/other-namespace/other-route",
-			},
-			expected: false,
-		},
-		{
-			name: "annotation without kind implies HTTPRoute",
-			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesTLSRouteAnnotation: "other-namespace/other-route",
 			},
 			expected: false,
 		},
@@ -716,54 +697,71 @@ func TestContainsRoute(t *testing.T) {
 	}
 }
 
-func TestGetRoutes(t *testing.T) {
+func TestGetRoutesWithKind(t *testing.T) {
 	logger := logr.Discard()
 	am := NewAnnotationManager(logger)
 
 	tests := []struct {
 		name                string
+		routeKind           string
 		existingAnnotations map[string]string
 		expected            []string
 	}{
 		{
 			name:                "no annotations",
+			routeKind:           kindHTTPRoute,
 			existingAnnotations: nil,
 			expected:            []string{},
 		},
 		{
-			name: "empty annotation",
+			name:      "empty annotation",
+			routeKind: kindHTTPRoute,
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "",
 			},
 			expected: []string{},
 		},
 		{
-			name: "single route",
+			name:      "single route",
+			routeKind: kindHTTPRoute,
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "test-namespace/test-route",
 			},
-			expected: []string{"HTTPRoute/test-namespace/test-route"},
+			expected: []string{"test-namespace/test-route"},
 		},
 		{
-			name: "multiple routes",
+			name:      "multiple routes",
+			routeKind: kindHTTPRoute,
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1,ns2/route2,ns3/route3",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route1,ns2/route2,ns3/route3",
 			},
-			expected: []string{"HTTPRoute/ns1/route1", "HTTPRoute/ns2/route2", "HTTPRoute/ns3/route3"},
+			expected: []string{"ns1/route1", "ns2/route2", "ns3/route3"},
 		},
 		{
-			name: "single route with kind",
+			name:      "single route - TLSRoute",
+			routeKind: kindTLSRoute,
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "TLSRoute/test-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesTLSRouteAnnotation: "test-namespace/test-route",
 			},
-			expected: []string{"TLSRoute/test-namespace/test-route"},
+			expected: []string{"test-namespace/test-route"},
 		},
 		{
-			name: "multiple routes with different kinds and without kind",
+			name:      "multiple routes with different kinds",
+			routeKind: kindTLSRoute,
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/ns1/route1,TLSRoute/ns2/route2,ns3/route3",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route1,ns2/route2",
+				consts.GatewayOperatorHybridRoutesTLSRouteAnnotation:  "ns2/route2,ns3/route3",
 			},
-			expected: []string{"HTTPRoute/ns1/route1", "TLSRoute/ns2/route2", "HTTPRoute/ns3/route3"},
+			expected: []string{"ns2/route2", "ns3/route3"},
+		},
+		{
+			name:      "unsupported route kind",
+			routeKind: "unsupportedKind",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route1,ns2/route2",
+				consts.GatewayOperatorHybridRoutesTLSRouteAnnotation:  "ns2/route2,ns3/route3",
+			},
+			expected: []string{},
 		},
 	}
 
@@ -777,19 +775,20 @@ func TestGetRoutes(t *testing.T) {
 				},
 			}
 
-			routes := am.GetRoutes(obj)
+			routes := am.GetRoutesWithKind(obj, tt.routeKind)
 			assert.Equal(t, tt.expected, routes)
 		})
 	}
 }
 
-func TestSetRoutes(t *testing.T) {
+func TestSetRoutesWithKind(t *testing.T) {
 	logger := logr.Discard()
 	am := NewAnnotationManager(logger)
 
 	tests := []struct {
 		name                string
 		existingAnnotations map[string]string
+		routeKind           string
 		routes              []string
 		expectedAnnotation  string
 		expectModification  bool
@@ -797,6 +796,7 @@ func TestSetRoutes(t *testing.T) {
 		{
 			name:                "set on empty object",
 			existingAnnotations: nil,
+			routeKind:           kindHTTPRoute,
 			routes:              []string{"ns1/route1"},
 			expectedAnnotation:  "ns1/route1",
 			expectModification:  true,
@@ -804,8 +804,9 @@ func TestSetRoutes(t *testing.T) {
 		{
 			name: "set same routes - no change",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route1",
 			},
+			routeKind:          kindHTTPRoute,
 			routes:             []string{"ns1/route1"},
 			expectedAnnotation: "ns1/route1",
 			expectModification: false,
@@ -813,17 +814,19 @@ func TestSetRoutes(t *testing.T) {
 		{
 			name: "replace routes",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route1",
 			},
-			routes:             []string{"HTTPRoute/ns2/route2"},
-			expectedAnnotation: "HTTPRoute/ns2/route2",
+			routeKind:          kindHTTPRoute,
+			routes:             []string{"ns2/route2"},
+			expectedAnnotation: "ns2/route2",
 			expectModification: true,
 		},
 		{
 			name: "set multiple routes",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "old/route",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "old/route",
 			},
+			routeKind:          kindHTTPRoute,
 			routes:             []string{"ns1/route1", "ns2/route2"},
 			expectedAnnotation: "ns1/route1,ns2/route2",
 			expectModification: true,
@@ -831,10 +834,32 @@ func TestSetRoutes(t *testing.T) {
 		{
 			name: "clear routes",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route1",
 			},
+			routeKind:          kindHTTPRoute,
 			routes:             []string{},
 			expectedAnnotation: "",
+			expectModification: true,
+		},
+		{
+			name: "set same routes - TLSRoute",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesTLSRouteAnnotation: "ns1/route1",
+			},
+			routeKind:          kindTLSRoute,
+			routes:             []string{"ns1/route1"},
+			expectedAnnotation: "ns1/route1",
+			expectModification: false,
+		},
+		{
+			name: "replace routes - TLSRoute",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route1",
+				consts.GatewayOperatorHybridRoutesTLSRouteAnnotation:  "ns2/route2",
+			},
+			routeKind:          kindTLSRoute,
+			routes:             []string{"ns1/route1"},
+			expectedAnnotation: "ns1/route1",
 			expectModification: true,
 		},
 	}
@@ -854,14 +879,16 @@ func TestSetRoutes(t *testing.T) {
 				maps.Copy(obj.Annotations, tt.existingAnnotations)
 			}
 
-			modified := am.SetRoutes(obj, tt.routes)
+			modified := am.SetRoutesWithKind(obj, tt.routeKind, tt.routes)
 			assert.Equal(t, tt.expectModification, modified)
 
+			routeKey := am.RouteAnnotationKeyForKind(tt.routeKind)
+			assert.NotEmpty(t, routeKey)
 			if tt.expectedAnnotation == "" {
-				_, exists := obj.Annotations[consts.GatewayOperatorHybridRoutesAnnotation]
+				_, exists := obj.Annotations[routeKey]
 				assert.False(t, exists, "annotation should be deleted when empty")
 			} else {
-				actualAnnotation := obj.Annotations[consts.GatewayOperatorHybridRoutesAnnotation]
+				actualAnnotation := obj.Annotations[routeKey]
 				assert.Equal(t, tt.expectedAnnotation, actualAnnotation)
 			}
 		})
@@ -982,8 +1009,8 @@ func TestGenericObjectTypes(t *testing.T) {
 			assert.True(t, contains)
 
 			// Test getting routes
-			routes := am.GetRoutes(obj)
-			assert.Equal(t, []string{"HTTPRoute/test-namespace/test-route"}, routes)
+			routes := am.GetRoutesWithKind(obj, kindHTTPRoute)
+			assert.Equal(t, []string{"test-namespace/test-route"}, routes)
 
 			// Test removing
 			modified = am.RemoveRouteFromAnnotation(obj, httpRoute)

--- a/controller/hybridgateway/metadata/annotation_test.go
+++ b/controller/hybridgateway/metadata/annotation_test.go
@@ -15,6 +15,17 @@ import (
 	"github.com/kong/kong-operator/v2/pkg/consts"
 )
 
+var (
+	httpRouteTypeMeta = metav1.TypeMeta{
+		Kind:       kindHTTPRoute,
+		APIVersion: "gateway.networking.k8s.io/v1",
+	}
+	tlsRouteTypeMeta = metav1.TypeMeta{
+		Kind:       "TLSRoute",
+		APIVersion: "gateway.networking.k8s.io/v1",
+	}
+)
+
 func TestExtractStripPath(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -150,6 +161,7 @@ func TestBuildAnnotations(t *testing.T) {
 		{
 			name: "with explicit parent namespace",
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
@@ -160,7 +172,7 @@ func TestBuildAnnotations(t *testing.T) {
 				Namespace: func() *gwtypes.Namespace { ns := gwtypes.Namespace("gateway-namespace"); return &ns }(),
 			},
 			expected: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation:   "test-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesAnnotation:   "HTTPRoute/test-namespace/test-route",
 				consts.GatewayOperatorHybridGatewaysAnnotation: "gateway-namespace/test-gateway",
 			},
 			description: "should use explicit parent namespace when provided",
@@ -168,6 +180,7 @@ func TestBuildAnnotations(t *testing.T) {
 		{
 			name: "with nil parent namespace",
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
@@ -178,7 +191,7 @@ func TestBuildAnnotations(t *testing.T) {
 				Namespace: nil,
 			},
 			expected: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation:   "test-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesAnnotation:   "HTTPRoute/test-namespace/test-route",
 				consts.GatewayOperatorHybridGatewaysAnnotation: "test-namespace/test-gateway",
 			},
 			description: "should use HTTPRoute namespace when parent namespace is nil",
@@ -186,6 +199,7 @@ func TestBuildAnnotations(t *testing.T) {
 		{
 			name: "with empty parent namespace",
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
@@ -196,7 +210,7 @@ func TestBuildAnnotations(t *testing.T) {
 				Namespace: func() *gwtypes.Namespace { ns := gwtypes.Namespace(""); return &ns }(),
 			},
 			expected: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation:   "test-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesAnnotation:   "HTTPRoute/test-namespace/test-route",
 				consts.GatewayOperatorHybridGatewaysAnnotation: "test-namespace/test-gateway",
 			},
 			description: "should use HTTPRoute namespace when parent namespace is empty",
@@ -204,6 +218,7 @@ func TestBuildAnnotations(t *testing.T) {
 		{
 			name: "with different route and gateway namespaces",
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-route",
 					Namespace: "apps",
@@ -214,7 +229,7 @@ func TestBuildAnnotations(t *testing.T) {
 				Namespace: func() *gwtypes.Namespace { ns := gwtypes.Namespace("infrastructure"); return &ns }(),
 			},
 			expected: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation:   "apps/my-route",
+				consts.GatewayOperatorHybridRoutesAnnotation:   "HTTPRoute/apps/my-route",
 				consts.GatewayOperatorHybridGatewaysAnnotation: "infrastructure/my-gateway",
 			},
 			description: "should handle different namespaces correctly",
@@ -231,6 +246,7 @@ func TestBuildAnnotations(t *testing.T) {
 
 func TestBuildAnnotationsObjectKeyCreation(t *testing.T) {
 	httpRoute := &gwtypes.HTTPRoute{
+		TypeMeta: httpRouteTypeMeta,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
 			Namespace: "test-namespace",
@@ -263,7 +279,7 @@ func TestBuildAnnotationsObjectKeyCreation(t *testing.T) {
 		routeAnnotation := result[consts.GatewayOperatorHybridRoutesAnnotation]
 
 		expectedRouteKey := client.ObjectKeyFromObject(httpRoute)
-		assert.Equal(t, expectedRouteKey.String(), routeAnnotation)
+		assert.Equal(t, kindHTTPRoute+"/"+expectedRouteKey.String(), routeAnnotation)
 	})
 }
 
@@ -282,12 +298,13 @@ func TestAppendRouteToAnnotation(t *testing.T) {
 			name:                "no existing annotations",
 			existingAnnotations: nil,
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "test-namespace/test-route",
+			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
 			expectModification: true,
 		},
 		{
@@ -296,54 +313,73 @@ func TestAppendRouteToAnnotation(t *testing.T) {
 				consts.GatewayOperatorHybridRoutesAnnotation: "",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "test-namespace/test-route",
+			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
 			expectModification: true,
 		},
 		{
 			name: "existing different route in annotation",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "other-namespace/other-route",
+				consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/other-namespace/other-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "other-namespace/other-route,test-namespace/test-route",
+			expectedAnnotation: "HTTPRoute/other-namespace/other-route,HTTPRoute/test-namespace/test-route",
 			expectModification: true,
 		},
 		{
 			name: "route already exists in annotation",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/test-namespace/test-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "test-namespace/test-route",
+			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
 			expectModification: false,
 		},
 		{
 			name: "multiple existing routes, adding new one",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1,ns2/route2",
+				consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/ns1/route1,HTTPRoute/ns2/route2",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "route3",
 					Namespace: "ns3",
 				},
 			},
-			expectedAnnotation: "ns1/route1,ns2/route2,ns3/route3",
+			expectedAnnotation: "HTTPRoute/ns1/route1,HTTPRoute/ns2/route2,HTTPRoute/ns3/route3",
+			expectModification: true,
+		},
+		{
+			name: "same namespace and name but different kinds",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesAnnotation: "TLSRoute/test-namespace/test-route",
+			},
+			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			expectedAnnotation: "TLSRoute/test-namespace/test-route,HTTPRoute/test-namespace/test-route",
 			expectModification: true,
 		},
 	}
@@ -372,14 +408,14 @@ func TestAppendRouteToAnnotation(t *testing.T) {
 	}
 }
 
-func TestRemoveRouteFromAnnotation(t *testing.T) {
+func TestRemoveRouteFromAnnotation_LegacyFormat(t *testing.T) {
 	logger := logr.Discard()
 	am := NewAnnotationManager(logger)
 
 	tests := []struct {
 		name                    string
 		existingAnnotations     map[string]string
-		httpRoute               *gwtypes.HTTPRoute
+		route                   client.Object
 		expectedAnnotation      string
 		expectModification      bool
 		expectAnnotationDeleted bool
@@ -387,7 +423,8 @@ func TestRemoveRouteFromAnnotation(t *testing.T) {
 		{
 			name:                "no annotations",
 			existingAnnotations: nil,
-			httpRoute: &gwtypes.HTTPRoute{
+			route: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
@@ -401,7 +438,8 @@ func TestRemoveRouteFromAnnotation(t *testing.T) {
 			existingAnnotations: map[string]string{
 				consts.GatewayOperatorHybridRoutesAnnotation: "other-namespace/other-route",
 			},
-			httpRoute: &gwtypes.HTTPRoute{
+			route: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
@@ -415,7 +453,8 @@ func TestRemoveRouteFromAnnotation(t *testing.T) {
 			existingAnnotations: map[string]string{
 				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
 			},
-			httpRoute: &gwtypes.HTTPRoute{
+			route: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
@@ -430,7 +469,8 @@ func TestRemoveRouteFromAnnotation(t *testing.T) {
 			existingAnnotations: map[string]string{
 				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route,ns2/route2",
 			},
-			httpRoute: &gwtypes.HTTPRoute{
+			route: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
@@ -444,7 +484,8 @@ func TestRemoveRouteFromAnnotation(t *testing.T) {
 			existingAnnotations: map[string]string{
 				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1,test-namespace/test-route,ns3/route3",
 			},
-			httpRoute: &gwtypes.HTTPRoute{
+			route: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
@@ -452,6 +493,22 @@ func TestRemoveRouteFromAnnotation(t *testing.T) {
 			},
 			expectedAnnotation: "ns1/route1,ns3/route3",
 			expectModification: true,
+		},
+		{
+			// No kind implies that the kind of parent route is HTTPRoute so TLSRoute with the same namespace and name should not trigger the removal.
+			name: "does not remove if kind does not match",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
+			},
+			route: &gwtypes.TLSRoute{
+				TypeMeta: tlsRouteTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			expectedAnnotation: "test-namespace/test-route",
+			expectModification: false,
 		},
 	}
 
@@ -470,7 +527,7 @@ func TestRemoveRouteFromAnnotation(t *testing.T) {
 				maps.Copy(obj.Annotations, tt.existingAnnotations)
 			}
 
-			modified := am.RemoveRouteFromAnnotation(obj, tt.httpRoute)
+			modified := am.RemoveRouteFromAnnotation(obj, tt.route)
 
 			assert.Equal(t, tt.expectModification, modified)
 
@@ -490,13 +547,22 @@ func TestContainsRoute(t *testing.T) {
 	am := NewAnnotationManager(logger)
 
 	httpRoute := &gwtypes.HTTPRoute{
+		TypeMeta: httpRouteTypeMeta,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
 			Namespace: "test-namespace",
 		},
 	}
 
-	tests := []struct {
+	tlsRoute := &gwtypes.TLSRoute{
+		TypeMeta: tlsRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+	}
+
+	testsHTTPRoute := []struct {
 		name                string
 		existingAnnotations map[string]string
 		expected            bool
@@ -534,9 +600,77 @@ func TestContainsRoute(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "annotation with kind",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/test-namespace/test-route",
+			},
+			expected: true,
+		},
+		{
+			name: "annotation with kind but other route",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/other-namespace/test-route",
+			},
+			expected: false,
+		},
+		{
+			name: "annotation with kind but the kind is different",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesAnnotation: "TLSRoute/test-namespace/test-route",
+			},
+			expected: false,
+		},
 	}
 
-	for _, tt := range tests {
+	testsTLSRoute := []struct {
+		name                string
+		existingAnnotations map[string]string
+		expected            bool
+	}{
+		{
+			name:                "no annotations",
+			existingAnnotations: nil,
+			expected:            false,
+		},
+		{
+			name: "empty annotation",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesAnnotation: "",
+			},
+			expected: false,
+		},
+		{
+			name: "route exists",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesAnnotation: "TLSRoute/test-namespace/test-route",
+			},
+			expected: true,
+		},
+		{
+			name: "route exists among others",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesAnnotation: "TLSRoute/ns1/route1,TLSRoute/test-namespace/test-route,HTTPRoute/ns3/route3",
+			},
+			expected: true,
+		},
+		{
+			name: "different route",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesAnnotation: "TLSRoute/other-namespace/other-route",
+			},
+			expected: false,
+		},
+		{
+			name: "annotation without kind implies HTTPRoute",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range testsHTTPRoute {
 		t.Run(tt.name, func(t *testing.T) {
 			obj := &configurationv1alpha1.KongUpstream{
 				ObjectMeta: metav1.ObjectMeta{
@@ -547,6 +681,21 @@ func TestContainsRoute(t *testing.T) {
 			}
 
 			result := am.ContainsRoute(obj, httpRoute)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+
+	for _, tt := range testsTLSRoute {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &configurationv1alpha1.KongUpstream{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-object",
+					Namespace:   "test-namespace",
+					Annotations: tt.existingAnnotations,
+				},
+			}
+
+			result := am.ContainsRoute(obj, tlsRoute)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -578,14 +727,28 @@ func TestGetRoutes(t *testing.T) {
 			existingAnnotations: map[string]string{
 				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
 			},
-			expected: []string{"test-namespace/test-route"},
+			expected: []string{"HTTPRoute/test-namespace/test-route"},
 		},
 		{
 			name: "multiple routes",
 			existingAnnotations: map[string]string{
 				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1,ns2/route2,ns3/route3",
 			},
-			expected: []string{"ns1/route1", "ns2/route2", "ns3/route3"},
+			expected: []string{"HTTPRoute/ns1/route1", "HTTPRoute/ns2/route2", "HTTPRoute/ns3/route3"},
+		},
+		{
+			name: "single route with kind",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesAnnotation: "TLSRoute/test-namespace/test-route",
+			},
+			expected: []string{"TLSRoute/test-namespace/test-route"},
+		},
+		{
+			name: "multiple routes with different kinds and without kind",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/ns1/route1,TLSRoute/ns2/route2,ns3/route3",
+			},
+			expected: []string{"HTTPRoute/ns1/route1", "TLSRoute/ns2/route2", "HTTPRoute/ns3/route3"},
 		},
 	}
 

--- a/controller/hybridgateway/metadata/annotation_test.go
+++ b/controller/hybridgateway/metadata/annotation_test.go
@@ -338,7 +338,22 @@ func TestAppendRouteToAnnotation(t *testing.T) {
 			expectModification: true,
 		},
 		{
-			name: "route already exists in annotation",
+			name: "route already exists in annotation without kind",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
+			},
+			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			expectedAnnotation: "test-namespace/test-route",
+			expectModification: false,
+		},
+		{
+			name: "route already exists in annotation with kind",
 			existingAnnotations: map[string]string{
 				consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/test-namespace/test-route",
 			},
@@ -800,8 +815,8 @@ func TestSetRoutes(t *testing.T) {
 			existingAnnotations: map[string]string{
 				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1",
 			},
-			routes:             []string{"ns2/route2"},
-			expectedAnnotation: "ns2/route2",
+			routes:             []string{"HTTPRoute/ns2/route2"},
+			expectedAnnotation: "HTTPRoute/ns2/route2",
 			expectModification: true,
 		},
 		{
@@ -933,6 +948,7 @@ func TestGenericObjectTypes(t *testing.T) {
 	am := NewAnnotationManager(logger)
 
 	httpRoute := &gwtypes.HTTPRoute{
+		TypeMeta: httpRouteTypeMeta,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
 			Namespace: "test-namespace",
@@ -967,7 +983,7 @@ func TestGenericObjectTypes(t *testing.T) {
 
 			// Test getting routes
 			routes := am.GetRoutes(obj)
-			assert.Equal(t, []string{"test-namespace/test-route"}, routes)
+			assert.Equal(t, []string{"HTTPRoute/test-namespace/test-route"}, routes)
 
 			// Test removing
 			modified = am.RemoveRouteFromAnnotation(obj, httpRoute)

--- a/controller/hybridgateway/plugin/plugin_test.go
+++ b/controller/hybridgateway/plugin/plugin_test.go
@@ -22,6 +22,13 @@ import (
 	"github.com/kong/kong-operator/v2/pkg/consts"
 )
 
+var (
+	httpRouteTypeMeta = metav1.TypeMeta{
+		Kind:       "HTTPRoute",
+		APIVersion: "gateway.networking.k8s.io/v1",
+	}
+)
+
 func TestAppendHTTPRouteToPluginAnnotations(t *testing.T) {
 	logger := logr.Discard()
 
@@ -36,12 +43,13 @@ func TestAppendHTTPRouteToPluginAnnotations(t *testing.T) {
 			name:                "no existing annotations",
 			existingAnnotations: nil,
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "test-namespace/test-route",
+			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
 			expectModification: true,
 		},
 		{
@@ -50,12 +58,13 @@ func TestAppendHTTPRouteToPluginAnnotations(t *testing.T) {
 				consts.GatewayOperatorHybridRoutesAnnotation: "",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "test-namespace/test-route",
+			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
 			expectModification: true,
 		},
 		{
@@ -64,20 +73,22 @@ func TestAppendHTTPRouteToPluginAnnotations(t *testing.T) {
 				consts.GatewayOperatorHybridRoutesAnnotation: "other-namespace/other-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "other-namespace/other-route,test-namespace/test-route",
+			expectedAnnotation: "other-namespace/other-route,HTTPRoute/test-namespace/test-route",
 			expectModification: true,
 		},
 		{
-			name: "route already exists in annotation",
+			name: "route already exists in annotation without kind",
 			existingAnnotations: map[string]string{
 				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
@@ -87,17 +98,33 @@ func TestAppendHTTPRouteToPluginAnnotations(t *testing.T) {
 			expectModification: false,
 		},
 		{
-			name: "multiple existing routes, adding new one",
+			name: "route already exists in annotation with kind",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1,ns2/route2",
+				consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/test-namespace/test-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
+			expectModification: false,
+		},
+		{
+			name: "multiple existing routes, adding new one",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1,HTTPRoute/ns2/route2",
+			},
+			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "route3",
 					Namespace: "ns3",
 				},
 			},
-			expectedAnnotation: "ns1/route1,ns2/route2,ns3/route3",
+			expectedAnnotation: "ns1/route1,HTTPRoute/ns2/route2,HTTPRoute/ns3/route3",
 			expectModification: true,
 		},
 	}
@@ -156,6 +183,7 @@ func TestPluginForFilter(t *testing.T) {
 			},
 			existingPlugin: nil,
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
@@ -171,7 +199,7 @@ func TestPluginForFilter(t *testing.T) {
 				assert.Equal(t, "test-namespace", plugin.Namespace)
 				assert.Equal(t, "request-transformer", plugin.PluginName)
 				assert.Contains(t, plugin.Annotations, consts.GatewayOperatorHybridRoutesAnnotation)
-				assert.Equal(t, "test-namespace/test-route", plugin.Annotations[consts.GatewayOperatorHybridRoutesAnnotation])
+				assert.Equal(t, "HTTPRoute/test-namespace/test-route", plugin.Annotations[consts.GatewayOperatorHybridRoutesAnnotation])
 			},
 		},
 	}

--- a/controller/hybridgateway/plugin/plugin_test.go
+++ b/controller/hybridgateway/plugin/plugin_test.go
@@ -64,7 +64,7 @@ func TestAppendHTTPRouteToPluginAnnotations(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
+			expectedAnnotation: "test-namespace/test-route",
 			expectModification: true,
 		},
 		{

--- a/controller/hybridgateway/plugin/plugin_test.go
+++ b/controller/hybridgateway/plugin/plugin_test.go
@@ -49,13 +49,13 @@ func TestAppendHTTPRouteToPluginAnnotations(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
+			expectedAnnotation: "test-namespace/test-route",
 			expectModification: true,
 		},
 		{
 			name: "empty hybrid-routes annotation",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -70,7 +70,7 @@ func TestAppendHTTPRouteToPluginAnnotations(t *testing.T) {
 		{
 			name: "existing different route in annotation",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "other-namespace/other-route",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "other-namespace/other-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -79,13 +79,13 @@ func TestAppendHTTPRouteToPluginAnnotations(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "other-namespace/other-route,HTTPRoute/test-namespace/test-route",
+			expectedAnnotation: "other-namespace/other-route,test-namespace/test-route",
 			expectModification: true,
 		},
 		{
-			name: "route already exists in annotation without kind",
+			name: "route already exists in annotation",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "test-namespace/test-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -98,24 +98,9 @@ func TestAppendHTTPRouteToPluginAnnotations(t *testing.T) {
 			expectModification: false,
 		},
 		{
-			name: "route already exists in annotation with kind",
-			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/test-namespace/test-route",
-			},
-			httpRoute: &gwtypes.HTTPRoute{
-				TypeMeta: httpRouteTypeMeta,
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-route",
-					Namespace: "test-namespace",
-				},
-			},
-			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
-			expectModification: false,
-		},
-		{
 			name: "multiple existing routes, adding new one",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1,HTTPRoute/ns2/route2",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route1,ns2/route2",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -124,7 +109,7 @@ func TestAppendHTTPRouteToPluginAnnotations(t *testing.T) {
 					Namespace: "ns3",
 				},
 			},
-			expectedAnnotation: "ns1/route1,HTTPRoute/ns2/route2,HTTPRoute/ns3/route3",
+			expectedAnnotation: "ns1/route1,ns2/route2,ns3/route3",
 			expectModification: true,
 		},
 	}
@@ -141,7 +126,7 @@ func TestAppendHTTPRouteToPluginAnnotations(t *testing.T) {
 
 			am := metadata.NewAnnotationManager(logger)
 			am.AppendRouteToAnnotation(plugin, tt.httpRoute)
-			actualAnnotation := plugin.Annotations[consts.GatewayOperatorHybridRoutesAnnotation]
+			actualAnnotation := plugin.Annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation]
 			assert.Equal(t, tt.expectedAnnotation, actualAnnotation)
 		})
 	}
@@ -198,8 +183,8 @@ func TestPluginForFilter(t *testing.T) {
 				require.NotNil(t, plugin)
 				assert.Equal(t, "test-namespace", plugin.Namespace)
 				assert.Equal(t, "request-transformer", plugin.PluginName)
-				assert.Contains(t, plugin.Annotations, consts.GatewayOperatorHybridRoutesAnnotation)
-				assert.Equal(t, "HTTPRoute/test-namespace/test-route", plugin.Annotations[consts.GatewayOperatorHybridRoutesAnnotation])
+				assert.Contains(t, plugin.Annotations, consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation)
+				assert.Equal(t, "test-namespace/test-route", plugin.Annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation])
 			},
 		},
 	}

--- a/controller/hybridgateway/pluginbinding/pluginbinding_test.go
+++ b/controller/hybridgateway/pluginbinding/pluginbinding_test.go
@@ -46,13 +46,13 @@ func TestAppendHTTPRouteToBindingAnnotations(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
+			expectedAnnotation: "test-namespace/test-route",
 			expectModification: true,
 		},
 		{
 			name: "empty hybrid-routes annotation",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -61,13 +61,13 @@ func TestAppendHTTPRouteToBindingAnnotations(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
+			expectedAnnotation: "test-namespace/test-route",
 			expectModification: true,
 		},
 		{
 			name: "existing different route in annotation",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "other-namespace/other-route",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "other-namespace/other-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -76,13 +76,13 @@ func TestAppendHTTPRouteToBindingAnnotations(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "other-namespace/other-route,HTTPRoute/test-namespace/test-route",
+			expectedAnnotation: "other-namespace/other-route,test-namespace/test-route",
 			expectModification: true,
 		},
 		{
-			name: "route already exists in annotation without kind",
+			name: "route already exists in annotation",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "test-namespace/test-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -95,24 +95,9 @@ func TestAppendHTTPRouteToBindingAnnotations(t *testing.T) {
 			expectModification: false,
 		},
 		{
-			name: "route already exists in annotation with kind",
-			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/test-namespace/test-route",
-			},
-			httpRoute: &gwtypes.HTTPRoute{
-				TypeMeta: httpRouteTypeMeta,
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-route",
-					Namespace: "test-namespace",
-				},
-			},
-			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
-			expectModification: false,
-		},
-		{
 			name: "multiple existing routes, adding new one",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1,ns2/route2",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route1,ns2/route2",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -121,7 +106,7 @@ func TestAppendHTTPRouteToBindingAnnotations(t *testing.T) {
 					Namespace: "ns3",
 				},
 			},
-			expectedAnnotation: "ns1/route1,ns2/route2,HTTPRoute/ns3/route3",
+			expectedAnnotation: "ns1/route1,ns2/route2,ns3/route3",
 			expectModification: true,
 		},
 	}
@@ -138,7 +123,7 @@ func TestAppendHTTPRouteToBindingAnnotations(t *testing.T) {
 
 			am := metadata.NewAnnotationManager(logger)
 			am.AppendRouteToAnnotation(binding, tt.httpRoute)
-			actualAnnotation := binding.Annotations[consts.GatewayOperatorHybridRoutesAnnotation]
+			actualAnnotation := binding.Annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation]
 			assert.Equal(t, tt.expectedAnnotation, actualAnnotation)
 		})
 	}
@@ -191,8 +176,8 @@ func TestBindingForPluginAndRoute(t *testing.T) {
 				assert.Equal(t, "test-route", binding.Spec.Targets.RouteReference.Name)
 				assert.Equal(t, "configuration.konghq.com", binding.Spec.Targets.RouteReference.Group)
 				assert.Equal(t, "KongRoute", binding.Spec.Targets.RouteReference.Kind)
-				assert.Contains(t, binding.Annotations, consts.GatewayOperatorHybridRoutesAnnotation)
-				assert.Equal(t, "HTTPRoute/test-namespace/test-httproute", binding.Annotations[consts.GatewayOperatorHybridRoutesAnnotation])
+				assert.Contains(t, binding.Annotations, consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation)
+				assert.Equal(t, "test-namespace/test-httproute", binding.Annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation])
 			},
 		},
 		{

--- a/controller/hybridgateway/pluginbinding/pluginbinding_test.go
+++ b/controller/hybridgateway/pluginbinding/pluginbinding_test.go
@@ -19,6 +19,13 @@ import (
 	"github.com/kong/kong-operator/v2/pkg/consts"
 )
 
+var (
+	httpRouteTypeMeta = metav1.TypeMeta{
+		Kind:       "HTTPRoute",
+		APIVersion: "gateway.networking.k8s.io/v1",
+	}
+)
+
 func TestAppendHTTPRouteToBindingAnnotations(t *testing.T) {
 	logger := logr.Discard()
 
@@ -33,12 +40,13 @@ func TestAppendHTTPRouteToBindingAnnotations(t *testing.T) {
 			name:                "no existing annotations",
 			existingAnnotations: nil,
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "test-namespace/test-route",
+			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
 			expectModification: true,
 		},
 		{
@@ -47,12 +55,13 @@ func TestAppendHTTPRouteToBindingAnnotations(t *testing.T) {
 				consts.GatewayOperatorHybridRoutesAnnotation: "",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "test-namespace/test-route",
+			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
 			expectModification: true,
 		},
 		{
@@ -61,20 +70,22 @@ func TestAppendHTTPRouteToBindingAnnotations(t *testing.T) {
 				consts.GatewayOperatorHybridRoutesAnnotation: "other-namespace/other-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "other-namespace/other-route,test-namespace/test-route",
+			expectedAnnotation: "other-namespace/other-route,HTTPRoute/test-namespace/test-route",
 			expectModification: true,
 		},
 		{
-			name: "route already exists in annotation",
+			name: "route already exists in annotation without kind",
 			existingAnnotations: map[string]string{
 				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
@@ -84,17 +95,33 @@ func TestAppendHTTPRouteToBindingAnnotations(t *testing.T) {
 			expectModification: false,
 		},
 		{
+			name: "route already exists in annotation with kind",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/test-namespace/test-route",
+			},
+			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
+			expectModification: false,
+		},
+		{
 			name: "multiple existing routes, adding new one",
 			existingAnnotations: map[string]string{
 				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1,ns2/route2",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "route3",
 					Namespace: "ns3",
 				},
 			},
-			expectedAnnotation: "ns1/route1,ns2/route2,ns3/route3",
+			expectedAnnotation: "ns1/route1,ns2/route2,HTTPRoute/ns3/route3",
 			expectModification: true,
 		},
 	}
@@ -138,6 +165,7 @@ func TestBindingForPluginAndRoute(t *testing.T) {
 			routeName:       "test-route",
 			existingBinding: nil,
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-httproute",
 					Namespace: "test-namespace",
@@ -164,7 +192,7 @@ func TestBindingForPluginAndRoute(t *testing.T) {
 				assert.Equal(t, "configuration.konghq.com", binding.Spec.Targets.RouteReference.Group)
 				assert.Equal(t, "KongRoute", binding.Spec.Targets.RouteReference.Kind)
 				assert.Contains(t, binding.Annotations, consts.GatewayOperatorHybridRoutesAnnotation)
-				assert.Equal(t, "test-namespace/test-httproute", binding.Annotations[consts.GatewayOperatorHybridRoutesAnnotation])
+				assert.Equal(t, "HTTPRoute/test-namespace/test-httproute", binding.Annotations[consts.GatewayOperatorHybridRoutesAnnotation])
 			},
 		},
 		{
@@ -172,6 +200,7 @@ func TestBindingForPluginAndRoute(t *testing.T) {
 			pluginName: "test-plugin-2",
 			routeName:  "test-route-2",
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-httproute-2",
 					Namespace: "test-namespace",

--- a/controller/hybridgateway/reconciler_utils_test.go
+++ b/controller/hybridgateway/reconciler_utils_test.go
@@ -291,7 +291,7 @@ func TestCleanOrphanedResources(t *testing.T) {
 						if annotations == nil {
 							annotations = make(map[string]string)
 						}
-						annotations[consts.GatewayOperatorHybridRoutesAnnotation] = "ns/httproute-owner"
+						annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation] = "ns/httproute-owner"
 						obj.SetAnnotations(annotations)
 
 						if extraFields {
@@ -386,7 +386,7 @@ func (f *fakeHTTPRouteConverter) HandleOrphanedResource(ctx context.Context, log
 		return true, nil
 	}
 
-	annotationValue, exists := annotations[consts.GatewayOperatorHybridRoutesAnnotation]
+	annotationValue, exists := annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation]
 	if !exists {
 		return true, nil
 	}

--- a/controller/hybridgateway/route/status_test.go
+++ b/controller/hybridgateway/route/status_test.go
@@ -773,7 +773,7 @@ func Test_BuildProgrammedCondition(t *testing.T) {
 		obj := &unstructured.Unstructured{}
 		obj.SetGroupVersionKind(gvk)
 		obj.SetAnnotations(map[string]string{
-			consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/default/route",
+			consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "default/route",
 		})
 		cond := map[string]any{"type": "Programmed", "status": "True"}
 		if !programmed {
@@ -787,7 +787,7 @@ func Test_BuildProgrammedCondition(t *testing.T) {
 		obj := &unstructured.Unstructured{}
 		obj.SetGroupVersionKind(gvk)
 		obj.SetAnnotations(map[string]string{
-			consts.GatewayOperatorHybridRoutesAnnotation: routeRef,
+			consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: routeRef,
 		})
 		cond := map[string]any{"type": "Programmed", "status": "True"}
 		if !programmed {

--- a/controller/hybridgateway/route/status_test.go
+++ b/controller/hybridgateway/route/status_test.go
@@ -762,6 +762,7 @@ func Test_BuildProgrammedCondition(t *testing.T) {
 	ctx := context.Background()
 	pRef := gwtypes.ParentReference{Name: "gw"}
 	route := &gwtypes.HTTPRoute{
+		TypeMeta:   metav1.TypeMeta{Kind: "HTTPRoute", APIVersion: "gateway.networking.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
 	}
 	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "FakeResource"}
@@ -772,7 +773,7 @@ func Test_BuildProgrammedCondition(t *testing.T) {
 		obj := &unstructured.Unstructured{}
 		obj.SetGroupVersionKind(gvk)
 		obj.SetAnnotations(map[string]string{
-			consts.GatewayOperatorHybridRoutesAnnotation: "default/route",
+			consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/default/route",
 		})
 		cond := map[string]any{"type": "Programmed", "status": "True"}
 		if !programmed {

--- a/controller/hybridgateway/service/service_test.go
+++ b/controller/hybridgateway/service/service_test.go
@@ -22,6 +22,13 @@ import (
 	"github.com/kong/kong-operator/v2/pkg/consts"
 )
 
+var (
+	httpRouteTypeMeta = metav1.TypeMeta{
+		Kind:       "HTTPRoute",
+		APIVersion: "gateway.networking.k8s.io/v1",
+	}
+)
+
 func TestServiceForRule(t *testing.T) {
 	ctx := context.Background()
 	logger := zap.New()
@@ -33,6 +40,7 @@ func TestServiceForRule(t *testing.T) {
 
 	// Create test HTTPRoute
 	httpRoute := &gwtypes.HTTPRoute{
+		TypeMeta: httpRouteTypeMeta,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
 			Namespace: "test-namespace",
@@ -77,7 +85,7 @@ func TestServiceForRule(t *testing.T) {
 		{
 			name:               "new service creation",
 			existingService:    nil,
-			expectedAnnotation: "test-namespace/test-route",
+			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
 			expectUpdate:       false,
 			expectedHost:       upstreamName,
 		},
@@ -89,7 +97,7 @@ func TestServiceForRule(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "test-namespace/test-route",
+			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
 			expectUpdate:       true,
 			expectedHost:       upstreamName,
 		},
@@ -100,11 +108,11 @@ func TestServiceForRule(t *testing.T) {
 					Name:      serviceName,
 					Namespace: "test-namespace",
 					Annotations: map[string]string{
-						consts.GatewayOperatorHybridRoutesAnnotation: "other-namespace/other-route",
+						consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/other-namespace/other-route",
 					},
 				},
 			},
-			expectedAnnotation: "other-namespace/other-route,test-namespace/test-route",
+			expectedAnnotation: "HTTPRoute/other-namespace/other-route,HTTPRoute/test-namespace/test-route",
 			expectUpdate:       true,
 			expectedHost:       upstreamName,
 		},
@@ -115,11 +123,11 @@ func TestServiceForRule(t *testing.T) {
 					Name:      serviceName,
 					Namespace: "test-namespace",
 					Annotations: map[string]string{
-						consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
+						consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/test-namespace/test-route",
 					},
 				},
 			},
-			expectedAnnotation: "test-namespace/test-route",
+			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
 			expectUpdate:       false,
 			expectedHost:       upstreamName,
 		},
@@ -130,11 +138,11 @@ func TestServiceForRule(t *testing.T) {
 					Name:      serviceName,
 					Namespace: "test-namespace",
 					Annotations: map[string]string{
-						consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1,ns2/route2",
+						consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/ns1/route1,HTTPRoute/ns2/route2",
 					},
 				},
 			},
-			expectedAnnotation: "ns1/route1,ns2/route2,test-namespace/test-route",
+			expectedAnnotation: "HTTPRoute/ns1/route1,HTTPRoute/ns2/route2,HTTPRoute/test-namespace/test-route",
 			expectUpdate:       true,
 			expectedHost:       upstreamName,
 		},

--- a/controller/hybridgateway/service/service_test.go
+++ b/controller/hybridgateway/service/service_test.go
@@ -97,7 +97,7 @@ func TestServiceForRule(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
+			expectedAnnotation: "test-namespace/test-route",
 			expectUpdate:       true,
 			expectedHost:       upstreamName,
 		},
@@ -108,11 +108,11 @@ func TestServiceForRule(t *testing.T) {
 					Name:      serviceName,
 					Namespace: "test-namespace",
 					Annotations: map[string]string{
-						consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/other-namespace/other-route",
+						consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "other-namespace/other-route",
 					},
 				},
 			},
-			expectedAnnotation: "HTTPRoute/other-namespace/other-route,HTTPRoute/test-namespace/test-route",
+			expectedAnnotation: "other-namespace/other-route,test-namespace/test-route",
 			expectUpdate:       true,
 			expectedHost:       upstreamName,
 		},
@@ -123,11 +123,11 @@ func TestServiceForRule(t *testing.T) {
 					Name:      serviceName,
 					Namespace: "test-namespace",
 					Annotations: map[string]string{
-						consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/test-namespace/test-route",
+						consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "test-namespace/test-route",
 					},
 				},
 			},
-			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
+			expectedAnnotation: "test-namespace/test-route",
 			expectUpdate:       false,
 			expectedHost:       upstreamName,
 		},
@@ -138,11 +138,11 @@ func TestServiceForRule(t *testing.T) {
 					Name:      serviceName,
 					Namespace: "test-namespace",
 					Annotations: map[string]string{
-						consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/ns1/route1,HTTPRoute/ns2/route2",
+						consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route1,ns2/route2",
 					},
 				},
 			},
-			expectedAnnotation: "HTTPRoute/ns1/route1,HTTPRoute/ns2/route2,HTTPRoute/test-namespace/test-route",
+			expectedAnnotation: "ns1/route1,ns2/route2,test-namespace/test-route",
 			expectUpdate:       true,
 			expectedHost:       upstreamName,
 		},
@@ -172,7 +172,7 @@ func TestServiceForRule(t *testing.T) {
 			// Check annotation
 			annotations := service.GetAnnotations()
 			assert.NotNil(t, annotations)
-			assert.Equal(t, tt.expectedAnnotation, annotations[consts.GatewayOperatorHybridRoutesAnnotation])
+			assert.Equal(t, tt.expectedAnnotation, annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation])
 		})
 	}
 }

--- a/controller/hybridgateway/service/service_test.go
+++ b/controller/hybridgateway/service/service_test.go
@@ -85,7 +85,7 @@ func TestServiceForRule(t *testing.T) {
 		{
 			name:               "new service creation",
 			existingService:    nil,
-			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
+			expectedAnnotation: "test-namespace/test-route",
 			expectUpdate:       false,
 			expectedHost:       upstreamName,
 		},

--- a/controller/hybridgateway/translator/translator.go
+++ b/controller/hybridgateway/translator/translator.go
@@ -68,7 +68,7 @@ func VerifyAndUpdate[T client.Object](
 	// See https://github.com/Kong/kong-operator/blob/main/docs/internal/hybridgateway/autogen-resource-naming.md for more details of
 	// how the resource are generated and associated with routes.
 	if exclusiveRoute {
-		if len(routes) > 1 || strings.TrimSpace(routes[0]) != metadata.ObjectToNameString(route) {
+		if len(routes) > 1 || !metadata.RouteAnnotationMatch(routes[0], route) {
 			err = fmt.Errorf("existing %s object %s/%s is associated with multiple routes %s",
 				obj.GetObjectKind().GroupVersionKind().Kind, existingObj.GetNamespace(), existingObj.GetName(), routesCSV)
 			log.Error(logger, err, "Tracking annotation exclusive source Route check failed")

--- a/controller/hybridgateway/translator/translator.go
+++ b/controller/hybridgateway/translator/translator.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
 	"github.com/kong/kong-operator/v2/controller/pkg/log"
-	"github.com/kong/kong-operator/v2/pkg/consts"
 )
 
 // VerifyAndUpdate verifies if the object passaed as parameter already exists or not in the cluster.
@@ -54,7 +53,10 @@ func VerifyAndUpdate[T client.Object](
 	}
 
 	// Update: verify and update the hybrid-routes annotation
-	routesCSV := existingObj.GetAnnotations()[consts.GatewayOperatorHybridRoutesAnnotation]
+	routeKind := route.GetObjectKind().GroupVersionKind().Kind
+	am := metadata.NewAnnotationManager(logger)
+	routeAnnotationKey := am.RouteAnnotationKeyForKind(routeKind)
+	routesCSV := existingObj.GetAnnotations()[routeAnnotationKey]
 	routes := strings.Split(routesCSV, ",")
 	if len(routes) == 0 {
 		err = fmt.Errorf("existing %s object %s/%s has empty hybrid-routes annotation",
@@ -77,8 +79,7 @@ func VerifyAndUpdate[T client.Object](
 	}
 
 	// Object exists, update annotation to include current route
-	am := metadata.NewAnnotationManager(logger)
-	am.SetRoutes(obj, am.GetRoutes(existingObj))
+	am.SetRoutesWithKind(obj, routeKind, am.GetRoutesWithKind(existingObj, routeKind))
 	am.AppendRouteToAnnotation(obj, route)
 
 	return true, nil

--- a/controller/hybridgateway/upstream/upstream_test.go
+++ b/controller/hybridgateway/upstream/upstream_test.go
@@ -46,13 +46,13 @@ func TestAppendHTTPRouteToAnnotations(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
+			expectedAnnotation: "test-namespace/test-route",
 			expectModification: true,
 		},
 		{
 			name: "empty hybrid-routes annotation",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -61,13 +61,13 @@ func TestAppendHTTPRouteToAnnotations(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
+			expectedAnnotation: "test-namespace/test-route",
 			expectModification: true,
 		},
 		{
 			name: "existing different route in annotation",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "other-namespace/other-route",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "other-namespace/other-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -76,13 +76,13 @@ func TestAppendHTTPRouteToAnnotations(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "other-namespace/other-route,HTTPRoute/test-namespace/test-route",
+			expectedAnnotation: "other-namespace/other-route,test-namespace/test-route",
 			expectModification: true,
 		},
 		{
 			name: "route already exists in annotation",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "test-namespace/test-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -97,7 +97,7 @@ func TestAppendHTTPRouteToAnnotations(t *testing.T) {
 		{
 			name: "multiple existing routes, adding new one",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1,HTTPRoute/ns2/route2",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route1,HTTPRoute/ns2/route2",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -123,7 +123,7 @@ func TestAppendHTTPRouteToAnnotations(t *testing.T) {
 
 			am := metadata.NewAnnotationManager(logger)
 			am.AppendRouteToAnnotation(upstream, tt.httpRoute)
-			actualAnnotation := upstream.Annotations[consts.GatewayOperatorHybridRoutesAnnotation]
+			actualAnnotation := upstream.Annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation]
 			assert.Equal(t, tt.expectedAnnotation, actualAnnotation)
 		})
 	}
@@ -156,7 +156,7 @@ func TestRemoveHTTPRouteFromAnnotations(t *testing.T) {
 		{
 			name: "route not in annotation",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "other-namespace/other-route",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "other-namespace/other-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -171,7 +171,7 @@ func TestRemoveHTTPRouteFromAnnotations(t *testing.T) {
 		{
 			name: "remove only route - annotation should be deleted",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "test-namespace/test-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -187,7 +187,7 @@ func TestRemoveHTTPRouteFromAnnotations(t *testing.T) {
 		{
 			name: "remove first route from multiple",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route,ns2/route2",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "test-namespace/test-route,ns2/route2",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -202,22 +202,7 @@ func TestRemoveHTTPRouteFromAnnotations(t *testing.T) {
 		{
 			name: "remove middle route from multiple",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1,test-namespace/test-route,ns3/route3",
-			},
-			httpRoute: &gwtypes.HTTPRoute{
-				TypeMeta: httpRouteTypeMeta,
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-route",
-					Namespace: "test-namespace",
-				},
-			},
-			expectedAnnotation: "ns1/route1,ns3/route3",
-			expectModification: true,
-		},
-		{
-			name: "remove annotation with kind",
-			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1,HTTPRoute/test-namespace/test-route,ns3/route3",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route1,test-namespace/test-route,ns3/route3",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -232,7 +217,8 @@ func TestRemoveHTTPRouteFromAnnotations(t *testing.T) {
 		{
 			name: "same namespace and name but different kind",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "TLSRoute/test-namespace/test-route,ns1/route1",
+				consts.GatewayOperatorHybridRoutesTLSRouteAnnotation:  "test-namespace/test-route,ns1/route1",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "other-namespace/other-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -241,7 +227,7 @@ func TestRemoveHTTPRouteFromAnnotations(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "TLSRoute/test-namespace/test-route,ns1/route1",
+			expectedAnnotation: "other-namespace/other-route",
 			expectModification: false,
 		},
 	}
@@ -266,10 +252,10 @@ func TestRemoveHTTPRouteFromAnnotations(t *testing.T) {
 			assert.Equal(t, tt.expectModification, modified)
 
 			if tt.expectAnnotationDeleted {
-				_, exists := upstream.Annotations[consts.GatewayOperatorHybridRoutesAnnotation]
+				_, exists := upstream.Annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation]
 				assert.False(t, exists, "annotation should be deleted")
 			} else if tt.expectedAnnotation != "" {
-				actualAnnotation := upstream.Annotations[consts.GatewayOperatorHybridRoutesAnnotation]
+				actualAnnotation := upstream.Annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation]
 				assert.Equal(t, tt.expectedAnnotation, actualAnnotation)
 			}
 		})
@@ -322,7 +308,7 @@ func TestUpstreamForRule_NewUpstream(t *testing.T) {
 	require.NotNil(t, upstream)
 
 	// Verify the upstream has the expected annotation
-	expectedAnnotation := "HTTPRoute/test-namespace/test-route"
-	actualAnnotation := upstream.Annotations[consts.GatewayOperatorHybridRoutesAnnotation]
+	expectedAnnotation := "test-namespace/test-route"
+	actualAnnotation := upstream.Annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation]
 	assert.Equal(t, expectedAnnotation, actualAnnotation)
 }

--- a/controller/hybridgateway/upstream/upstream_test.go
+++ b/controller/hybridgateway/upstream/upstream_test.go
@@ -19,6 +19,13 @@ import (
 	"github.com/kong/kong-operator/v2/pkg/consts"
 )
 
+var (
+	httpRouteTypeMeta = metav1.TypeMeta{
+		Kind:       "HTTPRoute",
+		APIVersion: "gateway.networking.k8s.io/v1",
+	}
+)
+
 func TestAppendHTTPRouteToAnnotations(t *testing.T) {
 	logger := logr.Discard()
 
@@ -33,12 +40,13 @@ func TestAppendHTTPRouteToAnnotations(t *testing.T) {
 			name:                "no existing annotations",
 			existingAnnotations: nil,
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "test-namespace/test-route",
+			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
 			expectModification: true,
 		},
 		{
@@ -47,12 +55,13 @@ func TestAppendHTTPRouteToAnnotations(t *testing.T) {
 				consts.GatewayOperatorHybridRoutesAnnotation: "",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "test-namespace/test-route",
+			expectedAnnotation: "HTTPRoute/test-namespace/test-route",
 			expectModification: true,
 		},
 		{
@@ -61,12 +70,13 @@ func TestAppendHTTPRouteToAnnotations(t *testing.T) {
 				consts.GatewayOperatorHybridRoutesAnnotation: "other-namespace/other-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
 				},
 			},
-			expectedAnnotation: "other-namespace/other-route,test-namespace/test-route",
+			expectedAnnotation: "other-namespace/other-route,HTTPRoute/test-namespace/test-route",
 			expectModification: true,
 		},
 		{
@@ -75,6 +85,7 @@ func TestAppendHTTPRouteToAnnotations(t *testing.T) {
 				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
@@ -86,15 +97,16 @@ func TestAppendHTTPRouteToAnnotations(t *testing.T) {
 		{
 			name: "multiple existing routes, adding new one",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1,ns2/route2",
+				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1,HTTPRoute/ns2/route2",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "route3",
 					Namespace: "ns3",
 				},
 			},
-			expectedAnnotation: "ns1/route1,ns2/route2,ns3/route3",
+			expectedAnnotation: "ns1/route1,HTTPRoute/ns2/route2,HTTPRoute/ns3/route3",
 			expectModification: true,
 		},
 	}
@@ -132,6 +144,7 @@ func TestRemoveHTTPRouteFromAnnotations(t *testing.T) {
 			name:                "no annotations",
 			existingAnnotations: nil,
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
@@ -146,6 +159,7 @@ func TestRemoveHTTPRouteFromAnnotations(t *testing.T) {
 				consts.GatewayOperatorHybridRoutesAnnotation: "other-namespace/other-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
@@ -160,6 +174,7 @@ func TestRemoveHTTPRouteFromAnnotations(t *testing.T) {
 				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
@@ -175,6 +190,7 @@ func TestRemoveHTTPRouteFromAnnotations(t *testing.T) {
 				consts.GatewayOperatorHybridRoutesAnnotation: "test-namespace/test-route,ns2/route2",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
@@ -189,6 +205,7 @@ func TestRemoveHTTPRouteFromAnnotations(t *testing.T) {
 				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1,test-namespace/test-route,ns3/route3",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "test-namespace",
@@ -196,6 +213,36 @@ func TestRemoveHTTPRouteFromAnnotations(t *testing.T) {
 			},
 			expectedAnnotation: "ns1/route1,ns3/route3",
 			expectModification: true,
+		},
+		{
+			name: "remove annotation with kind",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesAnnotation: "ns1/route1,HTTPRoute/test-namespace/test-route,ns3/route3",
+			},
+			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			expectedAnnotation: "ns1/route1,ns3/route3",
+			expectModification: true,
+		},
+		{
+			name: "same namespace and name but different kind",
+			existingAnnotations: map[string]string{
+				consts.GatewayOperatorHybridRoutesAnnotation: "TLSRoute/test-namespace/test-route,ns1/route1",
+			},
+			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			expectedAnnotation: "TLSRoute/test-namespace/test-route,ns1/route1",
+			expectModification: false,
 		},
 	}
 
@@ -238,6 +285,7 @@ func TestUpstreamForRule_NewUpstream(t *testing.T) {
 	ctx := context.Background()
 
 	httpRoute := &gwtypes.HTTPRoute{
+		TypeMeta: httpRouteTypeMeta,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
 			Namespace: "test-namespace",
@@ -274,7 +322,7 @@ func TestUpstreamForRule_NewUpstream(t *testing.T) {
 	require.NotNil(t, upstream)
 
 	// Verify the upstream has the expected annotation
-	expectedAnnotation := "test-namespace/test-route"
+	expectedAnnotation := "HTTPRoute/test-namespace/test-route"
 	actualAnnotation := upstream.Annotations[consts.GatewayOperatorHybridRoutesAnnotation]
 	assert.Equal(t, expectedAnnotation, actualAnnotation)
 }

--- a/controller/hybridgateway/upstream/upstream_test.go
+++ b/controller/hybridgateway/upstream/upstream_test.go
@@ -97,7 +97,7 @@ func TestAppendHTTPRouteToAnnotations(t *testing.T) {
 		{
 			name: "multiple existing routes, adding new one",
 			existingAnnotations: map[string]string{
-				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route1,HTTPRoute/ns2/route2",
+				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route1,ns2/route2",
 			},
 			httpRoute: &gwtypes.HTTPRoute{
 				TypeMeta: httpRouteTypeMeta,
@@ -106,7 +106,7 @@ func TestAppendHTTPRouteToAnnotations(t *testing.T) {
 					Namespace: "ns3",
 				},
 			},
-			expectedAnnotation: "ns1/route1,HTTPRoute/ns2/route2,HTTPRoute/ns3/route3",
+			expectedAnnotation: "ns1/route1,ns2/route2,ns3/route3",
 			expectModification: true,
 		},
 	}

--- a/controller/hybridgateway/watch/mapfuncs_gateway_route.go
+++ b/controller/hybridgateway/watch/mapfuncs_gateway_route.go
@@ -40,13 +40,14 @@ type kongResource interface {
 // MapRouteForKongResource returns a handler.MapFunc that, given a Kong resource object of type T,
 // retrieves the routes referenced in its annotations. It returns a slice of reconcile.Requests
 // for each matching route.
-func MapRouteForKongResource[T kongResource](cl client.Client, kind string) handler.MapFunc {
+func MapRouteForKongResource[T kongResource](kind string) handler.MapFunc {
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {
 		_, ok := obj.(T)
 		if !ok {
 			return nil
 		}
 
+		// am.GetRoutes adds the `HTTPRoute/` prefix for annotations in namespace/name format used in KO 2.1.
 		am := metadata.NewAnnotationManager(logr.Discard())
 		routes := am.GetRoutes(obj)
 		if len(routes) == 0 {
@@ -55,12 +56,11 @@ func MapRouteForKongResource[T kongResource](cl client.Client, kind string) hand
 
 		var requests []reconcile.Request
 		for _, r := range routes {
-			if strings.HasPrefix(r, kind+"/") {
+			if objectKeyStr, ok := strings.CutPrefix(r, kind+"/"); ok {
 				requests = append(requests, reconcile.Request{
-					NamespacedName: metadata.NameStringToObjectKey(strings.TrimPrefix(r, kind+"/")),
+					NamespacedName: metadata.NameStringToObjectKey(objectKeyStr),
 				})
 			}
-
 		}
 		return requests
 	}

--- a/controller/hybridgateway/watch/mapfuncs_gateway_route.go
+++ b/controller/hybridgateway/watch/mapfuncs_gateway_route.go
@@ -2,6 +2,7 @@ package watch
 
 import (
 	"context"
+	"strings"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -19,6 +20,12 @@ import (
 
 // This file is for map functions shared by all supported routes in gateway APIs.
 
+const (
+	// REVIEW: define the kinds in some common packages?
+	kindHTTPRoute = "HTTPRoute"
+	kindTLSRoute  = "TLSRoute"
+)
+
 // kongResource is a type constraint that encompasses all Kong resource types
 // that can be mapped back to routes with supported type via annotations.
 type kongResource interface {
@@ -33,7 +40,7 @@ type kongResource interface {
 // MapRouteForKongResource returns a handler.MapFunc that, given a Kong resource object of type T,
 // retrieves the routes referenced in its annotations. It returns a slice of reconcile.Requests
 // for each matching route.
-func MapRouteForKongResource[T kongResource](cl client.Client) handler.MapFunc {
+func MapRouteForKongResource[T kongResource](cl client.Client, kind string) handler.MapFunc {
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {
 		_, ok := obj.(T)
 		if !ok {
@@ -48,9 +55,12 @@ func MapRouteForKongResource[T kongResource](cl client.Client) handler.MapFunc {
 
 		var requests []reconcile.Request
 		for _, r := range routes {
-			requests = append(requests, reconcile.Request{
-				NamespacedName: metadata.NameStringToObjectKey(r),
-			})
+			if strings.HasPrefix(r, kind+"/") {
+				requests = append(requests, reconcile.Request{
+					NamespacedName: metadata.NameStringToObjectKey(strings.TrimPrefix(r, kind+"/")),
+				})
+			}
+
 		}
 		return requests
 	}

--- a/controller/hybridgateway/watch/mapfuncs_gateway_route.go
+++ b/controller/hybridgateway/watch/mapfuncs_gateway_route.go
@@ -2,9 +2,9 @@ package watch
 
 import (
 	"context"
-	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,22 +47,18 @@ func MapRouteForKongResource[T kongResource](kind string) handler.MapFunc {
 			return nil
 		}
 
-		// am.GetRoutes adds the `HTTPRoute/` prefix for annotations in namespace/name format used in KO 2.1.
 		am := metadata.NewAnnotationManager(logr.Discard())
-		routes := am.GetRoutes(obj)
+		routes := am.GetRoutesWithKind(obj, kind)
 		if len(routes) == 0 {
 			return nil
 		}
 
-		var requests []reconcile.Request
-		for _, r := range routes {
-			if objectKeyStr, ok := strings.CutPrefix(r, kind+"/"); ok {
-				requests = append(requests, reconcile.Request{
-					NamespacedName: metadata.NameStringToObjectKey(objectKeyStr),
-				})
+		return lo.Map(routes, func(routeKey string, _ int) reconcile.Request {
+			return reconcile.Request{
+				NamespacedName: metadata.NameStringToObjectKey(routeKey),
 			}
-		}
-		return requests
+		})
+
 	}
 }
 

--- a/controller/hybridgateway/watch/mapfuncs_gateway_route_test.go
+++ b/controller/hybridgateway/watch/mapfuncs_gateway_route_test.go
@@ -459,22 +459,7 @@ func TestMapRouteForKongResource_HTTPRoute(t *testing.T) {
 					Name:      "test-obj",
 					Namespace: "test-ns",
 					Annotations: map[string]string{
-						consts.GatewayOperatorHybridRoutesAnnotation: "test-ns/test-httproute",
-					},
-				},
-			},
-			expectedRequests: []reconcile.Request{
-				{NamespacedName: types.NamespacedName{Namespace: "test-ns", Name: "test-httproute"}},
-			},
-		},
-		{
-			name: "single route with kind",
-			obj: &configurationv1alpha1.KongUpstream{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-obj",
-					Namespace: "test-ns",
-					Annotations: map[string]string{
-						consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/test-ns/test-httproute",
+						consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "test-ns/test-httproute",
 					},
 				},
 			},
@@ -489,7 +474,7 @@ func TestMapRouteForKongResource_HTTPRoute(t *testing.T) {
 					Name:      "test-obj",
 					Namespace: "test-ns",
 					Annotations: map[string]string{
-						consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/ns1/route-1,HTTPRoute/ns2/route-2",
+						consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route-1,ns2/route-2",
 					},
 				},
 			},
@@ -505,7 +490,8 @@ func TestMapRouteForKongResource_HTTPRoute(t *testing.T) {
 					Name:      "test-obj",
 					Namespace: "test-ns",
 					Annotations: map[string]string{
-						consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/ns1/route-1,TLSRoute/ns2/route-2",
+						consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route-1",
+						consts.GatewayOperatorHybridRoutesTLSRouteAnnotation:  "ns2/route-2",
 					},
 				},
 			},
@@ -551,26 +537,13 @@ func TestMapRouteForKongResource_TLSRoute(t *testing.T) {
 			expectedRequests: []reconcile.Request{},
 		},
 		{
-			name: "single route without kind",
+			name: "single route",
 			obj: &configurationv1alpha1.KongUpstream{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-obj",
 					Namespace: "test-ns",
 					Annotations: map[string]string{
-						consts.GatewayOperatorHybridRoutesAnnotation: "test-ns/test-route",
-					},
-				},
-			},
-			expectedRequests: []reconcile.Request{},
-		},
-		{
-			name: "single route with kind",
-			obj: &configurationv1alpha1.KongUpstream{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-obj",
-					Namespace: "test-ns",
-					Annotations: map[string]string{
-						consts.GatewayOperatorHybridRoutesAnnotation: "TLSRoute/test-ns/test-route",
+						consts.GatewayOperatorHybridRoutesTLSRouteAnnotation: "test-ns/test-route",
 					},
 				},
 			},
@@ -585,7 +558,7 @@ func TestMapRouteForKongResource_TLSRoute(t *testing.T) {
 					Name:      "test-obj",
 					Namespace: "test-ns",
 					Annotations: map[string]string{
-						consts.GatewayOperatorHybridRoutesAnnotation: "TLSRoute/ns1/route-1,TLSRoute/ns2/route-2",
+						consts.GatewayOperatorHybridRoutesTLSRouteAnnotation: "ns1/route-1,ns2/route-2",
 					},
 				},
 			},
@@ -601,7 +574,8 @@ func TestMapRouteForKongResource_TLSRoute(t *testing.T) {
 					Name:      "test-obj",
 					Namespace: "test-ns",
 					Annotations: map[string]string{
-						consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/ns1/route-1,TLSRoute/ns2/route-2",
+						consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns1/route-1",
+						consts.GatewayOperatorHybridRoutesTLSRouteAnnotation:  "ns2/route-2",
 					},
 				},
 			},

--- a/controller/hybridgateway/watch/mapfuncs_gateway_route_test.go
+++ b/controller/hybridgateway/watch/mapfuncs_gateway_route_test.go
@@ -11,12 +11,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/internal/utils/index"
+	"github.com/kong/kong-operator/v2/pkg/consts"
 )
 
 // partialErrorClient simulates a client.Client that returns an error only when listing HTTPRoutes for a Gateway.
@@ -419,4 +423,198 @@ func Test_MapRouteForEndpointSlice(t *testing.T) {
 		requests := mapFuncErrList(ctx, obj)
 		require.Nil(t, requests)
 	})
+}
+
+func TestMapRouteForKongResource_HTTPRoute(t *testing.T) {
+
+	testCases := []struct {
+		name             string
+		obj              client.Object
+		expectedRequests []reconcile.Request
+	}{
+		{
+			name: "no annotation",
+			obj: &configurationv1alpha1.KongUpstream{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-obj",
+					Namespace: "test-ns",
+				},
+			},
+			expectedRequests: []reconcile.Request{},
+		},
+		{
+			name: "unmatched source object type",
+			obj: &configurationv1alpha1.KongTarget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-obj",
+					Namespace: "test-ns",
+				},
+			},
+			expectedRequests: []reconcile.Request{},
+		},
+		{
+			name: "single route without kind",
+			obj: &configurationv1alpha1.KongUpstream{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-obj",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						consts.GatewayOperatorHybridRoutesAnnotation: "test-ns/test-httproute",
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: "test-ns", Name: "test-httproute"}},
+			},
+		},
+		{
+			name: "single route with kind",
+			obj: &configurationv1alpha1.KongUpstream{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-obj",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/test-ns/test-httproute",
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: "test-ns", Name: "test-httproute"}},
+			},
+		},
+		{
+			name: "multiple routes",
+			obj: &configurationv1alpha1.KongUpstream{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-obj",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/ns1/route-1,HTTPRoute/ns2/route-2",
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "route-1"}},
+				{NamespacedName: types.NamespacedName{Namespace: "ns2", Name: "route-2"}},
+			},
+		},
+		{
+			name: "multiple routes with unmatched kind",
+			obj: &configurationv1alpha1.KongUpstream{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-obj",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/ns1/route-1,TLSRoute/ns2/route-2",
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "route-1"}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			requests := MapRouteForKongResource[*configurationv1alpha1.KongUpstream](kindHTTPRoute)(context.Background(), tc.obj)
+			require.ElementsMatch(t, tc.expectedRequests, requests)
+		})
+	}
+}
+
+func TestMapRouteForKongResource_TLSRoute(t *testing.T) {
+
+	testCases := []struct {
+		name             string
+		obj              client.Object
+		expectedRequests []reconcile.Request
+	}{
+		{
+			name: "no annotation",
+			obj: &configurationv1alpha1.KongUpstream{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-obj",
+					Namespace: "test-ns",
+				},
+			},
+			expectedRequests: []reconcile.Request{},
+		},
+		{
+			name: "unmatched source object type",
+			obj: &configurationv1alpha1.KongTarget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-obj",
+					Namespace: "test-ns",
+				},
+			},
+			expectedRequests: []reconcile.Request{},
+		},
+		{
+			name: "single route without kind",
+			obj: &configurationv1alpha1.KongUpstream{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-obj",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						consts.GatewayOperatorHybridRoutesAnnotation: "test-ns/test-route",
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{},
+		},
+		{
+			name: "single route with kind",
+			obj: &configurationv1alpha1.KongUpstream{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-obj",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						consts.GatewayOperatorHybridRoutesAnnotation: "TLSRoute/test-ns/test-route",
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: "test-ns", Name: "test-route"}},
+			},
+		},
+		{
+			name: "multiple routes",
+			obj: &configurationv1alpha1.KongUpstream{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-obj",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						consts.GatewayOperatorHybridRoutesAnnotation: "TLSRoute/ns1/route-1,TLSRoute/ns2/route-2",
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "route-1"}},
+				{NamespacedName: types.NamespacedName{Namespace: "ns2", Name: "route-2"}},
+			},
+		},
+		{
+			name: "multiple routes with unmatched kind",
+			obj: &configurationv1alpha1.KongUpstream{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-obj",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						consts.GatewayOperatorHybridRoutesAnnotation: "HTTPRoute/ns1/route-1,TLSRoute/ns2/route-2",
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: "ns2", Name: "route-2"}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			requests := MapRouteForKongResource[*configurationv1alpha1.KongUpstream](kindTLSRoute)(context.Background(), tc.obj)
+			require.ElementsMatch(t, tc.expectedRequests, requests)
+		})
+	}
 }

--- a/controller/hybridgateway/watch/mapfuncs_httproute.go
+++ b/controller/hybridgateway/watch/mapfuncs_httproute.go
@@ -102,7 +102,7 @@ func MapHTTPRouteForKongPlugin(cl client.Client) handler.MapFunc {
 		}
 
 		// Add requests for Plugins referencing the HTTPRoute via annotation.
-		requests := MapRouteForKongResource[*configurationv1.KongPlugin](cl)(ctx, obj)
+		requests := MapRouteForKongResource[*configurationv1.KongPlugin](cl, kindHTTPRoute)(ctx, obj)
 		return append(requests, indexRequests...)
 	}
 }

--- a/controller/hybridgateway/watch/mapfuncs_httproute.go
+++ b/controller/hybridgateway/watch/mapfuncs_httproute.go
@@ -102,7 +102,7 @@ func MapHTTPRouteForKongPlugin(cl client.Client) handler.MapFunc {
 		}
 
 		// Add requests for Plugins referencing the HTTPRoute via annotation.
-		requests := MapRouteForKongResource[*configurationv1.KongPlugin](cl, kindHTTPRoute)(ctx, obj)
+		requests := MapRouteForKongResource[*configurationv1.KongPlugin](kindHTTPRoute)(ctx, obj)
 		return append(requests, indexRequests...)
 	}
 }

--- a/controller/hybridgateway/watch/watch.go
+++ b/controller/hybridgateway/watch/watch.go
@@ -42,19 +42,19 @@ func Watches(obj client.Object, cl client.Client) []Watcher {
 				&discoveryv1.EndpointSlice{},
 			},
 			{
-				MapRouteForKongResource[*configurationv1alpha1.KongUpstream](cl, kindHTTPRoute),
+				MapRouteForKongResource[*configurationv1alpha1.KongUpstream](kindHTTPRoute),
 				&configurationv1alpha1.KongUpstream{},
 			},
 			{
-				MapRouteForKongResource[*configurationv1alpha1.KongTarget](cl, kindHTTPRoute),
+				MapRouteForKongResource[*configurationv1alpha1.KongTarget](kindHTTPRoute),
 				&configurationv1alpha1.KongTarget{},
 			},
 			{
-				MapRouteForKongResource[*configurationv1alpha1.KongService](cl, kindHTTPRoute),
+				MapRouteForKongResource[*configurationv1alpha1.KongService](kindHTTPRoute),
 				&configurationv1alpha1.KongService{},
 			},
 			{
-				MapRouteForKongResource[*configurationv1alpha1.KongRoute](cl, kindHTTPRoute),
+				MapRouteForKongResource[*configurationv1alpha1.KongRoute](kindHTTPRoute),
 				&configurationv1alpha1.KongRoute{},
 			},
 			{
@@ -62,7 +62,7 @@ func Watches(obj client.Object, cl client.Client) []Watcher {
 				&configurationv1.KongPlugin{},
 			},
 			{
-				MapRouteForKongResource[*configurationv1alpha1.KongPluginBinding](cl, kindHTTPRoute),
+				MapRouteForKongResource[*configurationv1alpha1.KongPluginBinding](kindHTTPRoute),
 				&configurationv1alpha1.KongPluginBinding{},
 			},
 			{
@@ -89,19 +89,19 @@ func Watches(obj client.Object, cl client.Client) []Watcher {
 				&discoveryv1.EndpointSlice{},
 			},
 			{
-				MapRouteForKongResource[*configurationv1alpha1.KongUpstream](cl, kindTLSRoute),
+				MapRouteForKongResource[*configurationv1alpha1.KongUpstream](kindTLSRoute),
 				&configurationv1alpha1.KongUpstream{},
 			},
 			{
-				MapRouteForKongResource[*configurationv1alpha1.KongTarget](cl, kindTLSRoute),
+				MapRouteForKongResource[*configurationv1alpha1.KongTarget](kindTLSRoute),
 				&configurationv1alpha1.KongTarget{},
 			},
 			{
-				MapRouteForKongResource[*configurationv1alpha1.KongService](cl, kindTLSRoute),
+				MapRouteForKongResource[*configurationv1alpha1.KongService](kindTLSRoute),
 				&configurationv1alpha1.KongService{},
 			},
 			{
-				MapRouteForKongResource[*configurationv1alpha1.KongRoute](cl, kindTLSRoute),
+				MapRouteForKongResource[*configurationv1alpha1.KongRoute](kindTLSRoute),
 				&configurationv1alpha1.KongRoute{},
 			},
 			{

--- a/controller/hybridgateway/watch/watch.go
+++ b/controller/hybridgateway/watch/watch.go
@@ -42,19 +42,19 @@ func Watches(obj client.Object, cl client.Client) []Watcher {
 				&discoveryv1.EndpointSlice{},
 			},
 			{
-				MapRouteForKongResource[*configurationv1alpha1.KongUpstream](cl),
+				MapRouteForKongResource[*configurationv1alpha1.KongUpstream](cl, kindHTTPRoute),
 				&configurationv1alpha1.KongUpstream{},
 			},
 			{
-				MapRouteForKongResource[*configurationv1alpha1.KongTarget](cl),
+				MapRouteForKongResource[*configurationv1alpha1.KongTarget](cl, kindHTTPRoute),
 				&configurationv1alpha1.KongTarget{},
 			},
 			{
-				MapRouteForKongResource[*configurationv1alpha1.KongService](cl),
+				MapRouteForKongResource[*configurationv1alpha1.KongService](cl, kindHTTPRoute),
 				&configurationv1alpha1.KongService{},
 			},
 			{
-				MapRouteForKongResource[*configurationv1alpha1.KongRoute](cl),
+				MapRouteForKongResource[*configurationv1alpha1.KongRoute](cl, kindHTTPRoute),
 				&configurationv1alpha1.KongRoute{},
 			},
 			{
@@ -62,7 +62,7 @@ func Watches(obj client.Object, cl client.Client) []Watcher {
 				&configurationv1.KongPlugin{},
 			},
 			{
-				MapRouteForKongResource[*configurationv1alpha1.KongPluginBinding](cl),
+				MapRouteForKongResource[*configurationv1alpha1.KongPluginBinding](cl, kindHTTPRoute),
 				&configurationv1alpha1.KongPluginBinding{},
 			},
 			{
@@ -89,19 +89,19 @@ func Watches(obj client.Object, cl client.Client) []Watcher {
 				&discoveryv1.EndpointSlice{},
 			},
 			{
-				MapRouteForKongResource[*configurationv1alpha1.KongUpstream](cl),
+				MapRouteForKongResource[*configurationv1alpha1.KongUpstream](cl, kindTLSRoute),
 				&configurationv1alpha1.KongUpstream{},
 			},
 			{
-				MapRouteForKongResource[*configurationv1alpha1.KongTarget](cl),
+				MapRouteForKongResource[*configurationv1alpha1.KongTarget](cl, kindTLSRoute),
 				&configurationv1alpha1.KongTarget{},
 			},
 			{
-				MapRouteForKongResource[*configurationv1alpha1.KongService](cl),
+				MapRouteForKongResource[*configurationv1alpha1.KongService](cl, kindTLSRoute),
 				&configurationv1alpha1.KongService{},
 			},
 			{
-				MapRouteForKongResource[*configurationv1alpha1.KongRoute](cl),
+				MapRouteForKongResource[*configurationv1alpha1.KongRoute](cl, kindTLSRoute),
 				&configurationv1alpha1.KongRoute{},
 			},
 			{

--- a/pkg/consts/hybridgateway.go
+++ b/pkg/consts/hybridgateway.go
@@ -26,14 +26,23 @@ const (
 	// are associated with the resource.
 	GatewayOperatorHybridGatewaysAnnotation = OperatorAnnotationPrefix + HybridGatewaysAnnotation
 
-	// HybridRouteAnnotation is used to annotate resources created for hybrid gateways,
-	// indicating which route is associated with the resource.
-	HybridRouteAnnotation = "hybrid-routes"
+	// HybridRouteHTTPRouteAnnotation is used to annotate resources created for hybrid gateways,
+	// indicating which HTTPRoute is associated with the resource.
+	HybridRouteHTTPRouteAnnotation = "hybrid-routes"
 
-	// GatewayOperatorHybridRoutesAnnotation is the fully qualified annotation key
-	// used to annotate resources created for hybrid gateways, indicating which route
+	// HybridRouteTLSRouteAnnotation is used to annotate resources created for hybrid gateways,
+	// indicating which TLSRoutes are associated with the resource.
+	HybridRouteTLSRouteAnnotation = "hybrid-routes-TLSRoute"
+
+	// GatewayOperatorHybridRoutesHTTPRouteAnnotation is the fully qualified annotation key
+	// used to annotate resources created for hybrid gateways, indicating which HTTPRoute
 	// is associated with the resource.
-	GatewayOperatorHybridRoutesAnnotation = OperatorAnnotationPrefix + HybridRouteAnnotation
+	GatewayOperatorHybridRoutesHTTPRouteAnnotation = OperatorAnnotationPrefix + HybridRouteHTTPRouteAnnotation
+
+	// GatewayOperatorHybridRoutesTLSRouteAnnotation is the fully qualified annotation key
+	// used to annotate resources created for hybrid gateways, indicating which TLSRoute
+	// is associated with the resource.
+	GatewayOperatorHybridRoutesTLSRouteAnnotation = OperatorAnnotationPrefix + HybridRouteTLSRouteAnnotation
 
 	// GatewayOperatorHybridListenerPortLabel is the fully qualified label key
 	// used to label resources created for hybrid gateways, indicating the listener port


### PR DESCRIPTION
**What this PR does / why we need it**:

Change the annotation in genreated resources for Kong/Konnect entities for marking parent route to include the kind of the route in its key(s). 

For example, if the a `KongService` is translated from a `TLSRoute` `test-ns/test-route`, there will be an annotation `konghq.com/hybrid-route-TLSRoute=test-ns/test-route`. For `HTTPRoute`s, the `konghq.com/hybrid-route` is kept unchanged for backward compatibility with KO 2.1.

**Which issue this PR fixes**

Fixes #3747
**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
