### PR TITLE
fix(controllers): do not enable TLSRoute controller and index when TLSRoute CRD absent

### DIFF
--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -89,6 +89,15 @@ func (c *ControllerDef) MaybeSetupWithManager(ctx context.Context, mgr ctrl.Mana
 func SetupCacheIndexes(ctx context.Context, mgr manager.Manager, cfg Config) error {
 	var indexOptions []index.Option
 
+	crdChecker := k8sutils.CRDChecker{
+		Client: mgr.GetClient(),
+	}
+	tlsRouteGVR := schema.GroupVersionResource{
+		Group:    gatewayv1.GroupVersion.Group,
+		Version:  gatewayv1.GroupVersion.Version,
+		Resource: "tlsroutes",
+	}
+
 	if cfg.ControlPlaneControllerEnabled || cfg.GatewayControllerEnabled {
 		indexOptions = slices.Concat(indexOptions,
 			index.OptionsForControlPlane(cfg.KonnectControllersEnabled),
@@ -105,8 +114,14 @@ func SetupCacheIndexes(ctx context.Context, mgr manager.Manager, cfg Config) err
 			index.OptionsForGatewayClass(),
 			index.OptionsForGateway(),
 			index.OptionsForHTTPRoute(),
-			index.OptionsForTLSRoute(),
 		)
+		hasTLSRoute, err := crdChecker.CRDExists(tlsRouteGVR)
+		if err != nil {
+			return fmt.Errorf("failed to check existence of CRD %s: %w", tlsRouteGVR.String(), err)
+		}
+		if hasTLSRoute {
+			indexOptions = slices.Concat(indexOptions, index.OptionsForTLSRoute())
+		}
 	}
 
 	if cfg.KonnectControllersEnabled {
@@ -799,8 +814,19 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 		controllers = append(controllers,
 			newGatewayAPIHybridController[gwtypes.Gateway](mgr, c.FQDNModeEnabled, c.ClusterDomain),
 			newGatewayAPIHybridController[gwtypes.HTTPRoute](mgr, c.FQDNModeEnabled, c.ClusterDomain),
-			newGatewayAPIHybridController[gwtypes.TLSRoute](mgr, c.FQDNModeEnabled, c.ClusterDomain),
 		)
+		tlsRouteGVR := schema.GroupVersionResource{
+			Group:    gatewayv1.GroupVersion.Group,
+			Version:  gatewayv1.GroupVersion.Version,
+			Resource: "tlsroutes",
+		}
+		hasTLSRoute, err := checker.CRDExists(tlsRouteGVR)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check existence of CRD %s: %w", tlsRouteGVR.String(), err)
+		}
+		if hasTLSRoute {
+			controllers = append(controllers, newGatewayAPIHybridController[gwtypes.TLSRoute](mgr, c.FQDNModeEnabled, c.ClusterDomain))
+		}
 	}
 
 	return controllers, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not enable the `TLSRoute` controller and index when `TLSRoute` is absent

**Which issue this PR fixes**

Fixes #3861

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
