### PR TITLE
chore(logs): update the warning message for cross namespace ref for KonnectAPIAuth -> Secret

### DIFF
--- a/controller/konnect/reconciler_konnectapiauth.go
+++ b/controller/konnect/reconciler_konnectapiauth.go
@@ -300,7 +300,7 @@ func GetTokenFromKonnectAPIAuthConfiguration(
 							client.ObjectKeyFromObject(apiAuth), nn,
 						),
 						"WARNING: referencing Secret in a different namespace. "+
-							"This will require a KongReferenceGrant in Secret's namespace in future versions.",
+							"This will require a KongReferenceGrant in Secret's namespace in KO 2.3 and later.",
 					)
 			}
 		}

--- a/controller/konnect/reconciler_konnectapiauth.go
+++ b/controller/konnect/reconciler_konnectapiauth.go
@@ -292,6 +292,8 @@ func GetTokenFromKonnectAPIAuthConfiguration(
 		if nn.Namespace != apiAuth.Namespace {
 			gvkAPIAuth := metav1.GroupVersionKind(apiAuth.GetObjectKind().GroupVersionKind())
 			gvkSecret := metav1.GroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
+			// TODO: Require a KongReferenceGrant for cross-namespace references in KO 2.3 and later:
+			// https://github.com/Kong/kong-operator/issues/2908
 			err := crossnamespace.CheckKongReferenceGrantForResource(ctx, cl, apiAuth.Namespace, nn.Namespace, nn.Name, gvkAPIAuth, gvkSecret)
 			if err != nil {
 				ctrllog.FromContext(ctx).


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the warning log message for cross namespace reference from `KonnectAPIAuthConfiguration` to `Secret` to tell the users this will need `KongReferenceGrant` from KO 2.3.

**Which issue this PR fixes**

Prev of #2908

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
