### PR TITLE
chore: implement MapErr and get rid of github.com/sourcegraph/conc/iter dependency

### DIFF
--- a/controller/konnect/ops/ops_controlplane.go
+++ b/controller/konnect/ops/ops_controlplane.go
@@ -8,13 +8,13 @@ import (
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
-	"github.com/sourcegraph/conc/iter"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
+	"github.com/kong/kong-operator/v2/internal/iter"
 )
 
 // ensureControlPlane ensures that the Konnect ControlPlane exists in Konnect. It is created

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/prometheus/common v0.67.5
 	github.com/samber/lo v1.53.0
 	github.com/samber/mo v1.16.0
-	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8
 	github.com/stretchr/testify v1.11.1
 	// TODO: update to v0.42.0 or v0.41.2 when they are released.
 	// This version will include the migration from github.com/docker/docker to github.com/moby/moby,

--- a/go.sum
+++ b/go.sum
@@ -537,8 +537,6 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
-github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 h1:+jumHNA0Wrelhe64i8F6HNlS8pkoyMv5sreGx2Ry5Rw=
-github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8/go.mod h1:3n1Cwaq1E1/1lhQhtRK2ts/ZwZEhjcQeJQ1RuC6Q/8U=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/ingress-controller/internal/dataplane/kong_client.go
+++ b/ingress-controller/internal/dataplane/kong_client.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kong/go-kong/kong"
 	"github.com/samber/lo"
 	"github.com/samber/mo"
-	"github.com/sourcegraph/conc/iter"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,6 +40,7 @@ import (
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/util"
 	k8sobj "github.com/kong/kong-operator/v2/ingress-controller/internal/util/kubernetes/object"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/util/kubernetes/object/status"
+	"github.com/kong/kong-operator/v2/internal/iter"
 )
 
 const (

--- a/internal/iter/maperr.go
+++ b/internal/iter/maperr.go
@@ -1,0 +1,39 @@
+package iter
+
+import (
+	"errors"
+	"sync"
+)
+
+// MapErr is a concurrent version of Map that allows the mapping function to
+// return an error.
+// If one or more mapping operations return an error, MapErr returns the
+// successfully mapped results along with a joined error containing all mapping
+// errors. The returned results are ordered by completion time and may differ
+// from the input order.
+func MapErr[T, R any](
+	input []T,
+	f func(*T) (R, error),
+) ([]R, error) {
+	var wg sync.WaitGroup
+	var errs []error
+	var muErrs, muMembers sync.Mutex
+	out := make([]R, 0, len(input))
+	for i := range input {
+		entry := &input[i]
+		wg.Go(func() {
+			res, err := f(entry)
+			if err != nil {
+				muErrs.Lock()
+				errs = append(errs, err)
+				muErrs.Unlock()
+				return
+			}
+			muMembers.Lock()
+			out = append(out, res)
+			muMembers.Unlock()
+		})
+	}
+	wg.Wait()
+	return out, errors.Join(errs...)
+}

--- a/internal/iter/maperr_test.go
+++ b/internal/iter/maperr_test.go
@@ -1,0 +1,142 @@
+package iter
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapErr(t *testing.T) {
+	type result struct {
+		values []string
+		err    error
+	}
+
+	errTwo := errors.New("two")
+	errFour := errors.New("four")
+
+	tests := []struct {
+		name     string
+		call     func(t *testing.T) result
+		want     []string
+		wantErrs []error
+	}{
+		{
+			name: "returns empty output for empty input",
+			call: func(t *testing.T) result {
+				got, err := MapErr([]int{}, func(value *int) (string, error) {
+					return fmt.Sprintf("value-%d", *value), nil
+				})
+				return result{values: got, err: err}
+			},
+			want: []string{},
+		},
+		{
+			name: "waits for all mappings and returns successful results",
+			call: func(t *testing.T) result {
+				input := []int{1, 2, 3}
+				release := make(chan struct{})
+				started := make(chan struct{}, len(input))
+				done := make(chan result, 1)
+
+				go func() {
+					got, err := MapErr(input, func(value *int) (string, error) {
+						started <- struct{}{}
+						<-release
+						return fmt.Sprintf("value-%d", *value), nil
+					})
+					done <- result{values: got, err: err}
+				}()
+
+				for range input {
+					select {
+					case <-started:
+					case <-time.After(time.Second):
+						t.Fatal("timed out waiting for mapper to start")
+					}
+				}
+
+				close(release)
+
+				select {
+				case res := <-done:
+					return res
+				case <-time.After(time.Second):
+					t.Fatal("MapErr did not wait for all mappers to finish")
+					return result{}
+				}
+			},
+			want: []string{"value-1", "value-2", "value-3"},
+		},
+		{
+			name: "joins mapper errors and keeps successful results",
+			call: func(t *testing.T) result {
+				got, err := MapErr([]int{1, 2, 3, 4}, func(value *int) (string, error) {
+					switch *value {
+					case 2:
+						return "", errTwo
+					case 4:
+						return "", errFour
+					default:
+						return fmt.Sprintf("value-%d", *value), nil
+					}
+				})
+				return result{values: got, err: err}
+			},
+			want:     []string{"value-1", "value-3"},
+			wantErrs: []error{errTwo, errFour},
+		},
+		{
+			name: "passes a stable pointer for each input element",
+			call: func(t *testing.T) result {
+				input := []int{1, 2, 3}
+				var (
+					mu       sync.Mutex
+					ptrAddrs []string
+				)
+
+				got, err := MapErr(input, func(value *int) (string, error) {
+					mu.Lock()
+					ptrAddrs = append(ptrAddrs, fmt.Sprintf("%p", value))
+					mu.Unlock()
+					return fmt.Sprintf("value-%d", *value), nil
+				})
+
+				require.NoError(t, err)
+				require.Len(t, ptrAddrs, len(input))
+
+				seen := make(map[string]struct{}, len(ptrAddrs))
+				for _, ptrAddr := range ptrAddrs {
+					seen[ptrAddr] = struct{}{}
+				}
+				require.Len(t, seen, len(input), "each mapper call should receive a pointer to a distinct input element")
+
+				return result{values: got, err: err}
+			},
+			want: []string{"value-1", "value-2", "value-3"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res := tc.call(t)
+
+			assert.ElementsMatch(t, tc.want, res.values)
+
+			if len(tc.wantErrs) == 0 {
+				require.NoError(t, res.err)
+				return
+			}
+
+			require.Error(t, res.err)
+			for _, wantErr := range tc.wantErrs {
+				require.ErrorIs(t, res.err, wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Get rid of `github.com/sourcegraph/conc/iter` by implementing the MapErr in tree.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
