### PR TITLE
chore: bump golang 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Builder
 # ------------------------------------------------------------------------------
 
-FROM --platform=$BUILDPLATFORM golang:1.26.2@sha256:b54cbf583d390341599d7bcbc062425c081105cc5ef6d170ced98ef9d047c716 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.3@sha256:efaccb5b497e90df3ebe5216cc25cd9f98e73874e2d638b56e38d4a3f098c41c AS builder
 
 WORKDIR /workspace
 ARG GOPATH

--- a/crd-from-oas/go.mod
+++ b/crd-from-oas/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kong-operator/v2/crd-from-oas
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/caarlos0/env/v11 v11.4.1

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -2,7 +2,7 @@
 # Debug image
 # ------------------------------------------------------------------------------
 
-FROM --platform=$BUILDPLATFORM golang:1.26.2@sha256:b54cbf583d390341599d7bcbc062425c081105cc5ef6d170ced98ef9d047c716 AS debug
+FROM --platform=$BUILDPLATFORM golang:1.26.3@sha256:efaccb5b497e90df3ebe5216cc25cd9f98e73874e2d638b56e38d4a3f098c41c AS debug
 
 ARG GOPATH
 ARG GOCACHE

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kong-operator/v2
 
-go 1.26.2
+go 1.26.3
 
 require (
 	cloud.google.com/go/container v1.50.0


### PR DESCRIPTION
**What this PR does / why we need it**:

https://groups.google.com/g/golang-announce/c/qcCIEXso47M 

**Which issue this PR fixes**

Fixes #

```
- GO-2026-4918 (aka CVE-2026-33814)
make: *** [Makefile:247: govulncheck] Error 2

	When processing HTTP/2 SETTINGS frames, transport will enter an infinite loop of writing CONTINUATION frames if it receives a SETTINGS_MAX_FRAME_SIZE with a value of 0.

- GO-2026-4971 (aka CVE-2026-39836)

	The Dial and LookupPort functions panic on Windows when provided with an input containing a NUL (0).

- GO-2026-4977 (aka CVE-2026-42499)

	Pathological inputs could cause DoS through consumePhrase when parsing an email address according to RFC 5322.

- GO-2026-4980 (aka CVE-2026-39826)

	If a trusted template author were to write a <script> tag containing an empty 'type' attribute or a 'type' attribute with an ASCII whitespace, the execution of the template would incorrectly escape any data passed into the <script> block.

- GO-2026-4982 (aka CVE-2026-39823)

	CVE-2026-27142 fixed a vulnerability in which URLs were not correctly escaped inside of a <meta> tag's <content> attribute. If the URL content were to insert ASCII whitespaces around the '=' rune inside of the <content> attribute, the escaper would fail to similarly escape it, leading to XSS.

- GO-2026-4986 (aka CVE-2026-39820)

	Well-crafted inputs reaching ParseAddress, ParseAddressList, and ParseDate were able to trigger excessive CPU exhaustion and memory allocations.

```

job link: https://github.com/Kong/kong-operator/actions/runs/25541931942/job/74969589676?pr=4178 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
