### PR TITLE
tests(conformance): skip HTTPRouteReferenceGrant for hybrid

### DIFF
--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -50,6 +50,10 @@ var skippedTestsForHybrid = []string{
 	// Extended profile.
 	tests.HTTPRouteRewriteHost.ShortName,
 	tests.HTTPRouteRewritePath.ShortName,
+
+	// This test is skipped because it proven to be flaky.
+	// TODO: https://github.com/Kong/kong-operator/issues/2793
+	tests.HTTPRouteReferenceGrant.ShortName,
 }
 
 // skippedTestsForConfig returns the list of skipped tests for the given router flavor and gateway type.


### PR DESCRIPTION
**What this PR does / why we need it**:

Related issue which tracks the flakiness of this test: https://github.com/Kong/kong-operator/issues/2793

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
