### PR TITLE
fix(gateway): Do not require certificateRefs in checking listener's ResolvedRef condition

### DIFF
--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -1431,11 +1431,12 @@ func getSupportedKindsWithResolvedRefsCondition(ctx context.Context, c client.Cl
 			resolvedRefsCondition.Reason = string(gatewayv1.ListenerReasonInvalidCertificateRef)
 			message = conditionMessage(message, "Only Terminate mode is supported")
 		}
-		// We currently do not support more that one listener certificate.
-		if len(listener.TLS.CertificateRefs) != 1 {
+		// We currently do not support more that one listener certificates.
+		// TODO: https://github.com/Kong/kong-operator/issues/3510
+		if len(listener.TLS.CertificateRefs) > 1 {
 			resolvedRefsCondition.Reason = string(kcfggateway.ListenerReasonTooManyTLSSecrets)
 			message = conditionMessage(message, "Only one certificate per listener is supported")
-		} else {
+		} else if len(listener.TLS.CertificateRefs) == 1 {
 			isValidGroupKind := true
 			certificateRef := listener.TLS.CertificateRefs[0]
 			gatewayNamespace := gatewayv1.Namespace(gateway.Namespace)
@@ -1483,6 +1484,9 @@ func getSupportedKindsWithResolvedRefsCondition(ctx context.Context, c client.Cl
 				}
 			}
 		}
+		// For the case of 0 certificate refs:
+		// If the listener's TLSMode is Terminate, this cannot happen because it is rejected by gateway API's validation.
+		// If the listener's TLSMode is not Terminate, this is valid and means that the listener will be used for passthrough TLS, so no certificate is needed.
 	}
 
 	if listener.AllowedRoutes == nil || len(listener.AllowedRoutes.Kinds) == 0 {

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -1258,6 +1258,29 @@ func TestGetSupportedKindsWithResolvedRefsCondition(t *testing.T) {
 			},
 		},
 		{
+			name:             "tls passthrough, TLS protocol, no certificate refs",
+			gatewayNamespace: "default",
+			listener: gwtypes.Listener{
+				Protocol: gatewayv1.TLSProtocolType,
+				TLS: &gatewayv1.ListenerTLSConfig{
+					Mode: new(gatewayv1.TLSModePassthrough),
+				},
+			},
+			expectedSupportedKinds: []gwtypes.RouteGroupKind{
+				{
+					Group: (*gwtypes.Group)(&gatewayv1.GroupVersion.Group),
+					Kind:  "TLSRoute",
+				},
+			},
+			expectedResolvedRefsCondition: metav1.Condition{
+				Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+				Status:             metav1.ConditionTrue,
+				Reason:             string(gatewayv1.ListenerReasonResolvedRefs),
+				Message:            "Listeners' references are accepted.",
+				ObservedGeneration: generation,
+			},
+		},
+		{
 			name:             "tls bad-formed, no tls secret, no cross-namespace reference",
 			gatewayNamespace: "default",
 			listener: gwtypes.Listener{

--- a/test/e2e/chainsaw/common/_step_templates/apply-assert-gateway-tls-passthrough-listener.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/apply-assert-gateway-tls-passthrough-listener.yaml
@@ -1,18 +1,15 @@
-# Template for creating and asserting a Gateway with a TLS (L4) listener.
+# Template for creating and asserting a Gateway with a TLS passthrough (L4) listener.
 #
 # Required bindings:
 #   - gateway_name: Name of the gateway to create.
 #   - test_name: Test name used to compose the gateway class name.
 #   - namespace: Namespace where the gateway will be created.
 #   - listener_tls_port: TLS listener port (e.g., "8899").
-#   - tls_mode: the mode of decrypting TLS connection, "Passthrough" or "Terminate".
 #   - sni_hostname: SNI hostname for the TLS listener (e.g., "*.example.com").
-#   - cert_secret_name: Name of the TLS secret.
-#   - cert_secret_namespace: Namespace of the TLS secret.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: StepTemplate
 metadata:
-  name: apply-assert-gateway-tls-listener
+  name: apply-assert-gateway-tls-passthrough-listener
 spec:
   try:
     - apply:
@@ -25,15 +22,13 @@ spec:
           spec:
             gatewayClassName: (join('-', [($test_name), 'gateway-class']))
             listeners:
-            - name: tls
+            - name: tls-passthrough
               protocol: TLS
               port: (to_number($listener_tls_port))
               hostname: ($sni_hostname)
               tls:
-                mode: ($tls_mode)
-                certificateRefs:
-                - name: ($cert_secret_name)
-                  namespace: ($cert_secret_namespace)
+                mode: Passthrough
+                # Passthrough mode does not require certificate references.
 
     - assert:
         resource:

--- a/test/e2e/chainsaw/common/_step_templates/apply-assert-gateway-tls-terminate-listener.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/apply-assert-gateway-tls-terminate-listener.yaml
@@ -1,0 +1,62 @@
+# Template for creating and asserting a Gateway with a TLS terminatre (L4) listener.
+#
+# Required bindings:
+#   - gateway_name: Name of the gateway to create.
+#   - test_name: Test name used to compose the gateway class name.
+#   - namespace: Namespace where the gateway will be created.
+#   - listener_tls_port: TLS listener port (e.g., "8899").
+#   - sni_hostname: SNI hostname for the TLS listener (e.g., "*.example.com").
+#   - cert_secret_name: Name of the TLS secret.
+#   - cert_secret_namespace: Namespace of the TLS secret.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: apply-assert-gateway-tls-terminate-listener
+spec:
+  try:
+    - apply:
+        resource:
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: Gateway
+          metadata:
+            name: ($gateway_name)
+            namespace: ($namespace)
+          spec:
+            gatewayClassName: (join('-', [($test_name), 'gateway-class']))
+            listeners:
+            - name: tls-passthrough
+              protocol: TLS
+              port: (to_number($listener_tls_port))
+              hostname: ($sni_hostname)
+              tls:
+                mode: Terminate
+                certificateRefs:
+                - name: ($cert_secret_name)
+                  namespace: ($cert_secret_namespace)
+
+    - assert:
+        resource:
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: Gateway
+          metadata:
+            name: ($gateway_name)
+            namespace: ($namespace)
+          status:
+            (conditions[?type == 'Accepted']):
+              - status: 'True'
+                reason: Accepted
+            (conditions[?type == 'Programmed']):
+              - status: 'True'
+                reason: Programmed
+            (conditions[?type == 'DataPlaneReady']):
+              - status: 'True'
+                reason: Ready
+            (conditions[?type == 'KonnectGatewayControlPlaneProgrammed']):
+              - status: 'True'
+                reason: Programmed
+            (conditions[?type == 'KonnectExtensionReady']):
+              - status: 'True'
+                reason: Ready
+            (conditions[?type == 'GatewayService']):
+              - status: 'True'
+                reason: Ready

--- a/test/e2e/chainsaw/hybridgateway/basic-tlsroute/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-tlsroute/chainsaw-test.yaml
@@ -16,8 +16,6 @@ spec:
       value: (env('KONNECT_TOKEN'))
     - name: konnect_api_auth_namespace
       value: ($namespace)
-    - name: tls_mode
-      value: "Passthrough"
     - name: listener_tls_port
       value: 8899
     - name: sni_hostname
@@ -80,11 +78,11 @@ spec:
       use:
         template: ../../common/_step_templates/apply-assert-gatewayClass.yaml
 
-    # Step 5: Create the Gateway with a TLS listener that references the TLS secret.
+    # Step 5: Create the Gateway with a TLS passthrough listener.
     - name: Create-gateway
       description: Create Gateway with TLS listener for the test.
       use:
-        template: ../../common/_step_templates/apply-assert-gateway-tls-listener.yaml
+        template: ../../common/_step_templates/apply-assert-gateway-tls-passthrough-listener.yaml
 
     # Step 6: Verify that the KonnectGatewayControlPlane is created and synchronized with Konnect.
     - name: Assert-konnect-gateway-control-plane

--- a/test/e2e/chainsaw/hybridgateway/basic-tlsroute/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-tlsroute/chainsaw-test.yaml
@@ -89,29 +89,14 @@ spec:
       description: Assert that the KonnectGatewayControlplane resource is created and synchronized.
       use:
         template: ../../common/_step_templates/assert-konnectGatewayControlPlane.yaml
-
-    # Step 7: Verify that the KongCertificate resource is created from the TLS secret.
-    - name: Assert-kong-certificate
-      description: Assert that the KongCertificate resource is created for the TLS secret.
-      use:
-       template: ../../common/_step_templates/assert-kongCertificate-tls-listener.yaml
   
-    # Step 8: Verify that the KongSNI resource is created for the SNI hostname.
-    - name: Assert-kong-sni
-      description: Assert that the KongSNI resource is created for the SNI hostname.
-      use:
-       template: ../../common/_step_templates/assert-kongSNI-tls-listener.yaml
-      bindings:
-        - name: resource_type
-          value: "kongcertificates.configuration.konghq.com"
-  
-    # Step 9: Create the echo service that will receive the routed traffic.
+    # Step 7: Create the echo service that will receive the routed traffic.
     - name: Create-echo-service
       description: Create and assert an echo service to route traffic to.
       use:
         template: ../../common/_step_templates/apply-assert-echoService-with-tls.yaml
 
-    # Step 10: Create the TLSRoute that routes traffic to the echo service.
+    # Step 8: Create the TLSRoute that routes traffic to the echo service.
     - name: Create-tlsroute-echo
       description: Create TLSRoute to route traffic to the echo service.
       try:
@@ -128,7 +113,7 @@ spec:
 
     # Since TLS passthrough is used, the certificate provided here when accessing the proxy IP and port is the cert from the backend service.
     # So we skip the verification of TLS certificate here,
-    # Step 12: Verify TLS traffic from host.
+    # Step 9: Verify TLS traffic from host.
     - name: Verify-TLS-traffic-from-host
       description: Verify that TLS traffic can be routed through the gateway to the echo service from the host.
       use:

--- a/test/e2e/chainsaw/hybridgateway/tlsroute-terminate-listener/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/tlsroute-terminate-listener/chainsaw-test.yaml
@@ -18,8 +18,6 @@ spec:
       value: (env('KONNECT_TOKEN'))
     - name: konnect_api_auth_namespace
       value: ($namespace)
-    - name: tls_mode
-      value: "Terminate"
     - name: listener_tls_port
       value: 8899
     - name: sni_hostname
@@ -88,7 +86,7 @@ spec:
     - name: Create-gateway
       description: Create Gateway with TLS listener (Terminate mode) for the test.
       use:
-        template: ../../common/_step_templates/apply-assert-gateway-tls-listener.yaml
+        template: ../../common/_step_templates/apply-assert-gateway-tls-terminate-listener.yaml
 
     # Step 6: Verify that the KonnectGatewayControlPlane is created and synchronized with Konnect.
     - name: Assert-konnect-gateway-control-plane


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not require `certificateRefs` to be exactly 1 (0 is allowed) in checking  listener's ResolvedRef condition since:
- For Terminate, 0 certificates is already rejected by the API
- For Passthrough, 0 certificates is allowed.

**Which issue this PR fixes**

Fixes #4183 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
