### PR TITLE
chore: decrease parallelism in CRD validation tests on CI to 2

### DIFF
--- a/.github/workflows/__crdvalidation_tests.yaml
+++ b/.github/workflows/__crdvalidation_tests.yaml
@@ -69,6 +69,8 @@ jobs:
           ${{ env.GO_CACHE_KEY_2 }}
 
     - name: Run the crds validation tests
+      env:
+        GO_TEST_PARALLEL: 2
       run: |
         VERSION="${{ matrix.kubernetes-node-version }}"
         # Remove leading 'v'

--- a/Makefile
+++ b/Makefile
@@ -607,6 +607,7 @@ _test.envtest: gotestsum setup-envtest
 		-timeout $(ENVTEST_TIMEOUT) \
 		-covermode=atomic \
 		-coverpkg=$(PKG_LIST) \
+		-parallel $(GO_TEST_PARALLEL) \
 		-coverprofile=coverage.envtest.out \
 		-ldflags "$(LDFLAGS_COMMON) $(LDFLAGS)" \
 		$(ENVTEST_TEST_PATHS)
@@ -621,11 +622,15 @@ test.envtest.pretty:
 
 .PHONY: test.crds-validation
 test.crds-validation:
-	$(MAKE) _test.envtest GOTESTSUM_FORMAT=standard-verbose ENVTEST_TEST_PATHS=./test/crdsvalidation/...
+	$(MAKE) _test.envtest \
+		GOTESTSUM_FORMAT=standard-verbose \
+		ENVTEST_TEST_PATHS=./test/crdsvalidation/...
 
 .PHONY: test.crds-validation.pretty
 test.crds-validation.pretty:
-	$(MAKE) _test.envtest GOTESTSUM_FORMAT=testname ENVTEST_TEST_PATHS=./test/crdsvalidation/...
+	$(MAKE) _test.envtest \
+		GOTESTSUM_FORMAT=testname \
+		ENVTEST_TEST_PATHS=./test/crdsvalidation/...
 
 # Define a constant list of channels
 CHANNELS := ingress-controller-incubator gateway-operator kong-operator
@@ -806,7 +811,7 @@ test.e2e.chainsaw: chainsaw ## Run chainsaw e2e tests.
 	$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --quiet --test-dir $(CHAINSAW_TEST_DIR)
 
 NCPU := $(shell getconf _NPROCESSORS_ONLN)
-PARALLEL := $(if $(PARALLEL),$(PARALLEL),$(NCPU))
+GO_TEST_PARALLEL := $(if $(GO_TEST_PARALLEL),$(GO_TEST_PARALLEL),$(NCPU))
 
 .PHONY: _test.conformance
 _test.conformance: gotestsum download.telepresence
@@ -817,7 +822,7 @@ _test.conformance: gotestsum download.telepresence
 		-timeout $(CONFORMANCE_TEST_TIMEOUT) \
 		-ldflags "$(LDFLAGS_COMMON) $(LDFLAGS) $(LDFLAGS_METADATA)" \
 		-race \
-		-parallel $(PARALLEL) \
+		-parallel $(GO_TEST_PARALLEL) \
 		$(TEST_SUITE_PATH)
 
 .PHONY: test.conformance


### PR DESCRIPTION
**What this PR does / why we need it**:

Attempt to fix flaky tests in CRD validation suite by reducing the parallelism to 2 ( even though [gh docs](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories) mention 4 cores available on standard hosted runners)

```
kongpluginbindings_test.go:20: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/envtest/setup.go:117
        	            				/home/runner/work/kong-operator/kong-operator/test/crdsvalidation/configuration.konghq.com/kongpluginbindings_test.go:20
        	Error:      	Received unexpected error:
        	            	unable to start control plane itself: failed to start the controlplane. retried 5 times: timeout waiting for process kube-apiserver to start successfully (it may have failed to start, or stopped unexpectedly before becoming ready)
        	Test:       	TestKongPluginBindings

=== FAIL: test/crdsvalidation/configuration.konghq.com TestKongReferenceGrant (46.29s)
2026-05-06T10:10:58Z	INFO	controller-runtime.certwatcher	Starting certificate poll+watcher	{"cert": "/tmp/envtest-serving-certs-2255034000/tls.crt", "key": "/tmp/envtest-serving-certs-2255034000/tls.key", "interval": "10s"}
    kongreferencegrant_test.go:19: starting envtest environment for test TestKongReferenceGrant...
2026-05-06T10:10:58Z	DEBUG	controller-runtime.test-env	starting control plane
    kongreferencegrant_test.go:19: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/envtest/setup.go:117
        	            				/home/runner/work/kong-operator/kong-operator/test/crdsvalidation/configuration.konghq.com/kongreferencegrant_test.go:19
        	Error:      	Received unexpected error:
        	            	unable to start control plane itself: failed to start the controlplane. retried 5 times: timeout waiting for process kube-apiserver to start successfully (it may have failed to start, or stopped unexpectedly before becoming ready)
        	Test:       	TestKongReferenceGrant
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
