### PR TITLE
enable conformance TLSRouteHostnameIntersection

### DIFF
--- a/ingress-controller/internal/dataplane/translator/subtranslator/atc_utils.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/atc_utils.go
@@ -62,3 +62,25 @@ func hostMatcherFromHosts(hosts []string) atc.Matcher {
 	}
 	return atc.Or(matchers...)
 }
+
+// sniMatcherFromSNIs generates matchers to match TLS SNIs.
+// used in translating TLSRoute rules and `SNIs` annotations in ingresses.
+// the SNI format includes:
+// - wildcard SNIs, starting with exactly one *
+// - precise SNIs, otherwise.
+func sniMatcherFromSNIs(snis []string) atc.Matcher {
+	matchers := make([]atc.Matcher, 0, len(snis))
+	for _, sni := range snis {
+		if !validHosts.MatchString(sni) {
+			continue
+		}
+		if suffix, ok := strings.CutPrefix(sni, "*"); ok {
+			// wildcard match on SNIs (like *.foo.com), genreate a suffix match.
+			matchers = append(matchers, atc.NewPredicateTLSSNI(atc.OpSuffixMatch, suffix))
+		} else {
+			// exact match on SNIs, generate an exact match.
+			matchers = append(matchers, atc.NewPredicateTLSSNI(atc.OpEqual, sni))
+		}
+	}
+	return atc.Or(matchers...)
+}

--- a/ingress-controller/internal/dataplane/translator/subtranslator/ingress_atc.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/ingress_atc.go
@@ -21,8 +21,6 @@ var (
 	validMethods = regexp.MustCompile(`\A[A-Z]+$`)
 
 	// hostnames are complicated. shamelessly cribbed from https://stackoverflow.com/a/18494710
-	// TODO if the Kong core adds support for wildcard SNI route match criteria, this should change.
-	validSNIs  = regexp.MustCompile(`^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)+(\.([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*))*$`)
 	validHosts = regexp.MustCompile(`^(\*\.)?([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)+(\.([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*))*?(\.\*)?$`)
 )
 
@@ -199,18 +197,6 @@ func methodMatcherFromMethods(methods []string) atc.Matcher {
 			continue
 		}
 		matchers = append(matchers, atc.NewPredicateHTTPMethod(atc.OpEqual, method))
-	}
-	return atc.Or(matchers...)
-}
-
-// sniMatcherFromSNIs generates matchers to match TLS SNIs.
-func sniMatcherFromSNIs(snis []string) atc.Matcher {
-	matchers := make([]atc.Matcher, 0, len(snis))
-	for _, sni := range snis {
-		if !validSNIs.MatchString(sni) {
-			continue
-		}
-		matchers = append(matchers, atc.NewPredicateTLSSNI(atc.OpEqual, sni))
 	}
 	return atc.Or(matchers...)
 }

--- a/ingress-controller/internal/dataplane/translator/subtranslator/ingress_atc_test.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/ingress_atc_test.go
@@ -811,9 +811,9 @@ func TestSNIMatcherFromSNIs(t *testing.T) {
 			expression: `(tls.sni == "docs.konghq.com") || (tls.sni == "apis.konghq.com")`,
 		},
 		{
-			name:       "multiple SNIs with wildcard SNI, which should be omitted",
+			name:       "multiple SNIs with wildcard SNI,",
 			snis:       []string{"foo.com", "*.bar.com"},
-			expression: `tls.sni == "foo.com"`,
+			expression: `(tls.sni == "foo.com") || (tls.sni =^ ".bar.com")`,
 		},
 		{
 			name:       "multiple SNIs with invalid SNI",

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -22,7 +22,6 @@ var skippedTestsShared = []string{
 	tests.GRPCRouteListenerHostnameMatching.ShortName,
 
 	// TLSRoute tests that cannot pass yet.
-	tests.TLSRouteHostnameIntersection.ShortName,
 	tests.TLSRouteListenerMixedTerminationNotSupported.ShortName,
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable core conformance test `TLSRouteHostnameIntersection` for TLSRoute

**Which issue this PR fixes**

Fixes #4276 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
