### PR TITLE
tests: fix flaky MCP server CRD validation test

### DIFF
--- a/test/crdsvalidation/konnect.konghq.com/mcpserver_test.go
+++ b/test/crdsvalidation/konnect.konghq.com/mcpserver_test.go
@@ -66,11 +66,19 @@ func TestMCPServer(t *testing.T) {
 				TestObject: func() *konnectv1alpha1.MCPServer {
 					obj := validMCPServer(ns.Name)
 					obj.Spec.ControlPlaneRef = commonv1alpha1.ControlPlaneRef{
-						Type: commonv1alpha1.ControlPlaneRefKonnectID,
+						Type:                 commonv1alpha1.ControlPlaneRefKonnectID,
+						KonnectNamespacedRef: nil, // Override CP ref.
 					}
 					return obj
 				}(),
-				ExpectedErrorMessage: new("Unsupported value: \"konnectID\""),
+				ExpectedErrorMessage: new("konnectID"),
+			},
+			{
+				Name: "konnectNamespacedRef is accepted",
+				TestObject: func() *konnectv1alpha1.MCPServer {
+					obj := validMCPServer(ns.Name)
+					return obj
+				}(),
 			},
 		}.RunWithConfig(t, cfg, scheme)
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR does 3 things:

- makes the MCP server `konnectID type is not supported` test case set `KonnectNamespacedRef` to `nil` explicitly to override it from `validMCPServer`
- use a broader, more relaxed `ExpectedErrorMessage: new("konnectID")` error in the same case to prevent test failing due to `konnectID` being rejected at `MCPServer` level and at the [CP ref level](https://github.com/Kong/kong-operator/blob/afbba16f7532fc8bbc6813eba49135e68f95c0af/api/common/v1alpha1/controlplaneref_types.go#L24-L33)
- add a valid test case


CI failures observed in https://github.com/Kong/kong-operator/actions/runs/24982412170/job/73147592994?pr=4021.


```
    testcase.go:140: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/crdsvalidation/common/testcase.go:140
        	Error:      	Condition never satisfied
        	Test:       	TestMCPServer/controlPlaneRef_validation/konnectID_type_is_not_supported
--- FAIL: TestMCPServer/controlPlaneRef_validation/konnectID_type_is_not_supported (3.02s)
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
