### PR TITLE
feat(DataPlane): extend Kong image validation to support sha256 digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
 
 ### Added
 
+- DataPlane: extend Kong image validation to support sha256 digest
+  [#4356](https://github.com/Kong/kong-operator/pull/4356)
 - Konnect: support `KongCertificate` ref in `KongUpstream`
   [#4305](https://github.com/Kong/kong-operator/pull/4305)
 - `KongTarget`: support cross-namespace `spec.upstreamRef` to reference a

--- a/internal/versions/validation.go
+++ b/internal/versions/validation.go
@@ -38,6 +38,10 @@ var ErrExpectedSemverVersion = errors.New(`expected "<image>:<tag>" format`)
 // forth segment on top the standard 3 segment supported by semver.
 // This also supports flavour suffixes which can be supplied after "-" character.
 func FromImage(image string) (semver.Version, error) {
+	if idx := strings.Index(image, "@sha256:"); idx != -1 {
+		image = image[:idx]
+	}
+
 	splitImage := strings.Split(image, ":")
 	if len(splitImage) != 2 {
 		return semver.Version{}, fmt.Errorf(`%w, got: %s`, ErrExpectedSemverVersion, image)

--- a/internal/versions/validation_test.go
+++ b/internal/versions/validation_test.go
@@ -79,6 +79,38 @@ func Test_versionFromImage(t *testing.T) {
 			Tag:           "kong/kong-gateway:3.a3.y.y",
 			ExpectedError: kgoerrors.ErrInvalidSemverVersion,
 		},
+		{
+			Tag: "kong/kong-gateway:3.12",
+			Expected: func(t *testing.T) semver.Version {
+				v, err := semver.Parse("3.12.0")
+				require.NoError(t, err)
+				return v
+			},
+		},
+		{
+			Tag: "kong/kong-gateway:3.12@sha256:8f0089833902c555bf02dee1a59d3fe1f9fed11745eb7dd75e9bf844755147c9",
+			Expected: func(t *testing.T) semver.Version {
+				v, err := semver.Parse("3.12.0")
+				require.NoError(t, err)
+				return v
+			},
+		},
+		{
+			Tag: "kong/kong-gateway:3.3.0.0@sha256:abc123def456",
+			Expected: func(t *testing.T) semver.Version {
+				v, err := semver.Parse("3.3.0.0")
+				require.NoError(t, err)
+				return v
+			},
+		},
+		{
+			Tag: "kong/kong-gateway:3.3-alpine@sha256:abc123def456",
+			Expected: func(t *testing.T) semver.Version {
+				v, err := semver.Parse("3.3.0")
+				require.NoError(t, err)
+				return v
+			},
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
**What this PR does / why we need it**:

Extends the `FromImage` function in `internal/versions/validation.go` to extract the semver image version from container image references that include a SHA256 digest (e.g., `kong/kong-gateway:3.12@sha256:8f0089833902c555bf02dee1a59d3fe1f9fed11745eb7dd75e9bf844755147c9`), in addition to the existing support for classic tag-only references (e.g., `kong/kong-gateway:3.12`).

**Which issue this PR fixes**

Fixes https://github.com/Kong/kong-operator/issues/4354

**Special notes for your reviewer**:

Added 4 new test cases covering:
- Minor-only version without digest (`kong/kong-gateway:3.12`)
- Minor-only version with SHA256 digest
- Full version with SHA256 digest (`kong/kong-gateway:3.3.0.0@sha256:...`)
- Version with flavour suffix and SHA256 digest (`kong/kong-gateway:3.3-alpine@sha256:...`)

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes