### PR TITLE
chore(ci): fix renovate bumping irrelevant Dockerfiles and KO module in crd-from-oas

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,9 @@
      "gomod",
      "dockerfile"
   ],
+  "dockerfile": {
+    "fileMatch": ["^Dockerfile$", "^debug\\.Dockerfile$"]
+  },
   "automerge": false,
   "separateMinorPatch": true,
   "labels": [
@@ -148,6 +151,19 @@
       "matchDepNames": [
         "/.*@only-patch/"
       ]
+    },
+
+    {
+      "description": "Disable updates of the root module in submodules (e.g. crd-from-oas/go.mod)",
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["/^github\\.com\\/kong\\/kong-operator/"],
+      "enabled": false
+    },
+    {
+      "description": "Disable KO image bumps in kustomize (done at release time)",
+      "matchManagers": ["kustomize"],
+      "matchDepNames": ["docker.io/kong/kong-operator"],
+      "enabled": false
     },
 
     // Latest release branch specific rules for updating patch versions of Go toolchain and Dockerfiles.


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent renovate from creating PRs like:

- https://github.com/Kong/kong-operator/pull/3935
- https://github.com/Kong/kong-operator/pull/3897
- and https://github.com/Kong/kong-operator/pull/3895

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
