### PR TITLE
add TLSRoute in conformance tests

### DIFF
--- a/pkg/gatewayapi/supportedfeatures.go
+++ b/pkg/gatewayapi/supportedfeatures.go
@@ -40,6 +40,9 @@ var commonSupportedFeatures = sets.New(
 	// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/5868
 	// Temporarily disabled and tracking through the following issue.
 	// features.SupportHTTPRouteBackendTimeout,
+
+	// TLSRoute extended.
+	features.SupportTLSRouteModeTerminate,
 )
 
 // GetSupportedFeatures returns the supported features for the given router type.

--- a/pkg/gatewayapi/supportedfeatures.go
+++ b/pkg/gatewayapi/supportedfeatures.go
@@ -25,6 +25,7 @@ var commonSupportedFeatures = sets.New(
 	// Core features.
 	features.SupportGateway,
 	features.SupportHTTPRoute,
+	features.SupportTLSRoute,
 	features.SupportGRPCRoute,
 	features.SupportReferenceGrant,
 

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -64,6 +64,7 @@ var skippedTestsForHybrid = []string{
 	// TODO: https://github.com/Kong/kong-operator/issues/2793
 	tests.HTTPRouteReferenceGrant.ShortName,
 	// This test is skipped because the `Reason` field in the `RouteCondition` is not the same as expected by the test.
+	// TODO: https://github.com/Kong/kong-operator/issues/67
 	tests.HTTPRouteDisallowedKind.ShortName,
 }
 

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -20,6 +20,15 @@ var skippedTestsShared = []string{
 	// When processing this scenario, the Kong's router requires `priority` to be specified for routes.
 	// We cannot provide that for routes that are part of the conformance suite.
 	tests.GRPCRouteListenerHostnameMatching.ShortName,
+
+	// TLSRoute tests that cannot pass yet.
+	tests.TLSRouteHostnameIntersection.ShortName,
+	tests.TLSRouteInvalidBackendRefNonexistent.ShortName,
+	tests.TLSRouteInvalidBackendRefUnknownKind.ShortName,
+	tests.TLSRouteInvalidNoMatchingListener.ShortName,
+	tests.TLSRouteInvalidReferenceGrant.ShortName,
+	tests.TLSRouteTerminateSimpleSameNamespace.ShortName,
+	tests.TLSRouteListenerMixedTerminationNotSupported.ShortName,
 }
 
 var skippedTestsForExpressionsRouter = []string{}
@@ -54,6 +63,8 @@ var skippedTestsForHybrid = []string{
 	// This test is skipped because it proven to be flaky.
 	// TODO: https://github.com/Kong/kong-operator/issues/2793
 	tests.HTTPRouteReferenceGrant.ShortName,
+	// This test is skipped because the `Reason` field in the `RouteCondition` is not the same as expected by the test.
+	tests.HTTPRouteDisallowedKind.ShortName,
 }
 
 // skippedTestsForConfig returns the list of skipped tests for the given router flavor and gateway type.


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable conformance tests for `TLSRoute`.

Currently only `TLSRouteSimpleSameNamespace` is enabled.

**Which issue this PR fixes**

Fixes #66 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
