### PR TITLE
test(conformance): enable HTTPRouteHostnameIntersection for Hybrid Gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -329,7 +329,14 @@
   [#3206](https://github.com/Kong/kong-operator/pull/3206) [#3836](https://github.com/Kong/kong-operator/pull/3836)
 - Fix incorrect Konnect API used for target lookup
   [#3910](https://github.com/Kong/kong-operator/pull/3910) [#3938](https://github.com/Kong/kong-operator/pull/3938)
-  [#3754](https://github.com/Kong/kong-operator/pull/3754)
+- HybridGateway: fix `HTTPRoute` hostname intersection with `Gateway`
+  listeners to follow Gateway API semantics. Routes that specify no
+  hostnames now inherit the matching listeners' hostnames instead of being
+  dropped, wildcard hostnames (`*` and `*.example.com`) are supported and
+  intersected with listener hostnames, and wildcards no longer match the
+  bare apex domain. This enables the `HTTPRouteHostnameIntersection`
+  Gateway API conformance test for Hybrid mode.
+  [#4077](https://github.com/Kong/kong-operator/pull/4077)
 
 ## [v2.1.3]
 

--- a/controller/hybridgateway/converter/common.go
+++ b/controller/hybridgateway/converter/common.go
@@ -82,6 +82,7 @@ func getHostnamesByParentRef[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRou
 
 	var err error
 	var hostnames []string
+	routeHostnames := routeHostNamesString(*route)
 
 	listeners, err := refs.GetListenersByParentRef(ctx, cl, route, pRef)
 	if err != nil {
@@ -109,18 +110,29 @@ func getHostnamesByParentRef[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRou
 		// No need to do further checks.
 		if listener.Hostname == nil || *listener.Hostname == "" {
 			log.Debug(logger, "Listener accepts all hostnames", "listener", listener.Name)
-			hostnames := routeHostNamesString(*route)
-			return hostnames, nil
+			return routeHostnames, nil
+		}
+
+		// If the route does not specify hostnames, it matches all listener hostnames.
+		if len(routeHostnames) == 0 {
+			hostnames = append(hostnames, string(*listener.Hostname))
+			continue
 		}
 
 		// Handle wildcard hostnames - get intersection
 		log.Debug(logger, "Processing listener with hostname", "listener", listener.Name, "listenerHostname", *listener.Hostname)
-		for _, host := range routeHostNamesString(*route) {
+		for _, host := range routeHostnames {
 			if intersection := utils.HostnameIntersection(string(*listener.Hostname), host); intersection != "" {
 				log.Trace(logger, "Found hostname intersection", "listenerHostname", *listener.Hostname, "routeHostname", host, "intersection", intersection)
 				hostnames = append(hostnames, intersection)
 			}
 		}
+	}
+
+	hostnames = lo.Uniq(hostnames)
+	if len(hostnames) == 0 {
+		log.Debug(logger, "No hostname intersection found for ParentRef")
+		return nil, nil
 	}
 
 	log.Debug(logger, "Finished processing hostnames", "finalHostnames", hostnames)

--- a/controller/hybridgateway/converter/common.go
+++ b/controller/hybridgateway/converter/common.go
@@ -122,7 +122,7 @@ func getHostnamesByParentRef[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRou
 		// Handle wildcard hostnames - get intersection
 		log.Debug(logger, "Processing listener with hostname", "listener", listener.Name, "listenerHostname", *listener.Hostname)
 		for _, host := range routeHostnames {
-			if intersection := utils.HostnameIntersection(string(*listener.Hostname), host); intersection != "" {
+			if intersection, ok := utils.HostnameIntersection(string(*listener.Hostname), host); ok {
 				log.Trace(logger, "Found hostname intersection", "listenerHostname", *listener.Hostname, "routeHostname", host, "intersection", intersection)
 				hostnames = append(hostnames, intersection)
 			}
@@ -131,6 +131,8 @@ func getHostnamesByParentRef[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRou
 
 	hostnames = lo.Uniq(hostnames)
 	if len(hostnames) == 0 {
+		// Returning nil tells the caller to skip this parent entirely. An empty slice
+		// would flow into WithHosts() and create a host-less KongRoute that matches any host.
 		log.Debug(logger, "No hostname intersection found for ParentRef")
 		return nil, nil
 	}

--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -1402,6 +1402,26 @@ func TestHTTPRouteConverter_GetHostnamesByParentRef(t *testing.T) {
 			wantHosts: []string{"api.example.com", "web.example.com"},
 		},
 		{
+			name: "returns nil when no hostname intersection",
+			setup: func() (*httpRouteConverter, gwtypes.ParentReference) {
+				route := newHTTPRouteWithHostnames("api.example.com")
+				gateway := newGatewayWithListenerHostnames("other.example.com")
+				gateway.UID = types.UID("gateway-uid")
+				objects := newKonnectGatewayStandardObjects(gateway)
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(objects...).Build()
+				converter := newHTTPRouteConverter(route, fakeClient, false, "").(*httpRouteConverter)
+				port := gwtypes.PortNumber(80)
+				pRef := gwtypes.ParentReference{
+					Name:  "test-gateway",
+					Port:  &port,
+					Group: new(gwtypes.Group(gwtypes.GroupName)),
+					Kind:  new(gwtypes.Kind("Gateway")),
+				}
+				return converter, pRef
+			},
+			wantNil: true,
+		},
+		{
 			name: "returns nil when port mismatches",
 			setup: func() (*httpRouteConverter, gwtypes.ParentReference) {
 				route := newHTTPRouteWithHostnames("api.example.com")
@@ -1428,6 +1448,26 @@ func TestHTTPRouteConverter_GetHostnamesByParentRef(t *testing.T) {
 			setup: func() (*httpRouteConverter, gwtypes.ParentReference) {
 				route := newHTTPRouteWithHostnames("api.example.com", "web.example.com")
 				gateway := newGatewayWithListenerHostnames()
+				gateway.UID = types.UID("gateway-uid")
+				objects := newKonnectGatewayStandardObjects(gateway)
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(objects...).Build()
+				converter := newHTTPRouteConverter(route, fakeClient, false, "").(*httpRouteConverter)
+				port := gwtypes.PortNumber(80)
+				pRef := gwtypes.ParentReference{
+					Name:  "test-gateway",
+					Port:  &port,
+					Group: new(gwtypes.Group(gwtypes.GroupName)),
+					Kind:  new(gwtypes.Kind("Gateway")),
+				}
+				return converter, pRef
+			},
+			wantHosts: []string{"api.example.com", "web.example.com"},
+		},
+		{
+			name: "route without hostnames uses listener hostnames",
+			setup: func() (*httpRouteConverter, gwtypes.ParentReference) {
+				route := newHTTPRouteWithHostnames()
+				gateway := newGatewayWithListenerHostnames("api.example.com", "web.example.com")
 				gateway.UID = types.UID("gateway-uid")
 				objects := newKonnectGatewayStandardObjects(gateway)
 				fakeClient := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(objects...).Build()

--- a/controller/hybridgateway/route/status.go
+++ b/controller/hybridgateway/route/status.go
@@ -994,7 +994,7 @@ func FilterListenersByHostnames(logger logr.Logger, listeners []gwtypes.Listener
 		// Check if any of the route hostnames match the listener hostname.
 		for _, hostname := range hostnames {
 			routeHostname := string(hostname)
-			if intersection := utils.HostnameIntersection(string(*listener.Hostname), routeHostname); intersection != "" {
+			if _, ok := utils.HostnameIntersection(string(*listener.Hostname), routeHostname); ok {
 				log.Debug(logger, "Listener matches route hostname", "listener", listener.Name, "listenerHostname", *listener.Hostname, "routeHostname", routeHostname)
 				matchingListeners = append(matchingListeners, listener)
 				break

--- a/controller/hybridgateway/route/status.go
+++ b/controller/hybridgateway/route/status.go
@@ -968,6 +968,20 @@ func FilterListenersByAllowedRoutes(logger logr.Logger, gw *gwtypes.Gateway, pRe
 // The returned condition will have status "False" with reason "NoMatchingListenerHostname" if no listeners
 // have hostname intersection with the route. If matching listeners are found, the condition will be nil.
 func FilterListenersByHostnames(logger logr.Logger, listeners []gwtypes.Listener, hostnames []gwtypes.Hostname) ([]gwtypes.Listener, *metav1.Condition) {
+	if len(hostnames) == 0 {
+		if len(listeners) == 0 {
+			log.Debug(logger, "No listeners available for route hostnames")
+			return nil, &metav1.Condition{
+				Type:    string(gwtypes.RouteConditionAccepted),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(gwtypes.RouteReasonNoMatchingListenerHostname),
+				Message: "No Gateway Listener hostname matches this route",
+			}
+		}
+		log.Debug(logger, "Route has no hostnames; all listeners match", "listenerCount", len(listeners))
+		return listeners, nil
+	}
+
 	var matchingListeners []gwtypes.Listener
 	for _, listener := range listeners {
 		// If the listener has no hostname, it matches all hostnames.

--- a/controller/hybridgateway/route/status_test.go
+++ b/controller/hybridgateway/route/status_test.go
@@ -1516,6 +1516,13 @@ func Test_FilterListenersByHostnames(t *testing.T) {
 			wantLen:   1,
 			wantCond:  false,
 		},
+		{
+			name:      "empty route hostnames match all listeners",
+			listeners: []gwtypes.Listener{listenerMismatch, listenerExact},
+			hostnames: []gwtypes.Hostname{},
+			wantLen:   2,
+			wantCond:  false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/controller/hybridgateway/utils/hostname.go
+++ b/controller/hybridgateway/utils/hostname.go
@@ -2,44 +2,47 @@ package utils
 
 import "strings"
 
-// HostnameIntersection returns the intersection of listener and route hostnames.
-// Returns the most specific hostname that satisfies both constraints, or an empty string if
-// there is no intersection.
-func HostnameIntersection(listenerHostname, routeHostname string) string {
+// HostnameIntersection returns the most specific hostname that satisfies both constraints
+// and whether an intersection exists.
+// Empty input hostnames are treated as the Gateway API match-any wildcard ("*").
+func HostnameIntersection(listenerHostname, routeHostname string) (string, bool) {
 	// Treat empty hostnames as the special match-any "*".
+	if listenerHostname == "" && routeHostname == "" {
+		return "*", true
+	}
 	if listenerHostname == "" {
-		return routeHostname
+		return routeHostname, true
 	}
 	if routeHostname == "" {
-		return listenerHostname
+		return listenerHostname, true
 	}
 
 	if listenerHostname == routeHostname {
-		return listenerHostname
+		return listenerHostname, true
 	}
 
 	// Listener wildcard, route precise.
 	if isWildcard(listenerHostname) && isPrecise(routeHostname) {
 		if wildcardMatches(listenerHostname, routeHostname) {
-			return routeHostname
+			return routeHostname, true
 		}
 	}
 
 	// Route wildcard, listener precise.
 	if isWildcard(routeHostname) && isPrecise(listenerHostname) {
 		if wildcardMatches(routeHostname, listenerHostname) {
-			return listenerHostname
+			return listenerHostname, true
 		}
 	}
 
 	// Wildcard vs wildcard overlap: return the more specific wildcard if they intersect.
 	if isWildcard(listenerHostname) && isWildcard(routeHostname) {
 		if wildcardOverlaps(listenerHostname, routeHostname) {
-			return moreSpecificWildcard(listenerHostname, routeHostname)
+			return moreSpecificWildcard(listenerHostname, routeHostname), true
 		}
 	}
 
-	return ""
+	return "", false
 }
 
 func isWildcard(hostname string) bool {
@@ -58,11 +61,8 @@ func wildcardMatches(wildcard, hostname string) bool {
 		return false
 	}
 	suffix := wildcard[1:] // includes leading dot
-	if !strings.HasSuffix(hostname, suffix) {
-		return false
-	}
 	// Ensure at least one label exists before the wildcard suffix.
-	return len(hostname) > len(suffix)
+	return strings.HasSuffix(hostname, suffix) && len(hostname) > len(suffix)
 }
 
 func wildcardOverlaps(a, b string) bool {

--- a/controller/hybridgateway/utils/hostname.go
+++ b/controller/hybridgateway/utils/hostname.go
@@ -6,30 +6,83 @@ import "strings"
 // Returns the most specific hostname that satisfies both constraints, or an empty string if
 // there is no intersection.
 func HostnameIntersection(listenerHostname, routeHostname string) string {
-	// Exact match - return the common hostname
-	if listenerHostname == routeHostname {
+	// Treat empty hostnames as the special match-any "*".
+	if listenerHostname == "" {
 		return routeHostname
 	}
+	if routeHostname == "" {
+		return listenerHostname
+	}
 
-	// Listener is wildcard (*.example.com), route is specific (api.example.com)
-	if strings.HasPrefix(listenerHostname, "*.") {
-		wildcardDomain := listenerHostname[1:] // Remove "*"
+	if listenerHostname == routeHostname {
+		return listenerHostname
+	}
 
-		// Route hostname must end with the wildcard domain
-		if strings.HasSuffix(routeHostname, wildcardDomain) {
-			return routeHostname // Return the more specific route hostname
+	// Listener wildcard, route precise.
+	if isWildcard(listenerHostname) && isPrecise(routeHostname) {
+		if wildcardMatches(listenerHostname, routeHostname) {
+			return routeHostname
 		}
 	}
 
-	// Route is wildcard (*.example.com), listener is specific (api.example.com)
-	if strings.HasPrefix(routeHostname, "*.") {
-		wildcardDomain := routeHostname[1:] // Remove "*"
-
-		// Listener hostname must end with the wildcard domain
-		if strings.HasSuffix(listenerHostname, wildcardDomain) {
-			return listenerHostname // Return the more specific listener hostname
+	// Route wildcard, listener precise.
+	if isWildcard(routeHostname) && isPrecise(listenerHostname) {
+		if wildcardMatches(routeHostname, listenerHostname) {
+			return listenerHostname
 		}
 	}
 
-	return "" // No intersection
+	// Wildcard vs wildcard overlap: return the more specific wildcard if they intersect.
+	if isWildcard(listenerHostname) && isWildcard(routeHostname) {
+		if wildcardOverlaps(listenerHostname, routeHostname) {
+			return moreSpecificWildcard(listenerHostname, routeHostname)
+		}
+	}
+
+	return ""
+}
+
+func isWildcard(hostname string) bool {
+	return hostname == "*" || strings.HasPrefix(hostname, "*.")
+}
+
+func isPrecise(hostname string) bool {
+	return hostname != "" && !isWildcard(hostname)
+}
+
+func wildcardMatches(wildcard, hostname string) bool {
+	if wildcard == "*" {
+		return hostname != ""
+	}
+	if !strings.HasPrefix(wildcard, "*.") {
+		return false
+	}
+	suffix := wildcard[1:] // includes leading dot
+	if !strings.HasSuffix(hostname, suffix) {
+		return false
+	}
+	// Ensure at least one label exists before the wildcard suffix.
+	return len(hostname) > len(suffix)
+}
+
+func wildcardOverlaps(a, b string) bool {
+	if a == "*" || b == "*" {
+		return true
+	}
+	suffixA := a[1:]
+	suffixB := b[1:]
+	return strings.HasSuffix(suffixA, suffixB) || strings.HasSuffix(suffixB, suffixA)
+}
+
+func moreSpecificWildcard(a, b string) string {
+	if a == "*" {
+		return b
+	}
+	if b == "*" {
+		return a
+	}
+	if len(a) >= len(b) {
+		return a
+	}
+	return b
 }

--- a/controller/hybridgateway/utils/hostname_test.go
+++ b/controller/hybridgateway/utils/hostname_test.go
@@ -12,90 +12,126 @@ func TestHostnameIntersection(t *testing.T) {
 		listenerHostname string
 		routeHostname    string
 		expected         string
+		intersects       bool
 	}{
 		{
 			name:             "exact match",
 			listenerHostname: "api.example.com",
 			routeHostname:    "api.example.com",
 			expected:         "api.example.com",
+			intersects:       true,
 		},
 		{
 			name:             "listener wildcard, route specific",
 			listenerHostname: "*.example.com",
 			routeHostname:    "api.example.com",
 			expected:         "api.example.com",
+			intersects:       true,
 		},
 		{
 			name:             "route wildcard, listener specific",
 			listenerHostname: "api.example.com",
 			routeHostname:    "*.example.com",
 			expected:         "api.example.com",
+			intersects:       true,
 		},
 		{
 			name:             "no intersection - different domains",
 			listenerHostname: "*.example.com",
 			routeHostname:    "api.other.com",
 			expected:         "",
+			intersects:       false,
 		},
 		{
 			name:             "multiple subdomains",
 			listenerHostname: "*.example.com",
 			routeHostname:    "sub.api.example.com",
 			expected:         "sub.api.example.com",
+			intersects:       true,
 		},
 		{
 			name:             "no intersection - exact mismatch",
 			listenerHostname: "api.example.com",
 			routeHostname:    "web.example.com",
 			expected:         "",
+			intersects:       false,
 		},
 		{
 			name:             "wildcard domain match",
 			listenerHostname: "*.example.com",
 			routeHostname:    "web.example.com",
 			expected:         "web.example.com",
+			intersects:       true,
 		},
 		{
 			name:             "wildcard does not match apex",
 			listenerHostname: "*.example.com",
 			routeHostname:    "example.com",
 			expected:         "",
+			intersects:       false,
 		},
 		{
 			name:             "both wildcards - no intersection",
 			listenerHostname: "*.example.com",
 			routeHostname:    "*.other.com",
 			expected:         "",
+			intersects:       false,
 		},
 		{
 			name:             "wildcard overlap returns more specific",
 			listenerHostname: "*.com",
 			routeHostname:    "*.example.com",
 			expected:         "*.example.com",
+			intersects:       true,
 		},
 		{
 			name:             "match-any listener",
 			listenerHostname: "*",
 			routeHostname:    "api.example.com",
 			expected:         "api.example.com",
+			intersects:       true,
 		},
 		{
 			name:             "match-any route",
 			listenerHostname: "api.example.com",
 			routeHostname:    "*",
 			expected:         "api.example.com",
+			intersects:       true,
 		},
 		{
 			name:             "both match-any",
 			listenerHostname: "*",
 			routeHostname:    "*",
 			expected:         "*",
+			intersects:       true,
+		},
+		{
+			name:             "empty listener matches route hostname",
+			listenerHostname: "",
+			routeHostname:    "api.example.com",
+			expected:         "api.example.com",
+			intersects:       true,
+		},
+		{
+			name:             "empty route matches listener hostname",
+			listenerHostname: "api.example.com",
+			routeHostname:    "",
+			expected:         "api.example.com",
+			intersects:       true,
+		},
+		{
+			name:             "both empty hostnames intersect as match-any",
+			listenerHostname: "",
+			routeHostname:    "",
+			expected:         "*",
+			intersects:       true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := HostnameIntersection(tt.listenerHostname, tt.routeHostname)
+			result, intersects := HostnameIntersection(tt.listenerHostname, tt.routeHostname)
+			assert.Equal(t, tt.intersects, intersects)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/controller/hybridgateway/utils/hostname_test.go
+++ b/controller/hybridgateway/utils/hostname_test.go
@@ -56,10 +56,40 @@ func TestHostnameIntersection(t *testing.T) {
 			expected:         "web.example.com",
 		},
 		{
+			name:             "wildcard does not match apex",
+			listenerHostname: "*.example.com",
+			routeHostname:    "example.com",
+			expected:         "",
+		},
+		{
 			name:             "both wildcards - no intersection",
 			listenerHostname: "*.example.com",
 			routeHostname:    "*.other.com",
 			expected:         "",
+		},
+		{
+			name:             "wildcard overlap returns more specific",
+			listenerHostname: "*.com",
+			routeHostname:    "*.example.com",
+			expected:         "*.example.com",
+		},
+		{
+			name:             "match-any listener",
+			listenerHostname: "*",
+			routeHostname:    "api.example.com",
+			expected:         "api.example.com",
+		},
+		{
+			name:             "match-any route",
+			listenerHostname: "api.example.com",
+			routeHostname:    "*",
+			expected:         "api.example.com",
+		},
+		{
+			name:             "both match-any",
+			listenerHostname: "*",
+			routeHostname:    "*",
+			expected:         "*",
 		},
 	}
 

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -48,7 +48,6 @@ var skippedTestsForHybrid = []string{
 	tests.HTTPRouteMatchingAcrossRoutes.ShortName,
 	tests.HTTPRoutePathMatchOrder.ShortName,
 	tests.HTTPRouteQueryParamMatching.ShortName,
-	tests.HTTPRouteHostnameIntersection.ShortName,
 	tests.GatewayModifyListeners.ShortName,
 	tests.GatewayObservedGenerationBump.ShortName,
 	tests.GatewaySecretReferenceGrantAllInNamespace.ShortName,


### PR DESCRIPTION


**What this PR does / why we need it**:

fix `HTTPRoute` hostname intersection with `Gateway`  listeners to follow Gateway API semantics.

**Which issue this PR fixes**

Fixes #3476 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
