### PR TITLE
fix: recreate KonnectGatewayControlPlane when externally deleted

### DIFF
--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -614,9 +614,21 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		if errURL, ok := errors.AsType[*url.Error](err); ok {
 			return r.handleOpsErr(ctx, ent, errURL)
 		}
-		return ctrl.Result{}, err
+		if errMatchingIDNotFound, ok := errors.AsType[ops.EntityWithMatchingIDNotFoundError](err); ok {
+			// If the error is that the entity with the matching ID was not found,
+			// in Konnect, it means that it was deleted from Konnect.
+			// We continue with the reconciliation which will recreate the entity on Konnect
+			// and update the status with the new Konnect ID.
+			logger.Info(
+				"Konnect entity with matching ID not found on Konnect, it might have been deleted. Continuing reconciliation to recreate it.",
+				"konnect_id", errMatchingIDNotFound.ID,
+			)
+			ent.SetKonnectID("")
+		} else {
+			return ctrl.Result{}, err
+		}
 	} else if !res.IsZero() || stop {
-		return res, err
+		return res, nil
 	}
 
 	// TODO: relying on status ID is OK but we need to rethink this because


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, when `KonnectGatewayControlPlane` is deleted, code will fail to list CPs in Konnect with a matching Konnect ID tag in `GetControlPlaneByID` in https://github.com/Kong/kong-operator/blob/5dce811c807ddb7a7da11ea65ee4e028ee2f094d/controller/konnect/reconciler_generic_type_specific.go#L71.

This PR fixes it by taking into account the returned error and allowing the passthrough behavior to recreate the CP in Konnect.

This prevents an endless request response loop where listing perpetually returns 404.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
