### PR TITLE
chore: get rid of `golang.org/x/net` and simplify `go.mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/kong/semver/v4 v4.0.1
 	github.com/kr/pretty v0.3.1
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/moby/moby/api v1.54.2
 	github.com/moul/pb v0.0.0-20220425114252-bca18df4138c
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
@@ -42,10 +43,6 @@ require (
 	github.com/samber/lo v1.53.0
 	github.com/samber/mo v1.16.0
 	github.com/stretchr/testify v1.11.1
-	// TODO: update to v0.42.0 or v0.41.2 when they are released.
-	// This version will include the migration from github.com/docker/docker to github.com/moby/moby,
-	// which is already done in ktf and will get rid of the github.com/docker/docker
-	// dependency in our go.mod file.
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
 	github.com/tidwall/gjson v1.19.0
@@ -54,7 +51,6 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/mod v0.36.0
-	golang.org/x/net v0.54.0
 	golang.org/x/sync v0.20.0
 	google.golang.org/api v0.278.0
 	google.golang.org/grpc v1.81.1
@@ -64,9 +60,9 @@ require (
 	k8s.io/apimachinery v0.36.0
 	k8s.io/cli-runtime v0.36.0
 	k8s.io/client-go v0.36.0
+	k8s.io/kube-openapi v0.0.0-20260502001324-b7f5293f4787
 	k8s.io/kubectl v0.35.4
 	k8s.io/kubernetes v1.36.0
-	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
 	oras.land/oras-go/v2 v2.6.0
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/controller-tools v0.21.0
@@ -74,13 +70,8 @@ require (
 	sigs.k8s.io/gateway-api v1.5.1
 	sigs.k8s.io/gateway-api/conformance v1.5.1
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0
-	sigs.k8s.io/yaml v1.6.0
-)
-
-require (
-	github.com/moby/moby/api v1.54.2
-	k8s.io/kube-openapi v0.0.0-20260502001324-b7f5293f4787
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -301,6 +292,7 @@ require (
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/exp v0.0.0-20260212183809-81e46e3db34a // indirect
+	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
@@ -320,6 +312,7 @@ require (
 	k8s.io/controller-manager v0.0.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/streaming v0.36.0 // indirect
+	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kind v0.31.0 // indirect
@@ -347,6 +340,7 @@ replace (
 	k8s.io/controller-manager => k8s.io/controller-manager v0.36.0
 	k8s.io/cri-api => k8s.io/cri-api v0.36.1
 	k8s.io/cri-client => k8s.io/cri-client v0.36.0
+	k8s.io/cri-streaming => k8s.io/cri-streaming v0.36.0
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.36.0
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.36.0
 	k8s.io/endpointslice => k8s.io/endpointslice v0.36.0
@@ -365,8 +359,5 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.36.0
 	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.36.0
 	k8s.io/sample-controller => k8s.io/sample-controller v0.36.0
+	k8s.io/streaming => k8s.io/streaming v0.36.1
 )
-
-replace k8s.io/cri-streaming => k8s.io/cri-streaming v0.36.0
-
-replace k8s.io/streaming => k8s.io/streaming v0.36.1

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -690,11 +690,7 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 
 	// Konnect controllers
 	if c.KonnectControllersEnabled {
-		httpClient, err := httpClientForKonnect(c)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create HTTP client for Konnect: %w", err)
-		}
-		sdkFactory := sdkops.NewSDKFactory(sdkops.WithHTTPClient(httpClient))
+		sdkFactory := sdkops.NewSDKFactory(sdkops.WithHTTPClient(httpClientForKonnect(c)))
 		ctrlOpts := controllerOptions(ctrlOpts, withMaxConcurrentReconciles(int(c.MaxConcurrentReconcilesKonnect)))
 
 		controllerFactory := konnectControllerFactory{

--- a/modules/manager/httpclient_konnect.go
+++ b/modules/manager/httpclient_konnect.go
@@ -1,33 +1,26 @@
 package manager
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/hashicorp/go-cleanhttp"
-	"golang.org/x/net/http2"
 )
 
-func httpClientForKonnect(c *Config) (*http.Client, error) {
-	// Clone the default transport to inherit all Go defaults (TLS settings,
-	// timeouts, proxy support, etc.) and only override what we need.
+func httpClientForKonnect(c *Config) *http.Client {
 	transport := cleanhttp.DefaultPooledTransport()
 	transport.IdleConnTimeout = 2 * c.KonnectSyncPeriod
-
 	// Configure HTTP/2 health checks to detect stalled connections.
-	// When no frames are received for ReadIdleTimeout, a PING is sent.
-	// If no PING response within PingTimeout, the connection is closed
+	// When no frames are received for SendPingTimeout, a PING is sent.
+	// If no PING response is received within PingTimeout, the connection is closed
 	// and removed from the pool, forcing new requests to open a fresh connection.
-	h2Transport, err := http2.ConfigureTransports(transport)
-	if err != nil {
-		return nil, fmt.Errorf("failed to configure HTTP/2 transport: %w", err)
+	transport.HTTP2 = &http.HTTP2Config{
+		SendPingTimeout: 30 * time.Second,
+		PingTimeout:     15 * time.Second,
 	}
-	h2Transport.ReadIdleTimeout = 30 * time.Second
-	h2Transport.PingTimeout = 15 * time.Second
 
 	return &http.Client{
 		Transport: transport,
 		Timeout:   c.KonnectRequestTimeout,
-	}, nil
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Parameters can be configured directly https://pkg.go.dev/net/http#Transport.HTTP2 in newer versions of Go and   `ReadIdleTimeout` seems to map to stdlib `SendPingTimeout` [see the source](https://github.com/golang/go/blob/93da30397d6c1596e3c67df70df9e2ccde378995/src/net/http/internal/http2/transport.go#L631-L632)
