### PR TITLE
fix(ingress-controller) Increase default interval for uploading config to Konnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,10 @@
 
 ### Changed
 
+- Increase default interval of uploading configuration and node status to the
+  read-only Konnect control plane (The legacy KIC type CP) to 3 minutes to
+  decrease the API calls to Konnect.
+  [#3969](https://github.com/Kong/kong-operator/pull/3969)
 - HybridGateway: generate one KongRoute per HTTPRouteMatch to honor Gateway API OR semantics across matches within a rule.
   This enables the `HTTPRouteMatching` conformance test for Hybrid mode.
   Note: routes count per rule may increase.

--- a/ingress-controller/pkg/manager/config/consts.go
+++ b/ingress-controller/pkg/manager/config/consts.go
@@ -24,9 +24,9 @@ const (
 	// MinKonnectConfigUploadPeriod is the minimum period between operations to upload Kong configuration to Konnect.
 	MinKonnectConfigUploadPeriod = 10 * time.Second
 	// DefaultKonnectConfigUploadPeriod is the default period between operations to upload Kong configuration to Konnect.
-	DefaultKonnectConfigUploadPeriod = 30 * time.Second
+	DefaultKonnectConfigUploadPeriod = 3 * time.Minute
 	// DefaultKonnectNodeRefreshPeriod is the default period between operations to refresh node in Konnect.
-	DefaultKonnectNodeRefreshPeriod = 60 * time.Second
+	DefaultKonnectNodeRefreshPeriod = 3 * time.Minute
 	// DefaultKonnectConfigUploadConcurrency is the default concurrency of the client to upload Kong configuration to Konnect.
 	DefaultKonnectConfigUploadConcurrency = 4
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Increase the interval of uploading status to Konnect control plane:

- Default interval for uploading config: `30s` -> `3m`
- Default interval for uploading node status: `1m` -> `3m`

**Which issue this PR fixes**

Fixes #3167 

**Special notes for your reviewer**:

Did not increase the minimum upload config interval to avoid breaking changes.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
