### PR TITLE
test(e2e): Add e2e chainsaw test case for Terminate TLS listener and TLSRoute attached

### DIFF
--- a/test/e2e/chainsaw/common/scripts/host_connectivity_test_with_tls_traffic.sh
+++ b/test/e2e/chainsaw/common/scripts/host_connectivity_test_with_tls_traffic.sh
@@ -34,7 +34,10 @@ for ATTEMPT in $(seq 1 $MAX_RETRIES); do
   if OUTPUT=$(eval $OPENSSL_CMD 2>&1 | tr '\n' ' '); then
     LAST_OUTPUT="$OUTPUT"
     # Check if the output contains the welcome message from the echo pod.
-    if [[ $OUTPUT =~ "Running on Pod" && $OUTPUT =~ "Through TLS connection" ]]; then
+    # Only "Running on Pod" is required: with TLS Passthrough the backend itself
+    # terminates TLS and also emits "Through TLS connection", but with TLS Terminate
+    # at the gateway the backend speaks plain TCP and never emits that substring.
+    if [[ $OUTPUT =~ "Running on Pod" ]]; then
       # Success! Got the welcome message.
       cat <<EOF
 {

--- a/test/e2e/chainsaw/hybridgateway/tlsroute-terminate-listener/01-tlsRoute-echo.yaml
+++ b/test/e2e/chainsaw/hybridgateway/tlsroute-terminate-listener/01-tlsRoute-echo.yaml
@@ -1,0 +1,18 @@
+---
+kind: TLSRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: (join('-', [($test_name), 'echo-tls-route']))
+  namespace: ($namespace)
+  labels:
+    chainsaw/test: ($test_name)
+spec:
+  hostnames: ($route_hosts)
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name)
+  rules:
+    - backendRefs:
+        - name: (join('-', [($test_name), 'echo']))
+          port: 1025

--- a/test/e2e/chainsaw/hybridgateway/tlsroute-terminate-listener/02-tlsRoute-echo-assert.yaml
+++ b/test/e2e/chainsaw/hybridgateway/tlsroute-terminate-listener/02-tlsRoute-echo-assert.yaml
@@ -1,0 +1,37 @@
+---
+# Assert TLSRoute is accepted and programmed.
+#
+# Required bindings:
+#   - test_name: The test name label to match.
+#   - gateway_name: The Gateway the TLSRoute is attached to.
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  (labels."chainsaw/test" == ($test_name)): true
+  namespace: ($namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        group: gateway.networking.k8s.io
+        kind: Gateway
+      controllerName: konghq.com/gateway-operator
+      # Filter conditions array to check for all required conditions.
+      (conditions[?type == 'Accepted']):
+        - status: "True"
+          reason: Accepted
+      (conditions[?type == 'ResolvedRefs']):
+        - status: "True"
+          reason: ResolvedRefs
+      (conditions[?type == 'KongRouteProgrammed']):
+        - status: "True"
+          reason: KongRouteProgrammed
+      (conditions[?type == 'KongServiceProgrammed']):
+        - status: "True"
+          reason: KongServiceProgrammed
+      (conditions[?type == 'KongUpstreamProgrammed']):
+        - status: "True"
+          reason: KongUpstreamProgrammed
+      (conditions[?type == 'KongTargetProgrammed']):
+        - status: "True"
+          reason: KongTargetProgrammed

--- a/test/e2e/chainsaw/hybridgateway/tlsroute-terminate-listener/README.md
+++ b/test/e2e/chainsaw/hybridgateway/tlsroute-terminate-listener/README.md
@@ -1,0 +1,42 @@
+# TLSRoute with `Terminate` Listener Test
+
+This test validates that the Hybrid Gateway controller correctly processes a
+`TLSRoute` attached to a Gateway listener using `protocol: TLS` with
+`tls.mode: Terminate`. In this mode the gateway terminates the inbound TLS
+connection using a certificate from the referenced TLS secret and forwards
+plain TCP traffic to the backend echo service.
+
+## Test Flow Overview
+
+1. **Create Prerequisite Resources**
+    - Creates the TLS secret used by the listener for terminating TLS.
+    - Sets up Konnect integration: auth secret and `KonnectAPIAuthConfiguration`.
+    - Sets up Gateway API resources: `GatewayConfiguration`, `GatewayClass`,
+      and a `Gateway` with a single listener `protocol: TLS`,
+      `tls.mode: Terminate` on port 8899.
+    - Asserts the Gateway is `Accepted` / `Programmed`, and that the
+      `KonnectGatewayControlPlane`, `KongCertificate`, and `KongSNI` resources
+      are created and reconciled.
+
+2. **Deploy Backend and TLSRoute**
+    - Deploys a plain-TCP `echo` backend (no TLS termination at the pod,
+      since the gateway terminates TLS upstream).
+    - Applies a `TLSRoute` selecting the gateway listener via `parentRefs`
+      and routing SNI `echo.<ns>.example.com` to the echo service on
+      its plain TCP port (1025).
+    - Verifies the controller creates the expected Kong resources
+      (`KongRoute`, `KongService`, `KongUpstream`, `KongTarget`) with
+      correct status.
+
+3. **Traffic Verification**
+    - From the host, performs an `openssl s_client` TLS handshake to the
+      gateway proxy IP on port 8899 with SNI `echo.<ns>.example.com`.
+    - Asserts the echo backend's welcome message is received, confirming
+      that the gateway terminated TLS and forwarded traffic to the pod.
+
+## Notes
+- The scenario differs from `basic-tlsroute`, which uses `tls.mode:
+  Passthrough` and a TLS-terminating backend on port 1030. Here the gateway
+  itself terminates TLS, so the backend uses the plain TCP port 1025.
+- All resource creation, assertions, and traffic checks run inside a
+  dynamically assigned namespace for isolation.

--- a/test/e2e/chainsaw/hybridgateway/tlsroute-terminate-listener/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/tlsroute-terminate-listener/chainsaw-test.yaml
@@ -1,0 +1,156 @@
+# TLSRoute attached to a TLS listener with `mode: Terminate`.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: tlsroute-terminate-listener
+spec:
+  description: |
+    This test validates that the hybrid gateway controller correctly
+    processes a TLSRoute attached to a Gateway listener using protocol TLS
+    with `mode: Terminate`, where the gateway terminates the TLS connection
+    and forwards plain TCP traffic to the backend echo service.
+
+  bindings:
+    # Common bindings.
+    - name: test_name
+      value: ($namespace)
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_api_auth_namespace
+      value: ($namespace)
+    - name: tls_mode
+      value: "Terminate"
+    - name: listener_tls_port
+      value: 8899
+    - name: sni_hostname
+      value: (join('.', ['*', ($test_name), 'example.com']))
+    - name: fqdn
+      value: (join('.', ['echo', ($test_name), 'example.com']))
+    - name: cert_secret_name
+      value: test-tls-secret
+    - name: cert_secret_namespace
+      value: ($namespace)
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
+    - name: gateway_image
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+    - name: gateway_name
+      value: (join('-', [($test_name), 'gateway']))
+    - name: gateway_namespace
+      value: ($namespace)
+    - name: echo_deployment_name
+      value: (join('-', [($test_name), 'echo']))
+    - name: echo_deployment_namespace
+      value: ($namespace)
+    - name: echo_deployment_replicas
+      value: 1
+
+  steps:
+    # Step 1: Create the TLS secret that will be referenced by the Gateway TLS listener.
+    - name: Create-tls-secret
+      description: Create TLS Secret for the Gateway TLS listener.
+      use:
+        template: ../../common/_step_templates/apply-assert-tlsSecret.yaml
+
+    # Step 2a: Create the secret for Konnect authentication.
+    - name: Create-auth-secret
+      description: Create Secret with Konnect token for KonnectAPIAuthConfiguration.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    # Step 2b: Create the KonnectAPIAuthConfiguration to authenticate with Konnect.
+    - name: Create-konnect-api-auth
+      description: Create KonnectAPIAuthConfiguration for the test.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
+
+    # Step 3: Create the GatewayConfiguration that defines the hybrid gateway setup.
+    - name: Create-gateway-configuration
+      description: Create GatewayConfiguration for the test.
+      use:
+        template: ../../common/_step_templates/apply-assert-gatewayConfiguration.yaml
+
+    # Step 4: Create the GatewayClass that will be used by the Gateway.
+    - name: Create-gateway-class
+      description: Create GatewayClass for the test.
+      use:
+        template: ../../common/_step_templates/apply-assert-gatewayClass.yaml
+
+    # Step 5: Create the Gateway with a TLS listener (mode: Terminate) that references the TLS secret.
+    - name: Create-gateway
+      description: Create Gateway with TLS listener (Terminate mode) for the test.
+      use:
+        template: ../../common/_step_templates/apply-assert-gateway-tls-listener.yaml
+
+    # Step 6: Verify that the KonnectGatewayControlPlane is created and synchronized with Konnect.
+    - name: Assert-konnect-gateway-control-plane
+      description: Assert that the KonnectGatewayControlplane resource is created and synchronized.
+      use:
+        template: ../../common/_step_templates/assert-konnectGatewayControlPlane.yaml
+
+    # Step 7: Verify that the KongCertificate resource is created from the TLS secret.
+    - name: Assert-kong-certificate
+      description: Assert that the KongCertificate resource is created for the TLS secret.
+      use:
+       template: ../../common/_step_templates/assert-kongCertificate-tls-listener.yaml
+
+    # Step 8: Verify that the KongSNI resource is created for the SNI hostname.
+    - name: Assert-kong-sni
+      description: Assert that the KongSNI resource is created for the SNI hostname.
+      use:
+       template: ../../common/_step_templates/assert-kongSNI-tls-listener.yaml
+      bindings:
+        - name: resource_type
+          value: "kongcertificates.configuration.konghq.com"
+
+    # Step 9: Create the echo service that will receive the routed traffic.
+    # Since the gateway terminates TLS, the backend receives plain TCP and does not
+    # need to mount TLS certs (uses apply-assert-echoService.yaml, not the *-with-tls variant).
+    - name: Create-echo-service
+      description: Create and assert an echo service to route traffic to.
+      use:
+        template: ../../common/_step_templates/apply-assert-echoService.yaml
+
+    # Step 10: Create the TLSRoute that routes traffic to the echo service.
+    - name: Create-tlsroute-echo
+      description: Create TLSRoute to route traffic to the echo service.
+      try:
+        - apply:
+            file: 01-tlsRoute-echo.yaml
+        - assert:
+            file: 02-tlsRoute-echo-assert.yaml
+      bindings:
+        - name: route_hosts
+          value:
+            - ($fqdn)
+
+    # Step 11: Verify TLS traffic from host. The gateway terminates TLS using the
+    # certificate from the TLS secret and forwards plain TCP to the echo backend.
+    - name: Verify-TLS-traffic-from-host
+      description: Verify that TLS traffic is terminated by the gateway and forwarded to the echo service.
+      use:
+        template: ../../common/_step_templates/verify-tls-traffic-from-host.yaml
+      bindings:
+        - name: request_sni
+          value: ($fqdn)
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-tlsroute-terminate-listener
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh


### PR DESCRIPTION

**What this PR does / why we need it**:

Add e2e chainsaw test cases for `TLSRoute` attached to the gateway with `Terminate` TLS listener.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
