### PR TITLE
fix(hybrid gateway): Fix build accepted conditions for TLSRoute

### DIFF
--- a/controller/hybridgateway/route/status.go
+++ b/controller/hybridgateway/route/status.go
@@ -739,7 +739,7 @@ func isProgrammed(obj *unstructured.Unstructured) bool {
 // The function performs the following checks for each listener:
 // 1. Matches the section name specified in the ParentReference (if any)
 // 2. Matches the port specified in the ParentReference (if any)
-// 3. Supports the protocol with properiate TLS mode
+// 3. Supports the protocol with appropriate TLS mode
 // 4. Is in a "Programmed" (ready) state according to the Gateway status
 //
 // Parameters:

--- a/controller/hybridgateway/route/status.go
+++ b/controller/hybridgateway/route/status.go
@@ -330,7 +330,7 @@ func isConditionEqual(a, b metav1.Condition) bool {
 		a.ObservedGeneration == b.ObservedGeneration
 }
 
-// BuildAcceptedCondition builds the "Accepted" condition for a given HTTPRoute and ParentReference.
+// BuildAcceptedCondition builds the "Accepted" condition for a given route and ParentReference.
 // It validates whether the route can be accepted by the gateway by checking multiple criteria
 // in sequence, returning the first failure condition encountered or a success condition if all checks pass.
 //
@@ -344,7 +344,7 @@ func isConditionEqual(a, b metav1.Condition) bool {
 //   - logger: Logger for debugging information
 //   - cl: The Kubernetes client for API operations
 //   - gateway: The Gateway object associated with the ParentReference
-//   - route: The HTTPRoute to validate for acceptance
+//   - route: The route to validate for acceptance
 //   - pRef: The ParentReference being evaluated
 //
 // Returns:
@@ -358,7 +358,7 @@ func BuildAcceptedCondition[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRout
 	ctx context.Context, logger logr.Logger, cl client.Client, gateway *gwtypes.Gateway,
 	route TPtr, pRef gwtypes.ParentReference) (*metav1.Condition, error) {
 	// Begin by excluding listeners that do not match the specified section name.
-	listeners, cond := FilterMatchingListeners(logger, gateway, pRef, gateway.Spec.Listeners)
+	listeners, cond := FilterMatchingListeners(logger, gateway, route.GetObjectKind().GroupVersionKind().Kind, pRef, gateway.Spec.Listeners)
 	if cond != nil {
 		log.Debug(logger, "No matching listeners for ParentReference", "parentRef", pRef, "gateway", gateway.Name)
 		// Return the condition indicating no matching listeners.
@@ -372,7 +372,7 @@ func BuildAcceptedCondition[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRout
 		return nil, fmt.Errorf("failed to get namespace %s for route %s while building accepted condition for gateway %s: %w",
 			route.GetNamespace(), client.ObjectKeyFromObject(route), client.ObjectKeyFromObject(gateway), err)
 	}
-	// Prepare the RouteGroupKind for the HTTPRoute.
+	// Prepare the RouteGroupKind for the route.
 	rgk := GetRouteGroupKind(route)
 	// Filter listeners by allowed routes.
 	listeners, cond, err := FilterListenersByAllowedRoutes(logger, gateway, pRef, listeners, rgk, &routeNamespace)
@@ -739,11 +739,12 @@ func isProgrammed(obj *unstructured.Unstructured) bool {
 // The function performs the following checks for each listener:
 // 1. Matches the section name specified in the ParentReference (if any)
 // 2. Matches the port specified in the ParentReference (if any)
-// 3. Supports HTTP/HTTPS protocol with appropriate TLS termination mode
+// 3. Supports the protocol with properiate TLS mode
 // 4. Is in a "Programmed" (ready) state according to the Gateway status
 //
 // Parameters:
 //   - gw: The Gateway object containing the listeners and their status
+//   - routeKind: The kind of the route
 //   - logger: Logger for debugging information
 //   - pRef: The ParentReference specifying matching criteria
 //   - listeners: The list of listeners from the Gateway spec to filter
@@ -754,7 +755,7 @@ func isProgrammed(obj *unstructured.Unstructured) bool {
 //
 // The returned condition will have status "False" with reason "NoMatchingParent" if no listeners
 // match the criteria. If listeners match but are not ready, the message will indicate this distinction.
-func FilterMatchingListeners(logger logr.Logger, gw *gwtypes.Gateway, pRef gwtypes.ParentReference, listeners []gwtypes.Listener) ([]gwtypes.Listener, *metav1.Condition) {
+func FilterMatchingListeners(logger logr.Logger, gw *gwtypes.Gateway, routeKind string, pRef gwtypes.ParentReference, listeners []gwtypes.Listener) ([]gwtypes.Listener, *metav1.Condition) {
 	var matchingListeners []gwtypes.Listener
 	var matchedNotReady bool
 	for _, listener := range listeners {
@@ -768,14 +769,7 @@ func FilterMatchingListeners(logger logr.Logger, gw *gwtypes.Gateway, pRef gwtyp
 			continue
 		}
 
-		// Check if the protocol matches.
-		// HTTPRoutes support Terminate only
-		// Note: this is a guess we are doing as the upstream documentation is unclear at the moment.
-		// see https://github.com/kubernetes-sigs/gateway-api/issues/1474
-		if listener.Protocol != gwtypes.HTTPProtocolType && listener.Protocol != gwtypes.HTTPSProtocolType {
-			continue
-		}
-		if listener.TLS != nil && *listener.TLS.Mode != gwtypes.TLSModeTerminate {
+		if !isListenerValidForKind(routeKind, listener) {
 			continue
 		}
 
@@ -818,6 +812,28 @@ func FilterMatchingListeners(logger logr.Logger, gw *gwtypes.Gateway, pRef gwtyp
 	// Return the list of matching and ready listeners that can be used for further processing.
 	log.Debug(logger, "Matching and ready listeners found", "parentRef", pRef, "count", len(matchingListeners))
 	return matchingListeners, nil
+}
+
+// isListenerValidForKind filters listeners that is valid for the given route kind.
+func isListenerValidForKind(routeKind string, listener gwtypes.Listener) bool {
+	switch routeKind {
+	case "HTTPRoute":
+		// Check if the protocol matches.
+		// HTTPRoutes support Terminate only
+		// Note: this is a guess we are doing as the upstream documentation is unclear at the moment.
+		// see https://github.com/kubernetes-sigs/gateway-api/issues/1474
+		if listener.Protocol != gwtypes.HTTPProtocolType && listener.Protocol != gwtypes.HTTPSProtocolType {
+			return false
+		}
+		if listener.TLS != nil && *listener.TLS.Mode != gwtypes.TLSModeTerminate {
+			return false
+		}
+		return true
+	case "TLSRoute":
+		return listener.Protocol == gwtypes.TLSProtocolType && listener.TLS != nil
+	}
+	// Not supported kinds. Should be unreachable.
+	return false
 }
 
 // FilterListenersByAllowedRoutes filters the provided listeners to find those that allow the given HTTPRoute based on its kind and namespace.

--- a/controller/hybridgateway/route/status_test.go
+++ b/controller/hybridgateway/route/status_test.go
@@ -556,7 +556,13 @@ func Test_BuildAcceptedCondition(t *testing.T) {
 		},
 	}
 
+	httpRouteTypeMeta := metav1.TypeMeta{
+		Kind:       "HTTPRoute",
+		APIVersion: "gateway.networking.k8s.io/v1",
+	}
+
 	route := &gwtypes.HTTPRoute{
+		TypeMeta: httpRouteTypeMeta,
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "route",
@@ -629,6 +635,7 @@ func Test_BuildAcceptedCondition(t *testing.T) {
 				},
 			},
 			route: &gwtypes.HTTPRoute{
+				TypeMeta:   httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
 				Spec:       gwtypes.HTTPRouteSpec{Hostnames: []gwtypes.Hostname{"not-matching.com"}},
 			},
@@ -677,6 +684,7 @@ func Test_BuildAcceptedCondition(t *testing.T) {
 				},
 			},
 			route: &gwtypes.HTTPRoute{
+				TypeMeta:   httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{Namespace: "nonexistent", Name: "route"},
 				Spec:       gwtypes.HTTPRouteSpec{},
 			},
@@ -718,6 +726,7 @@ func Test_BuildAcceptedCondition(t *testing.T) {
 				},
 			},
 			route: &gwtypes.HTTPRoute{
+				TypeMeta:   httpRouteTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
 				Spec:       gwtypes.HTTPRouteSpec{},
 			},
@@ -1147,13 +1156,17 @@ func Test_FilterMatchingListeners(t *testing.T) {
 	}
 	listenerReady := gwtypes.Listener{Name: "listener1", Port: 80, Protocol: gwtypes.HTTPProtocolType}
 	listenerNotReady := gwtypes.Listener{Name: "listener2", Port: 80, Protocol: gwtypes.HTTPProtocolType}
-	listenerWrongProtocol := gwtypes.Listener{Name: "listener1", Port: 80, Protocol: "TCP"}
+	listenerProtocolTCP := gwtypes.Listener{Name: "listener1", Port: 80, Protocol: "TCP"}
 	tlsModePassthrough := gatewayv1.TLSModePassthrough
-	listenerWrongTLS := gwtypes.Listener{Name: "listener1", Port: 80, Protocol: gwtypes.HTTPSProtocolType, TLS: &gatewayv1.ListenerTLSConfig{Mode: &tlsModePassthrough}}
+	tlsModeTerminate := gatewayv1.TLSModeTerminate
+	listenerTLSPassthrough := gwtypes.Listener{Name: "listener1", Port: 80, Protocol: gwtypes.HTTPSProtocolType, TLS: &gatewayv1.ListenerTLSConfig{Mode: &tlsModePassthrough}}
+	listenerNotReadyTLS := gwtypes.Listener{Name: "listener2", Port: 80, Protocol: gwtypes.TLSProtocolType, TLS: &gatewayv1.ListenerTLSConfig{Mode: &tlsModeTerminate}}
+	listenerProtocolTLS := gwtypes.Listener{Name: "listener1", Port: 80, Protocol: gwtypes.TLSProtocolType, TLS: &gatewayv1.ListenerTLSConfig{Mode: &tlsModePassthrough}}
 
 	tests := []struct {
 		name      string
 		pRef      gwtypes.ParentReference
+		routeKind string
 		listeners []gwtypes.Listener
 		wantLen   int
 		wantCond  bool
@@ -1162,6 +1175,7 @@ func Test_FilterMatchingListeners(t *testing.T) {
 		{
 			name:      "no listeners",
 			pRef:      pRef,
+			routeKind: "HTTPRoute",
 			listeners: []gwtypes.Listener{},
 			wantLen:   0,
 			wantCond:  true,
@@ -1170,6 +1184,7 @@ func Test_FilterMatchingListeners(t *testing.T) {
 		{
 			name:      "section name mismatch",
 			pRef:      gwtypes.ParentReference{Name: "listener1", SectionName: sectionPtr("notfound")},
+			routeKind: "HTTPRoute",
 			listeners: []gwtypes.Listener{listenerReady},
 			wantLen:   0,
 			wantCond:  true,
@@ -1178,6 +1193,7 @@ func Test_FilterMatchingListeners(t *testing.T) {
 		{
 			name:      "port mismatch",
 			pRef:      gwtypes.ParentReference{Name: "listener1", Port: new(int32(81))},
+			routeKind: "HTTPRoute",
 			listeners: []gwtypes.Listener{listenerReady},
 			wantLen:   0,
 			wantCond:  true,
@@ -1186,7 +1202,8 @@ func Test_FilterMatchingListeners(t *testing.T) {
 		{
 			name:      "protocol mismatch",
 			pRef:      pRef,
-			listeners: []gwtypes.Listener{listenerWrongProtocol},
+			routeKind: "HTTPRoute",
+			listeners: []gwtypes.Listener{listenerProtocolTCP},
 			wantLen:   0,
 			wantCond:  true,
 			condMsg:   string(gwtypes.RouteReasonNoMatchingParent),
@@ -1194,7 +1211,8 @@ func Test_FilterMatchingListeners(t *testing.T) {
 		{
 			name:      "TLS mode mismatch",
 			pRef:      pRef,
-			listeners: []gwtypes.Listener{listenerWrongTLS},
+			routeKind: "HTTPRoute",
+			listeners: []gwtypes.Listener{listenerTLSPassthrough},
 			wantLen:   0,
 			wantCond:  true,
 			condMsg:   string(gwtypes.RouteReasonNoMatchingParent),
@@ -1202,6 +1220,7 @@ func Test_FilterMatchingListeners(t *testing.T) {
 		{
 			name:      "listener matches but not ready",
 			pRef:      gwtypes.ParentReference{Name: "listener2"},
+			routeKind: "HTTPRoute",
 			listeners: []gwtypes.Listener{listenerNotReady},
 			wantLen:   0,
 			wantCond:  true,
@@ -1210,6 +1229,7 @@ func Test_FilterMatchingListeners(t *testing.T) {
 		{
 			name:      "listener matches and is ready",
 			pRef:      pRef,
+			routeKind: "HTTPRoute",
 			listeners: []gwtypes.Listener{listenerReady},
 			wantLen:   1,
 			wantCond:  false,
@@ -1217,14 +1237,41 @@ func Test_FilterMatchingListeners(t *testing.T) {
 		{
 			name:      "multiple listeners, mixed readiness",
 			pRef:      gwtypes.ParentReference{Name: "listener1"},
+			routeKind: "HTTPRoute",
 			listeners: []gwtypes.Listener{listenerReady, listenerNotReady},
 			wantLen:   1,
 			wantCond:  false,
 		},
+		{
+			name:      "TLSRoute - no ready listeners",
+			pRef:      pRef,
+			routeKind: "TLSRoute",
+			listeners: []gwtypes.Listener{listenerNotReadyTLS},
+			wantLen:   0,
+			wantCond:  true,
+			condMsg:   "A Gateway Listener matches this route but is not ready",
+		},
+		{
+			name:      "TLSRoute - ready and match listener",
+			pRef:      pRef,
+			routeKind: "TLSRoute",
+			listeners: []gwtypes.Listener{listenerProtocolTLS},
+			wantLen:   1,
+			wantCond:  false,
+		},
+		{
+			name:      "TLSRoute - protocol mismatch",
+			pRef:      pRef,
+			routeKind: "TLSRoute",
+			listeners: []gwtypes.Listener{listenerProtocolTCP},
+			wantLen:   0,
+			wantCond:  true,
+			condMsg:   string(gwtypes.RouteReasonNoMatchingParent),
+		},
 	}
 
 	for _, tt := range tests {
-		matches, cond := FilterMatchingListeners(logr.Discard(), gw, tt.pRef, tt.listeners)
+		matches, cond := FilterMatchingListeners(logr.Discard(), gw, tt.routeKind, tt.pRef, tt.listeners)
 		require.Len(t, matches, tt.wantLen, tt.name)
 		if tt.wantCond {
 			require.NotNil(t, cond, tt.name)

--- a/internal/types/gatewaytypes.go
+++ b/internal/types/gatewaytypes.go
@@ -59,6 +59,7 @@ const (
 	GroupName                             = gatewayv1.GroupName
 	HTTPProtocolType                      = gatewayv1.HTTPProtocolType
 	HTTPSProtocolType                     = gatewayv1.HTTPSProtocolType
+	TLSProtocolType                       = gatewayv1.TLSProtocolType
 	HTTPRouteFilterExtensionRef           = gatewayv1.HTTPRouteFilterExtensionRef
 	HTTPRouteFilterRequestHeaderModifier  = gatewayv1.HTTPRouteFilterRequestHeaderModifier
 	ListenerConditionProgrammed           = gatewayv1.ListenerConditionProgrammed


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the method to choose available listeners for `TLSRoute` in `BuildAcceptedConditions` for hybrid gateway routes.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
