### PR TITLE
tests: increase CRD validation tests timeout to 5s

### DIFF
--- a/test/crdsvalidation/common/testcase.go
+++ b/test/crdsvalidation/common/testcase.go
@@ -37,7 +37,7 @@ func (g TestCasesGroup[T]) Run(t *testing.T) {
 
 const (
 	// DefaultEventuallyTimeout is the default timeout for EventuallyConfig.
-	DefaultEventuallyTimeout = 3 * time.Second
+	DefaultEventuallyTimeout = 5 * time.Second
 	// DefaultEventuallyPeriod is the default period for EventuallyConfig.
 	DefaultEventuallyPeriod = 10 * time.Millisecond
 )
@@ -117,6 +117,7 @@ func (tc *TestCase[T]) RunWithConfig(t *testing.T, cfg *rest.Config, scheme *run
 
 		t.Parallel()
 		ctx := context.Background()
+		var lastCreateErr error
 
 		// Create a new controller-runtime client.Client.
 		cl, err := client.New(cfg, client.Options{
@@ -144,6 +145,7 @@ func (tc *TestCase[T]) RunWithConfig(t *testing.T, cfg *rest.Config, scheme *run
 
 				// Create the object and set a cleanup function to delete it after the test if created successfully.
 				err = cl.Create(ctx, toCreate)
+				lastCreateErr = err
 				if err == nil {
 					tCleanupObject(ctx, t, toCreate)
 				}
@@ -182,6 +184,7 @@ func (tc *TestCase[T]) RunWithConfig(t *testing.T, cfg *rest.Config, scheme *run
 			},
 			timeout, period,
 		) {
+			t.Logf("Last create error before timeout: %v", lastCreateErr)
 			return
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix failures like: https://github.com/Kong/kong-operator/actions/runs/25164079554/job/73765694580?pr=4075

```
2026-04-30T12:04:27Z	INFO	controller-runtime.certwatcher	Starting certificate poll+watcher	{"cert": "/tmp/envtest-serving-certs-10808352/tls.crt", "key": "/tmp/envtest-serving-certs-10808352/tls.key", "interval": "10s"}
    testcase.go:140: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/crdsvalidation/common/testcase.go:140
        	Error:      	Condition never satisfied
        	Test:       	TestIdentityProviderRequest/OIDC_config_validation_and_defaults/invalid_identity_provider_type_fails_validation
2026-04-30T12:04:29Z	DEBUG	controller-runtime.test-env	installing webhooks
2026-04-30T12:04:29Z	INFO	controller-runtime.webhook	Registering webhook	{"path": "/convert"}
2026-04-30T12:04:29Z	INFO	controller-runtime.webhook	Starting webhook server

=== FAIL: test/crdsvalidation/konnect.konghq.com TestKonnectAPIAuthConfiguration/spec/valid_token_type_-_kpat_prefix (3.00s)
    testcase.go:140: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/crdsvalidation/common/testcase.go:140
        	Error:      	Condition never satisfied
        	Test:       	TestKonnectAPIAuthConfiguration/spec/valid_token_type_-_kpat_prefix

=== FAIL: test/crdsvalidation/konnect.konghq.com TestKonnectAPIAuthConfiguration/spec/server_URL_must_use_HTTPs_if_specifying_scheme (3.00s)
    testcase.go:140: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/crdsvalidation/common/testcase.go:140
        	Error:      	Condition never satisfied
        	Test:       	TestKonnectAPIAuthConfiguration/spec/server_URL_must_use_HTTPs_if_specifying_scheme

=== FAIL: test/crdsvalidation/konnect.konghq.com TestKonnectAPIAuthConfiguration/spec/server_URL_must_satisfy_hostname_(RFC_1123)_regex_if_not_a_valid_absolute_URL (3.00s)
2026-04-30T12:04:30Z	DEBUG	controller-runtime.test-env	installing webhooks
2026-04-30T12:04:30Z	INFO	controller-runtime.webhook	Registering webhook	{"path": "/convert"}
2026-04-30T12:04:30Z	INFO	controller-runtime.webhook	Starting webhook server
    testcase.go:140: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/crdsvalidation/common/testcase.go:140
        	Error:      	Condition never satisfied
        	Test:       	TestKonnectAPIAuthConfiguration/spec/server_URL_must_satisfy_hostname_(RFC_1123)_regex_if_not_a_valid_absolute_URL
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
