### PR TITLE
chore: don't hide unsupported cluster type, delegate to CRD validation

### DIFF
--- a/controller/konnect/konnectextension_controller_utils.go
+++ b/controller/konnect/konnectextension_controller_utils.go
@@ -315,16 +315,20 @@ func enforceKonnectExtensionStatus(
 
 func konnectClusterTypeToCRDClusterType(clusterType sdkkonnectcomp.ControlPlaneClusterType) konnectv1alpha2.KonnectExtensionClusterType {
 	switch clusterType {
-	// When it's not specified by the caller (left empty) in Konnect it's set to CLUSTER_TYPE_CONTROL_PLANE.
-	case sdkkonnectcomp.ControlPlaneClusterTypeClusterTypeControlPlane, "":
+	// When it's not specified by the caller (left empty) in Konnect it's set
+	// to CLUSTER_TYPE_CONTROL_PLANE.
+	case "",
+		sdkkonnectcomp.ControlPlaneClusterTypeClusterTypeControlPlane:
 		return konnectv1alpha2.ClusterTypeControlPlane
 	case sdkkonnectcomp.ControlPlaneClusterTypeClusterTypeK8SIngressController:
 		return konnectv1alpha2.ClusterTypeK8sIngressController
 	case sdkkonnectcomp.ControlPlaneClusterTypeClusterTypeControlPlaneGroup:
 		return konnectv1alpha2.ClusterTypeControlPlaneGroup
 	default:
-		// default never happens as the validation is at the CRD level
-		return ""
+		// Simply translate the SDK cluster type to the CRD cluster type.
+		// This way bubble up any unsupported cluster types to be handled at the CRD validation level,
+		// instead of silently ignored here.
+		return konnectv1alpha2.KonnectExtensionClusterType(clusterType)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR aims to prevent the following logs:

```
Unsupported value: \"\": supported values: \"ControlPlane\", \"K8SIngressController\", <nil>: Invalid value: null
```

```
"KonnectExtension.konnect.konghq.com \"kong-86dst\" is invalid: [status.konnect.clusterType: Unsupported value: \"\": supported values: \"ControlPlane\", \"K8SIngressController\", <nil>: Invalid value: null: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]",
  "stacktrace": "sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:495\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:438\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:313"
```

by not hiding the unsupported value.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
