### PR TITLE
fix(konnect): add KongReferenceGrant watch to KongVault and KongConsumerGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,11 @@
 
 ### Fixes
 
+- Add `KongReferenceGrant` watch to `KongVault` and `KongConsumerGroup` reconcilers.
+  Previously, creating or deleting a grant would not trigger re-reconciliation of these
+  resources until the next full resync cycle. Grant changes now immediately re-queue
+  affected objects.
+  [#4219](https://github.com/Kong/kong-operator/pull/4219)
 - Fix cross-namespace `KongRoute → KongService` reference resolution: `handleKongServiceRef`
   and `GetAPIAuthRefNN` (serviceRef branch) now derive the `KongService` namespace from
   `serviceRef.namespace` instead of always using the route's namespace, so a cross-namespace

--- a/controller/konnect/watch_kongconsumergroup.go
+++ b/controller/konnect/watch_kongconsumergroup.go
@@ -7,6 +7,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	configurationv1beta1 "github.com/kong/kong-operator/v2/api/configuration/v1beta1"
 	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
@@ -51,6 +52,14 @@ func KongConsumerGroupReconciliationWatchOptions(
 					enqueueObjectForKonnectGatewayControlPlane[configurationv1beta1.KongConsumerGroupList](
 						cl, index.IndexFieldKongConsumerGroupOnKonnectGatewayControlPlane,
 					),
+				),
+			)
+		},
+		func(b *ctrl.Builder) *ctrl.Builder {
+			return b.Watches(
+				&configurationv1alpha1.KongReferenceGrant{},
+				handler.EnqueueRequestsFromMapFunc(
+					enqueueObjectsForKongReferenceGrant[configurationv1beta1.KongConsumerGroupList](cl),
 				),
 			)
 		},

--- a/controller/konnect/watch_kongvault.go
+++ b/controller/konnect/watch_kongvault.go
@@ -49,6 +49,14 @@ func KongVaultReconciliationWatchOptions(cl client.Client) []func(*ctrl.Builder)
 				),
 			)
 		},
+		func(b *ctrl.Builder) *ctrl.Builder {
+			return b.Watches(
+				&configurationv1alpha1.KongReferenceGrant{},
+				handler.EnqueueRequestsFromMapFunc(
+					enqueueObjectsForKongReferenceGrant[configurationv1alpha1.KongVaultList](cl),
+				),
+			)
+		},
 	}
 }
 


### PR DESCRIPTION




**What this PR does / why we need it**:

Neither KongVault nor KongConsumerGroup had a watch on KongReferenceGrant, so creating or deleting a grant would not trigger re-reconciliation until the next full resync cycle.

Wire the existing enqueueObjectsForKongReferenceGrant helper into both KongVaultReconciliationWatchOptions and KongConsumerGroupReconciliationWatchOptions so grant changes immediately re-queue affected objects.

**Which issue this PR fixes**

Fixes #4151 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
