### PR TITLE
chore: fix mise backend configurations

### DIFF
--- a/.github/workflows/__e2e_chainsaw_tests.yaml
+++ b/.github/workflows/__e2e_chainsaw_tests.yaml
@@ -42,7 +42,7 @@ jobs:
 
     - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
-        install_args: github:Kong/kubernetes-testing-framework http:helm
+        install_args: github:Kong/kubernetes-testing-framework aqua:helm/helm
 
     - name: Create k8s KinD Cluster with ktf
       env:

--- a/.github/workflows/charts-tests.yaml
+++ b/.github/workflows/charts-tests.yaml
@@ -142,7 +142,7 @@ jobs:
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          install_args: kind github:Kong/kubernetes-testing-framework http:helm
+          install_args: kind github:Kong/kubernetes-testing-framework aqua:helm/helm
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.mise.toml
+++ b/.mise.toml
@@ -56,13 +56,9 @@ linux-x64 = { asset_pattern = "telepresence-linux-amd64" }
 linux-arm64 = { asset_pattern = "telepresence-linux-arm64" }
 macos-arm64 = { asset_pattern = "telepresence-darwin-arm64" }
 
-[tools."http:helm"]
+[tools."aqua:helm/helm"]
 # renovate: datasource=github-releases depName=helm/helm
 version = "4.2.0"
-[tools."http:helm".platforms]
-linux-x64 = { url = "https://get.helm.sh/helm-v{{version}}-linux-amd64.tar.gz" }
-linux-arm64 = { url = "https://get.helm.sh/helm-v{{version}}-linux-arm64.tar.gz" }
-macos-arm64 = { url = "https://get.helm.sh/helm-v{{version}}-darwin-arm64.tar.gz" }
 
 [tools."go:sigs.k8s.io/kube-api-linter/cmd/golangci-lint-kube-api-linter"]
 # renovate: datasource=git-refs packageName=https://github.com/kubernetes-sigs/kube-api-linter.git
@@ -71,7 +67,6 @@ version = "3fa174937a6b9f0c1c2203efb312fff4ac8477c8"
 [tools."yq"]
 # renovate: datasource=github-releases depName=mikefarah/yq
 version = "v4.53.2"
-bin = "yq"
 
 ################################################################################
 # Tasks

--- a/Makefile
+++ b/Makefile
@@ -180,11 +180,11 @@ MARKDOWNLINT = $(PROJECT_DIR)/bin/installs/npm-markdownlint-cli2/$(MARKDOWNLINT_
 download.markdownlint-cli2: mise yq ## Download markdownlint-cli2 locally if necessary.
 	$(MAKE) mise-install DEP_VER=npm:markdownlint-cli2@$(MARKDOWNLINT_VERSION)
 
-HELM_VERSION = $(shell $(YQ) -p toml -o yaml '.tools["http:helm"].version' < $(MISE_FILE))
+HELM_VERSION = $(shell $(YQ) -p toml -o yaml '.tools["aqua:helm/helm"].version' < $(MISE_FILE))
 HELM = helm
 .PHONY: download.helm
 download.helm: mise yq ## Download helm locally if necessary.
-	$(MAKE) mise-install-global DEP_VER=http:helm
+	$(MAKE) mise-install-global DEP_VER=aqua:helm/helm
 
 KUBE_API_LINTER_VERSION = $(shell $(YQ) -p toml -o yaml '.tools["go:sigs.k8s.io/kube-api-linter/cmd/golangci-lint-kube-api-linter"].version' < $(MISE_FILE))
 KUBE_API_LINTER = $(PROJECT_DIR)/bin/installs/go-sigs-k8s-io-kube-api-linter-cmd-golangci-lint-kube-api-linter/$(KUBE_API_LINTER_VERSION)/bin/golangci-lint-kube-api-linter


### PR DESCRIPTION
**What this PR does / why we need it**:


```
$ mise upgrade
mise backend for 'yq' changed from stored 'aqua:mikefarah/yq[bin=yq]' to registry 'aqua:mikefarah/yq'
mise backend for 'yq' changed from stored 'aqua:mikefarah/yq[bin=yq]' to registry 'aqua:mikefarah/yq'
mise backend for 'yq' changed from stored 'aqua:mikefarah/yq[bin=yq]' to registry 'aqua:mikefarah/yq'
mise backend for 'yq' changed from stored 'aqua:mikefarah/yq[bin=yq]' to registry 'aqua:mikefarah/yq'
mise backend for 'yq' changed from stored 'aqua:mikefarah/yq[bin=yq]' to registry 'aqua:mikefarah/yq'
mise ERROR Failed to install http:helm[platforms={ linux-arm64 = { url = "https://get.helm.sh/helm-v{version}-linux-arm64.tar.gz" }, linux-x64 = { url = "https://get.helm.sh/helm-v{version}-linux-amd64.tar.gz" }, macos-arm64 = { url = "https://get.helm.sh/helm-v{version}-darwin-arm64.tar.gz" } }]@4.2.0: Http backend requires 'url' option mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
```

[`aqua`](https://mise.jdx.dev/dev-tools/backends/aqua.html) has been the Tier 1 backend for mise.

https://mise.jdx.dev/registry.html#backends

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
