### PR TITLE
test(conformance): enable HTTPRouteDisallowedKind

### DIFF
--- a/controller/hybridgateway/route/status.go
+++ b/controller/hybridgateway/route/status.go
@@ -769,10 +769,6 @@ func FilterMatchingListeners(logger logr.Logger, gw *gwtypes.Gateway, routeKind 
 			continue
 		}
 
-		if !isListenerValidForKind(routeKind, listener) {
-			continue
-		}
-
 		// At this point, the listener matches the parent reference.
 		log.Debug(logger, "Listener matches ParentReference criteria", "listener", listener.Name, "parentRef", pRef)
 		// Now check if the listener is ready.
@@ -860,6 +856,13 @@ func FilterListenersByAllowedRoutes(logger logr.Logger, gw *gwtypes.Gateway, pRe
 	var matchingListeners []gwtypes.Listener
 
 	for _, listener := range listeners {
+		// Check if the listener is valid for the route kind. If not, skip this listener.
+		// We check the whether the listener is valid for the route here because the conformance tests requires
+		// the Accepted condition to have "NotAllowedByListeners" reason.
+		if !isListenerValidForKind(string(rgk.Kind), listener) {
+			continue
+		}
+
 		if listener.AllowedRoutes == nil {
 			// If AllowedRoutes is nil, all routes are allowed.
 			log.Debug(logger, "Listener allows all routes (AllowedRoutes is nil)", "listener", listener.Name)

--- a/controller/hybridgateway/route/status_test.go
+++ b/controller/hybridgateway/route/status_test.go
@@ -1157,10 +1157,8 @@ func Test_FilterMatchingListeners(t *testing.T) {
 	}
 	listenerReady := gwtypes.Listener{Name: "listener1", Port: 80, Protocol: gwtypes.HTTPProtocolType}
 	listenerNotReady := gwtypes.Listener{Name: "listener2", Port: 80, Protocol: gwtypes.HTTPProtocolType}
-	listenerProtocolTCP := gwtypes.Listener{Name: "listener1", Port: 80, Protocol: "TCP"}
 	tlsModePassthrough := gatewayv1.TLSModePassthrough
 	tlsModeTerminate := gatewayv1.TLSModeTerminate
-	listenerTLSPassthrough := gwtypes.Listener{Name: "listener1", Port: 80, Protocol: gwtypes.HTTPSProtocolType, TLS: &gatewayv1.ListenerTLSConfig{Mode: &tlsModePassthrough}}
 	listenerNotReadyTLS := gwtypes.Listener{Name: "listener2", Port: 80, Protocol: gwtypes.TLSProtocolType, TLS: &gatewayv1.ListenerTLSConfig{Mode: &tlsModeTerminate}}
 	listenerProtocolTLS := gwtypes.Listener{Name: "listener1", Port: 80, Protocol: gwtypes.TLSProtocolType, TLS: &gatewayv1.ListenerTLSConfig{Mode: &tlsModePassthrough}}
 
@@ -1196,24 +1194,6 @@ func Test_FilterMatchingListeners(t *testing.T) {
 			pRef:      gwtypes.ParentReference{Name: "listener1", Port: new(int32(81))},
 			routeKind: "HTTPRoute",
 			listeners: []gwtypes.Listener{listenerReady},
-			wantLen:   0,
-			wantCond:  true,
-			condMsg:   string(gwtypes.RouteReasonNoMatchingParent),
-		},
-		{
-			name:      "protocol mismatch",
-			pRef:      pRef,
-			routeKind: "HTTPRoute",
-			listeners: []gwtypes.Listener{listenerProtocolTCP},
-			wantLen:   0,
-			wantCond:  true,
-			condMsg:   string(gwtypes.RouteReasonNoMatchingParent),
-		},
-		{
-			name:      "TLS mode mismatch",
-			pRef:      pRef,
-			routeKind: "HTTPRoute",
-			listeners: []gwtypes.Listener{listenerTLSPassthrough},
 			wantLen:   0,
 			wantCond:  true,
 			condMsg:   string(gwtypes.RouteReasonNoMatchingParent),
@@ -1260,15 +1240,6 @@ func Test_FilterMatchingListeners(t *testing.T) {
 			wantLen:   1,
 			wantCond:  false,
 		},
-		{
-			name:      "TLSRoute - protocol mismatch",
-			pRef:      pRef,
-			routeKind: "TLSRoute",
-			listeners: []gwtypes.Listener{listenerProtocolTCP},
-			wantLen:   0,
-			wantCond:  true,
-			condMsg:   string(gwtypes.RouteReasonNoMatchingParent),
-		},
 	}
 
 	for _, tt := range tests {
@@ -1288,6 +1259,7 @@ func Test_FilterListenersByAllowedRoutes(t *testing.T) {
 	pRef := gwtypes.ParentReference{Name: "listener1"}
 	listener := gwtypes.Listener{Name: "listener1", Port: 80, Protocol: gwtypes.HTTPProtocolType}
 	kind := gwtypes.RouteGroupKind{Group: groupPtr(gwtypes.GroupName), Kind: "HTTPRoute"}
+	kindTLSRoute := gwtypes.RouteGroupKind{Group: groupPtr(gwtypes.GroupName), Kind: "TLSRoute"}
 	routeNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
 
 	selector := &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}
@@ -1317,6 +1289,10 @@ func Test_FilterListenersByAllowedRoutes(t *testing.T) {
 	listenerNSSelectorInvalid := listener
 	listenerNSSelectorInvalid.AllowedRoutes = &gwtypes.AllowedRoutes{Namespaces: &gwtypes.RouteNamespaces{From: new(gwtypes.NamespacesFromSelector), Selector: invalidSelector}}
 
+	listenerTLSPassthrough := listener
+	listenerTLSPassthrough.Protocol = gwtypes.HTTPSProtocolType
+	listenerTLSPassthrough.TLS = &gatewayv1.ListenerTLSConfig{Mode: new(gwtypes.TLSModePassthrough)}
+
 	unknownFrom := gwtypes.NamespacesFromAll
 	listenerNSUnknown := listener
 	listenerNSUnknown.AllowedRoutes = &gwtypes.AllowedRoutes{Namespaces: &gwtypes.RouteNamespaces{From: &unknownFrom}}
@@ -1331,6 +1307,22 @@ func Test_FilterListenersByAllowedRoutes(t *testing.T) {
 		wantCond  bool
 		wantErr   bool
 	}{
+		{
+			name:      "TLSRoute - protocol mismatch",
+			kind:      kindTLSRoute,
+			listeners: []gwtypes.Listener{listener},
+			routeNS:   routeNS,
+			wantLen:   0,
+			wantCond:  true,
+		},
+		{
+			name:      "TLS mode mismatch",
+			kind:      kind,
+			listeners: []gwtypes.Listener{listenerTLSPassthrough},
+			routeNS:   routeNS,
+			wantLen:   0,
+			wantCond:  true,
+		},
 		{
 			name:      "AllowedRoutes nil (all allowed)",
 			listeners: []gwtypes.Listener{listener},

--- a/internal/types/gatewaytypes.go
+++ b/internal/types/gatewaytypes.go
@@ -79,4 +79,5 @@ const (
 	RouteReasonRefNotPermitted            = gatewayv1.RouteReasonRefNotPermitted
 	RouteReasonResolvedRefs               = gatewayv1.RouteReasonResolvedRefs
 	TLSModeTerminate                      = gatewayv1.TLSModeTerminate
+	TLSModePassthrough                    = gatewayv1.TLSModePassthrough
 )

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -62,9 +62,6 @@ var skippedTestsForHybrid = []string{
 	// This test is skipped because it proven to be flaky.
 	// TODO: https://github.com/Kong/kong-operator/issues/2793
 	tests.HTTPRouteReferenceGrant.ShortName,
-	// This test is skipped because the `Reason` field in the `RouteCondition` is not the same as expected by the test.
-	// TODO: https://github.com/Kong/kong-operator/issues/67
-	tests.HTTPRouteDisallowedKind.ShortName,
 }
 
 // skippedTestsForConfig returns the list of skipped tests for the given router flavor and gateway type.


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable `HTTPRouteDisallowedKind` conformance test case.

**Which issue this PR fixes**

Fixes #67

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
