### PR TITLE
chore(makefile): add _ensure-kong-operator-ca dev target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -951,6 +951,19 @@ endif
 _ensure-kong-system-namespace:
 	@kubectl create ns kong-system 2>/dev/null || true
 
+.PHONY: _ensure-kong-operator-ca
+_ensure-kong-operator-ca: _ensure-kong-system-namespace
+	@kubectl get secret kong-operator-ca -n kong-system >/dev/null 2>&1 || \
+	(openssl genrsa -out /tmp/ko-makefile-ca.key 4096 2>/dev/null && \
+	openssl req -x509 -new -key /tmp/ko-makefile-ca.key -days 3650 -out /tmp/ko-makefile-ca.crt -subj "/CN=Kong Operator CA" 2>/dev/null && \
+	kubectl create secret tls kong-operator-ca \
+		--cert=/tmp/ko-makefile-ca.crt \
+		--key=/tmp/ko-makefile-ca.key \
+		--namespace kong-system \
+		--dry-run=client -o yaml | \
+		kubectl label -f - konghq.com/secret=internal --overwrite --local -o yaml | \
+		kubectl apply -f -)
+
 # Run a controller from your host.
 # TODO: https://github.com/Kong/kong-operator/issues/1989
 .PHONY: run


### PR DESCRIPTION


**What this PR does / why we need it**:

Adds a developer-only Makefile target to ensure the kong-operator-ca TLS secret exists in the kong-system namespace.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
