### PR TITLE
fix: redact plugin config when controlplane dump sensitive isn't set (#4119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
 - Fix endless reconciliation in Konnect controllers when referenced parent objects
   are not marked as Ready yet.
   [#4048](https://github.com/Kong/kong-operator/pull/4048) [#4060](https://github.com/Kong/kong-operator/pull/4060)
+- Sanitize the plugin configuration when `ControlPlane`'s `configDump.dumpSensitive` isn't enabled.
+  [#4119](https://github.com/Kong/kong-operator/pull/4119) [#4194](https://github.com/Kong/kong-operator/pull/4194)
 
 ## [v2.1.5]
 

--- a/ingress-controller/internal/dataplane/kongstate/kongstate.go
+++ b/ingress-controller/internal/dataplane/kongstate/kongstate.go
@@ -79,7 +79,14 @@ func (ks *KongState) SanitizedCopy(uuidGenerator util.UUIDGenerator) *KongState 
 			})
 		}(),
 		CACertificates: ks.CACertificates,
-		Plugins:        ks.Plugins,
+		Plugins: func() []Plugin {
+			if ks.Plugins == nil {
+				return nil
+			}
+			return lo.Map(ks.Plugins, func(p Plugin, _ int) Plugin {
+				return p.SanitizedCopy()
+			})
+		}(),
 		Consumers: func() []Consumer {
 			if ks.Consumers == nil {
 				return nil

--- a/ingress-controller/internal/dataplane/kongstate/kongstate_test.go
+++ b/ingress-controller/internal/dataplane/kongstate/kongstate_test.go
@@ -110,7 +110,7 @@ func TestKongState_SanitizedCopy(t *testing.T) {
 				Upstreams:      []Upstream{{Upstream: kong.Upstream{ID: kong.String("1")}}},
 				Certificates:   []Certificate{{Certificate: kong.Certificate{ID: kong.String("1"), Key: redactedString}}},
 				CACertificates: []kong.CACertificate{{ID: kong.String("1")}},
-				Plugins:        []Plugin{{Plugin: kong.Plugin{ID: kong.String("1"), Config: map[string]any{"key": "secret"}}}}, // We don't redact plugins' config.
+				Plugins:        []Plugin{{Plugin: kong.Plugin{ID: kong.String("1"), Config: map[string]any{"key": "{REDACTED}"}}}},
 				Consumers: []Consumer{
 					{
 						KeyAuths: []*KeyAuth{

--- a/ingress-controller/internal/dataplane/kongstate/plugin.go
+++ b/ingress-controller/internal/dataplane/kongstate/plugin.go
@@ -353,3 +353,12 @@ type PluginRelatedEntitiesRefs struct {
 	RelatedEntities      map[string]RelatedEntitiesRef
 	RouteAttachedService map[string]*Service
 }
+
+func (p *Plugin) SanitizedCopy() Plugin {
+	sanitized := p.DeepCopy()
+	// Replace all config values with a redaction marker.
+	for k := range sanitized.Config {
+		sanitized.Config[k] = "{REDACTED}"
+	}
+	return sanitized
+}

--- a/ingress-controller/internal/dataplane/kongstate/plugin_test.go
+++ b/ingress-controller/internal/dataplane/kongstate/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/kong/go-kong/kong"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -761,6 +762,161 @@ func TestKongPluginFromK8SPlugin(t *testing.T) {
 			got.Tags = nil
 			assert.Equal(tt.want, got.Plugin)
 			assert.NotEmpty(t, got.K8sParent)
+		})
+	}
+}
+
+func TestPluginSanitizedCopy(t *testing.T) {
+	parent := &configurationv1.KongPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "plugin-parent",
+			Namespace: "default",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		in        Plugin
+		want      Plugin
+		postCheck func(t *testing.T, in Plugin, got Plugin)
+	}{
+		{
+			name: "redacts all top level config values and preserves other fields",
+			in: Plugin{
+				Plugin: kong.Plugin{
+					ID:           lo.ToPtr("plugin-id"),
+					Name:         lo.ToPtr("rate-limiting"),
+					InstanceName: lo.ToPtr("instance-name"),
+					RunOn:        lo.ToPtr("first"),
+					Enabled:      lo.ToPtr(false),
+					Protocols:    kong.StringSlice("http", "https"),
+					Tags:         []*string{lo.ToPtr("tag-1"), lo.ToPtr("tag-2")},
+					Ordering: &kong.PluginOrdering{
+						Before: map[string][]string{
+							"access": {"key-auth"},
+						},
+					},
+					Config: kong.Configuration{
+						"string":  "secret",
+						"number":  123,
+						"boolean": true,
+						"object": map[string]any{
+							"nested": "secret",
+						},
+						"array": []any{"first", "second"},
+						"null":  nil,
+					},
+				},
+				K8sParent: parent,
+			},
+			want: Plugin{
+				Plugin: kong.Plugin{
+					ID:           lo.ToPtr("plugin-id"),
+					Name:         lo.ToPtr("rate-limiting"),
+					InstanceName: lo.ToPtr("instance-name"),
+					RunOn:        lo.ToPtr("first"),
+					Enabled:      lo.ToPtr(false),
+					Protocols:    kong.StringSlice("http", "https"),
+					Tags:         []*string{lo.ToPtr("tag-1"), lo.ToPtr("tag-2")},
+					Ordering: &kong.PluginOrdering{
+						Before: map[string][]string{
+							"access": {"key-auth"},
+						},
+					},
+					Config: kong.Configuration{
+						"string":  "{REDACTED}",
+						"number":  "{REDACTED}",
+						"boolean": "{REDACTED}",
+						"object":  "{REDACTED}",
+						"array":   "{REDACTED}",
+						"null":    "{REDACTED}",
+					},
+				},
+				K8sParent: parent,
+			},
+			postCheck: func(t *testing.T, in Plugin, got Plugin) {
+				assert.Equal(t, "secret", in.Config["string"])
+				assert.Equal(t, 123, in.Config["number"])
+				assert.Equal(t, true, in.Config["boolean"])
+				assert.Equal(t, map[string]any{"nested": "secret"}, in.Config["object"])
+				assert.Equal(t, []any{"first", "second"}, in.Config["array"])
+				assert.Nil(t, in.Config["null"])
+				assert.Same(t, in.K8sParent, got.K8sParent)
+			},
+		},
+		{
+			name: "keeps nil config nil",
+			in: Plugin{
+				Plugin: kong.Plugin{
+					Name: lo.ToPtr("key-auth"),
+				},
+			},
+			want: Plugin{
+				Plugin: kong.Plugin{
+					Name: lo.ToPtr("key-auth"),
+				},
+			},
+			postCheck: func(t *testing.T, in Plugin, got Plugin) {
+				assert.Nil(t, in.Config)
+				assert.Nil(t, got.Config)
+			},
+		},
+		{
+			name: "returns an isolated config map copy",
+			in: Plugin{
+				Plugin: kong.Plugin{
+					Name: lo.ToPtr("request-transformer"),
+					Config: kong.Configuration{
+						"add": "sensitive",
+					},
+				},
+			},
+			want: Plugin{
+				Plugin: kong.Plugin{
+					Name: lo.ToPtr("request-transformer"),
+					Config: kong.Configuration{
+						"add": "{REDACTED}",
+					},
+				},
+			},
+			postCheck: func(t *testing.T, in Plugin, got Plugin) {
+				got.Config["add"] = "changed"
+				got.Config["new"] = "new-value"
+				assert.Equal(t, "sensitive", in.Config["add"])
+				_, exists := in.Config["new"]
+				assert.False(t, exists)
+			},
+		},
+		{
+			name: "keeps empty config empty",
+			in: Plugin{
+				Plugin: kong.Plugin{
+					Name:   lo.ToPtr("cors"),
+					Config: kong.Configuration{},
+				},
+			},
+			want: Plugin{
+				Plugin: kong.Plugin{
+					Name:   lo.ToPtr("cors"),
+					Config: kong.Configuration{},
+				},
+			},
+			postCheck: func(t *testing.T, in Plugin, got Plugin) {
+				assert.Empty(t, in.Config)
+				assert.Empty(t, got.Config)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.in.SanitizedCopy()
+
+			assert.Equal(t, tt.want, got)
+
+			if tt.postCheck != nil {
+				tt.postCheck(t, tt.in, got)
+			}
 		})
 	}
 }


### PR DESCRIPTION
(cherry picked from commit 604beae0f9b81eb1e34c172445a34cd47b0b53da)

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
