### PR TITLE
test(e2e/chainsaw): add cross-namespace KongCACertificate test

### DIFF
--- a/test/e2e/chainsaw/common/_step_templates/apply-assert-caSecret.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/apply-assert-caSecret.yaml
@@ -1,0 +1,39 @@
+# Template for generating and creating a CA certificate Secret.
+# The Secret is of type Opaque with key 'ca.crt' holding the PEM-encoded CA certificate.
+#
+# Required bindings:
+#   - ca_secret_name: Name of the Secret to create.
+#   - ca_secret_namespace: Namespace where the Secret will be created.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: apply-assert-ca-secret
+spec:
+  try:
+    - script:
+        content: |
+          bash ../../common/scripts/generate_ca_certificate.sh
+        outputs:
+          - name: cert_data
+            value: (json_parse($stdout).cert)
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: ($ca_secret_name)
+            namespace: ($ca_secret_namespace)
+            labels:
+              konghq.com/secret: "true"
+          type: Opaque
+          stringData:
+            ca.crt: ($cert_data)
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: ($ca_secret_name)
+            namespace: ($ca_secret_namespace)
+            labels:
+              konghq.com/secret: "true"

--- a/test/e2e/chainsaw/common/scripts/generate_ca_certificate.sh
+++ b/test/e2e/chainsaw/common/scripts/generate_ca_certificate.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Abort on nonzero exit status, unbound variable, and pipefail.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Generates a self-signed CA certificate and outputs JSON: {cert: "<pem>"}.
+# The certificate has basicConstraints=critical,CA:TRUE so it is accepted as a CA cert.
+
+tmp_key=$(mktemp)
+tmp_crt=$(mktemp)
+trap 'rm -f "$tmp_key" "$tmp_crt"' EXIT
+
+if ! OPENSSL_OUTPUT=$(openssl req -x509 -nodes -days 3650 -newkey rsa:2048 \
+  -keyout "$tmp_key" \
+  -out "$tmp_crt" \
+  -subj "/CN=test-ca" \
+  -addext "basicConstraints=critical,CA:TRUE" \
+  -addext "keyUsage=critical,keyCertSign,cRLSign" 2>&1); then
+  jq -n \
+    --arg error "OpenSSL CA certificate generation failed" \
+    --arg openssl_output "$OPENSSL_OUTPUT" \
+    '{error: $error, openssl_output: $openssl_output}'
+  exit 1
+fi
+
+jq -n \
+  --arg cert "$(cat "$tmp_crt")" \
+  '{cert: $cert}'

--- a/test/e2e/chainsaw/konnect/kongcacertificate_cross-namespace/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/konnect/kongcacertificate_cross-namespace/chainsaw-test.yaml
@@ -1,0 +1,701 @@
+# KongCACertificate cross-namespace ControlPlaneRef test.
+#
+# KongCACertificate uses type=secretRef backed by a same-namespace CA Secret.
+# The cross-namespace axis under test is the controlPlaneRef only.
+#
+# Scenario A: All resources in the same namespace — baseline, no grants needed.
+#
+# Scenario B: CP and AuthConfig co-located in ns-B, KongCACertificate in ns-A.
+#   Only a CACertificate->CP grant is needed.
+#
+# Scenario C: CP in ns-B, AuthConfig in ns-C (separate namespace), KongCACertificate in ns-A.
+#   Both CACertificate->CP AND CP->AuthConfig grants are required.
+#
+# Scenario D: starting from Scenario B (Programmed=True), deleting the
+#   KongReferenceGrant reverts the CACertificate to ResolvedRefs=False/RefNotPermitted.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kongcacertificate-cross-namespace
+spec:
+  description: |
+    Scenario A: All resources (KongCACertificate, KonnectGatewayControlPlane,
+    KonnectAPIAuthConfiguration) in the same namespace. No grants needed; baseline sanity check.
+
+    Scenario B: KongCACertificate (ns-A) -> KonnectGatewayControlPlane (ns-B) -> KonnectAPIAuthConfiguration (ns-B).
+    CP and AuthConfig co-located: only one CACertificate->CP grant is needed.
+
+    Steps:
+      1. Create ns-B and provision KonnectAPIAuthConfiguration + KonnectGatewayControlPlane there.
+      2. Create CA Secret and KongCACertificate in ns-A pointing to the cross-namespace CP.
+      3. Assert it has a negative condition (no grant yet).
+      4. Create the KongReferenceGrant in ns-B.
+      5. Assert it becomes Programmed.
+      6. Explicitly delete Konnect-registered resources before chainsaw tears down the auth namespace.
+
+    Scenario C: KongCACertificate (ns-A) -> KonnectGatewayControlPlane (ns-B) -> KonnectAPIAuthConfiguration (ns-C).
+    CP and AuthConfig in different namespaces: both CACertificate->CP AND CP->AuthConfig grants are required.
+
+    Steps:
+      1. Create ns-C; provision AuthConfig in ns-C, CP in ns-B with cross-namespace authRef.
+      2. Assert CP has APIAuthResolvedRef=False (missing CP->AuthConfig grant).
+      3. Create CA Secret and KongCACertificate in ns-A; add CACertificate->CP grant.
+      4. Assert CACertificate is not Programmed (CP not programmed yet).
+      5. Add CP->AuthConfig grant; assert CP and CACertificate both become Programmed.
+      6. Explicitly delete Konnect-registered resources before chainsaw tears down the auth namespaces.
+
+    Scenario D: starting from Scenario B (Programmed=True), deleting the
+    KongReferenceGrant reverts the CACertificate to ResolvedRefs=False/RefNotPermitted
+    immediately, validating that the KongReferenceGrant watch is in place.
+
+  bindings:
+    # Common bindings.
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    # Namespace bindings (Scenario B and C).
+    - name: cp_namespace
+      value: (join('-', [$namespace, 'cp']))
+    - name: auth_namespace
+      value: (join('-', [$namespace, 'auth']))
+    # Scenario A resource names (same namespace as test).
+    - name: cp0_name
+      value: (join('-', [$namespace, 'cp0']))
+    - name: auth0_name
+      value: (join('-', [$namespace, 'auth0-konnect-api-auth']))
+    - name: cacert0_name
+      value: (join('-', [$namespace, 'cacert0']))
+    - name: casecret0_name
+      value: (join('-', [$namespace, 'casecret0']))
+    # Scenario B resource names (CACertificate in test namespace, CP+AuthConfig in cp_namespace).
+    - name: cp_name
+      value: (join('-', [$namespace, 'cp']))
+    - name: auth_name
+      value: (join('-', [$namespace, 'konnect-api-auth']))
+    - name: cacert_name
+      value: (join('-', [$namespace, 'cacert']))
+    - name: casecret_name
+      value: (join('-', [$namespace, 'casecret']))
+    # Scenario C resource names (CP in cp_namespace, AuthConfig in auth_namespace).
+    - name: cp2_name
+      value: (join('-', [$namespace, 'cp2']))
+    - name: auth2_name
+      value: (join('-', [$namespace, 'auth2-konnect-api-auth']))
+    - name: cacert2_name
+      value: (join('-', [$namespace, 'cacert2']))
+    - name: casecret2_name
+      value: (join('-', [$namespace, 'casecret2']))
+
+  steps:
+    # =========================================================================
+    # Scenario A: All resources in the same namespace. No grants needed.
+    # =========================================================================
+
+    # Step 1: Create KonnectAPIAuthConfiguration in the test namespace.
+    - name: 1-create-auth-config-same-ns
+      description: Create KonnectAPIAuthConfiguration in the test namespace.
+      bindings:
+        - name: test_name
+          value: (join('-', [$namespace, 'auth0']))
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    # Step 2: Create KonnectGatewayControlPlane in the test namespace.
+    - name: 2-create-control-plane-same-ns
+      description: Create KonnectGatewayControlPlane in the test namespace referencing auth config in the same namespace.
+      bindings:
+        - name: cp_name
+          value: ($cp0_name)
+        - name: cp_namespace
+          value: ($namespace)
+        - name: auth_name
+          value: ($auth0_name)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectGatewayControlPlane.yaml
+
+    # Step 3: Create CA Secret and KongCACertificate in the test namespace.
+    # No grants are required since all resources share the same namespace.
+    - name: 3-create-ca-secret-same-ns
+      description: Generate a CA certificate and store it in a Secret in the test namespace.
+      bindings:
+        - name: ca_secret_name
+          value: ($casecret0_name)
+        - name: ca_secret_namespace
+          value: ($namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-caSecret.yaml
+
+    - name: 4-create-cacert-same-ns
+      description: Create KongCACertificate in the test namespace (no grants needed).
+      try:
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCACertificate
+              metadata:
+                name: ($cacert0_name)
+                namespace: ($namespace)
+              spec:
+                type: secretRef
+                secretRef:
+                  name: ($casecret0_name)
+                controlPlaneRef:
+                  type: konnectNamespacedRef
+                  konnectNamespacedRef:
+                    name: ($cp0_name)
+
+    # Step 5: Assert CACertificate is Programmed without any grants.
+    - name: 5-assert-cacert-programmed-same-ns
+      description: Assert KongCACertificate is Programmed (no grants needed for same namespace).
+      timeouts:
+        assert: 90s
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCACertificate
+              metadata:
+                name: ($cacert0_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+
+    # Step 6: Cleanup scenario A resources in dependency order.
+    - name: 6-cleanup-scenario-a
+      description: Delete cacert0 and CP0 in order; wait for each to be gone before proceeding.
+      timeouts:
+        delete: 120s
+        error: 120s
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCACertificate
+              name: ($cacert0_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCACertificate
+              metadata:
+                name: ($cacert0_name)
+                namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              name: ($cp0_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp0_name)
+                namespace: ($namespace)
+
+    # =========================================================================
+    # Scenario B: CP and AuthConfig in the same namespace (ns-B), CACertificate in ns-A.
+    # Only the CACertificate->CP grant is needed.
+    # =========================================================================
+
+    # Step 7: Create namespace for KonnectGatewayControlPlane and KonnectAPIAuthConfiguration.
+    - name: 7-create-cp-namespace
+      description: Create namespace for KonnectGatewayControlPlane and KonnectAPIAuthConfiguration.
+      bindings:
+        - name: namespace_name
+          value: ($cp_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-namespace.yaml
+
+    # Step 8: Create KonnectAPIAuthConfiguration in the CP namespace.
+    - name: 8-create-auth-config
+      description: Create KonnectAPIAuthConfiguration in the CP namespace.
+      bindings:
+        - name: test_name
+          value: ($namespace)
+        - name: namespace
+          value: ($cp_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    # Step 9: Create KonnectGatewayControlPlane in the CP namespace.
+    - name: 9-create-control-plane
+      description: Create KonnectGatewayControlPlane in the CP namespace referencing auth config in the same namespace.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectGatewayControlPlane.yaml
+
+    # Step 10: Create CA Secret in the test namespace (same as KongCACertificate).
+    - name: 10-create-ca-secret
+      description: Generate a CA certificate and store it in a Secret in the test namespace.
+      bindings:
+        - name: ca_secret_name
+          value: ($casecret_name)
+        - name: ca_secret_namespace
+          value: ($namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-caSecret.yaml
+
+    # Step 11: Create KongCACertificate before any KongReferenceGrant exists.
+    - name: 11-create-cacert-no-grant
+      description: Create KongCACertificate before any grant exists.
+      try:
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCACertificate
+              metadata:
+                name: ($cacert_name)
+                namespace: ($namespace)
+              spec:
+                type: secretRef
+                secretRef:
+                  name: ($casecret_name)
+                controlPlaneRef:
+                  type: konnectNamespacedRef
+                  konnectNamespacedRef:
+                    name: ($cp_name)
+                    namespace: ($cp_namespace)
+
+    # Step 12: Assert negative condition — CACertificate ResolvedRefs=False.
+    - name: 12-assert-negative-no-grant
+      description: Assert CACertificate ResolvedRefs=False/RefNotPermitted (no grant yet).
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCACertificate
+              metadata:
+                name: ($cacert_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    # Step 13: Create KongReferenceGrant allowing KongCACertificate (ns-A) -> KonnectGatewayControlPlane (ns-B).
+    - name: 13-create-reference-grant
+      description: Create KongReferenceGrant in cp_namespace allowing KongCACertificate from test namespace to reference KonnectGatewayControlPlane.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'cacert-to-cp']))
+        - name: kong_reference_grant_namespace
+          value: ($cp_namespace)
+        - name: from
+          value:
+            - group: configuration.konghq.com
+              kind: KongCACertificate
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectGatewayControlPlane
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    # Step 14: Assert CACertificate becomes Programmed after the grant is in place.
+    - name: 14-assert-cacert-programmed
+      description: Assert KongCACertificate is Programmed after the grant is added.
+      timeouts:
+        assert: 90s
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCACertificate
+              metadata:
+                name: ($cacert_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'True'
+                    reason: ResolvedRefs
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+
+    # =========================================================================
+    # Scenario D: delete the CACertificate->CP grant and verify the CACertificate
+    # reverts to ResolvedRefs=False/RefNotPermitted (validates grant watch).
+    # =========================================================================
+
+    - name: 15-delete-cacert-to-cp-grant
+      description: Delete the CACertificate->CP grant to verify the CACertificate reverts to RefNotPermitted.
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'cacert-to-cp']))
+              namespace: ($cp_namespace)
+
+    - name: 16-assert-cacert-reverts-to-not-permitted
+      description: Assert CACertificate transitions back to ResolvedRefs=False/RefNotPermitted after grant deletion.
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCACertificate
+              metadata:
+                name: ($cacert_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    - name: 17-recreate-cacert-to-cp-grant
+      description: Recreate the CACertificate->CP grant so the CA certificate can be deprovisioned cleanly during cleanup.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'cacert-to-cp']))
+        - name: kong_reference_grant_namespace
+          value: ($cp_namespace)
+        - name: from
+          value:
+            - group: configuration.konghq.com
+              kind: KongCACertificate
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectGatewayControlPlane
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    # Step 18: Explicitly delete Konnect-registered resources in dependency order before chainsaw
+    # tears down the namespace containing the KonnectAPIAuthConfiguration.
+    # The cacert-to-cp grant is deleted before the CP wait (safe — does not affect CP auth deprovisioning).
+    - name: 18-cleanup-scenario-b
+      description: |
+        Delete cacert and CP in order; wait for each to be gone.
+        cacert-to-cp grant is deleted before the CP wait (safe — does not affect CP auth deprovisioning).
+      timeouts:
+        delete: 120s
+        error: 120s
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCACertificate
+              name: ($cacert_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCACertificate
+              metadata:
+                name: ($cacert_name)
+                namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'cacert-to-cp']))
+              namespace: ($cp_namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              name: ($cp_name)
+              namespace: ($cp_namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp_name)
+                namespace: ($cp_namespace)
+
+    # =========================================================================
+    # Scenario C: CP in cp_namespace (ns-B), AuthConfig in auth_namespace (ns-C).
+    # Both CACertificate->CP AND CP->AuthConfig grants are required.
+    # =========================================================================
+
+    # Step 16: Create a separate namespace for KonnectAPIAuthConfiguration (ns-C).
+    - name: 19-create-auth-namespace
+      description: Create separate auth namespace for KonnectAPIAuthConfiguration (different from CP namespace).
+      bindings:
+        - name: namespace_name
+          value: ($auth_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-namespace.yaml
+
+    # Step 17: Create KonnectAPIAuthConfiguration in the auth namespace (ns-C).
+    - name: 20-create-auth-config-cross-ns
+      description: Create KonnectAPIAuthConfiguration in auth_namespace (ns-C, separate from CP namespace).
+      bindings:
+        - name: test_name
+          value: (join('-', [$namespace, 'auth2']))
+        - name: namespace
+          value: ($auth_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    # Step 18: Create CP2 in cp_namespace with cross-namespace authRef to auth_namespace.
+    # Without a CP->AuthConfig grant this CP should not become Programmed.
+    - name: 21-create-cp2-cross-ns-auth
+      description: Create KonnectGatewayControlPlane in cp_namespace with cross-namespace authRef to auth_namespace.
+      try:
+        - apply:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp2_name)
+                namespace: ($cp_namespace)
+              spec:
+                createControlPlaneRequest:
+                  name: ($cp2_name)
+                konnect:
+                  authRef:
+                    name: ($auth2_name)
+                    namespace: ($auth_namespace)
+
+    # Step 19: Assert CP2 has APIAuthResolvedRef=False/RefNotPermitted (no CP->AuthConfig grant).
+    - name: 22-assert-cp2-auth-grant-missing
+      description: Assert CP2 has APIAuthResolvedRef=False/RefNotPermitted because no CP->AuthConfig grant exists.
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp2_name)
+                namespace: ($cp_namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    # Step 20: Create CA Secret and KongCACertificate2 before CP2 is programmed.
+    - name: 23-create-ca-secret2
+      description: Generate a CA certificate and store it in a Secret in the test namespace for Scenario C.
+      bindings:
+        - name: ca_secret_name
+          value: ($casecret2_name)
+        - name: ca_secret_namespace
+          value: ($namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-caSecret.yaml
+
+    - name: 24-create-cacert2
+      description: Create KongCACertificate2 referencing cp2.
+      try:
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCACertificate
+              metadata:
+                name: ($cacert2_name)
+                namespace: ($namespace)
+              spec:
+                type: secretRef
+                secretRef:
+                  name: ($casecret2_name)
+                controlPlaneRef:
+                  type: konnectNamespacedRef
+                  konnectNamespacedRef:
+                    name: ($cp2_name)
+                    namespace: ($cp_namespace)
+
+    # Step 22: Add CACertificate2->CP2 grant so cacert2 can reference cp2 across namespaces.
+    - name: 25-create-cacert2-to-cp2-grant
+      description: Create KongReferenceGrant in cp_namespace allowing cacert2 from test namespace to reference cp2.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'cacert2-to-cp2']))
+        - name: kong_reference_grant_namespace
+          value: ($cp_namespace)
+        - name: from
+          value:
+            - group: configuration.konghq.com
+              kind: KongCACertificate
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectGatewayControlPlane
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    # Step 23: Assert cacert2 is still not Programmed.
+    # CP2 is not Programmed (CP->AuthConfig grant missing), so cacert2 is not Programmed.
+    - name: 26-assert-cacert2-not-programmed
+      description: Assert cacert2 ControlPlaneRefValid=False/NotProgrammed because CP->AuthConfig grant is still missing.
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCACertificate
+              metadata:
+                name: ($cacert2_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'False'
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'False'
+                    reason: NotProgrammed
+
+    # Step 24: Create CP2->AuthConfig2 grant in auth_namespace.
+    - name: 27-create-cp2-to-auth2-grant
+      description: Create KongReferenceGrant in auth_namespace allowing cp2 from cp_namespace to reference auth2.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'cp2-to-auth2']))
+        - name: kong_reference_grant_namespace
+          value: ($auth_namespace)
+        - name: from
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectGatewayControlPlane
+              namespace: ($cp_namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectAPIAuthConfiguration
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    # Step 25: Assert CP2 and cacert2 both become Programmed.
+    - name: 28-assert-all-programmed
+      description: Assert CP2 and cacert2 are both Programmed after both grants are in place.
+      timeouts:
+        assert: 90s
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp2_name)
+                namespace: ($cp_namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCACertificate
+              metadata:
+                name: ($cacert2_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'True'
+                    reason: ResolvedRefs
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+
+    # Step 26: Explicitly delete Konnect-registered resources in dependency order before chainsaw
+    # tears down the namespaces containing the KonnectAPIAuthConfigurations.
+    # cacert2-to-cp2 is deleted before the CP wait (safe — does not affect CP auth deprovisioning).
+    # cp2-to-auth2 is deleted last, after CP2 is fully deprovisioned.
+    - name: 29-cleanup-scenario-c
+      description: |
+        Delete cacert2 and CP2 in order; wait for each to be gone.
+        cacert2-to-cp2 grant is deleted before the CP wait (safe — does not affect CP auth deprovisioning).
+        cp2-to-auth2 is deleted last, after CP2 is fully deprovisioned.
+      timeouts:
+        delete: 120s
+        error: 120s
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCACertificate
+              name: ($cacert2_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCACertificate
+              metadata:
+                name: ($cacert2_name)
+                namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'cacert2-to-cp2']))
+              namespace: ($cp_namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              name: ($cp2_name)
+              namespace: ($cp_namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp2_name)
+                namespace: ($cp_namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'cp2-to-auth2']))
+              namespace: ($auth_namespace)
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: kongcacertificate-cross-namespace
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: ADDITIONAL_NAMESPACES
+            value: (join(',', [$cp_namespace, $auth_namespace]))
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh


### PR DESCRIPTION


**What this PR does / why we need it**:

Tests cross-namespace ControlPlaneRef behaviour for KongCACertificate (secretRef-backed; the cross-namespace axis under test is the controlPlaneRef only).

Scenario A: all resources in the same namespace; no grants needed. Baseline sanity check.

Scenario B: KongCACertificate (test-ns) -> CP+AuthConfig (cp_namespace). A single CACertificate->CP grant is required. Includes a negative assertion (step 12) before the grant is created.

Scenario C: KongCACertificate (test-ns) -> CP (cp_namespace) -> AuthConfig (auth_namespace). Both CACertificate->CP AND CP->AuthConfig grants required. Intermediate assertion (step 26) confirms the CA certificate is still not Programmed when only the CACertificate->CP grant is present but CP->AuthConfig is still missing.

Scenario D: starting from Scenario B (Programmed=True), deleting the KongReferenceGrant immediately reverts the CACertificate to ResolvedRefs=False/RefNotPermitted, validating that the KongReferenceGrant watch is wired correctly. The grant is then recreated to allow clean Konnect deprovisioning.

**Which issue this PR fixes**

Fixes #4158 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
