### PR TITLE
fix(konnect): adopt shared client-cert CR instead of hot-looping Konnect List API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,7 +163,7 @@
   adding itself as an additional ownerReference instead of retrying `Create`
   on every reconcile, eliminating redundant calls to Konnect's
   `dp-client-certificates` List API.
-  [#3940](https://github.com/Kong/kong-operator/issues/3940)
+  [#3949](https://github.com/Kong/kong-operator/pull/3949)
 - Fix `ResolvedRefs` status condition on `HTTPRoute` not being updated when a
   referenced `KongPlugin` is deleted in self-managed ControlPlane mode.
   [#3206](https://github.com/Kong/kong-operator/pull/3206)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,13 @@
 
 ### Fixes
 
+- Fix a hot loop in the `KonnectExtension` reconciler when two
+  `KonnectExtension`s share the same client-certificate `Secret`: the losing
+  extension now adopts the existing `KongDataPlaneClientCertificate` CR by
+  adding itself as an additional ownerReference instead of retrying `Create`
+  on every reconcile, eliminating redundant calls to Konnect's
+  `dp-client-certificates` List API.
+  [#3940](https://github.com/Kong/kong-operator/issues/3940)
 - Fix `ResolvedRefs` status condition on `HTTPRoute` not being updated when a
   referenced `KongPlugin` is deleted in self-managed ControlPlane mode.
   [#3206](https://github.com/Kong/kong-operator/pull/3206)

--- a/api/konnect/v1alpha1/konnect_conditions.go
+++ b/api/konnect/v1alpha1/konnect_conditions.go
@@ -206,6 +206,12 @@ const (
 	// used with the DataPlaneCertificateProvisioned condition type indicating that the
 	// DataPlane client certificate creation in Konnect is in progress.
 	DataPlaneCertificateProvisionedReasonProvisioning = "Provisioning"
+	// DataPlaneCertificateProvisionedReasonNameConflict is the reason
+	// used with the DataPlaneCertificateProvisioned condition type indicating that a
+	// KongDataPlaneClientCertificate with the target name already exists in the namespace
+	// but carries a different certificate than the one referenced by this KonnectExtension,
+	// so it cannot be adopted.
+	DataPlaneCertificateProvisionedReasonNameConflict = "NameConflict"
 )
 
 const (

--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -501,6 +502,8 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 		return "", false
 	})
+	// Sort so that the annotation value is stable regardless of list order.
+	sort.Strings(mappedIDs)
 
 	// update the secret annotation with the IDs of the mapped certificates
 	newMappedIDsStr := strings.Join(mappedIDs, ",")
@@ -562,6 +565,8 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			}
 			return "", false
 		})
+		// Sort so that the annotation value is stable regardless of list order.
+		sort.Strings(mappedIDs)
 	}
 
 	switch {
@@ -584,34 +589,14 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 				},
 			)
 
-			err := controllerutil.SetOwnerReference(&ext, &dpCert, r.Scheme(), controllerutil.WithBlockOwnerDeletion(true))
-			if err != nil {
+			if err := controllerutil.SetOwnerReference(&ext, &dpCert, r.Scheme(), controllerutil.WithBlockOwnerDeletion(true)); err != nil {
 				return ctrl.Result{}, err
 			}
 
-			if err := r.Create(ctx, &dpCert); err != nil {
-				if errS, ok := errors.AsType[*apierrors.StatusError](err); ok {
-					if errS.ErrStatus.Reason == metav1.StatusReasonAlreadyExists {
-						log.Debug(logger, "DataPlane client certificate already exists", "name", dpCert.Name, "namespace", dpCert.Namespace)
-					}
-				} else {
-					certProvisionedCond.Status = metav1.ConditionFalse
-					certProvisionedCond.Reason = konnectv1alpha1.DataPlaneCertificateProvisionedReasonKonnectAPIOpFailed
-					certProvisionedCond.Message = err.Error()
-					if res, updated, err := patch.StatusWithConditions(
-						ctx,
-						r.Client,
-						&ext,
-						readyCondition,
-						certProvisionedCond,
-					); err != nil || updated || !res.IsZero() {
-						return res, err
-					}
-					// In case of an error when creating the object in Konnect, we requeue "immediately"
-					// so that the operation is retried without waiting for the resync period.
-					return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
-				}
+			if res, err := r.createOrAdoptDataPlaneClientCertificate(ctx, logger, &ext, &dpCert, certDataStr, &certProvisionedCond, readyCondition); err != nil || !res.IsZero() {
+				return res, err
 			}
+
 			updated, res, err := patch.WithFinalizer(ctx, r.Client, certificateSecret, KonnectCleanupFinalizer)
 			if err != nil || !res.IsZero() {
 				return res, err
@@ -645,34 +630,14 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 					}
 				},
 			)
-			err := controllerutil.SetOwnerReference(&ext, &dpCert, r.Scheme(), controllerutil.WithBlockOwnerDeletion(true))
-			if err != nil {
+			if err := controllerutil.SetOwnerReference(&ext, &dpCert, r.Scheme(), controllerutil.WithBlockOwnerDeletion(true)); err != nil {
 				return ctrl.Result{}, err
 			}
 
-			if err := r.Create(ctx, &dpCert); err != nil {
-				if errS, ok := errors.AsType[*apierrors.StatusError](err); ok {
-					if errS.ErrStatus.Reason == metav1.StatusReasonAlreadyExists {
-						log.Debug(logger, "DataPlane client certificate already exists", "name", dpCert.Name, "namespace", dpCert.Namespace)
-					}
-				} else {
-					certProvisionedCond.Status = metav1.ConditionFalse
-					certProvisionedCond.Reason = konnectv1alpha1.DataPlaneCertificateProvisionedReasonKonnectAPIOpFailed
-					certProvisionedCond.Message = err.Error()
-					if res, updated, err := patch.StatusWithConditions(
-						ctx,
-						r.Client,
-						&ext,
-						readyCondition,
-						certProvisionedCond,
-					); err != nil || updated || !res.IsZero() {
-						return res, err
-					}
-					// In case of an error when creating the object in Konnect, we requeue "immediately"
-					// so that the operation is retried without waiting for the resync period.
-					return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
-				}
+			if res, err := r.createOrAdoptDataPlaneClientCertificate(ctx, logger, &ext, &dpCert, certDataStr, &certProvisionedCond, readyCondition); err != nil || !res.IsZero() {
+				return res, err
 			}
+
 			updated, res, err := patch.WithFinalizer(ctx, r.Client, certificateSecret, KonnectCleanupFinalizer)
 			if err != nil || !res.IsZero() {
 				return res, err
@@ -886,6 +851,138 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		Requeue:      true,
 		RequeueAfter: r.SyncPeriod,
 	}, nil
+}
+
+// errDataPlaneClientCertificateNameConflict is returned by createOrAdoptDataPlaneClientCertificate
+// when a KongDataPlaneClientCertificate with the target name already exists in the namespace but
+// holds certificate data that does not match the one referenced by the reconciling extension.
+// In that case the operator cannot safely adopt the existing CR without overwriting
+// user-managed data.
+var errDataPlaneClientCertificateNameConflict = errors.New("KongDataPlaneClientCertificate name conflict: a CR with the same name exists but holds a different certificate")
+
+// createOrAdoptDataPlaneClientCertificate creates the desired KongDataPlaneClientCertificate.
+// If a CR with the same name already exists, it attempts to adopt it by adding the reconciling
+// KonnectExtension as an additional (non-controller) ownerReference, provided the cert content
+// matches. This allows multiple KonnectExtension resources that share the same client-certificate
+// Secret to coexist without the reconciler retrying Create on every loop and repeatedly falling
+// back to the Konnect dp-client-certificates List API.
+//
+// The returned ctrl.Result and error match the conventions of a reconcile step: a non-zero Result
+// means the caller should return immediately; a nil error means normal flow can continue (the CR
+// was created, adopted, or is already owned by this extension).
+func (r *KonnectExtensionReconciler) createOrAdoptDataPlaneClientCertificate(
+	ctx context.Context,
+	logger logr.Logger,
+	ext *konnectv1alpha2.KonnectExtension,
+	dpCert *configurationv1alpha1.KongDataPlaneClientCertificate,
+	certDataStr string,
+	certProvisionedCond *metav1.Condition,
+	readyCondition metav1.Condition,
+) (ctrl.Result, error) {
+	err := r.Create(ctx, dpCert)
+	if err == nil {
+		return ctrl.Result{}, nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		certProvisionedCond.Status = metav1.ConditionFalse
+		certProvisionedCond.Reason = konnectv1alpha1.DataPlaneCertificateProvisionedReasonKonnectAPIOpFailed
+		certProvisionedCond.Message = err.Error()
+		if res, updated, err := patch.StatusWithConditions(
+			ctx,
+			r.Client,
+			ext,
+			readyCondition,
+			*certProvisionedCond,
+		); err != nil || updated || !res.IsZero() {
+			return res, err
+		}
+		// In case of an error when creating the CR, we requeue "immediately"
+		// so that the operation is retried without waiting for the resync period.
+		return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
+	}
+
+	// A CR with the same name already exists. Try to adopt it by adding ourselves as an owner.
+	if err := r.adoptExistingDataPlaneClientCertificate(ctx, logger, ext, dpCert, certDataStr); err != nil {
+		if errors.Is(err, errDataPlaneClientCertificateNameConflict) {
+			certProvisionedCond.Status = metav1.ConditionFalse
+			certProvisionedCond.Reason = konnectv1alpha1.DataPlaneCertificateProvisionedReasonNameConflict
+			certProvisionedCond.Message = fmt.Sprintf(
+				"a KongDataPlaneClientCertificate named %q already exists in namespace %q but holds a different certificate; cannot adopt",
+				dpCert.Name, dpCert.Namespace,
+			)
+			if res, updated, err := patch.StatusWithConditions(
+				ctx,
+				r.Client,
+				ext,
+				readyCondition,
+				*certProvisionedCond,
+			); err != nil || updated || !res.IsZero() {
+				return res, err
+			}
+			// Do not tight-requeue on a name conflict; the user must resolve it.
+			// Keep the standard sync period so the condition is re-asserted but the log is not spammed.
+			return ctrl.Result{RequeueAfter: r.SyncPeriod}, nil
+		}
+		certProvisionedCond.Status = metav1.ConditionFalse
+		certProvisionedCond.Reason = konnectv1alpha1.DataPlaneCertificateProvisionedReasonKonnectAPIOpFailed
+		certProvisionedCond.Message = err.Error()
+		if res, updated, err := patch.StatusWithConditions(
+			ctx,
+			r.Client,
+			ext,
+			readyCondition,
+			*certProvisionedCond,
+		); err != nil || updated || !res.IsZero() {
+			return res, err
+		}
+		return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// adoptExistingDataPlaneClientCertificate fetches the KongDataPlaneClientCertificate with the
+// given name/namespace and, if its cert content matches, adds the reconciling KonnectExtension
+// as an additional (non-controller) ownerReference when absent. Returns
+// errDataPlaneClientCertificateNameConflict when the cert content does not match.
+func (r *KonnectExtensionReconciler) adoptExistingDataPlaneClientCertificate(
+	ctx context.Context,
+	logger logr.Logger,
+	ext *konnectv1alpha2.KonnectExtension,
+	dpCert *configurationv1alpha1.KongDataPlaneClientCertificate,
+	certDataStr string,
+) error {
+	var existing configurationv1alpha1.KongDataPlaneClientCertificate
+	if err := r.Get(ctx, client.ObjectKeyFromObject(dpCert), &existing); err != nil {
+		return err
+	}
+
+	if sanitizeCert(existing.Spec.Cert) != certDataStr {
+		return errDataPlaneClientCertificateNameConflict
+	}
+
+	for _, or := range existing.OwnerReferences {
+		if or.UID == ext.UID {
+			// This KonnectExtension already owns the CR — nothing to do.
+			return nil
+		}
+	}
+
+	if err := controllerutil.SetOwnerReference(ext, &existing, r.Scheme()); err != nil {
+		return err
+	}
+	if err := r.Update(ctx, &existing); err != nil {
+		if apierrors.IsConflict(err) {
+			// Let controller-runtime retry on the next reconcile.
+			return nil
+		}
+		return err
+	}
+	log.Debug(logger,
+		"adopted existing KongDataPlaneClientCertificate by adding this KonnectExtension as an owner",
+		"name", existing.Name, "namespace", existing.Namespace,
+	)
+	return nil
 }
 
 // SecretInUseEnforceT is an enum type for enforcing or removing the secret-in-use finalizer.

--- a/test/envtest/dataplane_konnectextensions_test.go
+++ b/test/envtest/dataplane_konnectextensions_test.go
@@ -487,6 +487,178 @@ func TestDataPlaneKonnectExtension(t *testing.T) {
 					}), "expected DataPlane to have KonnectExtensionApplied condition, got: %+v", dp.Status.Conditions)
 				}, waitTime, tickTime)
 			})
+
+			// Regression test for https://github.com/Kong/kong-operator/issues/3940.
+			// Two KonnectExtensions that reference the same client-certificate Secret must not
+			// keep retrying Create (returning AlreadyExists) and falling back to Konnect's
+			// dp-client-certificates List API on every reconcile. The losing extension must
+			// adopt the existing KongDataPlaneClientCertificate CR by adding itself as an
+			// additional (non-controller) ownerReference, so subsequent reconciles find the
+			// CR via the owner index without calling the SDK fallback.
+			t.Run("two extensions sharing the same Secret adopt one CR (issue #3940)", func(t *testing.T) {
+				const (
+					konnectControlPlaneIDA = "aee0667a-90c6-45a6-a2d8-575e1e48aaaa"
+					konnectControlPlaneIDB = "aee0667a-90c6-45a6-a2d8-575e1e48bbbb"
+					dpCertIDA              = "33333333-3333-3333-3333-33333333333a"
+					dpCertIDB              = "33333333-3333-3333-3333-33333333333b"
+				)
+
+				// Either CP may receive the List/Create depending on which extension wins the
+				// race to create the CR. Mark expectations as Maybe so neither outcome causes
+				// the test to fail on strict mock expectations.
+				sdk.EXPECT().ListDpClientCertificates(mock.Anything, konnectControlPlaneIDA).
+					Return(&sdkkonnectops.ListDpClientCertificatesResponse{StatusCode: http.StatusOK}, nil).Maybe()
+				sdk.EXPECT().ListDpClientCertificates(mock.Anything, konnectControlPlaneIDB).
+					Return(&sdkkonnectops.ListDpClientCertificatesResponse{StatusCode: http.StatusOK}, nil).Maybe()
+				sdk.EXPECT().CreateDataplaneCertificate(mock.Anything, konnectControlPlaneIDA, mock.Anything).
+					Return(&sdkkonnectops.CreateDataplaneCertificateResponse{
+						DataPlaneClientCertificateResponse: &sdkkonnectcomp.DataPlaneClientCertificateResponse{
+							Item: &sdkkonnectcomp.DataPlaneClientCertificate{
+								ID:   new(dpCertIDA),
+								Cert: new(deploy.TestValidCACertPEM),
+							},
+						},
+					}, nil).Maybe()
+				sdk.EXPECT().CreateDataplaneCertificate(mock.Anything, konnectControlPlaneIDB, mock.Anything).
+					Return(&sdkkonnectops.CreateDataplaneCertificateResponse{
+						DataPlaneClientCertificateResponse: &sdkkonnectcomp.DataPlaneClientCertificateResponse{
+							Item: &sdkkonnectcomp.DataPlaneClientCertificate{
+								ID:   new(dpCertIDB),
+								Cert: new(deploy.TestValidCACertPEM),
+							},
+						},
+					}, nil).Maybe()
+
+				t.Logf("Waiting for caches to sync")
+				mgr.GetCache().WaitForCacheSync(ctx)
+
+				t.Logf("Creating KonnectAPIAuthConfiguration")
+				konnectAPIAuthConfiguration := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, cl)
+
+				t.Logf("Creating two KonnectGatewayControlPlanes with distinct Konnect IDs")
+				cpA := deploy.KonnectGatewayControlPlaneWithID(t, ctx, cl, konnectAPIAuthConfiguration, deploy.WithKonnectID(konnectControlPlaneIDA))
+				cpB := deploy.KonnectGatewayControlPlaneWithID(t, ctx, cl, konnectAPIAuthConfiguration, deploy.WithKonnectID(konnectControlPlaneIDB))
+
+				t.Logf("Creating shared client-certificate Secret")
+				certPEM, keyPEM := certificate.MustGenerateCertPEMFormat(
+					certificate.WithCommonName("kong-client"),
+					certificate.WithKeyType(keyType),
+				)
+				sharedSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "shared-dp-cert-",
+						Namespace:    ns.Name,
+						Labels: map[string]string{
+							konnect.SecretKonnectDataPlaneCertificateLabel: "true",
+						},
+					},
+					Type: corev1.SecretTypeTLS,
+					Data: map[string][]byte{
+						"tls.crt": certPEM,
+						"tls.key": keyPEM,
+					},
+				}
+				require.NoError(t, cl.Create(ctx, sharedSecret))
+
+				mkExtension := func(name, cpName string) *konnectv1alpha2.KonnectExtension {
+					provisioning := konnectv1alpha2.ManualSecretProvisioning
+					return &konnectv1alpha2.KonnectExtension{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      name,
+							Namespace: ns.Name,
+						},
+						Spec: konnectv1alpha2.KonnectExtensionSpec{
+							ClientAuth: &konnectv1alpha2.KonnectExtensionClientAuth{
+								CertificateSecret: konnectv1alpha2.CertificateSecret{
+									Provisioning: &provisioning,
+									CertificateSecretRef: &konnectv1alpha2.SecretRef{
+										Name: sharedSecret.Name,
+									},
+								},
+							},
+							Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+								ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+									Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+										Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+										KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+											Name: cpName,
+										},
+									},
+								},
+							},
+						},
+					}
+				}
+
+				t.Logf("Creating two KonnectExtensions sharing the same Secret, each targeting a different Konnect CP")
+				extA := mkExtension("ke-shared-a", cpA.Name)
+				extB := mkExtension("ke-shared-b", cpB.Name)
+				require.NoError(t, cl.Create(ctx, extA))
+				require.NoError(t, cl.Create(ctx, extB))
+
+				mkDP := func(name, extName string) *operatorv1beta1.DataPlane {
+					return &operatorv1beta1.DataPlane{
+						ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns.Name},
+						Spec: operatorv1beta1.DataPlaneSpec{
+							DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+								Extensions: []commonv1alpha1.ExtensionRef{{
+									Group: konnectv1alpha1.GroupVersion.Group,
+									Kind:  "KonnectExtension",
+									NamespacedRef: commonv1alpha1.NamespacedRef{
+										Name: extName,
+									},
+								}},
+								Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+									DeploymentOptions: operatorv1beta1.DeploymentOptions{
+										PodTemplateSpec: &corev1.PodTemplateSpec{
+											Spec: corev1.PodSpec{
+												Containers: []corev1.Container{{
+													Name:  consts.DataPlaneProxyContainerName,
+													Image: consts.DefaultDataPlaneImage,
+												}},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+				}
+
+				t.Logf("Creating a DataPlane per KonnectExtension to keep the extension-in-use finalizer in place")
+				require.NoError(t, cl.Create(ctx, mkDP("dp-shared-a", extA.Name)))
+				require.NoError(t, cl.Create(ctx, mkDP("dp-shared-b", extB.Name)))
+
+				t.Logf("Waiting for both KonnectExtensions to become Ready")
+				for _, name := range []string{extA.Name, extB.Name} {
+					nameCopy := name
+					require.EventuallyWithT(t, func(t *assert.CollectT) {
+						var ke konnectv1alpha2.KonnectExtension
+						require.NoError(t, cl.Get(ctx, types.NamespacedName{Name: nameCopy, Namespace: ns.Name}, &ke))
+						require.True(t, k8sutils.HasConditionTrue("Ready", &ke),
+							"expected %s to have Ready=True, got: %+v", nameCopy, ke.Status.Conditions)
+					}, waitTime, tickTime)
+				}
+
+				t.Logf("Verifying only one KongDataPlaneClientCertificate is bound to the shared Secret and is owned by both KonnectExtensions")
+				require.EventuallyWithT(t, func(t *assert.CollectT) {
+					var dpCerts configurationv1alpha1.KongDataPlaneClientCertificateList
+					require.NoError(t, cl.List(ctx, &dpCerts, client.InNamespace(ns.Name)))
+					shared := lo.Filter(dpCerts.Items, func(c configurationv1alpha1.KongDataPlaneClientCertificate, _ int) bool {
+						return c.Name == sharedSecret.Name
+					})
+					require.Len(t, shared, 1,
+						"expected exactly one KongDataPlaneClientCertificate named %q, got: %v",
+						sharedSecret.Name, lo.Map(dpCerts.Items, func(c configurationv1alpha1.KongDataPlaneClientCertificate, _ int) string { return c.Name }))
+					owners := lo.Map(shared[0].OwnerReferences, func(or metav1.OwnerReference, _ int) string {
+						return or.Name
+					})
+					require.Contains(t, owners, extA.Name,
+						"expected %q in owner references, got %v", extA.Name, owners)
+					require.Contains(t, owners, extB.Name,
+						"expected %q in owner references, got %v", extB.Name, owners)
+				}, waitTime, tickTime)
+			})
 		})
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When two `KonnectExtension` resources in the same namespace reference the **same** client-certificate `Secret` (a valid configuration — two Konnect control planes sharing one client cert), the operator enters a permanent hot loop against Konnect's `GET /v2/control-planes/{cpID}/dp-client-certificates` API. Each reconcile of the "losing" extension falls back to the SDK List path (because its owner-filtered index lookup returns no `KongDataPlaneClientCertificate` CR) and retries `r.Create(...)` with a name equal to the Secret name, which collides with the CR already created by the "winning" extension. The `AlreadyExists` error is silently swallowed and the loop repeats every reconcile.

On top of this, both extensions fight over an annotation on the shared Secret (`konnect.konghq.com/certificate-ids`), re-enqueueing each other. In a live repro this amounted to ~25 `KonnectExtension` reconciles/sec and ~6–7 `ListDpClientCertificates` calls/sec per cluster — enough to produce millions of Konnect API calls over typical operating windows.

This PR replaces the two "Create + swallow AlreadyExists" sites in `controller/konnect/konnectextension_controller.go` with a helper that, on `AlreadyExists`:
1. fetches the existing CR,
2. verifies the cert content matches (otherwise surfaces a clear `DataPlaneCertificateProvisioned=False` condition with a new reason `NameConflict`, and stops tight-requeuing), and
3. adopts the CR by adding the reconciling `KonnectExtension` as an **additional, non-controller** ownerReference.

After the one-time adoption update, the owner index `kongDataPlaneCertificateOnKonnectExtensionOwner` returns the CR for both extensions, `mappedIDs` is populated on every subsequent reconcile, the SDK List fallback is never re-entered, and the annotation ping-pong disappears as a side-effect (both extensions compute identical `mappedIDs`). `mappedIDs` is also now sorted before joining into the annotation so its value is stable regardless of slice order.

### Upgrade safety

- **Single-extension installs (the common case):** `Create` never returns `AlreadyExists`, the new adoption path is never entered, behaviour is bit-for-bit identical.
- **Multi-extension installs sharing a Secret (the bug case):** on the losing extension's first post-upgrade reconcile, one adoption `Update` adds its ownerReference to the existing CR. No new `KongDataPlaneClientCertificate` CR is created, no new Konnect entity is created, no spec/status changes beyond one extra ownerReference.
- No CRD, API, or schema changes.

### End-to-end verification

Reproduced in a kind cluster with the customer-shaped manifests (two `KonnectExtension`s sharing one client-cert Secret, pointing at two different Konnect CPs). Before the fix, the operator averaged ~25 `KONNECTEXTENSION - reconciling` log lines/sec with ~6–7 `"DataPlane client certificate already exists"` per second (steady state). After rolling the patched image into the same cluster:

- The adoption helper logs `"adopted existing KongDataPlaneClientCertificate by adding this KonnectExtension as an owner"` exactly once.
- Zero subsequent `"already exists"` log lines.
- Reconciles drop to ~2/min (one per extension, driven by `--konnect-sync-period`).
- `KongDataPlaneClientCertificate/repro-dp-cert` carries both extensions in `ownerReferences` (first one `controller: true, blockOwnerDeletion: true`, second non-controller).
- Both extensions remain `Ready=True` / `DataPlaneCertificateProvisioned=True`.

### Tests

- New envtest in `test/envtest/dataplane_konnectextensions_test.go`: two `KonnectExtension`s sharing one Secret, two `DataPlane`s consuming them, two `KonnectGatewayControlPlane`s. Asserts exactly one `KongDataPlaneClientCertificate` is bound to the shared Secret and carries both extensions in `ownerReferences`.
- Full `TestDataPlaneKonnectExtension` suite (all sub-tests, both key types) passes.

**Which issue this PR fixes**

Fixes #3940

**Special notes for your reviewer**:

- The SDK List fallback itself is not removed — that is still tracked by #2630. This PR only stops the hot loop that results from its interaction with the name-collision on the generated CR.
- `errors.AsType[*apierrors.StatusError]` at the original Create sites is replaced with `apierrors.IsAlreadyExists`, which is the idiomatic check for that one condition.
- The new `DataPlaneCertificateProvisionedReasonNameConflict` condition reason is only surfaced when the existing CR's cert content genuinely does not match the one in the referenced Secret (e.g. a user-managed CR sharing the name).

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes