### PR TITLE
fix: fix TLSRoute readiness

### DIFF
--- a/ingress-controller/internal/adminapi/client.go
+++ b/ingress-controller/internal/adminapi/client.go
@@ -35,6 +35,8 @@ type Client struct {
 	lastConfigSHA     []byte
 	// podRef (optional) describes the Pod that the Client communicates with.
 	podRef *k8stypes.NamespacedName
+	// tlsServerName stores the SNI used to verify the Admin API certificate.
+	tlsServerName string
 }
 
 // NewClient creates an Admin API client that is to be used with a regular Admin API exposed by Kong Gateways.
@@ -198,12 +200,22 @@ func (c *Client) AttachPodReference(podNN k8stypes.NamespacedName) {
 	c.podRef = &podNN
 }
 
+// AttachTLSServerName stores the SNI used to verify the Admin API certificate.
+func (c *Client) AttachTLSServerName(tlsServerName string) {
+	c.tlsServerName = tlsServerName
+}
+
 // PodReference returns an optional reference to the Pod the client communicates with.
 func (c *Client) PodReference() (k8stypes.NamespacedName, bool) {
 	if c.podRef != nil {
 		return *c.podRef, true
 	}
 	return k8stypes.NamespacedName{}, false
+}
+
+// TLSServerName returns the SNI used to verify the Admin API certificate.
+func (c *Client) TLSServerName() string {
+	return c.tlsServerName
 }
 
 type ClientFactory struct {
@@ -241,5 +253,6 @@ func (cf ClientFactory) CreateAdminAPIClient(ctx context.Context, discoveredAdmi
 	}
 
 	cl.AttachPodReference(discoveredAdminAPI.PodRef)
+	cl.AttachTLSServerName(discoveredAdminAPI.TLSServerName)
 	return cl, nil
 }

--- a/ingress-controller/internal/adminapi/client_test.go
+++ b/ingress-controller/internal/adminapi/client_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kong/kong-operator/v2/ingress-controller/test/mocks"
 )
 
-func TestClientFactory_CreateAdminAPIClientAttachesPodReference(t *testing.T) {
+func TestClientFactory_CreateAdminAPIClientAttachesDiscoveryMetadata(t *testing.T) {
 	factory := adminapi.NewClientFactoryForWorkspace(logr.Discard(), "workspace", managercfg.AdminAPIClientConfig{}, "")
 
 	adminAPIHandler := mocks.NewAdminAPIHandler(t)
@@ -21,7 +21,8 @@ func TestClientFactory_CreateAdminAPIClientAttachesPodReference(t *testing.T) {
 	t.Cleanup(func() { adminAPIServer.Close() })
 
 	client, err := factory.CreateAdminAPIClient(t.Context(), adminapi.DiscoveredAdminAPI{
-		Address: adminAPIServer.URL,
+		Address:       adminAPIServer.URL,
+		TLSServerName: "pod.dataplane-admin.namespace.svc",
 		PodRef: k8stypes.NamespacedName{
 			Namespace: "namespace",
 			Name:      "name",
@@ -36,4 +37,5 @@ func TestClientFactory_CreateAdminAPIClientAttachesPodReference(t *testing.T) {
 		Namespace: "namespace",
 		Name:      "name",
 	}, ref)
+	require.Equal(t, "pod.dataplane-admin.namespace.svc", client.TLSServerName())
 }

--- a/ingress-controller/internal/clients/readiness.go
+++ b/ingress-controller/internal/clients/readiness.go
@@ -47,6 +47,7 @@ type AlreadyCreatedClient interface {
 	IsReady(context.Context) error
 	PodReference() (k8stypes.NamespacedName, bool)
 	BaseRootURL() string
+	TLSServerName() string
 }
 
 type DefaultReadinessChecker struct {
@@ -178,8 +179,9 @@ func (c DefaultReadinessChecker) checkAlreadyExistingClients(ctx context.Context
 				select {
 				case <-ctx.Done():
 				case pendingChan <- adminapi.DiscoveredAdminAPI{
-					Address: client.BaseRootURL(),
-					PodRef:  podRef,
+					Address:       client.BaseRootURL(),
+					TLSServerName: client.TLSServerName(),
+					PodRef:        podRef,
 				}:
 				}
 			}

--- a/ingress-controller/internal/clients/readiness_test.go
+++ b/ingress-controller/internal/clients/readiness_test.go
@@ -57,9 +57,10 @@ func (cf *mockClientFactory) CallsForAddress(address string) int {
 }
 
 type mockAlreadyCreatedClient struct {
-	url     string
-	isReady bool
-	podRef  k8stypes.NamespacedName
+	url           string
+	isReady       bool
+	podRef        k8stypes.NamespacedName
+	tlsServerName string
 }
 
 func (m mockAlreadyCreatedClient) IsReady(context.Context) error {
@@ -75,6 +76,10 @@ func (m mockAlreadyCreatedClient) PodReference() (k8stypes.NamespacedName, bool)
 
 func (m mockAlreadyCreatedClient) BaseRootURL() string {
 	return m.url
+}
+
+func (m mockAlreadyCreatedClient) TLSServerName() string {
+	return m.tlsServerName
 }
 
 func TestDefaultReadinessChecker(t *testing.T) {
@@ -275,4 +280,35 @@ func TestDefaultReadinessChecker(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDefaultReadinessChecker_PreservesTLSServerNameForPendingClients(t *testing.T) {
+	t.Parallel()
+
+	const (
+		testURL           = "https://10.0.0.1:8444"
+		testTLSServerName = "pod.dataplane-admin.default.svc"
+	)
+
+	testPodRef := k8stypes.NamespacedName{
+		Namespace: "default",
+		Name:      "mock",
+	}
+
+	checker := clients.NewDefaultReadinessChecker(newMockClientFactory(t, nil), managercfg.DefaultDataPlanesReadinessCheckTimeout, logr.Discard())
+	result := checker.CheckReadiness(t.Context(), []clients.AlreadyCreatedClient{
+		mockAlreadyCreatedClient{
+			url:           testURL,
+			isReady:       false,
+			podRef:        testPodRef,
+			tlsServerName: testTLSServerName,
+		},
+	}, nil)
+
+	require.Len(t, result.ClientsTurnedPending, 1)
+	require.Equal(t, adminapi.DiscoveredAdminAPI{
+		Address:       testURL,
+		TLSServerName: testTLSServerName,
+		PodRef:        testPodRef,
+	}, result.ClientsTurnedPending[0])
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The fix preserves `TLSServerName` when a ready Admin API client is demoted back to pending and keeps that metadata attached when the client is recreated. Added regression unit tests for the readiness fallback path and for Admin API client metadata attachment so this SNI loss does not regress.

The problem was in Admin API client readiness reconciliation: when a previously ready client became not ready, it was moved back to the pending set without its `TLSServerName`. After that, reconnect attempts used the dataplane IP without SNI, TLS verification failed because the dataplane certificate does not include IP SANs, and the Gateway never reached `Programmed`.

Fixes #

**Special notes for your reviewer**:

`TestTLSRoute` failing in CI: https://github.com/Kong/kong-operator/actions/runs/24897185741/job/72905138001

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
