### PR TITLE
test(envtest): Add envtest cases for `TLSRoute` controller and fix setting of `Accepted` conditions

### DIFF
--- a/ingress-controller/internal/controllers/gateway/route_utils.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils.go
@@ -536,6 +536,11 @@ func existsMatchingListenerInStatus[T gatewayapi.RouteT](route T, listener gatew
 					Group: gatewayv1.GroupVersion.Group,
 					Kind:  "HTTPRoute",
 				}
+			case *gatewayapi.TLSRoute:
+				gvk = schema.GroupVersionKind{
+					Group: gatewayv1.GroupVersion.Group,
+					Kind:  "TLSRoute",
+				}
 			default:
 				gvk = route.GetObjectKind().GroupVersionKind()
 			}

--- a/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
@@ -453,3 +453,8 @@ func (r *TLSRouteReconciler) ensureGatewayReferenceStatusAdded(
 	// the status needed an update and it was updated successfully
 	return true, ctrl.Result{}, nil
 }
+
+// SetLogger sets the logger.
+func (r *TLSRouteReconciler) SetLogger(l logr.Logger) {
+	r.Log = l
+}

--- a/ingress-controller/test/controllers/gateway/gateway.go
+++ b/ingress-controller/test/controllers/gateway/gateway.go
@@ -7,6 +7,7 @@ import (
 
 type GatewayReconciler = internal.GatewayReconciler
 type HTTPRouteReconciler = internal.HTTPRouteReconciler
+type TLSRouteReconciler = internal.TLSRouteReconciler
 
 func GetControllerName() internalgatewayapi.GatewayController {
 	return internal.GetControllerName()

--- a/ingress-controller/test/helpers/conditions.go
+++ b/ingress-controller/test/helpers/conditions.go
@@ -104,3 +104,47 @@ func HTTPRouteEventuallyNotContainsConditions(ctx context.Context, t *testing.T,
 		})
 	}
 }
+
+// TLSRouteEventuallyContainsConditions returns a predicate function that can be
+// used with assert.Eventually or require.Eventually to check that the TLSRoute
+// identified by the provided NamespacedName contains the provided conditions
+// in any of its parent statuses.
+func TLSRouteEventuallyContainsConditions(ctx context.Context, t *testing.T, client ctrlclient.Client, nn k8stypes.NamespacedName, conds ...metav1.Condition) func() bool {
+	return func() bool {
+		t.Helper()
+
+		var (
+			ns    = nn.Namespace
+			name  = nn.Name
+			route = gatewayapi.TLSRoute{}
+		)
+
+		err := client.Get(ctx, ctrlclient.ObjectKey{Namespace: ns, Name: name}, &route)
+		if err != nil {
+			// No point in continuing if connection is down.
+			if net.IsConnectionRefused(err) {
+				require.NoError(t, err)
+				return false
+			}
+			t.Logf("Failed to get TLSRoute: %v", err)
+			return false
+		}
+
+		return lo.ContainsBy(route.Status.Parents, func(p gatewayapi.RouteParentStatus) bool {
+			var count int
+			for _, cond := range conds {
+				contains := lo.ContainsBy(p.Conditions, func(c metav1.Condition) bool {
+					return c.Type == cond.Type && c.Status == cond.Status && c.Reason == cond.Reason
+				})
+				if !contains {
+					t.Logf("condition Type:%s, Status:%s, Reason:%s missing from route:%s/%s status",
+						cond.Type, cond.Status, cond.Reason, ns, name,
+					)
+					return false
+				}
+				count++
+			}
+			return count == len(conds)
+		})
+	}
+}

--- a/ingress-controller/test/mocks/dataplane.go
+++ b/ingress-controller/test/mocks/dataplane.go
@@ -18,6 +18,18 @@ type Dataplane struct {
 	ObjectsStatuses map[string]map[string]k8sobj.ConfigurationStatus
 }
 
+// SetObjectStatus sets the mock dataplane report status for a single object.
+// It creates internal maps as needed.
+func (d *Dataplane) SetObjectStatus(namespace, name string, status string) {
+	if d.ObjectsStatuses == nil {
+		d.ObjectsStatuses = make(map[string]map[string]k8sobj.ConfigurationStatus)
+	}
+	if d.ObjectsStatuses[namespace] == nil {
+		d.ObjectsStatuses[namespace] = make(map[string]k8sobj.ConfigurationStatus)
+	}
+	d.ObjectsStatuses[namespace][name] = k8sobj.ConfigurationStatus(status)
+}
+
 func (d Dataplane) UpdateObject(_ client.Object) error {
 	return nil
 }

--- a/test/envtest/tlsroute_controller_envtest_test.go
+++ b/test/envtest/tlsroute_controller_envtest_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -140,7 +139,7 @@ func TestTLSRouteReconcilerTranslatesAndUpdatesProgrammedCondition(t *testing.T)
 				},
 				SupportedKinds: []gatewayapi.RouteGroupKind{
 					{
-						Group: lo.ToPtr(gatewayapi.Group(gatewayv1.GroupVersion.Group)),
+						Group: new(gatewayapi.Group(gatewayv1.GroupVersion.Group)),
 						Kind:  gatewayapi.Kind("TLSRoute"),
 					},
 				},
@@ -150,6 +149,10 @@ func TestTLSRouteReconcilerTranslatesAndUpdatesProgrammedCondition(t *testing.T)
 	require.NoError(t, client.Status().Patch(ctx, &gw, ctrlclient.MergeFrom(gwOld)))
 
 	route := gatewayapi.TLSRoute{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gatewayv1.GroupVersion.String(),
+			Kind:       "TLSRoute",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns.Name,
 			Name:      "tlsroute-1",
@@ -160,7 +163,7 @@ func TestTLSRouteReconcilerTranslatesAndUpdatesProgrammedCondition(t *testing.T)
 				ParentRefs: []gatewayapi.ParentReference{
 					{
 						Name:      gatewayapi.ObjectName(gw.Name),
-						Namespace: lo.ToPtr(gatewayapi.Namespace(ns.Name)),
+						Namespace: new(gatewayapi.Namespace(ns.Name)),
 					},
 				},
 			},
@@ -169,9 +172,9 @@ func TestTLSRouteReconcilerTranslatesAndUpdatesProgrammedCondition(t *testing.T)
 					BackendRefs: []gatewayapi.BackendRef{
 						{
 							BackendObjectReference: gatewayapi.BackendObjectReference{
-								Kind: lo.ToPtr(gatewayapi.Kind("Service")),
+								Kind: new(gatewayapi.Kind("Service")),
 								Name: gatewayapi.ObjectName(svc.Name),
-								Port: lo.ToPtr(gatewayapi.PortNumber(443)),
+								Port: new(gatewayapi.PortNumber(443)),
 							},
 						},
 					},
@@ -186,10 +189,12 @@ func TestTLSRouteReconcilerTranslatesAndUpdatesProgrammedCondition(t *testing.T)
 		metav1.Condition{
 			Type:   string(gatewayapi.RouteConditionAccepted),
 			Status: metav1.ConditionTrue,
+			Reason: "Accepted",
 		},
 		metav1.Condition{
 			Type:   "Programmed",
 			Status: metav1.ConditionTrue,
+			Reason: "ConfiguredInGateway",
 		},
 	)
 

--- a/test/envtest/tlsroute_controller_envtest_test.go
+++ b/test/envtest/tlsroute_controller_envtest_test.go
@@ -1,0 +1,221 @@
+package envtest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kong/kong-operator/v2/ingress-controller/test/controllers/gateway"
+	"github.com/kong/kong-operator/v2/ingress-controller/test/gatewayapi"
+	"github.com/kong/kong-operator/v2/ingress-controller/test/helpers"
+	"github.com/kong/kong-operator/v2/ingress-controller/test/mocks"
+)
+
+const (
+	tlsRouteWaitDuration = 5 * time.Second
+	tlsRouteTickDuration = 100 * time.Millisecond
+)
+
+func TestTLSRouteReconcilerTranslatesAndUpdatesProgrammedCondition(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	scheme := Scheme(t, WithGatewayAPI, WithKong)
+	cfg, _ := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
+	client := NewControllerClient(t, scheme, cfg)
+
+	ns := CreateNamespace(ctx, t, client)
+
+	svc := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns.Name,
+			Name:      "backend-tls",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "tls",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       443,
+					TargetPort: intstr.FromInt(8443),
+				},
+			},
+		},
+	}
+	require.NoError(t, client.Create(ctx, &svc))
+
+	dataplane := mocks.Dataplane{KubernetesObjectReportsEnabled: true}
+	dataplane.SetObjectStatus(ns.Name, "tlsroute-1", "Succeeded")
+
+	reconciler := &gateway.TLSRouteReconciler{
+		Client:          client,
+		DataplaneClient: dataplane,
+	}
+	StartReconciler(ctx, t, client.Scheme(), cfg, reconciler)
+
+	gwc := gatewayapi.GatewayClass{
+		Spec: gatewayapi.GatewayClassSpec{
+			ControllerName: gateway.GetControllerName(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: uuid.NewString(),
+			Annotations: map[string]string{
+				"konghq.com/gatewayclass-unmanaged": "placeholder",
+			},
+		},
+	}
+	require.NoError(t, client.Create(ctx, &gwc))
+	t.Cleanup(func() { _ = client.Delete(ctx, &gwc) })
+
+	mode := gatewayapi.TLSModePassthrough
+	gw := gatewayapi.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns.Name,
+			Name:      "gateway-tls",
+		},
+		Spec: gatewayapi.GatewaySpec{
+			GatewayClassName: gatewayapi.ObjectName(gwc.Name),
+			Listeners: []gatewayapi.Listener{
+				{
+					Name:     gatewayapi.SectionName("tls"),
+					Port:     gatewayapi.PortNumber(443),
+					Protocol: gatewayapi.TLSProtocolType,
+					TLS: &gatewayapi.GatewayTLSConfig{
+						Mode: &mode,
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, client.Create(ctx, &gw))
+
+	gwOld := gw.DeepCopy()
+	gw.Status = gatewayapi.GatewayStatus{
+		Conditions: []metav1.Condition{
+			{
+				Type:               string(gatewayapi.GatewayConditionProgrammed),
+				Status:             metav1.ConditionTrue,
+				Reason:             string(gatewayapi.GatewayReasonProgrammed),
+				LastTransitionTime: metav1.Now(),
+				ObservedGeneration: gw.Generation,
+			},
+			{
+				Type:               string(gatewayapi.GatewayConditionAccepted),
+				Status:             metav1.ConditionTrue,
+				Reason:             "Accepted",
+				LastTransitionTime: metav1.Now(),
+				ObservedGeneration: gw.Generation,
+			},
+		},
+		Listeners: []gatewayapi.ListenerStatus{
+			{
+				Name: gatewayapi.SectionName("tls"),
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Accepted",
+						Status:             metav1.ConditionTrue,
+						Reason:             "Accepted",
+						LastTransitionTime: metav1.Now(),
+					},
+					{
+						Type:               string(gatewayapi.ListenerConditionProgrammed),
+						Status:             metav1.ConditionTrue,
+						Reason:             string(gatewayapi.ListenerReasonProgrammed),
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+				SupportedKinds: []gatewayapi.RouteGroupKind{
+					{
+						Group: lo.ToPtr(gatewayapi.Group(gatewayv1.GroupVersion.Group)),
+						Kind:  gatewayapi.Kind("TLSRoute"),
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, client.Status().Patch(ctx, &gw, ctrlclient.MergeFrom(gwOld)))
+
+	route := gatewayapi.TLSRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns.Name,
+			Name:      "tlsroute-1",
+		},
+		Spec: gatewayapi.TLSRouteSpec{
+			Hostnames: []gatewayapi.Hostname{"app.example.com"},
+			CommonRouteSpec: gatewayapi.CommonRouteSpec{
+				ParentRefs: []gatewayapi.ParentReference{
+					{
+						Name:      gatewayapi.ObjectName(gw.Name),
+						Namespace: lo.ToPtr(gatewayapi.Namespace(ns.Name)),
+					},
+				},
+			},
+			Rules: []gatewayapi.TLSRouteRule{
+				{
+					BackendRefs: []gatewayapi.BackendRef{
+						{
+							BackendObjectReference: gatewayapi.BackendObjectReference{
+								Kind: lo.ToPtr(gatewayapi.Kind("Service")),
+								Name: gatewayapi.ObjectName(svc.Name),
+								Port: lo.ToPtr(gatewayapi.PortNumber(443)),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, client.Create(ctx, &route))
+
+	nn := k8stypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}
+	containsAcceptedAndProgrammed := helpers.TLSRouteEventuallyContainsConditions(ctx, t, client, nn,
+		metav1.Condition{
+			Type:   string(gatewayapi.RouteConditionAccepted),
+			Status: metav1.ConditionTrue,
+		},
+		metav1.Condition{
+			Type:   "Programmed",
+			Status: metav1.ConditionTrue,
+		},
+	)
+
+	if !assert.Eventually(t, containsAcceptedAndProgrammed, tlsRouteWaitDuration, tlsRouteTickDuration) {
+		t.Fatal(printTLSRouteConditions(ctx, client, nn))
+	}
+
+	assert.True(t, dataplane.KubernetesObjectIsConfigured(&route))
+}
+
+func printTLSRouteConditions(ctx context.Context, client ctrlclient.Client, nn k8stypes.NamespacedName) string {
+	route := &gatewayapi.TLSRoute{}
+	if err := client.Get(ctx, nn, route); err != nil {
+		return fmt.Sprintf("failed to get TLSRoute %s: %v", nn.String(), err)
+	}
+
+	conditions := make([]string, 0, len(route.Status.Parents)*2)
+	for _, parent := range route.Status.Parents {
+		for _, cond := range parent.Conditions {
+			conditions = append(conditions, fmt.Sprintf("parent=%s type=%s status=%s reason=%s", parent.ParentRef.Name, cond.Type, cond.Status, cond.Reason))
+		}
+	}
+
+	if len(conditions) == 0 {
+		return "TLSRoute has no parent conditions"
+	}
+
+	return fmt.Sprintf("TLSRoute conditions: %v", conditions)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Fix setting `Accepted` condition for `TLSRoute`
- Add env test case for reconciling `TLSRoute` and setting status

**Which issue this PR fixes**

Part of #3132

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
