### PR TITLE
fix: fix endless reconciliation on not Programmed referenced entities

### DIFF
--- a/controller/konnect/reconciler_certificateref.go
+++ b/controller/konnect/reconciler_certificateref.go
@@ -91,7 +91,8 @@ func handleKongCertificateRef[T constraints.SupportedKonnectEntityType, TEnt con
 		); err != nil || !res.IsZero() {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{Requeue: true}, nil
+		// Don't requeue. The referenced entity's changes will trigger the reconciliation.
+		return ctrl.Result{}, nil
 	}
 
 	// TODO: make this more generic.

--- a/controller/konnect/reconciler_certificateref_test.go
+++ b/controller/konnect/reconciler_certificateref_test.go
@@ -247,7 +247,7 @@ func TestHandleCertificateRef(t *testing.T) {
 				testKongCertNotProgrammed,
 			},
 			expectError:  false,
-			expectResult: ctrl.Result{Requeue: true},
+			expectResult: ctrl.Result{},
 			updatedEntAssertions: []func(*configurationv1alpha1.KongSNI) (bool, string){
 				func(ks *configurationv1alpha1.KongSNI) (bool, string) {
 					return lo.ContainsBy(ks.GetConditions(), func(c metav1.Condition) bool {

--- a/controller/konnect/reconciler_consumerref.go
+++ b/controller/konnect/reconciler_consumerref.go
@@ -161,7 +161,8 @@ func handleKongConsumerRef[T constraints.SupportedKonnectEntityType, TEnt constr
 			return res, errStatus
 		}
 
-		return ctrl.Result{Requeue: true}, nil
+		// Don't requeue. The referenced entity's changes will trigger the reconciliation.
+		return ctrl.Result{}, nil
 	}
 
 	if resource, ok := any(ent).(EntityWithControlPlaneRef); ok {

--- a/controller/konnect/reconciler_controlplaneref.go
+++ b/controller/konnect/reconciler_controlplaneref.go
@@ -104,7 +104,8 @@ func handleControlPlaneRef[T constraints.SupportedKonnectEntityType, TEnt constr
 			return res, errStatus
 		}
 
-		return ctrl.Result{Requeue: true}, nil
+		// Don't requeue. The referenced entity's changes will trigger the reconciliation.
+		return ctrl.Result{}, nil
 	}
 
 	if resource, ok := any(ent).(EntityWithControlPlaneRef); ok {

--- a/controller/konnect/reconciler_controlplaneref_test.go
+++ b/controller/konnect/reconciler_controlplaneref_test.go
@@ -230,7 +230,7 @@ func TestHandleControlPlaneRef(t *testing.T) {
 			objects: []client.Object{
 				cpNotProgrammed,
 			},
-			expectResult: ctrl.Result{Requeue: true},
+			expectResult: ctrl.Result{},
 			expectError:  false,
 			updatedEntAssertions: []func(svc *configurationv1alpha1.KongService) (ok bool, message string){
 				func(svc *configurationv1alpha1.KongService) (bool, string) {

--- a/controller/konnect/reconciler_keysetref.go
+++ b/controller/konnect/reconciler_keysetref.go
@@ -114,7 +114,8 @@ func handleKongKeySetRef[T constraints.SupportedKonnectEntityType, TEnt constrai
 		); err != nil || !res.IsZero() {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{Requeue: true}, nil
+		// Don't requeue. The referenced entity's changes will trigger the reconciliation.
+		return ctrl.Result{}, nil
 	}
 
 	old := ent.DeepCopyObject().(TEnt)

--- a/controller/konnect/reconciler_keysetref_test.go
+++ b/controller/konnect/reconciler_keysetref_test.go
@@ -232,7 +232,7 @@ func TestHandleKeySetRef(t *testing.T) {
 				},
 			},
 			objects:      []client.Object{notProgrammedKeySet},
-			expectResult: ctrl.Result{Requeue: true},
+			expectResult: ctrl.Result{},
 			updatedEntAssertions: []func(*configurationv1alpha1.KongKey) (ok bool, message string){
 				keySetIDIsEmpty,
 				keySetRefConditionIs(metav1.ConditionFalse),

--- a/controller/konnect/reconciler_serviceref.go
+++ b/controller/konnect/reconciler_serviceref.go
@@ -18,7 +18,6 @@ import (
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	"github.com/kong/kong-operator/v2/controller/konnect/constraints"
 	"github.com/kong/kong-operator/v2/controller/pkg/controlplane"
-	"github.com/kong/kong-operator/v2/controller/pkg/op"
 	"github.com/kong/kong-operator/v2/controller/pkg/patch"
 	"github.com/kong/kong-operator/v2/internal/utils/crossnamespace"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
@@ -157,16 +156,15 @@ func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constra
 			fmt.Sprintf("Referenced KongService %s is not programmed yet", nn),
 		)
 
-		res, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
+		_, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
 		if err != nil {
 			if apierrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{}, err
 		}
-		if res == op.Updated {
-			return ctrl.Result{}, nil
-		}
+		// Don't requeue. The referenced entity's changes will trigger the reconciliation.
+		return ctrl.Result{}, nil
 	}
 
 	// TODO(pmalek): make this generic.

--- a/controller/konnect/reconciler_upstreamref.go
+++ b/controller/konnect/reconciler_upstreamref.go
@@ -18,7 +18,6 @@ import (
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	"github.com/kong/kong-operator/v2/controller/konnect/constraints"
 	"github.com/kong/kong-operator/v2/controller/pkg/controlplane"
-	"github.com/kong/kong-operator/v2/controller/pkg/op"
 	"github.com/kong/kong-operator/v2/controller/pkg/patch"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
 )
@@ -93,16 +92,15 @@ func handleKongUpstreamRef[T constraints.SupportedKonnectEntityType, TEnt constr
 			fmt.Sprintf("Referenced KongUpstream %s is not programmed yet", nn),
 		)
 
-		res, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
+		_, err := patch.ApplyStatusPatchIfNotEmpty(ctx, cl, ctrllog.FromContext(ctx), ent, old)
 		if err != nil {
 			if apierrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{}, err
 		}
-		if res == op.Updated {
-			return ctrl.Result{}, nil
-		}
+		// Don't requeue. The referenced entity's changes will trigger the reconciliation.
+		return ctrl.Result{}, nil
 	}
 
 	// TODO: make this more generic.

--- a/test/envtest/konnect_entities_kongconsumer_test.go
+++ b/test/envtest/konnect_entities_kongconsumer_test.go
@@ -163,6 +163,8 @@ func TestKongConsumer(t *testing.T) {
 				))
 			}, waitTime, tickTime,
 		)
+
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
 	})
 
 	cgWatch := setupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, cl, client.InNamespace(ns.Name))
@@ -305,6 +307,9 @@ func TestKongConsumer(t *testing.T) {
 		consumerToPatch := createdConsumer.DeepCopy()
 		consumerToPatch.Username = "user-2-updated"
 		require.NoError(t, clientNamespaced.Patch(ctx, consumerToPatch, client.MergeFrom(createdConsumer)))
+
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
 	})
 
 	t.Run("should handle conflict in creation correctly", func(t *testing.T) {
@@ -491,21 +496,23 @@ func TestKongConsumer(t *testing.T) {
 				cpNew.Name = cp.Name
 			},
 		)
-		t.Log("Setting up SDK expectation on KongConsumerGroups listing")
-		sdk.ConsumersSDK.EXPECT().
-			ListConsumerGroupsForConsumer(mock.Anything, sdkkonnectops.ListConsumerGroupsForConsumerRequest{
-				ConsumerID:     id,
-				ControlPlaneID: cp.GetKonnectStatus().GetKonnectID(),
-			}).Return(&sdkkonnectops.ListConsumerGroupsForConsumerResponse{}, nil)
+
+		t.Log("Patching KongConsumer to attach to new ControlPlane")
+		consumerToPatch := created.DeepCopy()
+		consumerToPatch.Spec.ControlPlaneRef.KonnectNamespacedRef.Name = cp.Name
+		require.NoError(t, clientNamespaced.Patch(ctx, consumerToPatch, client.MergeFrom(created)))
 
 		t.Log("Waiting for object to be get Programmed with status=True and konnect cleanup finalizer re added")
 		watchFor(t, ctx, w, apiwatch.Modified,
 			assertsAnd(
+				objectMatchesName(created),
 				objectHasConditionProgrammedSetToTrue[*configurationv1.KongConsumer](),
 				objectHasFinalizer[*configurationv1.KongConsumer](konnect.KonnectCleanupFinalizer),
 			),
 			"Object didn't get Programmed set to True",
 		)
+
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix endless reconciliation when referenced Konnect entities are not yet programmed

- Stop explicitly requeueing dependent Konnect resources when their referenced entity exists but is not yet Programmed.
- Rely on reconciliation triggered by the referenced resource once it becomes ready, which prevents reconcile loops while still updating status conditions correctly.
- Align related handlers and tests with the new behavior, and relax KongTarget UID lookup to avoid over-filtering by upstream during target discovery.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
