### PR TITLE
test(conformance): Specify dataplane image for conformance tests by environment variable

### DIFF
--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -228,6 +228,8 @@ func createGatewayConfiguration(
 								Containers: []corev1.Container{
 									{
 										Name: consts.DataPlaneProxyContainerName,
+										// TODO: Use a dataplane image from environment variable or flag instead of the default image, to allow testing with different versions of the dataplane.
+										Image: consts.DefaultDataPlaneImage,
 										ReadinessProbe: &corev1.Probe{
 											InitialDelaySeconds: 1,
 											PeriodSeconds:       1,

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -227,9 +227,8 @@ func createGatewayConfiguration(
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
 									{
-										Name: consts.DataPlaneProxyContainerName,
-										// TODO: Use a dataplane image from environment variable or flag instead of the default image, to allow testing with different versions of the dataplane.
-										Image: consts.DefaultDataPlaneImage,
+										Name:  consts.DataPlaneProxyContainerName,
+										Image: test.DataPlaneImage(),
 										ReadinessProbe: &corev1.Probe{
 											InitialDelaySeconds: 1,
 											PeriodSeconds:       1,

--- a/test/envvars.go
+++ b/test/envvars.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/kong/kong-operator/v2/pkg/consts"
 )
 
 // IsCalicoCNIDisabled returns true if the Calico CNI plugin is disabled in the test environment.
@@ -48,6 +50,16 @@ func IsInstallingCRDsDisabled() bool {
 		fmt.Println("INFO: Installing CRDs is enabled")
 	}
 	return ret
+}
+
+// DataPlaneImage returns the data plane image to use in the test environment.
+// It reads the KONG_TEST_DATA_PLANE_IMAGE environment variable, and defaults to consts.DefaultDataPlaneImage if not set.
+func DataPlaneImage() string {
+	image := os.Getenv("KONG_TEST_DATA_PLANE_IMAGE")
+	if image == "" {
+		image = consts.DefaultDataPlaneImage
+	}
+	return image
 }
 
 // KonnectAccessToken returns the Konnect access token for the test environment.


### PR DESCRIPTION
**What this PR does / why we need it**:

Support specifying dataplane image of conformance tests by `KONG_TEST_DATA_PLANE_IMAGE` environment variable.

**Which issue this PR fixes**

Fixes #4405 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
