### PR TITLE
feat: handle parent refs generically

### DIFF
--- a/api/konnect/v1alpha1/zz_generated_eventgatewaybackendcluster_funcs.go
+++ b/api/konnect/v1alpha1/zz_generated_eventgatewaybackendcluster_funcs.go
@@ -6,6 +6,7 @@ import (
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 // GetKonnectLabels gets the Konnect labels from the object's API spec.
 func (obj *EventGatewayBackendCluster) GetKonnectLabels() map[string]string {
@@ -56,6 +57,11 @@ func (obj EventGatewayBackendCluster) GetTypeName() string {
 	return "EventGatewayBackendCluster"
 }
 
+// HasParent returns true if the EventGatewayBackendCluster has a parent entity.
+func (obj EventGatewayBackendCluster) HasParent() bool {
+	return true
+}
+
 // GetConditions returns the Status Conditions.
 func (obj *EventGatewayBackendCluster) GetConditions() []metav1.Condition {
 	return obj.Status.Conditions
@@ -100,6 +106,11 @@ func (obj *EventGatewayBackendCluster) GetParentRef() commonv1alpha1.ObjectRef {
 // SetParentID sets the Konnect ID of the immediate parent entity.
 func (obj *EventGatewayBackendCluster) SetParentID(id string) {
 	obj.SetGatewayID(id)
+}
+
+// GetParentGVK returns the GroupVersionKind of the parent entity.
+func (obj *EventGatewayBackendCluster) GetParentGVK() schema.GroupVersionKind {
+	return GroupVersion.WithKind("KonnectEventGateway")
 }
 
 // GetStatusConditionTypeParentRefValid returns the status condition type

--- a/api/konnect/v1alpha1/zz_generated_eventgatewaylistener_funcs.go
+++ b/api/konnect/v1alpha1/zz_generated_eventgatewaylistener_funcs.go
@@ -6,6 +6,7 @@ import (
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 // GetKonnectLabels gets the Konnect labels from the object's API spec.
 func (obj *EventGatewayListener) GetKonnectLabels() map[string]string {
@@ -56,6 +57,11 @@ func (obj EventGatewayListener) GetTypeName() string {
 	return "EventGatewayListener"
 }
 
+// HasParent returns true if the EventGatewayListener has a parent entity.
+func (obj EventGatewayListener) HasParent() bool {
+	return true
+}
+
 // GetConditions returns the Status Conditions.
 func (obj *EventGatewayListener) GetConditions() []metav1.Condition {
 	return obj.Status.Conditions
@@ -100,6 +106,11 @@ func (obj *EventGatewayListener) GetParentRef() commonv1alpha1.ObjectRef {
 // SetParentID sets the Konnect ID of the immediate parent entity.
 func (obj *EventGatewayListener) SetParentID(id string) {
 	obj.SetGatewayID(id)
+}
+
+// GetParentGVK returns the GroupVersionKind of the parent entity.
+func (obj *EventGatewayListener) GetParentGVK() schema.GroupVersionKind {
+	return GroupVersion.WithKind("KonnectEventGateway")
 }
 
 // GetStatusConditionTypeParentRefValid returns the status condition type

--- a/api/konnect/v1alpha1/zz_generated_eventgatewaylistenerpolicy_funcs.go
+++ b/api/konnect/v1alpha1/zz_generated_eventgatewaylistenerpolicy_funcs.go
@@ -6,6 +6,7 @@ import (
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // GetKonnectStatus returns the Konnect status contained in the EventGatewayListenerPolicy status.
@@ -26,6 +27,11 @@ func (obj *EventGatewayListenerPolicy) GetKonnectID() string {
 // GetTypeName returns the EventGatewayListenerPolicy Kind name.
 func (obj EventGatewayListenerPolicy) GetTypeName() string {
 	return "EventGatewayListenerPolicy"
+}
+
+// HasParent returns true if the EventGatewayListenerPolicy has a parent entity.
+func (obj EventGatewayListenerPolicy) HasParent() bool {
+	return true
 }
 
 // GetConditions returns the Status Conditions.
@@ -88,6 +94,11 @@ func (obj *EventGatewayListenerPolicy) GetParentRef() commonv1alpha1.ObjectRef {
 // SetParentID sets the Konnect ID of the immediate parent entity.
 func (obj *EventGatewayListenerPolicy) SetParentID(id string) {
 	obj.SetEventGatewayListenerID(id)
+}
+
+// GetParentGVK returns the GroupVersionKind of the parent entity.
+func (obj *EventGatewayListenerPolicy) GetParentGVK() schema.GroupVersionKind {
+	return GroupVersion.WithKind("EventGatewayListener")
 }
 
 // GetStatusConditionTypeParentRefValid returns the status condition type

--- a/api/konnect/v1alpha1/zz_generated_eventgatewayvirtualcluster_funcs.go
+++ b/api/konnect/v1alpha1/zz_generated_eventgatewayvirtualcluster_funcs.go
@@ -6,6 +6,7 @@ import (
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 // GetKonnectLabels gets the Konnect labels from the object's API spec.
 func (obj *EventGatewayVirtualCluster) GetKonnectLabels() map[string]string {
@@ -56,6 +57,11 @@ func (obj EventGatewayVirtualCluster) GetTypeName() string {
 	return "EventGatewayVirtualCluster"
 }
 
+// HasParent returns true if the EventGatewayVirtualCluster has a parent entity.
+func (obj EventGatewayVirtualCluster) HasParent() bool {
+	return true
+}
+
 // GetConditions returns the Status Conditions.
 func (obj *EventGatewayVirtualCluster) GetConditions() []metav1.Condition {
 	return obj.Status.Conditions
@@ -100,6 +106,11 @@ func (obj *EventGatewayVirtualCluster) GetParentRef() commonv1alpha1.ObjectRef {
 // SetParentID sets the Konnect ID of the immediate parent entity.
 func (obj *EventGatewayVirtualCluster) SetParentID(id string) {
 	obj.SetGatewayID(id)
+}
+
+// GetParentGVK returns the GroupVersionKind of the parent entity.
+func (obj *EventGatewayVirtualCluster) GetParentGVK() schema.GroupVersionKind {
+	return GroupVersion.WithKind("KonnectEventGateway")
 }
 
 // GetStatusConditionTypeParentRefValid returns the status condition type

--- a/api/konnect/v1alpha1/zz_generated_identityproviderrequest_funcs.go
+++ b/api/konnect/v1alpha1/zz_generated_identityproviderrequest_funcs.go
@@ -6,6 +6,7 @@ import (
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // GetKonnectStatus returns the Konnect status contained in the IdentityProviderRequest status.
@@ -26,6 +27,11 @@ func (obj *IdentityProviderRequest) GetKonnectID() string {
 // GetTypeName returns the IdentityProviderRequest Kind name.
 func (obj IdentityProviderRequest) GetTypeName() string {
 	return "IdentityProviderRequest"
+}
+
+// HasParent returns true if the IdentityProviderRequest has a parent entity.
+func (obj IdentityProviderRequest) HasParent() bool {
+	return true
 }
 
 // GetConditions returns the Status Conditions.
@@ -67,6 +73,11 @@ func (obj *IdentityProviderRequest) GetParentRef() commonv1alpha1.ObjectRef {
 // SetParentID sets the Konnect ID of the immediate parent entity.
 func (obj *IdentityProviderRequest) SetParentID(id string) {
 	obj.SetPortalID(id)
+}
+
+// GetParentGVK returns the GroupVersionKind of the parent entity.
+func (obj *IdentityProviderRequest) GetParentGVK() schema.GroupVersionKind {
+	return GroupVersion.WithKind("Portal")
 }
 
 // GetStatusConditionTypeParentRefValid returns the status condition type

--- a/api/konnect/v1alpha1/zz_generated_konnect_eventdataplanecertificate_funcs.go
+++ b/api/konnect/v1alpha1/zz_generated_konnect_eventdataplanecertificate_funcs.go
@@ -6,6 +6,7 @@ import (
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // GetKonnectStatus returns the Konnect status contained in the KonnectEventDataPlaneCertificate status.
@@ -26,6 +27,11 @@ func (obj *KonnectEventDataPlaneCertificate) GetKonnectID() string {
 // GetTypeName returns the KonnectEventDataPlaneCertificate Kind name.
 func (obj KonnectEventDataPlaneCertificate) GetTypeName() string {
 	return "KonnectEventDataPlaneCertificate"
+}
+
+// HasParent returns true if the KonnectEventDataPlaneCertificate has a parent entity.
+func (obj KonnectEventDataPlaneCertificate) HasParent() bool {
+	return true
 }
 
 // GetConditions returns the Status Conditions.
@@ -72,6 +78,11 @@ func (obj *KonnectEventDataPlaneCertificate) GetParentRef() commonv1alpha1.Objec
 // SetParentID sets the Konnect ID of the immediate parent entity.
 func (obj *KonnectEventDataPlaneCertificate) SetParentID(id string) {
 	obj.SetGatewayID(id)
+}
+
+// GetParentGVK returns the GroupVersionKind of the parent entity.
+func (obj *KonnectEventDataPlaneCertificate) GetParentGVK() schema.GroupVersionKind {
+	return GroupVersion.WithKind("KonnectEventGateway")
 }
 
 // GetStatusConditionTypeParentRefValid returns the status condition type

--- a/api/konnect/v1alpha1/zz_generated_konnect_eventgateway_funcs.go
+++ b/api/konnect/v1alpha1/zz_generated_konnect_eventgateway_funcs.go
@@ -55,6 +55,11 @@ func (obj KonnectEventGateway) GetTypeName() string {
 	return "KonnectEventGateway"
 }
 
+// HasParent returns true if the KonnectEventGateway has a parent entity.
+func (obj KonnectEventGateway) HasParent() bool {
+	return false
+}
+
 // GetConditions returns the Status Conditions.
 func (obj *KonnectEventGateway) GetConditions() []metav1.Condition {
 	return obj.Status.Conditions

--- a/api/konnect/v1alpha1/zz_generated_portal_funcs.go
+++ b/api/konnect/v1alpha1/zz_generated_portal_funcs.go
@@ -55,6 +55,11 @@ func (obj Portal) GetTypeName() string {
 	return "Portal"
 }
 
+// HasParent returns true if the Portal has a parent entity.
+func (obj Portal) HasParent() bool {
+	return false
+}
+
 // GetConditions returns the Status Conditions.
 func (obj *Portal) GetConditions() []metav1.Condition {
 	return obj.Status.Conditions

--- a/api/konnect/v1alpha1/zz_generated_portalemailconfig_funcs.go
+++ b/api/konnect/v1alpha1/zz_generated_portalemailconfig_funcs.go
@@ -6,6 +6,7 @@ import (
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // GetKonnectStatus returns the Konnect status contained in the PortalEmailConfig status.
@@ -26,6 +27,11 @@ func (obj *PortalEmailConfig) GetKonnectID() string {
 // GetTypeName returns the PortalEmailConfig Kind name.
 func (obj PortalEmailConfig) GetTypeName() string {
 	return "PortalEmailConfig"
+}
+
+// HasParent returns true if the PortalEmailConfig has a parent entity.
+func (obj PortalEmailConfig) HasParent() bool {
+	return true
 }
 
 // GetConditions returns the Status Conditions.
@@ -67,6 +73,11 @@ func (obj *PortalEmailConfig) GetParentRef() commonv1alpha1.ObjectRef {
 // SetParentID sets the Konnect ID of the immediate parent entity.
 func (obj *PortalEmailConfig) SetParentID(id string) {
 	obj.SetPortalID(id)
+}
+
+// GetParentGVK returns the GroupVersionKind of the parent entity.
+func (obj *PortalEmailConfig) GetParentGVK() schema.GroupVersionKind {
+	return GroupVersion.WithKind("Portal")
 }
 
 // GetStatusConditionTypeParentRefValid returns the status condition type

--- a/api/konnect/v1alpha1/zz_generated_portalpage_funcs.go
+++ b/api/konnect/v1alpha1/zz_generated_portalpage_funcs.go
@@ -6,6 +6,7 @@ import (
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // GetKonnectStatus returns the Konnect status contained in the PortalPage status.
@@ -26,6 +27,11 @@ func (obj *PortalPage) GetKonnectID() string {
 // GetTypeName returns the PortalPage Kind name.
 func (obj PortalPage) GetTypeName() string {
 	return "PortalPage"
+}
+
+// HasParent returns true if the PortalPage has a parent entity.
+func (obj PortalPage) HasParent() bool {
+	return true
 }
 
 // GetConditions returns the Status Conditions.
@@ -67,6 +73,11 @@ func (obj *PortalPage) GetParentRef() commonv1alpha1.ObjectRef {
 // SetParentID sets the Konnect ID of the immediate parent entity.
 func (obj *PortalPage) SetParentID(id string) {
 	obj.SetPortalID(id)
+}
+
+// GetParentGVK returns the GroupVersionKind of the parent entity.
+func (obj *PortalPage) GetParentGVK() schema.GroupVersionKind {
+	return GroupVersion.WithKind("Portal")
 }
 
 // GetStatusConditionTypeParentRefValid returns the status condition type

--- a/api/konnect/v1alpha1/zz_generated_portalteam_funcs.go
+++ b/api/konnect/v1alpha1/zz_generated_portalteam_funcs.go
@@ -6,6 +6,7 @@ import (
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // GetKonnectStatus returns the Konnect status contained in the PortalTeam status.
@@ -26,6 +27,11 @@ func (obj *PortalTeam) GetKonnectID() string {
 // GetTypeName returns the PortalTeam Kind name.
 func (obj PortalTeam) GetTypeName() string {
 	return "PortalTeam"
+}
+
+// HasParent returns true if the PortalTeam has a parent entity.
+func (obj PortalTeam) HasParent() bool {
+	return true
 }
 
 // GetConditions returns the Status Conditions.
@@ -67,6 +73,11 @@ func (obj *PortalTeam) GetParentRef() commonv1alpha1.ObjectRef {
 // SetParentID sets the Konnect ID of the immediate parent entity.
 func (obj *PortalTeam) SetParentID(id string) {
 	obj.SetPortalID(id)
+}
+
+// GetParentGVK returns the GroupVersionKind of the parent entity.
+func (obj *PortalTeam) GetParentGVK() schema.GroupVersionKind {
+	return GroupVersion.WithKind("Portal")
 }
 
 // GetStatusConditionTypeParentRefValid returns the status condition type

--- a/config/samples/konnect_eventgateway_backendcluster.yaml
+++ b/config/samples/konnect_eventgateway_backendcluster.yaml
@@ -31,6 +31,10 @@ metadata:
   name: cp-event-1-listener-1
   namespace: default
 spec:
+  gatewayRef:
+    type: namespacedRef
+    namespacedRef:
+      name: cp-event-1
   apiSpec:
     name: cp-event-1-backend-cluster-1
     description: Test Event Gateway Backend Cluster
@@ -110,7 +114,3 @@ spec:
           Q1FRQ3krL3BLCjR0cmdpMm5NY3pIUEZ2b3MycS9XelJEeDE5akRrSldPT0NSOUlyUGFNU3JrNFFw
           blJVbWpXdWcrUWhrVDR5MjEKZTJDcUNnSUNRTVhXUmpQdwotLS0tLUVORCBQUklWQVRFIEtFWS0t
           LS0tCg==
-  gatewayRef:
-    type: namespacedRef
-    namespacedRef:
-      name: cp-event-1

--- a/config/samples/portal_team.yaml
+++ b/config/samples/portal_team.yaml
@@ -10,6 +10,9 @@ spec:
   apiSpec:
     name: portal1
     authenticationEnabled: Enabled
+    labels:
+      env: production
+      team: team1
 ---
 kind: PortalTeam
 apiVersion: konnect.konghq.com/v1alpha1

--- a/controller/konnect/reconciler_apiauthref_parent.go
+++ b/controller/konnect/reconciler_apiauthref_parent.go
@@ -17,7 +17,7 @@ import (
 
 func getAPIAuthConfigurationRefFromParent[
 	ParentT parentT,
-	ParentTPtr parentTPtr[ParentT],
+	ParentTPtr parentWithAPIAuthTPtr[ParentT],
 ](
 	ctx context.Context,
 	cl client.Client,

--- a/controller/konnect/reconciler_apiauthref_parent_test.go
+++ b/controller/konnect/reconciler_apiauthref_parent_test.go
@@ -98,7 +98,7 @@ func TestGetAPIAuthConfigurationRefFromParent_EventGateway(t *testing.T) {
 
 func testGetAPIAuthConfigurationRefFromParent[
 	ParentT parentT,
-	ParentTPtr parentTPtr[ParentT],
+	ParentTPtr parentWithAPIAuthTPtr[ParentT],
 ](
 	t *testing.T,
 	childBuilder func(commonv1alpha1.ObjectRef) objectWithParentRef,

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -175,7 +175,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		return patchWithProgrammedStatusConditionBasedOnOtherConditions(ctx, r.Client, ent)
 	}
 
-	if stop, res, err := r.handleGeneratedTypeReferences(ctx, ent); stop {
+	if stop, res, err := r.handleGeneratedTypeReferences(ctx, ent); stop || err != nil {
 		return res, err
 	}
 

--- a/controller/konnect/reconciler_generic_handle_generated_refs.go
+++ b/controller/konnect/reconciler_generic_handle_generated_refs.go
@@ -6,7 +6,6 @@ package konnect
 
 import (
 	"context"
-	"errors"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -25,24 +24,42 @@ type parentTPtr[T parentT] interface {
 	k8sutils.ConditionsAwareObject
 	GetKonnectID() string
 	GetTypeName() string
+	GetNamespace() string
+}
+
+type parentWithAPIAuthTPtr[T parentT] interface {
+	parentTPtr[T]
 	GetKonnectAPIAuthConfigurationRef() konnectv1alpha2.ControlPlaneKonnectAPIAuthConfigurationRef
 }
 
 type generatedParentRefHandler interface {
 	handleParentRef(context.Context, client.Client, objectWithParentRef) (ctrl.Result, error)
+	parentTypeName() string
 }
 
-var _generatedHandlers []generatedParentRefHandler
+var (
+	_generatedHandlers        []generatedParentRefHandler
+	_generatedHandlersPerKind map[string]generatedParentRefHandler
+)
 
 func init() {
 	_generatedHandlers = []generatedParentRefHandler{
+		parentRefHandler[konnectv1alpha1.EventGatewayListener, *konnectv1alpha1.EventGatewayListener]{},
 		parentRefHandler[konnectv1alpha1.KonnectEventGateway, *konnectv1alpha1.KonnectEventGateway]{},
 		parentRefHandler[konnectv1alpha1.Portal, *konnectv1alpha1.Portal]{},
 	}
+
+	_generatedHandlersPerKind = make(map[string]generatedParentRefHandler)
+	for _, handler := range _generatedHandlers {
+		_generatedHandlersPerKind[handler.parentTypeName()] = handler
+	}
 }
 
-func _generatedTypeReferenceHandlers() []generatedParentRefHandler {
-	return _generatedHandlers
+// _generatedTypeReferenceHandlers returns a map of generated reference handlers
+// keyed by the Kind of the parent type they handle, for example:
+// "Portal" for handlers that handle references to Portal parents.
+func _generatedTypeReferenceHandlers() map[string]generatedParentRefHandler {
+	return _generatedHandlersPerKind
 }
 
 // UnsupportedGeneratedReferenceTypeError is returned by generated reference handlers
@@ -62,26 +79,24 @@ func (r *KonnectEntityReconciler[T, TEnt]) handleGeneratedTypeReferences(
 	ctx context.Context,
 	ent TEnt,
 ) (bool, ctrl.Result, error) {
-	for _, handler := range _generatedTypeReferenceHandlers() {
-		obj, ok := any(ent).(objectWithParentRef)
-		if !ok {
-			continue
-		}
-		res, err := handler.handleParentRef(ctx, r.Client, obj)
-		if err != nil {
-			// Only UnsupportedGeneratedReferenceTypeError are handled here
-			// to continue to the next handler.
-			// All other errors should be handled in handleRefResult.
-			if _, ok := errors.AsType[*UnsupportedGeneratedReferenceTypeError](err); ok {
-				// This handler is not applicable to the given type, continue to the next handler.
-				continue
-			}
-		}
+	obj, ok := any(ent).(objectWithParentRef)
+	if !ok {
+		return false, ctrl.Result{}, nil
+	}
 
-		stop, res, err := handleRefResult(ctx, r.Client, ent, res, err)
-		if stop || err != nil {
-			return true, res, err
+	// TODO: This only compares the Kind and doesn't consider the Group or API Version.
+	handler, ok := _generatedTypeReferenceHandlers()[obj.GetParentGVK().Kind]
+	if !ok || handler.parentTypeName() != obj.GetParentGVK().Kind {
+		return false, ctrl.Result{}, &UnsupportedGeneratedReferenceTypeError{
+			TypeName: obj.GetParentGVK().Kind,
 		}
+	}
+
+	res, err := handler.handleParentRef(ctx, r.Client, obj)
+
+	stop, res, err := handleRefResult(ctx, r.Client, ent, res, err)
+	if stop || err != nil {
+		return true, res, err
 	}
 
 	return false, ctrl.Result{}, nil

--- a/controller/konnect/reconciler_generic_handle_generated_refs_test.go
+++ b/controller/konnect/reconciler_generic_handle_generated_refs_test.go
@@ -1,0 +1,284 @@
+package konnect
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kcfgconsts "github.com/kong/kong-operator/v2/api/common/consts"
+	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+)
+
+func TestHandleGeneratedTypeReferences(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "ignores entities without generated parent refs",
+			run: func(t *testing.T) {
+				ent := &configurationv1alpha1.KongService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc",
+						Namespace: "default",
+					},
+				}
+
+				r := &KonnectEntityReconciler[
+					configurationv1alpha1.KongService, *configurationv1alpha1.KongService,
+				]{
+					Client: fake.NewClientBuilder().WithScheme(scheme.Get()).Build(),
+				}
+
+				stop, res, err := r.handleGeneratedTypeReferences(t.Context(), ent)
+
+				require.NoError(t, err)
+				assert.False(t, stop)
+				assert.True(t, res.IsZero())
+			},
+		},
+		{
+			name: "continues when event gateway listener parent ref is resolved",
+			run: func(t *testing.T) {
+				ent := &konnectv1alpha1.EventGatewayListenerPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "listener-policy",
+						Namespace:  "default",
+						Generation: 1,
+					},
+					Spec: konnectv1alpha1.EventGatewayListenerPolicySpec{
+						EventGatewayListenerRef: commonv1alpha1.ObjectRef{
+							Type: commonv1alpha1.ObjectRefTypeNamespacedRef,
+							NamespacedRef: &commonv1alpha1.NamespacedRef{
+								Name: "listener",
+							},
+						},
+					},
+				}
+
+				parent := &konnectv1alpha1.EventGatewayListener{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "listener",
+						Namespace: "default",
+					},
+					Status: konnectv1alpha1.EventGatewayListenerStatus{
+						Conditions: []metav1.Condition{{
+							Type:               string(konnectv1alpha1.KonnectEntityProgrammedConditionType),
+							Status:             metav1.ConditionTrue,
+							Reason:             "Programmed",
+							ObservedGeneration: 1,
+							LastTransitionTime: metav1.Now(),
+						}},
+						KonnectEntityStatus: konnectv1alpha1.KonnectEntityStatus{ID: "listener-konnect-id"},
+					},
+				}
+
+				cl := fake.NewClientBuilder().
+					WithScheme(scheme.Get()).
+					WithStatusSubresource(ent).
+					WithObjects(ent, parent).
+					Build()
+
+				r := &KonnectEntityReconciler[
+					konnectv1alpha1.EventGatewayListenerPolicy, *konnectv1alpha1.EventGatewayListenerPolicy,
+				]{
+					Client: cl,
+				}
+
+				stop, res, err := r.handleGeneratedTypeReferences(t.Context(), ent)
+
+				require.NoError(t, err)
+				assert.False(t, stop)
+				assert.True(t, res.IsZero())
+
+				updated := &konnectv1alpha1.EventGatewayListenerPolicy{}
+				require.NoError(t, cl.Get(t.Context(), client.ObjectKeyFromObject(ent), updated))
+				assert.Equal(t, "listener-konnect-id", updated.GetEventGatewayListenerID())
+
+				cond, ok := k8sutils.GetCondition(
+					kcfgconsts.ConditionType(ent.GetStatusConditionTypeParentRefValid()),
+					updated,
+				)
+				require.True(t, ok)
+				assert.Equal(t, metav1.ConditionTrue, cond.Status)
+				assert.Equal(t, konnectv1alpha1.EventGatewayListenerRefReasonValid, cond.Reason)
+			},
+		},
+		{
+			name: "continues when event gateway parent ref is resolved",
+			run: func(t *testing.T) {
+				ent := &konnectv1alpha1.EventGatewayBackendCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "backend-cluster",
+						Namespace:  "default",
+						Generation: 1,
+					},
+					Spec: konnectv1alpha1.EventGatewayBackendClusterSpec{
+						GatewayRef: gatewayRef("event-gateway"),
+					},
+				}
+
+				parent := &konnectv1alpha1.KonnectEventGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "event-gateway",
+						Namespace: "default",
+					},
+					Status: konnectv1alpha1.KonnectEventGatewayStatus{
+						Conditions: []metav1.Condition{{
+							Type:               string(konnectv1alpha1.KonnectEntityProgrammedConditionType),
+							Status:             metav1.ConditionTrue,
+							Reason:             "Programmed",
+							ObservedGeneration: 1,
+							LastTransitionTime: metav1.Now(),
+						}},
+						KonnectEntityStatus: konnectv1alpha1.KonnectEntityStatus{ID: "gateway-konnect-id"},
+					},
+				}
+
+				cl := fake.NewClientBuilder().
+					WithScheme(scheme.Get()).
+					WithStatusSubresource(ent).
+					WithObjects(ent, parent).
+					Build()
+
+				r := &KonnectEntityReconciler[
+					konnectv1alpha1.EventGatewayBackendCluster, *konnectv1alpha1.EventGatewayBackendCluster,
+				]{Client: cl}
+
+				stop, res, err := r.handleGeneratedTypeReferences(t.Context(), ent)
+
+				require.NoError(t, err)
+				assert.False(t, stop)
+				assert.True(t, res.IsZero())
+
+				updated := &konnectv1alpha1.EventGatewayBackendCluster{}
+				require.NoError(t, cl.Get(t.Context(), client.ObjectKeyFromObject(ent), updated))
+				assert.Equal(t, "gateway-konnect-id", updated.GetGatewayID())
+
+				cond, ok := k8sutils.GetCondition(
+					kcfgconsts.ConditionType(ent.GetStatusConditionTypeParentRefValid()),
+					updated,
+				)
+				require.True(t, ok)
+				assert.Equal(t, metav1.ConditionTrue, cond.Status)
+				assert.Equal(t, konnectv1alpha1.EventGatewayRefReasonValid, cond.Reason)
+			},
+		},
+		{
+			name: "stops and requeues when event gateway parent is not programmed",
+			run: func(t *testing.T) {
+				ent := &konnectv1alpha1.EventGatewayBackendCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "backend-cluster",
+						Namespace:  "default",
+						Generation: 1,
+					},
+					Spec: konnectv1alpha1.EventGatewayBackendClusterSpec{
+						GatewayRef: gatewayRef("event-gateway"),
+					},
+				}
+
+				parent := &konnectv1alpha1.KonnectEventGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "event-gateway",
+						Namespace: "default",
+					},
+					Status: konnectv1alpha1.KonnectEventGatewayStatus{
+						Conditions: []metav1.Condition{{
+							Type:               string(konnectv1alpha1.KonnectEntityProgrammedConditionType),
+							Status:             metav1.ConditionFalse,
+							Reason:             "Pending",
+							ObservedGeneration: 1,
+							LastTransitionTime: metav1.Now(),
+						}},
+						KonnectEntityStatus: konnectv1alpha1.KonnectEntityStatus{ID: "gateway-konnect-id"},
+					},
+				}
+
+				cl := fake.NewClientBuilder().
+					WithScheme(scheme.Get()).
+					WithStatusSubresource(ent).
+					WithObjects(ent, parent).
+					Build()
+
+				r := &KonnectEntityReconciler[
+					konnectv1alpha1.EventGatewayBackendCluster, *konnectv1alpha1.EventGatewayBackendCluster,
+				]{Client: cl}
+
+				stop, res, err := r.handleGeneratedTypeReferences(t.Context(), ent)
+
+				require.NoError(t, err)
+				assert.True(t, stop)
+				assert.Greater(t, res.RequeueAfter, time.Duration(0))
+
+				updated := &konnectv1alpha1.EventGatewayBackendCluster{}
+				require.NoError(t, cl.Get(t.Context(), client.ObjectKeyFromObject(ent), updated))
+
+				cond, ok := k8sutils.GetCondition(
+					kcfgconsts.ConditionType(ent.GetStatusConditionTypeParentRefValid()),
+					updated,
+				)
+				require.True(t, ok)
+				assert.Equal(t, metav1.ConditionFalse, cond.Status)
+				assert.Equal(t, konnectv1alpha1.EventGatewayRefReasonNotProgrammed, cond.Reason)
+			},
+		},
+		{
+			name: "removes cleanup finalizer when portal parent does not exist",
+			run: func(t *testing.T) {
+				ent := &konnectv1alpha1.PortalPage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "portal-page",
+						Namespace:  "default",
+						Generation: 1,
+						Finalizers: []string{KonnectCleanupFinalizer},
+					},
+					Spec: konnectv1alpha1.PortalPageSpec{
+						PortalRef: portalRef("portal"),
+					},
+				}
+
+				cl := fake.NewClientBuilder().
+					WithScheme(scheme.Get()).
+					WithStatusSubresource(ent).
+					WithObjects(ent).
+					Build()
+
+				r := &KonnectEntityReconciler[
+					konnectv1alpha1.PortalPage, *konnectv1alpha1.PortalPage,
+				]{Client: cl}
+
+				stop, res, err := r.handleGeneratedTypeReferences(t.Context(), ent)
+
+				require.NoError(t, err)
+				assert.True(t, stop)
+				assert.True(t, res.IsZero())
+
+				updated := &konnectv1alpha1.PortalPage{}
+				require.NoError(t, cl.Get(t.Context(), client.ObjectKeyFromObject(ent), updated))
+				assert.Empty(t, updated.Finalizers)
+
+				cond, ok := k8sutils.GetCondition(
+					kcfgconsts.ConditionType(ent.GetStatusConditionTypeParentRefValid()),
+					updated,
+				)
+				require.True(t, ok)
+				assert.Equal(t, metav1.ConditionFalse, cond.Status)
+				assert.Equal(t, konnectv1alpha1.PortalRefReasonInvalid, cond.Reason)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, tc.run)
+	}
+}

--- a/controller/konnect/reconciler_generic_handle_parentref.go
+++ b/controller/konnect/reconciler_generic_handle_parentref.go
@@ -6,6 +6,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,6 +32,7 @@ type objectWithParentRef interface {
 	GetStatusConditionReasonParentRefValid() string
 	GetStatusConditionReasonParentRefInvalid() string
 	GetStatusConditionReasonParentRefNotProgrammed() string
+	GetParentGVK() schema.GroupVersionKind
 }
 
 func ensureKongReferenceGrantForParentRef[
@@ -109,6 +111,10 @@ type parentRefHandler[
 	ParentT parentT,
 	ParentTPtr parentTPtr[ParentT],
 ] struct{}
+
+func (prh parentRefHandler[p, pPTr]) parentTypeName() string {
+	return constraints.EntityTypeName[p]()
+}
 
 // handleParentRef handles the parent refercence for an entity.
 // It ensures that the referenced parent object exists, is programmed, and has a Konnect ID,

--- a/crd-from-oas/pkg/generator/generator.go
+++ b/crd-from-oas/pkg/generator/generator.go
@@ -1238,6 +1238,11 @@ func (g *Generator) generateCRDFuncs(name string, schema *parser.Schema) (string
 	if rootRefDependency != nil && g.objectRefImported() {
 		imports = appendUniqueImportConfig(imports, g.config.CommonTypes.ObjectRef.Import)
 	}
+	if rootRefDependency != nil {
+		imports = appendUniqueImportConfig(imports, &config.ImportConfig{
+			Path: "k8s.io/apimachinery/pkg/runtime/schema",
+		})
+	}
 	if isReconcilerRoot {
 		imports = appendUniqueImportConfig(imports, &config.ImportConfig{
 			Alias: defaultKonnectStatusAlias,
@@ -1261,6 +1266,7 @@ func (g *Generator) generateCRDFuncs(name string, schema *parser.Schema) (string
 		RefConditionPrefix                 string
 		IsReconcilerRoot                   bool
 		KonnectAPIAuthConfigurationRefType string
+		ParentKind                         string
 	}{
 		EntityName:                entityName,
 		APIVersion:                g.config.APIVersion,
@@ -1279,6 +1285,15 @@ func (g *Generator) generateCRDFuncs(name string, schema *parser.Schema) (string
 		}(),
 		IsReconcilerRoot:                   isReconcilerRoot,
 		KonnectAPIAuthConfigurationRefType: defaultKonnectStatusAlias + ".ControlPlaneKonnectAPIAuthConfigurationRef",
+		ParentKind: func() string {
+			if rootRefDependency == nil {
+				return ""
+			}
+			if rc := g.config.ReconcilerConfig[entityName]; rc != nil && rc.ParentEntityType != "" {
+				return rc.ParentEntityType
+			}
+			return refConditionEntityName(rootRefDependency)
+		}(),
 	}
 
 	if err := tmpl.Execute(&buf, data); err != nil {

--- a/crd-from-oas/pkg/generator/templates.go
+++ b/crd-from-oas/pkg/generator/templates.go
@@ -216,6 +216,11 @@ func (obj {{.EntityName}}) GetTypeName() string {
 	return "{{.EntityName}}"
 }
 
+// HasParent returns true if the {{.EntityName}} has a parent entity.
+func (obj {{.EntityName}}) HasParent() bool {
+	return {{if .RootRefDependency}}true{{else}}false{{end}}
+}
+
 // GetConditions returns the Status Conditions.
 func (obj *{{.EntityName}}) GetConditions() []metav1.Condition {
 	return obj.Status.Conditions
@@ -269,6 +274,11 @@ func (obj *{{.EntityName}}) GetParentRef() {{.RootRefTypeName}} {
 // SetParentID sets the Konnect ID of the immediate parent entity.
 func (obj *{{.EntityName}}) SetParentID(id string) {
 	obj.Set{{.RootRefDependency.EntityName}}ID(id)
+}
+
+// GetParentGVK returns the GroupVersionKind of the parent entity.
+func (obj *{{.EntityName}}) GetParentGVK() schema.GroupVersionKind {
+	return GroupVersion.WithKind("{{.ParentKind}}")
 }
 
 // GetStatusConditionTypeParentRefValid returns the status condition type


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix generic parent ref handling by adding necessary functions to CRD types:

- `HasParent() bool` returning `true` for types that have parents
- `GetParentGVK() schema.GroupVersionKind` which are attached to all non root objects

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
