### PR TITLE
fix(ingress-controller): Support wildcard TLS SNIs in routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@
   `KONG_OPERATOR_ENABLE_CONTROLLER_KEGDATAPLANE`, default `false`) to enable
   the KEG (Kong Event Gateway) DataPlane controller.
   [#4391](https://github.com/Kong/kong-operator/pull/4391)
+- Support wildcard TLS SNI matching in Kong routes for Kong 3.7.0 and above in
+  on-prem gateways.
+  [#4389](https://github.com/Kong/kong-operator/pull/4389)
 - DataPlane: extend Kong image validation to support sha256 digest
   [#4356](https://github.com/Kong/kong-operator/pull/4356)
 - Konnect: support `KongCertificate` ref in `KongUpstream`

--- a/ingress-controller/internal/admission/validation/gateway/httproute.go
+++ b/ingress-controller/internal/admission/validation/gateway/httproute.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr"
 	"github.com/kong/go-kong/kong"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -35,6 +36,7 @@ type routeValidator interface {
 func ValidateHTTPRoute(
 	ctx context.Context,
 	routesValidator routeValidator,
+	kongVersion semver.Version,
 	translatorFeatures translator.FeatureFlags,
 	httproute *gatewayapi.HTTPRoute,
 	managerClient client.Client,
@@ -71,7 +73,7 @@ func ValidateHTTPRoute(
 	}
 
 	// Validate that the route is valid against Kong Gateway.
-	ok, msg := validateWithKongGateway(ctx, routesValidator, translatorFeatures, httproute)
+	ok, msg := validateWithKongGateway(ctx, routesValidator, kongVersion, translatorFeatures, httproute)
 	return ok, msg, nil
 }
 
@@ -233,7 +235,7 @@ func validateHTTPRouteRegexes(httproute *gatewayapi.HTTPRoute) error {
 // -----------------------------------------------------------------------------
 
 func validateWithKongGateway(
-	ctx context.Context, routesValidator routeValidator, translatorFeatures translator.FeatureFlags, httproute *gatewayapi.HTTPRoute,
+	ctx context.Context, routesValidator routeValidator, kongVersion semver.Version, translatorFeatures translator.FeatureFlags, httproute *gatewayapi.HTTPRoute,
 ) (bool, string) {
 	// Translate HTTPRoute to Kong Route object(s) that can be sent directly to the Admin API for validation.
 	// Reuse KIC translator that works both for traditional and expressions router to use exactly the same logic.
@@ -259,7 +261,7 @@ func validateWithKongGateway(
 	}
 	for _, service := range translationResult.ServiceNameToKongstateService {
 		for _, route := range service.Routes {
-			route.Override(logr.Discard())
+			route.Override(logr.Discard(), kongVersion)
 			ok, msg, err := routesValidator.Validate(ctx, &route.Route)
 			if err != nil {
 				return false, fmt.Sprintf("Unable to validate HTTPRoute schema: %s", err.Error())

--- a/ingress-controller/internal/admission/validation/gateway/httproute_test.go
+++ b/ingress-controller/internal/admission/validation/gateway/httproute_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -34,6 +35,7 @@ func TestValidateHTTPRoute(t *testing.T) {
 				ControllerName: gatewaycontroller.GetControllerName(),
 			},
 		}
+		kongVersionSupportWildcardSNI = semver.MustParse("3.7.0")
 	)
 
 	for _, tt := range []struct {
@@ -1064,7 +1066,7 @@ func TestValidateHTTPRoute(t *testing.T) {
 
 			// Passed routesValidator is irrelevant for the above test cases.
 			valid, validMsg, err := ValidateHTTPRoute(
-				t.Context(), mockRoutesValidator{}, translator.FeatureFlags{}, tt.route, fakeClient,
+				t.Context(), mockRoutesValidator{}, kongVersionSupportWildcardSNI, translator.FeatureFlags{}, tt.route, fakeClient,
 			)
 			assert.Equal(t, tt.valid, valid, tt.msg)
 			assert.Equal(t, tt.validationMsg, validMsg, tt.msg)

--- a/ingress-controller/internal/admission/validation/ingress/ingress.go
+++ b/ingress-controller/internal/admission/validation/ingress/ingress.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr"
 	"github.com/kong/go-kong/kong"
 	netv1 "k8s.io/api/networking/v1"
@@ -24,6 +25,7 @@ type routeValidator interface {
 func ValidateIngress(
 	ctx context.Context,
 	routesValidator routeValidator,
+	kongVersion semver.Version,
 	translatorFeatures translator.FeatureFlags,
 	ingress *netv1.Ingress,
 	logger logr.Logger,
@@ -38,7 +40,7 @@ func ValidateIngress(
 		return false, fmt.Sprintf("Ingress has invalid Kong annotations: %s", err), nil
 	}
 
-	for _, kg := range ingressToKongRoutesForValidation(translatorFeatures, ingress, failuresCollector, logger, storer) {
+	for _, kg := range ingressToKongRoutesForValidation(kongVersion, translatorFeatures, ingress, failuresCollector, logger, storer) {
 		// Validate by using feature of Kong Gateway.
 		ok, msg, err := routesValidator.Validate(ctx, &kg)
 		if err != nil {
@@ -61,6 +63,7 @@ func ValidateIngress(
 // ingressToKongRoutesForValidation converts Ingress to Kong Routes that can be validated by Kong Gateway,
 // discards everything else that is not needed for validation.
 func ingressToKongRoutesForValidation(
+	kongVersion semver.Version,
 	translatorFeatures translator.FeatureFlags,
 	ingress *netv1.Ingress,
 	failuresCollector subtranslator.FailuresCollector,
@@ -82,7 +85,7 @@ func ingressToKongRoutesForValidation(
 	var kongRoutes []kong.Route
 	for _, svc := range kongServices {
 		for _, route := range svc.Routes {
-			route.Override(logger)
+			route.Override(logger, kongVersion)
 			kongRoutes = append(kongRoutes, route.Route)
 		}
 	}

--- a/ingress-controller/internal/admission/validation/ingress/ingress_test.go
+++ b/ingress-controller/internal/admission/validation/ingress/ingress_test.go
@@ -18,9 +18,11 @@ import (
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/annotations"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/dataplane/translator"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/store"
+	"github.com/kong/kong-operator/v2/ingress-controller/internal/versions"
 )
 
 func TestValidateIngress(t *testing.T) {
+	kongVersionSupportWildcardSNI := versions.KongWildcardSNICutoff
 	for _, tt := range []struct {
 		msg           string
 		ingress       *netv1.Ingress
@@ -91,6 +93,7 @@ func TestValidateIngress(t *testing.T) {
 			valid, validMsg, err := ValidateIngress(
 				t.Context(),
 				mockRoutesValidator{},
+				kongVersionSupportWildcardSNI,
 				translator.FeatureFlags{},
 				tt.ingress,
 				logger,

--- a/ingress-controller/internal/admission/validator.go
+++ b/ingress-controller/internal/admission/validator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr"
 	"github.com/kong/go-kong/kong"
 	"github.com/samber/lo"
@@ -118,6 +119,7 @@ type KongHTTPValidator struct {
 	Storer                   store.Storer
 	ManagerClient            client.Client
 	AdminAPIServicesProvider AdminAPIServicesProvider
+	KongVersion              semver.Version
 	TranslatorFeatures       translator.FeatureFlags
 	// ReferenceIndexers gets the resources (KongPlugin and KongClusterPlugin)
 	// referring the validated resource (Secret) to check the changes on
@@ -137,6 +139,7 @@ func NewKongHTTPValidator(
 	managerClient client.Client,
 	ingressClass string,
 	servicesProvider AdminAPIServicesProvider,
+	kongVersion semver.Version,
 	translatorFeatures translator.FeatureFlags,
 	storer store.Storer,
 	referenceIndexer ctrlref.CacheIndexers,
@@ -148,6 +151,7 @@ func NewKongHTTPValidator(
 		Storer:                   storer,
 		ManagerClient:            managerClient,
 		AdminAPIServicesProvider: servicesProvider,
+		KongVersion:              kongVersion,
 		TranslatorFeatures:       translatorFeatures,
 		ReferenceIndexers:        referenceIndexer,
 
@@ -466,7 +470,7 @@ func (validator KongHTTPValidator) ValidateHTTPRoute(
 		routeValidator = routesSvc
 	}
 	return gatewayvalidation.ValidateHTTPRoute(
-		ctx, routeValidator, validator.TranslatorFeatures, &httproute, validator.ManagerClient,
+		ctx, routeValidator, validator.KongVersion, validator.TranslatorFeatures, &httproute, validator.ManagerClient,
 	)
 }
 
@@ -477,7 +481,7 @@ func (validator KongHTTPValidator) ValidateIngress(
 	if routesSvc, ok := validator.AdminAPIServicesProvider.GetRoutesService(); ok {
 		routeValidator = routesSvc
 	}
-	return ingressvalidation.ValidateIngress(ctx, routeValidator, validator.TranslatorFeatures, &ingress, validator.Logger, validator.Storer)
+	return ingressvalidation.ValidateIngress(ctx, routeValidator, validator.KongVersion, validator.TranslatorFeatures, &ingress, validator.Logger, validator.Storer)
 }
 
 type routeValidator interface {

--- a/ingress-controller/internal/dataplane/kongstate/kongstate.go
+++ b/ingress-controller/internal/dataplane/kongstate/kongstate.go
@@ -292,7 +292,7 @@ func (ks *KongState) FillOverrides(
 			// down into the kongstate.Route copy looked a bit annoying. Protocol validation for routes instead lives in the
 			// HTTPRoute and Ingress translators (these may override to ws/wss, whereas the others are expected to derive
 			// their protocol from the resource type alone).
-			ks.Services[i].Routes[j].Override(logger)
+			ks.Services[i].Routes[j].Override(logger, kongVersion)
 		}
 	}
 

--- a/ingress-controller/internal/dataplane/kongstate/route.go
+++ b/ingress-controller/internal/dataplane/kongstate/route.go
@@ -5,11 +5,13 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr"
 	"github.com/kong/go-kong/kong"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/annotations"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/util"
+	"github.com/kong/kong-operator/v2/ingress-controller/internal/versions"
 )
 
 // Route represents a Kong Route and holds a reference to the Ingress
@@ -202,7 +204,7 @@ func (r *Route) overrideMethods(logger logr.Logger, anns map[string]string) {
 	r.Methods = methods
 }
 
-func (r *Route) overrideSNIs(logger logr.Logger, anns map[string]string) {
+func (r *Route) overrideSNIs(logger logr.Logger, anns map[string]string, kongVersion semver.Version) {
 	var annSNIs []string
 	var exists bool
 	annSNIs, exists = annotations.ExtractSNIs(anns)
@@ -213,12 +215,23 @@ func (r *Route) overrideSNIs(logger logr.Logger, anns map[string]string) {
 	}
 	var snis []*string
 	for _, sni := range annSNIs {
-		if validSNIs.MatchString(sni) {
-			snis = append(snis, new(sni))
+		if kongVersion.LT(versions.KongWildcardSNICutoff) {
+			if validSNIs.MatchString(sni) {
+				snis = append(snis, new(sni))
+			} else {
+				// SNI is not a valid hostname
+				logger.Error(nil, "Invalid SNI", "route_name", r.Name, "sni", sni)
+				return
+			}
 		} else {
-			// SNI is not a valid hostname
-			logger.Error(nil, "Invalid SNI", "route_name", r.Name, "sni", sni)
-			return
+			// for Kong versions that support wildcard SNIs, we can validate against the more permissive validHosts regex
+			if validHosts.MatchString(sni) {
+				snis = append(snis, new(sni))
+			} else {
+				// SNI is not a valid hostname or wildcard hostname
+				logger.Error(nil, "Invalid SNI", "route_name", r.Name, "sni", sni)
+				return
+			}
 		}
 	}
 
@@ -226,7 +239,7 @@ func (r *Route) overrideSNIs(logger logr.Logger, anns map[string]string) {
 }
 
 // overrideByAnnotation sets Route protocols via annotation.
-func (r *Route) overrideByAnnotation(logger logr.Logger) {
+func (r *Route) overrideByAnnotation(logger logr.Logger, kongVersion semver.Version) {
 	r.overrideStripPath(r.Ingress.Annotations)
 	r.overrideHTTPSRedirectCode(r.Ingress.Annotations)
 	r.overridePreserveHost(r.Ingress.Annotations)
@@ -238,7 +251,7 @@ func (r *Route) overrideByAnnotation(logger logr.Logger) {
 	if !r.ExpressionRoutes {
 		r.overrideRegexPriority(r.Ingress.Annotations)
 		r.overrideMethods(logger, r.Ingress.Annotations)
-		r.overrideSNIs(logger, r.Ingress.Annotations)
+		r.overrideSNIs(logger, r.Ingress.Annotations, kongVersion)
 		r.overrideHosts(logger, r.Ingress.Annotations)
 		r.overrideHeaders(r.Ingress.Annotations)
 		r.overridePathHandling(logger, r.Ingress.Annotations)
@@ -246,12 +259,12 @@ func (r *Route) overrideByAnnotation(logger logr.Logger) {
 }
 
 // Override sets Route fields by annotation.
-func (r *Route) Override(logger logr.Logger) {
+func (r *Route) Override(logger logr.Logger, kongVersion semver.Version) {
 	if r == nil {
 		return
 	}
 
-	r.overrideByAnnotation(logger)
+	r.overrideByAnnotation(logger, kongVersion)
 	r.normalizeProtocols()
 }
 

--- a/ingress-controller/internal/dataplane/kongstate/route.go
+++ b/ingress-controller/internal/dataplane/kongstate/route.go
@@ -25,13 +25,16 @@ type Route struct {
 }
 
 var (
-	validMethods      = regexp.MustCompile(`\A[A-Z]+$`)
-	validPathHandling = regexp.MustCompile(`v\d`)
+	// ValidMethods is a regex to validate HTTP methods, which should be uppercase alpha strings.
+	ValidMethods = regexp.MustCompile(`\A[A-Z]+$`)
+	// ValidPathHandling is a regex to validate path handling modes, which should be "v0" or "v1" for now.
+	ValidPathHandling = regexp.MustCompile(`v\d`)
 
+	// ValidSNIs is a regex to validate SNIs, which should be valid hostnames without wildcard prefix.
 	// hostnames are complicated. shamelessly cribbed from https://stackoverflow.com/a/18494710
-	// TODO if the Kong core adds support for wildcard SNI route match criteria, this should change.
-	validSNIs  = regexp.MustCompile(`^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)+(\.([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*))*$`)
-	validHosts = regexp.MustCompile(`^(\*\.)?([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)+(\.([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*))*?(\.\*)?$`)
+	ValidSNIs = regexp.MustCompile(`^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)+(\.([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*))*$`)
+	// ValidHosts is a regex to validate hosts, which should be valid hostnames or wildcard hostnames.
+	ValidHosts = regexp.MustCompile(`^(\*\.)?([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)+(\.([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*))*?(\.\*)?$`)
 )
 
 // normalizeProtocols prevents users from mismatching grpc/http.
@@ -191,7 +194,7 @@ func (r *Route) overrideMethods(logger logr.Logger, anns map[string]string) {
 	}
 	var methods []*string
 	for _, method := range annMethods {
-		if validMethods.MatchString(method) {
+		if ValidMethods.MatchString(method) {
 			methods = append(methods, new(method))
 		} else {
 			// if any method is invalid (not an uppercase alpha string),
@@ -216,7 +219,7 @@ func (r *Route) overrideSNIs(logger logr.Logger, anns map[string]string, kongVer
 	var snis []*string
 	for _, sni := range annSNIs {
 		if kongVersion.LT(versions.KongWildcardSNICutoff) {
-			if validSNIs.MatchString(sni) {
+			if ValidSNIs.MatchString(sni) {
 				snis = append(snis, new(sni))
 			} else {
 				// SNI is not a valid hostname
@@ -225,7 +228,7 @@ func (r *Route) overrideSNIs(logger logr.Logger, anns map[string]string, kongVer
 			}
 		} else {
 			// for Kong versions that support wildcard SNIs, we can validate against the more permissive validHosts regex
-			if validHosts.MatchString(sni) {
+			if ValidHosts.MatchString(sni) {
 				snis = append(snis, new(sni))
 			} else {
 				// SNI is not a valid hostname or wildcard hostname
@@ -328,7 +331,7 @@ func (r *Route) overrideHosts(logger logr.Logger, anns map[string]string) {
 	// Merge hosts and host-aliases
 	hosts = append(hosts, r.Hosts...)
 	for _, hostAlias := range annHostAliases {
-		if validHosts.MatchString(hostAlias) {
+		if ValidHosts.MatchString(hostAlias) {
 			hosts = appendIfMissing(hosts, hostAlias)
 		} else {
 			// Host Alias is not a valid hostname
@@ -354,7 +357,7 @@ func (r *Route) overridePathHandling(logger logr.Logger, anns map[string]string)
 		return
 	}
 
-	if !validPathHandling.MatchString(val) {
+	if !ValidPathHandling.MatchString(val) {
 		logger.Error(nil, "Invalid path_handling", "value", val, "kongroute", r.Name)
 		return
 	}

--- a/ingress-controller/internal/dataplane/kongstate/route_test.go
+++ b/ingress-controller/internal/dataplane/kongstate/route_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-logr/zapr"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
@@ -211,7 +212,7 @@ func TestOverrideRoute(t *testing.T) {
 			route.Ingress = util.K8sObjectInfo{
 				Annotations: tc.inAnnotations,
 			}
-			route.overrideByAnnotation(zapr.NewLogger(zap.NewNop()))
+			route.overrideByAnnotation(zapr.NewLogger(zap.NewNop()), defaultTestKongVersion)
 			require.Equal(t, tc.expectedRoute.Route, route.Route)
 		})
 	}
@@ -220,7 +221,7 @@ func TestOverrideRoute(t *testing.T) {
 func TestNilRouteOverrideDoesntPanic(t *testing.T) {
 	require.NotPanics(t, func() {
 		var nilRoute *Route
-		nilRoute.Override(zapr.NewLogger(zap.NewNop()))
+		nilRoute.Override(zapr.NewLogger(zap.NewNop()), defaultTestKongVersion)
 	})
 }
 
@@ -305,7 +306,7 @@ func TestOverrideExpressionRoute(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i)+"-"+tc.name, func(t *testing.T) {
-			tc.inRoute.Override(zapr.NewLogger(zap.NewNop()))
+			tc.inRoute.Override(zapr.NewLogger(zap.NewNop()), defaultTestKongVersion)
 			assert.Equal(t, tc.outRoute, tc.inRoute, "should be the same as expected after overriding")
 		})
 	}
@@ -800,9 +801,12 @@ func TestOverrideRouteMethods(t *testing.T) {
 }
 
 func TestOverrideRouteSNIs(t *testing.T) {
+	kongVersionNotSupportingWildcardSNI := semver.MustParse("3.4.3")
+	kongVersionSupportingWildcardSNI := semver.MustParse("3.10.0")
 	type args struct {
-		route Route
-		anns  map[string]string
+		route       Route
+		anns        map[string]string
+		kongVersion semver.Version
 	}
 	tests := []struct {
 		name string
@@ -816,6 +820,7 @@ func TestOverrideRouteSNIs(t *testing.T) {
 				anns: map[string]string{
 					"konghq.com/snis": "hrodna.kong.example, katowice.kong.example",
 				},
+				kongVersion: kongVersionNotSupportingWildcardSNI,
 			},
 			want: Route{
 				Route: kong.Route{
@@ -829,20 +834,36 @@ func TestOverrideRouteSNIs(t *testing.T) {
 				anns: map[string]string{
 					"konghq.com/snis": "-10,GET",
 				},
+				kongVersion: kongVersionNotSupportingWildcardSNI,
 			},
 		},
 		{
-			name: "wildcard hostname, not valid for SNI",
+			name: "wildcard hostname, not valid for SNI if version does not support it",
 			args: args{
 				anns: map[string]string{
 					"konghq.com/snis": "*.example.com",
+				},
+				kongVersion: kongVersionNotSupportingWildcardSNI,
+			},
+		},
+		{
+			name: "wildcard hostname, valid for SNI if version supports it",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/snis": "*.example.com",
+				},
+				kongVersion: kongVersionSupportingWildcardSNI,
+			},
+			want: Route{
+				Route: kong.Route{
+					SNIs: kong.StringSlice("*.example.com"),
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.args.route.overrideSNIs(zapr.NewLogger(zap.NewNop()), tt.args.anns)
+			tt.args.route.overrideSNIs(zapr.NewLogger(zap.NewNop()), tt.args.anns, tt.args.kongVersion)
 			if !reflect.DeepEqual(tt.args.route, tt.want) {
 				t.Errorf("overrideRouteSNIs() got = %v, want %v", tt.args.route, tt.want)
 			}

--- a/ingress-controller/internal/dataplane/translator/subtranslator/atc_utils.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/atc_utils.go
@@ -3,6 +3,7 @@ package subtranslator
 import (
 	"strings"
 
+	"github.com/kong/kong-operator/v2/ingress-controller/internal/dataplane/kongstate"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/dataplane/translator/atc"
 )
 
@@ -48,7 +49,7 @@ const (
 func hostMatcherFromHosts(hosts []string) atc.Matcher {
 	matchers := make([]atc.Matcher, 0, len(hosts))
 	for _, host := range hosts {
-		if !validHosts.MatchString(host) {
+		if !kongstate.ValidHosts.MatchString(host) {
 			continue
 		}
 
@@ -71,7 +72,7 @@ func hostMatcherFromHosts(hosts []string) atc.Matcher {
 func sniMatcherFromSNIs(snis []string) atc.Matcher {
 	matchers := make([]atc.Matcher, 0, len(snis))
 	for _, sni := range snis {
-		if !validHosts.MatchString(sni) {
+		if !kongstate.ValidHosts.MatchString(sni) {
 			continue
 		}
 		if suffix, ok := strings.CutPrefix(sni, "*"); ok {

--- a/ingress-controller/internal/dataplane/translator/subtranslator/atc_utils.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/atc_utils.go
@@ -62,3 +62,25 @@ func hostMatcherFromHosts(hosts []string) atc.Matcher {
 	}
 	return atc.Or(matchers...)
 }
+
+// sniMatcherFromSNIs generates matchers to match TLS SNIs.
+// used in translating TLSRoute rules and `SNIs` annotations in ingresses.
+// the SNI format includes:
+// - wildcard SNIs, starting with exactly one *
+// - precise SNIs, otherwise.
+func sniMatcherFromSNIs(snis []string) atc.Matcher {
+	matchers := make([]atc.Matcher, 0, len(snis))
+	for _, sni := range snis {
+		if !validHosts.MatchString(sni) {
+			continue
+		}
+		if suffix, ok := strings.CutPrefix(sni, "*"); ok {
+			// wildcard match on SNIs (like *.foo.com), genreate a suffix match.
+			matchers = append(matchers, atc.NewPredicateTLSSNI(atc.OpSuffixMatch, suffix))
+		} else {
+			// exact match on SNIs, generate an exact match.
+			matchers = append(matchers, atc.NewPredicateTLSSNI(atc.OpEqual, sni))
+		}
+	}
+	return atc.Or(matchers...)
+}

--- a/ingress-controller/internal/dataplane/translator/subtranslator/atc_utils_test.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/atc_utils_test.go
@@ -41,3 +41,37 @@ func TestHostMatcherFromHosts(t *testing.T) {
 		})
 	}
 }
+
+func TestSNIMatcherFromSNIs(t *testing.T) {
+	testCases := []struct {
+		name       string
+		snis       []string
+		expression string
+	}{
+		{
+			name:       "single SNI",
+			snis:       []string{"konghq.com"},
+			expression: `tls.sni == "konghq.com"`,
+		},
+		{
+			name:       "multiple SNIs",
+			snis:       []string{"docs.konghq.com", "apis.konghq.com"},
+			expression: `(tls.sni == "docs.konghq.com") || (tls.sni == "apis.konghq.com")`,
+		},
+		{
+			name:       "multiple SNIs with wildcard SNI,",
+			snis:       []string{"foo.com", "*.bar.com"},
+			expression: `(tls.sni == "foo.com") || (tls.sni =^ ".bar.com")`,
+		},
+		{
+			name:       "multiple SNIs with invalid SNI",
+			snis:       []string{"foo.com", "a..bar.com"},
+			expression: `tls.sni == "foo.com"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		matcher := sniMatcherFromSNIs(tc.snis)
+		require.Equal(t, tc.expression, matcher.Expression())
+	}
+}

--- a/ingress-controller/internal/dataplane/translator/subtranslator/ingress_atc.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/ingress_atc.go
@@ -21,8 +21,6 @@ var (
 	validMethods = regexp.MustCompile(`\A[A-Z]+$`)
 
 	// hostnames are complicated. shamelessly cribbed from https://stackoverflow.com/a/18494710
-	// TODO if the Kong core adds support for wildcard SNI route match criteria, this should change.
-	validSNIs  = regexp.MustCompile(`^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)+(\.([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*))*$`)
 	validHosts = regexp.MustCompile(`^(\*\.)?([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)+(\.([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*))*?(\.\*)?$`)
 )
 
@@ -199,18 +197,6 @@ func methodMatcherFromMethods(methods []string) atc.Matcher {
 			continue
 		}
 		matchers = append(matchers, atc.NewPredicateHTTPMethod(atc.OpEqual, method))
-	}
-	return atc.Or(matchers...)
-}
-
-// sniMatcherFromSNIs generates matchers to match TLS SNIs.
-func sniMatcherFromSNIs(snis []string) atc.Matcher {
-	matchers := make([]atc.Matcher, 0, len(snis))
-	for _, sni := range snis {
-		if !validSNIs.MatchString(sni) {
-			continue
-		}
-		matchers = append(matchers, atc.NewPredicateTLSSNI(atc.OpEqual, sni))
 	}
 	return atc.Or(matchers...)
 }

--- a/ingress-controller/internal/dataplane/translator/subtranslator/ingress_atc.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/ingress_atc.go
@@ -1,7 +1,6 @@
 package subtranslator
 
 import (
-	"regexp"
 	"sort"
 	"strings"
 
@@ -17,11 +16,6 @@ import (
 
 var (
 	headerAnnotationRegexPrefix = "~*"
-
-	validMethods = regexp.MustCompile(`\A[A-Z]+$`)
-
-	// hostnames are complicated. shamelessly cribbed from https://stackoverflow.com/a/18494710
-	validHosts = regexp.MustCompile(`^(\*\.)?([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)+(\.([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*))*?(\.\*)?$`)
 )
 
 const IngressDefaultBackendPriority RoutePriorityType = 0
@@ -193,7 +187,7 @@ func headerMatcherFromHeaders(headers map[string][]string) atc.Matcher {
 func methodMatcherFromMethods(methods []string) atc.Matcher {
 	matchers := make([]atc.Matcher, 0, len(methods))
 	for _, method := range methods {
-		if !validMethods.MatchString(method) {
+		if !kongstate.ValidMethods.MatchString(method) {
 			continue
 		}
 		matchers = append(matchers, atc.NewPredicateHTTPMethod(atc.OpEqual, method))

--- a/ingress-controller/internal/dataplane/translator/subtranslator/ingress_atc_test.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/ingress_atc_test.go
@@ -793,37 +793,3 @@ func TestMethodMatcherFromMethods(t *testing.T) {
 		require.Equal(t, tc.expression, matcher.Expression())
 	}
 }
-
-func TestSNIMatcherFromSNIs(t *testing.T) {
-	testCases := []struct {
-		name       string
-		snis       []string
-		expression string
-	}{
-		{
-			name:       "single SNI",
-			snis:       []string{"konghq.com"},
-			expression: `tls.sni == "konghq.com"`,
-		},
-		{
-			name:       "multiple SNIs",
-			snis:       []string{"docs.konghq.com", "apis.konghq.com"},
-			expression: `(tls.sni == "docs.konghq.com") || (tls.sni == "apis.konghq.com")`,
-		},
-		{
-			name:       "multiple SNIs with wildcard SNI,",
-			snis:       []string{"foo.com", "*.bar.com"},
-			expression: `(tls.sni == "foo.com") || (tls.sni =^ ".bar.com")`,
-		},
-		{
-			name:       "multiple SNIs with invalid SNI",
-			snis:       []string{"foo.com", "a..bar.com"},
-			expression: `tls.sni == "foo.com"`,
-		},
-	}
-
-	for _, tc := range testCases {
-		matcher := sniMatcherFromSNIs(tc.snis)
-		require.Equal(t, tc.expression, matcher.Expression())
-	}
-}

--- a/ingress-controller/internal/dataplane/translator/subtranslator/ingress_atc_test.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/ingress_atc_test.go
@@ -811,9 +811,9 @@ func TestSNIMatcherFromSNIs(t *testing.T) {
 			expression: `(tls.sni == "docs.konghq.com") || (tls.sni == "apis.konghq.com")`,
 		},
 		{
-			name:       "multiple SNIs with wildcard SNI, which should be omitted",
+			name:       "multiple SNIs with wildcard SNI,",
 			snis:       []string{"foo.com", "*.bar.com"},
-			expression: `tls.sni == "foo.com"`,
+			expression: `(tls.sni == "foo.com") || (tls.sni =^ ".bar.com")`,
 		},
 		{
 			name:       "multiple SNIs with invalid SNI",

--- a/ingress-controller/internal/dataplane/translator/translate_tlsroute.go
+++ b/ingress-controller/internal/dataplane/translator/translate_tlsroute.go
@@ -33,6 +33,7 @@ func (t *Translator) ingressRulesFromTLSRoutes() ingressRules {
 	var errs []error
 	for _, tlsroute := range tlsRouteList {
 		if err := t.ingressRulesFromTLSRoute(&result, tlsroute); err != nil {
+			t.failuresCollector.PushResourceFailure(err.Error(), tlsroute)
 			err = fmt.Errorf("TLSRoute %s/%s can't be routed: %w", tlsroute.Namespace, tlsroute.Name, err)
 			errs = append(errs, err)
 		} else {

--- a/ingress-controller/internal/dataplane/translator/translate_tlsroute.go
+++ b/ingress-controller/internal/dataplane/translator/translate_tlsroute.go
@@ -3,8 +3,10 @@ package translator
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/kong/go-kong/kong"
+	"github.com/samber/lo"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/dataplane/translator/subtranslator"
@@ -56,6 +58,13 @@ func (t *Translator) ingressRulesFromTLSRoute(result *ingressRules, tlsroute *ga
 	if len(spec.Hostnames) == 0 {
 		return fmt.Errorf("no hostnames provided")
 	}
+	if t.kongVersion.LT(TLSWildcardSNIMinimumKongVersion) &&
+		lo.ContainsBy(spec.Hostnames, func(hostname gatewayapi.Hostname) bool {
+			return strings.HasPrefix(string(hostname), "*.")
+		}) {
+		return fmt.Errorf("wildcard TLS SNIs are not supported in TLSRoute with Kong versions below %s", TLSWildcardSNIMinimumKongVersion)
+	}
+
 	if len(spec.Rules) == 0 {
 		return subtranslator.ErrRouteValidationNoRules
 	}

--- a/ingress-controller/internal/dataplane/translator/translate_tlsroute.go
+++ b/ingress-controller/internal/dataplane/translator/translate_tlsroute.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/dataplane/translator/subtranslator"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/gatewayapi"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/store"
+	"github.com/kong/kong-operator/v2/ingress-controller/internal/versions"
 )
 
 // -----------------------------------------------------------------------------
@@ -58,11 +59,11 @@ func (t *Translator) ingressRulesFromTLSRoute(result *ingressRules, tlsroute *ga
 	if len(spec.Hostnames) == 0 {
 		return fmt.Errorf("no hostnames provided")
 	}
-	if t.kongVersion.LT(TLSWildcardSNIMinimumKongVersion) &&
+	if t.kongVersion.LT(versions.KongWildcardSNICutoff) &&
 		lo.ContainsBy(spec.Hostnames, func(hostname gatewayapi.Hostname) bool {
 			return strings.HasPrefix(string(hostname), "*.")
 		}) {
-		return fmt.Errorf("wildcard TLS SNIs are not supported in TLSRoute with Kong versions below %s", TLSWildcardSNIMinimumKongVersion)
+		return fmt.Errorf("wildcard TLS SNIs are not supported in TLSRoute with Kong versions below %s", versions.KongWildcardSNICutoff.String())
 	}
 
 	if len(spec.Rules) == 0 {

--- a/ingress-controller/internal/dataplane/translator/translate_tlsroute_test.go
+++ b/ingress-controller/internal/dataplane/translator/translate_tlsroute_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-logr/zapr"
 	"github.com/kong/go-kong/kong"
 	"github.com/samber/lo"
@@ -11,6 +12,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/dataplane/failures"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/dataplane/kongstate"
@@ -19,42 +21,74 @@ import (
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/util/builder"
 )
 
-func TestIngressRulesFromTLSRoutesUsingExpressionRoutes(t *testing.T) {
-	tlsRouteTypeMeta := metav1.TypeMeta{Kind: "TLSRoute", APIVersion: corev1.SchemeGroupVersion.String()}
+func TestIngressRulesFromTLSRoutes(t *testing.T) {
+	tlsRouteTypeMeta := gatewayapi.TLSRouteTypeMeta
+	kongVersionNotSupportingWildcardSNI := semver.MustParse("3.4.3")
+	kongVersionSupportingWildcardSNI := semver.MustParse("3.7.0")
 
-	testCases := []struct {
-		name                 string
-		tcpRoutes            []*gatewayapi.TLSRoute
-		services             []*corev1.Service
-		expectedKongServices []kongstate.Service
-		expectedKongRoutes   map[string][]kongstate.Route
-		expectedFailures     []failures.ResourceFailure
-	}{
-		{
-			name: "tlsroute with single rule",
-			tcpRoutes: []*gatewayapi.TLSRoute{
+	mustCreateResourceFailure := func(message string, causingObjects ...client.Object) failures.ResourceFailure {
+		failure, err := failures.NewResourceFailure(message, causingObjects...)
+		require.NoError(t, err)
+		return failure
+	}
+
+	tlsRouteExactHostname := &gatewayapi.TLSRoute{
+		TypeMeta: tlsRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "tlsroute-1",
+		},
+		Spec: gatewayapi.TLSRouteSpec{
+			Hostnames: []gatewayapi.Hostname{
+				"foo.com",
+				"bar.com",
+			},
+			Rules: []gatewayapi.TLSRouteRule{
 				{
-					TypeMeta: tlsRouteTypeMeta,
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "tlsroute-1",
-					},
-					Spec: gatewayapi.TLSRouteSpec{
-						Hostnames: []gatewayapi.Hostname{
-							"foo.com",
-							"bar.com",
-						},
-						Rules: []gatewayapi.TLSRouteRule{
-							{
-								BackendRefs: []gatewayapi.BackendRef{
-									builder.NewBackendRef("service1").WithPort(80).Build(),
-									builder.NewBackendRef("service2").WithPort(443).Build(),
-								},
-							},
-						},
+					BackendRefs: []gatewayapi.BackendRef{
+						builder.NewBackendRef("service1").WithPort(80).Build(),
+						builder.NewBackendRef("service2").WithPort(443).Build(),
 					},
 				},
 			},
+		},
+	}
+
+	tlsRouteWildcardHostname := &gatewayapi.TLSRoute{
+		TypeMeta: tlsRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "tlsroute-1",
+		},
+		Spec: gatewayapi.TLSRouteSpec{
+			Hostnames: []gatewayapi.Hostname{
+				"*.foo.com",
+			},
+			Rules: []gatewayapi.TLSRouteRule{
+				{
+					BackendRefs: []gatewayapi.BackendRef{
+						builder.NewBackendRef("service1").WithPort(80).Build(),
+					},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name                    string
+		kongVersion             semver.Version
+		expressionRoutesEnabled bool
+		tlsRoutes               []*gatewayapi.TLSRoute
+		services                []*corev1.Service
+		expectedKongServices    []kongstate.Service
+		expectedKongRoutes      map[string][]kongstate.Route
+		expectedFailures        []failures.ResourceFailure
+	}{
+		{
+			name:                    "tlsroute with single rule and exact hostnames",
+			kongVersion:             kongVersionNotSupportingWildcardSNI,
+			expressionRoutesEnabled: true,
+			tlsRoutes:               []*gatewayapi.TLSRoute{tlsRouteExactHostname},
 			// After https://github.com/Kong/kubernetes-ingress-controller/pull/5392
 			// is merged the backendRef will be checked for existence in the store
 			// so we need to add them here.
@@ -100,39 +134,9 @@ func TestIngressRulesFromTLSRoutesUsingExpressionRoutes(t *testing.T) {
 			},
 		},
 		{
-			name: "tlsroute with multiple rules",
-			tcpRoutes: []*gatewayapi.TLSRoute{
-				{
-					TypeMeta: tlsRouteTypeMeta,
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "tlsroute-1",
-					},
-					Spec: gatewayapi.TLSRouteSpec{
-						Hostnames: []gatewayapi.Hostname{
-							"foo.com",
-							"bar.com",
-						},
-						Rules: []gatewayapi.TLSRouteRule{
-							{
-								BackendRefs: []gatewayapi.BackendRef{
-									builder.NewBackendRef("service1").WithPort(80).Build(),
-									builder.NewBackendRef("service2").WithPort(443).Build(),
-								},
-							},
-							{
-								BackendRefs: []gatewayapi.BackendRef{
-									builder.NewBackendRef("service3").WithPort(8080).Build(),
-									builder.NewBackendRef("service4").WithPort(8443).Build(),
-								},
-							},
-						},
-					},
-				},
-			},
-			// After https://github.com/Kong/kubernetes-ingress-controller/pull/5392
-			// is merged the backendRef will be checked for existence in the store
-			// so we need to add them here.
+			name:        "tlsroute with wildcard hostname on Kong version not supporting it",
+			kongVersion: kongVersionNotSupportingWildcardSNI,
+			tlsRoutes:   []*gatewayapi.TLSRoute{tlsRouteWildcardHostname},
 			services: []*corev1.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -140,22 +144,21 @@ func TestIngressRulesFromTLSRoutesUsingExpressionRoutes(t *testing.T) {
 						Name:      "service1",
 					},
 				},
+			},
+			expectedFailures: []failures.ResourceFailure{
+				mustCreateResourceFailure("wildcard TLS SNIs are not supported in TLSRoute with Kong versions below 3.7.0", tlsRouteWildcardHostname),
+			},
+		},
+		{
+			name:                    "tlsroute with wildcard hostname on Kong version supporting it",
+			kongVersion:             kongVersionSupportingWildcardSNI,
+			expressionRoutesEnabled: true,
+			tlsRoutes:               []*gatewayapi.TLSRoute{tlsRouteWildcardHostname},
+			services: []*corev1.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
-						Name:      "service2",
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "service3",
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "service4",
+						Name:      "service1",
 					},
 				},
 			},
@@ -168,16 +171,7 @@ func TestIngressRulesFromTLSRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(80).
-							MustBuild(), builder.NewKongstateServiceBackend("service2").WithPortNumber(443).MustBuild(),
-					},
-				},
-				{
-					Service: kong.Service{
-						Name: new("tlsroute.default.tlsroute-1.1"),
-					},
-					Backends: []kongstate.ServiceBackend{
-						builder.NewKongstateServiceBackend("service3").WithPortNumber(8080).MustBuild(),
-						builder.NewKongstateServiceBackend("service4").WithPortNumber(8443).MustBuild(),
+							MustBuild(),
 					},
 				},
 			},
@@ -186,18 +180,7 @@ func TestIngressRulesFromTLSRoutesUsingExpressionRoutes(t *testing.T) {
 					{
 						Route: kong.Route{
 							Name:         new("tlsroute.default.tlsroute-1.0.0"),
-							Expression:   new(`(tls.sni == "foo.com") || (tls.sni == "bar.com")`),
-							PreserveHost: new(true),
-							Protocols:    kong.StringSlice("tls"),
-						},
-						ExpressionRoutes: true,
-					},
-				},
-				"tlsroute.default.tlsroute-1.1": {
-					{
-						Route: kong.Route{
-							Name:         new("tlsroute.default.tlsroute-1.1.0"),
-							Expression:   new(`(tls.sni == "foo.com") || (tls.sni == "bar.com")`),
+							Expression:   new(`tls.sni =^ ".foo.com"`),
 							PreserveHost: new(true),
 							Protocols:    kong.StringSlice("tls"),
 						},
@@ -211,12 +194,13 @@ func TestIngressRulesFromTLSRoutesUsingExpressionRoutes(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fakestore, err := store.NewFakeStore(store.FakeObjects{
-				TLSRoutes: tc.tcpRoutes,
+				TLSRoutes: tc.tlsRoutes,
 				Services:  tc.services,
 			})
 			require.NoError(t, err)
 			translator := mustNewTranslator(t, fakestore)
-			translator.featureFlags.ExpressionRoutes = true
+			translator.kongVersion = tc.kongVersion
+			translator.featureFlags.ExpressionRoutes = tc.expressionRoutesEnabled
 
 			failureCollector := failures.NewResourceFailuresCollector(zapr.NewLogger(zap.NewNop()))
 			translator.failuresCollector = failureCollector

--- a/ingress-controller/internal/dataplane/translator/translate_vars.go
+++ b/ingress-controller/internal/dataplane/translator/translate_vars.go
@@ -2,6 +2,8 @@ package translator
 
 import (
 	"regexp"
+
+	"github.com/blang/semver/v4"
 )
 
 // -----------------------------------------------------------------------------
@@ -25,3 +27,7 @@ const (
 
 // LegacyRegexPathExpression is the regular expression used by Kong <3.0 to determine if a path is not a regex.
 var LegacyRegexPathExpression = regexp.MustCompile(`^[a-zA-Z0-9\.\-_~/%]*$`)
+
+var (
+	TLSWildcardSNIMinimumKongVersion = semver.MustParse("3.7.0")
+)

--- a/ingress-controller/internal/dataplane/translator/translator_test.go
+++ b/ingress-controller/internal/dataplane/translator/translator_test.go
@@ -5118,6 +5118,13 @@ func TestNewFeatureFlags(t *testing.T) {
 				CombinedServicesFromDifferentHTTPRoutes: true,
 			},
 		},
+		{
+			name:                  "support redirect plugin enabled",
+			supportRedirectPlugin: true,
+			expectedFeatureFlags: FeatureFlags{
+				SupportRedirectPlugin: true,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/ingress-controller/internal/manager/run.go
+++ b/ingress-controller/internal/manager/run.go
@@ -308,6 +308,7 @@ func New(
 		allNamespacesClient,
 		c.IngressClassName,
 		admission.NewDefaultAdminAPIServicesProvider(m.clientsManager),
+		kongSemVersion,
 		translatorFeatureFlags,
 		storer,
 		referenceIndexers,

--- a/ingress-controller/internal/versions/versions.go
+++ b/ingress-controller/internal/versions/versions.go
@@ -13,5 +13,8 @@ var KongRedirectPluginCutoff = semver.Version{Major: 3, Minor: 9, Patch: 0}
 // KongStickySessionsCutoff is the lowest version of Kong Gateway that supports `sticky_sessions` loadbalancing algorithm.
 var KongStickySessionsCutoff = semver.Version{Major: 3, Minor: 11, Patch: 0}
 
+// KongWildcardSNICutoff is the lowest version of Kong Gateway that supports wildcard SNIs in routes for matching TLS requests.
+var KongWildcardSNICutoff = semver.Version{Major: 3, Minor: 7, Patch: 0}
+
 // DeckFileFormatVersion is the version of the decK file format used by KIC everywhere.
 const DeckFileFormatVersion = "3.0"

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -22,11 +22,7 @@ var skippedTestsShared = []string{
 	tests.GRPCRouteListenerHostnameMatching.ShortName,
 }
 
-var skippedTestsForExpressionsRouter = []string{
-	// TODO: support wildcard SNI in TLSRoute and Gateway and remove this from the skipped tests list.
-	// https://github.com/Kong/kong-operator/issues/4350
-	tests.TLSRouteHostnameIntersection.ShortName,
-}
+var skippedTestsForExpressionsRouter = []string{}
 
 var skippedTestsForTraditionalCompatibleRouter = []string{
 	// HTTPRoute


### PR DESCRIPTION
**What this PR does / why we need it**:

When Kong DP supports (version >= 3.7.0), support wildcard TLS SNIs in translated routes.

**Which issue this PR fixes**

Fixes #4350 

**Special notes for your reviewer**:

Should be reviewed after #4369

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
