### PR TITLE
tests: fix KongConsumer envtest

### DIFF
--- a/test/envtest/konnect_entities_kongconsumer_test.go
+++ b/test/envtest/konnect_entities_kongconsumer_test.go
@@ -466,6 +466,8 @@ func TestKongConsumer(t *testing.T) {
 		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
 			fmt.Sprintf("Consumer didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
+		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
+
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
@@ -489,6 +491,13 @@ func TestKongConsumer(t *testing.T) {
 					ID: new(id2),
 				},
 			}, nil)
+
+		t.Log("Setting up SDK expectation on KongConsumerGroups listing after KonnectGatewayControlPlane reattachment")
+		sdk.ConsumersSDK.EXPECT().
+			ListConsumerGroupsForConsumer(mock.Anything, mock.MatchedBy(func(req sdkkonnectops.ListConsumerGroupsForConsumerRequest) bool {
+				return req.ConsumerID == id
+			})).
+			Return(&sdkkonnectops.ListConsumerGroupsForConsumerResponse{}, nil)
 
 		cp = deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth,
 			func(obj client.Object) {


### PR DESCRIPTION
**What this PR does / why we need it**:

The test failed in CI with the following log:

```
mock.go:361: 
    
    mock: Unexpected Method Call
    -----------------------------
    
    ListConsumerGroupsForConsumer(*context.valueCtx,operations.ListConsumerGroupsForConsumerRequest)
            0: &context.valueCtx{Context:(*context.valueCtx)(0xc00c68cab0), key:logr.contextKey{}, val:logr.Logger{sink:(*zapr.zapLogger)(0xc00c68cba0), level:0}}
            1: operations.ListConsumerGroupsForConsumerRequest{ControlPlaneID:"234eca07-9ac3-416a-90df-d7ef0ea5fc50", ConsumerID:"abc-1234567", Size:(*int64)(nil), Offset:(*string)(nil), Tags:(*string)(nil)}
    
    The closest call I have is: 
    
    ListConsumerGroupsForConsumer(string,operations.ListConsumerGroupsForConsumerRequest)
            0: "mock.Anything"
            1: operations.ListConsumerGroupsForConsumerRequest{ControlPlaneID:"d8fb3ef6-a527-4ba6-b0f8-283a2f2e8149", ConsumerID:"consumer-id", Size:(*int64)(nil), Offset:(*string)(nil), Tags:(*string)(nil)}
    
    Difference found in argument 1:
    
    --- Expected
    +++ Actual
    @@ -1,4 +1,4 @@
     (operations.ListConsumerGroupsForConsumerRequest) {
    - ControlPlaneID: (string) (len=36) "d8fb3ef6-a527-4ba6-b0f8-283a2f2e8149",
    - ConsumerID: (string) (len=11) "consumer-id",
    + ControlPlaneID: (string) (len=36) "234eca07-9ac3-416a-90df-d7ef0ea5fc50",
    + ConsumerID: (string) (len=11) "abc-1234567",
      Size: (*int64)(<nil>),
```


In the reattach subtest at konnect_entities_kongconsumer_test.go:419, recreating the ControlPlane causes the KongConsumer reconcile path to run again, and that path always re-lists consumer groups in ops_kongconsumer.go:166. The test only mocked `ListConsumerGroupsForConsumer` for the initial create, so the second call during reattachment had no matching expectation. Because the whole TestKongConsumer suite shares one ConsumersSDK mock across subtests, testify showed the “closest” leftover expectation from another subtest, which is why the error mentioned consumer-id instead of abc-1234567.

Fixed it in konnect_entities_kongconsumer_test.go:469 by asserting the initial create-side expectations before moving on, and in konnect_entities_kongconsumer_test.go:495 by adding the missing `ListConsumerGroupsForConsumer` expectation for the reattach reconcile

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
