### PR TITLE
test(e2e/chainsaw): add cross-namespace KongTarget test

### DIFF
--- a/config/samples/kongreferencegrant_kongtarget_to_kongupstream.yaml
+++ b/config/samples/kongreferencegrant_kongtarget_to_kongupstream.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: upstream-ns
+---
+# KongReferenceGrant that allows KongTarget in default namespace
+# to reference a KongUpstream in upstream-ns namespace.
+apiVersion: configuration.konghq.com/v1alpha1
+kind: KongReferenceGrant
+metadata:
+  name: allow-kongtarget-to-kongupstream
+  namespace: upstream-ns
+spec:
+  from:
+    - group: configuration.konghq.com
+      kind: KongTarget
+      namespace: default
+  to:
+    - group: configuration.konghq.com
+      kind: KongUpstream
+      # Optionally restrict to a specific KongUpstream name
+      # name: upstream-1
+---
+kind: KongUpstream
+apiVersion: configuration.konghq.com/v1alpha1
+metadata:
+  name: upstream-1
+  namespace: upstream-ns
+spec:
+  name: upstream-1
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: my-control-plane
+      namespace: upstream-ns
+---
+kind: KongTarget
+apiVersion: configuration.konghq.com/v1alpha1
+metadata:
+  name: target-1
+  namespace: default
+spec:
+  upstreamRef:
+    name: upstream-1
+    namespace: upstream-ns
+  target: "10.0.0.1"
+  weight: 100

--- a/test/e2e/chainsaw/konnect/kongtarget_cross-namespace/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/konnect/kongtarget_cross-namespace/chainsaw-test.yaml
@@ -1,0 +1,1628 @@
+# KongTarget cross-namespace test.
+#
+# Exercises two orthogonal cross-namespace axes:
+#   1. KongTarget -> KongUpstream -> KonnectGatewayControlPlane (cross-namespace controlPlaneRef
+#      via KongUpstreamRef) and KonnectGatewayControlPlane -> KonnectAPIAuthConfiguration
+#      (cross-namespace authRef)
+#   2. KongTarget -> KongUpstream (cross-namespace upstreamRef)
+#
+# Scenario A: All resources in the same namespace — baseline, no grants needed.
+#   ResolvedRefs condition is absent (same-namespace CPRef removes it).
+#
+# Scenario B: KongUpstream+KongTarget in ns-A, CP and AuthConfig co-located in ns-B.
+#   Only an Upstream->CP grant is needed.
+#
+# Scenario C: KongUpstream+KongTarget in ns-A, CP in ns-B, AuthConfig in ns-C.
+#   Both Upstream->CP AND CP->AuthConfig grants are required.
+#
+# Scenario D: KongUpstream+KongTarget and CP in the same namespace ns-B, AuthConfig in ns-C.
+#   No Upstream->CP grant needed (same namespace). Only CP->AuthConfig grant required.
+#   ResolvedRefs condition is absent (same-namespace CPRef removes it).
+#
+# Scenario E: KongTarget in target_namespace (ns-A), KongUpstream+CP+AuthConfig in cp_namespace (ns-B).
+#   Only a Target->Upstream grant is needed (CP and AuthConfig are co-located with the upstream).
+#   Target shows KongUpstreamRefValid=False/RefNotPermitted when the grant is missing.
+#
+# Scenario F: Both cross-namespace axes simultaneously.
+#   KongTarget in target_namespace (ns-A), KongUpstream in test namespace (ns-B), CP+AuthConfig in cp_namespace (ns-C).
+#   Two grants required: Target->Upstream in ns-B AND Upstream->CP in ns-C.
+#   Exercises that removing one grant re-blocks the entity even when the other grant is present.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kongtarget-cross-namespace
+spec:
+  description: |
+    Tests cross-namespace behaviour for KongTarget along two dimensions.
+
+    === Dimension 1: Cross-namespace controlPlaneRef (via KongUpstreamRef) ===
+
+    Scenario A: All resources in the same namespace. No grants needed; baseline sanity check.
+
+    Scenario B: KongUpstream+KongTarget (ns-A) -> KonnectGatewayControlPlane (ns-B) -> KonnectAPIAuthConfiguration (ns-B).
+    CP and AuthConfig co-located: only one Upstream->CP grant is needed.
+
+    Scenario C: KongUpstream+KongTarget (ns-A) -> KonnectGatewayControlPlane (ns-B) -> KonnectAPIAuthConfiguration (ns-C).
+    All three in different namespaces: both Upstream->CP AND CP->AuthConfig grants required.
+    Includes an intermediate assertion that shows the upstream fails when CP->AuthConfig
+    grant is missing even after the Upstream->CP grant is in place.
+
+    Scenario D: KongUpstream+KongTarget (ns-B) -> KonnectGatewayControlPlane (ns-B) -> KonnectAPIAuthConfiguration (ns-C).
+    Upstream and CP in the same namespace: no Upstream->CP grant needed.
+    Only the CP->AuthConfig grant is required.
+
+    === Dimension 2: Cross-namespace upstreamRef (Feature 2) ===
+
+    Scenario E: KongTarget (target-ns) -> KongUpstream+CP+AuthConfig (cp-ns).
+    A single KongReferenceGrant in cp-ns allows KongTarget from target-ns to reference KongUpstream.
+    No grant → KongUpstreamRefValid=False/RefNotPermitted on the KongTarget.
+    Grant present → KongTarget reaches Programmed=True with upstreamID set.
+
+    Scenario F: KongTarget (target-ns) -> KongUpstream (test-ns) -> CP+AuthConfig (cp-ns).
+    Both axes are cross-namespace simultaneously. Two grants required:
+      1. Target->Upstream in test-ns (for the cross-namespace upstreamRef)
+      2. Upstream->CP in cp-ns (for the cross-namespace CPRef)
+    Includes an intermediate assertion showing target5 is still blocked after only the
+    Upstream->CP grant is in place (Target->Upstream grant still missing).
+
+  bindings:
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    # Namespace bindings.
+    - name: cp_namespace
+      value: (join('-', [$namespace, 'cp']))
+    - name: auth_namespace
+      value: (join('-', [$namespace, 'auth']))
+    # Scenario A resource names (all in test namespace).
+    - name: cp0_name
+      value: (join('-', [$namespace, 'cp0']))
+    - name: auth0_name
+      value: (join('-', [$namespace, 'auth0-konnect-api-auth']))
+    - name: upstream0_name
+      value: (join('-', [$namespace, 'upstream0']))
+    - name: target0_name
+      value: (join('-', [$namespace, 'target0']))
+    # Scenario B resource names (upstream+target in test namespace, CP+AuthConfig in cp_namespace).
+    - name: cp_name
+      value: (join('-', [$namespace, 'cp']))
+    - name: auth_name
+      value: (join('-', [$namespace, 'konnect-api-auth']))
+    - name: upstream_name
+      value: (join('-', [$namespace, 'upstream']))
+    - name: target_name
+      value: (join('-', [$namespace, 'target']))
+    # Scenario C resource names (upstream+target in test namespace, CP in cp_namespace, AuthConfig in auth_namespace).
+    - name: cp2_name
+      value: (join('-', [$namespace, 'cp2']))
+    - name: auth2_name
+      value: (join('-', [$namespace, 'auth2-konnect-api-auth']))
+    - name: upstream2_name
+      value: (join('-', [$namespace, 'upstream2']))
+    - name: target2_name
+      value: (join('-', [$namespace, 'target2']))
+    # Scenario D resource names (upstream+target+CP in cp_namespace, AuthConfig in auth_namespace).
+    - name: cp3_name
+      value: (join('-', [$namespace, 'cp3']))
+    - name: auth3_name
+      value: (join('-', [$namespace, 'auth3-konnect-api-auth']))
+    - name: upstream3_name
+      value: (join('-', [$namespace, 'upstream3']))
+    - name: target3_name
+      value: (join('-', [$namespace, 'target3']))
+    # Scenario E resource names (target4 in target_namespace, upstream4+cp4+auth4 in cp_namespace).
+    - name: target_namespace
+      value: (join('-', [$namespace, 'target']))
+    - name: cp4_name
+      value: (join('-', [$namespace, 'cp4']))
+    - name: auth4_name
+      value: (join('-', [$namespace, 'auth4-konnect-api-auth']))
+    - name: upstream4_name
+      value: (join('-', [$namespace, 'upstream4']))
+    - name: target4_name
+      value: (join('-', [$namespace, 'target4']))
+    # Scenario F resource names (target5 in target_namespace, upstream5 in test namespace, cp5+auth5 in cp_namespace).
+    - name: cp5_name
+      value: (join('-', [$namespace, 'cp5']))
+    - name: auth5_name
+      value: (join('-', [$namespace, 'auth5-konnect-api-auth']))
+    - name: upstream5_name
+      value: (join('-', [$namespace, 'upstream5']))
+    - name: target5_name
+      value: (join('-', [$namespace, 'target5']))
+
+  steps:
+    # =========================================================================
+    # Scenario A: All resources in the same namespace. No grants needed.
+    # ResolvedRefs condition is absent for same-namespace CPRefs.
+    # =========================================================================
+
+    - name: 1-create-auth-config-same-ns
+      description: Create KonnectAPIAuthConfiguration in the test namespace.
+      bindings:
+        - name: test_name
+          value: (join('-', [$namespace, 'auth0']))
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    - name: 2-create-control-plane-same-ns
+      description: Create KonnectGatewayControlPlane in the test namespace.
+      bindings:
+        - name: cp_name
+          value: ($cp0_name)
+        - name: cp_namespace
+          value: ($namespace)
+        - name: auth_name
+          value: ($auth0_name)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectGatewayControlPlane.yaml
+
+    - name: 3-create-upstream-and-target-same-ns
+      description: Create KongUpstream and KongTarget in the test namespace (no grants needed).
+      try:
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream0_name)
+                namespace: ($namespace)
+              spec:
+                name: ($upstream0_name)
+                controlPlaneRef:
+                  type: konnectNamespacedRef
+                  konnectNamespacedRef:
+                    name: ($cp0_name)
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target0_name)
+                namespace: ($namespace)
+              spec:
+                upstreamRef:
+                  name: ($upstream0_name)
+                target: "10.0.0.1"
+                weight: 100
+
+    - name: 4-assert-upstream-and-target-programmed-same-ns
+      description: Assert KongUpstream and KongTarget are Programmed. ResolvedRefs is absent (same-namespace CPRef).
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream0_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target0_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'KongUpstreamRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+                (konnect.upstreamID != null): true
+
+    - name: 5-cleanup-scenario-a
+      description: Delete target, upstream, and CP in order; wait for each to be gone.
+      timeouts:
+        delete: 120s
+        error: 120s
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              name: ($target0_name)
+              namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              name: ($upstream0_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target0_name)
+                namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream0_name)
+                namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              name: ($cp0_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp0_name)
+                namespace: ($namespace)
+
+    # =========================================================================
+    # Scenario B: KongUpstream+KongTarget in test namespace, CP+AuthConfig in cp_namespace.
+    # Only the Upstream->CP grant is needed.
+    # =========================================================================
+
+    - name: 6-create-cp-namespace
+      description: Create namespace for KonnectGatewayControlPlane and KonnectAPIAuthConfiguration.
+      bindings:
+        - name: namespace_name
+          value: ($cp_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-namespace.yaml
+
+    - name: 7-create-auth-config
+      description: Create KonnectAPIAuthConfiguration in the CP namespace.
+      bindings:
+        - name: test_name
+          value: ($namespace)
+        - name: namespace
+          value: ($cp_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    - name: 8-create-control-plane
+      description: Create KonnectGatewayControlPlane in the CP namespace with same-namespace authRef.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectGatewayControlPlane.yaml
+
+    - name: 9-create-upstream-and-target-no-grant
+      description: Create KongUpstream and KongTarget before any KongReferenceGrant exists.
+      try:
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream_name)
+                namespace: ($namespace)
+              spec:
+                name: ($upstream_name)
+                controlPlaneRef:
+                  type: konnectNamespacedRef
+                  konnectNamespacedRef:
+                    name: ($cp_name)
+                    namespace: ($cp_namespace)
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target_name)
+                namespace: ($namespace)
+              spec:
+                upstreamRef:
+                  name: ($upstream_name)
+                target: "10.0.0.1"
+                weight: 100
+
+    - name: 10-assert-negative-no-grant
+      description: Assert upstream ResolvedRefs=False and target KongUpstreamRefValid=False (no grant yet).
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'False'
+                (conditions[?type == 'KongUpstreamRefValid']):
+                  - status: 'False'
+                    reason: Invalid
+
+    - name: 11-create-upstream-to-cp-grant
+      description: Create KongReferenceGrant in cp_namespace allowing KongUpstream from test namespace to reference the CP.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'upstream-to-cp']))
+        - name: kong_reference_grant_namespace
+          value: ($cp_namespace)
+        - name: from
+          value:
+            - group: configuration.konghq.com
+              kind: KongUpstream
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectGatewayControlPlane
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 12-assert-upstream-and-target-programmed
+      description: Assert KongUpstream and KongTarget are both Programmed after the Upstream->CP grant is in place.
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'True'
+                    reason: ResolvedRefs
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'KongUpstreamRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+                (konnect.upstreamID != null): true
+
+    - name: 13-cleanup-scenario-b
+      description: |
+        Delete target, upstream, and CP in order; wait for each to be gone.
+        The upstream->CP grant is deleted after the upstream is confirmed gone (the upstream
+        needs the grant during Konnect deprovisioning to locate the CP).
+      timeouts:
+        delete: 120s
+        error: 120s
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              name: ($target_name)
+              namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              name: ($upstream_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target_name)
+                namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream_name)
+                namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'upstream-to-cp']))
+              namespace: ($cp_namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              name: ($cp_name)
+              namespace: ($cp_namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp_name)
+                namespace: ($cp_namespace)
+
+    # =========================================================================
+    # Scenario C: KongUpstream+KongTarget in test namespace, CP in cp_namespace,
+    # AuthConfig in auth_namespace. Both Upstream->CP AND CP->AuthConfig grants required.
+    # =========================================================================
+
+    - name: 14-create-auth-namespace
+      description: Create separate auth namespace for KonnectAPIAuthConfiguration.
+      bindings:
+        - name: namespace_name
+          value: ($auth_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-namespace.yaml
+
+    - name: 15-create-auth-config-cross-ns
+      description: Create KonnectAPIAuthConfiguration in auth_namespace (ns-C).
+      bindings:
+        - name: test_name
+          value: (join('-', [$namespace, 'auth2']))
+        - name: namespace
+          value: ($auth_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    - name: 16-create-cp2-cross-ns-auth
+      description: Create KonnectGatewayControlPlane in cp_namespace with cross-namespace authRef to auth_namespace.
+      try:
+        - apply:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp2_name)
+                namespace: ($cp_namespace)
+              spec:
+                createControlPlaneRequest:
+                  name: ($cp2_name)
+                konnect:
+                  authRef:
+                    name: ($auth2_name)
+                    namespace: ($auth_namespace)
+
+    - name: 17-assert-cp2-auth-grant-missing
+      description: Assert CP2 has APIAuthResolvedRef=False/RefNotPermitted because no CP->AuthConfig grant exists.
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp2_name)
+                namespace: ($cp_namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    - name: 18-create-upstream2-and-target2-no-grant
+      description: Create KongUpstream2 and KongTarget2 before any Upstream->CP grant exists.
+      try:
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream2_name)
+                namespace: ($namespace)
+              spec:
+                name: ($upstream2_name)
+                controlPlaneRef:
+                  type: konnectNamespacedRef
+                  konnectNamespacedRef:
+                    name: ($cp2_name)
+                    namespace: ($cp_namespace)
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target2_name)
+                namespace: ($namespace)
+              spec:
+                upstreamRef:
+                  name: ($upstream2_name)
+                target: "10.0.0.1"
+                weight: 100
+
+    - name: 19-assert-negative-no-upstream-grant
+      description: Assert upstream2 ResolvedRefs=False and target2 KongUpstreamRefValid=False (no Upstream->CP grant).
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream2_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target2_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'False'
+                (conditions[?type == 'KongUpstreamRefValid']):
+                  - status: 'False'
+                    reason: Invalid
+
+    - name: 20-create-upstream2-to-cp2-grant
+      description: Create KongReferenceGrant in cp_namespace allowing upstream2 from test namespace to reference CP2.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'upstream2-to-cp2']))
+        - name: kong_reference_grant_namespace
+          value: ($cp_namespace)
+        - name: from
+          value:
+            - group: configuration.konghq.com
+              kind: KongUpstream
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectGatewayControlPlane
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 21-assert-upstream2-cp-not-programmed
+      description: |
+        Assert upstream2 ResolvedRefs=True (Upstream->CP grant resolved) but ControlPlaneRefValid=False/NotProgrammed
+        because CP2 is not yet Programmed (CP->AuthConfig grant still missing).
+        Target2 is still not Programmed (upstream2 is not Programmed).
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream2_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'True'
+                    reason: ResolvedRefs
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'False'
+                    reason: NotProgrammed
+
+    - name: 22-create-cp2-to-auth2-grant
+      description: Create KongReferenceGrant in auth_namespace allowing CP2 from cp_namespace to reference auth2.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'cp2-to-auth2']))
+        - name: kong_reference_grant_namespace
+          value: ($auth_namespace)
+        - name: from
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectGatewayControlPlane
+              namespace: ($cp_namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectAPIAuthConfiguration
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 23-assert-cp2-upstream2-target2-programmed
+      description: Assert CP2, upstream2, and target2 are all Programmed after both grants are in place.
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp2_name)
+                namespace: ($cp_namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream2_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'True'
+                    reason: ResolvedRefs
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target2_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'KongUpstreamRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+                (konnect.upstreamID != null): true
+
+    - name: 24-cleanup-scenario-c
+      description: |
+        Delete target2, upstream2, and CP2 in order; wait for each to be gone.
+        upstream2->CP2 grant is deleted after upstream2 is confirmed gone.
+        cp2->auth2 grant is deleted last, after CP2 is fully deprovisioned.
+      timeouts:
+        delete: 120s
+        error: 120s
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              name: ($target2_name)
+              namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              name: ($upstream2_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target2_name)
+                namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream2_name)
+                namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'upstream2-to-cp2']))
+              namespace: ($cp_namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              name: ($cp2_name)
+              namespace: ($cp_namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp2_name)
+                namespace: ($cp_namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'cp2-to-auth2']))
+              namespace: ($auth_namespace)
+
+    # =========================================================================
+    # Scenario D: KongUpstream+KongTarget and CP in the same namespace (cp_namespace),
+    # AuthConfig in auth_namespace. No Upstream->CP grant needed (same namespace).
+    # Only the CP->AuthConfig grant is required.
+    # ResolvedRefs condition is absent (same-namespace CPRef removes it).
+    # =========================================================================
+
+    - name: 25-create-auth3-cross-ns
+      description: Create a second KonnectAPIAuthConfiguration in auth_namespace for Scenario D.
+      bindings:
+        - name: test_name
+          value: (join('-', [$namespace, 'auth3']))
+        - name: namespace
+          value: ($auth_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    - name: 26-create-cp3-cross-ns-auth
+      description: Create CP3 in cp_namespace with cross-namespace authRef to auth_namespace (no grant yet).
+      try:
+        - apply:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp3_name)
+                namespace: ($cp_namespace)
+              spec:
+                createControlPlaneRequest:
+                  name: ($cp3_name)
+                konnect:
+                  authRef:
+                    name: ($auth3_name)
+                    namespace: ($auth_namespace)
+
+    - name: 27-assert-cp3-auth-grant-missing
+      description: Assert CP3 has APIAuthResolvedRef=False/RefNotPermitted because no CP->AuthConfig grant exists.
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp3_name)
+                namespace: ($cp_namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    - name: 28-create-upstream3-and-target3-same-ns-as-cp
+      description: Create KongUpstream3 and KongTarget3 in cp_namespace (same namespace as CP3). No Upstream->CP grant needed.
+      try:
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream3_name)
+                namespace: ($cp_namespace)
+              spec:
+                name: ($upstream3_name)
+                controlPlaneRef:
+                  type: konnectNamespacedRef
+                  konnectNamespacedRef:
+                    name: ($cp3_name)
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target3_name)
+                namespace: ($cp_namespace)
+              spec:
+                upstreamRef:
+                  name: ($upstream3_name)
+                target: "10.0.0.1"
+                weight: 100
+
+    - name: 29-assert-negative-cp-not-programmed
+      description: |
+        Assert upstream3 ControlPlaneRefValid=False/NotProgrammed (CP3 not Programmed, no CP->AuthConfig grant)
+        and target3 KongUpstreamRefValid=False/Invalid (upstream3 not Programmed).
+        No ResolvedRefs condition on upstream3 (same-namespace CPRef removes it).
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream3_name)
+                namespace: ($cp_namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'False'
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'False'
+                    reason: NotProgrammed
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target3_name)
+                namespace: ($cp_namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'False'
+                (conditions[?type == 'KongUpstreamRefValid']):
+                  - status: 'False'
+                    reason: Invalid
+
+    - name: 30-create-cp3-to-auth3-grant
+      description: Create KongReferenceGrant in auth_namespace allowing CP3 from cp_namespace to reference auth3.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'cp3-to-auth3']))
+        - name: kong_reference_grant_namespace
+          value: ($auth_namespace)
+        - name: from
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectGatewayControlPlane
+              namespace: ($cp_namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectAPIAuthConfiguration
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 31-assert-cp3-upstream3-target3-programmed
+      description: Assert CP3, upstream3, and target3 are all Programmed. No ResolvedRefs on upstream3 (same-namespace CPRef).
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp3_name)
+                namespace: ($cp_namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream3_name)
+                namespace: ($cp_namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target3_name)
+                namespace: ($cp_namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'KongUpstreamRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+                (konnect.upstreamID != null): true
+
+    - name: 32-cleanup-scenario-d
+      description: |
+        Delete target3, upstream3, and CP3 in order; wait for each to be gone.
+        CP3->auth3 grant is deleted last, after CP3 is fully deprovisioned.
+      timeouts:
+        delete: 120s
+        error: 120s
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              name: ($target3_name)
+              namespace: ($cp_namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              name: ($upstream3_name)
+              namespace: ($cp_namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target3_name)
+                namespace: ($cp_namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream3_name)
+                namespace: ($cp_namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              name: ($cp3_name)
+              namespace: ($cp_namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp3_name)
+                namespace: ($cp_namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'cp3-to-auth3']))
+              namespace: ($auth_namespace)
+
+    # =========================================================================
+    # Scenario E: cross-namespace upstreamRef.
+    # KongTarget in target_namespace, KongUpstream+CP+AuthConfig in cp_namespace.
+    # A KongReferenceGrant in cp_namespace (allowing KongTarget from target_namespace
+    # to reference KongUpstream) is required.
+    # =========================================================================
+
+    - name: 33-create-auth4-for-upstream-cross-ns
+      description: Create KonnectAPIAuthConfiguration in cp_namespace for Scenario E.
+      bindings:
+        - name: test_name
+          value: (join('-', [$namespace, 'auth4']))
+        - name: namespace
+          value: ($cp_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    - name: 34-create-cp4-same-ns-auth
+      description: Create KonnectGatewayControlPlane in cp_namespace with same-namespace authRef.
+      bindings:
+        - name: cp_name
+          value: ($cp4_name)
+        - name: cp_namespace
+          value: ($cp_namespace)
+        - name: auth_name
+          value: ($auth4_name)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectGatewayControlPlane.yaml
+
+    - name: 35-create-upstream4-same-ns-as-cp
+      description: Create KongUpstream upstream4 in cp_namespace with cpRef to cp4.
+      try:
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream4_name)
+                namespace: ($cp_namespace)
+              spec:
+                name: ($upstream4_name)
+                controlPlaneRef:
+                  type: konnectNamespacedRef
+                  konnectNamespacedRef:
+                    name: ($cp4_name)
+
+    - name: 36-assert-upstream4-programmed
+      description: Assert upstream4 is Programmed before creating the cross-namespace target.
+      timeouts:
+        assert: 90s
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream4_name)
+                namespace: ($cp_namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (konnect.id != null): true
+
+    - name: 37-create-target-namespace
+      description: Create dedicated namespace for target4 in Scenario E.
+      bindings:
+        - name: namespace_name
+          value: ($target_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-namespace.yaml
+
+    - name: 38-create-target4-cross-ns-upstream-no-grant
+      description: |
+        Create KongTarget in target_namespace with a cross-namespace upstreamRef
+        pointing to upstream4 in cp_namespace. No KongReferenceGrant exists yet.
+      try:
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target4_name)
+                namespace: ($target_namespace)
+              spec:
+                upstreamRef:
+                  name: ($upstream4_name)
+                  namespace: ($cp_namespace)
+                target: "10.0.0.1"
+                weight: 100
+
+    - name: 39-assert-target4-ref-not-permitted
+      description: |
+        Assert target4 has KongUpstreamRefValid=False/RefNotPermitted because no
+        KongReferenceGrant allows KongTarget from target_namespace to reference
+        KongUpstream in cp_namespace.
+      timeouts:
+        assert: 60s
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target4_name)
+                namespace: ($target_namespace)
+              status:
+                (conditions[?type == 'KongUpstreamRefValid']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+                (conditions[?type == 'Programmed']):
+                  - status: 'False'
+
+    - name: 40-create-target-to-upstream-grant
+      description: |
+        Create KongReferenceGrant in cp_namespace allowing KongTarget from
+        target_namespace to reference KongUpstream.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'target-to-upstream']))
+        - name: kong_reference_grant_namespace
+          value: ($cp_namespace)
+        - name: from
+          value:
+            - group: configuration.konghq.com
+              kind: KongTarget
+              namespace: ($target_namespace)
+        - name: to
+          value:
+            - group: configuration.konghq.com
+              kind: KongUpstream
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 41-assert-target4-programmed
+      description: |
+        Assert target4 is Programmed with upstreamID set
+        after the KongReferenceGrant is in place.
+      timeouts:
+        assert: 90s
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target4_name)
+                namespace: ($target_namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'KongUpstreamRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+                (konnect.upstreamID != null): true
+
+    - name: 42-delete-target-to-upstream-grant
+      description: Delete the Target->Upstream grant and verify target4 reverts to KongUpstreamRefValid=False/RefNotPermitted.
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'target-to-upstream']))
+              namespace: ($cp_namespace)
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target4_name)
+                namespace: ($target_namespace)
+              status:
+                (conditions[?type == 'KongUpstreamRefValid']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    - name: 43-cleanup-scenario-e
+      description: |
+        Recreate the grant so target4 can be deprovisioned from Konnect, then
+        delete target4, upstream4, and cp4 in order.
+      timeouts:
+        delete: 120s
+        error: 120s
+      try:
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              metadata:
+                name: (join('-', [$namespace, 'target-to-upstream']))
+                namespace: ($cp_namespace)
+              spec:
+                from:
+                  - group: configuration.konghq.com
+                    kind: KongTarget
+                    namespace: ($target_namespace)
+                to:
+                  - group: configuration.konghq.com
+                    kind: KongUpstream
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              name: ($target4_name)
+              namespace: ($target_namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target4_name)
+                namespace: ($target_namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              name: ($upstream4_name)
+              namespace: ($cp_namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream4_name)
+                namespace: ($cp_namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'target-to-upstream']))
+              namespace: ($cp_namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              name: ($cp4_name)
+              namespace: ($cp_namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp4_name)
+                namespace: ($cp_namespace)
+
+    # =========================================================================
+    # Scenario F: Both cross-namespace axes active simultaneously.
+    # KongTarget in target_namespace, KongUpstream in test namespace ($namespace),
+    # CP+AuthConfig in cp_namespace. Two grants required:
+    #   - Upstream->CP grant in cp_namespace (for the cross-namespace CPRef on upstream5)
+    #   - Target->Upstream grant in test namespace (for the cross-namespace upstreamRef on target5)
+    # =========================================================================
+
+    - name: 44-create-auth5-for-all-xns
+      description: Create KonnectAPIAuthConfiguration in cp_namespace for Scenario F.
+      bindings:
+        - name: test_name
+          value: (join('-', [$namespace, 'auth5']))
+        - name: namespace
+          value: ($cp_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    - name: 45-create-cp5-same-ns-auth
+      description: Create KonnectGatewayControlPlane in cp_namespace with same-namespace authRef.
+      bindings:
+        - name: cp_name
+          value: ($cp5_name)
+        - name: cp_namespace
+          value: ($cp_namespace)
+        - name: auth_name
+          value: ($auth5_name)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectGatewayControlPlane.yaml
+
+    - name: 46-create-upstream5-no-grants
+      description: |
+        Create upstream5 in test namespace with cross-namespace CPRef to cp_namespace.
+        No grants exist yet.
+      try:
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream5_name)
+                namespace: ($namespace)
+              spec:
+                name: ($upstream5_name)
+                controlPlaneRef:
+                  type: konnectNamespacedRef
+                  konnectNamespacedRef:
+                    name: ($cp5_name)
+                    namespace: ($cp_namespace)
+
+    - name: 47-create-target5-no-grants
+      description: |
+        Create target5 in target_namespace with cross-namespace upstreamRef to test namespace.
+        No grants exist yet.
+      try:
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target5_name)
+                namespace: ($target_namespace)
+              spec:
+                upstreamRef:
+                  name: ($upstream5_name)
+                  namespace: ($namespace)
+                target: "10.0.0.1"
+                weight: 100
+
+    - name: 48-assert-negative-both-grants-missing
+      description: |
+        Assert upstream5 ResolvedRefs=False (no Upstream->CP grant) and
+        target5 KongUpstreamRefValid=False/RefNotPermitted (no Target->Upstream grant). Neither is Programmed.
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream5_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target5_name)
+                namespace: ($target_namespace)
+              status:
+                (conditions[?type == 'KongUpstreamRefValid']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+                (conditions[?type == 'Programmed']):
+                  - status: 'False'
+
+    - name: 49-create-upstream5-to-cp5-grant
+      description: Create KongReferenceGrant in cp_namespace allowing upstream5 from test namespace to reference cp5.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'upstream5-to-cp5']))
+        - name: kong_reference_grant_namespace
+          value: ($cp_namespace)
+        - name: from
+          value:
+            - group: configuration.konghq.com
+              kind: KongUpstream
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectGatewayControlPlane
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 50-assert-upstream5-programmed-target5-still-blocked
+      description: |
+        Assert upstream5 is Programmed (Upstream->CP grant in place) but target5 is still
+        blocked: KongUpstreamRefValid=False/RefNotPermitted because the Target->Upstream grant is
+        still missing.
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream5_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'True'
+                    reason: ResolvedRefs
+                (konnect.id != null): true
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target5_name)
+                namespace: ($target_namespace)
+              status:
+                (conditions[?type == 'KongUpstreamRefValid']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+                (conditions[?type == 'Programmed']):
+                  - status: 'False'
+
+    - name: 51-create-target5-to-upstream5-grant
+      description: |
+        Create KongReferenceGrant in test namespace allowing target5 from target_namespace
+        to reference upstream5.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'target5-to-upstream5']))
+        - name: kong_reference_grant_namespace
+          value: ($namespace)
+        - name: from
+          value:
+            - group: configuration.konghq.com
+              kind: KongTarget
+              namespace: ($target_namespace)
+        - name: to
+          value:
+            - group: configuration.konghq.com
+              kind: KongUpstream
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 52-assert-upstream5-and-target5-programmed
+      description: |
+        Assert both upstream5 and target5 are Programmed after both grants are in place.
+        target5 has upstreamID set.
+      timeouts:
+        assert: 90s
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream5_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'True'
+                    reason: ResolvedRefs
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target5_name)
+                namespace: ($target_namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'KongUpstreamRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+                (konnect.upstreamID != null): true
+
+    - name: 53-cleanup-scenario-f
+      description: |
+        Delete target5 first, then remove the Target->Upstream grant.
+        Delete upstream5, then remove the Upstream->CP grant.
+        Delete cp5 last.
+      timeouts:
+        delete: 120s
+        error: 120s
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              name: ($target5_name)
+              namespace: ($target_namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongTarget
+              metadata:
+                name: ($target5_name)
+                namespace: ($target_namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'target5-to-upstream5']))
+              namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              name: ($upstream5_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongUpstream
+              metadata:
+                name: ($upstream5_name)
+                namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'upstream5-to-cp5']))
+              namespace: ($cp_namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              name: ($cp5_name)
+              namespace: ($cp_namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp5_name)
+                namespace: ($cp_namespace)
+
+  catch:
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: kongtarget-cross-namespace
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: ADDITIONAL_NAMESPACES
+            value: (join(',', [$cp_namespace, $auth_namespace, $target_namespace]))
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh


### PR DESCRIPTION
**What this PR does / why we need it**:



Add a Chainsaw E2E test covering all cross-namespace scenarios for
KongTarget, exercising two orthogonal reference axes:

Scenario A: all resources in the same namespace (baseline, no grants).

Scenario B: KongUpstream+KongTarget in ns-A, CP+AuthConfig co-located
in ns-B. Only an Upstream→CP KongReferenceGrant is needed.

Scenario C: KongUpstream+KongTarget in ns-A, CP in ns-B, AuthConfig in
ns-C. Both Upstream→CP and CP→AuthConfig grants required. Includes an
intermediate assertion that shows the upstream stalls when the
CP→AuthConfig grant is still missing.

Scenario D: KongUpstream+KongTarget and CP in the same namespace, AuthConfig
in a separate namespace. No Upstream→CP grant needed; only CP→AuthConfig
grant required.

Scenario E: cross-namespace upstreamRef — KongTarget in target-ns,
KongUpstream+CP+AuthConfig in cp-ns. A single Target→Upstream
KongReferenceGrant in cp-ns is required. Verifies that
KongUpstreamRefValid=False/RefNotPermitted is set when the grant is absent
and clears once the grant is created.

Scenario F: both axes cross-namespace simultaneously — KongTarget in
target-ns, KongUpstream in test-ns, CP+AuthConfig in cp-ns. Two grants
required (Target→Upstream and Upstream→CP). Verifies that target5 remains
blocked when only one of the two grants is present.

**Which issue this PR fixes**

Fixes #4169 

**Special notes for your reviewer**:

Depends on https://github.com/Kong/kong-operator/pull/4263

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
