### PR TITLE
fix: don't flap DataPlane ready status on rolling update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,10 +141,17 @@
   [#5284](https://github.com/Kong/kong-operator/pull/5284)
 - `DataPlane`: the `Ready` status condition no longer flaps to `False` while a
   rolling update is in progress and the old `Deployment` replicas are still
-  serving. Its `observedGeneration` now only advances once the `Deployment`
-  has fully rolled out the new generation, and `Ready` is set to `False` if
-  Kubernetes reports the rollout as stalled
-  (`Progressing=False`/`ProgressDeadlineExceeded`).
+  serving. A new `DeploymentRolledOut` status condition reports separately
+  whether the live `Deployment` has fully rolled out the generation reported
+  in its `observedGeneration`, and is set to `False` with reason
+  `ProgressDeadlineExceeded` if Kubernetes reports the rollout as stalled.
+  `Ready.observedGeneration` always reports the generation it was computed
+  for; it no longer lags to signal an in-progress rollout. Consumers that
+  previously waited for `Ready=True && observedGeneration==metadata.generation`
+  to mean "the current spec has fully rolled out" should switch to
+  `DeploymentRolledOut=True && observedGeneration==metadata.generation`
+  instead, which can take up to `progressDeadlineSeconds` (Kubernetes default
+  600s) to resolve if the rollout stalls.
   [#3909](https://github.com/Kong/kong-operator/pull/3909)
 
 ## [v2.3.0-rc.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,13 @@
 - Fix Gateway API routes becoming transiently unaccepted and removed from dataplane
   when listener is intermittently marked as Programmed=False.
   [#5237](https://github.com/Kong/kong-operator/pull/5237)
+- `DataPlane`: the `Ready` status condition no longer flaps to `False` while a
+  rolling update is in progress and the old `Deployment` replicas are still
+  serving. Its `observedGeneration` now only advances once the `Deployment`
+  has fully rolled out the new generation, and `Ready` is set to `False` if
+  Kubernetes reports the rollout as stalled
+  (`Progressing=False`/`ProgressDeadlineExceeded`).
+  [#3909](https://github.com/Kong/kong-operator/pull/3909)
 
 ## [v2.3.0-rc.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,10 +118,17 @@
   [#5237](https://github.com/Kong/kong-operator/pull/5237)
 - `DataPlane`: the `Ready` status condition no longer flaps to `False` while a
   rolling update is in progress and the old `Deployment` replicas are still
-  serving. Its `observedGeneration` now only advances once the `Deployment`
-  has fully rolled out the new generation, and `Ready` is set to `False` if
-  Kubernetes reports the rollout as stalled
-  (`Progressing=False`/`ProgressDeadlineExceeded`).
+  serving. A new `DeploymentRolledOut` status condition reports separately
+  whether the live `Deployment` has fully rolled out the generation reported
+  in its `observedGeneration`, and is set to `False` with reason
+  `ProgressDeadlineExceeded` if Kubernetes reports the rollout as stalled.
+  `Ready.observedGeneration` always reports the generation it was computed
+  for; it no longer lags to signal an in-progress rollout. Consumers that
+  previously waited for `Ready=True && observedGeneration==metadata.generation`
+  to mean "the current spec has fully rolled out" should switch to
+  `DeploymentRolledOut=True && observedGeneration==metadata.generation`
+  instead, which can take up to `progressDeadlineSeconds` (Kubernetes default
+  600s) to resolve if the rollout stalls.
   [#3909](https://github.com/Kong/kong-operator/pull/3909)
 
 ## [v2.3.0-rc.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,13 @@
   tags in `KongPlugin`s' annotation to plugins in Konnect.
   [#5280](https://github.com/Kong/kong-operator/pull/5280)
   [#5284](https://github.com/Kong/kong-operator/pull/5284)
+- `DataPlane`: the `Ready` status condition no longer flaps to `False` while a
+  rolling update is in progress and the old `Deployment` replicas are still
+  serving. Its `observedGeneration` now only advances once the `Deployment`
+  has fully rolled out the new generation, and `Ready` is set to `False` if
+  Kubernetes reports the rollout as stalled
+  (`Progressing=False`/`ProgressDeadlineExceeded`).
+  [#3909](https://github.com/Kong/kong-operator/pull/3909)
 
 ## [v2.3.0-rc.3]
 

--- a/api/gateway-operator/dataplane/conditions.go
+++ b/api/gateway-operator/dataplane/conditions.go
@@ -47,6 +47,27 @@ const (
 )
 
 // -----------------------------------------------------------------------------
+// DataPlane - DeploymentRolledOut Condition Constants
+// -----------------------------------------------------------------------------
+
+const (
+	// DeploymentRolledOutType indicates whether the DataPlane's live Deployment
+	// has fully rolled out the generation reported in the condition's
+	// observedGeneration.
+	// It is separate from ReadyType: a DataPlane keeps serving traffic from the
+	// previous generation's replicas while a rolling update is in progress, so
+	// it stays Ready while DeploymentRolledOut is False.
+	DeploymentRolledOutType consts.ConditionType = "DeploymentRolledOut"
+
+	// DeploymentRolloutCompleteReason indicates all replicas run the current generation.
+	DeploymentRolloutCompleteReason consts.ConditionReason = "RolloutComplete"
+	// DeploymentRolloutProgressingReason indicates a rollout is still in progress.
+	DeploymentRolloutProgressingReason consts.ConditionReason = "Progressing"
+	// DeploymentRolloutStalledReason indicates Kubernetes gave up on the rollout.
+	DeploymentRolloutStalledReason consts.ConditionReason = "ProgressDeadlineExceeded"
+)
+
+// -----------------------------------------------------------------------------
 // DataPlane - BlueGreen Condition Constants
 // -----------------------------------------------------------------------------
 

--- a/controller/dataplane/controller_reconciler_utils.go
+++ b/controller/dataplane/controller_reconciler_utils.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kcfgconsts "github.com/kong/kong-operator/v2/api/common/consts"
 	kcfgdataplane "github.com/kong/kong-operator/v2/api/gateway-operator/dataplane"
 	operatorv1alpha1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1alpha1"
 	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
@@ -227,7 +226,7 @@ func verifyKPIReadinessForDataPlane(
 	if err := c.Get(ctx, kpiNN, &kpi); err != nil {
 		if apierrors.IsNotFound(err) {
 			msg := fmt.Sprintf("referenced KongPluginInstallation %s not found", kpiNN)
-			markErr := ensureDataPlaneIsMarkedNotReady(ctx, logger, c, dataplane, kcfgdataplane.DataPlaneConditionReferencedResourcesNotAvailable, msg)
+			markErr := ensureDataPlaneIsMarkedNotReady(ctx, logger, c, dataplane, msg)
 			return kpi, false, markErr
 		} else {
 			return kpi, true, err
@@ -239,9 +238,7 @@ func verifyKPIReadinessForDataPlane(
 			c.Reason == string(operatorv1alpha1.KongPluginInstallationReasonPending)
 	}) {
 		msgPending := fmt.Sprintf("please wait, referenced KongPluginInstallation %s has not been fully reconciled yet", kpiNN)
-		markErr := ensureDataPlaneIsMarkedNotReady(
-			ctx, logger, c, dataplane, kcfgdataplane.DataPlaneConditionReferencedResourcesNotAvailable, msgPending,
-		)
+		markErr := ensureDataPlaneIsMarkedNotReady(ctx, logger, c, dataplane, msgPending)
 		return kpi, false, markErr
 	}
 	if lo.ContainsBy(kpi.Status.Conditions, func(c metav1.Condition) bool {
@@ -250,9 +247,7 @@ func verifyKPIReadinessForDataPlane(
 			c.Reason == string(operatorv1alpha1.KongPluginInstallationReasonFailed)
 	}) {
 		msgFailed := fmt.Sprintf("something wrong with referenced KongPluginInstallation %s, please check it", kpiNN)
-		markErr := ensureDataPlaneIsMarkedNotReady(
-			ctx, logger, c, dataplane, kcfgdataplane.DataPlaneConditionReferencedResourcesNotAvailable, msgFailed,
-		)
+		markErr := ensureDataPlaneIsMarkedNotReady(ctx, logger, c, dataplane, msgFailed)
 		return kpi, false, markErr
 	}
 	return kpi, true, nil
@@ -264,7 +259,8 @@ func isSameDataPlaneCondition(condition1, condition2 metav1.Condition) bool {
 	return condition1.Type == condition2.Type &&
 		condition1.Status == condition2.Status &&
 		condition1.Reason == condition2.Reason &&
-		condition1.Message == condition2.Message
+		condition1.Message == condition2.Message &&
+		condition1.ObservedGeneration == condition2.ObservedGeneration
 }
 
 func ensureDataPlaneIsMarkedNotReady(
@@ -272,12 +268,12 @@ func ensureDataPlaneIsMarkedNotReady(
 	log logr.Logger,
 	c client.Client,
 	dataplane *operatorv1beta1.DataPlane,
-	reason kcfgconsts.ConditionReason, message string,
+	message string,
 ) error {
 	notReadyCondition := metav1.Condition{
 		Type:               string(kcfgdataplane.ReadyType),
 		Status:             metav1.ConditionFalse,
-		Reason:             string(reason),
+		Reason:             string(kcfgdataplane.DataPlaneConditionReferencedResourcesNotAvailable),
 		Message:            message,
 		ObservedGeneration: dataplane.Generation,
 		LastTransitionTime: metav1.Now(),

--- a/controller/dataplane/controller_reconciler_utils_test.go
+++ b/controller/dataplane/controller_reconciler_utils_test.go
@@ -19,11 +19,13 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	kcfgdataplane "github.com/kong/kong-operator/v2/api/gateway-operator/dataplane"
 	operatorv1alpha1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1alpha1"
 	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
 	"github.com/kong/kong-operator/v2/controller/pkg/op"
 	"github.com/kong/kong-operator/v2/internal/versions"
 	"github.com/kong/kong-operator/v2/pkg/consts"
+	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
 	k8sresources "github.com/kong/kong-operator/v2/pkg/utils/kubernetes/resources"
 )
 
@@ -744,4 +746,46 @@ func TestDataPlaneIngressServiceIsReady(t *testing.T) {
 			assert.Equal(t, tc.expected, res)
 		})
 	}
+}
+
+func TestEnsureDataPlaneIsMarkedNotReady(t *testing.T) {
+	dataplane := &operatorv1beta1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test",
+			Namespace:  "default",
+			Generation: 6,
+		},
+		Status: operatorv1beta1.DataPlaneStatus{
+			Conditions: []metav1.Condition{
+				k8sutils.NewConditionWithGeneration(
+					kcfgdataplane.ReadyType,
+					metav1.ConditionFalse,
+					kcfgdataplane.DataPlaneConditionReferencedResourcesNotAvailable,
+					"referenced KongPluginInstallation kpi-x not found",
+					5,
+				),
+			},
+		},
+	}
+
+	fakeClient := fakectrlruntimeclient.
+		NewClientBuilder().
+		WithStatusSubresource(dataplane).
+		WithScheme(scheme.Scheme).
+		WithObjects(dataplane).
+		Build()
+
+	// The same failure (identical message) persists across a generation bump:
+	// this must still refresh observedGeneration, otherwise a client polling
+	// Ready.observedGeneration == metadata.generation never sees this Ready
+	// condition catch up, even though it is correctly reporting False.
+	err := ensureDataPlaneIsMarkedNotReady(
+		t.Context(), logr.Discard(), fakeClient, dataplane,
+		"referenced KongPluginInstallation kpi-x not found",
+	)
+	require.NoError(t, err)
+
+	condition, ok := k8sutils.GetCondition(kcfgdataplane.ReadyType, dataplane)
+	require.True(t, ok)
+	assert.EqualValues(t, 6, condition.ObservedGeneration)
 }

--- a/controller/dataplane/controller_reconciler_utils_test.go
+++ b/controller/dataplane/controller_reconciler_utils_test.go
@@ -785,7 +785,9 @@ func TestEnsureDataPlaneIsMarkedNotReady(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	condition, ok := k8sutils.GetCondition(kcfgdataplane.ReadyType, dataplane)
+	stored := &operatorv1beta1.DataPlane{}
+	require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKeyFromObject(dataplane), stored))
+	condition, ok := k8sutils.GetCondition(kcfgdataplane.ReadyType, stored)
 	require.True(t, ok)
 	assert.EqualValues(t, 6, condition.ObservedGeneration)
 }

--- a/controller/dataplane/controller_utils.go
+++ b/controller/dataplane/controller_utils.go
@@ -197,7 +197,7 @@ func ensureDataPlaneReadyStatus(
 	}
 
 	deployment := deployments[0]
-	if _, ready := isDeploymentReady(deployment.Status); !ready {
+	if _, ready := isDeploymentReady(&deployment); !ready {
 		log.Debug(logger, "Deployment for DataPlane not ready yet")
 
 		// Set Ready to false for dataplane as the underlying deployment is not ready.
@@ -318,16 +318,24 @@ func listDataPlaneLiveServices(
 	)
 }
 
-// isDeploymentReady if the DataPlane's Deployment is ready.
-// It does not indicate if the rollout has completed, that is a DataPlane can indicate
+// isDeploymentReady reports whether the DataPlane's Deployment is ready.
+// It does not indicate whether the rollout has completed, that is a DataPlane can indicate
 // that it's ready (e.g. all replicas are available) but not fully rolled out
 // (e.g. new spec has not completely rolled out).
-func isDeploymentReady(deploymentStatus appsv1.DeploymentStatus) (metav1.ConditionStatus, bool) {
+// This will return ConditionTrue if the Deployment has .Status.AvailableReplicas equal
+// at least to the number of replicas specified in .Spec.Replicas, and .Status.Replicas is not 0.
+// This way, the DataPlane Ready status condition does not flap when a rolling update
+// is performed.
+func isDeploymentReady(deployment *appsv1.Deployment) (metav1.ConditionStatus, bool) {
 	// We check if the Deployment is not Ready.
 	// This is the case when status has replicas set to 0 or status.availableReplicas
 	// in status is less than status.replicas.
-	if deploymentStatus.Replicas == 0 ||
-		deploymentStatus.AvailableReplicas < deploymentStatus.Replicas {
+	if deployment.Status.Replicas == 0 {
+		return metav1.ConditionFalse, false
+	}
+
+	if specReplicas := deployment.Spec.Replicas; specReplicas != nil &&
+		deployment.Status.AvailableReplicas < *specReplicas {
 		return metav1.ConditionFalse, false
 	}
 

--- a/controller/dataplane/controller_utils.go
+++ b/controller/dataplane/controller_utils.go
@@ -218,6 +218,7 @@ func ensureDataPlaneReadyStatus(
 			),
 			dataplane,
 		)
+		setDeploymentRolledOutCondition(dataplane, nil, generation)
 		ensureDataPlaneReadinessStatus(dataplane, appsv1.DeploymentStatus{
 			Replicas:      0,
 			ReadyReplicas: 0,
@@ -252,6 +253,7 @@ func ensureDataPlaneReadyStatus(
 			),
 			dataplane,
 		)
+		setDeploymentRolledOutCondition(dataplane, &deployment, generation)
 		ensureDataPlaneReadinessStatus(dataplane, deployment.Status)
 		if _, err := patchDataPlaneStatus(ctx, cl, logger, dataplane); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed patching status (Deployment not ready) for DataPlane %s/%s: %w", dataplane.Namespace, dataplane.Name, err)
@@ -279,6 +281,7 @@ func ensureDataPlaneReadyStatus(
 			),
 			dataplane,
 		)
+		setDeploymentRolledOutCondition(dataplane, &deployment, generation)
 		ensureDataPlaneReadinessStatus(dataplane, deployment.Status)
 		_, err := patchDataPlaneStatus(ctx, cl, logger, dataplane)
 		if err != nil {
@@ -308,6 +311,7 @@ func ensureDataPlaneReadyStatus(
 			),
 			dataplane,
 		)
+		setDeploymentRolledOutCondition(dataplane, &deployment, generation)
 		ensureDataPlaneReadinessStatus(dataplane, deployment.Status)
 		_, err := patchDataPlaneStatus(ctx, cl, logger, dataplane)
 		if err != nil {
@@ -316,17 +320,8 @@ func ensureDataPlaneReadyStatus(
 		return ctrl.Result{}, nil
 	}
 
-	readyGeneration := generation
-	if !isDeploymentRolledOut(&deployment) {
-		// The Deployment still has old replicas serving traffic for a previous
-		// generation of the DataPlane spec, so do not claim the current generation
-		// is ready. Ready.status does not flap; only observedGeneration lags until
-		// the rollout completes (or isDeploymentReady above catches a stalled one).
-		if c, ok := k8sutils.GetCondition(kcfgdataplane.ReadyType, dataplane); ok && c.Status == metav1.ConditionTrue {
-			readyGeneration = c.ObservedGeneration
-		}
-	}
-	k8sutils.SetReadyWithGeneration(dataplane, readyGeneration)
+	k8sutils.SetReadyWithGeneration(dataplane, generation)
+	setDeploymentRolledOutCondition(dataplane, &deployment, generation)
 	ensureDataPlaneReadinessStatus(dataplane, deployment.Status)
 
 	if _, err := patchDataPlaneStatus(ctx, cl, logger, dataplane); err != nil {
@@ -395,7 +390,7 @@ func isDeploymentReady(deployment *appsv1.Deployment) (metav1.ConditionStatus, b
 	}
 
 	if c := getDeploymentCondition(deployment, appsv1.DeploymentProgressing); c != nil &&
-		c.Status == corev1.ConditionFalse && c.Reason == "ProgressDeadlineExceeded" {
+		c.Status == corev1.ConditionFalse && c.Reason == string(kcfgdataplane.DeploymentRolloutStalledReason) {
 		return metav1.ConditionFalse, false
 	}
 
@@ -425,4 +420,42 @@ func isDeploymentRolledOut(deployment *appsv1.Deployment) bool {
 	}
 	return deployment.Status.Replicas == deployment.Status.UpdatedReplicas &&
 		deployment.Status.AvailableReplicas == deployment.Status.UpdatedReplicas
+}
+
+// setDeploymentRolledOutCondition records whether the DataPlane's live Deployment
+// has fully rolled out the given generation of the DataPlane spec.
+// deployment is nil when no live Deployment exists yet.
+// This is deliberately kept separate from the Ready condition: Ready reports
+// whether the DataPlane is currently serving traffic (which stays true across a
+// rolling update as long as old replicas are still available), while this
+// condition reports whether the *current* generation's spec is what is actually
+// serving. It is recomputed from the Deployment on every reconcile, so unlike a
+// value inherited from a previous reconcile, it can never go stale.
+func setDeploymentRolledOutCondition(
+	dataplane *operatorv1beta1.DataPlane,
+	deployment *appsv1.Deployment,
+	generation int64,
+) {
+	status, reason, message := metav1.ConditionFalse,
+		kcfgdataplane.DeploymentRolloutProgressingReason,
+		"Waiting for the Deployment to roll out"
+
+	switch {
+	case deployment == nil:
+		message = "Deployment not present yet"
+	case isDeploymentRolledOut(deployment):
+		status, reason, message = metav1.ConditionTrue,
+			kcfgdataplane.DeploymentRolloutCompleteReason,
+			"All replicas run the current generation"
+	default:
+		if c := getDeploymentCondition(deployment, appsv1.DeploymentProgressing); c != nil &&
+			c.Status == corev1.ConditionFalse && c.Reason == string(kcfgdataplane.DeploymentRolloutStalledReason) {
+			reason, message = kcfgdataplane.DeploymentRolloutStalledReason, c.Message
+		}
+	}
+
+	k8sutils.SetCondition(
+		k8sutils.NewConditionWithGeneration(kcfgdataplane.DeploymentRolledOutType, status, reason, message, generation),
+		dataplane,
+	)
 }

--- a/controller/dataplane/controller_utils.go
+++ b/controller/dataplane/controller_utils.go
@@ -316,7 +316,17 @@ func ensureDataPlaneReadyStatus(
 		return ctrl.Result{}, nil
 	}
 
-	k8sutils.SetReadyWithGeneration(dataplane, generation)
+	readyGeneration := generation
+	if !isDeploymentRolledOut(&deployment) {
+		// The Deployment still has old replicas serving traffic for a previous
+		// generation of the DataPlane spec, so do not claim the current generation
+		// is ready. Ready.status does not flap; only observedGeneration lags until
+		// the rollout completes (or isDeploymentReady above catches a stalled one).
+		if c, ok := k8sutils.GetCondition(kcfgdataplane.ReadyType, dataplane); ok && c.Status == metav1.ConditionTrue {
+			readyGeneration = c.ObservedGeneration
+		}
+	}
+	k8sutils.SetReadyWithGeneration(dataplane, readyGeneration)
 	ensureDataPlaneReadinessStatus(dataplane, deployment.Status)
 
 	if _, err := patchDataPlaneStatus(ctx, cl, logger, dataplane); err != nil {
@@ -367,6 +377,10 @@ func listDataPlaneLiveServices(
 // at least to the number of replicas specified in .Spec.Replicas, and .Status.Replicas is not 0.
 // This way, the DataPlane Ready status condition does not flap when a rolling update
 // is performed.
+// It will still return ConditionFalse if Kubernetes gave up on the rollout
+// (Progressing=False/ProgressDeadlineExceeded), so a stalled rollout (e.g. a broken
+// readiness probe on the new ReplicaSet) is eventually reported as not ready even
+// though the old replicas are still available.
 func isDeploymentReady(deployment *appsv1.Deployment) (metav1.ConditionStatus, bool) {
 	// We check if the Deployment is not Ready.
 	// This is the case when status has replicas set to 0 or status.availableReplicas
@@ -380,5 +394,35 @@ func isDeploymentReady(deployment *appsv1.Deployment) (metav1.ConditionStatus, b
 		return metav1.ConditionFalse, false
 	}
 
+	if c := getDeploymentCondition(deployment, appsv1.DeploymentProgressing); c != nil &&
+		c.Status == corev1.ConditionFalse && c.Reason == "ProgressDeadlineExceeded" {
+		return metav1.ConditionFalse, false
+	}
+
 	return metav1.ConditionTrue, true
+}
+
+// getDeploymentCondition returns the Deployment condition of the given type, or nil if absent.
+func getDeploymentCondition(deployment *appsv1.Deployment, condType appsv1.DeploymentConditionType) *appsv1.DeploymentCondition {
+	for i := range deployment.Status.Conditions {
+		if deployment.Status.Conditions[i].Type == condType {
+			return &deployment.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+// isDeploymentRolledOut reports whether the Deployment has fully rolled out its current spec,
+// i.e. all replicas have been updated to the latest ReplicaSet and are available.
+// This mirrors the check `kubectl rollout status` performs.
+func isDeploymentRolledOut(deployment *appsv1.Deployment) bool {
+	if deployment.Status.ObservedGeneration < deployment.Generation {
+		return false
+	}
+	if specReplicas := deployment.Spec.Replicas; specReplicas != nil &&
+		deployment.Status.UpdatedReplicas < *specReplicas {
+		return false
+	}
+	return deployment.Status.Replicas == deployment.Status.UpdatedReplicas &&
+		deployment.Status.AvailableReplicas == deployment.Status.UpdatedReplicas
 }

--- a/controller/dataplane/controller_utils.go
+++ b/controller/dataplane/controller_utils.go
@@ -238,7 +238,7 @@ func ensureDataPlaneReadyStatus(
 	}
 
 	deployment := deployments[0]
-	if _, ready := isDeploymentReady(deployment.Status); !ready {
+	if _, ready := isDeploymentReady(&deployment); !ready {
 		log.Debug(logger, "Deployment for DataPlane not ready yet")
 
 		// Set Ready to false for dataplane as the underlying deployment is not ready.
@@ -359,16 +359,24 @@ func listDataPlaneLiveServices(
 	)
 }
 
-// isDeploymentReady if the DataPlane's Deployment is ready.
-// It does not indicate if the rollout has completed, that is a DataPlane can indicate
+// isDeploymentReady reports whether the DataPlane's Deployment is ready.
+// It does not indicate whether the rollout has completed, that is a DataPlane can indicate
 // that it's ready (e.g. all replicas are available) but not fully rolled out
 // (e.g. new spec has not completely rolled out).
-func isDeploymentReady(deploymentStatus appsv1.DeploymentStatus) (metav1.ConditionStatus, bool) {
+// This will return ConditionTrue if the Deployment has .Status.AvailableReplicas equal
+// at least to the number of replicas specified in .Spec.Replicas, and .Status.Replicas is not 0.
+// This way, the DataPlane Ready status condition does not flap when a rolling update
+// is performed.
+func isDeploymentReady(deployment *appsv1.Deployment) (metav1.ConditionStatus, bool) {
 	// We check if the Deployment is not Ready.
 	// This is the case when status has replicas set to 0 or status.availableReplicas
 	// in status is less than status.replicas.
-	if deploymentStatus.Replicas == 0 ||
-		deploymentStatus.AvailableReplicas < deploymentStatus.Replicas {
+	if deployment.Status.Replicas == 0 {
+		return metav1.ConditionFalse, false
+	}
+
+	if specReplicas := deployment.Spec.Replicas; specReplicas != nil &&
+		deployment.Status.AvailableReplicas < *specReplicas {
 		return metav1.ConditionFalse, false
 	}
 

--- a/controller/dataplane/controller_utils_test.go
+++ b/controller/dataplane/controller_utils_test.go
@@ -34,7 +34,7 @@ func TestEnsureDataPlaneReadyStatus(t *testing.T) {
 		dataPlane               *operatorv1beta1.DataPlane
 	}{
 		{
-			name: "not all replicas are ready",
+			name: "not all replicas are ready (.spec.replicas is set)",
 			dataPlane: &operatorv1beta1.DataPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					UID:        "test-uid",
@@ -88,7 +88,9 @@ func TestEnsureDataPlaneReadyStatus(t *testing.T) {
 									},
 								},
 							},
-							Spec: appsv1.DeploymentSpec{},
+							Spec: appsv1.DeploymentSpec{
+								Replicas: new(int32(2)),
+							},
 							Status: appsv1.DeploymentStatus{
 								Replicas:          2,
 								ReadyReplicas:     1,
@@ -660,6 +662,118 @@ func TestAddLabelsForDataPlaneIngressService(t *testing.T) {
 			svc.Labels = tc.existingLabels
 			addLabelsForDataPlaneIngressService(svc, tc.dataplane)
 			require.Equal(t, tc.expectedLabels, svc.Labels)
+		})
+	}
+}
+
+func TestIsDeploymentReady(t *testing.T) {
+	testCases := []struct {
+		name           string
+		deployment     *appsv1.Deployment
+		expectedStatus metav1.ConditionStatus
+		expectedReady  bool
+	}{
+		{
+			name: "zero replicas in status",
+			deployment: &appsv1.Deployment{
+				Status: appsv1.DeploymentStatus{
+					Replicas: 0,
+				},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReady:  false,
+		},
+		{
+			name: "available replicas less than spec replicas",
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: new(int32(3)),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:          3,
+					AvailableReplicas: 1,
+				},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReady:  false,
+		},
+		{
+			name: "available replicas equal to spec replicas",
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: new(int32(3)),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:          3,
+					AvailableReplicas: 3,
+				},
+			},
+			expectedStatus: metav1.ConditionTrue,
+			expectedReady:  true,
+		},
+		{
+			name: "available replicas greater than spec replicas",
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: new(int32(2)),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:          3,
+					AvailableReplicas: 3,
+				},
+			},
+			expectedStatus: metav1.ConditionTrue,
+			expectedReady:  true,
+		},
+		{
+			name: "spec replicas nil with non-zero status replicas",
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: nil,
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:          1,
+					AvailableReplicas: 1,
+				},
+			},
+			expectedStatus: metav1.ConditionTrue,
+			expectedReady:  true,
+		},
+		{
+			name: "zero available replicas with non-zero spec",
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: new(int32(1)),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:          1,
+					AvailableReplicas: 0,
+				},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReady:  false,
+		},
+		{
+			name: "rolling update: status replicas exceed spec but available meets spec",
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: new(int32(3)),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:          5, // old + new pods during rollout
+					AvailableReplicas: 3,
+				},
+			},
+			expectedStatus: metav1.ConditionTrue,
+			expectedReady:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, ready := isDeploymentReady(tc.deployment)
+			assert.Equal(t, tc.expectedStatus, status)
+			assert.Equal(t, tc.expectedReady, ready)
 		})
 	}
 }

--- a/controller/dataplane/controller_utils_test.go
+++ b/controller/dataplane/controller_utils_test.go
@@ -576,6 +576,16 @@ func TestEnsureDataPlaneReadyStatus(t *testing.T) {
 							"",
 							102,
 						),
+						// Left behind by the previous reconcile. Without the
+						// DeploymentRolledOut skip in AreAllConditionsHaveTrueStatus,
+						// SetReadyWithGeneration writes Ready=False/DependenciesNotReady here.
+						k8sutils.NewConditionWithGeneration(
+							kcfgdataplane.DeploymentRolledOutType,
+							metav1.ConditionFalse,
+							kcfgdataplane.DeploymentRolloutProgressingReason,
+							"Waiting for the Deployment to roll out",
+							102,
+						),
 					},
 				},
 			},

--- a/controller/dataplane/controller_utils_test.go
+++ b/controller/dataplane/controller_utils_test.go
@@ -34,7 +34,7 @@ func TestEnsureDataPlaneReadyStatus(t *testing.T) {
 		dataPlane               *operatorv1beta1.DataPlane
 	}{
 		{
-			name: "not all replicas are ready",
+			name: "not all replicas are ready (.spec.replicas is set)",
 			dataPlane: &operatorv1beta1.DataPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					UID:        "test-uid",
@@ -88,7 +88,9 @@ func TestEnsureDataPlaneReadyStatus(t *testing.T) {
 									},
 								},
 							},
-							Spec: appsv1.DeploymentSpec{},
+							Spec: appsv1.DeploymentSpec{
+								Replicas: new(int32(2)),
+							},
 							Status: appsv1.DeploymentStatus{
 								Replicas:          2,
 								ReadyReplicas:     1,
@@ -778,6 +780,118 @@ func TestAddLabelsForDataPlaneDeployment(t *testing.T) {
 			addLabelsForDataPlaneDeployment(logr.New(infoCountSink{count: &infoCount}), deployment, dataplane)
 			require.Equal(t, tc.expectedLabels, deployment.Labels)
 			assert.Equal(t, tc.expectedInfoCount, infoCount)
+		})
+	}
+}
+
+func TestIsDeploymentReady(t *testing.T) {
+	testCases := []struct {
+		name           string
+		deployment     *appsv1.Deployment
+		expectedStatus metav1.ConditionStatus
+		expectedReady  bool
+	}{
+		{
+			name: "zero replicas in status",
+			deployment: &appsv1.Deployment{
+				Status: appsv1.DeploymentStatus{
+					Replicas: 0,
+				},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReady:  false,
+		},
+		{
+			name: "available replicas less than spec replicas",
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: new(int32(3)),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:          3,
+					AvailableReplicas: 1,
+				},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReady:  false,
+		},
+		{
+			name: "available replicas equal to spec replicas",
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: new(int32(3)),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:          3,
+					AvailableReplicas: 3,
+				},
+			},
+			expectedStatus: metav1.ConditionTrue,
+			expectedReady:  true,
+		},
+		{
+			name: "available replicas greater than spec replicas",
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: new(int32(2)),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:          3,
+					AvailableReplicas: 3,
+				},
+			},
+			expectedStatus: metav1.ConditionTrue,
+			expectedReady:  true,
+		},
+		{
+			name: "spec replicas nil with non-zero status replicas",
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: nil,
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:          1,
+					AvailableReplicas: 1,
+				},
+			},
+			expectedStatus: metav1.ConditionTrue,
+			expectedReady:  true,
+		},
+		{
+			name: "zero available replicas with non-zero spec",
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: new(int32(1)),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:          1,
+					AvailableReplicas: 0,
+				},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReady:  false,
+		},
+		{
+			name: "rolling update: status replicas exceed spec but available meets spec",
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: new(int32(3)),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:          5, // old + new pods during rollout
+					AvailableReplicas: 3,
+				},
+			},
+			expectedStatus: metav1.ConditionTrue,
+			expectedReady:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, ready := isDeploymentReady(tc.deployment)
+			assert.Equal(t, tc.expectedStatus, status)
+			assert.Equal(t, tc.expectedReady, ready)
 		})
 	}
 }

--- a/controller/dataplane/controller_utils_test.go
+++ b/controller/dataplane/controller_utils_test.go
@@ -111,6 +111,13 @@ func TestEnsureDataPlaneReadyStatus(t *testing.T) {
 						fmt.Sprintf("%s: Deployment %s is not ready yet", kcfgdataplane.WaitingToBecomeReadyMessage, "dataplane-deployment-1"),
 						102,
 					),
+					k8sutils.NewConditionWithGeneration(
+						kcfgdataplane.DeploymentRolledOutType,
+						metav1.ConditionFalse,
+						kcfgdataplane.DeploymentRolloutProgressingReason,
+						"Waiting for the Deployment to roll out",
+						102,
+					),
 				},
 				Replicas:      2,
 				ReadyReplicas: 1,
@@ -235,6 +242,13 @@ func TestEnsureDataPlaneReadyStatus(t *testing.T) {
 						metav1.ConditionFalse,
 						kcfgdataplane.WaitingToBecomeReadyReason,
 						fmt.Sprintf("%s: ingress Service %s is not ready yet", kcfgdataplane.WaitingToBecomeReadyMessage, "dataplane-service-1"),
+						102,
+					),
+					k8sutils.NewConditionWithGeneration(
+						kcfgdataplane.DeploymentRolledOutType,
+						metav1.ConditionFalse,
+						kcfgdataplane.DeploymentRolloutProgressingReason,
+						"Waiting for the Deployment to roll out",
 						102,
 					),
 				},
@@ -367,6 +381,13 @@ func TestEnsureDataPlaneReadyStatus(t *testing.T) {
 						"",
 						102,
 					),
+					k8sutils.NewConditionWithGeneration(
+						kcfgdataplane.DeploymentRolledOutType,
+						metav1.ConditionFalse,
+						kcfgdataplane.DeploymentRolloutProgressingReason,
+						"Waiting for the Deployment to roll out",
+						102,
+					),
 				},
 				Replicas:      1,
 				ReadyReplicas: 1,
@@ -374,10 +395,11 @@ func TestEnsureDataPlaneReadyStatus(t *testing.T) {
 		},
 		{
 			// The Deployment is available (old replica still serving) but has not
-			// finished rolling out generation 102 yet: it must not be reported as
-			// Ready at generation 102, it must keep reporting the last generation
-			// that was actually rolled out (101).
-			name: "deployment available but not fully rolled out keeps previous observedGeneration",
+			// finished rolling out generation 102 yet: Ready still reports True at
+			// generation 102 (the DataPlane is serving traffic), while the separate
+			// DeploymentRolledOut condition reports that generation 102 itself has
+			// not rolled out yet.
+			name: "deployment available but not fully rolled out reports DeploymentRolledOut=False at the current generation",
 			dataPlane: &operatorv1beta1.DataPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					UID:        "test-uid",
@@ -496,7 +518,156 @@ func TestEnsureDataPlaneReadyStatus(t *testing.T) {
 						metav1.ConditionTrue,
 						kcfgdataplane.ResourceReadyReason,
 						"",
-						101,
+						102,
+					),
+					k8sutils.NewConditionWithGeneration(
+						kcfgdataplane.DeploymentRolledOutType,
+						metav1.ConditionFalse,
+						kcfgdataplane.DeploymentRolloutProgressingReason,
+						"Waiting for the Deployment to roll out",
+						102,
+					),
+				},
+				Replicas:      2,
+				ReadyReplicas: 1,
+			},
+		},
+		{
+			// Regression guard: a transient dip below spec.Replicas during a rollout
+			// previously wrote {Ready: False, observedGeneration: <current>}. The next
+			// reconcile, seeing the stored condition was not True, used to skip a
+			// generation fallback and report {Ready: True, observedGeneration: <current>}
+			// while most pods still ran the old template. Ready.observedGeneration must
+			// simply track the generation it was computed for; DeploymentRolledOut is
+			// the one that reports the rollout is still in progress.
+			name: "Ready recovers to the current generation after a transient dip, DeploymentRolledOut still reports the rollout in progress",
+			dataPlane: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:        "test-uid",
+					Name:       "test",
+					Namespace:  "default",
+					Generation: 102,
+				},
+				Spec: operatorv1beta1.DataPlaneSpec{
+					DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+						Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+							DeploymentOptions: operatorv1beta1.DeploymentOptions{
+								PodTemplateSpec: &corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										Containers: []corev1.Container{
+											{
+												Name:  consts.DataPlaneProxyContainerName,
+												Image: consts.DefaultDataPlaneImage,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Status: operatorv1beta1.DataPlaneStatus{
+					Conditions: []metav1.Condition{
+						// Left behind by the transient dip.
+						k8sutils.NewConditionWithGeneration(
+							kcfgdataplane.ReadyType,
+							metav1.ConditionFalse,
+							kcfgdataplane.WaitingToBecomeReadyReason,
+							"",
+							102,
+						),
+					},
+				},
+			},
+			objectLists: []client.ObjectList{
+				&appsv1.DeploymentList{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "DeploymentList",
+						APIVersion: "apps/v1",
+					},
+					Items: []appsv1.Deployment{
+						{
+							TypeMeta: metav1.TypeMeta{
+								Kind:       "Deployment",
+								APIVersion: "apps/v1",
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:       "dataplane-deployment-1",
+								Namespace:  "default",
+								Generation: 102,
+								Labels: map[string]string{
+									"app":                                "test",
+									consts.DataPlaneDeploymentStateLabel: consts.DataPlaneStateLabelValueLive,
+								},
+								OwnerReferences: []metav1.OwnerReference{
+									{
+										APIVersion: "gateway-operator.konghq.com/v1beta1",
+										Kind:       "DataPlane",
+										UID:        "test-uid",
+									},
+								},
+							},
+							Spec: appsv1.DeploymentSpec{
+								Replicas: new(int32(1)),
+							},
+							Status: appsv1.DeploymentStatus{
+								ObservedGeneration: 102,
+								Replicas:           2, // old + surging new replica.
+								UpdatedReplicas:    1, // new replica not available yet.
+								AvailableReplicas:  1, // old replica still serving.
+								ReadyReplicas:      1,
+							},
+						},
+					},
+				},
+				&corev1.ServiceList{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ServiceList",
+						APIVersion: "apps/v1",
+					},
+					Items: []corev1.Service{
+						{
+							TypeMeta: metav1.TypeMeta{
+								Kind:       "Service",
+								APIVersion: "v1",
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "dataplane-service-1",
+								Namespace: "default",
+								Labels: map[string]string{
+									"app":                             "test",
+									consts.DataPlaneServiceStateLabel: consts.DataPlaneStateLabelValueLive,
+									consts.DataPlaneServiceTypeLabel:  string(consts.DataPlaneIngressServiceLabelValue),
+								},
+								OwnerReferences: []metav1.OwnerReference{
+									{
+										APIVersion: "gateway-operator.konghq.com/v1beta1",
+										Kind:       "DataPlane",
+										UID:        "test-uid",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError:  false,
+			expectedResult: ctrl.Result{},
+			expectedDataPlaneStatus: operatorv1beta1.DataPlaneStatus{
+				Conditions: []metav1.Condition{
+					k8sutils.NewConditionWithGeneration(
+						kcfgdataplane.ReadyType,
+						metav1.ConditionTrue,
+						kcfgdataplane.ResourceReadyReason,
+						"",
+						102,
+					),
+					k8sutils.NewConditionWithGeneration(
+						kcfgdataplane.DeploymentRolledOutType,
+						metav1.ConditionFalse,
+						kcfgdataplane.DeploymentRolloutProgressingReason,
+						"Waiting for the Deployment to roll out",
+						102,
 					),
 				},
 				Replicas:      2,
@@ -1047,6 +1218,110 @@ func TestIsDeploymentReady(t *testing.T) {
 			status, ready := isDeploymentReady(tc.deployment)
 			assert.Equal(t, tc.expectedStatus, status)
 			assert.Equal(t, tc.expectedReady, ready)
+		})
+	}
+}
+
+func TestSetDeploymentRolledOutCondition(t *testing.T) {
+	testCases := []struct {
+		name       string
+		deployment *appsv1.Deployment
+		generation int64
+		expected   metav1.Condition
+	}{
+		{
+			name:       "no Deployment yet",
+			deployment: nil,
+			generation: 102,
+			expected: k8sutils.NewConditionWithGeneration(
+				kcfgdataplane.DeploymentRolledOutType,
+				metav1.ConditionFalse,
+				kcfgdataplane.DeploymentRolloutProgressingReason,
+				"Deployment not present yet",
+				102,
+			),
+		},
+		{
+			name: "fully rolled out",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 102},
+				Spec:       appsv1.DeploymentSpec{Replicas: new(int32(1))},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 102,
+					Replicas:           1,
+					UpdatedReplicas:    1,
+					AvailableReplicas:  1,
+				},
+			},
+			generation: 102,
+			expected: k8sutils.NewConditionWithGeneration(
+				kcfgdataplane.DeploymentRolledOutType,
+				metav1.ConditionTrue,
+				kcfgdataplane.DeploymentRolloutCompleteReason,
+				"All replicas run the current generation",
+				102,
+			),
+		},
+		{
+			name: "mid-rollout",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 102},
+				Spec:       appsv1.DeploymentSpec{Replicas: new(int32(1))},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 102,
+					Replicas:           2,
+					UpdatedReplicas:    1,
+					AvailableReplicas:  1,
+				},
+			},
+			generation: 102,
+			expected: k8sutils.NewConditionWithGeneration(
+				kcfgdataplane.DeploymentRolledOutType,
+				metav1.ConditionFalse,
+				kcfgdataplane.DeploymentRolloutProgressingReason,
+				"Waiting for the Deployment to roll out",
+				102,
+			),
+		},
+		{
+			name: "rollout stalled",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 102},
+				Spec:       appsv1.DeploymentSpec{Replicas: new(int32(1))},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 102,
+					Replicas:           2,
+					UpdatedReplicas:    1,
+					AvailableReplicas:  1,
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:    appsv1.DeploymentProgressing,
+							Status:  corev1.ConditionFalse,
+							Reason:  "ProgressDeadlineExceeded",
+							Message: "ReplicaSet has timed out progressing",
+						},
+					},
+				},
+			},
+			generation: 102,
+			expected: k8sutils.NewConditionWithGeneration(
+				kcfgdataplane.DeploymentRolledOutType,
+				metav1.ConditionFalse,
+				kcfgdataplane.DeploymentRolloutStalledReason,
+				"ReplicaSet has timed out progressing",
+				102,
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dataplane := &operatorv1beta1.DataPlane{}
+			setDeploymentRolledOutCondition(dataplane, tc.deployment, tc.generation)
+			got, ok := k8sutils.GetCondition(kcfgdataplane.DeploymentRolledOutType, dataplane)
+			require.True(t, ok)
+			got.LastTransitionTime = tc.expected.LastTransitionTime
+			assert.Equal(t, tc.expected, got)
 		})
 	}
 }

--- a/controller/dataplane/controller_utils_test.go
+++ b/controller/dataplane/controller_utils_test.go
@@ -372,6 +372,137 @@ func TestEnsureDataPlaneReadyStatus(t *testing.T) {
 				ReadyReplicas: 1,
 			},
 		},
+		{
+			// The Deployment is available (old replica still serving) but has not
+			// finished rolling out generation 102 yet: it must not be reported as
+			// Ready at generation 102, it must keep reporting the last generation
+			// that was actually rolled out (101).
+			name: "deployment available but not fully rolled out keeps previous observedGeneration",
+			dataPlane: &operatorv1beta1.DataPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:        "test-uid",
+					Name:       "test",
+					Namespace:  "default",
+					Generation: 102,
+				},
+				Spec: operatorv1beta1.DataPlaneSpec{
+					DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+						Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+							DeploymentOptions: operatorv1beta1.DeploymentOptions{
+								PodTemplateSpec: &corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										Containers: []corev1.Container{
+											{
+												Name:  consts.DataPlaneProxyContainerName,
+												Image: consts.DefaultDataPlaneImage,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Status: operatorv1beta1.DataPlaneStatus{
+					Conditions: []metav1.Condition{
+						k8sutils.NewConditionWithGeneration(
+							kcfgdataplane.ReadyType,
+							metav1.ConditionTrue,
+							kcfgdataplane.ResourceReadyReason,
+							"",
+							101,
+						),
+					},
+				},
+			},
+			objectLists: []client.ObjectList{
+				&appsv1.DeploymentList{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "DeploymentList",
+						APIVersion: "apps/v1",
+					},
+					Items: []appsv1.Deployment{
+						{
+							TypeMeta: metav1.TypeMeta{
+								Kind:       "Deployment",
+								APIVersion: "apps/v1",
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:       "dataplane-deployment-1",
+								Namespace:  "default",
+								Generation: 102,
+								Labels: map[string]string{
+									"app":                                "test",
+									consts.DataPlaneDeploymentStateLabel: consts.DataPlaneStateLabelValueLive,
+								},
+								OwnerReferences: []metav1.OwnerReference{
+									{
+										APIVersion: "gateway-operator.konghq.com/v1beta1",
+										Kind:       "DataPlane",
+										UID:        "test-uid",
+									},
+								},
+							},
+							Spec: appsv1.DeploymentSpec{
+								Replicas: new(int32(1)),
+							},
+							Status: appsv1.DeploymentStatus{
+								ObservedGeneration: 102,
+								Replicas:           2, // old + surging new replica.
+								UpdatedReplicas:    1, // new replica not available yet.
+								AvailableReplicas:  1, // old replica still serving.
+								ReadyReplicas:      1,
+							},
+						},
+					},
+				},
+				&corev1.ServiceList{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ServiceList",
+						APIVersion: "apps/v1",
+					},
+					Items: []corev1.Service{
+						{
+							TypeMeta: metav1.TypeMeta{
+								Kind:       "Service",
+								APIVersion: "v1",
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "dataplane-service-1",
+								Namespace: "default",
+								Labels: map[string]string{
+									"app":                             "test",
+									consts.DataPlaneServiceStateLabel: consts.DataPlaneStateLabelValueLive,
+									consts.DataPlaneServiceTypeLabel:  string(consts.DataPlaneIngressServiceLabelValue),
+								},
+								OwnerReferences: []metav1.OwnerReference{
+									{
+										APIVersion: "gateway-operator.konghq.com/v1beta1",
+										Kind:       "DataPlane",
+										UID:        "test-uid",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError:  false,
+			expectedResult: ctrl.Result{},
+			expectedDataPlaneStatus: operatorv1beta1.DataPlaneStatus{
+				Conditions: []metav1.Condition{
+					k8sutils.NewConditionWithGeneration(
+						kcfgdataplane.ReadyType,
+						metav1.ConditionTrue,
+						kcfgdataplane.ResourceReadyReason,
+						"",
+						101,
+					),
+				},
+				Replicas:      2,
+				ReadyReplicas: 1,
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -884,6 +1015,30 @@ func TestIsDeploymentReady(t *testing.T) {
 			},
 			expectedStatus: metav1.ConditionTrue,
 			expectedReady:  true,
+		},
+		{
+			// Old replicas keep the Deployment "available" during a rollout, but
+			// once Kubernetes gives up on the rollout (ProgressDeadlineExceeded)
+			// this must not be masked by the anti-flap replica check above.
+			name: "available replicas meet spec but rollout has stalled",
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: new(int32(1)),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:          2,
+					AvailableReplicas: 1,
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:   appsv1.DeploymentProgressing,
+							Status: corev1.ConditionFalse,
+							Reason: "ProgressDeadlineExceeded",
+						},
+					},
+				},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReady:  false,
 		},
 	}
 

--- a/pkg/utils/kubernetes/status.go
+++ b/pkg/utils/kubernetes/status.go
@@ -261,7 +261,9 @@ func SetAcceptedConditionOnGateway(resource ConditionsAndListenerConditionsAndGe
 func AreAllConditionsHaveTrueStatus(resource ConditionsAware) bool {
 	for _, condition := range resource.GetConditions() {
 		switch condition.Type {
-		case string(kcfgdataplane.ReadyType), string(gatewayv1.GatewayConditionProgrammed):
+		case string(kcfgdataplane.ReadyType),
+			string(kcfgdataplane.DeploymentRolledOutType),
+			string(gatewayv1.GatewayConditionProgrammed):
 			continue
 		default:
 			if condition.Status != metav1.ConditionTrue {

--- a/pkg/utils/kubernetes/status.go
+++ b/pkg/utils/kubernetes/status.go
@@ -256,8 +256,10 @@ func SetAcceptedConditionOnGateway(resource ConditionsAndListenerConditionsAndGe
 }
 
 // AreAllConditionsHaveTrueStatus checks if all the conditions on the resource are in the True state.
-// It skips the Programmed condition as that particular condition will be set based on
-// the return value of this function.
+// It skips Ready and Programmed, because those conditions are set from the return
+// value of this function.
+// It also skips DeploymentRolledOut, which reports rollout
+// progress only and must not make the resource not Ready.
 func AreAllConditionsHaveTrueStatus(resource ConditionsAware) bool {
 	for _, condition := range resource.GetConditions() {
 		switch condition.Type {

--- a/test/envtest/dataplane_test.go
+++ b/test/envtest/dataplane_test.go
@@ -321,6 +321,11 @@ func TestDataPlane(t *testing.T) {
 			assert.Equal(ct, metav1.ConditionTrue, condition.Status)
 			assert.EqualValues(ct, 1, current.Status.ReadyReplicas)
 			assert.EqualValues(ct, 1, current.Status.Replicas)
+
+			rolledOut, ok := k8sutils.GetCondition(kcfgdataplane.DeploymentRolledOutType, current)
+			require.True(ct, ok)
+			assert.Equal(ct, metav1.ConditionTrue, rolledOut.Status)
+			assert.Equal(ct, current.Generation, rolledOut.ObservedGeneration)
 		}, waitTime, tickTime)
 
 		updated := &operatorv1beta1.DataPlane{}
@@ -346,6 +351,22 @@ func TestDataPlane(t *testing.T) {
 			assert.Greater(ct, deploymentList.Items[0].Generation, deployment.Generation)
 		}, waitTime, tickTime)
 
+		// Before the Deployment reports the new generation as rolled out,
+		// DeploymentRolledOut must reflect that, while Ready must not flap.
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			current := &operatorv1beta1.DataPlane{}
+			require.NoError(ct, cl.Get(ctx, client.ObjectKeyFromObject(dp), current))
+
+			rolledOut, ok := k8sutils.GetCondition(kcfgdataplane.DeploymentRolledOutType, current)
+			require.True(ct, ok)
+			assert.Equal(ct, metav1.ConditionFalse, rolledOut.Status)
+			assert.Equal(ct, current.Generation, rolledOut.ObservedGeneration)
+
+			condition, ok := k8sutils.GetCondition(kcfgdataplane.ReadyType, current)
+			require.True(ct, ok)
+			assert.Equal(ct, metav1.ConditionTrue, condition.Status)
+		}, waitTime, tickTime)
+
 		deployment = deploymentList.Items[0]
 		deployment.Status = appsv1.DeploymentStatus{
 			ObservedGeneration: deployment.Generation,
@@ -366,6 +387,11 @@ func TestDataPlane(t *testing.T) {
 			assert.Equal(ct, current.Generation, condition.ObservedGeneration)
 			assert.EqualValues(ct, 1, current.Status.ReadyReplicas)
 			assert.EqualValues(ct, 1, current.Status.Replicas)
+
+			rolledOut, ok := k8sutils.GetCondition(kcfgdataplane.DeploymentRolledOutType, current)
+			require.True(ct, ok)
+			assert.Equal(ct, metav1.ConditionTrue, rolledOut.Status)
+			assert.Equal(ct, current.Generation, rolledOut.ObservedGeneration)
 		}, waitTime, tickTime)
 	})
 }

--- a/test/envtest/dataplane_test.go
+++ b/test/envtest/dataplane_test.go
@@ -285,9 +285,11 @@ func TestDataPlane(t *testing.T) {
 
 		deployment := deploymentList.Items[0]
 		deployment.Status = appsv1.DeploymentStatus{
-			AvailableReplicas: 1,
-			ReadyReplicas:     1,
-			Replicas:          1,
+			ObservedGeneration: deployment.Generation,
+			UpdatedReplicas:    1,
+			AvailableReplicas:  1,
+			ReadyReplicas:      1,
+			Replicas:           1,
 		}
 		require.NoError(t, cl.Status().Update(ctx, &deployment))
 
@@ -325,6 +327,34 @@ func TestDataPlane(t *testing.T) {
 		require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(dp), updated))
 		updated.Spec.Deployment.PodTemplateSpec.Spec.Containers[0].LivenessProbe.PeriodSeconds = 2
 		require.NoError(t, cl.Update(ctx, updated))
+
+		// envtest does not run the Deployment controller, so nothing rolls the
+		// Deployment out or advances its Status on its own: wait for our controller
+		// to push the new PodTemplateSpec onto the Deployment (bumping its
+		// .Generation), then fake the rollout completing for that generation the
+		// same way a real Deployment controller would.
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			require.NoError(ct, cl.List(ctx, &deploymentList,
+				client.InNamespace(ns.Name),
+				client.MatchingLabels{
+					"app":                                dp.Name,
+					consts.DataPlaneDeploymentStateLabel: consts.DataPlaneStateLabelValueLive,
+					consts.GatewayOperatorManagedByLabel: string(consts.DataPlaneManagedLabelValue),
+				},
+			))
+			require.Len(ct, deploymentList.Items, 1)
+			assert.Greater(ct, deploymentList.Items[0].Generation, deployment.Generation)
+		}, waitTime, tickTime)
+
+		deployment = deploymentList.Items[0]
+		deployment.Status = appsv1.DeploymentStatus{
+			ObservedGeneration: deployment.Generation,
+			UpdatedReplicas:    1,
+			AvailableReplicas:  1,
+			ReadyReplicas:      1,
+			Replicas:           1,
+		}
+		require.NoError(t, cl.Status().Update(ctx, &deployment))
 
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			current := &operatorv1beta1.DataPlane{}

--- a/test/integration/ko/dataplane_test.go
+++ b/test/integration/ko/dataplane_test.go
@@ -443,7 +443,7 @@ func TestDataPlaneUpdate(t *testing.T) {
 		}
 	}
 
-	t.Run("dataplane does not report Ready for a generation that can not roll out", func(t *testing.T) {
+	t.Run("dataplane does not report the Deployment as rolled out for a generation that can not roll out", func(t *testing.T) {
 		require.Eventually(t,
 			testutils.DataPlaneUpdateEventually(t, ctx, dataplaneName, clients.MgrClient, func(dp *operatorv1beta1.DataPlane) {
 				container := k8sutils.GetPodContainerByName(&dp.Spec.Deployment.PodTemplateSpec.Spec, consts.DataPlaneProxyContainerName)
@@ -472,16 +472,38 @@ func TestDataPlaneUpdate(t *testing.T) {
 
 		// The rollout of this generation can never complete (readiness probe always
 		// fails on the new replica), but the old replica keeps serving, so Ready.status
-		// must not flap to False for it. It also must never report this generation as
-		// the observedGeneration of a True Ready condition, since it was never rolled out.
-		readyAtCurrentGeneration := dataPlaneConditionPredicate(t, &metav1.Condition{
+		// must not flap to False for it -- it genuinely reports the current generation,
+		// since the DataPlane is serving traffic. DeploymentRolledOut is the condition
+		// that must never report this generation as rolled out, since it never was.
+		isReady := dataPlaneConditionPredicate(t, &metav1.Condition{
 			Type:               string(kcfgdataplane.ReadyType),
 			Status:             metav1.ConditionTrue,
 			Reason:             string(kcfgdataplane.ResourceReadyReason),
 			ObservedGeneration: dataplane.Generation,
 		})
+		require.Eventually(t,
+			testutils.DataPlanePredicate(t, ctx, dataplaneName, isReady, integration.GetClients().OperatorClient),
+			testutils.DataPlaneCondDeadline, testutils.DataPlaneCondTick,
+		)
+
+		// Now that Ready has settled to True, prove both anti-flap properties hold
+		// for the rest of the stuck rollout: Ready never flaps back to False (the
+		// old replica keeps serving), and DeploymentRolledOut never claims this
+		// generation rolled out (it never did).
+		badState := func(dp *operatorv1beta1.DataPlane) bool {
+			if ready, ok := k8sutils.GetCondition(kcfgdataplane.ReadyType, dp); ok && ready.Status == metav1.ConditionFalse {
+				t.Logf("DataPlane %q Ready flapped to False: reason=%q message=%q", dp.Name, ready.Reason, ready.Message)
+				return true
+			}
+			if rolledOut, ok := k8sutils.GetCondition(kcfgdataplane.DeploymentRolledOutType, dp); ok &&
+				rolledOut.Status == metav1.ConditionTrue && rolledOut.ObservedGeneration == dataplane.Generation {
+				t.Logf("DataPlane %q DeploymentRolledOut reported generation %d as rolled out", dp.Name, dataplane.Generation)
+				return true
+			}
+			return false
+		}
 		require.Never(t,
-			testutils.DataPlanePredicate(t, ctx, dataplaneName, readyAtCurrentGeneration, integration.GetClients().OperatorClient),
+			testutils.DataPlanePredicate(t, ctx, dataplaneName, badState, integration.GetClients().OperatorClient),
 			30*time.Second, testutils.DataPlaneCondTick,
 		)
 	})

--- a/test/integration/ko/dataplane_test.go
+++ b/test/integration/ko/dataplane_test.go
@@ -443,7 +443,7 @@ func TestDataPlaneUpdate(t *testing.T) {
 		}
 	}
 
-	t.Run("dataplane is not Ready when the underlying deployment changes state to not Ready", func(t *testing.T) {
+	t.Run("dataplane does not report Ready for a generation that can not roll out", func(t *testing.T) {
 		require.Eventually(t,
 			testutils.DataPlaneUpdateEventually(t, ctx, dataplaneName, clients.MgrClient, func(dp *operatorv1beta1.DataPlane) {
 				container := k8sutils.GetPodContainerByName(&dp.Spec.Deployment.PodTemplateSpec.Spec, consts.DataPlaneProxyContainerName)
@@ -470,15 +470,19 @@ func TestDataPlaneUpdate(t *testing.T) {
 		dataplane, err := clients.OperatorClient.GatewayOperatorV1beta1().DataPlanes(dataplaneName.Namespace).Get(ctx, dataplane.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 
-		isNotReady := dataPlaneConditionPredicate(t, &metav1.Condition{
+		// The rollout of this generation can never complete (readiness probe always
+		// fails on the new replica), but the old replica keeps serving, so Ready.status
+		// must not flap to False for it. It also must never report this generation as
+		// the observedGeneration of a True Ready condition, since it was never rolled out.
+		readyAtCurrentGeneration := dataPlaneConditionPredicate(t, &metav1.Condition{
 			Type:               string(kcfgdataplane.ReadyType),
-			Status:             metav1.ConditionFalse,
-			Reason:             string(kcfgdataplane.WaitingToBecomeReadyReason),
+			Status:             metav1.ConditionTrue,
+			Reason:             string(kcfgdataplane.ResourceReadyReason),
 			ObservedGeneration: dataplane.Generation,
 		})
-		require.Eventually(t,
-			testutils.DataPlanePredicate(t, ctx, dataplaneName, isNotReady, integration.GetClients().OperatorClient),
-			testutils.DataPlaneCondDeadline, testutils.DataPlaneCondTick,
+		require.Never(t,
+			testutils.DataPlanePredicate(t, ctx, dataplaneName, readyAtCurrentGeneration, integration.GetClients().OperatorClient),
+			30*time.Second, testutils.DataPlaneCondTick,
 		)
 	})
 	t.Run("dataplane gets Ready when the underlying deployment changes state to Ready", func(t *testing.T) {

--- a/test/integration/ko/kongplugininstallation_test.go
+++ b/test/integration/ko/kongplugininstallation_test.go
@@ -28,6 +28,7 @@ import (
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/modules/manager/config"
 	"github.com/kong/kong-operator/v2/pkg/metadata"
+	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
 	testutils "github.com/kong/kong-operator/v2/pkg/utils/test"
 	"github.com/kong/kong-operator/v2/test/helpers"
 	"github.com/kong/kong-operator/v2/test/integration"
@@ -382,12 +383,11 @@ func checkDataPlaneStatus(
 		if assert.Len(c, dps.Items, 1) {
 			dp = dps.Items[0]
 		}
-		if !assert.Len(c, dp.Status.Conditions, 1) {
+
+		condition, ok := k8sutils.GetCondition(kcfgdataplane.ReadyType, &dp)
+		if !assert.True(c, ok, "Ready condition not present") {
 			return
 		}
-
-		condition := dp.Status.Conditions[0]
-		assert.EqualValues(c, kcfgdataplane.ReadyType, condition.Type)
 		assert.Equal(c, expectedConditionStatus, condition.Status)
 		assert.EqualValues(c, expectedConditionReason, condition.Reason)
 		assert.Equal(c, expectedConditionMessage, condition.Message)


### PR DESCRIPTION
**What this PR does / why we need it**:

This changes how DataPlane defines its `Ready` status condition.

Previously it has been: 

```
if status.AvailableReplicas < status.Replicas {
  // not ready
}
```

This PR proposes the following:

```
if status.AvailableReplicas < spec.Replicas {
  // not ready
}
```

This prevents `DataPlane` flapping its `Ready` status condition during a rolling update


**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

Related: https://github.com/Kong/gateway-operator-archive/pull/1348/

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
