### PR TITLE
fix: immediately requeue KongPluginBinding on pluginRef grant revocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,13 @@
   because the reconciler returned early before calling
   `patchWithProgrammedStatusConditionBasedOnOtherConditions`.
   [#4318](https://github.com/Kong/kong-operator/pull/4318)
+- `KongPluginBinding`: the `PluginRefValid` status condition is now set promptly
+  when the referenced `KongPlugin` does not exist (same-namespace or cross-namespace)
+  or when a cross-namespace `KongReferenceGrant` is deleted. Previously the binding
+  could take up to the full sync period (~60 s) to reflect these changes because the
+  check lived in the Konnect SDK ops layer. The check is now a pre-ops handler that
+  runs early in the reconcile loop and reacts immediately to watch-triggered enqueues.
+  [#4312](https://github.com/Kong/kong-operator/pull/4312)
 - Add `KongReferenceGrant` watch to `KongVault` and `KongConsumerGroup` reconcilers.
   Previously, creating or deleting a grant would not trigger re-reconciliation of these
   resources until the next full resync cycle. Grant changes now immediately re-queue

--- a/api/konnect/v1alpha1/konnect_conditions.go
+++ b/api/konnect/v1alpha1/konnect_conditions.go
@@ -275,6 +275,25 @@ const (
 )
 
 const (
+	// KongPluginRefValidConditionType is the type of the condition that indicates
+	// whether the KongPlugin reference in KongPluginBinding.spec.pluginRef is valid,
+	// i.e. the KongPlugin exists and the cross-namespace access is permitted by a
+	// KongReferenceGrant (when applicable).
+	KongPluginRefValidConditionType = "PluginRefValid"
+
+	// KongPluginRefReasonValid is the reason used with the PluginRefValid condition type
+	// indicating that the pluginRef is valid (same-namespace, or cross-namespace with a grant).
+	KongPluginRefReasonValid = "Valid"
+	// KongPluginRefReasonRefNotPermitted is the reason used with the PluginRefValid
+	// condition type indicating that a KongReferenceGrant is missing or invalid for a
+	// cross-namespace pluginRef.
+	KongPluginRefReasonRefNotPermitted = "RefNotPermitted"
+	// KongPluginRefReasonInvalid is the reason used with the PluginRefValid condition type
+	// indicating that the referenced KongPlugin does not exist or cannot be fetched.
+	KongPluginRefReasonInvalid = "Invalid"
+)
+
+const (
 	// KongCACertificateRefsValidConditionType is the type of the condition that indicates
 	// whether the KongCACertificate references are valid and point to existing KongCACertificates.
 	KongCACertificateRefsValidConditionType = "KongCACertificateRefsValid"

--- a/controller/konnect/ops/ops_kongpluginbinding.go
+++ b/controller/konnect/ops/ops_kongpluginbinding.go
@@ -12,17 +12,13 @@ import (
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
 	"github.com/samber/lo"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kong/kong-operator/v2/api/common/consts"
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	configurationv1beta1 "github.com/kong/kong-operator/v2/api/configuration/v1beta1"
 	"github.com/kong/kong-operator/v2/controller/konnect/constraints"
-	"github.com/kong/kong-operator/v2/controller/pkg/patch"
-	"github.com/kong/kong-operator/v2/internal/utils/crossnamespace"
 	"github.com/kong/kong-operator/v2/pkg/metadata"
 )
 
@@ -308,55 +304,11 @@ func getReferencedPlugin(
 
 	var (
 		plugin    configurationv1.KongPlugin
-		pluginGVK = metav1.GroupVersionKind{
-			Group: configurationv1.SchemeGroupVersion.Group,
-			Kind:  "KongPlugin",
-		}
 		pluginRef = pluginBinding.Spec.PluginReference
 	)
 	plugin.SetName(pluginRef.Name)
 	if ns := pluginRef.Namespace; ns != "" && ns != pluginBinding.GetNamespace() {
-
-		err := crossnamespace.CheckKongReferenceGrantForResource(
-			ctx,
-			cl,
-			pluginBinding.Namespace,
-			ns,
-			pluginRef.Name,
-			metav1.GroupVersionKind(pluginBinding.GetObjectKind().GroupVersionKind()),
-			pluginGVK,
-		)
-		if err != nil {
-			msg := err.Error()
-			if crossnamespace.IsReferenceNotGranted(err) {
-				msg = fmt.Sprintf("KongReferenceGrants do not allow access to KongPlugin %s/%s", ns, pluginRef.Name)
-			}
-
-			if _, errStatus := patch.StatusWithCondition(
-				ctx, cl, pluginBinding,
-				consts.ConditionType(configurationv1alpha1.KongReferenceGrantConditionTypeResolvedRefs),
-				metav1.ConditionFalse,
-				configurationv1alpha1.KongReferenceGrantReasonRefNotPermitted,
-				msg,
-			); errStatus != nil {
-				return nil, errStatus
-			}
-			return nil, err
-		}
-
-		// Grant allows access.
-		if _, errStatus := patch.StatusWithCondition(
-			ctx, cl, pluginBinding,
-			consts.ConditionType(configurationv1alpha1.KongReferenceGrantConditionTypeResolvedRefs),
-			metav1.ConditionTrue,
-			configurationv1alpha1.KongReferenceGrantReasonResolvedRefs,
-			fmt.Sprintf("KongReferenceGrants allow access to KongPlugin %s/%s", ns, pluginRef.Name),
-		); errStatus != nil {
-			return nil, errStatus
-		}
-
 		plugin.SetNamespace(pluginRef.Namespace)
-
 	} else {
 		plugin.SetNamespace(pluginBinding.GetNamespace())
 	}

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -179,6 +179,16 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		return res, err
 	}
 
+	// For KongPluginBinding, verify the pluginRef early: check plugin existence for all refs,
+	// and additionally check the KongReferenceGrant for cross-namespace refs. Running this
+	// before the Konnect SDK ops layer ensures that grant/plugin changes are reflected
+	// immediately via the watch-triggered enqueue rather than waiting for the sync period.
+	if res, stop, err := handlePluginRef(ctx, r.Client, ent); err != nil || !res.IsZero() {
+		return res, err
+	} else if stop {
+		return patchWithProgrammedStatusConditionBasedOnOtherConditions(ctx, r.Client, ent)
+	}
+
 	// If a type has a KongService ref, handle it.
 	res, err = handleKongServiceRef(ctx, r.Client, ent)
 	if err != nil {

--- a/controller/konnect/reconciler_pluginref.go
+++ b/controller/konnect/reconciler_pluginref.go
@@ -1,0 +1,116 @@
+package konnect
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kong-operator/v2/api/common/consts"
+	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	"github.com/kong/kong-operator/v2/controller/pkg/patch"
+	"github.com/kong/kong-operator/v2/internal/utils/crossnamespace"
+)
+
+// handlePluginRef validates the pluginRef of a KongPluginBinding before Konnect SDK operations.
+// It checks that the referenced KongPlugin exists, and for cross-namespace refs it also verifies
+// that a KongReferenceGrant permits the reference. If ent is not a KongPluginBinding, it returns
+// immediately with no action.
+//
+// Running this check early in the reconcile loop (before Konnect SDK operations) ensures that
+// plugin and grant changes are reflected immediately via the watch-triggered enqueue rather than
+// waiting for the sync period.
+//
+// Returns:
+//   - ctrl.Result: non-zero if a requeue is needed
+//   - bool: true if reconciliation should stop (ref is invalid)
+//   - error: any error encountered
+func handlePluginRef(
+	ctx context.Context,
+	cl client.Client,
+	ent client.Object,
+) (ctrl.Result, bool, error) {
+	pluginBinding, ok := ent.(*configurationv1alpha1.KongPluginBinding)
+	if !ok {
+		return ctrl.Result{}, false, nil
+	}
+
+	pluginRef := pluginBinding.Spec.PluginReference
+	pluginNS := pluginRef.Namespace
+	if pluginNS == "" {
+		pluginNS = pluginBinding.GetNamespace()
+	}
+
+	deleting := !pluginBinding.GetDeletionTimestamp().IsZero()
+
+	// For cross-namespace references, verify a KongReferenceGrant permits access.
+	if pluginNS != pluginBinding.GetNamespace() {
+		err := crossnamespace.CheckKongReferenceGrantForResource(
+			ctx,
+			cl,
+			pluginBinding.GetNamespace(),
+			pluginNS,
+			pluginRef.Name,
+			metav1.GroupVersionKind(pluginBinding.GetObjectKind().GroupVersionKind()),
+			metav1.GroupVersionKind(configurationv1.SchemeGroupVersion.WithKind("KongPlugin")),
+		)
+		if err != nil {
+			if deleting {
+				return ctrl.Result{}, false, nil
+			}
+			if crossnamespace.IsReferenceNotGranted(err) {
+				if res, errStatus := patch.StatusWithCondition(
+					ctx, cl, pluginBinding,
+					consts.ConditionType(konnectv1alpha1.KongPluginRefValidConditionType),
+					metav1.ConditionFalse,
+					consts.ConditionReason(konnectv1alpha1.KongPluginRefReasonRefNotPermitted),
+					fmt.Sprintf("KongReferenceGrants do not allow access to KongPlugin %s/%s", pluginNS, pluginRef.Name),
+				); errStatus != nil || !res.IsZero() {
+					return res, true, errStatus
+				}
+				return ctrl.Result{}, true, nil
+			}
+			return ctrl.Result{}, true, err
+		}
+	}
+
+	// Verify the referenced KongPlugin actually exists.
+	var plugin configurationv1.KongPlugin
+	if err := cl.Get(ctx, client.ObjectKey{Name: pluginRef.Name, Namespace: pluginNS}, &plugin); err != nil {
+		if deleting {
+			return ctrl.Result{}, false, nil
+		}
+		msg := fmt.Sprintf("KongPlugin %s/%s not found", pluginNS, pluginRef.Name)
+		if !apierrors.IsNotFound(err) {
+			msg = fmt.Sprintf("failed to get KongPlugin %s/%s: %s", pluginNS, pluginRef.Name, err)
+		}
+		if res, errStatus := patch.StatusWithCondition(
+			ctx, cl, pluginBinding,
+			consts.ConditionType(konnectv1alpha1.KongPluginRefValidConditionType),
+			metav1.ConditionFalse,
+			consts.ConditionReason(konnectv1alpha1.KongPluginRefReasonInvalid),
+			msg,
+		); errStatus != nil || !res.IsZero() {
+			return res, true, errStatus
+		}
+		return ctrl.Result{}, true, nil
+	}
+
+	// Plugin exists (and grant is valid for cross-namespace refs).
+	if res, errStatus := patch.StatusWithCondition(
+		ctx, cl, pluginBinding,
+		consts.ConditionType(konnectv1alpha1.KongPluginRefValidConditionType),
+		metav1.ConditionTrue,
+		consts.ConditionReason(konnectv1alpha1.KongPluginRefReasonValid),
+		fmt.Sprintf("KongPlugin %s/%s exists and is accessible", pluginNS, pluginRef.Name),
+	); errStatus != nil || !res.IsZero() {
+		return res, true, errStatus
+	}
+
+	return ctrl.Result{}, false, nil
+}

--- a/controller/konnect/reconciler_pluginref_test.go
+++ b/controller/konnect/reconciler_pluginref_test.go
@@ -1,0 +1,612 @@
+package konnect
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/kong/kong-operator/v2/api/common/consts"
+	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+)
+
+func TestHandlePluginRef(t *testing.T) {
+	ctx := context.Background()
+	scheme := scheme.Get()
+
+	testCases := []struct {
+		name string
+		// ent is the object passed to handlePluginRef — may be any client.Object.
+		ent                 client.Object
+		plugins             []configurationv1.KongPlugin
+		grants              []configurationv1alpha1.KongReferenceGrant
+		interceptorFuncs    *interceptor.Funcs
+		expectStop          bool
+		expectError         bool
+		expectConditionType consts.ConditionType
+		expectCondition     metav1.ConditionStatus
+		expectReason        string
+	}{
+		{
+			name: "non-KongPluginBinding object is a no-op",
+			ent: &configurationv1.KongPlugin{
+				ObjectMeta: metav1.ObjectMeta{Name: "plugin", Namespace: "ns"},
+			},
+			expectStop:  false,
+			expectError: false,
+		},
+		{
+			name: "same-namespace pluginRef with existing plugin sets PluginRefValid=True",
+			ent: &configurationv1alpha1.KongPluginBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "pb", Namespace: "ns"},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: configurationv1alpha1.GroupVersion.String(),
+					Kind:       "KongPluginBinding",
+				},
+				Spec: configurationv1alpha1.KongPluginBindingSpec{
+					PluginReference: configurationv1alpha1.PluginRef{
+						Name:      "my-plugin",
+						Namespace: "ns",
+					},
+				},
+			},
+			plugins: []configurationv1.KongPlugin{
+				{ObjectMeta: metav1.ObjectMeta{Name: "my-plugin", Namespace: "ns"}},
+			},
+			expectStop:          false,
+			expectError:         false,
+			expectConditionType: consts.ConditionType(konnectv1alpha1.KongPluginRefValidConditionType),
+			expectCondition:     metav1.ConditionTrue,
+			expectReason:        konnectv1alpha1.KongPluginRefReasonValid,
+		},
+		{
+			name: "same-namespace pluginRef with missing plugin sets PluginRefValid=False",
+			ent: &configurationv1alpha1.KongPluginBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "pb", Namespace: "ns"},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: configurationv1alpha1.GroupVersion.String(),
+					Kind:       "KongPluginBinding",
+				},
+				Spec: configurationv1alpha1.KongPluginBindingSpec{
+					PluginReference: configurationv1alpha1.PluginRef{
+						Name:      "my-plugin",
+						Namespace: "ns",
+					},
+				},
+			},
+			expectStop:          true,
+			expectError:         false,
+			expectConditionType: consts.ConditionType(konnectv1alpha1.KongPluginRefValidConditionType),
+			expectCondition:     metav1.ConditionFalse,
+			expectReason:        konnectv1alpha1.KongPluginRefReasonInvalid,
+		},
+		{
+			name: "same-namespace pluginRef missing plugin during deletion is a no-op",
+			ent: func() client.Object {
+				now := metav1.Now()
+				return &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "pb",
+						Namespace:         "ns",
+						DeletionTimestamp: &now,
+						Finalizers:        []string{KonnectCleanupFinalizer},
+					},
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: configurationv1alpha1.GroupVersion.String(),
+						Kind:       "KongPluginBinding",
+					},
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Name:      "my-plugin",
+							Namespace: "ns",
+						},
+					},
+				}
+			}(),
+			expectStop:  false,
+			expectError: false,
+		},
+		{
+			name: "empty pluginRef namespace with existing plugin sets PluginRefValid=True",
+			ent: &configurationv1alpha1.KongPluginBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "pb", Namespace: "ns"},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: configurationv1alpha1.GroupVersion.String(),
+					Kind:       "KongPluginBinding",
+				},
+				Spec: configurationv1alpha1.KongPluginBindingSpec{
+					PluginReference: configurationv1alpha1.PluginRef{
+						Name:      "my-plugin",
+						Namespace: "",
+					},
+				},
+			},
+			plugins: []configurationv1.KongPlugin{
+				{ObjectMeta: metav1.ObjectMeta{Name: "my-plugin", Namespace: "ns"}},
+			},
+			expectStop:          false,
+			expectError:         false,
+			expectConditionType: consts.ConditionType(konnectv1alpha1.KongPluginRefValidConditionType),
+			expectCondition:     metav1.ConditionTrue,
+			expectReason:        konnectv1alpha1.KongPluginRefReasonValid,
+		},
+		{
+			name: "cross-namespace pluginRef with valid grant sets PluginRefValid=True",
+			ent: &configurationv1alpha1.KongPluginBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "pb", Namespace: "binding-ns"},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: configurationv1alpha1.GroupVersion.String(),
+					Kind:       "KongPluginBinding",
+				},
+				Spec: configurationv1alpha1.KongPluginBindingSpec{
+					PluginReference: configurationv1alpha1.PluginRef{
+						Name:      "my-plugin",
+						Namespace: "plugin-ns",
+					},
+				},
+			},
+			plugins: []configurationv1.KongPlugin{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-plugin", Namespace: "plugin-ns"},
+				},
+			},
+			grants: []configurationv1alpha1.KongReferenceGrant{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "allow-pb-to-plugin",
+						Namespace: "plugin-ns",
+					},
+					Spec: configurationv1alpha1.KongReferenceGrantSpec{
+						From: []configurationv1alpha1.ReferenceGrantFrom{
+							{
+								Group:     "configuration.konghq.com",
+								Kind:      "KongPluginBinding",
+								Namespace: "binding-ns",
+							},
+						},
+						To: []configurationv1alpha1.ReferenceGrantTo{
+							{
+								Group: "configuration.konghq.com",
+								Kind:  "KongPlugin",
+							},
+						},
+					},
+				},
+			},
+			expectStop:          false,
+			expectError:         false,
+			expectConditionType: consts.ConditionType(konnectv1alpha1.KongPluginRefValidConditionType),
+			expectCondition:     metav1.ConditionTrue,
+			expectReason:        konnectv1alpha1.KongPluginRefReasonValid,
+		},
+		{
+			name: "cross-namespace pluginRef without grant sets PluginRefValid=False",
+			ent: &configurationv1alpha1.KongPluginBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "pb", Namespace: "binding-ns"},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: configurationv1alpha1.GroupVersion.String(),
+					Kind:       "KongPluginBinding",
+				},
+				Spec: configurationv1alpha1.KongPluginBindingSpec{
+					PluginReference: configurationv1alpha1.PluginRef{
+						Name:      "my-plugin",
+						Namespace: "plugin-ns",
+					},
+				},
+			},
+			grants:              []configurationv1alpha1.KongReferenceGrant{},
+			expectStop:          true,
+			expectError:         false,
+			expectConditionType: consts.ConditionType(konnectv1alpha1.KongPluginRefValidConditionType),
+			expectCondition:     metav1.ConditionFalse,
+			expectReason:        konnectv1alpha1.KongPluginRefReasonRefNotPermitted,
+		},
+		{
+			name: "cross-namespace pluginRef with grant for wrong namespace sets PluginRefValid=False",
+			ent: &configurationv1alpha1.KongPluginBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "pb", Namespace: "binding-ns"},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: configurationv1alpha1.GroupVersion.String(),
+					Kind:       "KongPluginBinding",
+				},
+				Spec: configurationv1alpha1.KongPluginBindingSpec{
+					PluginReference: configurationv1alpha1.PluginRef{
+						Name:      "my-plugin",
+						Namespace: "plugin-ns",
+					},
+				},
+			},
+			grants: []configurationv1alpha1.KongReferenceGrant{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "allow-pb-to-plugin",
+						Namespace: "plugin-ns",
+					},
+					Spec: configurationv1alpha1.KongReferenceGrantSpec{
+						From: []configurationv1alpha1.ReferenceGrantFrom{
+							{
+								Group:     "configuration.konghq.com",
+								Kind:      "KongPluginBinding",
+								Namespace: "other-ns", // wrong source namespace
+							},
+						},
+						To: []configurationv1alpha1.ReferenceGrantTo{
+							{
+								Group: "configuration.konghq.com",
+								Kind:  "KongPlugin",
+							},
+						},
+					},
+				},
+			},
+			expectStop:          true,
+			expectError:         false,
+			expectConditionType: consts.ConditionType(konnectv1alpha1.KongPluginRefValidConditionType),
+			expectCondition:     metav1.ConditionFalse,
+			expectReason:        konnectv1alpha1.KongPluginRefReasonRefNotPermitted,
+		},
+		{
+			name: "cross-namespace pluginRef with grant for wrong kind sets PluginRefValid=False",
+			ent: &configurationv1alpha1.KongPluginBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "pb", Namespace: "binding-ns"},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: configurationv1alpha1.GroupVersion.String(),
+					Kind:       "KongPluginBinding",
+				},
+				Spec: configurationv1alpha1.KongPluginBindingSpec{
+					PluginReference: configurationv1alpha1.PluginRef{
+						Name:      "my-plugin",
+						Namespace: "plugin-ns",
+					},
+				},
+			},
+			grants: []configurationv1alpha1.KongReferenceGrant{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "allow-pb-to-plugin",
+						Namespace: "plugin-ns",
+					},
+					Spec: configurationv1alpha1.KongReferenceGrantSpec{
+						From: []configurationv1alpha1.ReferenceGrantFrom{
+							{
+								Group:     "configuration.konghq.com",
+								Kind:      "KongService", // wrong from kind
+								Namespace: "binding-ns",
+							},
+						},
+						To: []configurationv1alpha1.ReferenceGrantTo{
+							{
+								Group: "configuration.konghq.com",
+								Kind:  "KongPlugin",
+							},
+						},
+					},
+				},
+			},
+			expectStop:          true,
+			expectError:         false,
+			expectConditionType: consts.ConditionType(konnectv1alpha1.KongPluginRefValidConditionType),
+			expectCondition:     metav1.ConditionFalse,
+			expectReason:        konnectv1alpha1.KongPluginRefReasonRefNotPermitted,
+		},
+		{
+			name: "cross-namespace pluginRef without grant during deletion is a no-op",
+			ent: func() client.Object {
+				now := metav1.Now()
+				return &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "pb",
+						Namespace:         "binding-ns",
+						DeletionTimestamp: &now,
+						Finalizers:        []string{KonnectCleanupFinalizer},
+					},
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: configurationv1alpha1.GroupVersion.String(),
+						Kind:       "KongPluginBinding",
+					},
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Name:      "my-plugin",
+							Namespace: "plugin-ns",
+						},
+					},
+				}
+			}(),
+			grants:      []configurationv1alpha1.KongReferenceGrant{},
+			expectStop:  false,
+			expectError: false,
+		},
+		{
+			name: "cross-namespace pluginRef with valid grant but missing plugin sets PluginRefValid=False",
+			ent: &configurationv1alpha1.KongPluginBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "pb", Namespace: "binding-ns"},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: configurationv1alpha1.GroupVersion.String(),
+					Kind:       "KongPluginBinding",
+				},
+				Spec: configurationv1alpha1.KongPluginBindingSpec{
+					PluginReference: configurationv1alpha1.PluginRef{
+						Name:      "my-plugin",
+						Namespace: "plugin-ns",
+					},
+				},
+			},
+			// plugins intentionally empty — plugin does not exist
+			plugins: []configurationv1.KongPlugin{},
+			grants: []configurationv1alpha1.KongReferenceGrant{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "allow-pb-to-plugin",
+						Namespace: "plugin-ns",
+					},
+					Spec: configurationv1alpha1.KongReferenceGrantSpec{
+						From: []configurationv1alpha1.ReferenceGrantFrom{
+							{
+								Group:     "configuration.konghq.com",
+								Kind:      "KongPluginBinding",
+								Namespace: "binding-ns",
+							},
+						},
+						To: []configurationv1alpha1.ReferenceGrantTo{
+							{
+								Group: "configuration.konghq.com",
+								Kind:  "KongPlugin",
+							},
+						},
+					},
+				},
+			},
+			expectStop:          true,
+			expectError:         false,
+			expectConditionType: consts.ConditionType(konnectv1alpha1.KongPluginRefValidConditionType),
+			expectCondition:     metav1.ConditionFalse,
+			expectReason:        konnectv1alpha1.KongPluginRefReasonInvalid,
+		},
+		{
+			name: "cross-namespace pluginRef missing plugin during deletion is a no-op",
+			ent: func() client.Object {
+				now := metav1.Now()
+				return &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "pb",
+						Namespace:         "binding-ns",
+						DeletionTimestamp: &now,
+						Finalizers:        []string{KonnectCleanupFinalizer},
+					},
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: configurationv1alpha1.GroupVersion.String(),
+						Kind:       "KongPluginBinding",
+					},
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						PluginReference: configurationv1alpha1.PluginRef{
+							Name:      "my-plugin",
+							Namespace: "plugin-ns",
+						},
+					},
+				}
+			}(),
+			plugins: []configurationv1.KongPlugin{},
+			grants: []configurationv1alpha1.KongReferenceGrant{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "allow-pb-to-plugin",
+						Namespace: "plugin-ns",
+					},
+					Spec: configurationv1alpha1.KongReferenceGrantSpec{
+						From: []configurationv1alpha1.ReferenceGrantFrom{
+							{
+								Group:     "configuration.konghq.com",
+								Kind:      "KongPluginBinding",
+								Namespace: "binding-ns",
+							},
+						},
+						To: []configurationv1alpha1.ReferenceGrantTo{
+							{
+								Group: "configuration.konghq.com",
+								Kind:  "KongPlugin",
+							},
+						},
+					},
+				},
+			},
+			expectStop:  false,
+			expectError: false,
+		},
+		{
+			// covers: return ctrl.Result{}, true, err (non-ReferenceNotGranted grant check error)
+			name: "cross-namespace grant check returns unexpected error stops reconciliation",
+			ent: &configurationv1alpha1.KongPluginBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "pb", Namespace: "binding-ns"},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: configurationv1alpha1.GroupVersion.String(),
+					Kind:       "KongPluginBinding",
+				},
+				Spec: configurationv1alpha1.KongPluginBindingSpec{
+					PluginReference: configurationv1alpha1.PluginRef{
+						Name:      "my-plugin",
+						Namespace: "plugin-ns",
+					},
+				},
+			},
+			interceptorFuncs: &interceptor.Funcs{
+				List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					if _, ok := list.(*configurationv1alpha1.KongReferenceGrantList); ok {
+						return fmt.Errorf("unexpected list error")
+					}
+					return c.List(ctx, list, opts...)
+				},
+			},
+			expectStop:  true,
+			expectError: true,
+		},
+		{
+			// covers: StatusWithCondition error path for RefNotPermitted
+			name: "cross-namespace RefNotPermitted patch error stops reconciliation with error",
+			ent: &configurationv1alpha1.KongPluginBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "pb", Namespace: "binding-ns"},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: configurationv1alpha1.GroupVersion.String(),
+					Kind:       "KongPluginBinding",
+				},
+				Spec: configurationv1alpha1.KongPluginBindingSpec{
+					PluginReference: configurationv1alpha1.PluginRef{
+						Name:      "my-plugin",
+						Namespace: "plugin-ns",
+					},
+				},
+			},
+			grants: []configurationv1alpha1.KongReferenceGrant{}, // no grant → RefNotPermitted
+			interceptorFuncs: &interceptor.Funcs{
+				SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, p client.Patch, opts ...client.SubResourcePatchOption) error {
+					return fmt.Errorf("status patch failed")
+				},
+			},
+			expectStop:  true,
+			expectError: true,
+		},
+		{
+			// covers: !apierrors.IsNotFound(err) branch when cl.Get returns a generic error
+			name: "cl.Get returns non-NotFound error sets PluginRefValid=False/Invalid",
+			ent: &configurationv1alpha1.KongPluginBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "pb", Namespace: "ns"},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: configurationv1alpha1.GroupVersion.String(),
+					Kind:       "KongPluginBinding",
+				},
+				Spec: configurationv1alpha1.KongPluginBindingSpec{
+					PluginReference: configurationv1alpha1.PluginRef{
+						Name:      "my-plugin",
+						Namespace: "ns",
+					},
+				},
+			},
+			interceptorFuncs: &interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*configurationv1.KongPlugin); ok {
+						return fmt.Errorf("internal server error")
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+			expectStop:          true,
+			expectError:         false,
+			expectConditionType: consts.ConditionType(konnectv1alpha1.KongPluginRefValidConditionType),
+			expectCondition:     metav1.ConditionFalse,
+			expectReason:        konnectv1alpha1.KongPluginRefReasonInvalid,
+		},
+		{
+			// covers: StatusWithCondition error path for Invalid (plugin not found)
+			name: "plugin not found patch error stops reconciliation with error",
+			ent: &configurationv1alpha1.KongPluginBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "pb", Namespace: "ns"},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: configurationv1alpha1.GroupVersion.String(),
+					Kind:       "KongPluginBinding",
+				},
+				Spec: configurationv1alpha1.KongPluginBindingSpec{
+					PluginReference: configurationv1alpha1.PluginRef{
+						Name:      "my-plugin",
+						Namespace: "ns",
+					},
+				},
+			},
+			// no plugins → not found → patch attempted → patch fails
+			interceptorFuncs: &interceptor.Funcs{
+				SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, p client.Patch, opts ...client.SubResourcePatchOption) error {
+					return fmt.Errorf("status patch failed")
+				},
+			},
+			expectStop:  true,
+			expectError: true,
+		},
+		{
+			// covers: StatusWithCondition error path for Valid (plugin exists)
+			name: "plugin exists patch error stops reconciliation with error",
+			ent: &configurationv1alpha1.KongPluginBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "pb", Namespace: "ns"},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: configurationv1alpha1.GroupVersion.String(),
+					Kind:       "KongPluginBinding",
+				},
+				Spec: configurationv1alpha1.KongPluginBindingSpec{
+					PluginReference: configurationv1alpha1.PluginRef{
+						Name:      "my-plugin",
+						Namespace: "ns",
+					},
+				},
+			},
+			plugins: []configurationv1.KongPlugin{
+				{ObjectMeta: metav1.ObjectMeta{Name: "my-plugin", Namespace: "ns"}},
+			},
+			interceptorFuncs: &interceptor.Funcs{
+				SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, p client.Patch, opts ...client.SubResourcePatchOption) error {
+					return fmt.Errorf("status patch failed")
+				},
+			},
+			expectStop:  true,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			objs := []client.Object{tc.ent}
+			for i := range tc.plugins {
+				objs = append(objs, &tc.plugins[i])
+			}
+			for i := range tc.grants {
+				objs = append(objs, &tc.grants[i])
+			}
+
+			builder := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objs...).
+				WithStatusSubresource(tc.ent)
+			if tc.interceptorFuncs != nil {
+				builder = builder.WithInterceptorFuncs(*tc.interceptorFuncs)
+			}
+			cl := builder.Build()
+
+			res, stop, err := handlePluginRef(ctx, cl, tc.ent)
+
+			assert.Equal(t, tc.expectStop, stop, "unexpected stop value")
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tc.expectConditionType != "" {
+				pb, ok := tc.ent.(*configurationv1alpha1.KongPluginBinding)
+				require.True(t, ok, "expected ent to be KongPluginBinding when checking condition")
+
+				updated := &configurationv1alpha1.KongPluginBinding{}
+				require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(pb), updated))
+
+				var found bool
+				for _, cond := range updated.Status.Conditions {
+					if cond.Type == string(tc.expectConditionType) {
+						found = true
+						assert.Equal(t, tc.expectCondition, cond.Status, "unexpected condition status")
+						assert.Equal(t, tc.expectReason, cond.Reason, "unexpected condition reason")
+						break
+					}
+				}
+				assert.True(t, found, "expected condition type %q not found in status", tc.expectConditionType)
+			}
+
+			if !tc.expectError && tc.expectStop {
+				assert.True(t, res.IsZero(), "expected zero result when stopping without error")
+			}
+		})
+	}
+}

--- a/test/envtest/kongpluginbinding_adoption_test.go
+++ b/test/envtest/kongpluginbinding_adoption_test.go
@@ -166,22 +166,7 @@ func TestKongPluginBindingAdoption(t *testing.T) {
 	})
 
 	t.Run("Adopting without KongPlugin reference should fail", func(t *testing.T) {
-		pluginID := uuid.NewString()
 		w := setupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, cl, client.InNamespace(ns.Name))
-
-		t.Log("Setting up SDK expectations for getting plugins")
-		sdk.PluginSDK.EXPECT().GetPlugin(
-			mock.Anything,
-			sdkkonnectops.GetPluginRequest{
-				PluginID:       pluginID,
-				ControlPlaneID: cp.GetKonnectID(),
-			}).Return(
-			&sdkkonnectops.GetPluginResponse{
-				Plugin: &sdkkonnectcomp.Plugin{
-					ID:   new(pluginID),
-					Name: "proxy-cache",
-				},
-			}, nil)
 
 		t.Log("Creating a KongPluginBinding without the KongPlugin to adopt the plugin")
 		kpbGlobal := deploy.KongPluginBinding(t, ctx, clientNamespaced, konnect.NewKongPluginBindingBuilder().
@@ -189,18 +174,18 @@ func TestKongPluginBindingAdoption(t *testing.T) {
 			WithPluginRefName("non-exist-plugin").
 			WithScope(configurationv1alpha1.KongPluginBindingScopeGlobalInControlPlane).
 			Build(),
-			deploy.WithKonnectAdoptOptions[*configurationv1alpha1.KongPluginBinding](commonv1alpha1.AdoptModeOverride, pluginID),
+			deploy.WithKonnectAdoptOptions[*configurationv1alpha1.KongPluginBinding](commonv1alpha1.AdoptModeOverride, uuid.NewString()),
 		)
 
-		t.Logf("Waiting for the KongPluginBinding %s/%s to be marked as not programmed and not adopted", ns.Name, kpbGlobal.Name)
+		t.Logf("Waiting for the KongPluginBinding %s/%s to be marked as not programmed with PluginRefValid=False", ns.Name, kpbGlobal.Name)
 		watchFor(t, ctx, w,
 			apiwatch.Modified,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				return kpb.Name == kpbGlobal.Name &&
 					conditionsContainProgrammedFalse(kpb.GetConditions()) &&
-					k8sutils.HasConditionFalse(konnectv1alpha1.KonnectEntityAdoptedConditionType, kpb)
+					k8sutils.HasConditionFalse(konnectv1alpha1.KongPluginRefValidConditionType, kpb)
 			},
-			"Did not see KongPluginBinding marked as not programmed and not adopted in its conditions.",
+			"Did not see KongPluginBinding marked as not programmed with PluginRefValid=False in its conditions.",
 		)
 	})
 }

--- a/test/envtest/kongpluginbinding_unmanaged_test.go
+++ b/test/envtest/kongpluginbinding_unmanaged_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
 	"github.com/kong/kong-operator/v2/controller/konnect"
 	"github.com/kong/kong-operator/v2/modules/manager/logging"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
@@ -580,14 +581,14 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			"KongPlugin wasn't created using Konnect API or its KonnectID wasn't set",
 		)
 
-		t.Log("Waiting for KongPluginBinding to get ResolvedRefs condition with status=True")
+		t.Log("Waiting for KongPluginBinding to get PluginRefValid condition with status=True")
 		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongPluginBinding) bool {
 			if k.GetName() != kpb.GetName() || k.GetNamespace() != kpb.GetNamespace() {
 				return false
 			}
 
-			return k8sutils.HasConditionTrue(configurationv1alpha1.KongReferenceGrantConditionTypeResolvedRefs, k)
-		}, "KongPluginBinding didn't get ResolvedRefs status condition set to True")
+			return k8sutils.HasConditionTrue(konnectv1alpha1.KongPluginRefValidConditionType, k)
+		}, "KongPluginBinding didn't get PluginRefValid status condition set to True")
 
 		deleteCall := sdk.PluginSDK.EXPECT().
 			DeletePlugin(mock.Anything, cp.GetKonnectStatus().GetKonnectID(), pluginID).
@@ -647,14 +648,14 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			client.ObjectKeyFromObject(kpb),
 		)
 
-		t.Log("Waiting for KongPluginBinding to get ResolvedRefs condition with status=False")
+		t.Log("Waiting for KongPluginBinding to get PluginRefValid condition with status=False")
 		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongPluginBinding) bool {
 			if k.GetName() != kpb.GetName() || k.GetNamespace() != kpb.GetNamespace() {
 				return false
 			}
 
-			return k8sutils.HasConditionFalse(configurationv1alpha1.KongReferenceGrantConditionTypeResolvedRefs, k)
-		}, "KongPluginBinding didn't get ResolvedRefs status condition set to False")
+			return k8sutils.HasConditionFalse(konnectv1alpha1.KongPluginRefValidConditionType, k)
+		}, "KongPluginBinding didn't get PluginRefValid status condition set to False")
 
 		t.Logf("delete the unmanaged KongPluginBinding %s, then check it gets collected",
 			client.ObjectKeyFromObject(kpb),
@@ -670,6 +671,120 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			"delete the KongService %s and check it gets collected, as there should be no finalizer blocking its deletion",
 			client.ObjectKeyFromObject(kongService),
 		)
+		require.NoError(t, clientNamespaced.Delete(ctx, kongService))
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, apierrors.IsNotFound(
+				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongService), kongService),
+			))
+		}, waitTime, tickTime)
+
+		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
+	})
+
+	t.Run("binding to KongService with same-namespace KongPlugin not found gets PluginRefValid=False/Invalid", func(t *testing.T) {
+		w := setupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, cl, client.InNamespace(ns.Name))
+
+		serviceID := uuid.NewString()
+
+		kongService := deploy.KongService(t, ctx, clientNamespaced,
+			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
+		)
+		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
+
+		// Create a binding that references a KongPlugin that does not exist.
+		kpb := deploy.KongPluginBinding(t, ctx, clientNamespaced,
+			konnect.NewKongPluginBindingBuilder().
+				WithControlPlaneRefKonnectNamespaced(cp.Name).
+				WithPluginRefName("does-not-exist").
+				WithServiceTarget(kongService.Name).
+				Build(),
+		)
+		t.Logf(
+			"wait for the controller to set PluginRefValid=False/Invalid on %s (plugin does not exist)",
+			client.ObjectKeyFromObject(kpb),
+		)
+
+		t.Log("Waiting for KongPluginBinding to get PluginRefValid=False/Invalid condition")
+		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongPluginBinding) bool {
+			if k.GetName() != kpb.GetName() || k.GetNamespace() != kpb.GetNamespace() {
+				return false
+			}
+			cond, ok := k8sutils.GetCondition(konnectv1alpha1.KongPluginRefValidConditionType, k)
+			return ok && cond.Status == "False" && cond.Reason == konnectv1alpha1.KongPluginRefReasonInvalid
+		}, "KongPluginBinding didn't get PluginRefValid=False/Invalid condition")
+
+		require.NoError(t, clientNamespaced.Delete(ctx, kpb))
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, apierrors.IsNotFound(
+				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
+			))
+		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
+
+		require.NoError(t, clientNamespaced.Delete(ctx, kongService))
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, apierrors.IsNotFound(
+				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongService), kongService),
+			))
+		}, waitTime, tickTime)
+
+		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
+	})
+
+	t.Run("binding to KongService with cross-namespace KongPlugin not found (grant present) gets PluginRefValid=False/Invalid", func(t *testing.T) {
+		w := setupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, cl, client.InNamespace(ns.Name))
+
+		serviceID := uuid.NewString()
+
+		// Grant is present but no KongPlugin exists in ns2 with this name.
+		krg := deploy.KongReferenceGrant(t, ctx, clientNamespaced2,
+			deploy.KongReferenceGrantFroms(configurationv1alpha1.ReferenceGrantFrom{
+				Group:     configurationv1alpha1.Group(configurationv1alpha1.GroupVersion.Group),
+				Kind:      "KongPluginBinding",
+				Namespace: configurationv1alpha1.Namespace(ns.Name),
+			}),
+			deploy.KongReferenceGrantTos(configurationv1alpha1.ReferenceGrantTo{
+				Group: configurationv1alpha1.Group(configurationv1alpha1.GroupVersion.Group),
+				Kind:  "KongPlugin",
+			}),
+		)
+		t.Cleanup(func() {
+			require.NoError(t, clientNamespaced2.Delete(ctx, krg))
+		})
+
+		kongService := deploy.KongService(t, ctx, clientNamespaced,
+			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
+		)
+		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
+
+		kpb := deploy.KongPluginBinding(t, ctx, clientNamespaced,
+			konnect.NewKongPluginBindingBuilder().
+				WithControlPlaneRefKonnectNamespaced(cp.Name).
+				WithPluginRefName("does-not-exist").
+				WithPluginRefNamespace(ns2.Name).
+				WithServiceTarget(kongService.Name).
+				Build(),
+		)
+		t.Logf(
+			"wait for the controller to set PluginRefValid=False/Invalid on %s (grant present, plugin absent)",
+			client.ObjectKeyFromObject(kpb),
+		)
+
+		t.Log("Waiting for KongPluginBinding to get PluginRefValid=False/Invalid condition")
+		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongPluginBinding) bool {
+			if k.GetName() != kpb.GetName() || k.GetNamespace() != kpb.GetNamespace() {
+				return false
+			}
+			cond, ok := k8sutils.GetCondition(konnectv1alpha1.KongPluginRefValidConditionType, k)
+			return ok && cond.Status == "False" && cond.Reason == konnectv1alpha1.KongPluginRefReasonInvalid
+		}, "KongPluginBinding didn't get PluginRefValid=False/Invalid condition")
+
+		require.NoError(t, clientNamespaced.Delete(ctx, kpb))
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, apierrors.IsNotFound(
+				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
+			))
+		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
+
 		require.NoError(t, clientNamespaced.Delete(ctx, kongService))
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.True(c, apierrors.IsNotFound(


### PR DESCRIPTION


**What this PR does / why we need it**:

The cross-namespace grant check for KongPluginBinding.spec.pluginRef was performed inside getReferencedPlugin() in the Konnect SDK ops layer. When a KongReferenceGrant was deleted, the KongReferenceGrant watch fired and triggered reconciliation, but the reconcile reached the Konnect API stage before failing, causing the next forced re-check to be deferred by the full SyncPeriod (~1 min) instead of being immediate.

Fix: add a handlePluginRef() pre-ops handler  that runs early in the generic reconcile loop. It performs the grant check for cross-namespace pluginRef and stops reconciliation immediately with PluginRefValid=False/RefNotPermitted when the grant is missing. The duplicate grant check is removed from getReferencedPlugin().

A new PluginRefValid condition type is introduced
(KongPluginRefValidConditionType, KongPluginRefReasonValid, KongPluginRefReasonRefNotPermitted, KongPluginRefReasonInvalid) to give the pluginRef validity its own observable status condition, consistent with KeySetRefValid, SecretRefValid and similar ref conditions.

**Which issue this PR fixes**

Fixes #4310 

**Special notes for your reviewer**:

E2E tests in #4313 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
