### PR TITLE
fix: more robust `HTTPRoute` validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,10 @@
 
 ### Fixes
 
+- More robust validation for `HTTPRoute`, when an unsupported feature is used, and the route refers
+  to existing and non-existing `Gateway`, it will be rejected.
+  [#4131](https://github.com/Kong/kong-operator/pull/4131)
+
 ## [v2.1.5]
 
 > Release date: 2026-04-24

--- a/ingress-controller/internal/admission/validation/gateway/httproute.go
+++ b/ingress-controller/internal/admission/validation/gateway/httproute.go
@@ -113,7 +113,7 @@ func ensureHTTPRouteIsManagedByController(ctx context.Context, httproute *gatewa
 			Name:      string(parentRef.Name),
 		}, &gateway); err != nil {
 			if apierrors.IsNotFound(err) {
-				return false, nil
+				continue
 			}
 			return false, fmt.Errorf("failed to get Gateway: %w", err)
 		}

--- a/ingress-controller/internal/admission/validation/gateway/httproute_test.go
+++ b/ingress-controller/internal/admission/validation/gateway/httproute_test.go
@@ -1013,6 +1013,47 @@ func TestValidateHTTPRoute(t *testing.T) {
 			},
 			valid: true,
 		},
+		{
+			msg: "HTTPRoute with unsupported filter when reference both existing and non-existing gateway should be rejected",
+			cachedObjects: []client.Object{
+				gatewayClass,
+				&gatewayapi.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: corev1.NamespaceDefault,
+						Name:      "existing-managed-gateway",
+					},
+					Spec: gatewayapi.GatewaySpec{GatewayClassName: gatewayClassName},
+				},
+			},
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: corev1.NamespaceDefault,
+					Name:      "example-route",
+				},
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{
+							{
+								Name:      "non-existent-gateway",
+								Namespace: new(gatewayapi.Namespace(corev1.NamespaceDefault)),
+							},
+							{
+								Name:      "existing-managed-gateway",
+								Namespace: new(gatewayapi.Namespace(corev1.NamespaceDefault)),
+							},
+						},
+					},
+					Rules: []gatewayapi.HTTPRouteRule{{
+						Filters: []gatewayapi.HTTPRouteFilter{{
+							// RequestMirror is explicitly unsupported — should be rejected.
+							Type: gatewayapi.HTTPRouteFilterRequestMirror,
+						}},
+					}},
+				},
+			},
+			valid:         false,
+			validationMsg: "HTTPRoute spec did not pass validation: rules[0].filters[0]: filter type RequestMirror is unsupported",
+		},
 	} {
 		t.Run(tt.msg, func(t *testing.T) {
 			fakeClient := fakeclient.


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry-pick/port of 

- https://github.com/Kong/kubernetes-ingress-controller/pull/7913



**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
