### PR TITLE
perf: add eager initialization of generated type reference handlers

### DIFF
--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -51,7 +51,8 @@ type KonnectEntityReconciler[T constraints.SupportedKonnectEntityType, TEnt cons
 	LoggingMode       logging.Mode
 	SyncPeriod        time.Duration
 
-	MetricRecorder metrics.Recorder
+	MetricRecorder       metrics.Recorder
+	generatedRefHandlers []generatedReferenceHandler[TEnt]
 }
 
 // KonnectEntityReconcilerOption is a functional option for the KonnectEntityReconciler.
@@ -105,6 +106,10 @@ func NewKonnectEntityReconciler[
 		SyncPeriod:     consts.DefaultKonnectSyncPeriod,
 		MetricRecorder: nil,
 	}
+
+	// initialiaze the generated reference handlers
+	// to avoid allocating slice of handlers on each reconciliation.
+	r.generatedRefHandlers = r.generatedTypeReferenceHandlers()
 	for _, opt := range opts {
 		opt(r)
 	}

--- a/controller/konnect/reconciler_generic_generated_refs.go
+++ b/controller/konnect/reconciler_generic_generated_refs.go
@@ -18,7 +18,13 @@ func (r *KonnectEntityReconciler[T, TEnt]) handleGeneratedTypeReferences(
 	ctx context.Context,
 	ent TEnt,
 ) (bool, ctrl.Result, error) {
-	for _, handler := range r.generatedTypeReferenceHandlers() {
+	// if the generated reference handlers are nil for some reason we re-generate them.
+	// e.g. reconciler created using struct literal instead of NewKonnectEntityReconciler.
+	if r.generatedRefHandlers == nil {
+		r.generatedRefHandlers = r.generatedTypeReferenceHandlers()
+	}
+
+	for _, handler := range r.generatedRefHandlers {
 		if stop, res, err := handler(ctx, ent); stop {
 			return true, res, err
 		}

--- a/controller/konnect/reconciler_generic_generated_refs_test.go
+++ b/controller/konnect/reconciler_generic_generated_refs_test.go
@@ -17,8 +17,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	"github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
 	ctrlconsts "github.com/kong/kong-operator/v2/controller/consts"
+	"github.com/kong/kong-operator/v2/modules/manager/logging"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 )
 
@@ -160,6 +162,37 @@ func TestHandleEventGatewayRefResult(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, stop)
 		assert.Equal(t, ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, result)
+	})
+
+	t.Run("generated reference handlers are nil after reconciler creation using struct literal", func(t *testing.T) {
+		r := &KonnectEntityReconciler[
+			konnectv1alpha1.KonnectEventDataPlaneCertificate,
+			*konnectv1alpha1.KonnectEventDataPlaneCertificate,
+		]{}
+
+		assert.Nil(t, r.generatedRefHandlers)
+	})
+
+	t.Run("generated reference handlers are not nil after handleGeneratedTypeReferences has been called", func(t *testing.T) {
+		r := &KonnectEntityReconciler[v1alpha1.KongService, *v1alpha1.KongService]{}
+
+		assert.Nil(t, r.generatedRefHandlers)
+
+		ent := &v1alpha1.KongService{}
+		stop, res, err := r.handleGeneratedTypeReferences(t.Context(), ent)
+
+		require.NoError(t, err)
+		assert.False(t, stop)
+		assert.Equal(t, ctrl.Result{}, res)
+		require.NotNil(t, r.generatedRefHandlers)
+	})
+
+	t.Run("generated reference handlers are not nil after reconciler creation using NewKonnectEntityReconciler", func(t *testing.T) {
+		r := NewKonnectEntityReconciler[
+			v1alpha1.KongService,
+			*v1alpha1.KongService,
+		](nil, logging.DevelopmentMode, nil)
+		assert.NotNil(t, r.generatedRefHandlers)
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR moves the initialization of generated reference handlers inside the `KonnectEntityReconciler` constructor function instead of the generation inside the handler in `handleGeneratedTypeReferences()` in `reconciler_generic_generated_refs.go`.
It also adds guardrails against `KonnectEntityReconciler` objects initialized using literals instead of `NewKonnectEntityReconciler()`.

Improvement suggested by @pmalek in PR #3908 

**Which issue this PR fixes**

fixes #3927 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes