### PR TITLE
fix(ingress-controller): Allow TLS terminate for TLSRoute and add tests

### DIFF
--- a/ingress-controller/internal/controllers/gateway/route_utils.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils.go
@@ -419,12 +419,6 @@ func routeTypeMatchesListenerType[T gatewayapi.RouteT](route T, listener gateway
 		if listener.Protocol != gatewayapi.TLSProtocolType {
 			return false
 		}
-		// TLSRoutes currently support Passthrough only
-		// Note: this is a guess we are doing as the upstream documentation is unclear at the moment.
-		// see https://github.com/kubernetes-sigs/gateway-api/issues/1474
-		if listener.TLS != nil && *listener.TLS.Mode != gatewayapi.TLSModePassthrough {
-			return false
-		}
 	case *gatewayapi.GRPCRoute:
 		if listener.Protocol != gatewayapi.HTTPSProtocolType && listener.Protocol != gatewayapi.HTTPProtocolType {
 			return false

--- a/ingress-controller/internal/controllers/gateway/route_utils_test.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils_test.go
@@ -1177,7 +1177,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 				},
 			},
 			{
-				name:  "basic TLSRoute does not get accepted because there is no listener with TLS in passthrough mode",
+				name:  "basic TLSRouteget accepted because there is a listener with TLS in terminate mode",
 				route: basicTLSRoute(),
 				objects: []client.Object{
 					func() *gatewayapi.Gateway {
@@ -1195,7 +1195,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 				},
 				expected: []expected{
 					{
-						condition: routeConditionAccepted(metav1.ConditionFalse, gatewayapi.RouteReasonNoMatchingParent),
+						condition: routeConditionAccepted(metav1.ConditionTrue, gatewayapi.RouteReasonAccepted),
 					},
 				},
 			},

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -27,7 +27,6 @@ var skippedTestsShared = []string{
 	tests.TLSRouteInvalidBackendRefUnknownKind.ShortName,
 	tests.TLSRouteInvalidNoMatchingListener.ShortName,
 	tests.TLSRouteInvalidReferenceGrant.ShortName,
-	tests.TLSRouteTerminateSimpleSameNamespace.ShortName,
 	tests.TLSRouteListenerMixedTerminationNotSupported.ShortName,
 }
 

--- a/test/integration/ko/tlsroute_test.go
+++ b/test/integration/ko/tlsroute_test.go
@@ -25,22 +25,26 @@ import (
 )
 
 const (
-	tlsPort = 1030
+	tlsPort     = 1030
+	tcpEchoPort = 1025
 )
 
 func setTLSListener(port int, mode gatewayv1.TLSModeType, certSecretName string) func(*gatewayv1.Gateway) {
+	tlsConfig := &gatewayv1.ListenerTLSConfig{
+		Mode: &mode,
+	}
+	if mode != gatewayv1.TLSModePassthrough {
+		tlsConfig.CertificateRefs = []gatewayv1.SecretObjectReference{
+			{
+				Name: gatewayv1.ObjectName(certSecretName),
+			},
+		}
+	}
 	tlsListener := gatewayv1.Listener{
 		Name:     "tls",
 		Port:     gatewayv1.PortNumber(port),
 		Protocol: gatewayv1.TLSProtocolType,
-		TLS: &gatewayv1.ListenerTLSConfig{
-			Mode: &mode,
-			CertificateRefs: []gatewayv1.SecretObjectReference{
-				{
-					Name: gatewayv1.ObjectName(certSecretName),
-				},
-			},
-		},
+		TLS:      tlsConfig,
 	}
 	return func(gw *gatewayv1.Gateway) {
 
@@ -55,7 +59,7 @@ func setTLSListener(port int, mode gatewayv1.TLSModeType, certSecretName string)
 	}
 }
 
-func TestTLSRoute(t *testing.T) {
+func TestTLSRoutePassthrough(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 	clients := integration.GetClients()
@@ -200,6 +204,126 @@ func TestTLSRoute(t *testing.T) {
 			})
 		if err != nil {
 			t.Logf("failed to access TLSRoute on %s:%d, error %+v", gatewayIPAddress, tlsPort, err)
+			return false
+		}
+		return true
+	}, testutils.DefaultTLSRouteWait, testutils.WaitTLSRouteTick)
+}
+
+func TestTLSTerminate(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	clients := integration.GetClients()
+	namespace, cleaner := helpers.SetupTestEnv(t, ctx, integration.GetEnv())
+
+	gatewayConfig := helpers.GenerateGatewayConfiguration(namespace.Name)
+	t.Logf("deploying GatewayConfiguration %s/%s", gatewayConfig.Namespace, gatewayConfig.Name)
+	gatewayConfig, err := integration.GetClients().OperatorClient.GatewayOperatorV2beta1().GatewayConfigurations(namespace.Name).Create(ctx, gatewayConfig, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(gatewayConfig)
+
+	gatewayClass := helpers.MustGenerateGatewayClass(t, gatewayv1.ParametersReference{
+		Group:     gatewayv1.Group(operatorv1beta1.SchemeGroupVersion.Group),
+		Kind:      gatewayv1.Kind("GatewayConfiguration"),
+		Namespace: (*gatewayv1.Namespace)(&gatewayConfig.Namespace),
+		Name:      gatewayConfig.Name,
+	})
+	t.Logf("deploying GatewayClass %s", gatewayClass.Name)
+	gatewayClass, err = integration.GetClients().GatewayClient.GatewayV1().GatewayClasses().Create(ctx, gatewayClass, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(gatewayClass)
+
+	const host = "tlsroute-terminate.integration.tests.org"
+	certSecretName := host + "-cert"
+	cert, key := certificate.MustGenerateCertPEMFormat(certificate.WithDNSNames(host))
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace.Name,
+			Name:      certSecretName,
+			Labels: map[string]string{
+				config.DefaultSecretLabelSelector: config.LabelValueForSelectorTrue,
+			},
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       cert,
+			corev1.TLSPrivateKeyKey: key,
+		},
+	}
+	t.Logf("deploying Secret %s/%s", secret.Namespace, secret.Name)
+	secret, err = integration.GetClients().K8sClient.CoreV1().Secrets(namespace.Name).Create(ctx, secret, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	gatewayNSN := types.NamespacedName{
+		Name:      uuid.NewString(),
+		Namespace: namespace.Name,
+	}
+
+	gateway := helpers.GenerateGateway(gatewayNSN, gatewayClass, setTLSListener(tlsPort, gatewayv1.TLSModeTerminate, secret.Name))
+	t.Logf("deploying Gateway %s/%s", gateway.Namespace, gateway.Name)
+	gateway, err = integration.GetClients().GatewayClient.GatewayV1().Gateways(namespace.Name).Create(ctx, gateway, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(gateway)
+
+	t.Logf("verifying Gateway %s/%s gets marked as Scheduled", gateway.Namespace, gateway.Name)
+	require.Eventually(t, testutils.GatewayIsAccepted(t, ctx, gatewayNSN, clients), testutils.GatewaySchedulingTimeLimit, time.Second)
+
+	t.Logf("verifying Gateway %s/%s gets marked as Programmed", gateway.Namespace, gateway.Name)
+	require.Eventually(t, testutils.GatewayIsProgrammed(t, ctx, gatewayNSN, clients.MgrClient), testutils.GatewayReadyTimeLimit, time.Second)
+	t.Logf("verifying Gateway %s/%s Listeners get marked as Programmed", gateway.Namespace, gateway.Name)
+	require.Eventually(t, testutils.GatewayListenersAreProgrammed(t, ctx, gatewayNSN, clients), testutils.GatewayReadyTimeLimit, time.Second)
+
+	t.Logf("verifying Gateway %s/%s gets an IP address", gateway.Namespace, gateway.Name)
+	require.Eventually(t, testutils.GatewayIPAddressExist(t, ctx, gatewayNSN, clients), testutils.SubresourceReadinessWait, time.Second)
+	gateway = testutils.MustGetGateway(t, ctx, gatewayNSN, clients.MgrClient)
+	gatewayIPAddress := gateway.Status.Addresses[0].Value
+
+	t.Log("deploying tcpecho backend deployment")
+	container := generators.NewContainer("tcpecho", testutils.TCPEchoImage, tcpEchoPort)
+	container.Env = []corev1.EnvVar{
+		{
+			Name:  "POD_NAME",
+			Value: "test-tls-terminate-echo",
+		},
+	}
+	deployment := generators.NewDeploymentForContainer(container)
+	deployment, err = integration.GetEnv().Cluster().Client().AppsV1().Deployments(namespace.Name).Create(ctx, deployment, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("exposing tcpecho deployment %s via service", deployment.Name)
+	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeClusterIP)
+	_, err = integration.GetEnv().Cluster().Client().CoreV1().Services(namespace.Name).Create(ctx, service, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("generating a TLSRoute")
+	tlsRoute := helpers.GenerateTLSRoute(namespace.Name, gateway.Name, service.Name, tcpEchoPort, func(r *gatewayv1.TLSRoute) {
+		r.Spec.Hostnames = []gatewayv1.Hostname{
+			gatewayv1.Hostname(host),
+		}
+	})
+
+	t.Logf("creating tlsroute %s/%s to access deployment %s via kong", tlsRoute.Namespace, tlsRoute.Name, deployment.Name)
+	require.EventuallyWithT(t,
+		func(c *assert.CollectT) {
+			result, err := integration.GetClients().GatewayClient.GatewayV1().TLSRoutes(namespace.Name).Create(ctx, tlsRoute, metav1.CreateOptions{})
+			require.NoError(c, err, "failed to deploy tlsroute %s/%s", tlsRoute.Namespace, tlsRoute.Name)
+			cleaner.Add(result)
+		},
+		testutils.DefaultIngressWait, testutils.WaitIngressTick,
+	)
+
+	t.Logf("verifying connectivity to the TLSRoute")
+	certPool := x509.NewCertPool()
+	require.True(t, certPool.AppendCertsFromPEM(cert), "Should add certificate to cert pool successfully")
+	require.Eventually(t, func() bool {
+		err := helpers.EchoResponds(t, helpers.ProtocolTLS, fmt.Sprintf("%s:%d", gatewayIPAddress, tcpEchoPort), "test-tls-terminate-echo",
+			helpers.TLSOpt{
+				Hostname: host,
+				CertPool: certPool,
+			})
+		if err != nil {
+			t.Logf("failed to access TLSRoute on %s:%d, error %+v", gatewayIPAddress, tcpEchoPort, err)
 			return false
 		}
 		return true

--- a/test/integration/ko/tlsroute_test.go
+++ b/test/integration/ko/tlsroute_test.go
@@ -317,13 +317,13 @@ func TestTLSTerminate(t *testing.T) {
 	certPool := x509.NewCertPool()
 	require.True(t, certPool.AppendCertsFromPEM(cert), "Should add certificate to cert pool successfully")
 	require.Eventually(t, func() bool {
-		err := helpers.EchoResponds(t, helpers.ProtocolTLS, fmt.Sprintf("%s:%d", gatewayIPAddress, tcpEchoPort), "test-tls-terminate-echo",
+		err := helpers.EchoResponds(t, helpers.ProtocolTLS, fmt.Sprintf("%s:%d", gatewayIPAddress, tlsPort), "test-tls-terminate-echo",
 			helpers.TLSOpt{
 				Hostname: host,
 				CertPool: certPool,
 			})
 		if err != nil {
-			t.Logf("failed to access TLSRoute on %s:%d, error %+v", gatewayIPAddress, tcpEchoPort, err)
+			t.Logf("failed to access TLSRoute on %s:%d, error %+v", gatewayIPAddress, tlsPort, err)
 			return false
 		}
 		return true


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable `Terminate` TLS mode for on-prem gateways and add related integration test case.

**Which issue this PR fixes**

Fixes #3132 & #4281

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
