### PR TITLE
fix(keg-dataplane): drop base Kafka Service port when user provides same-named port

### DIFF
--- a/controller/eventgateway/dataplane/owned_service.go
+++ b/controller/eventgateway/dataplane/owned_service.go
@@ -89,7 +89,40 @@ func buildKafkaService(
 // generateBaseKafkaService returns the operator defaults for the Kafka Service:
 // the pod selector and a default Kafka port. These are used only when the user
 // has not provided conflicting values in ServiceOptions.
+//
+// Service.spec.ports is a list-map keyed by [port, protocol], so SSA merges
+// ports by port number. Two ports with different port numbers but the same
+// name would both be kept after the merge, causing Kubernetes to reject the
+// Service (port names must be unique). To prevent this, any base port whose
+// name is already used by a user-provided port is omitted here so the user's
+// port wins cleanly.
 func generateBaseKafkaService(egdp *eventgatewayv1alpha1.KegDataPlane) *corev1.Service {
+	// Collect user-provided port names so we can skip conflicting base ports.
+	userPortNames := make(map[string]struct{})
+	if egdp.Spec.Network != nil &&
+		egdp.Spec.Network.Services != nil &&
+		egdp.Spec.Network.Services.Kafka != nil {
+		for _, p := range egdp.Spec.Network.Services.Kafka.Ports {
+			if p.Name != nil {
+				userPortNames[*p.Name] = struct{}{}
+			}
+		}
+	}
+
+	basePorts := []corev1.ServicePort{
+		{
+			Name:       "kafka",
+			Port:       DefaultKafkaPort,
+			TargetPort: intstr.FromInt32(DefaultKafkaPort),
+			Protocol:   corev1.ProtocolTCP,
+		},
+	}
+	var ports []corev1.ServicePort
+	for _, bp := range basePorts {
+		if _, clash := userPortNames[bp.Name]; !clash {
+			ports = append(ports, bp)
+		}
+	}
 	svc := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -104,14 +137,7 @@ func generateBaseKafkaService(egdp *eventgatewayv1alpha1.KegDataPlane) *corev1.S
 				consts.GatewayOperatorManagedByLabel:     consts.DataPlaneManagedByLabelValue,
 				consts.GatewayOperatorManagedByNameLabel: egdp.Name,
 			},
-			Ports: []corev1.ServicePort{
-				{
-					Name:       "kafka",
-					Port:       DefaultKafkaPort,
-					TargetPort: intstr.FromInt32(DefaultKafkaPort),
-					Protocol:   corev1.ProtocolTCP,
-				},
-			},
+			Ports: ports,
 		},
 	}
 	k8sutils.SetOwnerForObject(svc, egdp)

--- a/controller/eventgateway/dataplane/owned_service_test.go
+++ b/controller/eventgateway/dataplane/owned_service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/managedfields"
@@ -202,6 +203,41 @@ func Test_buildKafkaService(t *testing.T) {
 			},
 			check: func(t *testing.T, obj client.Object) {
 				assert.Equal(t, "dp-kafka", obj.GetName())
+			},
+		},
+		{
+			// A user port named "kafka" (same name as the base port) but on a
+			// different port number must replace the base port and not produce a
+			// Service with two ports that share the same name.
+			name: "user port with same name as base port replaces it (no duplicate names)",
+			egdp: &eventgatewayv1alpha1.KegDataPlane{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "dp"},
+				Spec: eventgatewayv1alpha1.KegDataPlaneSpec{
+					Network: &eventgatewayv1alpha1.NetworkOptions{
+						Services: &eventgatewayv1alpha1.Services{
+							Kafka: &eventgatewayv1alpha1.ServiceOptions{
+								Ports: []eventgatewayv1alpha1.ServicePort{
+									{Name: new("kafka"), Port: 19092},
+								},
+							},
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, obj client.Object) {
+				u, ok := obj.(*unstructured.Unstructured)
+				require.True(t, ok)
+				ports, _, _ := unstructured.NestedSlice(u.Object, "spec", "ports")
+				var kafkaPorts []any
+				for _, p := range ports {
+					pm, ok := p.(map[string]any)
+					if ok && pm["name"] == "kafka" {
+						kafkaPorts = append(kafkaPorts, pm)
+					}
+				}
+				require.Len(t, kafkaPorts, 1, "expected exactly one port named 'kafka'")
+				portNum, _, _ := unstructured.NestedInt64(kafkaPorts[0].(map[string]any), "port")
+				assert.Equal(t, int64(19092), portNum)
 			},
 		},
 		{

--- a/test/envtest/keg_dataplane_controller_test.go
+++ b/test/envtest/keg_dataplane_controller_test.go
@@ -771,6 +771,50 @@ func TestKEGDataPlaneReconciler(t *testing.T) {
 		}, waitTime, tickTime)
 	})
 
+	t.Run("Kafka Service: user port with same name as base port replaces it (no duplicate port names)", func(t *testing.T) {
+		t.Parallel()
+
+		// This tests the port-name clash: when the user provides a port named
+		// "kafka" at a different port number than the base (9092), the base port
+		// must be suppressed so the Service does not end up with two ports sharing
+		// the name "kafka", which the Kubernetes API server rejects.
+		egdp := setupProgrammedKEGDP(t, ctx, cl, ns.Name,
+			"kep-svc-name-clash", "konnect-id-svc-name-clash", "egdp-svc-name-clash",
+			eventgatewayv1alpha1.KegDataPlaneSpec{
+				Network: &eventgatewayv1alpha1.NetworkOptions{
+					Services: &eventgatewayv1alpha1.Services{
+						Kafka: &eventgatewayv1alpha1.ServiceOptions{
+							Ports: []eventgatewayv1alpha1.ServicePort{
+								{Name: new("kafka"), Port: 19092},
+							},
+						},
+					},
+				},
+			},
+		)
+
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			var svc corev1.Service
+			if !assert.NoError(ct, cl.Get(ctx, client.ObjectKey{
+				Name: fmt.Sprintf("%s-kafka", egdp.Name), Namespace: ns.Name,
+			}, &svc)) {
+				return
+			}
+			var kafkaPorts []corev1.ServicePort
+			for _, p := range svc.Spec.Ports {
+				if p.Name == "kafka" {
+					kafkaPorts = append(kafkaPorts, p)
+				}
+			}
+			// Exactly one port named "kafka", no duplicate from the base.
+			if !assert.Len(ct, kafkaPorts, 1, "expected exactly one port named 'kafka'") {
+				return
+			}
+			// The user's port number (19092) wins; the base port (9092) is gone.
+			assert.EqualValues(ct, 19092, kafkaPorts[0].Port)
+		}, waitTime, tickTime)
+	})
+
 	t.Run("Kafka Service: annotations propagated; operator-owned selector and default port preserved", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

SSA merges Service ports by [port, protocol], so a user port with the same name as the base "kafka" port but a different number would produce two ports sharing the same name, which the Kubernetes API server rejects. Pre-filter base ports whose name already appears in the user overlay to let the user's port win cleanly.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
