### PR TITLE
feat(gateway): add support for on-prem TCPRoute

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,9 @@
 [settings.github]
 github_attestations = false
 
+[tools]
+node = "latest"
+
 ################################################################################
 # Tools
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@
 
 - EventGateway CRDs: added `EventGatewaySchemaRegistry` CRD and reconciliation logic.
   [#5017](https://github.com/Kong/kong-operator/pull/5017)
+- Gateway: Support `TCPRoute` for on-prem gateways.
+  [#4207](https://github.com/Kong/kong-operator/pull/4207)
 
 ### Changed
 

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	kcfgconsts "github.com/kong/kong-operator/v2/api/common/consts"
@@ -131,6 +132,14 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 		Watches(
 			&gatewayv1.HTTPRoute{},
 			handler.EnqueueRequestsFromMapFunc(r.listGatewaysAttachedByHTTPRoute),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(
+			&gatewayv1.TLSRoute{},
+			handler.EnqueueRequestsFromMapFunc(r.listGatewaysAttachedByTLSRoute),
+		).
+		Watches(
+			&gatewayv1alpha2.TCPRoute{},
+			handler.EnqueueRequestsFromMapFunc(r.listGatewaysAttachedByTCPRoute),
 			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		// watch Namespaces so that managed routes have correct status reflected in Gateway's
 		// status in status.listeners.attachedRoutes

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -216,8 +216,8 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 	}
 
 	tcpRouteGVR := schema.GroupVersionResource{
-		Group:    gatewayv1alpha2.GroupName,
-		Version:  gatewayv1alpha2.GroupVersion.Version,
+		Group:    gatewayv1.GroupName,
+		Version:  gatewayv1.GroupVersion.Version,
 		Resource: "tcproutes",
 	}
 	tcpRouteExist, err := crdChecker.CRDExists(tcpRouteGVR)

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -132,10 +132,6 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 			&gatewayv1.HTTPRoute{},
 			handler.EnqueueRequestsFromMapFunc(r.listGatewaysAttachedByHTTPRoute),
 			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(
-			&gatewayv1.TLSRoute{},
-			handler.EnqueueRequestsFromMapFunc(r.listGatewaysAttachedByTLSRoute),
-		).
 		// watch Namespaces so that managed routes have correct status reflected in Gateway's
 		// status in status.listeners.attachedRoutes
 		// This is required to properly support Gateway's listeners.allowedRoutes.namespaces.selector.

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	kcfgconsts "github.com/kong/kong-operator/v2/api/common/consts"
@@ -226,7 +225,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 	}
 	if tcpRouteExist {
 		blder.Watches(
-			&gatewayv1alpha2.TCPRoute{},
+			&gatewayv1.TCPRoute{},
 			handler.EnqueueRequestsFromMapFunc(r.listGatewaysAttachedByTCPRoute),
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		)

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -137,10 +137,6 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 			&gatewayv1.TLSRoute{},
 			handler.EnqueueRequestsFromMapFunc(r.listGatewaysAttachedByTLSRoute),
 		).
-		Watches(
-			&gatewayv1alpha2.TCPRoute{},
-			handler.EnqueueRequestsFromMapFunc(r.listGatewaysAttachedByTCPRoute),
-			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		// watch Namespaces so that managed routes have correct status reflected in Gateway's
 		// status in status.listeners.attachedRoutes
 		// This is required to properly support Gateway's listeners.allowedRoutes.namespaces.selector.
@@ -217,6 +213,23 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 		)
 	} else {
 		log.Info(mgr.GetLogger(), "UDPRoute CRD not found in cluster, skipping watch for UDPRoute resources")
+	}
+
+	tcpRouteGVR := schema.GroupVersionResource{
+		Group:    gatewayv1alpha2.GroupName,
+		Version:  gatewayv1alpha2.GroupVersion.Version,
+		Resource: "tcproutes",
+	}
+	tcpRouteExist, err := crdChecker.CRDExists(tcpRouteGVR)
+	if err != nil {
+		return err
+	}
+	if tcpRouteExist {
+		blder.Watches(
+			&gatewayv1alpha2.TCPRoute{},
+			handler.EnqueueRequestsFromMapFunc(r.listGatewaysAttachedByTCPRoute),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		)
 	}
 
 	// Watch Secrets to requeue Gateways that reference them via listeners.tls.certificateRefs.

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -1390,7 +1390,7 @@ func setDataPlaneDeploymentListenPorts(
 			// Also re-assign a port if known ports (<1024) are used because we usually cannot listen on those port on Kong DP.
 			assignStreamPort(i, portNumber)
 			streamPorts = append(streamPorts, streamListenPort{
-				kongPort: listenerPortToKongListenPort[portNumber],
+				kongPort: portNumber,
 				protocol: gatewayv1.TLSProtocolType,
 			})
 		case gatewayv1.UDPProtocolType:
@@ -1399,6 +1399,13 @@ func setDataPlaneDeploymentListenPorts(
 			streamPorts = append(streamPorts, streamListenPort{
 				kongPort: listenerPortToKongListenPort[portNumber],
 				protocol: gatewayv1.UDPProtocolType,
+			})
+		case gatewayv1.TCPProtocolType:
+			portNumber := int(l.Port)
+			assignStreamPort(int(l.Port), portNumber)
+			streamPorts = append(streamPorts, streamListenPort{
+				kongPort: portNumber,
+				protocol: gatewayv1.TCPProtocolType,
 			})
 		default:
 			errs = errors.Join(errs, fmt.Errorf("listener %d uses unsupported protocol %s", i, l.Protocol))

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -1189,17 +1189,13 @@ func countAttachedUDPRoutes(gateway *gwtypes.Gateway, listener gwtypes.Listener,
 // taking into account the ParentRefs' sectionName between the listener and the route.
 // TCPRoute has no hostnames, so only sectionName matching applies.
 func countAttachedTCPRoutes(listener gwtypes.Listener, tcpRoutes []gatewayv1.TCPRoute) int32 {
-	var count int32
-
-	for _, tcpRoute := range tcpRoutes {
-		if lo.ContainsBy(tcpRoute.Spec.ParentRefs, func(parentRef gatewayv1.ParentReference) bool {
-			return parentRef.SectionName == nil || *parentRef.SectionName == listener.Name
-		}) {
-			count++
-		}
-	}
-
-	return count
+	count := lo.CountBy(tcpRoutes, func(r gatewayv1.TCPRoute) bool {
+		return lo.ContainsBy(r.Spec.ParentRefs, func(parentRef gatewayv1.ParentReference) bool {
+			return parentRef.SectionName == nil || *parentRef.SectionName == listener.Name &&
+				(parentRef.Port == nil || *parentRef.Port == listener.Port)
+		})
+	})
+	return int32(count)
 }
 
 func listenerHostnameIntersectsRouteHostnames(
@@ -1386,11 +1382,9 @@ func setDataPlaneDeploymentListenPorts(
 			portNumber := int(l.Port)
 			// TODO: support multiple listeners using the same port:
 			// https://github.com/Kong/kong-operator/issues/3511
-			// Assign another port if the listener's port is already allocated on Kong DP.
-			// Also re-assign a port if known ports (<1024) are used because we usually cannot listen on those port on Kong DP.
 			assignStreamPort(i, portNumber)
 			streamPorts = append(streamPorts, streamListenPort{
-				kongPort: portNumber,
+				kongPort: listenerPortToKongListenPort[portNumber],
 				protocol: gatewayv1.TLSProtocolType,
 			})
 		case gatewayv1.UDPProtocolType:
@@ -1402,9 +1396,9 @@ func setDataPlaneDeploymentListenPorts(
 			})
 		case gatewayv1.TCPProtocolType:
 			portNumber := int(l.Port)
-			assignStreamPort(int(l.Port), portNumber)
+			assignStreamPort(i, portNumber)
 			streamPorts = append(streamPorts, streamListenPort{
-				kongPort: portNumber,
+				kongPort: listenerPortToKongListenPort[portNumber],
 				protocol: gatewayv1.TCPProtocolType,
 			})
 		default:

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -687,12 +687,19 @@ func generateDataPlaneNetworkPolicy(
 		if err != nil {
 			return nil, fmt.Errorf("failed parsing KONG_STREAM_LISTEN env: %w", err)
 		}
-		streamListenPorts = lo.Map(kongListenConfig.SSLEndpoints, func(ep *proxyListenEndpoint, _ int) intstr.IntOrString {
-			return intstr.FromInt(ep.Port)
-		})
 		streamUDPListenPorts = lo.Map(kongListenConfig.UDPEndpoints, func(ep *proxyListenEndpoint, _ int) intstr.IntOrString {
 			return intstr.FromInt(ep.Port)
 		})
+		// Include both plain-TCP entries (TCPRoute) and SSL entries (TLSRoute) — the
+		// NetworkPolicy must allow ingress on every port Kong is listening on for stream.
+		streamListenPorts = append(
+			lo.Map(kongListenConfig.Endpoints, func(ep *proxyListenEndpoint, _ int) intstr.IntOrString {
+				return intstr.FromInt(ep.Port)
+			}),
+			lo.Map(kongListenConfig.SSLEndpoints, func(ep *proxyListenEndpoint, _ int) intstr.IntOrString {
+				return intstr.FromInt(ep.Port)
+			})...,
+		)
 	}
 
 	// Construct the policy to allow the KO pod to access DataPlane admin APIs.

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -1191,7 +1191,7 @@ func countAttachedUDPRoutes(gateway *gwtypes.Gateway, listener gwtypes.Listener,
 func countAttachedTCPRoutes(listener gwtypes.Listener, tcpRoutes []gatewayv1.TCPRoute) int32 {
 	count := lo.CountBy(tcpRoutes, func(r gatewayv1.TCPRoute) bool {
 		return lo.ContainsBy(r.Spec.ParentRefs, func(parentRef gatewayv1.ParentReference) bool {
-			return parentRef.SectionName == nil || *parentRef.SectionName == listener.Name &&
+			return (parentRef.SectionName == nil || *parentRef.SectionName == listener.Name) &&
 				(parentRef.Port == nil || *parentRef.Port == listener.Port)
 		})
 	})

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kcfgconsts "github.com/kong/kong-operator/v2/api/common/consts"
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
@@ -852,9 +853,8 @@ func supportedRoutesByProtocol() map[gatewayv1.ProtocolType]map[gatewayv1.Kind]s
 		gatewayv1.HTTPProtocolType:  {"HTTPRoute": {}, "GRPCRoute": {}},
 		gatewayv1.HTTPSProtocolType: {"HTTPRoute": {}, "GRPCRoute": {}},
 		gatewayv1.TLSProtocolType:   {"TLSRoute": {}},
+		gatewayv1.TCPProtocolType:   {"TCPRoute": {}},
 		gatewayv1.UDPProtocolType:   {"UDPRoute": {}},
-		// TCPRoutes are not supported yet
-		// gatewayv1.TCPProtocolType:   {"TCPRoute": {}},
 	}
 }
 
@@ -1100,6 +1100,15 @@ func countAttachedRoutesForGatewayListener(ctx context.Context, g *gwtypes.Gatew
 				)
 			}
 			count += countAttachedUDPRoutes(g, listener, udpRoutes)
+		case "TCPRoute":
+			tcpRoutes, err := gatewayutils.ListTCPRoutesForGateway(ctx, cl, g, opts...)
+			if err != nil {
+				return 0, fmt.Errorf(
+					"failed to list TCPRoutes for Gateway %s when counting AttachedRoutes: %w",
+					client.ObjectKeyFromObject(g), err,
+				)
+			}
+			count += countAttachedTCPRoutes(listener, tcpRoutes)
 		// Unsupported route kinds. Should be unreachable.
 		default:
 			return 0, fmt.Errorf("unsupported route kind: %s", k)
@@ -1168,6 +1177,23 @@ func countAttachedUDPRoutes(gateway *gwtypes.Gateway, listener gwtypes.Listener,
 		})
 	})
 	return int32(count)
+}
+
+// countAttachedTCPRoutes counts the number of attached TCPRoutes for a given listener,
+// taking into account the ParentRefs' sectionName between the listener and the route.
+// TCPRoute has no hostnames, so only sectionName matching applies.
+func countAttachedTCPRoutes(listener gwtypes.Listener, tcpRoutes []gatewayv1alpha2.TCPRoute) int32 {
+	var count int32
+
+	for _, tcpRoute := range tcpRoutes {
+		if lo.ContainsBy(tcpRoute.Spec.ParentRefs, func(parentRef gatewayv1.ParentReference) bool {
+			return parentRef.SectionName == nil || *parentRef.SectionName == listener.Name
+		}) {
+			count++
+		}
+	}
+
+	return count
 }
 
 func listenerHostnameIntersectsRouteHostnames(
@@ -1486,7 +1512,7 @@ func setDataPlaneIngressServicePorts(
 			port.TargetPort = intstr.FromInt(consts.DataPlaneProxySSLPort)
 		case gatewayv1.HTTPProtocolType:
 			port.TargetPort = intstr.FromInt(consts.DataPlaneProxyPort)
-		case gatewayv1.TLSProtocolType:
+		case gatewayv1.TLSProtocolType, gatewayv1.TCPProtocolType:
 			targetPort, ok := servicePortMap[int(l.Port)]
 			if !ok {
 				errs = errors.Join(errs, fmt.Errorf("no target port assigned listener %s on port %d", l.Name, l.Port))

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kcfgconsts "github.com/kong/kong-operator/v2/api/common/consts"
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
@@ -1182,7 +1181,7 @@ func countAttachedUDPRoutes(gateway *gwtypes.Gateway, listener gwtypes.Listener,
 // countAttachedTCPRoutes counts the number of attached TCPRoutes for a given listener,
 // taking into account the ParentRefs' sectionName between the listener and the route.
 // TCPRoute has no hostnames, so only sectionName matching applies.
-func countAttachedTCPRoutes(listener gwtypes.Listener, tcpRoutes []gatewayv1alpha2.TCPRoute) int32 {
+func countAttachedTCPRoutes(listener gwtypes.Listener, tcpRoutes []gatewayv1.TCPRoute) int32 {
 	var count int32
 
 	for _, tcpRoute := range tcpRoutes {

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -933,7 +933,75 @@ func TestSetDataPlaneDeploymentListenPorts(t *testing.T) {
 					Port:     gatewayv1.PortNumber(8888),
 				},
 			},
-			expectedError: errors.New("listener 2 uses unsupported protocol TCP"),
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "KONG_PORT_MAPS",
+					Value: "80:8000,443:8443,8888:8888",
+				},
+				{
+					// TCP listener: stream entry without `ssl`.
+					Name:  "KONG_STREAM_LISTEN",
+					Value: "0.0.0.0:8888 reuseport",
+				},
+			},
+			expectedPortMap: map[int]int{
+				80:   8000,
+				443:  8443,
+				8888: 8888,
+			},
+		},
+		{
+			name: "TCP listener uses known port (reassigned)",
+			listeners: []gwtypes.Listener{
+				{
+					Name:     "tcp",
+					Protocol: gatewayv1.TCPProtocolType,
+					Port:     gatewayv1.PortNumber(80),
+				},
+			},
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "KONG_PORT_MAPS",
+					Value: "80:16384",
+				},
+				{
+					Name:  "KONG_STREAM_LISTEN",
+					Value: "0.0.0.0:16384 reuseport",
+				},
+			},
+			expectedPortMap: map[int]int{
+				80: 16384,
+			},
+		},
+		{
+			name: "TCP and TLS listeners co-exist on stream proxy",
+			listeners: []gwtypes.Listener{
+				{
+					Name:     "tcp",
+					Protocol: gatewayv1.TCPProtocolType,
+					Port:     gatewayv1.PortNumber(9000),
+				},
+				{
+					Name:     "tls",
+					Protocol: gatewayv1.TLSProtocolType,
+					Port:     gatewayv1.PortNumber(9443),
+				},
+			},
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "KONG_PORT_MAPS",
+					Value: "9000:9000,9443:9443",
+				},
+				{
+					// TCP entries first (sorted), then TLS entries with `ssl`.
+					Name:  "KONG_STREAM_LISTEN",
+					Value: "0.0.0.0:9000 reuseport,0.0.0.0:9443 ssl reuseport",
+				},
+			},
+			expectedPortMap: map[int]int{
+				9000: 9000,
+				9443: 9443,
+			},
 		},
 	}
 
@@ -1327,6 +1395,25 @@ func TestGetSupportedKindsWithResolvedRefsCondition(t *testing.T) {
 				{
 					Group: (*gwtypes.Group)(&gatewayv1.GroupVersion.Group),
 					Kind:  "UDPRoute",
+				},
+			},
+			expectedResolvedRefsCondition: metav1.Condition{
+				Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+				Status:             metav1.ConditionTrue,
+				Reason:             string(gatewayv1.ListenerReasonResolvedRefs),
+				Message:            "Listeners' references are accepted.",
+				ObservedGeneration: generation,
+			},
+		},
+		{
+			name: "no tls, TCP protocol, no allowed routes",
+			listener: gwtypes.Listener{
+				Protocol: gatewayv1.TCPProtocolType,
+			},
+			expectedSupportedKinds: []gwtypes.RouteGroupKind{
+				{
+					Group: (*gwtypes.Group)(&gatewayv1.GroupVersion.Group),
+					Kind:  "TCPRoute",
 				},
 			},
 			expectedResolvedRefsCondition: metav1.Condition{
@@ -4964,8 +5051,8 @@ func TestSetAcceptedAndAttachedRoutes(t *testing.T) {
 			name: "single listener with unsupported protocol is not accepted",
 			listeners: []gwtypes.Listener{
 				{
-					Name:          "tcp",
-					Protocol:      gatewayv1.TCPProtocolType,
+					Name:          "unsupported",
+					Protocol:      gatewayv1.ProtocolType("UnsupportedProtocol"),
 					Port:          80,
 					AllowedRoutes: allowedRoutesFromSame,
 				},

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -4979,6 +4979,60 @@ func TestGenerateDataPlaneNetworkPolicy(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Regression test for the on-prem TCPRoute path: a KONG_STREAM_LISTEN
+			// entry without the `ssl` flag must be reflected in the DP NetworkPolicy
+			// too, otherwise metallb-routed TCP traffic to the DP pod is dropped and
+			// EchoResponds times out (see CI failure ktf-diag-440076529).
+			name: "dataplane with plain-TCP stream listen",
+			proxyContainerOptions: func(c *corev1.Container) {
+				c.Env = append(c.Env, corev1.EnvVar{
+					Name:  "KONG_STREAM_LISTEN",
+					Value: "0.0.0.0:8888 reuseport",
+				})
+			},
+			expectedIngressRules: []networkingv1.NetworkPolicyIngressRule{
+				defaultIngressRuleAdminAPI,
+				defaultIngressRuleProxy,
+				defaultIngressRuleMetrics,
+				{
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: &protocolTCP,
+							Port:     new(intstr.FromInt(8888)),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "dataplane with mixed TCP and TLS stream listeners",
+			proxyContainerOptions: func(c *corev1.Container) {
+				c.Env = append(c.Env, corev1.EnvVar{
+					Name:  "KONG_STREAM_LISTEN",
+					Value: "0.0.0.0:8888 reuseport,0.0.0.0:9443 ssl reuseport",
+				})
+			},
+			// Plain-TCP endpoints come first, then SSL — matches the order in
+			// generateDataPlaneNetworkPolicy.
+			expectedIngressRules: []networkingv1.NetworkPolicyIngressRule{
+				defaultIngressRuleAdminAPI,
+				defaultIngressRuleProxy,
+				defaultIngressRuleMetrics,
+				{
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: &protocolTCP,
+							Port:     new(intstr.FromInt(8888)),
+						},
+						{
+							Protocol: &protocolTCP,
+							Port:     new(intstr.FromInt(9443)),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/controller/gateway/controller_watch.go
+++ b/controller/gateway/controller_watch.go
@@ -488,9 +488,7 @@ func (r *Reconciler) listGatewaysAttachedByUDPRoute(ctx context.Context, obj cli
 }
 
 // listGatewaysAttachedByTCPRoute is a watch predicate which finds all Gateways mentioned
-// in TCPRoutes' ParentRefs. TCPRoute lives in gateway-api v1alpha2, which is not part of
-// the generic gwtypes.SupportedRoute union, so this function is specialized rather than
-// delegating to listGatewaysAttachedByRoute.
+// in TCPRoutes' ParentRefs.
 func (r *Reconciler) listGatewaysAttachedByTCPRoute(ctx context.Context, obj client.Object) []reconcile.Request {
 	logger := ctrllog.FromContext(ctx)
 

--- a/controller/gateway/controller_watch.go
+++ b/controller/gateway/controller_watch.go
@@ -15,6 +15,7 @@ import (
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
@@ -485,6 +486,46 @@ func (r *Reconciler) listGatewaysAttachedByUDPRoute(ctx context.Context, obj cli
 		return nil
 	}
 	return listGatewaysAttachedByRoute(udpRoute)
+}
+
+// listGatewaysAttachedByTCPRoute is a watch predicate which finds all Gateways mentioned
+// in TCPRoutes' ParentRefs. TCPRoute lives in gateway-api v1alpha2, which is not part of
+// the generic gwtypes.SupportedRoute union, so this function is specialized rather than
+// delegating to listGatewaysAttachedByRoute.
+func (r *Reconciler) listGatewaysAttachedByTCPRoute(ctx context.Context, obj client.Object) []reconcile.Request {
+	logger := ctrllog.FromContext(ctx)
+
+	tcpRoute, ok := obj.(*gatewayv1alpha2.TCPRoute)
+	if !ok {
+		logger.Error(
+			fmt.Errorf("unexpected object type"),
+			"TCPRoute watch predicate received unexpected object type",
+			"expected", "*gatewayapi.TCPRoute", "found", reflect.TypeOf(obj),
+		)
+		return nil
+	}
+
+	gateways := &gatewayv1.GatewayList{}
+	if err := r.List(ctx, gateways); err != nil {
+		logger.Error(err, "Failed to list gateways in watch", "tcproute", client.ObjectKeyFromObject(tcpRoute))
+		return nil
+	}
+	var recs []reconcile.Request
+	for _, gateway := range gateways.Items {
+		for _, parentRef := range tcpRoute.Spec.ParentRefs {
+			if parentRef.Group != nil && string(*parentRef.Group) == gatewayv1.GroupName &&
+				parentRef.Kind != nil && string(*parentRef.Kind) == "Gateway" &&
+				string(parentRef.Name) == gateway.Name {
+				recs = append(recs, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: gateway.Namespace,
+						Name:      gateway.Name,
+					},
+				})
+			}
+		}
+	}
+	return recs
 }
 
 // -----------------------------------------------------------------------------

--- a/controller/gateway/controller_watch.go
+++ b/controller/gateway/controller_watch.go
@@ -502,27 +502,7 @@ func (r *Reconciler) listGatewaysAttachedByTCPRoute(ctx context.Context, obj cli
 		return nil
 	}
 
-	gateways := &gatewayv1.GatewayList{}
-	if err := r.List(ctx, gateways); err != nil {
-		logger.Error(err, "Failed to list gateways in watch", "tcproute", client.ObjectKeyFromObject(tcpRoute))
-		return nil
-	}
-	var recs []reconcile.Request
-	for _, gateway := range gateways.Items {
-		for _, parentRef := range tcpRoute.Spec.ParentRefs {
-			if parentRef.Group != nil && string(*parentRef.Group) == gatewayv1.GroupName &&
-				parentRef.Kind != nil && string(*parentRef.Kind) == "Gateway" &&
-				string(parentRef.Name) == gateway.Name {
-				recs = append(recs, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Namespace: gateway.Namespace,
-						Name:      gateway.Name,
-					},
-				})
-			}
-		}
-	}
-	return recs
+	return listGatewaysAttachedByRoute(tcpRoute)
 }
 
 // -----------------------------------------------------------------------------

--- a/controller/gateway/controller_watch.go
+++ b/controller/gateway/controller_watch.go
@@ -15,7 +15,6 @@ import (
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
@@ -495,7 +494,7 @@ func (r *Reconciler) listGatewaysAttachedByUDPRoute(ctx context.Context, obj cli
 func (r *Reconciler) listGatewaysAttachedByTCPRoute(ctx context.Context, obj client.Object) []reconcile.Request {
 	logger := ctrllog.FromContext(ctx)
 
-	tcpRoute, ok := obj.(*gatewayv1alpha2.TCPRoute)
+	tcpRoute, ok := obj.(*gatewayv1.TCPRoute)
 	if !ok {
 		logger.Error(
 			fmt.Errorf("unexpected object type"),

--- a/controller/hybridgateway/watch/mapfuncs_secret_test.go
+++ b/controller/hybridgateway/watch/mapfuncs_secret_test.go
@@ -10,7 +10,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/internal/utils/index"
@@ -20,7 +19,7 @@ func TestMapHTTPRouteForClientCertSecret(t *testing.T) {
 	ctx := context.Background()
 
 	scheme := schemeWithAll()
-	require.NoError(t, gatewayv1alpha2.Install(scheme))
+	require.NoError(t, gatewayv1.Install(scheme))
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-cert", Namespace: "ns1"},
@@ -153,7 +152,7 @@ func TestMapTLSRouteForClientCertSecret(t *testing.T) {
 	ctx := context.Background()
 
 	scheme := schemeWithAll()
-	require.NoError(t, gatewayv1alpha2.Install(scheme))
+	require.NoError(t, gatewayv1.Install(scheme))
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-cert", Namespace: "ns1"},

--- a/go.mod
+++ b/go.mod
@@ -356,5 +356,4 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.36.3
 	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.36.3
 	k8s.io/sample-controller => k8s.io/sample-controller v0.36.3
-	k8s.io/streaming => k8s.io/streaming v0.36.3
 )

--- a/go.mod
+++ b/go.mod
@@ -356,4 +356,5 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.36.3
 	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.36.3
 	k8s.io/sample-controller => k8s.io/sample-controller v0.36.3
+	k8s.io/streaming => k8s.io/streaming v0.36.3
 )

--- a/ingress-controller/internal/controllers/gateway/gatewayclass_controller.go
+++ b/ingress-controller/internal/controllers/gateway/gatewayclass_controller.go
@@ -63,7 +63,7 @@ func (r *GatewayClassReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&gatewayapi.GatewayClass{}).
 		// set the event filters
 		WithEventFilter(predicate.NewPredicateFuncs(r.GatewayClassIsUnmanaged)).
-		Complete(reconcile.AsReconciler[*gatewayapi.GatewayClass](mgr.GetClient(), r))
+		Complete(reconcile.AsReconciler(mgr.GetClient(), r))
 }
 
 // -----------------------------------------------------------------------------

--- a/ingress-controller/internal/controllers/gateway/referencegrant_controller.go
+++ b/ingress-controller/internal/controllers/gateway/referencegrant_controller.go
@@ -65,7 +65,7 @@ func (r *ReferenceGrantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *ReferenceGrantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("GatewayV1Alpha2ReferenceGrant", req.NamespacedName)
+	log := r.Log.WithValues("GatewayV1ReferenceGrant", req.NamespacedName)
 	grant := new(gatewayapi.ReferenceGrant)
 	if err := r.Get(ctx, req.NamespacedName, grant); err != nil {
 		// if the queued object is no longer present in the proxy cache we need

--- a/ingress-controller/internal/controllers/gateway/route_utils.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils.go
@@ -786,6 +786,33 @@ func isTLSReferenceGranted(grantSpec gatewayapi.ReferenceGrantSpec, backendRef g
 	return false
 }
 
+// isTCPReferenceGranted checks that the backendRef referenced by the TCPRoute is granted by a ReferenceGrant.
+func isTCPReferenceGranted(grantSpec gatewayapi.ReferenceGrantSpec, backendRef gatewayapi.BackendRef, fromNamespace string) bool {
+	var backendRefGroup gatewayapi.Group
+	var backendRefKind gatewayapi.Kind
+
+	if backendRef.Group != nil {
+		backendRefGroup = *backendRef.Group
+	}
+	if backendRef.Kind != nil {
+		backendRefKind = *backendRef.Kind
+	}
+	for _, from := range grantSpec.From {
+		if from.Group != gatewayv1.GroupName || from.Kind != "TCPRoute" || fromNamespace != string(from.Namespace) {
+			continue
+		}
+
+		for _, to := range grantSpec.To {
+			if backendRefGroup == to.Group &&
+				backendRefKind == to.Kind &&
+				(to.Name == nil || *to.Name == backendRef.Name) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // setRouteParentInStatusForParent checks if the provided route Status, contains
 // status for the provided parent and if it does it sets it to the provided
 // RouteStatusParent. If it does not then it appends the provided RouteStatusParent

--- a/ingress-controller/internal/controllers/gateway/tcproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tcproute_controller.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,9 +24,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/controllers"
+	ctrlutils "github.com/kong/kong-operator/v2/ingress-controller/internal/controllers/utils"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/gatewayapi"
+	"github.com/kong/kong-operator/v2/ingress-controller/internal/util"
 	k8sobj "github.com/kong/kong-operator/v2/ingress-controller/internal/util/kubernetes/object"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/util/kubernetes/object/status"
 )
@@ -44,6 +48,12 @@ type TCPRouteReconciler struct {
 	CacheSyncTimeout time.Duration
 	StatusQueue      *status.Queue
 
+	// If enableReferenceGrant is true, we will check for ReferenceGrant if backend in another
+	// namespace is in backendRefs.
+	// If it is false, referencing backend in different namespace will be rejected.
+	// It's resolved on SetupWithManager call.
+	enableReferenceGrant bool
+
 	// If GatewayNN is set,
 	// only resources managed by the specified Gateway are reconciled.
 	GatewayNN controllers.OptionalNamespacedName
@@ -51,6 +61,17 @@ type TCPRouteReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// We're verifying whether ReferenceGrant CRD is installed at setup of the TCPRouteReconciler
+	// to decide whether we should run additional ReferenceGrant watch and handle ReferenceGrants
+	// when reconciling TCPRoutes.
+	// Once the TCPRouteReconciler is set up without ReferenceGrant, there's no possibility to enable
+	// ReferenceGrant handling again in this reconciler at runtime.
+	r.enableReferenceGrant = ctrlutils.CRDExists(mgr.GetRESTMapper(), schema.GroupVersionResource{
+		Group:    gatewayv1beta1.GroupVersion.Group,
+		Version:  gatewayv1beta1.GroupVersion.Version,
+		Resource: "referencegrants",
+	})
+
 	blder := ctrl.NewControllerManagedBy(mgr).
 		Named("tcproute-controller").
 		WithOptions(controller.Options{
@@ -79,6 +100,13 @@ func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&gatewayapi.Gateway{},
 			handler.EnqueueRequestsFromMapFunc(r.listTCPRoutesForGateway),
 		)
+
+	if r.enableReferenceGrant {
+		blder.Watches(&gatewayapi.ReferenceGrant{},
+			handler.EnqueueRequestsFromMapFunc(r.listTCPRoutesForReferenceGrant),
+			builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantHasTCPRouteFrom)),
+		)
+	}
 
 	if r.StatusQueue != nil {
 		blder.WatchesRawSource(
@@ -249,6 +277,54 @@ func (r *TCPRouteReconciler) listTCPRoutesForGateway(ctx context.Context, obj cl
 	}
 
 	return queue
+}
+
+// listTCPRoutesForReferenceGrant is a watch predicate which finds all TCPRoutes
+// mentioned in a From clause for a ReferenceGrant.
+func (r *TCPRouteReconciler) listTCPRoutesForReferenceGrant(ctx context.Context, obj client.Object) []reconcile.Request {
+	grant, ok := obj.(*gatewayapi.ReferenceGrant)
+	if !ok {
+		r.Log.Error(
+			errInvalidType,
+			"Referencegrant watch predicate received unexpected object type",
+			"expected", "*gatewayapi.ReferenceGrant", "found", reflect.TypeOf(obj),
+		)
+		return nil
+	}
+	tcproutes := &gatewayapi.TCPRouteList{}
+	if err := r.List(ctx, tcproutes); err != nil {
+		r.Log.Error(err, "Failed to list tcproutes in watch", "referencegrant", grant.Name)
+		return nil
+	}
+	recs := []reconcile.Request{}
+	for _, tcproute := range tcproutes.Items {
+		for _, from := range grant.Spec.From {
+			if string(from.Namespace) == tcproute.Namespace &&
+				from.Kind == "TCPRoute" &&
+				from.Group == "gateway.networking.k8s.io" {
+				recs = append(recs, reconcile.Request{
+					NamespacedName: k8stypes.NamespacedName{
+						Namespace: tcproute.Namespace,
+						Name:      tcproute.Name,
+					},
+				})
+			}
+		}
+	}
+	return recs
+}
+
+func referenceGrantHasTCPRouteFrom(obj client.Object) bool {
+	grant, ok := obj.(*gatewayapi.ReferenceGrant)
+	if !ok {
+		return false
+	}
+	for _, from := range grant.Spec.From {
+		if from.Kind == "TCPRoute" && from.Group == "gateway.networking.k8s.io" {
+			return true
+		}
+	}
+	return false
 }
 
 // -----------------------------------------------------------------------------
@@ -444,10 +520,15 @@ func (r *TCPRouteReconciler) ensureGatewayReferenceStatusAdded(
 		gateways...,
 	)
 
+	parentStatuses, resolvedRefsChanged, err := r.setRouteConditionResolvedRefsCondition(ctx, tcproute, parentStatuses)
+	if err != nil {
+		return false, ctrl.Result{}, err
+	}
+
 	programmedConditionChanged := initializeParentStatusesWithProgrammedCondition(tcproute, parentStatuses)
 
 	// if we didn't have to actually make any changes, no status update is needed
-	if !statusChangesWereMade && !programmedConditionChanged {
+	if !statusChangesWereMade && !resolvedRefsChanged && !programmedConditionChanged {
 		return false, ctrl.Result{}, nil
 	}
 
@@ -468,4 +549,124 @@ func (r *TCPRouteReconciler) ensureGatewayReferenceStatusAdded(
 
 	// the status needed an update and it was updated successfully
 	return true, ctrl.Result{}, nil
+}
+
+// SetLogger sets the logger.
+func (r *TCPRouteReconciler) SetLogger(l logr.Logger) {
+	r.Log = l
+}
+
+// setRouteConditionResolvedRefsCondition sets a condition of type ResolvedRefs on the route status.
+func (r *TCPRouteReconciler) setRouteConditionResolvedRefsCondition(
+	ctx context.Context,
+	tcpRoute *gatewayapi.TCPRoute,
+	parentStatuses map[string]*gatewayapi.RouteParentStatus,
+) (map[string]*gatewayapi.RouteParentStatus, bool, error) {
+	var changed bool
+	resolvedRefsStatus := metav1.ConditionFalse
+	reason, msg, err := r.getTCPRouteRuleReason(ctx, *tcpRoute)
+	if err != nil {
+		return nil, false, err
+	}
+	if reason == gatewayapi.RouteReasonResolvedRefs {
+		resolvedRefsStatus = metav1.ConditionTrue
+	}
+
+	// iterate over all the parentStatuses conditions, and if no RouteConditionResolvedRefs is found,
+	// or if the condition is found but has to be changed, update the status and mark it to be updated
+	resolvedRefsCondition := metav1.Condition{
+		Type:               string(gatewayapi.RouteConditionResolvedRefs),
+		Status:             resolvedRefsStatus,
+		ObservedGeneration: tcpRoute.Generation,
+		LastTransitionTime: metav1.Now(),
+		Reason:             string(reason),
+		Message:            msg,
+	}
+	for _, parentStatus := range parentStatuses {
+		var conditionFound bool
+		for i, cond := range parentStatus.Conditions {
+			if cond.Type == string(gatewayapi.RouteConditionResolvedRefs) {
+				if cond.Status != resolvedRefsStatus ||
+					cond.Reason != string(reason) {
+					parentStatus.Conditions[i] = resolvedRefsCondition
+					changed = true
+				}
+				conditionFound = true
+				break
+			}
+		}
+		if !conditionFound {
+			parentStatus.Conditions = append(parentStatus.Conditions, resolvedRefsCondition)
+			changed = true
+		}
+	}
+
+	return parentStatuses, changed, nil
+}
+
+// getTCPRouteRuleReason validates the backendRefs of every rule in the TCPRoute
+// and returns the first failure encountered. When all backendRefs are valid it
+// returns gatewayapi.RouteReasonResolvedRefs.
+func (r *TCPRouteReconciler) getTCPRouteRuleReason(ctx context.Context, tcpRoute gatewayapi.TCPRoute) (reason gatewayapi.RouteConditionReason, msg string, err error) {
+	for _, rule := range tcpRoute.Spec.Rules {
+		for _, backendRef := range rule.BackendRefs {
+			backendNamespace := tcpRoute.Namespace
+			if backendRef.Namespace != nil && *backendRef.Namespace != "" {
+				backendNamespace = string(*backendRef.Namespace)
+			}
+
+			backendRefGK := string(*backendRef.Kind)
+			if gr := string(*backendRef.Group); gr != "" {
+				backendRefGK = gr + "/" + backendRefGK
+			}
+			targetNN := k8stypes.NamespacedName{Namespace: backendNamespace, Name: string(backendRef.Name)}
+
+			// Check if the BackendRef GroupKind is supported.
+			if !util.IsBackendRefGroupKindSupported(backendRef.Group, backendRef.Kind) {
+				return gatewayapi.RouteReasonInvalidKind, fmt.Sprintf("target %s has unsupported type %s", targetNN, backendRefGK), nil
+			}
+
+			// Check if the referenced object actually exists.
+			// Only Services are currently supported as BackendRef objects.
+			service := &corev1.Service{}
+			if err := r.Get(ctx, targetNN, service); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return "", "", err
+				}
+				return gatewayapi.RouteReasonBackendNotFound, fmt.Sprintf("target %s of type %s does not exist", targetNN, backendRefGK), nil
+			}
+
+			// If the object referenced is in another namespace,
+			// verify that a ReferenceGrant permits the reference.
+			if tcpRoute.Namespace != backendNamespace {
+				differentNamespaceMsg := fmt.Sprintf("%s is in a different namespace than the TCPRoute (namespace %s)", targetNN, tcpRoute.Namespace)
+				if !r.enableReferenceGrant {
+					return gatewayapi.RouteReasonRefNotPermitted,
+						differentNamespaceMsg + " install ReferenceGrant CRD and configure a proper grant",
+						nil
+				}
+
+				referenceGrantList := &gatewayapi.ReferenceGrantList{}
+				if err := r.List(ctx, referenceGrantList, client.InNamespace(backendNamespace)); err != nil {
+					return "", "", err
+				}
+				notGrantedMsg := differentNamespaceMsg + " and no ReferenceGrant allowing reference is configured"
+				if len(referenceGrantList.Items) == 0 {
+					return gatewayapi.RouteReasonRefNotPermitted, notGrantedMsg, nil
+				}
+				var isGranted bool
+				for _, grant := range referenceGrantList.Items {
+					if isTCPReferenceGranted(grant.Spec, backendRef, tcpRoute.Namespace) {
+						isGranted = true
+						break
+					}
+				}
+				if !isGranted {
+					return gatewayapi.RouteReasonRefNotPermitted, notGrantedMsg, nil
+				}
+			}
+		}
+	}
+
+	return gatewayapi.RouteReasonResolvedRefs, "", nil
 }

--- a/ingress-controller/internal/controllers/gateway/tcproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tcproute_controller.go
@@ -626,16 +626,6 @@ func (r *TCPRouteReconciler) getTCPRouteRuleReason(ctx context.Context, tcpRoute
 				return gatewayapi.RouteReasonInvalidKind, fmt.Sprintf("target %s has unsupported type %s", targetNN, backendRefGK), nil
 			}
 
-			// Check if the referenced object actually exists.
-			// Only Services are currently supported as BackendRef objects.
-			service := &corev1.Service{}
-			if err := r.Get(ctx, targetNN, service); err != nil {
-				if !apierrors.IsNotFound(err) {
-					return "", "", err
-				}
-				return gatewayapi.RouteReasonBackendNotFound, fmt.Sprintf("target %s of type %s does not exist", targetNN, backendRefGK), nil
-			}
-
 			// If the object referenced is in another namespace,
 			// verify that a ReferenceGrant permits the reference.
 			if tcpRoute.Namespace != backendNamespace {
@@ -664,6 +654,16 @@ func (r *TCPRouteReconciler) getTCPRouteRuleReason(ctx context.Context, tcpRoute
 				if !isGranted {
 					return gatewayapi.RouteReasonRefNotPermitted, notGrantedMsg, nil
 				}
+			}
+
+			// Check if the referenced object actually exists.
+			// Only Services are currently supported as BackendRef objects.
+			service := &corev1.Service{}
+			if err := r.Get(ctx, targetNN, service); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return "", "", err
+				}
+				return gatewayapi.RouteReasonBackendNotFound, fmt.Sprintf("target %s of type %s does not exist", targetNN, backendRefGK), nil
 			}
 		}
 	}

--- a/ingress-controller/internal/controllers/gateway/tcproute_controller_test.go
+++ b/ingress-controller/internal/controllers/gateway/tcproute_controller_test.go
@@ -1,0 +1,367 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kong/kong-operator/v2/ingress-controller/internal/gatewayapi"
+	"github.com/kong/kong-operator/v2/ingress-controller/internal/util"
+	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+)
+
+func newTCPRoute(backendRef gatewayapi.BackendRef) gatewayapi.TCPRoute {
+	return gatewayapi.TCPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "route",
+			Namespace:  "default",
+			Generation: 1,
+		},
+		Spec: gatewayapi.TCPRouteSpec{
+			Rules: []gatewayapi.TCPRouteRule{{
+				BackendRefs: []gatewayapi.BackendRef{backendRef},
+			}},
+		},
+	}
+}
+
+func TestGetTCPRouteRuleReason(t *testing.T) {
+	ctx := t.Context()
+	logger := logr.Discard()
+
+	otherNS := gatewayapi.Namespace("other")
+	grantFromTCPRouteToService := gatewayapi.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{Name: "grant", Namespace: "other"},
+		Spec: gatewayapi.ReferenceGrantSpec{
+			From: []gatewayapi.ReferenceGrantFrom{{
+				Group:     gatewayapi.V1Group,
+				Kind:      "TCPRoute",
+				Namespace: "default",
+			}},
+			To: []gatewayapi.ReferenceGrantTo{{
+				Group: "",
+				Kind:  "Service",
+			}},
+		},
+	}
+
+	tests := []struct {
+		name               string
+		enableRefGrant     bool
+		objects            []client.Object
+		route              gatewayapi.TCPRoute
+		wantReason         gatewayapi.RouteConditionReason
+		wantMessageContain string
+	}{
+		{
+			name:           "resolves",
+			enableRefGrant: true,
+			objects: []client.Object{
+				&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"}},
+			},
+			route:      newTCPRoute(serviceBackendRef(nil)),
+			wantReason: gatewayapi.RouteReasonResolvedRefs,
+		},
+		{
+			name:               "backend service missing",
+			enableRefGrant:     true,
+			objects:            []client.Object{},
+			route:              newTCPRoute(serviceBackendRef(nil)),
+			wantReason:         gatewayapi.RouteReasonBackendNotFound,
+			wantMessageContain: "target default/svc",
+		},
+		{
+			name:           "unsupported backend kind",
+			enableRefGrant: true,
+			objects:        []client.Object{},
+			route: newTCPRoute(gatewayapi.BackendRef{
+				BackendObjectReference: gatewayapi.BackendObjectReference{
+					Name:  "svc",
+					Kind:  util.StringToGatewayAPIKindPtr("Foo"),
+					Group: util.StringToTypedPtr[*gatewayapi.Group]("example.com"),
+				},
+			}),
+			wantReason:         gatewayapi.RouteReasonInvalidKind,
+			wantMessageContain: "unsupported type example.com/Foo",
+		},
+		{
+			name:           "cross-namespace without ReferenceGrant CRD",
+			enableRefGrant: false,
+			objects: []client.Object{
+				&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "other"}},
+			},
+			route:              newTCPRoute(serviceBackendRef(&otherNS)),
+			wantReason:         gatewayapi.RouteReasonRefNotPermitted,
+			wantMessageContain: "install ReferenceGrant CRD and configure a proper grant",
+		},
+		{
+			name:           "cross-namespace without matching grant",
+			enableRefGrant: true,
+			objects: []client.Object{
+				&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "other"}},
+			},
+			route:              newTCPRoute(serviceBackendRef(&otherNS)),
+			wantReason:         gatewayapi.RouteReasonRefNotPermitted,
+			wantMessageContain: "no ReferenceGrant allowing reference is configured",
+		},
+		{
+			name:           "cross-namespace with matching grant",
+			enableRefGrant: true,
+			objects: []client.Object{
+				&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "other"}},
+				grantFromTCPRouteToService.DeepCopy(),
+			},
+			route:      newTCPRoute(serviceBackendRef(&otherNS)),
+			wantReason: gatewayapi.RouteReasonResolvedRefs,
+		},
+		{
+			name:           "cross-namespace grant for wrong from-kind (TLSRoute, not TCPRoute)",
+			enableRefGrant: true,
+			objects: []client.Object{
+				&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "other"}},
+				&gatewayapi.ReferenceGrant{
+					ObjectMeta: metav1.ObjectMeta{Name: "grant", Namespace: "other"},
+					Spec: gatewayapi.ReferenceGrantSpec{
+						From: []gatewayapi.ReferenceGrantFrom{{
+							Group:     gatewayapi.V1Group,
+							Kind:      "TLSRoute",
+							Namespace: "default",
+						}},
+						To: []gatewayapi.ReferenceGrantTo{{
+							Group: "",
+							Kind:  "Service",
+						}},
+					},
+				},
+			},
+			route:              newTCPRoute(serviceBackendRef(&otherNS)),
+			wantReason:         gatewayapi.RouteReasonRefNotPermitted,
+			wantMessageContain: "no ReferenceGrant allowing reference is configured",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cl := fakeclient.NewClientBuilder().
+				WithScheme(scheme.Get()).
+				WithObjects(tc.objects...).
+				Build()
+			reconciler := &TCPRouteReconciler{
+				Client:               cl,
+				Log:                  logger,
+				enableReferenceGrant: tc.enableRefGrant,
+			}
+
+			reason, msg, err := reconciler.getTCPRouteRuleReason(ctx, tc.route)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantReason, reason)
+			if tc.wantMessageContain != "" {
+				assert.Contains(t, msg, tc.wantMessageContain)
+			}
+		})
+	}
+}
+
+func TestSetRouteConditionResolvedRefsCondition_TCPRoute(t *testing.T) {
+	ctx := t.Context()
+	logger := logr.Discard()
+
+	otherNS := gatewayapi.Namespace("other")
+	parentKey := "default/gw//"
+
+	newParentStatuses := func(conds ...metav1.Condition) map[string]*gatewayapi.RouteParentStatus {
+		return map[string]*gatewayapi.RouteParentStatus{
+			parentKey: {
+				ParentRef:      gatewayapi.ParentReference{Name: "gw"},
+				ControllerName: gatewayapi.GatewayController("test"),
+				Conditions:     conds,
+			},
+		}
+	}
+
+	t.Run("inserts new condition when missing", func(t *testing.T) {
+		cl := fakeclient.NewClientBuilder().
+			WithScheme(scheme.Get()).
+			WithObjects(&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"}}).
+			Build()
+		r := &TCPRouteReconciler{Client: cl, Log: logger}
+		route := newTCPRoute(serviceBackendRef(nil))
+		parentStatuses := newParentStatuses()
+
+		_, changed, err := r.setRouteConditionResolvedRefsCondition(ctx, &route, parentStatuses)
+		require.NoError(t, err)
+		assert.True(t, changed)
+
+		conds := parentStatuses[parentKey].Conditions
+		require.Len(t, conds, 1)
+		assert.Equal(t, string(gatewayapi.RouteConditionResolvedRefs), conds[0].Type)
+		assert.Equal(t, metav1.ConditionTrue, conds[0].Status)
+		assert.Equal(t, string(gatewayapi.RouteReasonResolvedRefs), conds[0].Reason)
+		assert.Equal(t, route.Generation, conds[0].ObservedGeneration)
+	})
+
+	t.Run("updates existing condition when reason changes", func(t *testing.T) {
+		cl := fakeclient.NewClientBuilder().
+			WithScheme(scheme.Get()).
+			Build()
+		r := &TCPRouteReconciler{Client: cl, Log: logger}
+		route := newTCPRoute(serviceBackendRef(nil))
+		parentStatuses := newParentStatuses(metav1.Condition{
+			Type:   string(gatewayapi.RouteConditionResolvedRefs),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayapi.RouteReasonResolvedRefs),
+		})
+
+		_, changed, err := r.setRouteConditionResolvedRefsCondition(ctx, &route, parentStatuses)
+		require.NoError(t, err)
+		assert.True(t, changed)
+
+		conds := parentStatuses[parentKey].Conditions
+		require.Len(t, conds, 1)
+		assert.Equal(t, metav1.ConditionFalse, conds[0].Status)
+		assert.Equal(t, string(gatewayapi.RouteReasonBackendNotFound), conds[0].Reason)
+	})
+
+	t.Run("no-op when condition already matches", func(t *testing.T) {
+		cl := fakeclient.NewClientBuilder().
+			WithScheme(scheme.Get()).
+			WithObjects(&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"}}).
+			Build()
+		r := &TCPRouteReconciler{Client: cl, Log: logger}
+		route := newTCPRoute(serviceBackendRef(nil))
+		parentStatuses := newParentStatuses(metav1.Condition{
+			Type:   string(gatewayapi.RouteConditionResolvedRefs),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayapi.RouteReasonResolvedRefs),
+		})
+
+		_, changed, err := r.setRouteConditionResolvedRefsCondition(ctx, &route, parentStatuses)
+		require.NoError(t, err)
+		assert.False(t, changed)
+	})
+
+	t.Run("cross-namespace without grant flips condition to false", func(t *testing.T) {
+		cl := fakeclient.NewClientBuilder().
+			WithScheme(scheme.Get()).
+			WithObjects(&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "other"}}).
+			Build()
+		r := &TCPRouteReconciler{Client: cl, Log: logger, enableReferenceGrant: true}
+		route := newTCPRoute(serviceBackendRef(&otherNS))
+		parentStatuses := newParentStatuses()
+
+		_, changed, err := r.setRouteConditionResolvedRefsCondition(ctx, &route, parentStatuses)
+		require.NoError(t, err)
+		assert.True(t, changed)
+
+		conds := parentStatuses[parentKey].Conditions
+		require.Len(t, conds, 1)
+		assert.Equal(t, metav1.ConditionFalse, conds[0].Status)
+		assert.Equal(t, string(gatewayapi.RouteReasonRefNotPermitted), conds[0].Reason)
+	})
+}
+
+func TestIsTCPReferenceGranted(t *testing.T) {
+	svcKind := gatewayapi.Kind("Service")
+	emptyGroup := gatewayapi.Group("")
+	specificName := gatewayapi.ObjectName("svc")
+	otherName := gatewayapi.ObjectName("other")
+
+	makeGrant := func(from gatewayapi.ReferenceGrantFrom, to gatewayapi.ReferenceGrantTo) gatewayapi.ReferenceGrantSpec {
+		return gatewayapi.ReferenceGrantSpec{
+			From: []gatewayapi.ReferenceGrantFrom{from},
+			To:   []gatewayapi.ReferenceGrantTo{to},
+		}
+	}
+
+	backendRef := gatewayapi.BackendRef{
+		BackendObjectReference: gatewayapi.BackendObjectReference{
+			Name:  specificName,
+			Kind:  &svcKind,
+			Group: &emptyGroup,
+		},
+	}
+
+	tests := []struct {
+		name   string
+		spec   gatewayapi.ReferenceGrantSpec
+		fromNS string
+		want   bool
+	}{
+		{
+			name: "matching grant (any name)",
+			spec: makeGrant(
+				gatewayapi.ReferenceGrantFrom{Group: gatewayapi.V1Group, Kind: "TCPRoute", Namespace: "default"},
+				gatewayapi.ReferenceGrantTo{Group: "", Kind: "Service"},
+			),
+			fromNS: "default",
+			want:   true,
+		},
+		{
+			name: "matching grant with specific to.Name",
+			spec: makeGrant(
+				gatewayapi.ReferenceGrantFrom{Group: gatewayapi.V1Group, Kind: "TCPRoute", Namespace: "default"},
+				gatewayapi.ReferenceGrantTo{Group: "", Kind: "Service", Name: &specificName},
+			),
+			fromNS: "default",
+			want:   true,
+		},
+		{
+			name: "to.Name mismatch",
+			spec: makeGrant(
+				gatewayapi.ReferenceGrantFrom{Group: gatewayapi.V1Group, Kind: "TCPRoute", Namespace: "default"},
+				gatewayapi.ReferenceGrantTo{Group: "", Kind: "Service", Name: &otherName},
+			),
+			fromNS: "default",
+			want:   false,
+		},
+		{
+			name: "wrong from.Kind (TLSRoute)",
+			spec: makeGrant(
+				gatewayapi.ReferenceGrantFrom{Group: gatewayapi.V1Group, Kind: "TLSRoute", Namespace: "default"},
+				gatewayapi.ReferenceGrantTo{Group: "", Kind: "Service"},
+			),
+			fromNS: "default",
+			want:   false,
+		},
+		{
+			name: "wrong from.Namespace",
+			spec: makeGrant(
+				gatewayapi.ReferenceGrantFrom{Group: gatewayapi.V1Group, Kind: "TCPRoute", Namespace: "elsewhere"},
+				gatewayapi.ReferenceGrantTo{Group: "", Kind: "Service"},
+			),
+			fromNS: "default",
+			want:   false,
+		},
+		{
+			name: "wrong to.Kind",
+			spec: makeGrant(
+				gatewayapi.ReferenceGrantFrom{Group: gatewayapi.V1Group, Kind: "TCPRoute", Namespace: "default"},
+				gatewayapi.ReferenceGrantTo{Group: "", Kind: "ConfigMap"},
+			),
+			fromNS: "default",
+			want:   false,
+		},
+		{
+			name: "wrong to.Group",
+			spec: makeGrant(
+				gatewayapi.ReferenceGrantFrom{Group: gatewayapi.V1Group, Kind: "TCPRoute", Namespace: "default"},
+				gatewayapi.ReferenceGrantTo{Group: "example.com", Kind: "Service"},
+			),
+			fromNS: "default",
+			want:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isTCPReferenceGranted(tc.spec, backendRef, tc.fromNS)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/types/gatewaytypes.go
+++ b/internal/types/gatewaytypes.go
@@ -57,6 +57,7 @@ type (
 	TCPRouteList           = gatewayv1.TCPRouteList
 	TCPRouteSpec           = gatewayv1.TCPRouteSpec
 	TCPRouteRule           = gatewayv1.TCPRouteRule
+	TCPRouteStatus         = gatewayv1.TCPRouteStatus
 	GRPCRoute              = gatewayv1.GRPCRoute
 	GRPCRouteList          = gatewayv1.GRPCRouteList
 	GRPCRouteSpec          = gatewayv1.GRPCRouteSpec

--- a/modules/manager/scheme/scheme.go
+++ b/modules/manager/scheme/scheme.go
@@ -7,6 +7,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	aigatewayv1alpha1 "github.com/kong/kong-operator/v2/api/aigateway/v1alpha1"
@@ -32,6 +33,7 @@ func Get() *runtime.Scheme {
 	utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
 
 	utilruntime.Must(gatewayv1.Install(scheme))
+	utilruntime.Must(gatewayv1alpha2.Install(scheme))
 	utilruntime.Must(gatewayv1beta1.Install(scheme))
 
 	utilruntime.Must(configurationv1.AddToScheme(scheme))

--- a/pkg/utils/gateway/ownerrefs.go
+++ b/pkg/utils/gateway/ownerrefs.go
@@ -7,6 +7,7 @@ import (
 	"github.com/samber/lo"
 	networkingv1 "k8s.io/api/networking/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
@@ -307,6 +308,60 @@ func ListGRPCRoutesForGateway(
 			return parentRefMatchGateway(r.Namespace, parentRef, gateway)
 		})
 	}), nil
+}
+
+func ListTCPRoutesForGateway(
+	ctx context.Context,
+	c client.Client,
+	gateway *gwtypes.Gateway,
+	opts ...client.ListOption,
+) ([]gatewayv1alpha2.TCPRoute, error) {
+	if gateway.Namespace == "" {
+		return nil, fmt.Errorf("can't list TCPRoutes for gateway: Gateway %s was missing namespace", gateway.Name)
+	}
+
+	var tcpRoutesList gatewayv1alpha2.TCPRouteList
+	if err := c.List(ctx, &tcpRoutesList, opts...); err != nil {
+		return nil, fmt.Errorf("can't list TCPRoutes for gateway: %w", err)
+	}
+
+	var tcpRoutes []gatewayv1alpha2.TCPRoute
+	for _, tcpRoute := range tcpRoutesList.Items {
+		if !lo.ContainsBy(tcpRoute.Spec.ParentRefs, func(parentRef gwtypes.ParentReference) bool {
+			gwGVK := gateway.GroupVersionKind()
+			if parentRef.Group != nil && string(*parentRef.Group) != gwGVK.Group {
+				return false
+			}
+			if parentRef.Kind != nil && string(*parentRef.Kind) != gwGVK.Kind {
+				return false
+			}
+			if string(parentRef.Name) != gateway.Name {
+				return false
+			}
+
+			if parentRef.SectionName != nil {
+				if !lo.ContainsBy(gateway.Spec.Listeners, func(listener gwtypes.Listener) bool {
+					if listener.Name != *parentRef.SectionName {
+						return false
+					}
+					if parentRef.Port != nil && listener.Port != *parentRef.Port {
+						return false
+					}
+					return true
+				}) {
+					return false
+				}
+			}
+
+			return true
+		}) {
+			continue
+		}
+
+		tcpRoutes = append(tcpRoutes, tcpRoute)
+	}
+
+	return tcpRoutes, nil
 }
 
 // GetDataPlaneServiceName is a helper function that retrieves the name of the service owned by provided dataplane.

--- a/pkg/utils/gateway/ownerrefs.go
+++ b/pkg/utils/gateway/ownerrefs.go
@@ -7,7 +7,6 @@ import (
 	"github.com/samber/lo"
 	networkingv1 "k8s.io/api/networking/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
@@ -310,22 +309,24 @@ func ListGRPCRoutesForGateway(
 	}), nil
 }
 
+// ListTCPRoutesForGateway is a helper function which returns a list of TCPRoutes
+// that have the provided Gateway set as parent in their status.
 func ListTCPRoutesForGateway(
 	ctx context.Context,
 	c client.Client,
 	gateway *gwtypes.Gateway,
 	opts ...client.ListOption,
-) ([]gatewayv1alpha2.TCPRoute, error) {
+) ([]gwtypes.TCPRoute, error) {
 	if gateway.Namespace == "" {
 		return nil, fmt.Errorf("can't list TCPRoutes for gateway: Gateway %s was missing namespace", gateway.Name)
 	}
 
-	var tcpRoutesList gatewayv1alpha2.TCPRouteList
+	var tcpRoutesList gwtypes.TCPRouteList
 	if err := c.List(ctx, &tcpRoutesList, opts...); err != nil {
 		return nil, fmt.Errorf("can't list TCPRoutes for gateway: %w", err)
 	}
 
-	var tcpRoutes []gatewayv1alpha2.TCPRoute
+	var tcpRoutes []gwtypes.TCPRoute
 	for _, tcpRoute := range tcpRoutesList.Items {
 		if !lo.ContainsBy(tcpRoute.Spec.ParentRefs, func(parentRef gwtypes.ParentReference) bool {
 			gwGVK := gateway.GroupVersionKind()

--- a/pkg/utils/test/consts.go
+++ b/pkg/utils/test/consts.go
@@ -56,6 +56,10 @@ const (
 	WaitTLSRouteTick = time.Second * 1
 	// DefaultTLSRouteWait is the default timeout for checking on TLSRoute resources.
 	DefaultTLSRouteWait = time.Minute * 3
+	// WaitTCPRouteTick is the default timeout tick interval for checking on TCPRoute resources.
+	WaitTCPRouteTick = time.Second * 1
+	// DefaultTCPRouteWait is the default timeout for checking on TCPRoute resources.
+	DefaultTCPRouteWait = time.Minute * 3
 )
 
 // -----------------------------------------------------------------------------

--- a/test/e2e/chainsaw/common/_step_templates/verify-tcp-traffic-from-host.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/verify-tcp-traffic-from-host.yaml
@@ -34,6 +34,6 @@ spec:
           - name: PROXY_PORT
             value: (to_string($listener_tcp_port))
         content: |
-          bash ../../common/scripts/host_connectivity_tcp.sh
+          bash ../../common/scripts/host_connectivity_test_tcp.sh
         check:
           (to_string(json_parse($stdout).success) == 'true'): true

--- a/test/e2e/chainsaw/common/_step_templates/verify-tcp-traffic-from-host.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/verify-tcp-traffic-from-host.yaml
@@ -1,0 +1,39 @@
+# Template for verifying TLS traffic from the host to the gateway.
+#
+# Required bindings:
+#   - gateway_name: Name of the Gateway.
+#   - gateway_namespace: Namespace of the Gateway.
+#   - listener_tcp_port: Port of the gateway listener for TCP traffic.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: verify-tcp-traffic-from-host
+spec:
+  try:
+    # 1. Dynamically discover the Gateway's Proxy IP
+    - script:
+        env:
+          - name: GATEWAY_NAME
+            value: ($gateway_name)
+          - name: GATEWAY_NAMESPACE
+            value: ($gateway_namespace)
+        content: |
+          bash ../../common/scripts/proxy_ip_address.sh
+        outputs:
+          - name: proxy_ip
+            value: (json_parse($stdout).proxy_ip_address)
+        check:
+          (json_parse($stdout).proxy_ip_address != null): true
+          (json_parse($stdout).proxy_ip_address != ''): true
+
+    # 2. Perform the TCP connectivity check.
+    - script:
+        env:
+          - name: PROXY_IP
+            value: ($proxy_ip)
+          - name: PROXY_PORT
+            value: (to_string($listener_tcp_port))
+        content: |
+          bash ../../common/scripts/host_connectivity_tcp.sh
+        check:
+          (to_string(json_parse($stdout).success) == 'true'): true

--- a/test/e2e/chainsaw/common/scripts/host_connectivity_test_tcp.sh
+++ b/test/e2e/chainsaw/common/scripts/host_connectivity_test_tcp.sh
@@ -19,22 +19,23 @@ PROXY_PORT="${PROXY_PORT}"
 MAX_RETRIES="${MAX_RETRIES:-180}"
 RETRY_DELAY="${RETRY_DELAY:-1}"
 
-# Build nc command.
-build_nc_cmd() {
-  local CMD="nc -zv ${PROXY_IP} ${PROXY_PORT}"
+
+# The `telnet` command to check TCP connectivity to the proxy.
+build_telnet_cmd() {
+  local CMD="telnet ${PROXY_IP} ${PROXY_PORT}"
+  # sleep for a second to receive the initial welcome message from the echo server.
+  echo "sleep 1 | $CMD"
 }
 
-OPENSSL_CMD=$(build_openssl_cmd)
+TELNET_CMD=$(build_telnet_cmd)
 
 # Retry loop: Keep trying until we get the correct repsonse or run out of retries.
 LAST_OUTPUT=""
 for ATTEMPT in $(seq 1 $MAX_RETRIES); do
-  if OUTPUT=$(eval $OPENSSL_CMD 2>&1 | tr '\n' ' '); then
+  if OUTPUT=$(eval $TELNET_CMD 2>&1 | tr '\n' ' '); then
     LAST_OUTPUT="$OUTPUT"
     # Check if the output contains the welcome message from the echo pod.
-    # Only "Running on Pod" is required: with TLS Passthrough the backend itself
-    # terminates TLS and also emits "Through TLS connection", but with TLS Terminate
-    # at the gateway the backend speaks plain TCP and never emits that substring.
+    # Only "Running on Pod" is required.
     if [[ $OUTPUT =~ "Running on Pod" ]]; then
       # Success! Got the welcome message.
       cat <<EOF
@@ -42,21 +43,20 @@ for ATTEMPT in $(seq 1 $MAX_RETRIES); do
   "success": true,
   "proxy_ip": "$PROXY_IP",
   "proxy_port": "$PROXY_PORT",
-  "sni": "$SNI",
   "retry_attempt": $ATTEMPT,
   "max_retries": $MAX_RETRIES,
-  "openssl_command": "$OPENSSL_CMD"
+  "telnet_command": "$TELNET_CMD"
 }
 EOF
       exit 0
     fi
 
-    # Got a response but not 200, retry.
+    # Got a response but not expected, retry.
     if [[ $ATTEMPT -lt $MAX_RETRIES ]]; then
       sleep $RETRY_DELAY
     fi
   else
-    # Curl command failed.
+    # nc command failed.
     LAST_OUTPUT="$OUTPUT"
     if [[ $ATTEMPT -lt $MAX_RETRIES ]]; then
       sleep $RETRY_DELAY
@@ -70,11 +70,10 @@ cat <<EOF
   "success": false,
   "proxy_ip": "$PROXY_IP",
   "proxy_port": "$PROXY_PORT",
-  "sni": "$SNI",
   "retry_attempt": $ATTEMPT,
   "max_retries": $MAX_RETRIES,
   "output": "$LAST_OUTPUT",
-  "openssl_command": "$OPENSSL_CMD"
+  "telnet_command": "$TELNET_CMD"
 }
 EOF
 exit 1

--- a/test/e2e/chainsaw/common/scripts/host_connectivity_test_tcp.sh
+++ b/test/e2e/chainsaw/common/scripts/host_connectivity_test_tcp.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Abort on nonzero exit status, unbound variable, and pipefail.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Variables (from environment):
+#   PROXY_IP: The IP address of the proxy to connect to.
+#   PROXY_PORT:  The port to connect to.
+#   SNI: The server name indicator (SNI) used in establishing the TLS connection.
+#   MAX_RETRIES: (optional) Maximum number of retry attempts. Default: '180'.
+#   RETRY_DELAY: (optional) Delay in seconds between retries. Default: '1'.
+
+PROXY_IP="${PROXY_IP}"
+PROXY_PORT="${PROXY_PORT}"
+
+# Retry configuration (configurable via environment variables).
+# Default: 180 retries with 1 second delay = up to 180 seconds total.
+MAX_RETRIES="${MAX_RETRIES:-180}"
+RETRY_DELAY="${RETRY_DELAY:-1}"
+
+# Build nc command.
+build_nc_cmd() {
+  local CMD="nc -zv ${PROXY_IP} ${PROXY_PORT}"
+}
+
+OPENSSL_CMD=$(build_openssl_cmd)
+
+# Retry loop: Keep trying until we get the correct repsonse or run out of retries.
+LAST_OUTPUT=""
+for ATTEMPT in $(seq 1 $MAX_RETRIES); do
+  if OUTPUT=$(eval $OPENSSL_CMD 2>&1 | tr '\n' ' '); then
+    LAST_OUTPUT="$OUTPUT"
+    # Check if the output contains the welcome message from the echo pod.
+    # Only "Running on Pod" is required: with TLS Passthrough the backend itself
+    # terminates TLS and also emits "Through TLS connection", but with TLS Terminate
+    # at the gateway the backend speaks plain TCP and never emits that substring.
+    if [[ $OUTPUT =~ "Running on Pod" ]]; then
+      # Success! Got the welcome message.
+      cat <<EOF
+{
+  "success": true,
+  "proxy_ip": "$PROXY_IP",
+  "proxy_port": "$PROXY_PORT",
+  "sni": "$SNI",
+  "retry_attempt": $ATTEMPT,
+  "max_retries": $MAX_RETRIES,
+  "openssl_command": "$OPENSSL_CMD"
+}
+EOF
+      exit 0
+    fi
+
+    # Got a response but not 200, retry.
+    if [[ $ATTEMPT -lt $MAX_RETRIES ]]; then
+      sleep $RETRY_DELAY
+    fi
+  else
+    # Curl command failed.
+    LAST_OUTPUT="$OUTPUT"
+    if [[ $ATTEMPT -lt $MAX_RETRIES ]]; then
+      sleep $RETRY_DELAY
+    fi
+  fi
+done
+
+# All retries exhausted, output failure.
+cat <<EOF
+{
+  "success": false,
+  "proxy_ip": "$PROXY_IP",
+  "proxy_port": "$PROXY_PORT",
+  "sni": "$SNI",
+  "retry_attempt": $ATTEMPT,
+  "max_retries": $MAX_RETRIES,
+  "output": "$LAST_OUTPUT",
+  "openssl_command": "$OPENSSL_CMD"
+}
+EOF
+exit 1

--- a/test/e2e/chainsaw/gateway/tcproute-onprem/01-gatewayconfiguration.yaml
+++ b/test/e2e/chainsaw/gateway/tcproute-onprem/01-gatewayconfiguration.yaml
@@ -1,0 +1,25 @@
+# On-prem GatewayConfiguration with no KONG_STREAM_LISTEN set.
+# The operator generates the default value for the TLS listener.
+apiVersion: gateway-operator.konghq.com/v2beta1
+kind: GatewayConfiguration
+metadata:
+  name: (join('-', [($test_name), 'gateway-configuration']))
+  namespace: ($namespace)
+spec:
+  dataPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        spec:
+          containers:
+            - name: proxy
+              image: ($gateway_image)
+              readinessProbe:
+                failureThreshold: 3
+                initialDelaySeconds: 1
+                periodSeconds: 1
+                successThreshold: 1
+                timeoutSeconds: 1
+                httpGet:
+                  path: /status/ready
+                  port: 8100
+                  scheme: HTTP

--- a/test/e2e/chainsaw/gateway/tcproute-onprem/02-assert-gateway.yaml
+++ b/test/e2e/chainsaw/gateway/tcproute-onprem/02-assert-gateway.yaml
@@ -1,0 +1,23 @@
+# The Gateway is accepted, programmed and its DataPlane is ready.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ($gateway_name)
+  namespace: ($gateway_namespace)
+status:
+  (conditions[?type == 'Accepted']):
+    - status: 'True'
+      reason: Accepted
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'DataPlaneReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'GatewayService']):
+    - status: 'True'
+      reason: Ready
+  (listeners[?name == 'tcp']):
+    - (conditions[?type == 'Accepted']):
+        - status: 'True'
+          reason: Accepted

--- a/test/e2e/chainsaw/gateway/tcproute-onprem/02-gateway.yaml
+++ b/test/e2e/chainsaw/gateway/tcproute-onprem/02-gateway.yaml
@@ -1,0 +1,13 @@
+# Operator-managed Gateway with a single TLS passthrough (L4) listener.
+# A TLS listener is what drives the operator to generate KONG_STREAM_LISTEN.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ($gateway_name)
+  namespace: ($gateway_namespace)
+spec:
+  gatewayClassName: (join('-', [($test_name), 'gateway-class']))
+  listeners:
+    - name: tcp
+      protocol: TCP
+      port: (to_number($listener_tcp_port))

--- a/test/e2e/chainsaw/gateway/tcproute-onprem/03-assert-tcproute.yaml
+++ b/test/e2e/chainsaw/gateway/tcproute-onprem/03-assert-tcproute.yaml
@@ -18,8 +18,11 @@ status:
         sectionName: tcp
        # Filter conditions array to check for all required conditions
       (conditions[?type == 'Accepted']):
-        - status: 'True'
+        - status: "True"
+          reason: Accepted
       (conditions[?type == 'ResolvedRefs']):
-        - status: 'True'
+        - status: "True"
+          reason: ResolvedRefs
       (conditions[?type == 'Programmed']):
-        - status: 'True'
+        - status: "True"
+          reason: Programmed

--- a/test/e2e/chainsaw/gateway/tcproute-onprem/03-assert-tcproute.yaml
+++ b/test/e2e/chainsaw/gateway/tcproute-onprem/03-assert-tcproute.yaml
@@ -9,15 +9,17 @@ spec:
       kind: Gateway
       name: ($gateway_name)
       sectionName: tcp
-  rules:
-    - backendRefs:
-        - name: ($echo_deployment_name)
-          port: ($tcp_echo_port)
 status:
-  (conditions[?type == 'Accepted']):
-    - status: 'True'
-  (conditions[?type == 'ResolvedRefs']):
-    - status: 'True'
-  (conditions[?type == 'Programmed']):
-    - status: 'True'
-  
+  parents:
+    - parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: ($gateway_name)
+        sectionName: tcp
+       # Filter conditions array to check for all required conditions
+      (conditions[?type == 'Accepted']):
+        - status: 'True'
+      (conditions[?type == 'ResolvedRefs']):
+        - status: 'True'
+      (conditions[?type == 'Programmed']):
+        - status: 'True'

--- a/test/e2e/chainsaw/gateway/tcproute-onprem/03-assert-tcproute.yaml
+++ b/test/e2e/chainsaw/gateway/tcproute-onprem/03-assert-tcproute.yaml
@@ -25,4 +25,4 @@ status:
           reason: ResolvedRefs
       (conditions[?type == 'Programmed']):
         - status: "True"
-          reason: Programmed
+          reason: ConfiguredInGateway

--- a/test/e2e/chainsaw/gateway/tcproute-onprem/03-assert-tcproute.yaml
+++ b/test/e2e/chainsaw/gateway/tcproute-onprem/03-assert-tcproute.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: TCPRoute
+metadata:
+  name: ($tcp_route_name)
+  namespace: ($namespace)
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name)
+      sectionName: tcp
+  rules:
+    - backendRefs:
+        - name: ($echo_deployment_name)
+          port: ($tcp_echo_port)
+status:
+  (conditions[?type == 'Accepted']):
+    - status: 'True'
+  (conditions[?type == 'ResolvedRefs']):
+    - status: 'True'
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+  

--- a/test/e2e/chainsaw/gateway/tcproute-onprem/03-tcproute.yaml
+++ b/test/e2e/chainsaw/gateway/tcproute-onprem/03-tcproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: TCPRoute
+metadata:
+  name: ($tcp_route_name)
+  namespace: ($namespace)
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name)
+      sectionName: tcp
+  rules:
+    - backendRefs:
+        - name: ($echo_deployment_name)
+          port: ($tcp_echo_port)

--- a/test/e2e/chainsaw/gateway/tcproute-onprem/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/gateway/tcproute-onprem/chainsaw-test.yaml
@@ -1,7 +1,7 @@
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: tcproute-onprem
+  name: gateway-tcproute-onprem
 spec:
   description: |
     Validates that an operator-managed on-prem Gateway supports TCPRoute by:
@@ -71,3 +71,16 @@ spec:
       description: Verify that TCP traffic to the Gateway is routed to the tcpecho backend.
       use:
         template: ../../common/_step_templates/verify-tcp-traffic-from-host.yaml
+
+  catch:
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: gateway-tcproute-onprem
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/gateway/tcproute-onprem/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/gateway/tcproute-onprem/chainsaw-test.yaml
@@ -1,0 +1,73 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: tcproute-onprem
+spec:
+  description: |
+    Validates that an operator-managed on-prem Gateway supports TCPRoute by:
+    1. Creating a GatewayConfiguration and GatewayClass for on-prem mode.
+    2. Creating a TCP Gateway listener whose SupportedKinds includes GRPCRoute.
+    3. Attaching a TCPRoute to that listener and verifying TCPRoute programmed.
+    4. Verifying end-to-end TCP traffic to a tcpecho backend.
+  bindings:
+    - name: test_name
+      value: ($namespace)
+    - name: gateway_namespace
+      value: ($namespace)
+    - name: gateway_name
+      value: (join('-', [($namespace), 'gateway']))
+    - name: gateway_image
+      value: (env('GATEWAY_IMAGE'))
+    - name: tcpecho_image
+      value: 'kong/go-echo:latest'
+    - name: tcp_route_name
+      value: tcproute-onprem
+    - name: echo_deployment_namespace
+      value: ($namespace)
+    - name: echo_deployment_name
+      value: tcpecho
+    - name: echo_deployment_replicas
+      value: 1
+    - name: tcp_echo_port
+      value: 1025
+    - name: listener_tcp_port
+      value: 8888
+  steps:
+    - name: Create-gateway-configuration
+      description: Create an on-prem GatewayConfiguration with no custom KONG_STREAM_LISTEN.
+      try:
+        - apply:
+            file: 01-gatewayconfiguration.yaml
+        - assert:
+            file: 01-gatewayconfiguration.yaml
+
+    - name: Create-gateway-class
+      description: Create a GatewayClass pointing at the on-prem GatewayConfiguration.
+      use:
+        template: ../../common/_step_templates/apply-assert-gatewayClass.yaml
+
+    - name: Create-gateway
+      description: Create an operator-managed Gateway with a TCP listener.
+      try:
+        - apply:
+            file: 02-gateway.yaml 
+        - assert:
+            file: 02-assert-gateway.yaml
+
+    - name: Create-tcpecho
+      description: Create a tcpecho backend Deployment and Service.
+      use:
+        template: ../../common/_step_templates/apply-assert-echoService.yaml
+
+    - name: Create-tcproute
+      description: Create a TCPRoute attached to the Gateway's TCP listener. 
+      try:
+        - apply:
+            file: 03-tcproute.yaml
+        - assert:
+            file: 03-assert-tcproute.yaml
+    
+    - name: Verify-tcp-traffic
+      description: Verify that TCP traffic to the Gateway is routed to the tcpecho backend.
+      use:
+        template: ../../common/_step_templates/verify-tcp-traffic-from-host.yaml

--- a/test/e2e/chainsaw/gateway/tcproute-onprem/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/gateway/tcproute-onprem/chainsaw-test.yaml
@@ -6,7 +6,7 @@ spec:
   description: |
     Validates that an operator-managed on-prem Gateway supports TCPRoute by:
     1. Creating a GatewayConfiguration and GatewayClass for on-prem mode.
-    2. Creating a TCP Gateway listener whose SupportedKinds includes GRPCRoute.
+    2. Creating a TCP Gateway listener whose SupportedKinds includes TCPRoute.
     3. Attaching a TCPRoute to that listener and verifying TCPRoute programmed.
     4. Verifying end-to-end TCP traffic to a tcpecho backend.
   bindings:

--- a/test/helpers/generators.go
+++ b/test/helpers/generators.go
@@ -161,6 +161,43 @@ func GenerateHTTPRoute(namespace string, gatewayName, serviceName string, opts .
 	return httpRoute
 }
 
+// GenerateTCPRoute generates a TCPRoute to be used in tests.
+func GenerateTCPRoute(namespace string, gatewayName, serviceName string, portNumber int, opts ...func(*gatewayv1.TCPRoute)) *gatewayv1.TCPRoute {
+	tcpRoute := &gatewayv1.TCPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      uuid.NewString(),
+			Namespace: namespace,
+		},
+		Spec: gatewayv1.TCPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{
+						Name: gatewayv1.ObjectName(gatewayName),
+					},
+				},
+			},
+			Rules: []gatewayv1.TCPRouteRule{
+				{
+					BackendRefs: []gatewayv1.BackendRef{
+						{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Name: gatewayv1.ObjectName(serviceName),
+								Port: new(gatewayv1.PortNumber(portNumber)),
+								Kind: new(gatewayv1.Kind("Service")),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(tcpRoute)
+	}
+	return tcpRoute
+}
+
 // GenerateTLSRoute generates a TLSRoute to be used in tests.
 func GenerateTLSRoute(namespace string, gatewayName, serviceName string, portNumber int, opts ...func(*gatewayv1.TLSRoute)) *gatewayv1.TLSRoute {
 	tlsRoute := &gatewayv1.TLSRoute{

--- a/test/integration/ko/tcproute_test.go
+++ b/test/integration/ko/tcproute_test.go
@@ -1,0 +1,174 @@
+package integration
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
+	testutils "github.com/kong/kong-operator/v2/pkg/utils/test"
+	"github.com/kong/kong-operator/v2/test/helpers"
+	"github.com/kong/kong-operator/v2/test/integration"
+)
+
+// tcpListenerPort is the Gateway listener port for the TCPRoute test.
+// tcpEchoPort (the backend port) is shared with tlsroute_test.go.
+const tcpListenerPort = 8888
+
+// setTCPListener returns a Gateway option that configures a "tcp" listener on
+// the given port with protocol TCP and no restrictions on route namespaces.
+func setTCPListener(port int) func(*gatewayv1.Gateway) {
+	tcpListener := gatewayv1.Listener{
+		Name:     "tcp",
+		Port:     gatewayv1.PortNumber(port),
+		Protocol: gatewayv1.TCPProtocolType,
+		AllowedRoutes: &gatewayv1.AllowedRoutes{
+			Namespaces: &gatewayv1.RouteNamespaces{
+				From: new(gatewayv1.NamespacesFromAll),
+			},
+		},
+	}
+	return func(gw *gatewayv1.Gateway) {
+		for i, listener := range gw.Spec.Listeners {
+			if listener.Name == "tcp" {
+				gw.Spec.Listeners[i] = tcpListener
+				return
+			}
+		}
+		gw.Spec.Listeners = append(gw.Spec.Listeners, tcpListener)
+	}
+}
+
+// hasRouteConditionTrue reports whether conds contains a condition of the given
+// type with Status == True.
+func hasRouteConditionTrue(conds []metav1.Condition, condType string) bool {
+	for _, c := range conds {
+		if c.Type == condType && c.Status == metav1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func TestTCPRoute(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	clients := integration.GetClients()
+	namespace, cleaner := helpers.SetupTestEnv(t, ctx, integration.GetEnv())
+
+	gatewayConfig := helpers.GenerateGatewayConfiguration(namespace.Name)
+	t.Logf("deploying GatewayConfiguration %s/%s", gatewayConfig.Namespace, gatewayConfig.Name)
+	gatewayConfig, err := clients.OperatorClient.GatewayOperatorV2beta1().GatewayConfigurations(namespace.Name).Create(ctx, gatewayConfig, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(gatewayConfig)
+
+	gatewayClass := helpers.MustGenerateGatewayClass(t, gatewayv1.ParametersReference{
+		Group:     gatewayv1.Group(operatorv1beta1.SchemeGroupVersion.Group),
+		Kind:      gatewayv1.Kind("GatewayConfiguration"),
+		Namespace: (*gatewayv1.Namespace)(&gatewayConfig.Namespace),
+		Name:      gatewayConfig.Name,
+	})
+	t.Logf("deploying GatewayClass %s", gatewayClass.Name)
+	gatewayClass, err = clients.GatewayClient.GatewayV1().GatewayClasses().Create(ctx, gatewayClass, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(gatewayClass)
+
+	gatewayNSN := types.NamespacedName{
+		Name:      uuid.NewString(),
+		Namespace: namespace.Name,
+	}
+
+	gateway := helpers.GenerateGateway(gatewayNSN, gatewayClass, setTCPListener(tcpListenerPort))
+	t.Logf("deploying Gateway %s/%s with a TCP listener on port %d", gateway.Namespace, gateway.Name, tcpListenerPort)
+	gateway, err = clients.GatewayClient.GatewayV1().Gateways(namespace.Name).Create(ctx, gateway, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(gateway)
+
+	t.Logf("verifying Gateway %s/%s gets marked as Accepted", gateway.Namespace, gateway.Name)
+	require.Eventually(t, testutils.GatewayIsAccepted(t, ctx, gatewayNSN, clients), testutils.GatewaySchedulingTimeLimit, time.Second)
+
+	t.Logf("verifying Gateway %s/%s gets marked as Programmed", gateway.Namespace, gateway.Name)
+	require.Eventually(t, testutils.GatewayIsProgrammed(t, ctx, gatewayNSN, clients.MgrClient), testutils.GatewayReadyTimeLimit, time.Second)
+	t.Logf("verifying Gateway %s/%s Listeners get marked as Programmed", gateway.Namespace, gateway.Name)
+	require.Eventually(t, testutils.GatewayListenersAreProgrammed(t, ctx, gatewayNSN, clients), testutils.GatewayReadyTimeLimit, time.Second)
+
+	t.Logf("verifying Gateway %s/%s gets an IP address", gateway.Namespace, gateway.Name)
+	require.Eventually(t, testutils.GatewayIPAddressExist(t, ctx, gatewayNSN, clients), testutils.SubresourceReadinessWait, time.Second)
+	gateway = testutils.MustGetGateway(t, ctx, gatewayNSN, clients.MgrClient)
+	gatewayIPAddress := gateway.Status.Addresses[0].Value
+
+	t.Log("deploying tcpecho backend deployment")
+	container := generators.NewContainer("tcpecho", testutils.TCPEchoImage, tcpEchoPort)
+	container.Env = []corev1.EnvVar{
+		{
+			Name:  "POD_NAME",
+			Value: "test-tcp-echo",
+		},
+		{
+			Name:  "TCP_PORT",
+			Value: strconv.Itoa(tcpEchoPort),
+		},
+	}
+	deployment := generators.NewDeploymentForContainer(container)
+	deployment, err = integration.GetEnv().Cluster().Client().AppsV1().Deployments(namespace.Name).Create(ctx, deployment, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("exposing tcpecho deployment %s via service", deployment.Name)
+	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeClusterIP)
+	service, err = integration.GetEnv().Cluster().Client().CoreV1().Services(namespace.Name).Create(ctx, service, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("generating a TCPRoute")
+	tcpRoute := helpers.GenerateTCPRoute(namespace.Name, gateway.Name, service.Name, tcpEchoPort)
+
+	t.Logf("creating tcproute %s/%s to access deployment %s via kong", tcpRoute.Namespace, tcpRoute.Name, deployment.Name)
+	require.EventuallyWithT(t,
+		func(c *assert.CollectT) {
+			result, err := clients.GatewayClient.GatewayV1().TCPRoutes(namespace.Name).Create(ctx, tcpRoute, metav1.CreateOptions{})
+			require.NoError(c, err, "failed to deploy tcproute %s/%s", tcpRoute.Namespace, tcpRoute.Name)
+			cleaner.Add(result)
+			tcpRoute = result
+		},
+		testutils.DefaultIngressWait, testutils.WaitIngressTick,
+	)
+
+	t.Logf("verifying TCPRoute %s/%s has Accepted, ResolvedRefs and Programmed conditions set to True", tcpRoute.Namespace, tcpRoute.Name)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		got, err := clients.GatewayClient.GatewayV1().TCPRoutes(namespace.Name).Get(ctx, tcpRoute.Name, metav1.GetOptions{})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotEmpty(c, got.Status.Parents, "TCPRoute has no parent statuses yet") {
+			return
+		}
+		conds := got.Status.Parents[0].Conditions
+		// gateway-api standardizes Accepted and ResolvedRefs on routes; the Programmed
+		// condition on routes is a Kong convention set by ensureParentsProgrammedCondition
+		// (Type == "Programmed").
+		assert.Truef(c, hasRouteConditionTrue(conds, string(gatewayv1.RouteConditionAccepted)), "expected %s=True on TCPRoute, got %+v", gatewayv1.RouteConditionAccepted, conds)
+		assert.Truef(c, hasRouteConditionTrue(conds, string(gatewayv1.RouteConditionResolvedRefs)), "expected %s=True on TCPRoute, got %+v", gatewayv1.RouteConditionResolvedRefs, conds)
+		assert.Truef(c, hasRouteConditionTrue(conds, "Programmed"), "expected Programmed=True on TCPRoute, got %+v", conds)
+	}, testutils.DefaultTCPRouteWait, testutils.WaitTCPRouteTick,
+		"TCPRoute %s/%s did not get Accepted, ResolvedRefs and Programmed conditions set to True, current status: %+v",
+		tcpRoute.Namespace, tcpRoute.Name, tcpRoute.Status)
+
+	t.Logf("verifying connectivity to the TCPRoute via %s:%d", gatewayIPAddress, tcpListenerPort)
+	require.Eventually(t, func() bool {
+		err := helpers.EchoResponds(t, helpers.ProtocolTCP, fmt.Sprintf("%s:%d", gatewayIPAddress, tcpListenerPort), "test-tcp-echo")
+		if err != nil {
+			t.Logf("failed to access TCPRoute on %s:%d, error %+v", gatewayIPAddress, tcpListenerPort, err)
+			return false
+		}
+		return true
+	}, testutils.DefaultTCPRouteWait, testutils.WaitTCPRouteTick)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support of `TCPRoute` for on-prem gateways. Also since gateway API 1.6.0 has promoted `TCPRoute` to `v1`, it moved TCPRoute controller out of `GatewayAlpha` feature gate. 

It also adds an integration test case and a e2e chainsaw test case for basic functions of TCPRoute.

**Which issue this PR fixes**

Fixes #4334 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
