### PR TITLE
chore(ci): group k8s package bumps with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,11 @@
      "gomod",
      "dockerfile"
   ],
+  "postUpdateOptions": [
+    // Run `go mod tidy` after updating Go modules to ensure go.sum is updated and tidy up any indirect dependencies.
+    // https://docs.renovatebot.com/modules/manager/gomod/#post-update-options
+    "gomodTidy"
+  ],
   "dockerfile": {
     "fileMatch": ["^Dockerfile$", "^debug\\.Dockerfile$"]
   },
@@ -135,6 +140,20 @@
     }
   ],
   "packageRules": [
+    {
+      "description": "Group all k8s.io/* module updates into one PR",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["/^k8s\\.io\\/.*/"],
+      "excludePackageNames": [
+        "k8s.io/utils",
+        "k8s.io/kube-openapi"
+      ],
+      "excludePackagePatterns": [
+        "^k8s\\.io/klog/.*$"
+      ],
+      "groupName": "k8s.io modules",
+      "groupSlug": "k8s-io-modules"
+    },
     {
       "description": "Strip kustomize/ version prefix",
       "matchBaseBranches": ["$default"],


### PR DESCRIPTION
**What this PR does / why we need it**:

Group k8s packages with renovate and ensure it runs `go mod tidy` after bumping deps.

There's already a dependabot config for this but this aims to have both tools running to observe which one fill fit teams requirements and workflows better.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
