### PR TITLE
test(e2e/chainsaw): add cross-namespace KongDataPlaneClientCertificate test

### DIFF
--- a/test/e2e/chainsaw/common/_step_templates/apply-kongDataPlaneClientCertificate-inline.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/apply-kongDataPlaneClientCertificate-inline.yaml
@@ -1,0 +1,38 @@
+# Template for generating a TLS certificate and creating a KongDataPlaneClientCertificate
+# with an inline spec.cert field (Konnect form — no Kubernetes Secret).
+#
+# Required bindings:
+#   - dpcc_name:        Name of the KongDataPlaneClientCertificate to create.
+#   - dpcc_namespace:   Namespace for the KongDataPlaneClientCertificate.
+#   - cp_name:          Name of the KonnectGatewayControlPlane to reference.
+#   - cp_ref_namespace: Namespace of the KonnectGatewayControlPlane. May equal dpcc_namespace
+#       for same-namespace references (no KongReferenceGrant required in that case).
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: apply-kong-data-plane-client-certificate-inline
+spec:
+  try:
+    - script:
+        env:
+          - name: HOSTNAME
+            value: ($dpcc_name)
+        content: |
+          bash ../../common/scripts/generate_tls_certificate.sh
+        outputs:
+          - name: cert_data
+            value: (json_parse($stdout).cert)
+    - apply:
+        resource:
+          apiVersion: configuration.konghq.com/v1alpha1
+          kind: KongDataPlaneClientCertificate
+          metadata:
+            name: ($dpcc_name)
+            namespace: ($dpcc_namespace)
+          spec:
+            controlPlaneRef:
+              type: konnectNamespacedRef
+              konnectNamespacedRef:
+                name: ($cp_name)
+                namespace: ($cp_ref_namespace)
+            cert: ($cert_data)

--- a/test/e2e/chainsaw/konnect/kongdataplaneclientcertificate_cross-namespace/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/konnect/kongdataplaneclientcertificate_cross-namespace/chainsaw-test.yaml
@@ -1,0 +1,647 @@
+# KongDataPlaneClientCertificate cross-namespace ControlPlaneRef test.
+#
+# Scenario A: All resources in the same namespace — baseline, no grants needed.
+#
+# Scenario B: CP and AuthConfig co-located in ns-B, KongDataPlaneClientCertificate in ns-A.
+#   Only a DataPlaneClientCertificate->CP grant is needed.
+#
+# Scenario C: CP in ns-B, AuthConfig in ns-C (separate namespace), KongDataPlaneClientCertificate in ns-A.
+#   Both DataPlaneClientCertificate->CP AND CP->AuthConfig grants are required.
+#
+# Scenario D: starting from Scenario B (Programmed=True), deleting the
+#   KongReferenceGrant reverts the DataPlaneClientCertificate to ResolvedRefs=False/RefNotPermitted.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kongdataplaneclientcertificate-cross-namespace
+spec:
+  description: |
+    Scenario A: All resources (KongDataPlaneClientCertificate, KonnectGatewayControlPlane,
+    KonnectAPIAuthConfiguration) in the same namespace. No grants needed; baseline sanity check.
+
+    Scenario B: KongDataPlaneClientCertificate (ns-A) -> KonnectGatewayControlPlane (ns-B) -> KonnectAPIAuthConfiguration (ns-B).
+    CP and AuthConfig co-located: only one DataPlaneClientCertificate->CP grant is needed.
+
+    Steps:
+      1. Create ns-B and provision KonnectAPIAuthConfiguration + KonnectGatewayControlPlane there.
+      2. Create KongDataPlaneClientCertificate in ns-A pointing to the cross-namespace CP.
+      3. Assert it has a negative condition (no grant yet).
+      4. Create the KongReferenceGrant in ns-B.
+      5. Assert it becomes Programmed.
+      6. Explicitly delete Konnect-registered resources before chainsaw tears down the auth namespace.
+
+    Scenario C: KongDataPlaneClientCertificate (ns-A) -> KonnectGatewayControlPlane (ns-B) -> KonnectAPIAuthConfiguration (ns-C).
+    CP and AuthConfig in different namespaces: both DataPlaneClientCertificate->CP AND CP->AuthConfig grants are required.
+
+    Steps:
+      1. Create ns-C; provision AuthConfig in ns-C, CP in ns-B with cross-namespace authRef.
+      2. Assert CP has APIAuthResolvedRef=False (missing CP->AuthConfig grant).
+      3. Create KongDataPlaneClientCertificate in ns-A; add DataPlaneClientCertificate->CP grant.
+      4. Assert DataPlaneClientCertificate is not Programmed (CP not programmed yet).
+      5. Add CP->AuthConfig grant; assert CP and DataPlaneClientCertificate both become Programmed.
+      6. Explicitly delete Konnect-registered resources before chainsaw tears down the auth namespaces.
+
+    Scenario D: starting from Scenario B (Programmed=True), deleting the
+    KongReferenceGrant reverts the DataPlaneClientCertificate to
+    ResolvedRefs=False/RefNotPermitted immediately, validating that the
+    KongReferenceGrant watch is wired correctly. The grant is then
+    recreated to allow clean Konnect deprovisioning.
+
+  bindings:
+    # Common bindings.
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    # Namespace bindings (Scenario B and C).
+    - name: cp_namespace
+      value: (join('-', [$namespace, 'cp']))
+    - name: auth_namespace
+      value: (join('-', [$namespace, 'auth']))
+    # Scenario A resource names (same namespace as test).
+    - name: cp0_name
+      value: (join('-', [$namespace, 'cp0']))
+    - name: auth0_name
+      value: (join('-', [$namespace, 'auth0-konnect-api-auth']))
+    - name: dpcc0_name
+      value: (join('-', [$namespace, 'dpcc0']))
+    # Scenario B resource names (DataPlaneClientCertificate in test namespace, CP+AuthConfig in cp_namespace).
+    - name: cp_name
+      value: (join('-', [$namespace, 'cp']))
+    - name: auth_name
+      value: (join('-', [$namespace, 'konnect-api-auth']))
+    - name: dpcc_name
+      value: (join('-', [$namespace, 'dpcc']))
+    # Scenario C resource names (CP in cp_namespace, AuthConfig in auth_namespace).
+    - name: cp2_name
+      value: (join('-', [$namespace, 'cp2']))
+    - name: auth2_name
+      value: (join('-', [$namespace, 'auth2-konnect-api-auth']))
+    - name: dpcc2_name
+      value: (join('-', [$namespace, 'dpcc2']))
+
+  steps:
+    # =========================================================================
+    # Scenario A: All resources in the same namespace. No grants needed.
+    # =========================================================================
+
+    # Step 1: Create KonnectAPIAuthConfiguration in the test namespace.
+    - name: 1-create-auth-config-same-ns
+      description: Create KonnectAPIAuthConfiguration in the test namespace.
+      bindings:
+        - name: test_name
+          value: (join('-', [$namespace, 'auth0']))
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    # Step 2: Create KonnectGatewayControlPlane in the test namespace.
+    - name: 2-create-control-plane-same-ns
+      description: Create KonnectGatewayControlPlane in the test namespace referencing auth config in the same namespace.
+      bindings:
+        - name: cp_name
+          value: ($cp0_name)
+        - name: cp_namespace
+          value: ($namespace)
+        - name: auth_name
+          value: ($auth0_name)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectGatewayControlPlane.yaml
+
+    # Step 3: Create KongDataPlaneClientCertificate in the test namespace.
+    # No grants are required since all resources share the same namespace.
+    - name: 3-create-dpcc-same-ns
+      description: Create KongDataPlaneClientCertificate in the test namespace (no grants needed).
+      bindings:
+        - name: dpcc_name
+          value: ($dpcc0_name)
+        - name: dpcc_namespace
+          value: ($namespace)
+        - name: cp_name
+          value: ($cp0_name)
+        - name: cp_ref_namespace
+          value: ($namespace)
+      use:
+        template: ../../common/_step_templates/apply-kongDataPlaneClientCertificate-inline.yaml
+
+    # Step 4: Assert DataPlaneClientCertificate is Programmed without any grants.
+    - name: 4-assert-dpcc-programmed-same-ns
+      description: Assert KongDataPlaneClientCertificate is Programmed (no grants needed for same namespace).
+      timeouts:
+        assert: 90s
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongDataPlaneClientCertificate
+              metadata:
+                name: ($dpcc0_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+
+    # Step 5: Cleanup scenario A resources in dependency order.
+    - name: 5-cleanup-scenario-a
+      description: Delete dpcc0 and CP0 in order; wait for each to be gone before proceeding.
+      timeouts:
+        delete: 120s
+        error: 120s
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongDataPlaneClientCertificate
+              name: ($dpcc0_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongDataPlaneClientCertificate
+              metadata:
+                name: ($dpcc0_name)
+                namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              name: ($cp0_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp0_name)
+                namespace: ($namespace)
+
+    # =========================================================================
+    # Scenario B: CP and AuthConfig in the same namespace (ns-B), DataPlaneClientCertificate in ns-A.
+    # Only the DataPlaneClientCertificate->CP grant is needed.
+    # =========================================================================
+
+    # Step 6: Create namespace for KonnectGatewayControlPlane and KonnectAPIAuthConfiguration.
+    - name: 6-create-cp-namespace
+      description: Create namespace for KonnectGatewayControlPlane and KonnectAPIAuthConfiguration.
+      bindings:
+        - name: namespace_name
+          value: ($cp_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-namespace.yaml
+
+    # Step 7: Create KonnectAPIAuthConfiguration in the CP namespace.
+    - name: 7-create-auth-config
+      description: Create KonnectAPIAuthConfiguration in the CP namespace.
+      bindings:
+        - name: test_name
+          value: ($namespace)
+        - name: namespace
+          value: ($cp_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    # Step 8: Create KonnectGatewayControlPlane in the CP namespace.
+    - name: 8-create-control-plane
+      description: Create KonnectGatewayControlPlane in the CP namespace referencing auth config in the same namespace.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectGatewayControlPlane.yaml
+
+    # Step 9: Create KongDataPlaneClientCertificate before any KongReferenceGrant exists.
+    - name: 9-create-dpcc-no-grant
+      description: Create KongDataPlaneClientCertificate before any grant exists.
+      bindings:
+        - name: dpcc_name
+          value: ($dpcc_name)
+        - name: dpcc_namespace
+          value: ($namespace)
+        - name: cp_name
+          value: ($cp_name)
+        - name: cp_ref_namespace
+          value: ($cp_namespace)
+      use:
+        template: ../../common/_step_templates/apply-kongDataPlaneClientCertificate-inline.yaml
+
+    # Step 10: Assert negative condition — DataPlaneClientCertificate ResolvedRefs=False.
+    - name: 10-assert-negative-no-grant
+      description: Assert DataPlaneClientCertificate ResolvedRefs=False/RefNotPermitted (no grant yet).
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongDataPlaneClientCertificate
+              metadata:
+                name: ($dpcc_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    # Step 11: Create KongReferenceGrant allowing KongDataPlaneClientCertificate (ns-A) -> KonnectGatewayControlPlane (ns-B).
+    - name: 11-create-reference-grant
+      description: Create KongReferenceGrant in cp_namespace allowing KongDataPlaneClientCertificate from test namespace to reference KonnectGatewayControlPlane.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'dpcc-to-cp']))
+        - name: kong_reference_grant_namespace
+          value: ($cp_namespace)
+        - name: from
+          value:
+            - group: configuration.konghq.com
+              kind: KongDataPlaneClientCertificate
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectGatewayControlPlane
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    # Step 12: Assert DataPlaneClientCertificate becomes Programmed after the grant is in place.
+    - name: 12-assert-dpcc-programmed
+      description: Assert KongDataPlaneClientCertificate is Programmed after the grant is added.
+      timeouts:
+        assert: 90s
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongDataPlaneClientCertificate
+              metadata:
+                name: ($dpcc_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'True'
+                    reason: ResolvedRefs
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+
+    # =========================================================================
+    # Scenario D: delete the DataPlaneClientCertificate->CP grant and verify
+    # the DataPlaneClientCertificate reverts to ResolvedRefs=False/RefNotPermitted
+    # (validates grant watch).
+    # =========================================================================
+
+    - name: 13-delete-dpcc-to-cp-grant
+      description: Delete the DataPlaneClientCertificate->CP grant to verify the DataPlaneClientCertificate reverts to RefNotPermitted.
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'dpcc-to-cp']))
+              namespace: ($cp_namespace)
+
+    - name: 14-assert-dpcc-reverts-to-not-permitted
+      description: Assert DataPlaneClientCertificate transitions back to ResolvedRefs=False/RefNotPermitted after grant deletion.
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongDataPlaneClientCertificate
+              metadata:
+                name: ($dpcc_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    - name: 15-recreate-dpcc-to-cp-grant
+      description: Recreate the DataPlaneClientCertificate->CP grant so the certificate can be deprovisioned cleanly during cleanup.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'dpcc-to-cp']))
+        - name: kong_reference_grant_namespace
+          value: ($cp_namespace)
+        - name: from
+          value:
+            - group: configuration.konghq.com
+              kind: KongDataPlaneClientCertificate
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectGatewayControlPlane
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    # Step 16: Explicitly delete Konnect-registered resources in dependency order before chainsaw
+    # tears down the namespace containing the KonnectAPIAuthConfiguration.
+    # The dpcc-to-cp grant is deleted before the CP wait (safe — does not affect CP auth deprovisioning).
+    - name: 16-cleanup-scenario-b
+      description: |
+        Delete dpcc and CP in order; wait for each to be gone.
+        dpcc-to-cp grant is deleted before the CP wait (safe — does not affect CP auth deprovisioning).
+      timeouts:
+        delete: 120s
+        error: 120s
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongDataPlaneClientCertificate
+              name: ($dpcc_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongDataPlaneClientCertificate
+              metadata:
+                name: ($dpcc_name)
+                namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'dpcc-to-cp']))
+              namespace: ($cp_namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              name: ($cp_name)
+              namespace: ($cp_namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp_name)
+                namespace: ($cp_namespace)
+
+    # =========================================================================
+    # Scenario C: CP in cp_namespace (ns-B), AuthConfig in auth_namespace (ns-C).
+    # Both DataPlaneClientCertificate->CP AND CP->AuthConfig grants are required.
+    # =========================================================================
+
+    # Step 17: Create a separate namespace for KonnectAPIAuthConfiguration (ns-C).
+    - name: 17-create-auth-namespace
+      description: Create separate auth namespace for KonnectAPIAuthConfiguration (different from CP namespace).
+      bindings:
+        - name: namespace_name
+          value: ($auth_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-namespace.yaml
+
+    # Step 18: Create KonnectAPIAuthConfiguration in the auth namespace (ns-C).
+    - name: 18-create-auth-config-cross-ns
+      description: Create KonnectAPIAuthConfiguration in auth_namespace (ns-C, separate from CP namespace).
+      bindings:
+        - name: test_name
+          value: (join('-', [$namespace, 'auth2']))
+        - name: namespace
+          value: ($auth_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    # Step 19: Create CP2 in cp_namespace with cross-namespace authRef to auth_namespace.
+    # Without a CP->AuthConfig grant this CP should not become Programmed.
+    - name: 19-create-cp2-cross-ns-auth
+      description: Create KonnectGatewayControlPlane in cp_namespace with cross-namespace authRef to auth_namespace.
+      try:
+        - apply:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp2_name)
+                namespace: ($cp_namespace)
+              spec:
+                createControlPlaneRequest:
+                  name: ($cp2_name)
+                konnect:
+                  authRef:
+                    name: ($auth2_name)
+                    namespace: ($auth_namespace)
+
+    # Step 20: Assert CP2 has APIAuthResolvedRef=False/RefNotPermitted (no CP->AuthConfig grant).
+    - name: 20-assert-cp2-auth-grant-missing
+      description: Assert CP2 has APIAuthResolvedRef=False/RefNotPermitted because no CP->AuthConfig grant exists.
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp2_name)
+                namespace: ($cp_namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    # Step 21: Create KongDataPlaneClientCertificate2 before CP2 is programmed.
+    - name: 21-create-dpcc2
+      description: Create KongDataPlaneClientCertificate2 referencing cp2.
+      bindings:
+        - name: dpcc_name
+          value: ($dpcc2_name)
+        - name: dpcc_namespace
+          value: ($namespace)
+        - name: cp_name
+          value: ($cp2_name)
+        - name: cp_ref_namespace
+          value: ($cp_namespace)
+      use:
+        template: ../../common/_step_templates/apply-kongDataPlaneClientCertificate-inline.yaml
+
+    # Step 22: Add DataPlaneClientCertificate2->CP2 grant so dpcc2 can reference cp2 across namespaces.
+    - name: 22-create-dpcc2-to-cp2-grant
+      description: Create KongReferenceGrant in cp_namespace allowing dpcc2 from test namespace to reference cp2.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'dpcc2-to-cp2']))
+        - name: kong_reference_grant_namespace
+          value: ($cp_namespace)
+        - name: from
+          value:
+            - group: configuration.konghq.com
+              kind: KongDataPlaneClientCertificate
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectGatewayControlPlane
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    # Step 23: Assert dpcc2 is still not Programmed.
+    # CP2 is not Programmed (CP->AuthConfig grant missing), so dpcc2 is not Programmed.
+    - name: 23-assert-dpcc2-not-programmed
+      description: Assert dpcc2 ControlPlaneRefValid=False/NotProgrammed because CP->AuthConfig grant is still missing.
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongDataPlaneClientCertificate
+              metadata:
+                name: ($dpcc2_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'False'
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'False'
+                    reason: NotProgrammed
+
+    # Step 24: Create CP2->AuthConfig2 grant in auth_namespace.
+    - name: 24-create-cp2-to-auth2-grant
+      description: Create KongReferenceGrant in auth_namespace allowing cp2 from cp_namespace to reference auth2.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'cp2-to-auth2']))
+        - name: kong_reference_grant_namespace
+          value: ($auth_namespace)
+        - name: from
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectGatewayControlPlane
+              namespace: ($cp_namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectAPIAuthConfiguration
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    # Step 25: Assert CP2 and dpcc2 both become Programmed.
+    - name: 25-assert-all-programmed
+      description: Assert CP2 and dpcc2 are both Programmed after both grants are in place.
+      timeouts:
+        assert: 90s
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp2_name)
+                namespace: ($cp_namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongDataPlaneClientCertificate
+              metadata:
+                name: ($dpcc2_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'True'
+                    reason: ResolvedRefs
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+
+    # Step 26: Explicitly delete Konnect-registered resources in dependency order before chainsaw
+    # tears down the namespaces containing the KonnectAPIAuthConfigurations.
+    # dpcc2-to-cp2 is deleted before the CP wait (safe — does not affect CP auth deprovisioning).
+    # cp2-to-auth2 is deleted last, after CP2 is fully deprovisioned.
+    - name: 26-cleanup-scenario-c
+      description: |
+        Delete dpcc2 and CP2 in order; wait for each to be gone.
+        dpcc2-to-cp2 grant is deleted before the CP wait (safe — does not affect CP auth deprovisioning).
+        cp2-to-auth2 is deleted last, after CP2 is fully deprovisioned.
+      timeouts:
+        delete: 120s
+        error: 120s
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongDataPlaneClientCertificate
+              name: ($dpcc2_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongDataPlaneClientCertificate
+              metadata:
+                name: ($dpcc2_name)
+                namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'dpcc2-to-cp2']))
+              namespace: ($cp_namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              name: ($cp2_name)
+              namespace: ($cp_namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp2_name)
+                namespace: ($cp_namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'cp2-to-auth2']))
+              namespace: ($auth_namespace)
+
+  catch:
+    # Capture debug snapshot on test failure for CI debugging.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: kongdataplaneclientcertificate-cross-namespace
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: ADDITIONAL_NAMESPACES
+            value: (join(',', [$cp_namespace, $auth_namespace]))
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh


### PR DESCRIPTION




**What this PR does / why we need it**:
Tests cross-namespace ControlPlaneRef behaviour for KongDataPlaneClientCertificate.

Scenario A: all resources in the same namespace; no grants needed. Baseline sanity check.

Scenario B: KongDataPlaneClientCertificate (test-ns) -> CP+AuthConfig (cp_namespace). A single DataPlaneClientCertificate->CP grant is required. Includes a negative assertion (step 10) before the grant is created.

Scenario C: KongDataPlaneClientCertificate (test-ns) -> CP (cp_namespace) -> AuthConfig (auth_namespace). Both DataPlaneClientCertificate->CP AND CP->AuthConfig grants required. Intermediate assertion (step 23) confirms the certificate is still not Programmed when only the DataPlaneClientCertificate->CP grant is present but CP->AuthConfig is still missing.

Scenario D: starting from Scenario B (Programmed=True), deleting the KongReferenceGrant immediately reverts the DataPlaneClientCertificate to ResolvedRefs=False/RefNotPermitted, validating that the KongReferenceGrant watch is wired correctly. The grant is then recreated to allow clean Konnect deprovisioning.

Replace hardcoded certificate PEM blocks in steps 3, 9 and 21 with the new apply-kongDataPlaneClientCertificate-inline.yaml step template, which generates a fresh self-signed cert via generate_tls_certificate.sh at test run time.

**Which issue this PR fixes**

Fixes #4164 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
