### PR TITLE
chore(ci): workflow for Kong image validation

### DIFF
--- a/.github/workflows/__integration_tests.yaml
+++ b/.github/workflows/__integration_tests.yaml
@@ -7,6 +7,20 @@ on:
         description: "The Kubernetes cluster version to use for envtest"
         type: string
         required: true
+      kong-image-repo:
+        description: "Kong Gateway Docker image repository override. If not set,
+          defaults are used."
+        type: string
+        required: false
+      kong-image-tag:
+        description: "Kong Gateway Docker image tag override."
+        type: string
+        required: false
+      kong-effective-version:
+        description: "Effective semantic version of Kong Gateway. If not given, parsed
+          from the image tag."
+        type: string
+        required: false
 
 permissions:
   contents: read
@@ -99,6 +113,9 @@ jobs:
         KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
         KONG_TEST_KONNECT_SERVER_URL: us.api.konghq.tech
         KONG_CLUSTER_VERSION: ${{ inputs.cluster_version }}
+        TEST_KONG_IMAGE: ${{ inputs.kong-image-repo }}
+        TEST_KONG_TAG: ${{ inputs.kong-image-tag }}
+        TEST_KONG_EFFECTIVE_VERSION: ${{ inputs.kong-effective-version }}
         # This is needed for ktf to find latest releases of addons.
         # This could be changed so that ktf addons have their versions pinned
         # in the test Makefile instead.

--- a/.github/workflows/__kongintegration_tests.yaml
+++ b/.github/workflows/__kongintegration_tests.yaml
@@ -1,7 +1,22 @@
 name: kong integration tests
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      kong-image-repo:
+        description: "Kong Gateway Docker image repository override. If not set,
+          defaults are used from test_dependencies.yaml."
+        type: string
+        required: false
+      kong-image-tag:
+        description: "Kong Gateway Docker image tag override."
+        type: string
+        required: false
+      kong-effective-version:
+        description: "Effective semantic version of Kong Gateway. If not given, parsed
+          from the image tag."
+        type: string
+        required: false
 
 permissions:
   contents: read
@@ -40,25 +55,39 @@ jobs:
           op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: set kong oss version
-        if: ${{ !matrix.enterprise }}
+        if: ${{ !matrix.enterprise && inputs.kong-image-repo == '' }}
         run: |
           echo "TEST_KONG_IMAGE=kong" >> $GITHUB_ENV
           echo "TEST_KONG_TAG=$(yq -ojson -r '.kongintegration.kong-oss' < test/test_dependencies.yaml )" >> $GITHUB_ENV
 
       - name: set kong ee version
-        if: ${{ matrix.enterprise }}
+        if: ${{ matrix.enterprise && inputs.kong-image-repo == '' }}
         run: |
           echo "TEST_KONG_IMAGE=kong/kong-gateway" >> $GITHUB_ENV
           echo "TEST_KONG_TAG=$(yq -ojson -r '.kongintegration.kong-ee' < test/test_dependencies.yaml )" >> $GITHUB_ENV
+
+      - name: set kong image override
+        if: ${{ inputs.kong-image-repo != '' }}
+        run: |
+          echo "TEST_KONG_IMAGE=${{ inputs.kong-image-repo }}" >> $GITHUB_ENV
+          echo "TEST_KONG_TAG=${{ inputs.kong-image-tag }}" >> $GITHUB_ENV
+
+      - name: set kong effective version
+        if: ${{ inputs.kong-effective-version != '' }}
+        run: |
+          echo "TEST_KONG_EFFECTIVE_VERSION=${{ inputs.kong-effective-version }}" >> $GITHUB_ENV
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: false
 
-      - run: echo "GOTESTSUM_JUNITFILE=kongintegration-${{ matrix.name }}-tests.xml" >> $GITHUB_ENV
+      - run: echo "GOTESTSUM_JUNITFILE=kongintegration-${{ matrix.name }}-tests.xml" >>
+          $GITHUB_ENV
       # Share the cache key across all kongintegration tests since they all use the same dependencies.
-      - run: echo "GO_CACHE_KEY=go-kongintegration-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
-      - run: echo "GO_CACHE_KEY_2=go-kongintegration-${{ runner.os }}-${{ runner.arch }}-go-" >> $GITHUB_ENV
+      - run: echo "GO_CACHE_KEY=go-kongintegration-${{ runner.os }}-${{ runner.arch
+          }}-go-${{ hashFiles('**/go.mod') }}" >> $GITHUB_ENV
+      - run: echo "GO_CACHE_KEY_2=go-kongintegration-${{ runner.os }}-${{ runner.arch
+          }}-go-" >> $GITHUB_ENV
 
       - name: Go cache main branch
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/validate_kong_image.yaml
+++ b/.github/workflows/validate_kong_image.yaml
@@ -1,0 +1,131 @@
+name: "validate Kong image (targeted)"
+run-name: "validate Kong ${{ format('{0}:{1}',
+  github.event.inputs.kong-image-repo, github.event.inputs.kong-image-tag) }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      kong-image-repo:
+        description: Kong Gateway Docker image to test with (repository). Must be an EE
+          variant.
+        type: string
+        required: true
+        default: "kong/kong-gateway"
+      kong-image-tag:
+        description: Kong Gateway Docker image to test with (tag).
+        type: string
+        required: true
+        default: "latest"
+      kong-effective-version:
+        description: Effective semantic version of Kong Gateway Docker image. If not
+          given, the semantic version will be parsed from the image tag.
+        type: string
+        required: false
+      issue-number:
+        description: Issue number to comment in, and close in case of success. Can be none.
+        type: string
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  startup-issue-comment:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    if: ${{ github.event.inputs.issue-number != '' }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
+      # URL is the current workflow's run URL.
+      # Sadly this is not readily available in github's context.
+      URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
+        github.run_id }}
+      ISSUE_NUMBER: ${{ github.event.inputs.issue-number }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - run: |
+          gh issue comment ${ISSUE_NUMBER} --body \
+            'Kong Gateway validation tests were started at ${{ env.URL }} with the following parameters:
+            ```json
+            ${{ toJSON(github.event.inputs) }}
+            ```
+            '
+
+  resolve-k8s-version:
+    runs-on: ubuntu-latest
+    outputs:
+      latest: ${{ steps.set-latest.outputs.latest }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - id: set-latest
+        run: |
+          (
+            echo 'latest<<EOF'
+            yq eval -r -o=json '. | sort | reverse | .[0]' .github/supported_k8s_node_versions.yaml
+            echo 'EOF'
+          ) >> "${GITHUB_OUTPUT}"
+
+  run-kongintegration-tests:
+    if: ${{ !cancelled() }}
+    uses: ./.github/workflows/__kongintegration_tests.yaml
+    secrets: inherit
+    with:
+      kong-image-repo: ${{ github.event.inputs.kong-image-repo }}
+      kong-image-tag: ${{ github.event.inputs.kong-image-tag }}
+      kong-effective-version: ${{ github.event.inputs.kong-effective-version }}
+
+  run-integration-tests:
+    if: ${{ !cancelled() }}
+    needs: [ resolve-k8s-version ]
+    uses: ./.github/workflows/__integration_tests.yaml
+    secrets: inherit
+    with:
+      cluster_version: ${{ needs.resolve-k8s-version.outputs.latest }}
+      kong-image-repo: ${{ github.event.inputs.kong-image-repo }}
+      kong-image-tag: ${{ github.event.inputs.kong-image-tag }}
+      kong-effective-version: ${{ github.event.inputs.kong-effective-version }}
+
+  on-finish-comment-or-close-issue:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    needs:
+      - startup-issue-comment
+      - run-kongintegration-tests
+      - run-integration-tests
+    if: ${{ always() && github.event.inputs.issue-number != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
+      URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
+        github.run_id }}
+      ISSUE_NUMBER: ${{ github.event.inputs.issue-number }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result,
+          'cancelled') }}
+        run: |
+          gh issue close ${ISSUE_NUMBER} --comment \
+            'Kong Gateway validation tests **PASSED** ✅ at ${{ env.URL }} with the following parameters:
+            ```json
+            ${{ toJSON(github.event.inputs) }}
+            ```
+            '
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result,
+          'cancelled') }}
+        run: |
+          gh issue comment ${ISSUE_NUMBER} --body \
+            'Kong Gateway validation tests **FAILED** ❌ at ${{ env.URL }} with the following parameters:
+            ```json
+            ${{ toJSON(github.event.inputs) }}
+            ```
+            '


### PR DESCRIPTION
**What this PR does / why we need it**:

Images can be [validated with KIC](https://github.com/Kong/kubernetes-ingress-controller/actions/workflows/validate_kong_image.yaml). This PR allows us to validate them with KO - copies and adjusts that workflow.
