### PR TITLE
fix(ingress-controller): Set intersected hostnames for TLSRoute in on-prem gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,9 @@
   **Attention**: This will re-create CA certificates in Konnect,
   as it changes the names of the generated `KongCertificate`s.
   [#4382](https://github.com/Kong/kong-operator/pull/4382)
+- `Gateway`: Pick the intersection of spec's `hostnames` and parent listener's
+  `hostname` as the hostnames in `TLSRoute` for translation in on-prem gateways.
+  [#4369](https://github.com/Kong/kong-operator/pull/4369)
 - `Gateway`: conflicting listeners (port/protocol or hostname conflict) now have
   `Accepted=False` with the conflict reason, per Gateway API spec rule that
   "ALL indistinct Listeners must not be accepted for processing".

--- a/ingress-controller/examples/gateway-tlsroute-hostname-intersection.yaml
+++ b/ingress-controller/examples/gateway-tlsroute-hostname-intersection.yaml
@@ -1,0 +1,119 @@
+# NOTE The Gateway APIs are not yet available by default in Kubernetes.
+# Follow these instructions to install them before using this example:
+# https://gateway-api.sigs.k8s.io/guides/#install-experimental-channel
+#
+# This example demonstrates TLSRoute hostname intersection between a Gateway
+# Listener and a TLSRoute. The Listener constrains attached routes to the
+# wildcard "*.example.com" and the route's spec hostnames are "*.com". The
+# controller computes the intersection — the more specific "*.example.com" —
+# and only programs Kong to accept SNIs matching that wildcard (e.g.
+# "abc.example.com"). Connections with an SNI outside the intersection,
+# such as "abc.kong.example", are rejected.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tlsecho
+  labels:
+    app: tlsecho
+spec:
+  selector:
+    matchLabels:
+      app: tlsecho
+  template:
+    metadata:
+      labels:
+        app: tlsecho
+    spec:
+      containers:
+      - name: tlsecho
+        image: kong/go-echo:0.3.0
+        ports:
+        - containerPort: 1030
+        env:
+        - name: POD_NAME
+          value: example-tlsroute-hostname-intersection
+        - name: TLS_PORT
+          value: "1030"
+        - name: TLS_CERT_FILE
+          value: /var/run/certs/tls.crt
+        - name: TLS_KEY_FILE
+          value: /var/run/certs/tls.key
+        volumeMounts:
+        - mountPath: /var/run/certs
+          name: secret-test
+          readOnly: true
+      volumes:
+      - name: secret-test
+        secret:
+          defaultMode: 420
+          secretName: example-tlsroute-hostname-intersection
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tlsecho
+spec:
+  ports:
+  - port: 8899
+    protocol: TCP
+    targetPort: 1030
+  selector:
+    app: tlsecho
+  type: ClusterIP
+---
+# A wildcard certificate covering "*.example.com" — generate your own with:
+#   openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+#     -keyout tls.key -out tls.crt \
+#     -subj "/CN=*.example.com" \
+#     -addext "subjectAltName=DNS:*.example.com"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: example-tlsroute-hostname-intersection
+type: kubernetes.io/tls
+data:
+  tls.crt: ""
+  tls.key: ""
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: example-tlsroute-hostname-intersection
+  annotations:
+    konghq.com/gatewayclass-unmanaged: "true"
+spec:
+  controllerName: konghq.com/kic-gateway-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-tlsroute-hostname-intersection
+spec:
+  gatewayClassName: example-tlsroute-hostname-intersection
+  listeners:
+  - name: tls
+    protocol: TLS
+    port: 8899
+    # Listener restricts attached routes to "*.example.com".
+    hostname: "*.example.com"
+    tls:
+      mode: Passthrough
+      certificateRefs:
+      - name: example-tlsroute-hostname-intersection
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  name: tlsecho
+spec:
+  parentRefs:
+  - name: example-tlsroute-hostname-intersection
+  # Route spec asks for the broader "*.com". The controller intersects this
+  # with the Listener's "*.example.com" and programs Kong with "*.example.com".
+  hostnames:
+  - "*.com"
+  rules:
+  - backendRefs:
+    - name: tlsecho
+      port: 8899

--- a/ingress-controller/internal/controllers/gateway/route_utils.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils.go
@@ -568,33 +568,52 @@ func isListenerHostnameEffective(listener gatewayapi.Listener) bool {
 		listener.Protocol == gatewayapi.TLSProtocolType
 }
 
-// filterHostnames accepts a HTTPRoute and returns a version of the same object with only a subset of the
-// hostnames, the ones matching with the listeners' hostname.
-// it returns an error if the intersection of hostname match in httproute and listeners is empty.
-func filterHostnames(gateways []supportedGatewayWithCondition, httpRoute *gatewayapi.HTTPRoute) (*gatewayapi.HTTPRoute, error) {
+// routeWithHostnames constrains filterHostnames to the route kinds that carry
+// a `Spec.Hostnames []gatewayapi.Hostname` field — currently HTTPRoute and TLSRoute.
+type routeWithHostnames interface {
+	*gatewayapi.HTTPRoute | *gatewayapi.TLSRoute
+}
+
+// filterHostnames accepts a route and returns the same object with only the subset
+// of hostnames that intersects with the listeners' hostnames.
+// It returns an error if the intersection of hostname match in the route and listeners is empty.
+func filterHostnames[T routeWithHostnames](gateways []supportedGatewayWithCondition, route T) (T, error) {
+	var (
+		specHostnames []gatewayapi.Hostname
+		setHostnames  func([]gatewayapi.Hostname)
+	)
+	switch r := any(route).(type) {
+	case *gatewayapi.HTTPRoute:
+		specHostnames = r.Spec.Hostnames
+		setHostnames = func(h []gatewayapi.Hostname) { r.Spec.Hostnames = h }
+	case *gatewayapi.TLSRoute:
+		specHostnames = r.Spec.Hostnames
+		setHostnames = func(h []gatewayapi.Hostname) { r.Spec.Hostnames = h }
+	}
+
 	filteredHostnames := make([]gatewayapi.Hostname, 0)
 	// if no hostnames are specified in the route spec, we use the UNION of all hostnames in supported gateways.
-	// if any of supported listener has not specified hostname, the hostnames of HTTPRoute remains empty
+	// if any of supported listener has not specified hostname, the route hostnames remain empty
 	// to match **ANY** hostname.
-	if len(httpRoute.Spec.Hostnames) == 0 {
+	if len(specHostnames) == 0 {
 		var matchAnyHost bool
 		filteredHostnames, matchAnyHost = getUnionOfGatewayHostnames(gateways)
 		if matchAnyHost {
-			return httpRoute, nil
+			return route, nil
 		}
 	} else {
-		for _, hostname := range httpRoute.Spec.Hostnames {
+		for _, hostname := range specHostnames {
 			if hostnameMatching := getMinimumHostnameIntersection(gateways, hostname); hostnameMatching != "" {
 				filteredHostnames = append(filteredHostnames, hostnameMatching)
 			}
 		}
 		if len(filteredHostnames) == 0 {
-			return httpRoute, ErrNoMatchingListenerHostname
+			return route, ErrNoMatchingListenerHostname
 		}
 	}
 
-	httpRoute.Spec.Hostnames = filteredHostnames
-	return httpRoute, nil
+	setHostnames(filteredHostnames)
+	return route, nil
 }
 
 // getUnionOfGatewayHostnames returns UNION of hostnames specified in supported gateways.

--- a/ingress-controller/internal/controllers/gateway/route_utils_test.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils_test.go
@@ -224,6 +224,153 @@ func TestFilterHostnames(t *testing.T) {
 	}
 }
 
+func TestFilterHostnames_TLSRoute(t *testing.T) {
+	// Listeners modelled on the gateway-api TLSRouteHostnameIntersection conformance:
+	// abc.example.com, *.example.com, *.com, and an empty (match-any) listener.
+	commonGateway := &gatewayapi.Gateway{
+		Spec: gatewayapi.GatewaySpec{
+			Listeners: []gatewayapi.Listener{
+				{
+					Name:     "listener-exact-hostname",
+					Hostname: util.StringToTypedPtr[*gatewayapi.Hostname]("abc.example.com"),
+				},
+				{
+					Name:     "listener-more-specific-wc-hostname",
+					Hostname: util.StringToTypedPtr[*gatewayapi.Hostname]("*.example.com"),
+				},
+				{
+					Name:     "listener-less-specific-wc-hostname",
+					Hostname: util.StringToTypedPtr[*gatewayapi.Hostname]("*.com"),
+				},
+				{
+					Name: "listener-empty-hostname",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name             string
+		gateways         []supportedGatewayWithCondition
+		tlsRoute         *gatewayapi.TLSRoute
+		expectedTLSRoute *gatewayapi.TLSRoute
+		hasError         bool
+		errString        string
+	}{
+		{
+			name: "exact listener × wildcard route — listener hostname returned",
+			gateways: []supportedGatewayWithCondition{
+				{gateway: commonGateway, listenerName: "listener-exact-hostname"},
+			},
+			tlsRoute: &gatewayapi.TLSRoute{
+				Spec: gatewayapi.TLSRouteSpec{
+					Hostnames: []gatewayapi.Hostname{"*.example.com"},
+				},
+			},
+			expectedTLSRoute: &gatewayapi.TLSRoute{
+				Spec: gatewayapi.TLSRouteSpec{
+					Hostnames: []gatewayapi.Hostname{"abc.example.com"},
+				},
+			},
+		},
+		{
+			name: "more-specific wildcard listener × exact route — exact route returned",
+			gateways: []supportedGatewayWithCondition{
+				{gateway: commonGateway, listenerName: "listener-more-specific-wc-hostname"},
+			},
+			tlsRoute: &gatewayapi.TLSRoute{
+				Spec: gatewayapi.TLSRouteSpec{
+					Hostnames: []gatewayapi.Hostname{"abc.example.com"},
+				},
+			},
+			expectedTLSRoute: &gatewayapi.TLSRoute{
+				Spec: gatewayapi.TLSRouteSpec{
+					Hostnames: []gatewayapi.Hostname{"abc.example.com"},
+				},
+			},
+		},
+		{
+			name: "more-specific wildcard listener × less-specific wildcard route — listener returned",
+			gateways: []supportedGatewayWithCondition{
+				{gateway: commonGateway, listenerName: "listener-more-specific-wc-hostname"},
+			},
+			tlsRoute: &gatewayapi.TLSRoute{
+				Spec: gatewayapi.TLSRouteSpec{
+					Hostnames: []gatewayapi.Hostname{"*.com"},
+				},
+			},
+			expectedTLSRoute: &gatewayapi.TLSRoute{
+				Spec: gatewayapi.TLSRouteSpec{
+					Hostnames: []gatewayapi.Hostname{"*.example.com"},
+				},
+			},
+		},
+		{
+			name: "less-specific wildcard listener × more-specific wildcard route — route returned",
+			gateways: []supportedGatewayWithCondition{
+				{gateway: commonGateway, listenerName: "listener-less-specific-wc-hostname"},
+			},
+			tlsRoute: &gatewayapi.TLSRoute{
+				Spec: gatewayapi.TLSRouteSpec{
+					Hostnames: []gatewayapi.Hostname{"*.example.com"},
+				},
+			},
+			expectedTLSRoute: &gatewayapi.TLSRoute{
+				Spec: gatewayapi.TLSRouteSpec{
+					Hostnames: []gatewayapi.Hostname{"*.example.com"},
+				},
+			},
+		},
+		{
+			name: "empty listener × wildcard route — route returned verbatim",
+			gateways: []supportedGatewayWithCondition{
+				{gateway: commonGateway, listenerName: "listener-empty-hostname"},
+			},
+			tlsRoute: &gatewayapi.TLSRoute{
+				Spec: gatewayapi.TLSRouteSpec{
+					Hostnames: []gatewayapi.Hostname{"*.com"},
+				},
+			},
+			expectedTLSRoute: &gatewayapi.TLSRoute{
+				Spec: gatewayapi.TLSRouteSpec{
+					Hostnames: []gatewayapi.Hostname{"*.com"},
+				},
+			},
+		},
+		{
+			name: "no intersection — returns ErrNoMatchingListenerHostname",
+			gateways: []supportedGatewayWithCondition{
+				{gateway: commonGateway, listenerName: "listener-exact-hostname"},
+			},
+			tlsRoute: &gatewayapi.TLSRoute{
+				Spec: gatewayapi.TLSRouteSpec{
+					Hostnames: []gatewayapi.Hostname{"some.other.org"},
+				},
+			},
+			expectedTLSRoute: &gatewayapi.TLSRoute{
+				Spec: gatewayapi.TLSRouteSpec{
+					Hostnames: []gatewayapi.Hostname{},
+				},
+			},
+			hasError:  true,
+			errString: "no matching hostnames in listener",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			filteredTLSRoute, err := filterHostnames(tc.gateways, tc.tlsRoute)
+			if tc.hasError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errString)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedTLSRoute.Spec, filteredTLSRoute.Spec)
+			}
+		})
+	}
+}
+
 func TestGetSupportedGatewayForRoute(t *testing.T) {
 	gatewayClass := &gatewayapi.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{

--- a/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
@@ -402,10 +402,15 @@ func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 	}
 
-	if isRouteAccepted(gateways) {
+	// if there is no matched hosts in listeners for the tlsroute, the tlsroute should not be accepted
+	// and have an "Accepted" condition with status false.
+	// https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.TLSRoute
+	filteredTLSRoute, err := filterHostnames(gateways, tlsroute.DeepCopy())
+	// perform operations on the kong store only if the route is in accepted status and there is hostname matching
+	if isRouteAccepted(gateways) && err == nil {
 		// if the gateways are ready, and the TLSRoute is destined for them, ensure that
 		// the object is pushed to the dataplane.
-		if err := r.DataplaneClient.UpdateObject(tlsroute); err != nil {
+		if err := r.DataplaneClient.UpdateObject(filteredTLSRoute); err != nil {
 			debug(log, tlsroute, "Failed to update object in data-plane, requeueing")
 			return ctrl.Result{}, err
 		}

--- a/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
@@ -407,11 +407,21 @@ func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.TLSRoute
 	filteredTLSRoute, err := filterHostnames(gateways, tlsroute.DeepCopy())
 	if err != nil {
-		// Should not be reachable here because filterHostnames should only return an error if there is no matched host in listeners for the tlsroute,
-		// which means the tlsroute should not be accepted and have an "Accepted" condition with status false.
-		// But we still want to log the error and requeue to make sure the status can be updated.
-		debug(log, tlsroute, "Failed to filter hostnames for TLSRoute, requeueing", "error", err)
-		return ctrl.Result{}, err
+		// Should not be reachable because the filterHostnames function only returns error `ErrNoMatchingListenerHostname`
+		// when there is no matched hostname in listeners for the tlsroute.
+		if !errors.Is(err, ErrNoMatchingListenerHostname) {
+			debug(log, tlsroute, "Failed to filter hostnames for the TLSRoute, requeueing", "error", err)
+			return ctrl.Result{}, err
+		}
+		// If there is no matched hosts in listeners for the tlsroute,
+		// the tlsroute should not be accepted and have an "Accepted" condition with status false.
+		// Then we remove the tlsroute from data-plane configuration if it was previously added,
+		//  and continue the reconciliation to update the status to reflect the condition change.
+		debug(log, tlsroute, "No matching listener hostname for the TLSRoute, removing it from data-plane")
+		if err := r.DataplaneClient.DeleteObject(tlsroute); err != nil {
+			debug(log, tlsroute, "Failed to delete object from data-plane, requeuing")
+			return ctrl.Result{}, err
+		}
 	}
 	// perform operations on the kong store only if the route is in accepted status and there is hostname matching
 	if isRouteAccepted(gateways) {

--- a/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
@@ -406,8 +406,15 @@ func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// and have an "Accepted" condition with status false.
 	// https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.TLSRoute
 	filteredTLSRoute, err := filterHostnames(gateways, tlsroute.DeepCopy())
+	if err != nil {
+		// Should not be reachable here because filterHostnames should only return an error if there is no matched host in listeners for the tlsroute,
+		// which means the tlsroute should not be accepted and have an "Accepted" condition with status false.
+		// But we still want to log the error and requeue to make sure the status can be updated.
+		debug(log, tlsroute, "Failed to filter hostnames for TLSRoute, requeueing", "error", err)
+		return ctrl.Result{}, err
+	}
 	// perform operations on the kong store only if the route is in accepted status and there is hostname matching
-	if isRouteAccepted(gateways) && err == nil {
+	if isRouteAccepted(gateways) {
 		// if the gateways are ready, and the TLSRoute is destined for them, ensure that
 		// the object is pushed to the dataplane.
 		if err := r.DataplaneClient.UpdateObject(filteredTLSRoute); err != nil {

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -20,12 +20,13 @@ var skippedTestsShared = []string{
 	// When processing this scenario, the Kong's router requires `priority` to be specified for routes.
 	// We cannot provide that for routes that are part of the conformance suite.
 	tests.GRPCRouteListenerHostnameMatching.ShortName,
-
-	// TLSRoute tests that cannot pass yet.
-	tests.TLSRouteHostnameIntersection.ShortName,
 }
 
-var skippedTestsForExpressionsRouter = []string{}
+var skippedTestsForExpressionsRouter = []string{
+	// TODO: support wildcard SNI in TLSRoute and Gateway and remove this from the skipped tests list.
+	// https://github.com/Kong/kong-operator/issues/4350
+	tests.TLSRouteHostnameIntersection.ShortName,
+}
 
 var skippedTestsForTraditionalCompatibleRouter = []string{
 	// HTTPRoute

--- a/test/integration/ko/tlsroute_test.go
+++ b/test/integration/ko/tlsroute_test.go
@@ -30,6 +30,13 @@ const (
 )
 
 func setTLSListener(port int, mode gatewayv1.TLSModeType, certSecretName string) func(*gatewayv1.Gateway) {
+	return setTLSListenerWithHostname(port, mode, certSecretName, "")
+}
+
+// setTLSListenerWithHostname returns a Gateway option that configures the "tls" listener.
+// If hostname is non-empty, the listener is restricted to that hostname (supports the
+// gateway-api wildcard form, e.g. "*.example.com").
+func setTLSListenerWithHostname(port int, mode gatewayv1.TLSModeType, certSecretName, hostname string) func(*gatewayv1.Gateway) {
 	tlsConfig := &gatewayv1.ListenerTLSConfig{
 		Mode: &mode,
 	}
@@ -45,6 +52,10 @@ func setTLSListener(port int, mode gatewayv1.TLSModeType, certSecretName string)
 		Port:     gatewayv1.PortNumber(port),
 		Protocol: gatewayv1.TLSProtocolType,
 		TLS:      tlsConfig,
+	}
+	if hostname != "" {
+		h := gatewayv1.Hostname(hostname)
+		tlsListener.Hostname = &h
 	}
 	return func(gw *gatewayv1.Gateway) {
 
@@ -321,6 +332,151 @@ func TestTLSTerminate(t *testing.T) {
 			helpers.TLSOpt{
 				Hostname: host,
 				CertPool: certPool,
+			})
+		if err != nil {
+			t.Logf("failed to access TLSRoute on %s:%d, error %+v", gatewayIPAddress, tlsPort, err)
+			return false
+		}
+		return true
+	}, testutils.DefaultTLSRouteWait, testutils.WaitTLSRouteTick)
+}
+
+// TestTLSRouteHostnameIntersection verifies that a TLSRoute attached to a Gateway
+// listener with a wildcard hostname is programmed using the intersection of the
+// listener's hostname and the route's spec hostnames. The listener uses
+// "*.example.com" and the route uses "*.com"; their intersection is the more
+// specific wildcard "*.example.com", so an SNI of "abc.example.com" must reach
+// the backend.
+func TestTLSRouteHostnameIntersection(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	clients := integration.GetClients()
+	namespace, cleaner := helpers.SetupTestEnv(t, ctx, integration.GetEnv())
+
+	gatewayConfig := helpers.GenerateGatewayConfiguration(namespace.Name)
+	t.Logf("deploying GatewayConfiguration %s/%s", gatewayConfig.Namespace, gatewayConfig.Name)
+	gatewayConfig, err := integration.GetClients().OperatorClient.GatewayOperatorV2beta1().GatewayConfigurations(namespace.Name).Create(ctx, gatewayConfig, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(gatewayConfig)
+
+	gatewayClass := helpers.MustGenerateGatewayClass(t, gatewayv1.ParametersReference{
+		Group:     gatewayv1.Group(operatorv1beta1.SchemeGroupVersion.Group),
+		Kind:      gatewayv1.Kind("GatewayConfiguration"),
+		Namespace: (*gatewayv1.Namespace)(&gatewayConfig.Namespace),
+		Name:      gatewayConfig.Name,
+	})
+	t.Logf("deploying GatewayClass %s", gatewayClass.Name)
+	gatewayClass, err = integration.GetClients().GatewayClient.GatewayV1().GatewayClasses().Create(ctx, gatewayClass, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(gatewayClass)
+
+	// SNI we will probe with: a name covered by the listener wildcard "*.example.com"
+	// AND by the route wildcard "*.com". A cert with SAN "*.example.com" matches the
+	// SNI for TLS negotiation; passthrough means Kong only routes by SNI.
+	const (
+		listenerHostname = "*.example.com"
+		routeHostname    = "*.com"
+		probeSNI         = "abc.example.com"
+	)
+	certSecretName := "tlsroute-hostname-intersection-cert"
+	cert, key := certificate.MustGenerateCertPEMFormat(certificate.WithDNSNames(listenerHostname, probeSNI))
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace.Name,
+			Name:      certSecretName,
+			Labels: map[string]string{
+				config.DefaultSecretLabelSelector: config.LabelValueForSelectorTrue,
+			},
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       cert,
+			corev1.TLSPrivateKeyKey: key,
+		},
+	}
+	t.Logf("deploying Secret %s/%s", secret.Namespace, secret.Name)
+	secret, err = integration.GetClients().K8sClient.CoreV1().Secrets(namespace.Name).Create(ctx, secret, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	gatewayNSN := types.NamespacedName{
+		Name:      uuid.NewString(),
+		Namespace: namespace.Name,
+	}
+
+	gateway := helpers.GenerateGateway(
+		gatewayNSN, gatewayClass,
+		setTLSListenerWithHostname(tlsPort, gatewayv1.TLSModePassthrough, secret.Name, listenerHostname),
+	)
+	t.Logf("deploying Gateway %s/%s with listener hostname %q", gateway.Namespace, gateway.Name, listenerHostname)
+	gateway, err = integration.GetClients().GatewayClient.GatewayV1().Gateways(namespace.Name).Create(ctx, gateway, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(gateway)
+
+	require.Eventually(t, testutils.GatewayIsAccepted(t, ctx, gatewayNSN, clients), testutils.GatewaySchedulingTimeLimit, time.Second)
+	require.Eventually(t, testutils.GatewayIsProgrammed(t, ctx, gatewayNSN, clients.MgrClient), testutils.GatewayReadyTimeLimit, time.Second)
+	require.Eventually(t, testutils.GatewayListenersAreProgrammed(t, ctx, gatewayNSN, clients), testutils.GatewayReadyTimeLimit, time.Second)
+	require.Eventually(t, testutils.GatewayIPAddressExist(t, ctx, gatewayNSN, clients), testutils.SubresourceReadinessWait, time.Second)
+	gateway = testutils.MustGetGateway(t, ctx, gatewayNSN, clients.MgrClient)
+	gatewayIPAddress := gateway.Status.Addresses[0].Value
+
+	t.Log("deploying tlsecho backend deployment")
+	container := generators.NewContainer("tlsecho", testutils.TCPEchoImage, tlsPort)
+	container.Env = []corev1.EnvVar{
+		{Name: "POD_NAME", Value: "test-tls-echo-intersection"},
+		{Name: "TLS_PORT", Value: strconv.Itoa(tlsPort)},
+		{Name: "TLS_CERT_FILE", Value: "/var/run/certs/tls.crt"},
+		{Name: "TLS_KEY_FILE", Value: "/var/run/certs/tls.key"},
+	}
+	container.VolumeMounts = []corev1.VolumeMount{
+		{MountPath: "/var/run/certs", Name: "cert-secret", ReadOnly: true},
+	}
+	deployment := generators.NewDeploymentForContainer(container)
+	deployment.Spec.Template.Spec.Volumes = []corev1.Volume{
+		{
+			Name: "cert-secret",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  secret.Name,
+					DefaultMode: new(int32(0o644)),
+				},
+			},
+		},
+	}
+	deployment, err = integration.GetEnv().Cluster().Client().AppsV1().Deployments(namespace.Name).Create(ctx, deployment, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("exposing tlsecho deployment %s via service", deployment.Name)
+	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeClusterIP)
+	_, err = integration.GetEnv().Cluster().Client().CoreV1().Services(namespace.Name).Create(ctx, service, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("generating a TLSRoute with spec hostname %q", routeHostname)
+	tlsRoute := helpers.GenerateTLSRoute(namespace.Name, gateway.Name, service.Name, tlsPort, func(r *gatewayv1.TLSRoute) {
+		r.Spec.Hostnames = []gatewayv1.Hostname{
+			gatewayv1.Hostname(routeHostname),
+		}
+	})
+
+	t.Logf("creating tlsroute %s/%s to access deployment %s via kong", tlsRoute.Namespace, tlsRoute.Name, deployment.Name)
+	require.EventuallyWithT(t,
+		func(c *assert.CollectT) {
+			result, err := integration.GetClients().GatewayClient.GatewayV1().TLSRoutes(namespace.Name).Create(ctx, tlsRoute, metav1.CreateOptions{})
+			require.NoError(c, err, "failed to deploy tlsroute %s/%s", tlsRoute.Namespace, tlsRoute.Name)
+			cleaner.Add(result)
+		},
+		testutils.DefaultIngressWait, testutils.WaitIngressTick,
+	)
+
+	t.Logf("verifying connectivity to the TLSRoute at the intersected SNI %q", probeSNI)
+	certPool := x509.NewCertPool()
+	require.True(t, certPool.AppendCertsFromPEM(cert), "Should add certificate to cert pool successfully")
+	require.Eventually(t, func() bool {
+		err := helpers.EchoResponds(t, helpers.ProtocolTLS, fmt.Sprintf("%s:%d", gatewayIPAddress, tlsPort), "test-tls-echo-intersection",
+			helpers.TLSOpt{
+				Hostname:    probeSNI,
+				CertPool:    certPool,
+				Passthrough: true,
 			})
 		if err != nil {
 			t.Logf("failed to access TLSRoute on %s:%d, error %+v", gatewayIPAddress, tlsPort, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Set the hostname of `TLSRoute` to the intersected part with listener's hostname before translating. 
This satisfies the spec of hostname intersection that more precise hostname should be matched when spec's hostname or listener's hostname is wildcard.

**Which issue this PR fixes**

Fixes #4363
Also enables `TLSRouteHostnameIntersection` conformance test case for traditional compatible routers.

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
