### PR TITLE
test(e2e/chainsaw): cover HTTPRoute-level konghq.com annotations

### DIFF
--- a/test/e2e/chainsaw/common/_step_templates/assert-kongRoute.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/assert-kongRoute.yaml
@@ -35,6 +35,7 @@ spec:
           spec:
             paths: ($route_paths)
             strip_path: ($strip_path)
+            preserve_host: ($preserve_host)
             serviceRef:
               namespacedRef:
                 name: ($kong_service_name)

--- a/test/e2e/chainsaw/hybridgateway/basic-httproute/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-httproute/chainsaw-test.yaml
@@ -151,6 +151,8 @@ spec:
             - "/echo/"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
     
@@ -296,6 +298,8 @@ spec:
             - "~/get$"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
 
@@ -309,6 +313,8 @@ spec:
             - "~/post$"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
 
@@ -322,6 +328,8 @@ spec:
             - "~/put$"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
 
@@ -335,6 +343,8 @@ spec:
             - "~/patch$"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
 
@@ -348,6 +358,8 @@ spec:
             - "~/delete$"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
 
@@ -362,6 +374,8 @@ spec:
             - "/status/"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
     - name: Assert-kong-upstream-httpbin

--- a/test/e2e/chainsaw/hybridgateway/gateway-tls-certificates/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/gateway-tls-certificates/chainsaw-test.yaml
@@ -148,6 +148,8 @@ spec:
             - "/echo/"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
     

--- a/test/e2e/chainsaw/hybridgateway/httproute-annotations/01-httpRoute.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-annotations/01-httpRoute.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ($http_route_name)
+  namespace: ($namespace)
+  # Created without konghq.com annotations. The test drives the full
+  # lifecycle (add -> patch -> remove) via subsequent patch/script steps.
+spec:
+  parentRefs:
+    - name: ($gateway_name)
+      namespace: ($gateway_namespace)
+  hostnames:
+    - ($fqdn)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /echo
+      backendRefs:
+        - name: ($echo_deployment_name)
+          port: 1027

--- a/test/e2e/chainsaw/hybridgateway/httproute-annotations/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-annotations/chainsaw-test.yaml
@@ -1,0 +1,314 @@
+# Test: HTTPRoute-level Kong annotations.
+# Verifies that the hybrid gateway controller propagates HTTPRoute-level
+# konghq.com annotations (strip-path, preserve-host) to the generated
+# KongRoute spec, and re-reconciles when the annotations change.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: httproute-annotations
+spec:
+  description: |
+    This test validates that the hybrid gateway controller correctly processes
+    annotations set directly on an HTTPRoute object.
+    Supported HTTPRoute-level annotations:
+    - konghq.com/strip-path:    <bool> (default: false) -> KongRoute.spec.strip_path
+    - konghq.com/preserve-host: <bool> (default: true)  -> KongRoute.spec.preserve_host
+    The test sets both annotations to the opposite of their defaults so a
+    regression in propagation surfaces as a failed assertion. It then patches
+    the HTTPRoute to flip them back and re-asserts the KongRoute spec to
+    verify that subsequent annotation changes are reconciled.
+
+  bindings:
+    - name: test_name
+      value: ($namespace)
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_api_auth_namespace
+      value: ($namespace)
+    - name: sni_hostname
+      value: (join('.', ['*', ($namespace), 'example.com']))
+    - name: fqdn
+      value: (join('.', ['echo', ($namespace), 'example.com']))
+    - name: cert_secret_name
+      value: test-tls-secret
+    - name: cert_secret_namespace
+      value: ($namespace)
+    - name: listener_https_port
+      value: 443
+    - name: listener_http_port
+      value: 80
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($namespace), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($namespace), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
+    - name: gateway_image
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+    - name: gateway_name
+      value: (join('-', [($namespace), 'gateway']))
+    - name: gateway_namespace
+      value: ($namespace)
+    - name: http_route_name
+      value: (join('-', [($namespace), 'echo-route']))
+    - name: http_route_namespace
+      value: ($namespace)
+    - name: echo_deployment_name
+      value: (join('-', [($namespace), 'echo']))
+    - name: echo_deployment_namespace
+      value: ($namespace)
+    - name: echo_deployment_replicas
+      value: 1
+    - name: http_method
+      value: "GET"
+
+  steps:
+    # Step 1: Create TLS secret for Gateway TLS listener.
+    - name: Create-tls-secret
+      description: Create TLS Secret for the Gateway TLS listener.
+      use:
+        template: ../../common/_step_templates/apply-assert-tlsSecret.yaml
+
+    # Step 2: Create secret for Konnect authentication.
+    - name: Create-auth-secret
+      description: Create Secret with Konnect token.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    # Step 3: Create KonnectAPIAuthConfiguration.
+    - name: Create-konnect-api-auth
+      description: Create KonnectAPIAuthConfiguration.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
+
+    # Step 4: Create GatewayConfiguration.
+    - name: Create-gateway-configuration
+      description: Create GatewayConfiguration for hybrid gateway.
+      use:
+        template: ../../common/_step_templates/apply-assert-gatewayConfiguration.yaml
+
+    # Step 5: Create GatewayClass.
+    - name: Create-gateway-class
+      description: Create GatewayClass.
+      use:
+        template: ../../common/_step_templates/apply-assert-gatewayClass.yaml
+
+    # Step 6: Create Gateway with TLS listener.
+    - name: Create-gateway
+      description: Create Gateway.
+      use:
+        template: ../../common/_step_templates/apply-assert-gateway.yaml
+
+    # Step 7: Assert KonnectGatewayControlPlane is created.
+    - name: Assert-konnect-gateway-control-plane
+      description: Assert KonnectGatewayControlPlane.
+      use:
+        template: ../../common/_step_templates/assert-konnectGatewayControlPlane.yaml
+
+    # Step 8: Assert KongCertificate from TLS secret.
+    - name: Assert-kong-certificate
+      description: Assert KongCertificate.
+      use:
+        template: ../../common/_step_templates/assert-kongCertificate.yaml
+
+    # Step 9: Assert KongSNI for SNI hostname.
+    - name: Assert-kong-sni
+      description: Assert KongSNI.
+      use:
+        template: ../../common/_step_templates/assert-kongSNI.yaml
+      bindings:
+        - name: resource_type
+          value: "kongcertificates.configuration.konghq.com"
+
+    # Step 10: Create echo service for traffic.
+    - name: Create-echo-service
+      description: Create echo service for backend.
+      use:
+        template: ../../common/_step_templates/apply-assert-echoService.yaml
+      bindings:
+        - name: echo_deployment_replicas
+          value: ($echo_deployment_replicas)
+
+    # ---------------------------------------------------------------------------
+    # Phase 1: HTTPRoute created without any konghq.com annotations.
+    # Expect the generated KongRoute to carry Kong's defaults
+    # (strip_path=false, preserve_host=true).
+    # ---------------------------------------------------------------------------
+    - name: Create-httproute-without-annotations
+      description: Create HTTPRoute with no konghq.com annotations.
+      try:
+        - apply:
+            file: 01-httpRoute.yaml
+        - assert:
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: HTTPRoute
+              metadata:
+                namespace: ($namespace)
+                name: ($http_route_name)
+
+    - name: Assert-kong-route-defaults
+      description: Assert KongRoute carries Kong defaults (strip_path=false, preserve_host=true).
+      use:
+        template: ../../common/_step_templates/assert-kongRoute.yaml
+      bindings:
+        - name: route_paths
+          value:
+            - "~/echo$"
+            - "/echo/"
+        - name: strip_path
+          value: false
+        - name: preserve_host
+          value: true
+        - name: resource_type
+          value: "kongservices.configuration.konghq.com"
+
+    # ---------------------------------------------------------------------------
+    # Phase 2: Add both annotations with non-default values.
+    # Expect the controller to re-reconcile the KongRoute with the new values.
+    # ---------------------------------------------------------------------------
+    - name: Patch-httproute-add-annotations
+      description: Patch HTTPRoute to add konghq.com/strip-path=true and konghq.com/preserve-host=false.
+      try:
+        - patch:
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: HTTPRoute
+              metadata:
+                namespace: ($namespace)
+                name: ($http_route_name)
+                annotations:
+                  konghq.com/strip-path: "true"
+                  konghq.com/preserve-host: "false"
+        - assert:
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: HTTPRoute
+              metadata:
+                namespace: ($namespace)
+                name: ($http_route_name)
+                annotations:
+                  konghq.com/strip-path: "true"
+                  konghq.com/preserve-host: "false"
+
+    - name: Assert-kong-route-with-added-annotations
+      description: Assert KongRoute reflects the added annotations (strip_path=true, preserve_host=false).
+      use:
+        template: ../../common/_step_templates/assert-kongRoute.yaml
+      bindings:
+        - name: route_paths
+          value:
+            - "~/echo$"
+            - "/echo/"
+        - name: strip_path
+          value: true
+        - name: preserve_host
+          value: false
+        - name: resource_type
+          value: "kongservices.configuration.konghq.com"
+
+    # ---------------------------------------------------------------------------
+    # Phase 3: Patch annotations to a mixed state (strip-path=false, preserve-host=false).
+    # ---------------------------------------------------------------------------
+    - name: Patch-httproute-mixed-annotations
+      description: Patch HTTPRoute annotations to a mixed state.
+      try:
+        - patch:
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: HTTPRoute
+              metadata:
+                namespace: ($namespace)
+                name: ($http_route_name)
+                annotations:
+                  konghq.com/strip-path: "false"
+                  konghq.com/preserve-host: "false"
+        - assert:
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: HTTPRoute
+              metadata:
+                namespace: ($namespace)
+                name: ($http_route_name)
+                annotations:
+                  konghq.com/strip-path: "false"
+                  konghq.com/preserve-host: "false"
+
+    - name: Assert-kong-route-with-mixed-annotations
+      description: Assert KongRoute reflects mixed annotations (strip_path=false, preserve_host=false).
+      use:
+        template: ../../common/_step_templates/assert-kongRoute.yaml
+      bindings:
+        - name: route_paths
+          value:
+            - "~/echo$"
+            - "/echo/"
+        - name: strip_path
+          value: false
+        - name: preserve_host
+          value: false
+        - name: resource_type
+          value: "kongservices.configuration.konghq.com"
+
+    # ---------------------------------------------------------------------------
+    # Phase 4: Remove both annotations from the HTTPRoute entirely.
+    # Expect the controller to re-reconcile the KongRoute back to Kong's defaults.
+    # `kubectl annotate <kind> <name> <key>-` is used.
+    # ---------------------------------------------------------------------------
+    - name: Remove-httproute-annotations
+      description: Strip both konghq.com annotations from the HTTPRoute via kubectl annotate -.
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: HTTP_ROUTE_NAME
+                value: ($http_route_name)
+            content: |
+              kubectl annotate -n "$NAMESPACE" httproute "$HTTP_ROUTE_NAME" \
+                konghq.com/strip-path- \
+                konghq.com/preserve-host- \
+                --overwrite
+        - assert:
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: HTTPRoute
+              metadata:
+                namespace: ($namespace)
+                name: ($http_route_name)
+                (annotations."konghq.com/strip-path" == null): true
+                (annotations."konghq.com/preserve-host" == null): true
+
+    - name: Assert-kong-route-defaults-after-removal
+      description: Assert KongRoute returns to Kong defaults after annotation removal.
+      use:
+        template: ../../common/_step_templates/assert-kongRoute.yaml
+      bindings:
+        - name: route_paths
+          value:
+            - "~/echo$"
+            - "/echo/"
+        - name: strip_path
+          value: false
+        - name: preserve_host
+          value: true
+        - name: resource_type
+          value: "kongservices.configuration.konghq.com"
+
+  catch:
+    # Capture debug snapshot on test failure.
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-httproute-annotations
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/chainsaw-test.yaml
@@ -156,6 +156,8 @@ spec:
             - "/echo/"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
     

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
@@ -160,6 +160,8 @@ spec:
             - "GET"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
 
@@ -176,6 +178,8 @@ spec:
             - "POST"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
 
@@ -192,6 +196,8 @@ spec:
             - "PUT"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
 
@@ -208,6 +214,8 @@ spec:
             - "PATCH"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
 
@@ -224,6 +232,8 @@ spec:
             - "DELETE"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
 
@@ -238,6 +248,8 @@ spec:
             - "/status/"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
     
@@ -434,6 +446,8 @@ spec:
             - "GET"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
     
@@ -677,6 +691,8 @@ spec:
             - "GET"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
     

--- a/test/e2e/chainsaw/hybridgateway/httproute-multiple-backends/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-multiple-backends/chainsaw-test.yaml
@@ -186,6 +186,8 @@ spec:
           - /echo/
       - name: strip_path
         value: false
+      - name: preserve_host
+        value: true
     use:
       template: ../../common/_step_templates/assert-kongRoute.yaml
 
@@ -295,6 +297,8 @@ spec:
           - /echo/
       - name: strip_path
         value: false
+      - name: preserve_host
+        value: true
     use:
       template: ../../common/_step_templates/assert-kongRoute.yaml
 
@@ -364,6 +368,8 @@ spec:
           - /echo/
       - name: strip_path
         value: false
+      - name: preserve_host
+        value: true
     use:
       template: ../../common/_step_templates/assert-kongRoute.yaml
 
@@ -513,6 +519,8 @@ spec:
           - /echo/
       - name: strip_path
         value: false
+      - name: preserve_host
+        value: true
     use:
       template: ../../common/_step_templates/assert-kongRoute.yaml
 

--- a/test/e2e/chainsaw/hybridgateway/httproute-multiple-parentrefs/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-multiple-parentrefs/chainsaw-test.yaml
@@ -268,6 +268,8 @@ spec:
             - "/get/"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
 
@@ -298,6 +300,8 @@ spec:
             - "/get/"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
 
@@ -534,6 +538,8 @@ spec:
             - "~/status/200$"
             - "/status/200/"
         - name: strip_path
+          value: true
+        - name: preserve_host
           value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"

--- a/test/e2e/chainsaw/hybridgateway/httproute-service-annotations/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-service-annotations/chainsaw-test.yaml
@@ -192,6 +192,8 @@ spec:
             - "/echo/"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
 

--- a/test/e2e/chainsaw/hybridgateway/httproute-upstream-policy/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-upstream-policy/chainsaw-test.yaml
@@ -208,6 +208,8 @@ spec:
             - "/echo/"
         - name: strip_path
           value: false
+        - name: preserve_host
+          value: true
         - name: resource_type
           value: "kongservices.configuration.konghq.com"
 


### PR DESCRIPTION


**What this PR does / why we need it**:

Add a hybridgateway chainsaw test that exercises the full lifecycle of the two HTTPRoute-level annotations supported by the hybrid gateway controller (konghq.com/strip-path, konghq.com/preserve-host):

  1. HTTPRoute created without annotations -> KongRoute carries Kong defaults (strip_path=false, preserve_host=true).
  2. Annotations added with non-default values -> KongRoute reflects the new values.
  3. Annotations patched to a mixed state -> KongRoute reflects the mixed values.
  4. Annotations removed (via `kubectl annotate <key>-`) -> KongRoute reverts to defaults.

Each phase produces a distinct (strip_path, preserve_host) pair, so a regression in any individual transition surfaces as a specific assert failure.

Also extend the shared assert-kongRoute.yaml step template to assert preserve_host via a new required binding, and update the 9 existing call sites to pass preserve_host=true (matches the controller's behavior in tests that do not set the annotation).

**Which issue this PR fixes**

Fixes #3384 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
