### PR TITLE
test(e2e/chainsaw): add cross-namespace TLS Secret ref test for KongCertificate

### DIFF
--- a/test/e2e/chainsaw/konnect/kongcertificate_secretref_cross-namespace/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/konnect/kongcertificate_secretref_cross-namespace/chainsaw-test.yaml
@@ -1,0 +1,417 @@
+# KongCertificate cross-namespace SecretRef test.
+#
+# The cross-namespace axis under test is the secretRef: the TLS Secret lives in a different
+# namespace from the KongCertificate. The controlPlaneRef is same-namespace throughout
+# (that axis is covered by kongcertificate_cross-namespace).
+#
+# Scenario A: All resources in the same namespace — baseline, no grants needed.
+#   ResolvedRefs condition is absent (same-namespace secretRef removes it).
+#
+# Scenario B: TLS Secret in secret_namespace, KongCertificate+CP+Auth in test namespace.
+#   One secretRef grant (in secret_namespace) is needed to allow the cross-namespace Secret reference.
+#   Includes an intermediate assertion that shows the binding fails when the grant is missing.
+#
+# Scenario D: starting from Scenario B (Programmed=True), deleting the
+#   KongReferenceGrant reverts the KongCertificate to ResolvedRefs=False/RefNotPermitted.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kongcertificate-secretref-cross-namespace
+spec:
+  description: |
+    Tests cross-namespace secretRef behaviour for KongCertificate.
+
+    The cross-namespace axis is spec.secretRef.namespace — a TLS Secret in a different namespace
+    from the KongCertificate. The controlPlaneRef is same-namespace throughout.
+
+    Scenario A: KongCertificate, KonnectGatewayControlPlane, KonnectAPIAuthConfiguration, and
+    TLS Secret all in the same namespace. No grants needed; baseline sanity check.
+
+    Scenario B: TLS Secret in secret_namespace, KongCertificate+CP+Auth all in test namespace.
+    Binding fails until a KongReferenceGrant in secret_namespace permits the cross-namespace
+    Secret reference.
+
+    Scenario D: starting from Scenario B (Programmed=True), deleting the
+    KongReferenceGrant reverts the KongCertificate to
+    ResolvedRefs=False/RefNotPermitted immediately, validating that the
+    KongReferenceGrant watch is wired correctly. The grant is then
+    recreated to allow clean Konnect deprovisioning.
+
+  bindings:
+    # Common bindings.
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    # Namespace bindings.
+    - name: secret_namespace
+      value: (join('-', [$namespace, 'secret']))
+    # Scenario A resource names (all in test namespace).
+    - name: cp0_name
+      value: (join('-', [$namespace, 'cp0']))
+    - name: auth0_name
+      value: (join('-', [$namespace, 'auth0-konnect-api-auth']))
+    - name: cert0_name
+      value: (join('-', [$namespace, 'cert0']))
+    - name: tlssecret0_name
+      value: (join('-', [$namespace, 'tlssecret0']))
+    # Scenario B resource names (TLS Secret in secret_namespace, everything else in test namespace).
+    - name: cp_name
+      value: (join('-', [$namespace, 'cp']))
+    - name: auth_name
+      value: (join('-', [$namespace, 'konnect-api-auth']))
+    - name: cert_name
+      value: (join('-', [$namespace, 'cert']))
+    - name: tlssecret_name
+      value: (join('-', [$namespace, 'tlssecret']))
+
+  steps:
+    # =========================================================================
+    # Scenario A: All resources in the same namespace. No grants needed.
+    # ResolvedRefs condition is absent for same-namespace secretRef.
+    # =========================================================================
+
+    - name: 1-create-auth-config-same-ns
+      description: Create KonnectAPIAuthConfiguration in the test namespace.
+      bindings:
+        - name: test_name
+          value: (join('-', [$namespace, 'auth0']))
+        - name: namespace
+          value: ($namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    - name: 2-create-control-plane-same-ns
+      description: Create KonnectGatewayControlPlane in the test namespace.
+      bindings:
+        - name: cp_name
+          value: ($cp0_name)
+        - name: cp_namespace
+          value: ($namespace)
+        - name: auth_name
+          value: ($auth0_name)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectGatewayControlPlane.yaml
+
+    - name: 3-create-tls-secret-same-ns
+      description: Create TLS Secret in the test namespace (same as KongCertificate).
+      bindings:
+        - name: sni_hostname
+          value: cross-namespace.example.com
+        - name: cert_secret_name
+          value: ($tlssecret0_name)
+        - name: cert_secret_namespace
+          value: ($namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-tlsSecret.yaml
+
+    - name: 4-create-cert-same-ns
+      description: Create KongCertificate in the test namespace with same-namespace secretRef. No grants needed.
+      try:
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCertificate
+              metadata:
+                name: ($cert0_name)
+                namespace: ($namespace)
+              spec:
+                type: secretRef
+                secretRef:
+                  name: ($tlssecret0_name)
+                controlPlaneRef:
+                  type: konnectNamespacedRef
+                  konnectNamespacedRef:
+                    name: ($cp0_name)
+
+    - name: 5-assert-cert-programmed-same-ns
+      description: Assert KongCertificate is Programmed. No ResolvedRefs condition for same-namespace secretRef.
+      timeouts:
+        assert: 90s
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCertificate
+              metadata:
+                name: ($cert0_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+
+    - name: 6-cleanup-scenario-a
+      description: Delete cert0 and CP0 in order; wait for each to be gone before proceeding.
+      timeouts:
+        delete: 120s
+        error: 120s
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCertificate
+              name: ($cert0_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCertificate
+              metadata:
+                name: ($cert0_name)
+                namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              name: ($cp0_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp0_name)
+                namespace: ($namespace)
+
+    # =========================================================================
+    # Scenario B: TLS Secret in secret_namespace, KongCertificate+CP+Auth in test namespace.
+    # A secretRef grant in secret_namespace is needed.
+    # =========================================================================
+
+    - name: 7-create-secret-namespace
+      description: Create separate namespace for the TLS Secret.
+      bindings:
+        - name: namespace_name
+          value: ($secret_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-namespace.yaml
+
+    - name: 8-create-auth-config
+      description: Create KonnectAPIAuthConfiguration in the test namespace for scenario B.
+      bindings:
+        - name: test_name
+          value: ($namespace)
+        - name: namespace
+          value: ($namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    - name: 9-create-control-plane
+      description: Create KonnectGatewayControlPlane in the test namespace for scenario B.
+      bindings:
+        - name: cp_namespace
+          value: ($namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectGatewayControlPlane.yaml
+
+    - name: 10-create-tls-secret-cross-ns
+      description: Create TLS Secret in secret_namespace (different from KongCertificate's namespace).
+      bindings:
+        - name: sni_hostname
+          value: cross-namespace.example.com
+        - name: cert_secret_name
+          value: ($tlssecret_name)
+        - name: cert_secret_namespace
+          value: ($secret_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-tlsSecret.yaml
+
+    - name: 11-create-cert-no-grant
+      description: Create KongCertificate in test namespace referencing TLS Secret in secret_namespace (no grant yet).
+      try:
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCertificate
+              metadata:
+                name: ($cert_name)
+                namespace: ($namespace)
+              spec:
+                type: secretRef
+                secretRef:
+                  name: ($tlssecret_name)
+                  namespace: ($secret_namespace)
+                controlPlaneRef:
+                  type: konnectNamespacedRef
+                  konnectNamespacedRef:
+                    name: ($cp_name)
+
+    - name: 12-assert-cert-grant-missing
+      description: Assert KongCertificate has ResolvedRefs=False/RefNotPermitted because no grant exists.
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCertificate
+              metadata:
+                name: ($cert_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    - name: 13-create-cert-to-secret-grant
+      description: Create KongReferenceGrant in secret_namespace allowing KongCertificate from test namespace to reference Secret.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'cert-to-secret']))
+        - name: kong_reference_grant_namespace
+          value: ($secret_namespace)
+        - name: from
+          value:
+            - group: configuration.konghq.com
+              kind: KongCertificate
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: core
+              kind: Secret
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 14-assert-cert-programmed
+      description: Assert KongCertificate is Programmed after the secretRef grant is in place.
+      timeouts:
+        assert: 90s
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCertificate
+              metadata:
+                name: ($cert_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'True'
+                    reason: ResolvedRefs
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+
+    # =========================================================================
+    # Scenario D: delete the cert->Secret grant and verify the KongCertificate
+    # reverts to ResolvedRefs=False/RefNotPermitted (validates grant watch).
+    # =========================================================================
+
+    - name: 15-delete-cert-to-secret-grant
+      description: Delete the cert->Secret grant to verify the KongCertificate reverts to RefNotPermitted.
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'cert-to-secret']))
+              namespace: ($secret_namespace)
+
+    - name: 16-assert-cert-reverts-to-not-permitted
+      description: Assert KongCertificate transitions back to ResolvedRefs=False/RefNotPermitted after grant deletion.
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCertificate
+              metadata:
+                name: ($cert_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    - name: 17-recreate-cert-to-secret-grant
+      description: Recreate the cert->Secret grant so the certificate can be deprovisioned cleanly during cleanup.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'cert-to-secret']))
+        - name: kong_reference_grant_namespace
+          value: ($secret_namespace)
+        - name: from
+          value:
+            - group: configuration.konghq.com
+              kind: KongCertificate
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: core
+              kind: Secret
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 18-cleanup-scenario-b
+      description: Delete cert and CP in order; wait for each to be gone before proceeding.
+      timeouts:
+        delete: 120s
+        error: 120s
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCertificate
+              name: ($cert_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongCertificate
+              metadata:
+                name: ($cert_name)
+                namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'cert-to-secret']))
+              namespace: ($secret_namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              name: ($cp_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp_name)
+                namespace: ($namespace)
+
+  catch:
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: kongcertificate-secretref-cross-namespace
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: ADDITIONAL_NAMESPACES
+            value: ($secret_namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh


### PR DESCRIPTION




**What this PR does / why we need it**:
Tests cross-namespace spec.secretRef behaviour for KongCertificate. The controlPlaneRef is same-namespace throughout; only the secretRef axis (TLS Secret in a different namespace) is exercised here.

Scenario A: all resources in the same namespace; no grants needed. ResolvedRefs condition is absent for same-namespace secretRef.

Scenario B: TLS Secret in secret_namespace, KongCertificate+CP+Auth in test namespace. Binding fails until a KongReferenceGrant in secret_namespace allows the cross-namespace Secret reference.

Scenario D: starting from Scenario B (Programmed=True), deleting the KongReferenceGrant immediately reverts the KongCertificate to ResolvedRefs=False/RefNotPermitted, validating that the KongReferenceGrant watch is wired correctly. The grant is then recreated to allow clean Konnect deprovisioning.
**Which issue this PR fixes**

Fixes #4176 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
