### PR TITLE
fix(hybrid gateway): Fix TLSRoute clear orphan when resolvedRefs is false

### DIFF
--- a/controller/hybridgateway/converter/tls_route.go
+++ b/controller/hybridgateway/converter/tls_route.go
@@ -121,8 +121,11 @@ func (c *tlsRouteConverter) UpdateRootObjectStatus(ctx context.Context, logger l
 		if err != nil {
 			return false, stop, fmt.Errorf("failed to build accepted condition for parentRef %s: %w", pRef.Name, err)
 		}
-		// If the Accepted or ResolvedRefs condition is False, we should stop further processing.
-		if acceptedCondition.Status == metav1.ConditionFalse || resolvedRefsCond.Status == metav1.ConditionFalse {
+		// Unresolved backend references should still translate so the desired state is
+		// recomputed (no KongTargets for unpermitted refs) and orphan cleanup can remove
+		// resources from a previous reconciliation. Only an unaccepted route halts state
+		// enforcement.
+		if acceptedCondition.Status == metav1.ConditionFalse {
 			stop = true
 		}
 

--- a/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/01-tlsroute-with-grant.yaml
+++ b/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/01-tlsroute-with-grant.yaml
@@ -1,0 +1,33 @@
+---
+kind: TLSRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: ($tls_route_name)
+  namespace: ($tls_route_namespace)
+spec:
+  hostnames:
+    - ($fqdn)
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name)
+  rules:
+    - backendRefs:
+        - name: ($echo_deployment_name)
+          namespace: ($echo_deployment_namespace)
+          port: 1030
+---
+kind: ReferenceGrant
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: ($reference_grant_name)
+  namespace: ($reference_grant_namespace)
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: TLSRoute
+      namespace: ($tls_route_namespace)
+  to:
+    - group: ""
+      kind: Service
+      name: ($echo_deployment_name)

--- a/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/01-tlsroute-with-grant.yaml
+++ b/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/01-tlsroute-with-grant.yaml
@@ -1,6 +1,6 @@
 ---
 kind: TLSRoute
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 metadata:
   name: ($tls_route_name)
   namespace: ($tls_route_namespace)

--- a/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/02-assert-tlsroute-resolved.yaml
+++ b/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/02-assert-tlsroute-resolved.yaml
@@ -1,6 +1,6 @@
 ---
 # Assert TLSRoute is accepted, ResolvedRefs=True, and Programmed.
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: ($tls_route_name)

--- a/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/02-assert-tlsroute-resolved.yaml
+++ b/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/02-assert-tlsroute-resolved.yaml
@@ -1,0 +1,32 @@
+---
+# Assert TLSRoute is accepted, ResolvedRefs=True, and Programmed.
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: ($tls_route_name)
+  namespace: ($tls_route_namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        group: gateway.networking.k8s.io
+        kind: Gateway
+      controllerName: konghq.com/gateway-operator
+      (conditions[?type == 'Accepted']):
+        - status: "True"
+          reason: Accepted
+      (conditions[?type == 'ResolvedRefs']):
+        - status: "True"
+          reason: ResolvedRefs
+      (conditions[?type == 'KongRouteProgrammed']):
+        - status: "True"
+          reason: KongRouteProgrammed
+      (conditions[?type == 'KongServiceProgrammed']):
+        - status: "True"
+          reason: KongServiceProgrammed
+      (conditions[?type == 'KongUpstreamProgrammed']):
+        - status: "True"
+          reason: KongUpstreamProgrammed
+      (conditions[?type == 'KongTargetProgrammed']):
+        - status: "True"
+          reason: KongTargetProgrammed

--- a/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/03-assert-kongtarget-exists.yaml
+++ b/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/03-assert-kongtarget-exists.yaml
@@ -1,0 +1,14 @@
+---
+# Assert that at least one KongTarget owned by this TLSRoute exists, is
+# Programmed, and is annotated with our TLSRoute reference.
+apiVersion: configuration.konghq.com/v1alpha1
+kind: KongTarget
+metadata:
+  namespace: ($namespace)
+  (labels."gateway-operator.konghq.com/managed-by" == 'TLSRoute'): true
+  (annotations."gateway-operator.konghq.com/hybrid-routes-TLSRoute" | contains(@, join('/', [($tls_route_namespace), ($tls_route_name)]))): true
+  (annotations."gateway-operator.konghq.com/hybrid-gateways" == join('/', [($gateway_namespace), ($gateway_name)])): true
+status:
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed

--- a/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/04-assert-tlsroute-not-permitted.yaml
+++ b/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/04-assert-tlsroute-not-permitted.yaml
@@ -2,7 +2,7 @@
 # Assert that, after the ReferenceGrant is removed, the TLSRoute's
 # ResolvedRefs condition flips to False with reason RefNotPermitted while
 # Accepted remains True.
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: ($tls_route_name)

--- a/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/04-assert-tlsroute-not-permitted.yaml
+++ b/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/04-assert-tlsroute-not-permitted.yaml
@@ -1,0 +1,22 @@
+---
+# Assert that, after the ReferenceGrant is removed, the TLSRoute's
+# ResolvedRefs condition flips to False with reason RefNotPermitted while
+# Accepted remains True.
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: ($tls_route_name)
+  namespace: ($tls_route_namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        group: gateway.networking.k8s.io
+        kind: Gateway
+      controllerName: konghq.com/gateway-operator
+      (conditions[?type == 'Accepted']):
+        - status: "True"
+          reason: Accepted
+      (conditions[?type == 'ResolvedRefs']):
+        - status: "False"
+          reason: RefNotPermitted

--- a/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/05-assert-kongtarget-absent.yaml
+++ b/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/05-assert-kongtarget-absent.yaml
@@ -1,0 +1,15 @@
+---
+# Regression assertion: after the ReferenceGrant is deleted, no KongTarget
+# owned by this TLSRoute should remain in the cluster. Orphan cleanup must
+# remove the previously-created KongTarget whose backend Service is no longer
+# permitted.
+#
+# Before the fix in controller/hybridgateway/converter/tls_route.go, the
+# reconciler short-circuited on ResolvedRefs=False before Phase 5 (orphan
+# cleanup), leaving this KongTarget behind.
+apiVersion: configuration.konghq.com/v1alpha1
+kind: KongTarget
+metadata:
+  namespace: ($namespace)
+  (labels."gateway-operator.konghq.com/managed-by" == 'TLSRoute'): true
+  (annotations."gateway-operator.konghq.com/hybrid-routes-TLSRoute" | contains(@, join('/', [($tls_route_namespace), ($tls_route_name)]))): true

--- a/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/06-referencegrant.yaml
+++ b/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/06-referencegrant.yaml
@@ -1,0 +1,18 @@
+---
+# Re-apply the ReferenceGrant to restore cross-namespace permission. After
+# this, the TLSRoute should return to ResolvedRefs=True and a KongTarget
+# should be re-created.
+kind: ReferenceGrant
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: ($reference_grant_name)
+  namespace: ($reference_grant_namespace)
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: TLSRoute
+      namespace: ($tls_route_namespace)
+  to:
+    - group: ""
+      kind: Service
+      name: ($echo_deployment_name)

--- a/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/chainsaw-test.yaml
@@ -1,0 +1,216 @@
+# Scenario for TLSRoute referencing a Service as backendRef in another namespace
+# granted by a ReferenceGrant, then validating that the orphaned Kong resources
+# are cleaned up when the ReferenceGrant is removed (regression for the case
+# where stale KongTargets were left in the cluster after a cross-namespace
+# backend became unpermitted).
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: tlsroute-backendref-cross-namespace-reference
+spec:
+  description: |
+    Validates that a TLSRoute with a cross-namespace backendRef:
+    1. Translates correctly into Kong resources (KongUpstream, KongService,
+       KongRoute, KongTarget) when a permissive ReferenceGrant exists.
+    2. On ReferenceGrant deletion, the TLSRoute's status correctly flips to
+       ResolvedRefs=False/RefNotPermitted AND the orphaned KongTarget for the
+       cross-namespace backend is removed via orphan cleanup.
+    3. Re-applying the ReferenceGrant restores ResolvedRefs=True and the
+       KongTarget is re-created.
+
+  bindings:
+    # Common bindings.
+    - name: test_name
+      value: ($namespace)
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_api_auth_namespace
+      value: ($namespace)
+    - name: listener_tls_port
+      value: 8899
+    - name: sni_hostname
+      value: (join('.', ['*', ($test_name), 'example.com']))
+    - name: fqdn
+      value: (join('.', ['echo', ($test_name), 'example.com']))
+    - name: cert_secret_name
+      value: test-tls-secret
+    - name: cert_secret_namespace
+      value: ($namespace)
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
+    - name: gateway_image
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+    - name: gateway_name
+      value: (join('-', [($test_name), 'gateway']))
+    - name: gateway_namespace
+      value: ($namespace)
+    - name: tls_route_name
+      value: (join('-', [($test_name), 'echo-tls-route']))
+    - name: tls_route_namespace
+      value: ($namespace)
+    - name: echo_deployment_name
+      value: (join('-', [($test_name), 'echo']))
+    - name: echo_deployment_namespace
+      value: (join('-', [($namespace), 'echo-backend']))
+    - name: reference_grant_name
+      value: echo-service-tls-reference-grant
+    - name: reference_grant_namespace
+      value: ($echo_deployment_namespace)
+
+  steps:
+    # Step 1: Create the TLS secret used by the echo backend (TLS passthrough).
+    - name: Create-tls-secret
+      description: Create TLS Secret for the echo backend.
+      use:
+        template: ../../common/_step_templates/apply-assert-tlsSecret.yaml
+
+    # Step 2a: Create the secret for Konnect authentication.
+    - name: Create-auth-secret
+      description: Create Secret with Konnect token for KonnectAPIAuthConfiguration.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    # Step 2b: Create the KonnectAPIAuthConfiguration.
+    - name: Create-konnect-api-auth
+      description: Create KonnectAPIAuthConfiguration for the test.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
+
+    # Step 3: Create the GatewayConfiguration.
+    - name: Create-gateway-configuration
+      description: Create GatewayConfiguration for the test.
+      use:
+        template: ../../common/_step_templates/apply-assert-gatewayConfiguration.yaml
+
+    # Step 4: Create the GatewayClass.
+    - name: Create-gateway-class
+      description: Create GatewayClass for the test.
+      use:
+        template: ../../common/_step_templates/apply-assert-gatewayClass.yaml
+
+    # Step 5: Create the Gateway with a TLS passthrough listener.
+    - name: Create-gateway
+      description: Create Gateway with a TLS passthrough listener.
+      use:
+        template: ../../common/_step_templates/apply-assert-gateway-tls-passthrough-listener.yaml
+
+    # Step 6: Assert the KonnectGatewayControlPlane is created and synchronized.
+    - name: Assert-konnect-gateway-control-plane
+      description: Assert that the KonnectGatewayControlplane resource is created and synchronized.
+      use:
+        template: ../../common/_step_templates/assert-konnectGatewayControlPlane.yaml
+
+    # Step 7: Create the cross-namespace where the backend Service will live.
+    - name: Create-backend-namespace
+      description: Create a separate namespace for the backend Service.
+      use:
+        template: ../../common/_step_templates/apply-assert-namespace.yaml
+      bindings:
+        - name: namespace_name
+          value: ($echo_deployment_namespace)
+
+    # Step 8: Create the echo Service (TLS-capable) in the cross-namespace.
+    - name: Create-echo-service
+      description: Create and assert an echo service in the cross-namespace.
+      use:
+        template: ../../common/_step_templates/apply-assert-echoService-with-tls.yaml
+
+    # Step 9: Apply the TLSRoute together with a permissive ReferenceGrant,
+    # and assert the TLSRoute reaches ResolvedRefs=True and is Programmed.
+    - name: Create-tlsroute-with-grant
+      description: Apply TLSRoute and ReferenceGrant; assert programmed.
+      try:
+        - apply:
+            file: 01-tlsroute-with-grant.yaml
+        - assert:
+            file: 02-assert-tlsroute-resolved.yaml
+
+    # Step 10: Assert that a KongTarget owned by the TLSRoute exists for the
+    # cross-namespace backend Service.
+    - name: Assert-kongtarget-exists
+      description: Assert that the KongTarget was created for the cross-namespace backend.
+      try:
+        - assert:
+            file: 03-assert-kongtarget-exists.yaml
+
+    # Step 11: Verify TLS traffic flows end-to-end through the gateway to the
+    # cross-namespace backend while the ReferenceGrant is in place.
+    - name: Verify-TLS-traffic-from-host
+      description: Verify that TLS traffic can be routed through the gateway to the cross-namespace echo service.
+      use:
+        template: ../../common/_step_templates/verify-tls-traffic-from-host.yaml
+      bindings:
+        - name: request_sni
+          value: ($fqdn)
+
+    # Step 12: Delete the ReferenceGrant. This is the trigger for the bug:
+    # the TLSRoute's ResolvedRefs becomes False/RefNotPermitted and (before
+    # the fix) the previously-created KongTarget was not cleaned up.
+    - name: Delete-referencegrant
+      description: Delete the ReferenceGrant to make the cross-namespace ref unpermitted.
+      use:
+        template: ../../common/_step_templates/delete-resource-non-blocking.yaml
+      bindings:
+        - name: resource_type
+          value: referencegrant.gateway.networking.k8s.io
+        - name: resource_name
+          value: ($reference_grant_name)
+        - name: resource_namespace
+          value: ($reference_grant_namespace)
+
+    # Step 13: Assert the TLSRoute's ResolvedRefs condition flips to
+    # False/RefNotPermitted, and that the previously-created KongTarget is
+    # removed by orphan cleanup. This is the regression assertion.
+    - name: Assert-tlsroute-not-permitted-and-kongtarget-gone
+      description: Assert ResolvedRefs=False/RefNotPermitted and KongTarget orphan was cleaned up.
+      try:
+        - assert:
+            file: 04-assert-tlsroute-not-permitted.yaml
+        - error:
+            file: 05-assert-kongtarget-absent.yaml
+
+    # Step 14: Re-apply the ReferenceGrant. The TLSRoute should recover and
+    # the KongTarget should be re-created.
+    - name: Reapply-referencegrant
+      description: Re-create the ReferenceGrant and assert recovery.
+      try:
+        - apply:
+            file: 06-referencegrant.yaml
+        - assert:
+            file: 02-assert-tlsroute-resolved.yaml
+        - assert:
+            file: 03-assert-kongtarget-exists.yaml
+
+    # Step 15: Verify TLS traffic flows end-to-end through the gateway to the
+    # cross-namespace backend again while the ReferenceGrant is re-created.
+    - name: Verify-TLS-traffic-from-host-referencegrant-recreated
+      description: Verify that TLS traffic can be routed through the gateway to the cross-namespace echo service when the ReferenceGrant is recreated.
+      use:
+        template: ../../common/_step_templates/verify-tls-traffic-from-host.yaml
+      bindings:
+        - name: request_sni
+          value: ($fqdn)
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-tlsroute-backendref-cross-namespace-reference
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: ADDITIONAL_NAMESPACES
+            value: ($echo_deployment_namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/chainsaw-test.yaml
@@ -32,10 +32,6 @@ spec:
       value: (join('.', ['*', ($test_name), 'example.com']))
     - name: fqdn
       value: (join('.', ['echo', ($test_name), 'example.com']))
-    - name: cert_secret_name
-      value: test-tls-secret
-    - name: cert_secret_namespace
-      value: ($namespace)
     - name: konnect_url
       value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
     - name: auth_secret_name
@@ -64,51 +60,50 @@ spec:
       value: echo-service-tls-reference-grant
     - name: reference_grant_namespace
       value: ($echo_deployment_namespace)
+    - name: cert_secret_name
+      value: test-tls-secret
+    # The TLS secret needs to be in the same namespace as the echo backend deployment since it's used for TLS passthrough.
+    - name: cert_secret_namespace
+      value: ($echo_deployment_namespace)
 
   steps:
-    # Step 1: Create the TLS secret used by the echo backend (TLS passthrough).
-    - name: Create-tls-secret
-      description: Create TLS Secret for the echo backend.
-      use:
-        template: ../../common/_step_templates/apply-assert-tlsSecret.yaml
-
-    # Step 2a: Create the secret for Konnect authentication.
+    # Step 1a: Create the secret for Konnect authentication.
     - name: Create-auth-secret
       description: Create Secret with Konnect token for KonnectAPIAuthConfiguration.
       use:
         template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
 
-    # Step 2b: Create the KonnectAPIAuthConfiguration.
+    # Step 1b: Create the KonnectAPIAuthConfiguration.
     - name: Create-konnect-api-auth
       description: Create KonnectAPIAuthConfiguration for the test.
       use:
         template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
 
-    # Step 3: Create the GatewayConfiguration.
+    # Step 2: Create the GatewayConfiguration.
     - name: Create-gateway-configuration
       description: Create GatewayConfiguration for the test.
       use:
         template: ../../common/_step_templates/apply-assert-gatewayConfiguration.yaml
 
-    # Step 4: Create the GatewayClass.
+    # Step 3: Create the GatewayClass.
     - name: Create-gateway-class
       description: Create GatewayClass for the test.
       use:
         template: ../../common/_step_templates/apply-assert-gatewayClass.yaml
 
-    # Step 5: Create the Gateway with a TLS passthrough listener.
+    # Step 4: Create the Gateway with a TLS passthrough listener.
     - name: Create-gateway
       description: Create Gateway with a TLS passthrough listener.
       use:
         template: ../../common/_step_templates/apply-assert-gateway-tls-passthrough-listener.yaml
 
-    # Step 6: Assert the KonnectGatewayControlPlane is created and synchronized.
+    # Step 5: Assert the KonnectGatewayControlPlane is created and synchronized.
     - name: Assert-konnect-gateway-control-plane
       description: Assert that the KonnectGatewayControlplane resource is created and synchronized.
       use:
         template: ../../common/_step_templates/assert-konnectGatewayControlPlane.yaml
 
-    # Step 7: Create the cross-namespace where the backend Service will live.
+    # Step 6: Create the cross-namespace where the backend Service will live.
     - name: Create-backend-namespace
       description: Create a separate namespace for the backend Service.
       use:
@@ -116,6 +111,12 @@ spec:
       bindings:
         - name: namespace_name
           value: ($echo_deployment_namespace)
+
+    # Step 7: Create the TLS secret used by the echo backend (TLS passthrough).
+    - name: Create-tls-secret
+      description: Create TLS Secret for the echo backend.
+      use:
+        template: ../../common/_step_templates/apply-assert-tlsSecret.yaml
 
     # Step 8: Create the echo Service (TLS-capable) in the cross-namespace.
     - name: Create-echo-service


### PR DESCRIPTION
**What this PR does / why we need it**:

Continue translate phase to clear orphaned resources of `TLSRoute` when its `ResolvedRef` is `False`. This fixes the issue where a `ReferenceGrant` is deleted for `TLSRoute`, the translated resources are not deleted. 

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
