### PR TITLE
chore(hack): use getconf for CPU count in update-k8sio-gomod-replace.sh

### DIFF
--- a/hack/update-k8sio-gomod-replace.sh
+++ b/hack/update-k8sio-gomod-replace.sh
@@ -11,8 +11,8 @@ MODS=($(
     sed -n 's|.*k8s.io/\(.*\) => ./staging/src/k8s.io/.*|k8s.io/\1|p'
 ))
 
-# Set concurrency level to the number of available CPU cores
-CONCURRENCY=$(nproc)
+# Set concurrency level to the number of available CPU cores (portable across Linux/macOS).
+CONCURRENCY=$(getconf _NPROCESSORS_ONLN)
 export VERSION
 
 # Create an empty array to store replace directives


### PR DESCRIPTION


**What this PR does / why we need it**:

`nproc` is GNU coreutils-only and absent on macOS, breaking the script locally for developers on Mac. Switch to `getconf _NPROCESSORS_ONLN`, which is available on both Linux (glibc) and macOS.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
