### PR TITLE
tests: use GITHUB_TOKEN for ktf cluster creation in e2e tests suite

### DIFF
--- a/.github/workflows/__e2e_chainsaw_tests.yaml
+++ b/.github/workflows/__e2e_chainsaw_tests.yaml
@@ -45,6 +45,12 @@ jobs:
         install_args: github:Kong/kubernetes-testing-framework http:helm
 
     - name: Create k8s KinD Cluster with ktf
+      env:
+        # NOTE: add GITHUB_TOKEN to env to allow ktf to query GitHub API without
+        # hitting unauthenticated rate limits.
+        # This token is being used e.g. in here:
+        # https://github.com/Kong/kubernetes-testing-framework/blob/f233236e89ebcaf79575c5084053e4196c037165/pkg/utils/github/release.go#L46
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         ktf environments create \
           --name ${{ env.CLUSTER_NAME }} \


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent errors like this:

```
Error: failed to deploy addon cert-manager: couldn't fetch latest jetstack/cert-manager release: GET https://api.github.com/repos/jetstack/cert-manager/releases/latest: 403 API rate limit exceeded for 13.88.85.248. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 3m01s]
```

https://github.com/Kong/kong-operator/actions/runs/25379319857/job/74423685624?pr=4110#step:8:25

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
