### PR TITLE
refactor(tests): replace uuid.NewString() with GenerateName in envtest tests

### DIFF
--- a/test/envtest/adminapi_discoverer_envtest_test.go
+++ b/test/envtest/adminapi_discoverer_envtest_test.go
@@ -83,7 +83,7 @@ func TestDiscoverer_GetAdminAPIsForServiceReturnsAllAddressesCorrectlyPagingThro
 					es := discoveryv1.EndpointSlice{
 						ObjectMeta: metav1.ObjectMeta{
 							GenerateName: "endpointslice-",
-							Namespace: ns.Name,
+							Namespace:    ns.Name,
 							Labels: map[string]string{
 								"kubernetes.io/service-name": serviceName,
 							},

--- a/test/envtest/adminapi_discoverer_envtest_test.go
+++ b/test/envtest/adminapi_discoverer_envtest_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -83,7 +82,7 @@ func TestDiscoverer_GetAdminAPIsForServiceReturnsAllAddressesCorrectlyPagingThro
 				for j := range tc.subnetD {
 					es := discoveryv1.EndpointSlice{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      uuid.NewString(),
+							GenerateName: "endpointslice-",
 							Namespace: ns.Name,
 							Labels: map[string]string{
 								"kubernetes.io/service-name": serviceName,

--- a/test/envtest/gateway_envtest_test.go
+++ b/test/envtest/gateway_envtest_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -153,7 +152,7 @@ func createHTTPRoutes(
 		pathMatchPrefix := gatewayapi.PathMatchPathPrefix
 		httpRoute := &gatewayapi.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      uuid.NewString(),
+				GenerateName: "httproute-",
 				Namespace: gw.Namespace,
 			},
 			Spec: gatewayapi.HTTPRouteSpec{

--- a/test/envtest/gateway_envtest_test.go
+++ b/test/envtest/gateway_envtest_test.go
@@ -153,7 +153,7 @@ func createHTTPRoutes(
 		httpRoute := &gatewayapi.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "httproute-",
-				Namespace: gw.Namespace,
+				Namespace:    gw.Namespace,
 			},
 			Spec: gatewayapi.HTTPRouteSpec{
 				CommonRouteSpec: gatewayapi.CommonRouteSpec{

--- a/test/envtest/httproute_controller_test.go
+++ b/test/envtest/httproute_controller_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,7 +71,7 @@ func TestHTTPRouteReconcilerProperlyReactsToReferenceGrant(t *testing.T) {
 			ControllerName: gateway.GetControllerName(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: uuid.NewString(),
+			GenerateName: "gwc-",
 			Annotations: map[string]string{
 				"konghq.com/gatewayclass-unmanaged": "placeholder",
 			},
@@ -98,8 +97,8 @@ func TestHTTPRouteReconcilerProperlyReactsToReferenceGrant(t *testing.T) {
 			},
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ns.Name,
-			Name:      uuid.NewString(),
+			Namespace:    ns.Name,
+			GenerateName: "gw-",
 		},
 	}
 	require.NoError(t, client.Create(ctx, &gw))
@@ -162,8 +161,8 @@ func TestHTTPRouteReconcilerProperlyReactsToReferenceGrant(t *testing.T) {
 			APIVersion: "v1beta1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: nsRoute.Name,
-			Name:      uuid.NewString(),
+			Namespace:    nsRoute.Name,
+			GenerateName: "httproute-",
 		},
 		Spec: gatewayapi.HTTPRouteSpec{
 			CommonRouteSpec: gatewayapi.CommonRouteSpec{
@@ -201,8 +200,8 @@ func TestHTTPRouteReconcilerProperlyReactsToReferenceGrant(t *testing.T) {
 
 	rg := gatewayapi.ReferenceGrant{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ns.Name,
-			Name:      uuid.NewString(),
+			Namespace:    ns.Name,
+			GenerateName: "referencegrant-",
 		},
 		Spec: gatewayapi.ReferenceGrantSpec{
 			From: []gatewayapi.ReferenceGrantFrom{

--- a/test/envtest/ingress_test.go
+++ b/test/envtest/ingress_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	gojson "github.com/goccy/go-json"
-	"github.com/google/uuid"
 	"github.com/kong/go-database-reconciler/pkg/file"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/stretchr/testify/require"
@@ -92,7 +91,7 @@ func TestIngressWorksWithServiceBackendsSpecifyingOnlyPortNames(t *testing.T) {
 
 	es := discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      uuid.NewString(),
+			GenerateName: "endpointslice-",
 			Namespace: ns.Name,
 			Labels: map[string]string{
 				"kubernetes.io/service-name": service.Name,

--- a/test/envtest/ingress_test.go
+++ b/test/envtest/ingress_test.go
@@ -92,7 +92,7 @@ func TestIngressWorksWithServiceBackendsSpecifyingOnlyPortNames(t *testing.T) {
 	es := discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "endpointslice-",
-			Namespace: ns.Name,
+			Namespace:    ns.Name,
 			Labels: map[string]string{
 				"kubernetes.io/service-name": service.Name,
 			},

--- a/test/envtest/k8s.go
+++ b/test/envtest/k8s.go
@@ -34,7 +34,7 @@ func CreatePod(ctx context.Context, t *testing.T, client ctrlclient.Client, ns s
 
 	pod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ns,
+			Namespace:    ns,
 			GenerateName: "pod-",
 		},
 		Spec: corev1.PodSpec{

--- a/test/envtest/k8s.go
+++ b/test/envtest/k8s.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,7 +16,7 @@ func CreateNamespace(ctx context.Context, t *testing.T, client ctrlclient.Client
 
 	ns := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: uuid.NewString(),
+			GenerateName: "ns-",
 			Labels: map[string]string{
 				"test": "envtest",
 			},
@@ -36,7 +35,7 @@ func CreatePod(ctx context.Context, t *testing.T, client ctrlclient.Client, ns s
 	pod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
-			Name:      uuid.NewString(),
+			GenerateName: "pod-",
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{

--- a/test/envtest/k8s_objects_status_envtest_test.go
+++ b/test/envtest/k8s_objects_status_envtest_test.go
@@ -61,8 +61,8 @@ func TestHTTPRouteReconciliation_DoesNotBlockSyncLoopWhenStatusQueueBufferIsExce
 
 	httpRoute := gatewayapi.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: gw.Namespace,
-			Name:      uuid.NewString(),
+			Namespace:    gw.Namespace,
+			GenerateName: "httproute-",
 		},
 		Spec: gatewayapi.HTTPRouteSpec{
 			CommonRouteSpec: gatewayapi.CommonRouteSpec{

--- a/test/envtest/kongadminapi_controller_envtest_test.go
+++ b/test/envtest/kongadminapi_controller_envtest_test.go
@@ -142,7 +142,7 @@ func TestKongAdminAPIController(t *testing.T) {
 						UID:        adminService.UID,
 					},
 				},
-				Name:      uuid.NewString(),
+				GenerateName: "endpointslice-",
 				Namespace: adminService.Namespace,
 				Labels: map[string]string{
 					"kubernetes.io/service-name": adminService.Name,
@@ -221,7 +221,7 @@ func TestKongAdminAPIController(t *testing.T) {
 						UID:        adminService.UID,
 					},
 				},
-				Name:      uuid.NewString(),
+				GenerateName: "endpointslice-",
 				Namespace: adminService.Namespace,
 				Labels: map[string]string{
 					"kubernetes.io/service-name": adminService.Name,
@@ -288,7 +288,7 @@ func TestKongAdminAPIController(t *testing.T) {
 						UID:        adminService.UID,
 					},
 				},
-				Name:      uuid.NewString(),
+				GenerateName: "endpointslice-",
 				Namespace: adminService.Namespace,
 				Labels: map[string]string{
 					"kubernetes.io/service-name": adminService.Name,
@@ -333,7 +333,7 @@ func TestKongAdminAPIController(t *testing.T) {
 						UID:        adminService.UID,
 					},
 				},
-				Name:      uuid.NewString(),
+				GenerateName: "endpointslice-",
 				Namespace: adminService.Namespace,
 				Labels: map[string]string{
 					"kubernetes.io/service-name": adminService.Name,
@@ -424,7 +424,7 @@ func TestKongAdminAPIController(t *testing.T) {
 						UID:        adminService.UID,
 					},
 				},
-				Name:      uuid.NewString(),
+				GenerateName: "endpointslice-",
 				Namespace: adminService.Namespace,
 				Labels: map[string]string{
 					"kubernetes.io/service-name": adminService.Name,
@@ -528,7 +528,7 @@ func TestKongAdminAPIController(t *testing.T) {
 						UID:        adminService.UID,
 					},
 				},
-				Name:      uuid.NewString(),
+				GenerateName: "endpointslice-",
 				Namespace: adminService.Namespace,
 				Labels: map[string]string{
 					"kubernetes.io/service-name": adminService.Name,

--- a/test/envtest/kongadminapi_controller_envtest_test.go
+++ b/test/envtest/kongadminapi_controller_envtest_test.go
@@ -143,7 +143,7 @@ func TestKongAdminAPIController(t *testing.T) {
 					},
 				},
 				GenerateName: "endpointslice-",
-				Namespace: adminService.Namespace,
+				Namespace:    adminService.Namespace,
 				Labels: map[string]string{
 					"kubernetes.io/service-name": adminService.Name,
 				},
@@ -222,7 +222,7 @@ func TestKongAdminAPIController(t *testing.T) {
 					},
 				},
 				GenerateName: "endpointslice-",
-				Namespace: adminService.Namespace,
+				Namespace:    adminService.Namespace,
 				Labels: map[string]string{
 					"kubernetes.io/service-name": adminService.Name,
 				},
@@ -289,7 +289,7 @@ func TestKongAdminAPIController(t *testing.T) {
 					},
 				},
 				GenerateName: "endpointslice-",
-				Namespace: adminService.Namespace,
+				Namespace:    adminService.Namespace,
 				Labels: map[string]string{
 					"kubernetes.io/service-name": adminService.Name,
 				},
@@ -334,7 +334,7 @@ func TestKongAdminAPIController(t *testing.T) {
 					},
 				},
 				GenerateName: "endpointslice-",
-				Namespace: adminService.Namespace,
+				Namespace:    adminService.Namespace,
 				Labels: map[string]string{
 					"kubernetes.io/service-name": adminService.Name,
 				},
@@ -425,7 +425,7 @@ func TestKongAdminAPIController(t *testing.T) {
 					},
 				},
 				GenerateName: "endpointslice-",
-				Namespace: adminService.Namespace,
+				Namespace:    adminService.Namespace,
 				Labels: map[string]string{
 					"kubernetes.io/service-name": adminService.Name,
 				},
@@ -529,7 +529,7 @@ func TestKongAdminAPIController(t *testing.T) {
 					},
 				},
 				GenerateName: "endpointslice-",
-				Namespace: adminService.Namespace,
+				Namespace:    adminService.Namespace,
 				Labels: map[string]string{
 					"kubernetes.io/service-name": adminService.Name,
 				},

--- a/test/envtest/kongupstreampolicy_test.go
+++ b/test/envtest/kongupstreampolicy_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -204,7 +203,7 @@ func TestKongUpstreamPolicyWithHTTPRoute(t *testing.T) {
 			ControllerName: gateway.GetControllerName(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: uuid.NewString(),
+			GenerateName: "gwc-",
 			Annotations: map[string]string{
 				"konghq.com/gatewayclass-unmanaged": "placeholder",
 			},
@@ -230,8 +229,8 @@ func TestKongUpstreamPolicyWithHTTPRoute(t *testing.T) {
 			},
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ns.Name,
-			Name:      uuid.NewString(),
+			Namespace:    ns.Name,
+			GenerateName: "gw-",
 		},
 	}
 	require.NoError(t, ctrlClient.Create(ctx, &gw))
@@ -309,8 +308,8 @@ func TestKongUpstreamPolicyWithHTTPRoute(t *testing.T) {
 			APIVersion: "v1beta1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ns.Name,
-			Name:      uuid.NewString(),
+			Namespace:    ns.Name,
+			GenerateName: "httproute-",
 		},
 		Spec: gatewayapi.HTTPRouteSpec{
 			CommonRouteSpec: gatewayapi.CommonRouteSpec{

--- a/test/envtest/setup.go
+++ b/test/envtest/setup.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -237,7 +236,7 @@ func deployGatewayUsingGatewayClass(ctx context.Context, t *testing.T, client cl
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns.Name,
-			Name:      uuid.NewString(),
+			GenerateName: "gw-",
 		},
 	}
 	require.NoError(t, client.Create(ctx, &gw))
@@ -252,7 +251,7 @@ func deployGateway(ctx context.Context, t *testing.T, client client.Client) (gat
 			ControllerName: gateway.GetControllerName(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: uuid.NewString(),
+			GenerateName: "gwc-",
 			Annotations: map[string]string{
 				"konghq.com/gatewayclass-unmanaged": "placeholder",
 			},

--- a/test/envtest/setup.go
+++ b/test/envtest/setup.go
@@ -235,7 +235,7 @@ func deployGatewayUsingGatewayClass(ctx context.Context, t *testing.T, client cl
 			},
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ns.Name,
+			Namespace:    ns.Name,
 			GenerateName: "gw-",
 		},
 	}

--- a/test/helpers/deploy/deploy_resources.go
+++ b/test/helpers/deploy/deploy_resources.go
@@ -390,7 +390,7 @@ func KonnectCloudGatewayDataPlaneGroupConfiguration(
 	t.Helper()
 	obj := konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "data-plane-group-configuration-" + randomSuffix(),
+			GenerateName: "data-plane-group-configuration-",
 		},
 		Spec: konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationSpec{
 			Version:         consts.DefaultDataPlaneTag,
@@ -1571,10 +1571,9 @@ func KongReferenceGrant(
 ) *configurationv1alpha1.KongReferenceGrant {
 	t.Helper()
 
-	name := "kongreferencegrant-" + randomSuffix()
 	krg := configurationv1alpha1.KongReferenceGrant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			GenerateName: "kongreferencegrant-",
 		},
 		Spec: configurationv1alpha1.KongReferenceGrantSpec{},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Due to the limitations of our CI, I will use this PR to replace https://github.com/Kong/kong-operator/pull/3707.

Thanks @superyyrrzz

**Which issue this PR fixes**

Fixes #102 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
