### PR TITLE
fix: redact plugin config when controlplane dump sensitive isn't set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,8 @@
 - More robust validation for `HTTPRoute`, when an unsupported feature is used, and the route refers
   to existing and non-existing `Gateway`, it will be rejected.
   [#4131](https://github.com/Kong/kong-operator/pull/4131)
+- Sanitize the plugin configuration when `ControlPlane`'s `configDump.dumpSensitive` isn't enabled.
+  [#4045](https://github.com/Kong/kong-operator/pull/4045)
 
 ## [v2.1.5]
 

--- a/ingress-controller/internal/dataplane/kongstate/kongstate.go
+++ b/ingress-controller/internal/dataplane/kongstate/kongstate.go
@@ -79,7 +79,14 @@ func (ks *KongState) SanitizedCopy(uuidGenerator util.UUIDGenerator) *KongState 
 			})
 		}(),
 		CACertificates: ks.CACertificates,
-		Plugins:        ks.Plugins,
+		Plugins: func() []Plugin {
+			if ks.Plugins == nil {
+				return nil
+			}
+			return lo.Map(ks.Plugins, func(p Plugin, _ int) Plugin {
+				return p.SanitizedCopy()
+			})
+		}(),
 		Consumers: func() []Consumer {
 			if ks.Consumers == nil {
 				return nil

--- a/ingress-controller/internal/dataplane/kongstate/kongstate_test.go
+++ b/ingress-controller/internal/dataplane/kongstate/kongstate_test.go
@@ -110,7 +110,7 @@ func TestKongState_SanitizedCopy(t *testing.T) {
 				Upstreams:      []Upstream{{Upstream: kong.Upstream{ID: new("1")}}},
 				Certificates:   []Certificate{{Certificate: kong.Certificate{ID: new("1"), Key: redactedString}}},
 				CACertificates: []kong.CACertificate{{ID: new("1")}},
-				Plugins:        []Plugin{{Plugin: kong.Plugin{ID: new("1"), Config: map[string]any{"key": "secret"}}}}, // We don't redact plugins' config.
+				Plugins:        []Plugin{{Plugin: kong.Plugin{ID: new("1"), Config: map[string]any{"key": "{REDACTED}"}}}},
 				Consumers: []Consumer{
 					{
 						KeyAuths: []*KeyAuth{

--- a/ingress-controller/internal/dataplane/kongstate/plugin.go
+++ b/ingress-controller/internal/dataplane/kongstate/plugin.go
@@ -353,3 +353,12 @@ type PluginRelatedEntitiesRefs struct {
 	RelatedEntities      map[string]RelatedEntitiesRef
 	RouteAttachedService map[string]*Service
 }
+
+func (p *Plugin) SanitizedCopy() Plugin {
+	sanitized := p.DeepCopy()
+	// Replace all config values with a redaction marker.
+	for k := range sanitized.Config {
+		sanitized.Config[k] = "{REDACTED}"
+	}
+	return sanitized
+}

--- a/ingress-controller/internal/dataplane/kongstate/plugin_test.go
+++ b/ingress-controller/internal/dataplane/kongstate/plugin_test.go
@@ -764,3 +764,158 @@ func TestKongPluginFromK8SPlugin(t *testing.T) {
 		})
 	}
 }
+
+func TestPluginSanitizedCopy(t *testing.T) {
+	parent := &configurationv1.KongPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "plugin-parent",
+			Namespace: "default",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		in        Plugin
+		want      Plugin
+		postCheck func(t *testing.T, in Plugin, got Plugin)
+	}{
+		{
+			name: "redacts all top level config values and preserves other fields",
+			in: Plugin{
+				Plugin: kong.Plugin{
+					ID:           new("plugin-id"),
+					Name:         new("rate-limiting"),
+					InstanceName: new("instance-name"),
+					RunOn:        new("first"),
+					Enabled:      new(false),
+					Protocols:    kong.StringSlice("http", "https"),
+					Tags:         []*string{new("tag-1"), new("tag-2")},
+					Ordering: &kong.PluginOrdering{
+						Before: map[string][]string{
+							"access": {"key-auth"},
+						},
+					},
+					Config: kong.Configuration{
+						"string":  "secret",
+						"number":  123,
+						"boolean": true,
+						"object": map[string]any{
+							"nested": "secret",
+						},
+						"array": []any{"first", "second"},
+						"null":  nil,
+					},
+				},
+				K8sParent: parent,
+			},
+			want: Plugin{
+				Plugin: kong.Plugin{
+					ID:           new("plugin-id"),
+					Name:         new("rate-limiting"),
+					InstanceName: new("instance-name"),
+					RunOn:        new("first"),
+					Enabled:      new(false),
+					Protocols:    kong.StringSlice("http", "https"),
+					Tags:         []*string{new("tag-1"), new("tag-2")},
+					Ordering: &kong.PluginOrdering{
+						Before: map[string][]string{
+							"access": {"key-auth"},
+						},
+					},
+					Config: kong.Configuration{
+						"string":  "{REDACTED}",
+						"number":  "{REDACTED}",
+						"boolean": "{REDACTED}",
+						"object":  "{REDACTED}",
+						"array":   "{REDACTED}",
+						"null":    "{REDACTED}",
+					},
+				},
+				K8sParent: parent,
+			},
+			postCheck: func(t *testing.T, in Plugin, got Plugin) {
+				assert.Equal(t, "secret", in.Config["string"])
+				assert.Equal(t, 123, in.Config["number"])
+				assert.Equal(t, true, in.Config["boolean"])
+				assert.Equal(t, map[string]any{"nested": "secret"}, in.Config["object"])
+				assert.Equal(t, []any{"first", "second"}, in.Config["array"])
+				assert.Nil(t, in.Config["null"])
+				assert.Same(t, in.K8sParent, got.K8sParent)
+			},
+		},
+		{
+			name: "keeps nil config nil",
+			in: Plugin{
+				Plugin: kong.Plugin{
+					Name: new("key-auth"),
+				},
+			},
+			want: Plugin{
+				Plugin: kong.Plugin{
+					Name: new("key-auth"),
+				},
+			},
+			postCheck: func(t *testing.T, in Plugin, got Plugin) {
+				assert.Nil(t, in.Config)
+				assert.Nil(t, got.Config)
+			},
+		},
+		{
+			name: "returns an isolated config map copy",
+			in: Plugin{
+				Plugin: kong.Plugin{
+					Name: new("request-transformer"),
+					Config: kong.Configuration{
+						"add": "sensitive",
+					},
+				},
+			},
+			want: Plugin{
+				Plugin: kong.Plugin{
+					Name: new("request-transformer"),
+					Config: kong.Configuration{
+						"add": "{REDACTED}",
+					},
+				},
+			},
+			postCheck: func(t *testing.T, in Plugin, got Plugin) {
+				got.Config["add"] = "changed"
+				got.Config["new"] = "new-value"
+				assert.Equal(t, "sensitive", in.Config["add"])
+				_, exists := in.Config["new"]
+				assert.False(t, exists)
+			},
+		},
+		{
+			name: "keeps empty config empty",
+			in: Plugin{
+				Plugin: kong.Plugin{
+					Name:   new("cors"),
+					Config: kong.Configuration{},
+				},
+			},
+			want: Plugin{
+				Plugin: kong.Plugin{
+					Name:   new("cors"),
+					Config: kong.Configuration{},
+				},
+			},
+			postCheck: func(t *testing.T, in Plugin, got Plugin) {
+				assert.Empty(t, in.Config)
+				assert.Empty(t, got.Config)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.in.SanitizedCopy()
+
+			assert.Equal(t, tt.want, got)
+
+			if tt.postCheck != nil {
+				tt.postCheck(t, tt.in, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport of https://github.com/Kong/kubernetes-ingress-controller/pull/7915

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
