### PR TITLE
feat(mcpserver): improve deployment controller with SSA-based workload reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,11 @@
 - `MCPServer`: set MCPServer ID as the name identifier for the Kubernetes resource and store
   the Konnect name in the `MCPServer` CRD status.
   [#3904](https://github.com/Kong/kong-operator/pull/3904)
+- `MCPServer`: reconcile the owned `Deployment` and `Service` via Server-Side
+  Apply so the full spec is enforced on every reconcile, and set the init and
+  runner container images (`kong/mcp-server-init`, `kong/mcp-server-runner`) to
+  the versions returned by Konnect.
+  [#3943](https://github.com/Kong/kong-operator/pull/3943)
 
 ### Changed
 

--- a/controller/eventgateway/dataplane/consts.go
+++ b/controller/eventgateway/dataplane/consts.go
@@ -17,9 +17,6 @@ limitations under the License.
 package dataplane
 
 const (
-	// FieldManager is the field manager name used for Server-Side Apply operations.
-	FieldManager = "gateway-operator"
-
 	// ControllerName is the name used for logging and event recording.
 	ControllerName = "keg-dataplane"
 

--- a/controller/eventgateway/dataplane/owned_deployment.go
+++ b/controller/eventgateway/dataplane/owned_deployment.go
@@ -57,7 +57,7 @@ func (r *Reconciler) ensureDeployment(
 			egdp.Namespace, egdp.Name, err)
 	}
 
-	result, err := controllerpkgssa.ApplyIfChanged(ctx, logger, r.Client, r.typeConverter, desired, FieldManager)
+	result, err := controllerpkgssa.ApplyIfChanged(ctx, logger, r.Client, r.typeConverter, desired, controllerpkgssa.FieldManager)
 	if err != nil {
 		r.eventRecorder.Eventf(egdp, nil, corev1.EventTypeWarning, "DeploymentFailed", "ApplyDeployment",
 			"Failed to apply Deployment: %v", err)

--- a/controller/eventgateway/dataplane/owned_konnect_cert.go
+++ b/controller/eventgateway/dataplane/owned_konnect_cert.go
@@ -69,7 +69,7 @@ func (r *Reconciler) ensureKonnectCertificate(
 
 	k8sutils.SetOwnerForObject(desired, egdp)
 
-	result, err := controllerpkgssa.ApplyIfChanged(ctx, logger, r.Client, r.typeConverter, desired, FieldManager)
+	result, err := controllerpkgssa.ApplyIfChanged(ctx, logger, r.Client, r.typeConverter, desired, controllerpkgssa.FieldManager)
 	if err != nil {
 		apimeta.SetStatusCondition(&egdp.Status.Conditions, metav1.Condition{
 			Type:               string(eventgatewayv1alpha1.KonnectCertificateRegisteredType),

--- a/controller/eventgateway/dataplane/owned_service.go
+++ b/controller/eventgateway/dataplane/owned_service.go
@@ -47,7 +47,7 @@ func (r *Reconciler) ensureKafkaService(
 			egdp.Namespace, egdp.Name, err)
 	}
 
-	result, err := controllerpkgssa.ApplyIfChanged(ctx, logger, r.Client, r.typeConverter, desired, FieldManager)
+	result, err := controllerpkgssa.ApplyIfChanged(ctx, logger, r.Client, r.typeConverter, desired, controllerpkgssa.FieldManager)
 	if err != nil {
 		r.eventRecorder.Eventf(egdp, nil, corev1.EventTypeWarning, "ServiceFailed", "ApplyService",
 			"Failed to apply Kafka Service: %v", err)

--- a/controller/eventgateway/dataplane/status.go
+++ b/controller/eventgateway/dataplane/status.go
@@ -88,7 +88,7 @@ func (r *Reconciler) applyStatus(
 	logger logr.Logger,
 	egdp *eventgatewayv1alpha1.KegDataPlane,
 ) error {
-	result, statusErr := controllerpkgssa.ApplyStatusIfChanged(ctx, logger, r.Client, r.typeConverter, egdp, FieldManager)
+	result, statusErr := controllerpkgssa.ApplyStatusIfChanged(ctx, logger, r.Client, r.typeConverter, egdp, controllerpkgssa.FieldManager)
 	if statusErr != nil {
 		log.Error(logger, statusErr, "failed to patch KegDataPlane status")
 		r.eventRecorder.Eventf(egdp, nil, corev1.EventTypeWarning, "StatusPatchFailed", "PatchStatus", "%s", statusErr.Error())

--- a/controller/hybridgateway/reconciler_utils.go
+++ b/controller/hybridgateway/reconciler_utils.go
@@ -19,13 +19,9 @@ import (
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/refs"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/utils"
 	"github.com/kong/kong-operator/v2/controller/pkg/log"
+	controllerpkgssa "github.com/kong/kong-operator/v2/controller/pkg/ssa"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
-)
-
-const (
-	// FieldManager is the field manager name used for server-side apply operations.
-	FieldManager = "gateway-operator"
 )
 
 // translate performs the full translation process using the provided APIConverter.
@@ -193,7 +189,7 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 				// Object doesn't exist, create it using server-side apply.
 				log.Debug(logger, "Creating new object", "kind", desired.GetKind(), "obj", namespacedNameDesired)
 				// Set field manager for server-side apply
-				if err := cl.Apply(ctx, client.ApplyConfigurationFromUnstructured(&desired), client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
+				if err := cl.Apply(ctx, client.ApplyConfigurationFromUnstructured(&desired), client.FieldOwner(controllerpkgssa.FieldManager), client.ForceOwnership); err != nil {
 					if apierrors.IsConflict(err) {
 						return false, false, fmt.Errorf("conflict during create of object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 					}
@@ -218,14 +214,14 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 		}
 
 		// Object exists, check if we need to update it.
-		managedFieldsObj, err := managedfields.ExtractAsUnstructured(existing, FieldManager, "")
+		managedFieldsObj, err := managedfields.ExtractAsUnstructured(existing, controllerpkgssa.FieldManager, "")
 		if err != nil {
 			return false, false, fmt.Errorf("failed to extract managed fields for kind %s obj %s: %w", existing.GetKind(), namespacedNameExisting, err)
 		}
 		if managedFieldsObj == nil {
 			// No managed fields for our field manager, we should update.
 			log.Debug(logger, "No managed fields found for our field manager, will apply desired state", "kind", existing.GetKind(), "obj", namespacedNameExisting)
-			if err := cl.Apply(ctx, client.ApplyConfigurationFromUnstructured(&desired), client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
+			if err := cl.Apply(ctx, client.ApplyConfigurationFromUnstructured(&desired), client.FieldOwner(controllerpkgssa.FieldManager), client.ForceOwnership); err != nil {
 				if apierrors.IsConflict(err) {
 					return false, false, fmt.Errorf("conflict during create of object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 				}
@@ -253,7 +249,7 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 		} else {
 			log.Info(logger, "Changes detected for obj, applying desired state", "kind", existing.GetKind(), "obj", namespacedNameExisting, "changes", compare.String())
 			// Changes detected, apply the desired state using server-side apply.
-			if err := cl.Apply(ctx, client.ApplyConfigurationFromUnstructured(&desired), client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
+			if err := cl.Apply(ctx, client.ApplyConfigurationFromUnstructured(&desired), client.FieldOwner(controllerpkgssa.FieldManager), client.ForceOwnership); err != nil {
 				if apierrors.IsConflict(err) {
 					return false, false, fmt.Errorf("conflict during create of object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 				}

--- a/controller/mcpserver/consts.go
+++ b/controller/mcpserver/consts.go
@@ -1,0 +1,6 @@
+package mcpserver
+
+const (
+	// ControllerName is the name used for logging and event recording.
+	ControllerName = "mcpserver"
+)

--- a/controller/mcpserver/mcpserver_controller.go
+++ b/controller/mcpserver/mcpserver_controller.go
@@ -7,6 +7,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -47,10 +49,24 @@ type MCPServerReconciler struct {
 	// events so that a Reconcile loop starts without an actual change on the
 	// MCPServer CRD.
 	ReconcileEventCh chan event.GenericEvent
+
+	// typeConverter is initialised once during SetupWithManager from the API
+	// server's OpenAPI v3 schemas. It supports all types (core K8s + CRDs) and
+	// is used for diff-before-apply via Server-Side Apply.
+	typeConverter managedfields.TypeConverter
+
+	// eventRecorder records Kubernetes events on MCPServer objects.
+	eventRecorder events.EventRecorder
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *MCPServerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	tc, err := initTypeConverter(mgr)
+	if err != nil {
+		return fmt.Errorf("MCPServer controller: failed to initialize TypeConverter: %w", err)
+	}
+	r.typeConverter = tc
+	r.eventRecorder = mgr.GetEventRecorder(ControllerName)
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(r.ControllerOptions).
 		For(&konnectv1alpha1.MCPServer{}).
@@ -139,21 +155,14 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	remoteMCPServer := resp.MCPServerCPInfo
 
 	// Ensure a Deployment exists for this MCPServer.
-	res, deployment, err := r.ensureDeployment(ctx, &mcpServer, remoteMCPServer, apiAuth)
+	deployment, err := r.ensureDeployment(ctx, logger, &mcpServer, remoteMCPServer, apiAuth)
 	if err != nil {
 		return ctrl.Result{}, err
-	}
-	if res != op.Noop {
-		log.Info(logger, fmt.Sprintf("%s Deployment for MCPServer", res), "namespace", mcpServer.Namespace, "name", mcpServer.Name)
 	}
 
 	// Ensure a Service exists for this MCPServer.
-	svcRes, _, err := r.ensureService(ctx, &mcpServer)
-	if err != nil {
+	if err := r.ensureService(ctx, logger, &mcpServer); err != nil {
 		return ctrl.Result{}, err
-	}
-	if svcRes != op.Noop {
-		log.Info(logger, fmt.Sprintf("%s Service for MCPServer", svcRes), "namespace", mcpServer.Namespace, "name", mcpServer.Name)
 	}
 
 	// Ensure Kong entities (KongService, KongRoute) are created in the cluster

--- a/controller/mcpserver/mcpserver_controller.go
+++ b/controller/mcpserver/mcpserver_controller.go
@@ -115,6 +115,12 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// Resolve the reference chain to KonnectAPIAuthConfiguration and build the SDK.
+	apiAuth, err := r.resolveAuth(ctx, &mcpServer)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to resolve auth for MCPServer %s/%s: %w",
+			mcpServer.Namespace, mcpServer.Name, err)
+	}
+
 	sdk, err := r.buildSDK(ctx, &mcpServer)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to build SDK for MCPServer %s/%s: %w",
@@ -133,7 +139,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	remoteMCPServer := resp.MCPServerCPInfo
 
 	// Ensure a Deployment exists for this MCPServer.
-	res, deployment, err := r.ensureDeployment(ctx, &mcpServer, remoteMCPServer)
+	res, deployment, err := r.ensureDeployment(ctx, &mcpServer, remoteMCPServer, apiAuth)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controller/mcpserver/mcpserver_controller_utils.go
+++ b/controller/mcpserver/mcpserver_controller_utils.go
@@ -50,12 +50,11 @@ func ownerControlPlaneName(mcpServer *konnectv1alpha1.MCPServer) string {
 	return ""
 }
 
-// buildSDK resolves the KonnectAPIAuthConfiguration for the given MCPServer
-// and returns an authenticated SDK wrapper.
-func (r *MCPServerReconciler) buildSDK(
+// resolveAuth resolves the KonnectAPIAuthConfiguration for the given MCPServer.
+func (r *MCPServerReconciler) resolveAuth(
 	ctx context.Context,
 	mcpServer *konnectv1alpha1.MCPServer,
-) (sdkops.SDKWrapper, error) {
+) (*konnectv1alpha1.KonnectAPIAuthConfiguration, error) {
 	apiAuthRef, err := konnectcontroller.GetAPIAuthRefNN(ctx, r.Client, mcpServer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get APIAuth ref: %w", err)
@@ -66,14 +65,30 @@ func (r *MCPServerReconciler) buildSDK(
 		return nil, fmt.Errorf("failed to get KonnectAPIAuthConfiguration %s: %w", apiAuthRef, err)
 	}
 
-	token, err := konnectcontroller.GetTokenFromKonnectAPIAuthConfiguration(ctx, r.Client, &apiAuth)
+	return &apiAuth, nil
+}
+
+// buildSDK resolves the KonnectAPIAuthConfiguration for the given MCPServer
+// and returns an authenticated SDK wrapper.
+func (r *MCPServerReconciler) buildSDK(
+	ctx context.Context,
+	mcpServer *konnectv1alpha1.MCPServer,
+) (sdkops.SDKWrapper, error) {
+	apiAuth, err := r.resolveAuth(ctx, mcpServer)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get token from KonnectAPIAuthConfiguration %s: %w", apiAuthRef, err)
+		return nil, err
+	}
+
+	token, err := konnectcontroller.GetTokenFromKonnectAPIAuthConfiguration(ctx, r.Client, apiAuth)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get token from KonnectAPIAuthConfiguration %s/%s: %w",
+			apiAuth.Namespace, apiAuth.Name, err)
 	}
 
 	srv, err := server.NewServer[konnectv1alpha1.MCPServer](apiAuth.Spec.ServerURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse server URL from KonnectAPIAuthConfiguration %s: %w", apiAuthRef, err)
+		return nil, fmt.Errorf("failed to parse server URL from KonnectAPIAuthConfiguration %s/%s: %w",
+			apiAuth.Namespace, apiAuth.Name, err)
 	}
 
 	return r.SdkFactory.NewKonnectSDK(srv, sdkops.SDKToken(token)), nil

--- a/controller/mcpserver/owned_workload.go
+++ b/controller/mcpserver/owned_workload.go
@@ -46,8 +46,9 @@ func (r *MCPServerReconciler) ensureDeployment(
 	ctx context.Context,
 	mcpServer *konnectv1alpha1.MCPServer,
 	remoteMCPServer *sdkkonnectcomp.MCPServerCPInfo,
+	apiAuth *konnectv1alpha1.KonnectAPIAuthConfiguration,
 ) (op.Result, *appsv1.Deployment, error) {
-	desired := generateDeployment(mcpServer, *remoteMCPServer)
+	desired := generateDeployment(mcpServer, *remoteMCPServer, apiAuth)
 
 	existing := &appsv1.Deployment{}
 	err := r.Get(ctx, types.NamespacedName{
@@ -98,7 +99,11 @@ func (r *MCPServerReconciler) ensureDeployment(
 }
 
 // generateDeployment creates the desired Deployment spec for the given MCPServer.
-func generateDeployment(mcpServer *konnectv1alpha1.MCPServer, remoteMCPServer sdkkonnectcomp.MCPServerCPInfo) *appsv1.Deployment {
+func generateDeployment(
+	mcpServer *konnectv1alpha1.MCPServer,
+	remoteMCPServer sdkkonnectcomp.MCPServerCPInfo,
+	apiAuth *konnectv1alpha1.KonnectAPIAuthConfiguration,
+) *appsv1.Deployment {
 	nn := generateWorkloadNN(mcpServer)
 	selectorLabels := map[string]string{
 		"app": nn.Name,
@@ -110,6 +115,10 @@ func generateDeployment(mcpServer *konnectv1alpha1.MCPServer, remoteMCPServer sd
 	}
 
 	var replicas int32 = 1
+
+	patEnvVar := patEnvVarFromAuth(apiAuth)
+
+	const mcpServerVolumeName = "mcp-server-code"
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -145,27 +154,58 @@ func generateDeployment(mcpServer *konnectv1alpha1.MCPServer, remoteMCPServer sd
 					},
 				},
 				Spec: corev1.PodSpec{
-					// TODO: replace containers with the actual MCP server container spec once we have it, this is just a placeholder to demonstrate the concept.
 					InitContainers: []corev1.Container{
 						{
 							Name:            "init-mcp-server",
-							Image:           "alpine:3.23",
+							Image:           "kong/mcp-server-init",
 							ImagePullPolicy: corev1.PullIfNotPresent,
-							Command:         []string{"sh", "-c", `echo "[DEMO] Fetch code from Konnect..."`},
+							Args: []string{
+								"-cp-url", apiAuth.Spec.ServerURL,
+								"-cp-id", mcpServer.GetControlPlaneID(),
+								"-mcp-server-id", mcpServer.GetKonnectID(),
+								"-output-path", "/mcp-server/app.py",
+								"-pat", "$(PAT)",
+							},
+							Env: []corev1.EnvVar{patEnvVar},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      mcpServerVolumeName,
+									MountPath: "/mcp-server",
+								},
+							},
 						},
 					},
 					Containers: []corev1.Container{
 						{
 							Name:            "mcp-server",
-							Image:           "alpine:3.23",
+							Image:           "kong/mcp-server-runner",
 							ImagePullPolicy: corev1.PullIfNotPresent,
-							Command:         []string{"sh", "-c", `echo "[DEMO] running code..." && sleep infinity`},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "MCP_SERVER_PATH",
+									Value: "/mcp-server/app.py",
+								},
+							},
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "mcp",
 									ContainerPort: consts.MCPServerDefaultPort,
 									Protocol:      corev1.ProtocolTCP,
 								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      mcpServerVolumeName,
+									MountPath: "/mcp-server",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: mcpServerVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},
@@ -177,6 +217,29 @@ func generateDeployment(mcpServer *konnectv1alpha1.MCPServer, remoteMCPServer sd
 	k8sresources.LabelObjectAsMCPServerManaged(deployment)
 
 	return deployment
+}
+
+// patEnvVarFromAuth builds a PAT environment variable from the given
+// KonnectAPIAuthConfiguration. For token-type auth the token value is inlined;
+// for secretRef-type auth the value is sourced from the referenced Secret.
+func patEnvVarFromAuth(apiAuth *konnectv1alpha1.KonnectAPIAuthConfiguration) corev1.EnvVar {
+	if apiAuth.Spec.Type == konnectv1alpha1.KonnectAPIAuthTypeSecretRef && apiAuth.Spec.SecretRef != nil {
+		return corev1.EnvVar{
+			Name: "PAT",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: apiAuth.Spec.SecretRef.Name,
+					},
+					Key: "token",
+				},
+			},
+		}
+	}
+	return corev1.EnvVar{
+		Name:  "PAT",
+		Value: apiAuth.Spec.Token,
+	}
 }
 
 // ----------------------------------------------------------------------------

--- a/controller/mcpserver/owned_workload.go
+++ b/controller/mcpserver/owned_workload.go
@@ -5,16 +5,19 @@ import (
 	"fmt"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	log "github.com/kong/kong-operator/v2/controller/pkg/log"
 	"github.com/kong/kong-operator/v2/controller/pkg/op"
+	controllerpkgssa "github.com/kong/kong-operator/v2/controller/pkg/ssa"
 	"github.com/kong/kong-operator/v2/pkg/consts"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
 	k8sresources "github.com/kong/kong-operator/v2/pkg/utils/kubernetes/resources"
@@ -39,63 +42,50 @@ func generateWorkloadNN(mcpServer *konnectv1alpha1.MCPServer) types.NamespacedNa
 // Deployment
 // ----------------------------------------------------------------------------
 
-// ensureDeployment ensures that exactly one Deployment exists for the given
-// MCPServer. It creates a new Deployment if none exists, updates it if needed,
-// and returns the operation result.
+// ensureDeployment reconciles the Deployment for the given MCPServer using
+// Server-Side Apply. It returns the live Deployment after the apply so callers
+// can derive ReplicaSet/Pod version statuses from it.
 func (r *MCPServerReconciler) ensureDeployment(
 	ctx context.Context,
+	logger logr.Logger,
 	mcpServer *konnectv1alpha1.MCPServer,
 	remoteMCPServer *sdkkonnectcomp.MCPServerCPInfo,
 	apiAuth *konnectv1alpha1.KonnectAPIAuthConfiguration,
-) (op.Result, *appsv1.Deployment, error) {
+) (*appsv1.Deployment, error) {
+	if remoteMCPServer.InitContainer == nil {
+		return nil, fmt.Errorf("remote MCPServer %s is missing init container info", remoteMCPServer.ID)
+	}
+	if remoteMCPServer.Container == nil {
+		return nil, fmt.Errorf("remote MCPServer %s is missing container info", remoteMCPServer.ID)
+	}
+
 	desired := generateDeployment(mcpServer, *remoteMCPServer, apiAuth)
 
-	existing := &appsv1.Deployment{}
-	err := r.Get(ctx, types.NamespacedName{
-		Namespace: desired.Namespace,
-		Name:      desired.Name,
-	}, existing)
+	result, err := controllerpkgssa.ApplyIfChanged(ctx, logger, r.Client, r.typeConverter, desired, controllerpkgssa.FieldManager)
 	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return op.Noop, nil, fmt.Errorf("failed to get Deployment for MCPServer %s/%s: %w",
-				mcpServer.Namespace, mcpServer.Name, err)
-		}
-
-		k8sutils.SetOwnerForObject(desired, mcpServer)
-		if err := r.Create(ctx, desired); err != nil {
-			return op.Noop, nil, fmt.Errorf("failed to create Deployment for MCPServer %s/%s: %w",
-				mcpServer.Namespace, mcpServer.Name, err)
-		}
-		return op.Created, desired, nil
+		r.eventRecorder.Eventf(mcpServer, nil, corev1.EventTypeWarning, "DeploymentFailed", "ApplyDeployment",
+			"Failed to apply Deployment: %v", err)
+		return nil, fmt.Errorf("failed to apply Deployment for MCPServer %s/%s: %w",
+			mcpServer.Namespace, mcpServer.Name, err)
+	}
+	switch result {
+	case op.Created:
+		log.Debug(logger, "Deployment created", "name", desired.GetName())
+		r.eventRecorder.Eventf(mcpServer, nil, corev1.EventTypeNormal, "DeploymentCreated", "CreateDeployment",
+			"Deployment %s created", desired.GetName())
+	case op.Updated:
+		log.Debug(logger, "Deployment updated", "name", desired.GetName())
+		r.eventRecorder.Eventf(mcpServer, nil, corev1.EventTypeNormal, "DeploymentUpdated", "UpdateDeployment",
+			"Deployment %s updated", desired.GetName())
+	case op.Noop, op.Deleted:
 	}
 
-	// Ensure the version annotation is up to date on both the Deployment and
-	// its pod template.
-	// TODO: ensure the whole deployment spec is up to date and enforced.
-	desiredVersion := desired.Annotations[mcpServerVersionAnnotationKey]
-
-	if existing.Annotations == nil {
-		existing.Annotations = make(map[string]string)
+	existing := &appsv1.Deployment{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(desired), existing); err != nil {
+		return nil, fmt.Errorf("failed to get Deployment after apply for MCPServer %s/%s: %w",
+			mcpServer.Namespace, mcpServer.Name, err)
 	}
-	if existing.Spec.Template.Annotations == nil {
-		existing.Spec.Template.Annotations = make(map[string]string)
-	}
-
-	deployNeedsUpdate := existing.Annotations[mcpServerVersionAnnotationKey] != desiredVersion
-	templateNeedsUpdate := existing.Spec.Template.Annotations[mcpServerVersionAnnotationKey] != desiredVersion
-
-	if deployNeedsUpdate || templateNeedsUpdate {
-		old := existing.DeepCopy()
-		existing.Annotations[mcpServerVersionAnnotationKey] = desiredVersion
-		existing.Spec.Template.Annotations[mcpServerVersionAnnotationKey] = desiredVersion
-		if err := r.Patch(ctx, existing, client.MergeFrom(old)); err != nil {
-			return op.Noop, nil, fmt.Errorf("failed to patch Deployment %s/%s version annotation: %w",
-				existing.Namespace, existing.Name, err)
-		}
-		return op.Updated, existing, nil
-	}
-
-	return op.Noop, existing, nil
+	return existing, nil
 }
 
 // generateDeployment creates the desired Deployment spec for the given MCPServer.
@@ -118,9 +108,16 @@ func generateDeployment(
 
 	patEnvVar := patEnvVarFromAuth(apiAuth)
 
-	const mcpServerVolumeName = "mcp-server-code"
+	const (
+		mcpServerVolumeName      = "mcp-server-code"
+		mcpServerVolumeMountPath = "/mcp-server"
+	)
 
 	deployment := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nn.Name,
 			Namespace: nn.Namespace,
@@ -157,20 +154,30 @@ func generateDeployment(
 					InitContainers: []corev1.Container{
 						{
 							Name:            "init-mcp-server",
-							Image:           "kong/mcp-server-init",
+							Image:           *remoteMCPServer.InitContainer.Image,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args: []string{
 								"-cp-url", apiAuth.Spec.ServerURL,
 								"-cp-id", mcpServer.GetControlPlaneID(),
 								"-mcp-server-id", mcpServer.GetKonnectID(),
-								"-output-path", "/mcp-server/app.py",
+								"-output-path", mcpServerVolumeMountPath + "/app.py",
 								"-pat", "$(PAT)",
 							},
 							Env: []corev1.EnvVar{patEnvVar},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      mcpServerVolumeName,
-									MountPath: "/mcp-server",
+									MountPath: mcpServerVolumeMountPath,
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
 								},
 							},
 						},
@@ -178,14 +185,8 @@ func generateDeployment(
 					Containers: []corev1.Container{
 						{
 							Name:            "mcp-server",
-							Image:           "kong/mcp-server-runner",
+							Image:           *remoteMCPServer.Container.Image,
 							ImagePullPolicy: corev1.PullIfNotPresent,
-							Env: []corev1.EnvVar{
-								{
-									Name:  "MCP_SERVER_PATH",
-									Value: "/mcp-server/app.py",
-								},
-							},
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "mcp",
@@ -196,7 +197,17 @@ func generateDeployment(
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      mcpServerVolumeName,
-									MountPath: "/mcp-server",
+									MountPath: mcpServerVolumeMountPath,
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1000m"),
+									corev1.ResourceMemory: resource.MustParse("512Mi"),
 								},
 							},
 						},
@@ -215,6 +226,7 @@ func generateDeployment(
 	}
 
 	k8sresources.LabelObjectAsMCPServerManaged(deployment)
+	k8sutils.SetOwnerForObject(deployment, mcpServer)
 
 	return deployment
 }
@@ -246,37 +258,34 @@ func patEnvVarFromAuth(apiAuth *konnectv1alpha1.KonnectAPIAuthConfiguration) cor
 // Service
 // ----------------------------------------------------------------------------
 
-// ensureService ensures that exactly one Service exists for the given
-// MCPServer. It creates a new Service if none exists and returns the
-// operation result.
+// ensureService reconciles the Service for the given MCPServer using
+// Server-Side Apply.
 func (r *MCPServerReconciler) ensureService(
 	ctx context.Context,
+	logger logr.Logger,
 	mcpServer *konnectv1alpha1.MCPServer,
-) (op.Result, *corev1.Service, error) {
+) error {
 	desired := generateService(mcpServer)
 
-	existing := &corev1.Service{}
-	err := r.Get(ctx, types.NamespacedName{
-		Namespace: desired.Namespace,
-		Name:      desired.Name,
-	}, existing)
+	result, err := controllerpkgssa.ApplyIfChanged(ctx, logger, r.Client, r.typeConverter, desired, controllerpkgssa.FieldManager)
 	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return op.Noop, nil, fmt.Errorf("failed to get Service for MCPServer %s/%s: %w",
-				mcpServer.Namespace, mcpServer.Name, err)
-		}
-
-		k8sutils.SetOwnerForObject(desired, mcpServer)
-		if err := r.Create(ctx, desired); err != nil {
-			return op.Noop, nil, fmt.Errorf("failed to create Service for MCPServer %s/%s: %w",
-				mcpServer.Namespace, mcpServer.Name, err)
-		}
-		return op.Created, desired, nil
+		r.eventRecorder.Eventf(mcpServer, nil, corev1.EventTypeWarning, "ServiceFailed", "ApplyService",
+			"Failed to apply Service: %v", err)
+		return fmt.Errorf("failed to apply Service for MCPServer %s/%s: %w",
+			mcpServer.Namespace, mcpServer.Name, err)
 	}
-
-	// TODO: if the service already exists, we should check if its spec is up to date and update it if needed.
-
-	return op.Noop, existing, nil
+	switch result {
+	case op.Created:
+		log.Debug(logger, "Service created", "name", desired.GetName())
+		r.eventRecorder.Eventf(mcpServer, nil, corev1.EventTypeNormal, "ServiceCreated", "CreateService",
+			"Service %s created", desired.GetName())
+	case op.Updated:
+		log.Debug(logger, "Service updated", "name", desired.GetName())
+		r.eventRecorder.Eventf(mcpServer, nil, corev1.EventTypeNormal, "ServiceUpdated", "UpdateService",
+			"Service %s updated", desired.GetName())
+	case op.Noop, op.Deleted:
+	}
+	return nil
 }
 
 // generateService creates the desired Service spec for the given MCPServer.
@@ -287,6 +296,10 @@ func generateService(mcpServer *konnectv1alpha1.MCPServer) *corev1.Service {
 	}
 
 	svc := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nn.Name,
 			Namespace: nn.Namespace,
@@ -305,6 +318,7 @@ func generateService(mcpServer *konnectv1alpha1.MCPServer) *corev1.Service {
 	}
 
 	k8sresources.LabelObjectAsMCPServerManaged(svc)
+	k8sutils.SetOwnerForObject(svc, mcpServer)
 
 	return svc
 }

--- a/controller/mcpserver/ssa.go
+++ b/controller/mcpserver/ssa.go
@@ -1,0 +1,25 @@
+package mcpserver
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	controllerpkgssa "github.com/kong/kong-operator/v2/controller/pkg/ssa"
+)
+
+// requiredSchemas lists the GroupVersions whose OpenAPI schemas are needed by
+// this controller for structured-merge-diff merging and diff-before-apply.
+var requiredSchemas = []schema.GroupVersion{
+	// core: Service
+	{Group: "", Version: "v1"},
+	// Deployment
+	{Group: "apps", Version: "v1"},
+}
+
+// initTypeConverter creates a TypeConverter from the API server's OpenAPI v3 schemas.
+// Only the schemas needed by this controller are fetched.
+// Called once during SetupWithManager.
+func initTypeConverter(mgr ctrl.Manager) (managedfields.TypeConverter, error) {
+	return controllerpkgssa.NewTypeConverter(mgr, requiredSchemas)
+}

--- a/controller/pkg/ssa/ssa.go
+++ b/controller/pkg/ssa/ssa.go
@@ -45,6 +45,10 @@ import (
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
 )
 
+// FieldManager is the field manager name used by the operator for
+// Server-Side Apply operations.
+const FieldManager = "gateway-operator"
+
 // NewTypeConverter builds a TypeConverter from the API server's live OpenAPI v3
 // schemas. Only schemas for the specified GroupVersions are fetched, reducing
 // startup latency compared to downloading the full schema set.


### PR DESCRIPTION
**What this PR does / why we need it**:

- Set and enforce the `MCPServer` deployment and service by using shared ssa logic
- set the `MCPServer` images to be the ones returned by Konnect

**Which issue this PR fixes**

Fixes #3942 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes