### PR TITLE
[Backport release/2.1.x] fix(hybridgateway): avoid KongCertificate name collisions on same-port listeners (#4382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - [v2.1.2](#v212)
 - [v2.1.1](#v211)
 - [v2.1.0](#v210)
+- [v2.0.9](#v209)
+- [v2.0.8](#v208)
+- [v2.0.7](#v207)
+- [v2.0.6](#v206)
 - [v2.0.5](#v205)
 - [v2.0.4](#v204)
 - [v2.0.3](#v203)
@@ -41,6 +45,19 @@
 - [v0.2.0](#v020)
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
+
+## Unreleased
+
+> Release date: XXXX-XX-XX
+
+### Fixes
+
+- Hybridgateway: fix `KongCertificate` name collisions when a `Gateway` has
+  multiple listeners using the same port by including listener identity in
+  generated certificate names.
+  **Attention**: This will re-create CA certificates in Konnect,
+  as it changes the names of the generated `KongCertificate`s.
+  [#4382](https://github.com/Kong/kong-operator/pull/4382)
 
 ## [v2.1.6]
 
@@ -185,6 +202,8 @@
   [#3315](https://github.com/Kong/kong-operator/pull/3315) [#3369](https://github.com/Kong/kong-operator/pull/3369)
 
 ## [v2.1.0]
+
+> Release date: 2026-02-05
 
 ### Added
 
@@ -478,6 +497,68 @@
   `spec.listeners.tls.certificateRef`, ensuring Gateway status conditions
   are updated when referenced certificates change.
   [#2661](https://github.com/Kong/kong-operator/pull/2661)
+
+## [v2.0.9]
+
+> Release date: 2026-04-23
+
+### Fixed
+
+- Fix a hot loop in the `KonnectExtension` reconciler when two
+  `KonnectExtension`s share the same client-certificate `Secret`: the
+  `KongDataPlaneClientCertificate` CR is now named after the `KonnectExtension`
+  instead of the `Secret`, so each extension gets its own CR in its own Konnect
+  ControlPlane and the reconciler no longer retries `Create` on every loop or
+  falls back to Konnect's `dp-client-certificates` List API.
+  [#3961](https://github.com/Kong/kong-operator/pull/3961) [#3978](https://github.com/Kong/kong-operator/pull/3978)
+- Fix incorrect Konnect API used for target lookup
+  [#3910](https://github.com/Kong/kong-operator/pull/3910) [#3939](https://github.com/Kong/kong-operator/pull/3939)
+
+## [v2.0.8]
+
+> Release date: 2026-03-24
+
+### Fixed
+
+- Do not try to list `Gateway`s for namespaces that are not being watched by controller
+  [#3625](https://github.com/Kong/kong-operator/pull/3625)
+- Fix the on-prem translator to set `protocols` in translated Kong routes to
+  `http,https`.
+  [#3587](https://github.com/Kong/kong-operator/pull/3587)
+
+## [v2.0.7]
+
+> Release date: 2026-02-19
+
+### Fixed
+
+- Fixed an issue where users could set the secret of configmap label selectors
+  to empty when the other one was left non-empty.
+  [#2815](https://github.com/Kong/kong-operator/pull/2815)
+- Bump Go to 1.25.7 and fix v2 module
+  [#3355](https://github.com/Kong/kong-operator/pull/3355)
+
+## [v2.0.6]
+
+> Release date: 2025-12-01
+
+### Fixes
+
+- Translate `healtchchecks.thershold` in `KongUpstreamPolicy` to the
+  `healthchecks.thershold` field in Kong upstreams.
+  [#2662](https://github.com/Kong/kong-operator/pull/2662)
+- Fix random, unexpected and invalid validation error during validation of `HTTPRoute`s
+  for `Gateway`s configured in different namespaces with `GatewayConfiguration` that
+  has field `spec.controlPlaneOptions.watchNamespaces.type` set to `own`.
+  [#2717](https://github.com/Kong/kong-operator/pull/2717)
+- Reject CA Secrets with multiple PEM certs.
+  [#2671](https://github.com/Kong/kong-operator/pull/2671)
+- Gateway controllers now watch changes on Secrets referenced by
+  `spec.listeners.tls.certificateRef`, ensuring Gateway status conditions
+  are updated when referenced certificates change.
+  [#2661](https://github.com/Kong/kong-operator/pull/2661)
+- Trigger reconciliation events on `KongPlugin`s upon changes on `KongPluginBinding`.
+  [#2637](https://github.com/Kong/kong-operator/pull/2637)
 
 ## [v2.0.5]
 
@@ -853,7 +934,7 @@
   the [Kong documentation](https://developer.konghq.com/operator/konnect/reference/migrate-1.4-1.5/).
   [#1183](https://github.com/kong/kong-operator/pull/1183)
 - Migrate KGO CRDs conditions to the kubernetes-configuration repo.
-  With this migration process, we have moved all conditions from the KGO repo to [kubernetes-configuration](kubernetes-configuration).
+  With this migration process, we have moved all conditions from the KGO repo to [kubernetes-configuration][kubernetes-configuration].
   This is a breaking change which requires manual action for projects that use operator's Go conditions types.
   In order to migrate please use the import paths from the [kong/kubernetes-configuration][kubernetes-configuration] repo instead.
   [#1281](https://github.com/kong/kong-operator/pull/1281)
@@ -1841,6 +1922,10 @@ re-installing the operator through the bundle.
 [v2.1.2]: https://github.com/Kong/kong-operator/compare/v2.1.1..v2.1.2
 [v2.1.1]: https://github.com/Kong/kong-operator/compare/v2.1.0..v2.1.1
 [v2.1.0]: https://github.com/Kong/kong-operator/compare/v2.0.5..v2.1.0
+[v2.0.9]: https://github.com/Kong/kong-operator/compare/v2.0.8..v2.0.9
+[v2.0.8]: https://github.com/Kong/kong-operator/compare/v2.0.7..v2.0.8
+[v2.0.7]: https://github.com/Kong/kong-operator/compare/v2.0.6..v2.0.7
+[v2.0.6]: https://github.com/Kong/kong-operator/compare/v2.0.5..v2.0.6
 [v2.0.5]: https://github.com/Kong/kong-operator/compare/v2.0.4..v2.0.5
 [v2.0.4]: https://github.com/Kong/kong-operator/compare/v2.0.3..v2.0.4
 [v2.0.3]: https://github.com/Kong/kong-operator/compare/v2.0.2..v2.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
   generated certificate names.
   **Attention**: This will re-create CA certificates in Konnect,
   as it changes the names of the generated `KongCertificate`s.
-  [#4382](https://github.com/Kong/kong-operator/pull/4382)
+  [#4382](https://github.com/Kong/kong-operator/pull/4382) [#4394](https://github.com/Kong/kong-operator/pull/4394)
 
 ## [v2.1.6]
 

--- a/controller/hybridgateway/converter/gateway.go
+++ b/controller/hybridgateway/converter/gateway.go
@@ -340,7 +340,7 @@ func (c *gatewayConverter) buildKongCertificate(
 ) (configurationv1alpha1.KongCertificate, error) {
 
 	// Generate a name for the KongCertificate resource.
-	certName := namegen.NewKongCertificateName(c.gateway.Name, strconv.Itoa(int(listener.Port)))
+	certName := namegen.NewKongCertificateName(c.gateway.Name, strconv.Itoa(int(listener.Port)), string(listener.Name))
 	cert, err := builder.NewKongCertificate().
 		WithName(certName).
 		WithNamespace(c.gateway.Namespace).

--- a/controller/hybridgateway/converter/gateway_test.go
+++ b/controller/hybridgateway/converter/gateway_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -186,6 +187,7 @@ func TestBuildKongCertificate(t *testing.T) {
 
 			require.NoError(t, err)
 			require.NotEmpty(t, cert.Name)
+			require.Contains(t, cert.Name, string(tt.listener.Name))
 			require.Equal(t, tt.gateway.Namespace, cert.Namespace)
 			require.Equal(t, string(tt.certRef.Name), cert.Spec.SecretRef.Name)
 			require.Equal(t, tt.secretNamespace, *cert.Spec.SecretRef.Namespace)
@@ -196,6 +198,38 @@ func TestBuildKongCertificate(t *testing.T) {
 			require.Equal(t, tt.gateway.Name, cert.OwnerReferences[0].Name)
 		})
 	}
+}
+
+func TestBuildKongCertificate_SamePortDifferentListenersDifferentNames(t *testing.T) {
+	gateway := &gwtypes.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gateway",
+			Namespace: "default",
+		},
+	}
+
+	controlPlaneRef := &commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: "test-cp",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().Build()
+	converter := newGatewayConverter(gateway, fakeClient).(*gatewayConverter)
+	converter.controlPlaneRef = controlPlaneRef
+
+	certRef := gatewayv1.SecretObjectReference{Name: "tls-secret"}
+
+	listenerOne := &gwtypes.Listener{Name: "https-1", Port: 443}
+	listenerTwo := &gwtypes.Listener{Name: "https-2", Port: 443}
+
+	certOne, err := converter.buildKongCertificate(listenerOne, certRef, "default")
+	require.NoError(t, err)
+	certTwo, err := converter.buildKongCertificate(listenerTwo, certRef, "default")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, certOne.Name, certTwo.Name)
 }
 
 func TestBuildKongSNI(t *testing.T) {
@@ -856,8 +890,8 @@ func TestTranslate(t *testing.T) {
 
 				require.NotNil(t, cert, "KongCertificate should be created")
 				require.NotNil(t, sni, "KongSNI should be created")
-				require.Equal(t, "cert.test-gateway.443", cert.Name)
-				require.Equal(t, "cert.test-gateway.443", sni.Spec.CertificateRef.Name)
+				require.Equal(t, "cert.test-gateway.443.https", cert.Name)
+				require.Equal(t, "cert.test-gateway.443.https", sni.Spec.CertificateRef.Name)
 			},
 		},
 		{

--- a/controller/hybridgateway/namegen/name.go
+++ b/controller/hybridgateway/namegen/name.go
@@ -15,9 +15,6 @@ const (
 	// httpProcolPrefix is the prefix used for HTTP-related resources.
 	httpProcolPrefix = "http"
 
-	// tlsProtocolPrefix is the prefix for TLS-related resources.
-	tlsProtocolPrefix = "tls"
-
 	// defaultCPPrefix is the prefix used when including a control-plane identifier.
 	defaultCPPrefix = "cp"
 

--- a/controller/hybridgateway/namegen/name.go
+++ b/controller/hybridgateway/namegen/name.go
@@ -15,6 +15,9 @@ const (
 	// httpProcolPrefix is the prefix used for HTTP-related resources.
 	httpProcolPrefix = "http"
 
+	// tlsProtocolPrefix is the prefix for TLS-related resources.
+	tlsProtocolPrefix = "tls"
+
 	// defaultCPPrefix is the prefix used when including a control-plane identifier.
 	defaultCPPrefix = "cp"
 
@@ -162,11 +165,12 @@ func NewKongTargetName(upstreamID, endpointID string, port int, br *gwtypes.HTTP
 
 // NewKongCertificateName generates a KongCertificate name based on the Gateway name and listener port.
 // It uses the hybrid naming approach: readable names for short combinations, hashed names for long ones.
-func NewKongCertificateName(gatewayName, listenerPort string) string {
+func NewKongCertificateName(gatewayName, listenerPort, listenerName string) string {
 	return newName(
 		certPrefix,
 		gatewayName,
 		listenerPort,
+		listenerName,
 	)
 }
 

--- a/controller/hybridgateway/namegen/name_test.go
+++ b/controller/hybridgateway/namegen/name_test.go
@@ -742,41 +742,51 @@ func TestNewKongCertificateName_Generated(t *testing.T) {
 		name         string
 		gatewayName  string
 		listenerPort string
+		listenerName string
 		expected     string
 	}{
 		{
 			name:         "short gateway and port",
 			gatewayName:  "my-gateway",
 			listenerPort: "443",
-			expected:     "cert.my-gateway.443",
+			listenerName: "https-1",
+			expected:     "cert.my-gateway.443.https-1",
 		},
 		{
 			name:         "gateway with namespace prefix",
 			gatewayName:  "prod-api-gateway",
 			listenerPort: "8443",
-			expected:     "cert.prod-api-gateway.8443",
+			listenerName: "tls-listener",
+			expected:     "cert.prod-api-gateway.8443.tls-listener",
 		},
 		{
 			name:         "different port",
 			gatewayName:  "test-gw",
 			listenerPort: "80",
-			expected:     "cert.test-gw.80",
+			listenerName: "http",
+			expected:     "cert.test-gw.80.http",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := NewKongCertificateName(tt.gatewayName, tt.listenerPort)
+			result := NewKongCertificateName(tt.gatewayName, tt.listenerPort, tt.listenerName)
 			require.NotEmpty(t, result)
 			require.Equal(t, tt.expected, result)
 		})
 	}
 
+	t.Run("same gateway and port with different listeners should differ", func(t *testing.T) {
+		first := NewKongCertificateName("gateway", "443", "https-1")
+		second := NewKongCertificateName("gateway", "443", "https-2")
+		require.NotEqual(t, first, second)
+	})
+
 	t.Run("very long gateway name should hash", func(t *testing.T) {
 		// Create a gateway name that when combined with "cert" and port exceeds 253 chars
 		// "cert." (5) + longName + "." (1) + "443" (3) = need longName > 244 chars
 		longGatewayName := strings.Repeat("very-long-gateway-name-segment-", 8) + "final-segment-to-exceed-limit"
-		result := NewKongCertificateName(longGatewayName, "443")
+		result := NewKongCertificateName(longGatewayName, "443", "https-listener")
 		require.NotEmpty(t, result)
 		require.True(t, strings.HasPrefix(result, namegenPrefix), "should hash when exceeding max length")
 		require.LessOrEqual(t, len(result), maxLen)


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
