### PR TITLE
Fix(gateway): Set conflicting listeners' `Accepted` conditions to `False`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,12 @@
   marked `Conflicted=True/ProtocolConflict` (and therefore not accepted), since
   multiplexing multiple TLS listeners on a single port is not yet supported —
   tracked in [#3511](https://github.com/Kong/kong-operator/issues/3511).
+- `Gateway`: listeners whose `Accepted` condition is `False` no longer report a
+  populated `supportedKinds` in their status. This satisfies the Gateway API
+  conformance helper's exact-empty comparison (e.g. used by
+  `TLSRouteListenerMixedTerminationNotSupported`); the Gateway API spec itself
+  does not explicitly define the expected `supportedKinds` value for unaccepted
+  listeners.
 - Add `ResolvedRefs` condition update for `TLSRoute`s and enable `ReferenceGrant`
   to control the cross-namespace reference from `TLSRoute`s to their backendRefs
   in on-prem `TLSRoute` controller.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,10 @@
 
 ### Fixes
 
+- `Gateway`: conflicting listeners (port/protocol or hostname conflict) now have
+  `Accepted=False` with the conflict reason, per Gateway API spec rule that
+  "ALL indistinct Listeners must not be accepted for processing". Previously
+  conflicting listeners stayed `Accepted=True`.
 - Add `ResolvedRefs` condition update for `TLSRoute`s and enable `ReferenceGrant`
   to control the cross-namespace reference from `TLSRoute`s to their backendRefs
   in on-prem `TLSRoute` controller.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,10 @@
   `Accepted=False` with the conflict reason, per Gateway API spec rule that
   "ALL indistinct Listeners must not be accepted for processing". Previously
   conflicting listeners stayed `Accepted=True`.
+  Additionally, TLS listeners that share a port with another listener are now
+  marked `Conflicted=True/ProtocolConflict` (and therefore not accepted), since
+  multiplexing multiple TLS listeners on a single port is not yet supported —
+  tracked in [#3511](https://github.com/Kong/kong-operator/issues/3511).
 - Add `ResolvedRefs` condition update for `TLSRoute`s and enable `ReferenceGrant`
   to control the cross-namespace reference from `TLSRoute`s to their backendRefs
   in on-prem `TLSRoute` controller.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,18 +240,10 @@
 
 - `Gateway`: conflicting listeners (port/protocol or hostname conflict) now have
   `Accepted=False` with the conflict reason, per Gateway API spec rule that
-  "ALL indistinct Listeners must not be accepted for processing". Previously
-  conflicting listeners stayed `Accepted=True`.
+  "ALL indistinct Listeners must not be accepted for processing".
   Additionally, TLS listeners that share a port with another listener are now
-  marked `Conflicted=True/ProtocolConflict` (and therefore not accepted), since
-  multiplexing multiple TLS listeners on a single port is not yet supported —
-  tracked in [#3511](https://github.com/Kong/kong-operator/issues/3511).
-- `Gateway`: listeners whose `Accepted` condition is `False` no longer report a
-  populated `supportedKinds` in their status. This satisfies the Gateway API
-  conformance helper's exact-empty comparison (e.g. used by
-  `TLSRouteListenerMixedTerminationNotSupported`); the Gateway API spec itself
-  does not explicitly define the expected `supportedKinds` value for unaccepted
-  listeners.
+  marked `Conflicted=True/ProtocolConflict` (and therefore not accepted).
+  [#4309](https://github.com/Kong/kong-operator/pull/4309)
 - Add `ResolvedRefs` condition update for `TLSRoute`s and enable `ReferenceGrant`
   to control the cross-namespace reference from `TLSRoute`s to their backendRefs
   in on-prem `TLSRoute` controller.

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -920,7 +920,25 @@ func (g *gatewayConditionsAndListenersAwareT) setResolvedRefsAndSupportedKinds(c
 			return err
 		}
 		lStatus := listenerConditionsAware(&g.Status.Listeners[i])
-		lStatus.SupportedKinds = supportedKinds
+
+		// Only report SupportedKinds for listeners whose Accepted condition is True.
+		//
+		// NOTE: this behavior is required by the Gateway API conformance test helper
+		// `gatewayListenersMatch` (sigs.k8s.io/gateway-api conformance/utils/kubernetes),
+		// which treats an empty expected SupportedKinds as an exact-empty assertion.
+		// Tests like TLSRouteListenerMixedTerminationNotSupported omit SupportedKinds
+		// for listeners they expect to be rejected, so any non-empty value here fails
+		// the test. The Gateway API spec itself does NOT explicitly require
+		// SupportedKinds to be empty when a listener is not accepted; the expected
+		// value for an unaccepted listener is not clearly defined in the spec. We
+		// follow the conformance helper's convention to remain conformant.
+		// setAcceptedAndAttachedRoutes() always runs before this function, so the
+		// Accepted condition is guaranteed to be present.
+		accepted, ok := k8sutils.GetCondition(kcfgconsts.ConditionType(gatewayv1.ListenerConditionAccepted), lStatus)
+		if ok && accepted.Status == metav1.ConditionTrue {
+			lStatus.SupportedKinds = supportedKinds
+		}
+
 		k8sutils.SetCondition(resolvedRefsCondition, lStatus)
 	}
 	return nil

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -1172,6 +1172,14 @@ func (g *gatewayConditionsAndListenersAwareT) setConflicted() {
 				conflictedCondition.Reason = string(gatewayv1.ListenerReasonProtocolConflict)
 				break
 			}
+			// TODO: support multiple TLS listeners sharing the same port (e.g. via SNI).
+			// Tracked in https://github.com/Kong/kong-operator/issues/3511.
+			// Until then, a TLS listener that shares its port with any other listener is conflicted.
+			if l.Port == l2.Port && l.Protocol == gatewayv1.TLSProtocolType {
+				conflictedCondition.Status = metav1.ConditionTrue
+				conflictedCondition.Reason = string(gatewayv1.ListenerReasonProtocolConflict)
+				break
+			}
 			// If two listeners specify the same hostname, they have a hostname conflict, and
 			// the conflicted condition must be updated accordingly.
 			if l.Hostname != nil && l2.Hostname != nil && *l.Hostname == *l2.Hostname {

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -885,7 +885,8 @@ func supportedRoutesByProtocol() map[gatewayv1.ProtocolType]map[gatewayv1.Kind]s
 // It also sets the listeners Programmed condition by setting the underlying
 // Listener Programmed status to false.
 func (g *gatewayConditionsAndListenersAwareT) initProgrammedAndListenersStatus() {
-	if !k8sutils.HasCondition(kcfgconsts.ConditionType(gatewayv1.GatewayConditionProgrammed), g) {
+	programmedCond, ok := k8sutils.GetCondition(kcfgconsts.ConditionType(gatewayv1.GatewayConditionProgrammed), g)
+	if !ok || programmedCond.ObservedGeneration != g.Generation {
 		k8sutils.SetCondition(
 			k8sutils.NewConditionWithGeneration(
 				kcfgconsts.ConditionType(gatewayv1.GatewayConditionProgrammed),

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -955,6 +955,16 @@ func (g *gatewayConditionsAndListenersAwareT) setAcceptedAndAttachedRoutes(ctx c
 			acceptedCondition.Reason = string(gatewayv1.ListenerReasonUnsupportedProtocol)
 		}
 		listenerConditionsAware := listenerConditionsAware(&g.Status.Listeners[i])
+		// Per Gateway API spec, conflicting listeners must not be accepted:
+		// "The implementation MUST NOT pick one conflicting Listener as the winner.
+		// ALL indistinct Listeners must not be accepted for processing."
+		// setConflicted() has already run, so the Conflicted condition is available here.
+		if conflicted, ok := k8sutils.GetCondition(
+			kcfgconsts.ConditionType(gatewayv1.ListenerConditionConflicted), listenerConditionsAware,
+		); ok && conflicted.Status == metav1.ConditionTrue {
+			acceptedCondition.Status = metav1.ConditionFalse
+			acceptedCondition.Reason = conflicted.Reason
+		}
 		listenerConditionsAware.SetConditions(append(listenerConditionsAware.Conditions, acceptedCondition))
 
 		// AttachedRoutes

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -3951,3 +3951,218 @@ func TestGenerateDataPlaneNetworkPolicy(t *testing.T) {
 		})
 	}
 }
+
+// TestSetAcceptedAndAttachedRoutes verifies the per-listener Accepted condition
+// computed by setAcceptedAndAttachedRoutes, including the spec-mandated rule
+// that conflicting listeners must not be accepted (Gateway API v1.5,
+// "Handling indistinct Listeners").
+func TestSetAcceptedAndAttachedRoutes(t *testing.T) {
+	type expectedCond struct {
+		acceptedStatus   metav1.ConditionStatus
+		acceptedReason   gatewayv1.ListenerConditionReason
+		conflictedStatus metav1.ConditionStatus
+		conflictedReason gatewayv1.ListenerConditionReason
+	}
+
+	allowedRoutesFromSame := &gwtypes.AllowedRoutes{
+		Namespaces: &gwtypes.RouteNamespaces{
+			From: new(gwtypes.NamespacesFromSame),
+		},
+	}
+
+	testCases := []struct {
+		name      string
+		listeners []gwtypes.Listener
+		expected  []expectedCond
+	}{
+		{
+			name: "single listener with supported protocol is accepted",
+			listeners: []gwtypes.Listener{
+				{
+					Name:          "http",
+					Protocol:      gatewayv1.HTTPProtocolType,
+					Port:          80,
+					AllowedRoutes: allowedRoutesFromSame,
+				},
+			},
+			expected: []expectedCond{
+				{
+					acceptedStatus:   metav1.ConditionTrue,
+					acceptedReason:   gatewayv1.ListenerReasonAccepted,
+					conflictedStatus: metav1.ConditionFalse,
+					conflictedReason: gatewayv1.ListenerReasonNoConflicts,
+				},
+			},
+		},
+		{
+			name: "single listener with unsupported protocol is not accepted",
+			listeners: []gwtypes.Listener{
+				{
+					Name:          "tcp",
+					Protocol:      gatewayv1.TCPProtocolType,
+					Port:          80,
+					AllowedRoutes: allowedRoutesFromSame,
+				},
+			},
+			expected: []expectedCond{
+				{
+					acceptedStatus:   metav1.ConditionFalse,
+					acceptedReason:   gatewayv1.ListenerReasonUnsupportedProtocol,
+					conflictedStatus: metav1.ConditionFalse,
+					conflictedReason: gatewayv1.ListenerReasonNoConflicts,
+				},
+			},
+		},
+		{
+			name: "two listeners sharing a port with different protocols are conflicted and not accepted",
+			listeners: []gwtypes.Listener{
+				{
+					Name:          "http",
+					Protocol:      gatewayv1.HTTPProtocolType,
+					Port:          80,
+					AllowedRoutes: allowedRoutesFromSame,
+				},
+				{
+					Name:          "https",
+					Protocol:      gatewayv1.HTTPSProtocolType,
+					Port:          80,
+					AllowedRoutes: allowedRoutesFromSame,
+				},
+			},
+			expected: []expectedCond{
+				{
+					acceptedStatus:   metav1.ConditionFalse,
+					acceptedReason:   gatewayv1.ListenerReasonProtocolConflict,
+					conflictedStatus: metav1.ConditionTrue,
+					conflictedReason: gatewayv1.ListenerReasonProtocolConflict,
+				},
+				{
+					acceptedStatus:   metav1.ConditionFalse,
+					acceptedReason:   gatewayv1.ListenerReasonProtocolConflict,
+					conflictedStatus: metav1.ConditionTrue,
+					conflictedReason: gatewayv1.ListenerReasonProtocolConflict,
+				},
+			},
+		},
+		{
+			name: "two listeners sharing a hostname are conflicted and not accepted",
+			listeners: []gwtypes.Listener{
+				{
+					Name:          "http-a",
+					Protocol:      gatewayv1.HTTPProtocolType,
+					Port:          80,
+					Hostname:      new(gatewayv1.Hostname("example.com")),
+					AllowedRoutes: allowedRoutesFromSame,
+				},
+				{
+					Name:          "http-b",
+					Protocol:      gatewayv1.HTTPProtocolType,
+					Port:          81,
+					Hostname:      new(gatewayv1.Hostname("example.com")),
+					AllowedRoutes: allowedRoutesFromSame,
+				},
+			},
+			expected: []expectedCond{
+				{
+					acceptedStatus:   metav1.ConditionFalse,
+					acceptedReason:   gatewayv1.ListenerReasonHostnameConflict,
+					conflictedStatus: metav1.ConditionTrue,
+					conflictedReason: gatewayv1.ListenerReasonHostnameConflict,
+				},
+				{
+					acceptedStatus:   metav1.ConditionFalse,
+					acceptedReason:   gatewayv1.ListenerReasonHostnameConflict,
+					conflictedStatus: metav1.ConditionTrue,
+					conflictedReason: gatewayv1.ListenerReasonHostnameConflict,
+				},
+			},
+		},
+		{
+			name: "two distinct listeners are both accepted and not conflicted",
+			listeners: []gwtypes.Listener{
+				{
+					Name:          "http",
+					Protocol:      gatewayv1.HTTPProtocolType,
+					Port:          80,
+					Hostname:      new(gatewayv1.Hostname("a.example.com")),
+					AllowedRoutes: allowedRoutesFromSame,
+				},
+				{
+					Name:          "https",
+					Protocol:      gatewayv1.HTTPSProtocolType,
+					Port:          443,
+					Hostname:      new(gatewayv1.Hostname("b.example.com")),
+					AllowedRoutes: allowedRoutesFromSame,
+				},
+			},
+			expected: []expectedCond{
+				{
+					acceptedStatus:   metav1.ConditionTrue,
+					acceptedReason:   gatewayv1.ListenerReasonAccepted,
+					conflictedStatus: metav1.ConditionFalse,
+					conflictedReason: gatewayv1.ListenerReasonNoConflicts,
+				},
+				{
+					acceptedStatus:   metav1.ConditionTrue,
+					acceptedReason:   gatewayv1.ListenerReasonAccepted,
+					conflictedStatus: metav1.ConditionFalse,
+					conflictedReason: gatewayv1.ListenerReasonNoConflicts,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := &gwtypes.Gateway{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: gatewayv1.GroupVersion.String(),
+					Kind:       "Gateway",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-gw",
+					Namespace:  "test-namespace",
+					Generation: 1,
+				},
+				Spec: gwtypes.GatewaySpec{
+					Listeners: tc.listeners,
+				},
+			}
+			gwAware := gatewayConditionsAndListenersAware(gw)
+
+			cl := fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Get()).
+				WithObjects(gw).
+				Build()
+
+			// Mirror the reconcile order in controller.go.
+			gwAware.initListenersStatus()
+			gwAware.setConflicted()
+			require.NoError(t, gwAware.setAcceptedAndAttachedRoutes(t.Context(), cl))
+
+			require.Len(t, gw.Status.Listeners, len(tc.expected))
+			for i, want := range tc.expected {
+				ls := listenerConditionsAware(&gw.Status.Listeners[i])
+
+				accepted, ok := k8sutils.GetCondition(
+					kcfgconsts.ConditionType(gatewayv1.ListenerConditionAccepted), ls,
+				)
+				require.True(t, ok, "listener %d: Accepted condition missing", i)
+				assert.Equal(t, want.acceptedStatus, accepted.Status,
+					"listener %d (%s): Accepted status", i, gw.Status.Listeners[i].Name)
+				assert.Equal(t, string(want.acceptedReason), accepted.Reason,
+					"listener %d (%s): Accepted reason", i, gw.Status.Listeners[i].Name)
+
+				conflicted, ok := k8sutils.GetCondition(
+					kcfgconsts.ConditionType(gatewayv1.ListenerConditionConflicted), ls,
+				)
+				require.True(t, ok, "listener %d: Conflicted condition missing", i)
+				assert.Equal(t, want.conflictedStatus, conflicted.Status,
+					"listener %d (%s): Conflicted status", i, gw.Status.Listeners[i].Name)
+				assert.Equal(t, string(want.conflictedReason), conflicted.Reason,
+					"listener %d (%s): Conflicted reason", i, gw.Status.Listeners[i].Name)
+			}
+		})
+	}
+}

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -4045,6 +4045,39 @@ func TestSetAcceptedAndAttachedRoutes(t *testing.T) {
 			},
 		},
 		{
+			name: "two TLS listeners sharing a port are conflicted and not accepted",
+			listeners: []gwtypes.Listener{
+				{
+					Name:          "tls-a",
+					Protocol:      gatewayv1.TLSProtocolType,
+					Port:          443,
+					Hostname:      new(gatewayv1.Hostname("a.example.com")),
+					AllowedRoutes: allowedRoutesFromSame,
+				},
+				{
+					Name:          "tls-b",
+					Protocol:      gatewayv1.TLSProtocolType,
+					Port:          443,
+					Hostname:      new(gatewayv1.Hostname("b.example.com")),
+					AllowedRoutes: allowedRoutesFromSame,
+				},
+			},
+			expected: []expectedCond{
+				{
+					acceptedStatus:   metav1.ConditionFalse,
+					acceptedReason:   gatewayv1.ListenerReasonProtocolConflict,
+					conflictedStatus: metav1.ConditionTrue,
+					conflictedReason: gatewayv1.ListenerReasonProtocolConflict,
+				},
+				{
+					acceptedStatus:   metav1.ConditionFalse,
+					acceptedReason:   gatewayv1.ListenerReasonProtocolConflict,
+					conflictedStatus: metav1.ConditionTrue,
+					conflictedReason: gatewayv1.ListenerReasonProtocolConflict,
+				},
+			},
+		},
+		{
 			name: "two listeners sharing a hostname are conflicted and not accepted",
 			listeners: []gwtypes.Listener{
 				{

--- a/pkg/gatewayapi/supportedfeatures.go
+++ b/pkg/gatewayapi/supportedfeatures.go
@@ -43,7 +43,9 @@ var commonSupportedFeatures = sets.New(
 
 	// TLSRoute extended.
 	features.SupportTLSRouteModeTerminate,
-	features.SupportTLSRouteModeMixed,
+	// TODO: support multiple TLSRoute modes on the same port:
+	// https://github.com/Kong/kong-operator/issues/3511
+	// features.SupportTLSRouteModeMixed,
 )
 
 // GetSupportedFeatures returns the supported features for the given router type.

--- a/pkg/gatewayapi/supportedfeatures.go
+++ b/pkg/gatewayapi/supportedfeatures.go
@@ -43,6 +43,7 @@ var commonSupportedFeatures = sets.New(
 
 	// TLSRoute extended.
 	features.SupportTLSRouteModeTerminate,
+	features.SupportTLSRouteModeMixed,
 )
 
 // GetSupportedFeatures returns the supported features for the given router type.

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -23,7 +23,6 @@ var skippedTestsShared = []string{
 
 	// TLSRoute tests that cannot pass yet.
 	tests.TLSRouteHostnameIntersection.ShortName,
-	tests.TLSRouteListenerMixedTerminationNotSupported.ShortName,
 }
 
 var skippedTestsForExpressionsRouter = []string{}


### PR DESCRIPTION
**What this PR does / why we need it**:

Set the `Accepted` condition to `False` when the listeners are conflicting as specified in gateway API: https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#gatewayspec.

Also enables the conformance 

**Which issue this PR fixes**

Fixes #4362 and also the conformance test #4280

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
