### PR TITLE
feat(eventgateway/dataplane): manage KonnectEventDataPlaneCertificate

### DIFF
--- a/api/eventgateway/v1alpha1/conditions.go
+++ b/api/eventgateway/v1alpha1/conditions.go
@@ -100,3 +100,24 @@ const (
 	// been resolved.
 	KonnectEventGatewayResolvedMessage = "Referenced KonnectEventGateway is resolved and Programmed"
 )
+
+// -----------------------------------------------------------------------------
+// DataPlane - KonnectCertificate Registration Condition Constants
+// -----------------------------------------------------------------------------
+
+const (
+	// KonnectCertificateRegisteredType indicates whether the
+	// KonnectEventDataPlaneCertificate resource has been ensured for the DataPlane.
+	KonnectCertificateRegisteredType consts.ConditionType = "KonnectCertificateRegistered"
+
+	// KonnectCertificateRegisteredReason indicates the certificate resource was
+	// successfully created or is already up-to-date.
+	KonnectCertificateRegisteredReason consts.ConditionReason = "KonnectCertificateRegistered"
+	// KonnectCertificateRegistrationFailedReason indicates the certificate resource
+	// could not be ensured.
+	KonnectCertificateRegistrationFailedReason consts.ConditionReason = "KonnectCertificateRegistrationFailed"
+	// KonnectCertificateNotProgrammedReason indicates the
+	// KonnectEventDataPlaneCertificate exists but has not yet been programmed
+	// on Konnect by the Konnect controller.
+	KonnectCertificateNotProgrammedReason consts.ConditionReason = "KonnectCertificateNotProgrammed"
+)

--- a/controller/eventgateway/dataplane/controller.go
+++ b/controller/eventgateway/dataplane/controller.go
@@ -74,6 +74,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.Secret{}).
+		Owns(&konnectv1alpha1.KonnectEventDataPlaneCertificate{}).
 		Watches(
 			&konnectv1alpha1.KonnectEventControlPlane{},
 			handler.EnqueueRequestsFromMapFunc(enqueueForKonnectEventGatewayRef(mgr.GetClient())),
@@ -110,6 +111,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 	// picks up the correct Secret name on the next reconcile. No explicit
 	// requeue is needed, the watch on the owned Secret triggers it.
 	if certResult != op.Noop {
+		return ctrl.Result{}, nil
+	}
+
+	// Ensure the KonnectEventDataPlaneCertificate is registered with Konnect.
+	// Return early if not yet programmed; the Owns() watch retriggeres once
+	// the Konnect controller flips Programmed to True.
+	certProgrammed, err := r.ensureKonnectCertificate(ctx, logger, egdp, keg, certSecret)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	// If the certificate is not yet programmed on Konnect, return early.
+	// Without this, we would create a deployment that uses a cert secret not yet present in Konnect.
+	if !certProgrammed {
 		return ctrl.Result{}, nil
 	}
 

--- a/controller/eventgateway/dataplane/controller_test.go
+++ b/controller/eventgateway/dataplane/controller_test.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kong/kong-operator/v2/api/common/consts"
+	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
 	eventgatewayv1alpha1 "github.com/kong/kong-operator/v2/api/eventgateway/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
 	managerscheme "github.com/kong/kong-operator/v2/modules/manager/scheme"
@@ -169,6 +170,34 @@ func drainEvents(recorder *events.FakeRecorder) []string {
 	}
 }
 
+// newProgrammedKonnectCert builds a KonnectEventDataPlaneCertificate with Programmed=True,
+// modelling the state after the Konnect controller has registered it.
+func newProgrammedKonnectCert() *konnectv1alpha1.KonnectEventDataPlaneCertificate {
+	gatewayID := "keg-id-123"
+	secretRefType := konnectv1alpha1.SensitiveDataSourceTypeSecretRef
+	return &konnectv1alpha1.KonnectEventDataPlaneCertificate{
+		ObjectMeta: metav1.ObjectMeta{Namespace: reconcileTestNS, Name: reconcileTestDPName},
+		Spec: konnectv1alpha1.KonnectEventDataPlaneCertificateSpec{
+			GatewayRef: commonv1alpha1.ObjectRef{
+				Type:      commonv1alpha1.ObjectRefTypeKonnectID,
+				KonnectID: &gatewayID,
+			},
+			Type:      &secretRefType,
+			SecretRef: &commonv1alpha1.NamespacedRef{Name: reconcileTestDPName},
+		},
+		Status: konnectv1alpha1.KonnectEventDataPlaneCertificateStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               konnectv1alpha1.KonnectEntityProgrammedConditionType,
+					Status:             metav1.ConditionTrue,
+					Reason:             "Programmed",
+					LastTransitionTime: metav1.NewTime(time.Now()),
+				},
+			},
+		},
+	}
+}
+
 // -----------------------------------------------------------------
 // TestReconciler_Reconcile
 // -----------------------------------------------------------------
@@ -276,9 +305,10 @@ func TestReconciler_Reconcile(t *testing.T) {
 				newReconcileEGDP(),
 				newProgrammedKEG(),
 				caSecret(),
+				newProgrammedKonnectCert(),
 			},
-			// 1st reconcile: cert created → returns early (owned Secret watch triggers next reconcile).
-			// 2nd reconcile: cert found → Deployment + Service created → Result{}.
+			// 1st reconcile: cert Secret created → returns early (owned Secret watch triggers next reconcile).
+			// 2nd reconcile: cert Secret + programmed KonnectEventDataPlaneCertificate present → Deployment + Service created.
 			reconcileCount: 2,
 			wantResult:     ctrl.Result{},
 			assertFn: func(t *testing.T, cl client.Client, recorder *events.FakeRecorder) {
@@ -327,8 +357,9 @@ func TestReconciler_Reconcile(t *testing.T) {
 				newReconcileEGDP(),
 				newProgrammedKEG(),
 				caSecret(),
+				newProgrammedKonnectCert(),
 			},
-			// 1st: cert created. 2nd: Deployment+Service created. 3rd: everything exists → noop.
+			// 1st: cert Secret created. 2nd: Deployment+Service created. 3rd: everything exists → noop.
 			reconcileCount: 3,
 			wantResult:     ctrl.Result{},
 			assertFn: func(t *testing.T, cl client.Client, recorder *events.FakeRecorder) {
@@ -347,7 +378,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			base := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithObjects(tc.objects...).
-				WithStatusSubresource(egdp).
+				WithStatusSubresource(egdp, &konnectv1alpha1.KonnectEventDataPlaneCertificate{}).
 				Build()
 
 			recorder := events.NewFakeRecorder(30)

--- a/controller/eventgateway/dataplane/owned_konnect_cert.go
+++ b/controller/eventgateway/dataplane/owned_konnect_cert.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2026 Kong, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	eventgatewayv1alpha1 "github.com/kong/kong-operator/v2/api/eventgateway/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	log "github.com/kong/kong-operator/v2/controller/pkg/log"
+	"github.com/kong/kong-operator/v2/controller/pkg/op"
+	controllerpkgssa "github.com/kong/kong-operator/v2/controller/pkg/ssa"
+	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+)
+
+// ensureKonnectCertificate ensures a KonnectEventDataPlaneCertificate resource
+// exists for the given DataPlane, referencing the provisioned mTLS Secret and the
+// resolved KonnectEventControlPlane's Konnect ID.
+func (r *Reconciler) ensureKonnectCertificate(
+	ctx context.Context,
+	logger logr.Logger,
+	egdp *eventgatewayv1alpha1.KegDataPlane,
+	keg *konnectv1alpha1.KonnectEventControlPlane,
+	certSecret *corev1.Secret,
+) (programmed bool, err error) {
+	secretRefType := konnectv1alpha1.SensitiveDataSourceTypeSecretRef
+	desired := &konnectv1alpha1.KonnectEventDataPlaneCertificate{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: konnectv1alpha1.GroupVersion.String(),
+			Kind:       "KonnectEventDataPlaneCertificate",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      egdp.Name,
+			Namespace: egdp.Namespace,
+		},
+		Spec: konnectv1alpha1.KonnectEventDataPlaneCertificateSpec{
+			GatewayRef: commonv1alpha1.ObjectRef{
+				Type:      commonv1alpha1.ObjectRefTypeKonnectID,
+				KonnectID: &keg.Status.ID,
+			},
+			Type: &secretRefType,
+			SecretRef: &commonv1alpha1.NamespacedRef{
+				Name: certSecret.Name,
+			},
+		},
+	}
+
+	k8sutils.SetOwnerForObject(desired, egdp)
+
+	result, err := controllerpkgssa.ApplyIfChanged(ctx, logger, r.Client, r.typeConverter, desired, FieldManager)
+	if err != nil {
+		apimeta.SetStatusCondition(&egdp.Status.Conditions, metav1.Condition{
+			Type:               string(eventgatewayv1alpha1.KonnectCertificateRegisteredType),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(eventgatewayv1alpha1.KonnectCertificateRegistrationFailedReason),
+			Message:            fmt.Sprintf("failed to ensure KonnectEventDataPlaneCertificate: %v", err),
+			ObservedGeneration: egdp.Generation,
+		})
+		return false, fmt.Errorf("failed to apply KonnectEventDataPlaneCertificate for DataPlane %s/%s: %w",
+			egdp.Namespace, egdp.Name, err)
+	}
+
+	switch result {
+	case op.Created:
+		log.Debug(logger, "KonnectEventDataPlaneCertificate created", "name", desired.Name)
+		r.eventRecorder.Eventf(egdp, nil, corev1.EventTypeNormal, "KonnectCertificateCreated", "CreateKonnectCertificate",
+			"KonnectEventDataPlaneCertificate %s created", desired.Name)
+	case op.Updated:
+		log.Debug(logger, "KonnectEventDataPlaneCertificate updated", "name", desired.Name)
+		r.eventRecorder.Eventf(egdp, nil, corev1.EventTypeNormal, "KonnectCertificateUpdated", "UpdateKonnectCertificate",
+			"KonnectEventDataPlaneCertificate %s updated", desired.Name)
+	case op.Noop, op.Deleted:
+	}
+
+	programmed, err = checkKonnectCertificateProgrammed(ctx, r.Client, egdp, desired)
+	if err != nil {
+		apimeta.SetStatusCondition(&egdp.Status.Conditions, metav1.Condition{
+			Type:               string(eventgatewayv1alpha1.KonnectCertificateRegisteredType),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(eventgatewayv1alpha1.KonnectCertificateRegistrationFailedReason),
+			Message:            fmt.Sprintf("failed to check KonnectEventDataPlaneCertificate status: %v", err),
+			ObservedGeneration: egdp.Generation,
+		})
+		return false, err
+	}
+	if !programmed {
+		return false, nil
+	}
+	apimeta.SetStatusCondition(&egdp.Status.Conditions, metav1.Condition{
+		Type:               string(eventgatewayv1alpha1.KonnectCertificateRegisteredType),
+		Status:             metav1.ConditionTrue,
+		Reason:             string(eventgatewayv1alpha1.KonnectCertificateRegisteredReason),
+		Message:            "KonnectEventDataPlaneCertificate ensured and programmed on Konnect",
+		ObservedGeneration: egdp.Generation,
+	})
+	return true, nil
+}
+
+// checkKonnectCertificateProgrammed fetches the KonnectEventDataPlaneCertificate
+// and checks whether the Konnect controller has programmed it on the Konnect API.
+// It sets KonnectCertificateRegistered=False on egdp when not yet programmed and
+// returns false so the caller can return early; the Owns() watch will retrigger
+// once the Konnect controller flips Programmed to True.
+func checkKonnectCertificateProgrammed(
+	ctx context.Context,
+	cl client.Client,
+	egdp *eventgatewayv1alpha1.KegDataPlane,
+	desired *konnectv1alpha1.KonnectEventDataPlaneCertificate,
+) (bool, error) {
+	current := &konnectv1alpha1.KonnectEventDataPlaneCertificate{}
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(desired), current); err != nil {
+		return false, fmt.Errorf("failed to get KonnectEventDataPlaneCertificate %s/%s: %w",
+			desired.Namespace, desired.Name, err)
+	}
+
+	programmedCond := apimeta.FindStatusCondition(current.Status.Conditions, konnectv1alpha1.KonnectEntityProgrammedConditionType)
+	if programmedCond == nil || programmedCond.Status != metav1.ConditionTrue {
+		// Not yet programmed, update condition and return early. The Owns()
+		// watch on KonnectEventDataPlaneCertificate will retrigger once the
+		// Konnect controller flips Programmed to True.
+		apimeta.SetStatusCondition(&egdp.Status.Conditions, metav1.Condition{
+			Type:               string(eventgatewayv1alpha1.KonnectCertificateRegisteredType),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(eventgatewayv1alpha1.KonnectCertificateNotProgrammedReason),
+			Message:            "KonnectEventDataPlaneCertificate is not yet programmed on Konnect",
+			ObservedGeneration: egdp.Generation,
+		})
+		return false, nil
+	}
+	return true, nil
+}

--- a/controller/eventgateway/dataplane/owned_konnect_cert_test.go
+++ b/controller/eventgateway/dataplane/owned_konnect_cert_test.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2026 Kong, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	eventgatewayv1alpha1 "github.com/kong/kong-operator/v2/api/eventgateway/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	managerscheme "github.com/kong/kong-operator/v2/modules/manager/scheme"
+)
+
+const (
+	testKonnectGatewayID = "keg-konnect-id-abc"
+	testCertSecretName   = "egdp-cert-secret"
+)
+
+func newTestEGDP() *eventgatewayv1alpha1.KegDataPlane {
+	return &eventgatewayv1alpha1.KegDataPlane{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "eventgateway.konghq.com/v1alpha1",
+			Kind:       "KegDataPlane",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-dp",
+			Namespace:  "default",
+			UID:        types.UID("egdp-uid-123"),
+			Generation: 1,
+		},
+	}
+}
+
+func newTestKEG() *konnectv1alpha1.KonnectEventControlPlane {
+	return &konnectv1alpha1.KonnectEventControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-keg",
+			Namespace: "default",
+		},
+		Status: konnectv1alpha1.KonnectEventControlPlaneStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               konnectv1alpha1.KonnectEntityProgrammedConditionType,
+					Status:             metav1.ConditionTrue,
+					Reason:             "Programmed",
+					LastTransitionTime: metav1.NewTime(time.Now()),
+				},
+			},
+			KonnectEntityStatus: konnectv1alpha1.KonnectEntityStatus{
+				ServerURL: "https://us.konghq.com",
+				ID:        testKonnectGatewayID,
+			},
+		},
+	}
+}
+
+func newTestCertSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testCertSecretName,
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"tls.crt": []byte("---- BEGIN CERTIFICATE ----"),
+			"tls.key": []byte("---- BEGIN KEY ----"),
+		},
+	}
+}
+
+func TestEnsureKonnectCertificate(t *testing.T) {
+	oldID := "old-gateway-id"
+	programmedGatewayID := testKonnectGatewayID
+	secretRefType := konnectv1alpha1.SensitiveDataSourceTypeSecretRef
+
+	tests := []struct {
+		name         string
+		extraObjs    []client.Object
+		interceptors interceptor.Funcs
+		// preCall performs a first call before the one under test (used for the noop scenario).
+		preCall         bool
+		wantProgrammed  bool
+		wantErrContains string
+		wantCondStatus  metav1.ConditionStatus
+		wantCondReason  string
+		verifyCert      func(t *testing.T, cert konnectv1alpha1.KonnectEventDataPlaneCertificate)
+	}{
+		{
+			name:           "creates cert when none exists",
+			wantProgrammed: false,
+			wantCondStatus: metav1.ConditionFalse,
+			wantCondReason: string(eventgatewayv1alpha1.KonnectCertificateNotProgrammedReason),
+			verifyCert: func(t *testing.T, cert konnectv1alpha1.KonnectEventDataPlaneCertificate) {
+				t.Helper()
+				assert.Equal(t, commonv1alpha1.ObjectRefTypeKonnectID, cert.Spec.GatewayRef.Type)
+				require.NotNil(t, cert.Spec.GatewayRef.KonnectID)
+				assert.Equal(t, testKonnectGatewayID, *cert.Spec.GatewayRef.KonnectID)
+				require.NotNil(t, cert.Spec.Type)
+				assert.Equal(t, konnectv1alpha1.SensitiveDataSourceTypeSecretRef, *cert.Spec.Type)
+				require.NotNil(t, cert.Spec.SecretRef)
+				assert.Equal(t, testCertSecretName, cert.Spec.SecretRef.Name)
+				require.Len(t, cert.OwnerReferences, 1)
+				assert.Equal(t, "test-dp", cert.OwnerReferences[0].Name)
+				assert.Equal(t, types.UID("egdp-uid-123"), cert.OwnerReferences[0].UID)
+				assert.True(t, *cert.OwnerReferences[0].Controller)
+			},
+		},
+		{
+			name:           "noop on second call with same inputs",
+			preCall:        true,
+			wantProgrammed: false,
+			wantCondStatus: metav1.ConditionFalse,
+			wantCondReason: string(eventgatewayv1alpha1.KonnectCertificateNotProgrammedReason),
+		},
+		{
+			name: "updates cert when gateway ID changes",
+			extraObjs: []client.Object{
+				&konnectv1alpha1.KonnectEventDataPlaneCertificate{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: konnectv1alpha1.GroupVersion.String(),
+						Kind:       "KonnectEventDataPlaneCertificate",
+					},
+					ObjectMeta: metav1.ObjectMeta{Name: "test-dp", Namespace: "default"},
+					Spec: konnectv1alpha1.KonnectEventDataPlaneCertificateSpec{
+						GatewayRef: commonv1alpha1.ObjectRef{
+							Type:      commonv1alpha1.ObjectRefTypeKonnectID,
+							KonnectID: &oldID,
+						},
+						Type:      &secretRefType,
+						SecretRef: &commonv1alpha1.NamespacedRef{Name: testCertSecretName},
+					},
+				},
+			},
+			wantProgrammed: false,
+			wantCondStatus: metav1.ConditionFalse,
+			wantCondReason: string(eventgatewayv1alpha1.KonnectCertificateNotProgrammedReason),
+			verifyCert: func(t *testing.T, cert konnectv1alpha1.KonnectEventDataPlaneCertificate) {
+				t.Helper()
+				require.NotNil(t, cert.Spec.GatewayRef.KonnectID)
+				assert.Equal(t, testKonnectGatewayID, *cert.Spec.GatewayRef.KonnectID)
+			},
+		},
+		{
+			name: "cert already programmed by Konnect sets KonnectCertificateRegistered=True", extraObjs: []client.Object{
+				&konnectv1alpha1.KonnectEventDataPlaneCertificate{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: konnectv1alpha1.GroupVersion.String(),
+						Kind:       "KonnectEventDataPlaneCertificate",
+					},
+					ObjectMeta: metav1.ObjectMeta{Name: "test-dp", Namespace: "default"},
+					Spec: konnectv1alpha1.KonnectEventDataPlaneCertificateSpec{
+						GatewayRef: commonv1alpha1.ObjectRef{
+							Type:      commonv1alpha1.ObjectRefTypeKonnectID,
+							KonnectID: &programmedGatewayID,
+						},
+						Type:      &secretRefType,
+						SecretRef: &commonv1alpha1.NamespacedRef{Name: testCertSecretName},
+					},
+					Status: konnectv1alpha1.KonnectEventDataPlaneCertificateStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               konnectv1alpha1.KonnectEntityProgrammedConditionType,
+								Status:             metav1.ConditionTrue,
+								Reason:             "Programmed",
+								LastTransitionTime: metav1.NewTime(time.Now()),
+							},
+						},
+					},
+				},
+			},
+			wantProgrammed: true,
+			wantCondStatus: metav1.ConditionTrue,
+			wantCondReason: string(eventgatewayv1alpha1.KonnectCertificateRegisteredReason),
+		},
+		{
+			name: "sets failed condition and returns error on client error",
+			interceptors: interceptor.Funcs{
+				Apply: func(_ context.Context, _ client.WithWatch, _ runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+					return assert.AnError
+				},
+			},
+			wantProgrammed:  false,
+			wantErrContains: "failed to apply KonnectEventDataPlaneCertificate",
+			wantCondStatus:  metav1.ConditionFalse,
+			wantCondReason:  string(eventgatewayv1alpha1.KonnectCertificateRegistrationFailedReason),
+		},
+		{
+			name: "cert exists with Programmed=False: returns not-programmed condition",
+			extraObjs: []client.Object{
+				&konnectv1alpha1.KonnectEventDataPlaneCertificate{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: konnectv1alpha1.GroupVersion.String(),
+						Kind:       "KonnectEventDataPlaneCertificate",
+					},
+					ObjectMeta: metav1.ObjectMeta{Name: "test-dp", Namespace: "default"},
+					Spec: konnectv1alpha1.KonnectEventDataPlaneCertificateSpec{
+						GatewayRef: commonv1alpha1.ObjectRef{
+							Type:      commonv1alpha1.ObjectRefTypeKonnectID,
+							KonnectID: &programmedGatewayID,
+						},
+						Type:      &secretRefType,
+						SecretRef: &commonv1alpha1.NamespacedRef{Name: testCertSecretName},
+					},
+					Status: konnectv1alpha1.KonnectEventDataPlaneCertificateStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               konnectv1alpha1.KonnectEntityProgrammedConditionType,
+								Status:             metav1.ConditionFalse,
+								Reason:             "Pending",
+								LastTransitionTime: metav1.NewTime(time.Now()),
+							},
+						},
+					},
+				},
+			},
+			wantProgrammed: false,
+			wantCondStatus: metav1.ConditionFalse,
+			wantCondReason: string(eventgatewayv1alpha1.KonnectCertificateNotProgrammedReason),
+		},
+		{
+			name: "Get error after apply: sets RegistrationFailed condition and returns error",
+			interceptors: interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*konnectv1alpha1.KonnectEventDataPlaneCertificate); ok {
+						return assert.AnError
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+			wantProgrammed:  false,
+			wantErrContains: "failed to get KonnectEventDataPlaneCertificate",
+			wantCondStatus:  metav1.ConditionFalse,
+			wantCondReason:  string(eventgatewayv1alpha1.KonnectCertificateRegistrationFailedReason),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Fresh objects per subtest to avoid state bleed between cases.
+			egdp := newTestEGDP()
+			keg := newTestKEG()
+			certSecret := newTestCertSecret()
+
+			objs := append([]client.Object{egdp}, tc.extraObjs...)
+			base := fake.NewClientBuilder().
+				WithScheme(managerscheme.Get()).
+				WithStatusSubresource(&konnectv1alpha1.KonnectEventDataPlaneCertificate{}).
+				WithObjects(objs...).
+				Build()
+			cl := interceptor.NewClient(base, tc.interceptors)
+
+			r := &Reconciler{
+				Client:        cl,
+				typeConverter: managedfields.NewDeducedTypeConverter(),
+				eventRecorder: events.NewFakeRecorder(10),
+			}
+
+			if tc.preCall {
+				_, err := r.ensureKonnectCertificate(t.Context(), logr.Discard(), egdp, keg, certSecret)
+				require.NoError(t, err)
+			}
+
+			programmed, err := r.ensureKonnectCertificate(t.Context(), logr.Discard(), egdp, keg, certSecret)
+
+			if tc.wantErrContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErrContains)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantProgrammed, programmed)
+
+			cond := apimeta.FindStatusCondition(egdp.Status.Conditions, string(eventgatewayv1alpha1.KonnectCertificateRegisteredType))
+			require.NotNil(t, cond)
+			assert.Equal(t, tc.wantCondStatus, cond.Status)
+			assert.Equal(t, tc.wantCondReason, cond.Reason)
+
+			if tc.verifyCert != nil {
+				var cert konnectv1alpha1.KonnectEventDataPlaneCertificate
+				require.NoError(t, cl.Get(t.Context(), types.NamespacedName{Name: egdp.Name, Namespace: egdp.Namespace}, &cert))
+				tc.verifyCert(t, cert)
+			}
+		})
+	}
+}

--- a/controller/eventgateway/dataplane/ssa.go
+++ b/controller/eventgateway/dataplane/ssa.go
@@ -33,6 +33,8 @@ var requiredSchemas = []schema.GroupVersion{
 	{Group: "apps", Version: "v1"},
 	// KegDataPlane (status apply)
 	{Group: "eventgateway.konghq.com", Version: "v1alpha1"},
+	// KonnectEventDataPlaneCertificate
+	{Group: "konnect.konghq.com", Version: "v1alpha1"},
 }
 
 // initTypeConverter creates a TypeConverter from the API server's OpenAPI v3 schemas.

--- a/controller/eventgateway/dataplane/ssa_test.go
+++ b/controller/eventgateway/dataplane/ssa_test.go
@@ -43,6 +43,7 @@ func Test_requiredSchemas(t *testing.T) {
 		{Group: "", Version: "v1"},
 		{Group: "apps", Version: "v1"},
 		{Group: "eventgateway.konghq.com", Version: "v1alpha1"},
+		{Group: "konnect.konghq.com", Version: "v1alpha1"},
 	}
 	assert.Equal(t, expected, requiredSchemas)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduce ensureKonnectCertificate to apply and track the lifecycle of
KonnectEventDataPlaneCertificate for each KegDataPlane. Deployment and
Service creation are gated on the certificate being programmed by Konnect,
with an Owns() watch to retrigger reconciliation automatically.

**Which issue this PR fixes**

Fixes #3903 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
