### PR TITLE
chore(ci): fix samples testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -865,7 +865,9 @@ test.samples: kustomize
 	@$(KUSTOMIZE) build config/crd | kubectl apply --server-side --force-conflicts --field-manager=kong-operator-tests -f -
 	@kubectl apply --server-side --force-conflicts --field-manager=kong-operator-tests -f charts/kong-operator/charts/gwapi-standard-crds/crds/gwapi-crds.yaml || true
 	@kubectl get crd -ojsonpath='{.items[*].metadata.name}' | xargs -n1 kubectl wait --for condition=established crd
-	@cd config/samples/ && find . -maxdepth 1 -name "*.yaml" -exec bash -c "echo; echo {}; kubectl apply -f {} && kubectl delete -f {}" \;
+	@find config/samples/ -maxdepth 1 -name "*.yaml" -print0 | while IFS= read -r -d '' file; do \
+		echo && echo $$file && kubectl apply -f $$file && kubectl delete -f $$file; \
+	done
 
 .PHONY: test.charts.golden
 test.charts.golden:

--- a/config/samples/konnect_eventgateway_virtualcluster.yaml
+++ b/config/samples/konnect_eventgateway_virtualcluster.yaml
@@ -14,6 +14,43 @@ spec:
     authRef:
       name: konnect-api-auth
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-backend-cluster-tls
+  namespace: default
+  labels:
+    konghq.com/secret: "true"
+type: kubernetes.io/tls
+stringData:
+  tls.key: |
+    -----BEGIN PRIVATE KEY-----
+    MIIBVAIBADANBgkqhkiG9w0BAQEFAASCAT4wggE6AgEAAkEAyiUO3sxXqhW+8aZp
+    pqczR9pyejKz3cMnrN3ujHJMf/ou1PyLk4bFtpxy4G8XERhntUUYNg1rhcmilSo7
+    +DAtcwIDAQABAkEAoi7LWHwwVZku4qi2mWwKm7qrIFmvr9wU6AADlZFayU2dpgnj
+    ymm/oHIo5aAvTfoMt0wZmqgXEkyoTRg/GvkXmQIhAPbkZkq50hqkoOJjETM+OLnJ
+    Sx8vvVSkcS1Yx2fNAlVHAiEA0ZoSn+KzT0e0aDFVCzwiAwKO67SEAqJnkoCyIPxR
+    LHUCIHBagDKBXZvCT3S2oJ0xM59Ye1c14nMiYl7Ah/40zVsBAiBVQ7v31pziz2SQ
+    TiEuZNPhLZU+RTy+ZZqEel38FShgUQIgOoMMEmMFT3k9uNXsOVHwJ9ZPyie4XPlW
+    NWzBf8ZCi+A=
+    -----END PRIVATE KEY-----
+  tls.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIICZTCCAg+gAwIBAgIUVjjwPhhV6XmuWKabaWpfKtwrS3kwDQYJKoZIhvcNAQEL
+    BQAwgYYxCzAJBgNVBAYTAlhYMRIwEAYDVQQIDAlTdGF0ZU5hbWUxETAPBgNVBAcM
+    CENpdHlOYW1lMRQwEgYDVQQKDAtDb21wYW55TmFtZTEbMBkGA1UECwwSQ29tcGFu
+    eVNlY3Rpb25OYW1lMR0wGwYDVQQDDBRDb21tb25OYW1lT3JIb3N0bmFtZTAeFw0y
+    NjA1MTQxMjMxMDNaFw0zNjA1MTExMjMxMDNaMIGGMQswCQYDVQQGEwJYWDESMBAG
+    A1UECAwJU3RhdGVOYW1lMREwDwYDVQQHDAhDaXR5TmFtZTEUMBIGA1UECgwLQ29t
+    cGFueU5hbWUxGzAZBgNVBAsMEkNvbXBhbnlTZWN0aW9uTmFtZTEdMBsGA1UEAwwU
+    Q29tbW9uTmFtZU9ySG9zdG5hbWUwXDANBgkqhkiG9w0BAQEFAANLADBIAkEAyiUO
+    3sxXqhW+8aZppqczR9pyejKz3cMnrN3ujHJMf/ou1PyLk4bFtpxy4G8XERhntUUY
+    Ng1rhcmilSo7+DAtcwIDAQABo1MwUTAdBgNVHQ4EFgQUBHpMVvFVJXmx9pZ2YnmU
+    Fn7MngswHwYDVR0jBBgwFoAUBHpMVvFVJXmx9pZ2YnmUFn7MngswDwYDVR0TAQH/
+    BAUwAwEB/zANBgkqhkiG9w0BAQsFAANBAMKT/Lb/3EqMOq/mMrr43arFL38stNku
+    toJJgydd1s7dp3bh2iVqSI3DECc8iyRX8/oExNitF2vNQpULUXj+q4U=
+    -----END CERTIFICATE-----
+---
 kind: EventGatewayBackendCluster
 apiVersion: konnect.konghq.com/v1alpha1
 metadata:
@@ -63,46 +100,24 @@ spec:
         i9cMhVYP4Xeq7z1NGiu/VB36Pbr4hHDY/t9YAj0DtrYRW5sa
         -----END CERTIFICATE-----
       clientIdentity:
-        # TODO: this needs to be a secret reference or a literal with certificate data.
-        # https://github.com/Kong/kong-operator/issues/4063
-        certificate: |
-          -----BEGIN CERTIFICATE-----
-          MIICxTCCAi6gAwIBAgIUaadvyb4GxCPmdtZeW0WcHnxZjbQwDQYJKoZIhvcNAQEL
-          BQAwajELMAkGA1UEBhMCWFgxEjAQBgNVBAgMCVN0YXRlTmFtZTERMA8GA1UEBwwI
-          Q2l0eU5hbWUxFDASBgNVBAoMC0NvbXBhbnlOYW1lMQswCQYDVQQLDAJDQTERMA8G
-          A1UEAwwITXlSb290Q0EwHhcNMjYwNDI5MTI0MDM4WhcNMjcwNDI5MTI0MDM4WjBg
-          MQswCQYDVQQGEwJYWDESMBAGA1UECAwJU3RhdGVOYW1lMREwDwYDVQQHDAhDaXR5
-          TmFtZTEUMBIGA1UECgwLQ29tcGFueU5hbWUxFDASBgNVBAMMC2V4YW1wbGUuY29t
-          MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCeTLe9Gqutr0gDfrE815NcBQJ4
-          qapE8vPPzjyX57ubB9U4kroCcY5qiFleS3YE9NzqB7KWdbK0a8/EVmMI4Ie0npbE
-          ttZBdBFdWITnFaYcK4TWmKLZmtTdVK1d1acwTm+RFG481AfRdSx4QN4FrgYLQ+8X
-          PDiXLH5zjLo7rnk/mwIDAQABo3IwcDAJBgNVHRMEAjAAMAsGA1UdDwQEAwIFoDAW
-          BgNVHREEDzANggtleGFtcGxlLmNvbTAdBgNVHQ4EFgQUrei4PTJFjCU5YCXIDMQe
-          v1ewTiowHwYDVR0jBBgwFoAUDLxc2ZS2Nvr6Xf51Dy1mX2VS4i8wDQYJKoZIhvcN
-          AQELBQADgYEACT3VPjnOohGpiLsNTxkiLfKmTl+RAzanZnr7g8d58H1yAYEet36E
-          FM7H5u3//BzA2BIiV2U5PvMNWwksWFMS1FegD5udBiYhreGZdPmcxlFj7jk087mQ
-          Mk+tdcQgo3LS74wO9G/upL+7UM414fCp8JqQ6IkG7wq920MmlfPNW4A=
-          -----END CERTIFICATE-----
-        # TODO: this needs to be a secret reference or a literal with certificate data.
-        # https://github.com/Kong/kong-operator/issues/4063
-        key: |
-          LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUNlQUlCQURBTkJna3Foa2lHOXcwQkFRRUZB
-          QVNDQW1Jd2dnSmVBZ0VBQW9HQkFKNU10NzBhcTYydlNBTisKc1R6WGsxd0ZBbmlwcWtUeTg4L09Q
-          SmZudTVzSDFUaVN1Z0p4am1xSVdWNUxkZ1QwM09vSHNwWjFzclJyejhSVwpZd2pnaDdTZWxzUzIx
-          a0YwRVYxWWhPY1ZwaHdyaE5hWW90bWExTjFVclYzVnB6Qk9iNUVVYmp6VUI5RjFMSGhBCjNnV3VC
-          Z3REN3hjOE9KY3Nmbk9NdWp1dWVUK2JBZ01CQUFFQ2dZRUFsdFlGTWdTcTEzbXdoZHYvcURqRjZp
-          Vy8KNEJmUzdaWU9xZEViUGFlS3hNTm04VndtTDlQaVh6S0M3VzI4RENjQ0pXR21VdVhkblRzcG95
-          eXBlemp2TkxUNgo4dDRFQ2daY1E0cUZIeDhNM05LTEcvK2tVTUtHK21heXdoMVNpbmtEVnFYL0Zw
-          RVR1U3BXUDg0Q0JjcEhKM0JSCjg5UWZlSklPaVlRSENIZUQ4emtDUVFEUjYxbXJYRVFBM2Z1Z1I5
-          ZjlYV0k1VENUU3FpZUs4OXpPT1lrbGFPMDYKdXREZjVDOFdqTFJlU1FJZzd6dFRhZmlxWGkrMHB0
-          b3ZDNW9DenJJUXZxS05Ba0VBd1F5TEp1NWNtT0xSdCtBQwpzWGdqSjBvYVNWRkJRTmNNZnp1TjBQ
-          M0I4Zjh3dzEvU21iWTRDUGNLT2JnY3lnRkU5czZZeVZrbmlJUEZJaUt1CmcyVjB4d0pCQUpFNVM1
-          aWtSUnVBZHVMa3NRVkVSSDYxTWNoWUZQRXBVam1OVGxjR0p4QjVTNldJdkJiU2tybWoKc29oTVdQ
-          T1ZIWVhua1FOZVp4VWk1cEpJb3FHNDhNVUNRRDVDWFY1ZzRWd3RTcFdTbVV2REF4Tll3c0dDZ3hq
-          MgpRZ0dHbzJZVGNNa3JFLzd1bUcwYVoxZjgxRDlwTVYrMHFSa3Y1L2FIMmtnY3R5Y2JLRTBZRzJF
-          Q1FRQ3krL3BLCjR0cmdpMm5NY3pIUEZ2b3MycS9XelJEeDE5akRrSldPT0NSOUlyUGFNU3JrNFFw
-          blJVbWpXdWcrUWhrVDR5MjEKZTJDcUNnSUNRTVhXUmpQdwotLS0tLUVORCBQUklWQVRFIEtFWS0t
-          LS0tCg==
+        certificate:
+        ## Sensitive data can also be provided inline:
+        #   type: inline
+        #   value: |
+        #     -----BEGIN CERTIFICATE-----
+        #     MIICxTCCAi6gAwIBAgIUaadvyb4GxCPmdtZeW0WcHnxZjbQwDQYJKoZIhvcNAQEL
+        #     BQAwajELMAkGA1UEBhMCWFgxEjAQBgNVBAgMCVN0YXRlTmFtZTERMA8GA1UEBwwI
+        #     Q2l0eU5hbWUxFDASBgNVBAoMC0NvbXBhbnlOYW1lMQswCQYDVQQLDAJDQTERMA8G
+        #     A1UEAwwITXlSb290Q0EwHhcNMjYwNDI5MTI0MDM4WhcNMjcwNDI5MTI0MDM4WjBg
+        #     -----END CERTIFICATE-----
+          type: secretRef
+          secretRef:
+            name: my-backend-cluster-tls
+        # Or source key from a Kubernetes Secret (key: tls.key from Secret my-backend-cluster-tls):
+        key:
+          type: secretRef
+          secretRef:
+            name: my-backend-cluster-tls
 ---
 kind: EventGatewayVirtualCluster
 apiVersion: konnect.konghq.com/v1alpha1


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix samples testing on CI. Currently, samples which fail to apply do not cause CI to fail, e.g. https://github.com/Kong/kong-operator/actions/runs/25912550920/job/76161164171?pr=4319#step:9:249

```
./konnect_eventgateway_virtualcluster.yaml
konnecteventgateway.konnect.konghq.com/cp-event-1 created
eventgatewayvirtualcluster.konnect.konghq.com/cp-event-1-virtual-cluster-1 created
The EventGatewayBackendCluster "cp-event-1-backend-cluster-2" is invalid: 
* spec.apiSpec.tls.clientIdentity.certificate: Invalid value: "string": spec.apiSpec.tls.clientIdentity.certificate in body must be of type object: "string"
* spec.apiSpec.tls.clientIdentity.key: Invalid value: "string": spec.apiSpec.tls.clientIdentity.key in body must be of type object: "string"
* <nil>: Invalid value: null: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
