### PR TITLE
tests: fix race in CRD validation test harness

### DIFF
--- a/test/crdsvalidation/common/testcase.go
+++ b/test/crdsvalidation/common/testcase.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -117,7 +118,6 @@ func (tc *TestCase[T]) RunWithConfig(t *testing.T, cfg *rest.Config, scheme *run
 
 		t.Parallel()
 		ctx := context.Background()
-		var lastCreateErr error
 
 		// Create a new controller-runtime client.Client.
 		cl, err := client.New(cfg, client.Options{
@@ -125,10 +125,12 @@ func (tc *TestCase[T]) RunWithConfig(t *testing.T, cfg *rest.Config, scheme *run
 		})
 		require.NoError(t, err)
 
+		templateObj := tc.TestObject.DeepCopyObject().(T)
+
 		// Take a copy so that we can update the status field if needed. Without copying, the Create call
 		// overwrites the status field in tc.TestObject with the default server returns, and we lose the status
 		// set in the test case.
-		desiredObj := tc.TestObject.DeepCopyObject().(T)
+		desiredObj := templateObj.DeepCopyObject().(T)
 
 		tCleanupObject := func(ctx context.Context, t *testing.T, obj client.Object) {
 			// NOTE: Deep copy the object as without this we end up causing a data race:
@@ -138,55 +140,64 @@ func (tc *TestCase[T]) RunWithConfig(t *testing.T, cfg *rest.Config, scheme *run
 			})
 		}
 
-		if !assert.EventuallyWithT(
-			t,
-			func(c *assert.CollectT) {
-				toCreate := tc.TestObject.DeepCopyObject().(T)
-
-				// Create the object and set a cleanup function to delete it after the test if created successfully.
-				err = cl.Create(ctx, toCreate)
-				lastCreateErr = err
-				if err == nil {
-					tCleanupObject(ctx, t, toCreate)
+		waitForCondition := func(condition func() (bool, string), failureTitle string) {
+			deadline := time.Now().Add(timeout)
+			for {
+				matched, details := condition()
+				if matched {
+					return
 				}
 
-				// If the error message is expected, check if the error message contains the expected message and return.
-				if tc.ExpectedErrorMessage != nil {
-					if !assert.ErrorContains(c, err, *tc.ExpectedErrorMessage) {
-						t.Logf("Create error: %v; expected: %q\n", err, *tc.ExpectedErrorMessage)
-						return
-					}
-				} else {
-					if !assert.NoError(c, err) {
-						t.Logf("Create error: %v\n", err)
-						return
+				if !time.Now().Before(deadline) {
+					require.FailNowf(t, failureTitle, "%s", details)
+				}
+
+				time.Sleep(period)
+			}
+		}
+
+		var createdObj T
+		waitForCondition(func() (bool, string) {
+			toCreate := templateObj.DeepCopyObject().(T)
+
+			createErr := cl.Create(ctx, toCreate)
+			if createErr == nil {
+				createdObj = toCreate
+				tCleanupObject(ctx, t, toCreate)
+			}
+
+			if tc.ExpectedErrorMessage != nil {
+				if createErr != nil && strings.Contains(createErr.Error(), *tc.ExpectedErrorMessage) {
+					return true, ""
+				}
+				return false, fmt.Sprintf("Create error: %v; expected: %q", createErr, *tc.ExpectedErrorMessage)
+			}
+
+			if createErr != nil {
+				return false, fmt.Sprintf("Create error: %v", createErr)
+			}
+
+			return true, ""
+		}, "create condition not satisfied before timeout")
+
+		if tc.WarningCollector != nil && tc.ExpectedWarningMessage != nil {
+			waitForCondition(func() (bool, string) {
+				msgs := tc.WarningCollector.GetWarnings()
+				for _, msg := range msgs {
+					if strings.Contains(msg, *tc.ExpectedWarningMessage) {
+						return true, ""
 					}
 				}
 
-				// If warnings are expected, verify at least one collected warning matches.
-				if tc.WarningCollector != nil && tc.ExpectedWarningMessage != nil {
-					msgs := tc.WarningCollector.GetWarnings()
-					matched := false
-					for _, m := range msgs {
-						if assert.Contains(c, m, *tc.ExpectedWarningMessage) {
-							matched = true
-							break
-						}
-					}
-					if !matched {
-						// Fail the attempt, Eventually will allow a bit of time in case messages are delayed.
-						assert.Failf(c, "expected warning not found", "expected warning containing: %q, got: %#v", *tc.ExpectedWarningMessage, msgs)
-						return
-					}
-				}
+				return false, fmt.Sprintf("expected warning containing: %q, got: %#v", *tc.ExpectedWarningMessage, msgs)
+			}, "expected warning not found before timeout")
+		}
 
-				tc.TestObject = toCreate
-			},
-			timeout, period,
-		) {
-			t.Logf("Last create error before timeout: %v", lastCreateErr)
+		if tc.ExpectedErrorMessage != nil {
 			return
 		}
+
+		tc.TestObject = createdObj
 
 		// Check with reflect if the status field is set and Update the status if so before updating the object.
 		// That's required to populate Status that is not set on Create.

--- a/test/crdsvalidation/common/testcase.go
+++ b/test/crdsvalidation/common/testcase.go
@@ -156,13 +156,35 @@ func (tc *TestCase[T]) RunWithConfig(t *testing.T, cfg *rest.Config, scheme *run
 			}
 		}
 
-		var createdObj T
+		warningFound := func() bool {
+			if tc.WarningCollector == nil || tc.ExpectedWarningMessage == nil {
+				return false
+			}
+
+			for _, msg := range tc.WarningCollector.GetWarnings() {
+				if strings.Contains(msg, *tc.ExpectedWarningMessage) {
+					return true
+				}
+			}
+
+			return false
+		}
+
+		var (
+			createdObj    T
+			hasCreatedObj bool
+		)
 		waitForCondition(func() (bool, string) {
+			if hasCreatedObj && warningFound() {
+				return true, ""
+			}
+
 			toCreate := templateObj.DeepCopyObject().(T)
 
 			createErr := cl.Create(ctx, toCreate)
 			if createErr == nil {
 				createdObj = toCreate
+				hasCreatedObj = true
 				tCleanupObject(ctx, t, toCreate)
 			}
 
@@ -177,21 +199,16 @@ func (tc *TestCase[T]) RunWithConfig(t *testing.T, cfg *rest.Config, scheme *run
 				return false, fmt.Sprintf("Create error: %v", createErr)
 			}
 
-			return true, ""
-		}, "create condition not satisfied before timeout")
-
-		if tc.WarningCollector != nil && tc.ExpectedWarningMessage != nil {
-			waitForCondition(func() (bool, string) {
-				msgs := tc.WarningCollector.GetWarnings()
-				for _, msg := range msgs {
-					if strings.Contains(msg, *tc.ExpectedWarningMessage) {
-						return true, ""
-					}
+			if tc.WarningCollector != nil && tc.ExpectedWarningMessage != nil {
+				if warningFound() {
+					return true, ""
 				}
 
-				return false, fmt.Sprintf("expected warning containing: %q, got: %#v", *tc.ExpectedWarningMessage, msgs)
-			}, "expected warning not found before timeout")
-		}
+				return false, fmt.Sprintf("expected warning containing: %q, got: %#v", *tc.ExpectedWarningMessage, tc.WarningCollector.GetWarnings())
+			}
+
+			return true, ""
+		}, "create condition not satisfied before timeout")
 
 		if tc.ExpectedErrorMessage != nil {
 			return


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix data race like: https://github.com/Kong/kong-operator/actions/runs/25324883199/job/74243106931?pr=4107

```
==================
WARNING: DATA RACE
Read at 0x00c005e829c0 by goroutine 3246:
  github.com/kong/kong-operator/v2/test/crdsvalidation/common.(*TestCase[go.shape.*uint8]).RunWithConfig.func1()
      /home/runner/work/kong-operator/kong-operator/test/crdsvalidation/common/testcase.go:187 +0xff0
  testing.tRunner()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2036 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2101 +0x38

Previous write at 0x00c005e829c0 by goroutine 5253:
  github.com/kong/kong-operator/v2/test/crdsvalidation/common.(*TestCase[go.shape.*uint8]).RunWithConfig.func1.2()
      /home/runner/work/kong-operator/kong-operator/test/crdsvalidation/common/testcase.go:148 +0x211
  github.com/stretchr/testify/assert.EventuallyWithT.func1()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.11.1/assert/assertions.go:2096 +0xb3

2026-05-04T14:36:30Z	DEBUG	controller-runtime.test-env	installing CRD	{"crd": "kongcredentialbasicauths.configuration.konghq.com"}
Goroutine 3246 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2101 +0xb12
  github.com/kong/kong-operator/v2/test/crdsvalidation/common.(*TestCase[go.shape.*uint8]).RunWithConfig()
      /home/runner/work/kong-operator/kong-operator/test/crdsvalidation/common/testcase.go:115 +0x419
  github.com/kong/kong-operator/v2/test/crdsvalidation/common.TestCasesGroup[go.shape.*uint8].RunWithConfig()
      /home/runner/work/kong-operator/kong-operator/test/crdsvalidation/common/testcase.go:27 +0x364
  github.com/kong/kong-operator/v2/test/crdsvalidation/konnect%2ekonghq%2ecom_test.TestIdentityProviderRequest.func2()
      /home/runner/work/kong-operator/kong-operator/test/crdsvalidation/konnect.konghq.com/identityproviderrequest_test.go:83 +0x2c6
  testing.tRunner()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2036 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2101 +0x38

Goroutine 5253 (running) created at:
  github.com/stretchr/testify/assert.EventuallyWithT()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.11.1/assert/assertions.go:2119 +0x3a4
  github.com/kong/kong-operator/v2/test/crdsvalidation/common.(*TestCase[go.shape.*uint8]).RunWithConfig.func1()
      /home/runner/work/kong-operator/kong-operator/test/crdsvalidation/common/testcase.go:141 +0x6be
  testing.tRunner()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2036 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2101 +0x38
==================
==================
WARNING: DATA RACE
Read at 0x00c00a6166a8 by goroutine 3246:
  k8s.io/apimachinery/pkg/api/errors.(*StatusError).Error()
      /home/runner/go/pkg/mod/k8s.io/apimachinery@v0.35.4/pkg/api/errors/errors.go:72 +0x2c
  fmt.(*pp).handleMethods()
      /opt/hostedtoolcache/go/1.26.2/x64/src/fmt/print.go:668 +0x7cd
  fmt.(*pp).printArg()
      /opt/hostedtoolcache/go/1.26.2/x64/src/fmt/print.go:757 +0xb3d
  fmt.(*pp).doPrintf()
      /opt/hostedtoolcache/go/1.26.2/x64/src/fmt/print.go:1075 +0x697
  fmt.Sprintf()
      /opt/hostedtoolcache/go/1.26.2/x64/src/fmt/print.go:239 +0x5c
  testing.(*common).Logf()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:1200 +0x7e
  github.com/kong/kong-operator/v2/test/crdsvalidation/common.(*TestCase[go.shape.*uint8]).RunWithConfig.func1()
      /home/runner/work/kong-operator/kong-operator/test/crdsvalidation/common/testcase.go:187 +0x1089
  testing.tRunner()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2036 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2101 +0x38

Previous write at 0x00c00a6166a8 by goroutine 5253:
  k8s.io/apimachinery/pkg/api/errors.FromObject()
      /home/runner/go/pkg/mod/k8s.io/apimachinery@v0.35.4/pkg/api/errors/errors.go:126 +0xa4
  k8s.io/client-go/rest.Result.Error()
      /home/runner/go/pkg/mod/k8s.io/client-go@v0.35.4/rest/request.go:1507 +0x347
  k8s.io/client-go/rest.Result.Into()
      /home/runner/go/pkg/mod/k8s.io/client-go@v0.35.4/rest/request.go:1452 +0x5fc
  sigs.k8s.io/controller-runtime/pkg/client.(*typedClient).Create()
      /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/client/typed_client.go:51 +0x879
  sigs.k8s.io/controller-runtime/pkg/client.(*client).Create()
      /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/client/client.go:303 +0x166
  github.com/kong/kong-operator/v2/test/crdsvalidation/common.(*TestCase[go.shape.*uint8]).RunWithConfig.func1.2()
      /home/runner/work/kong-operator/kong-operator/test/crdsvalidation/common/testcase.go:147 +0x187
  github.com/stretchr/testify/assert.EventuallyWithT.func1()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.11.1/assert/assertions.go:2096 +0xb3

Goroutine 3246 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2101 +0xb12
  github.com/kong/kong-operator/v2/test/crdsvalidation/common.(*TestCase[go.shape.*uint8]).RunWithConfig()
      /home/runner/work/kong-operator/kong-operator/test/crdsvalidation/common/testcase.go:115 +0x419
  github.com/kong/kong-operator/v2/test/crdsvalidation/common.TestCasesGroup[go.shape.*uint8].RunWithConfig()
      /home/runner/work/kong-operator/kong-operator/test/crdsvalidation/common/testcase.go:27 +0x364
  github.com/kong/kong-operator/v2/test/crdsvalidation/konnect%2ekonghq%2ecom_test.TestIdentityProviderRequest.func2()
      /home/runner/work/kong-operator/kong-operator/test/crdsvalidation/konnect.konghq.com/identityproviderrequest_test.go:83 +0x2c6
  testing.tRunner()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2036 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2101 +0x38

Goroutine 5253 (running) created at:
  github.com/stretchr/testify/assert.EventuallyWithT()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.11.1/assert/assertions.go:2119 +0x3a4
  github.com/kong/kong-operator/v2/test/crdsvalidation/common.(*TestCase[go.shape.*uint8]).RunWithConfig.func1()
      /home/runner/work/kong-operator/kong-operator/test/crdsvalidation/common/testcase.go:141 +0x6be
  testing.tRunner()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2036 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2101 +0x38
==================
```

Changed testcase.go:128 to remove the racy create-phase callback pattern. The helper now deep-copies a stable template object once, retries create checks in the test goroutine via a local wait loop, and only assigns the created object back to the test case after a successful create. That removes the shared mutable state that was being touched concurrently through EventuallyWithT. I also split warning verification into a separate wait phase at testcase.go:183), so successful creates are not retried just to wait for delayed warning deliver

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
