### PR TITLE
fix: use upstream scoped listing of targets when upstream ID available, controlplane scoped otherwise

### DIFF
--- a/controller/konnect/ops/ops_kongtarget.go
+++ b/controller/konnect/ops/ops_kongtarget.go
@@ -177,24 +177,48 @@ func getKongTargetForUID(
 	sdk sdkkonnectgo.TargetsSDK,
 	target *configurationv1alpha1.KongTarget,
 ) (string, error) {
-	reqList := sdkkonnectops.ListTargetWithUpstreamRequest{
-		// NOTE: only filter on object's UID.
-		// Other fields like name might have changed in the meantime but that's OK.
-		// Those will be enforced via subsequent updates.
-		Tags:           new(UIDLabelForObject(target)),
-		ControlPlaneID: target.GetControlPlaneID(),
+	var targets []sdkkonnectcomp.Target
+	switch upstreamID := target.Status.Konnect.UpstreamID; upstreamID {
+	case "":
+		reqList := sdkkonnectops.ListTargetsRequest{
+			// NOTE: only filter on object's UID.
+			// Other fields like name might have changed in the meantime but that's OK.
+			// Those will be enforced via subsequent updates.
+			Tags:           new(UIDLabelForObject(target)),
+			ControlPlaneID: target.GetControlPlaneID(),
+		}
+
+		resp, err := sdk.ListTargets(ctx, reqList)
+		if err != nil {
+			return "", fmt.Errorf("failed listing %s: %w", target.GetTypeName(), err)
+		}
+
+		if resp == nil || resp.ListTargets == nil {
+			return "", fmt.Errorf("failed listing %s: %w", target.GetTypeName(), ErrNilResponse)
+		}
+		targets = resp.ListTargets.Data
+	default:
+		reqList := sdkkonnectops.ListTargetWithUpstreamRequest{
+			// NOTE: only filter on object's UID.
+			// Other fields like name might have changed in the meantime but that's OK.
+			// Those will be enforced via subsequent updates.
+			Tags:                new(UIDLabelForObject(target)),
+			ControlPlaneID:      target.GetControlPlaneID(),
+			UpstreamIDForTarget: upstreamID,
+		}
+
+		resp, err := sdk.ListTargetWithUpstream(ctx, reqList)
+		if err != nil {
+			return "", fmt.Errorf("failed listing %s: %w", target.GetTypeName(), err)
+		}
+
+		if resp == nil || resp.Object == nil {
+			return "", fmt.Errorf("failed listing %s: %w", target.GetTypeName(), ErrNilResponse)
+		}
+		targets = resp.Object.Data
 	}
 
-	resp, err := sdk.ListTargetWithUpstream(ctx, reqList)
-	if err != nil {
-		return "", fmt.Errorf("failed listing %s: %w", target.GetTypeName(), err)
-	}
-
-	if resp == nil || resp.Object == nil {
-		return "", fmt.Errorf("failed listing %s: %w", target.GetTypeName(), ErrNilResponse)
-	}
-
-	return getMatchingEntryFromListResponseData(sliceToEntityWithIDPtrSlice(resp.Object.Data), target)
+	return getMatchingEntryFromListResponseData(sliceToEntityWithIDPtrSlice(targets), target)
 }
 
 func targetMatch(konnectTarget *sdkkonnectcomp.Target, target *configurationv1alpha1.KongTarget) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:

Using upstream scoped target listing can lead to missing upstream ID in URL when upstream ID is not set:

```
/v2/control-planes/xxxxxxxxxxxxxxxxxxxxx/core-entities/upstreams//targets?size=100&tags=k8s-uid%3Adae5954b-2222-1111-1111-1111111111
```

Note the `upstreams//targets`.

This PR changes it to use:

```
/v2/control-planes/xxxxxxxxxxxxxxxxxxxxx/core-entities/targets?size=100&tags=k8s-uid%3Adae5954b-2222-1111-1111-1111111111
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

x-ref: https://kongstrong.slack.com/archives/C02KEASTTRC/p1776282022862589?thread_ts=1776259617.347409&cid=C02KEASTTRC

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
