### PR TITLE
test: enable HTTPRouteListenerHostnameMatching conformance for HybridyGateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,11 @@
 
 ### Fixes
 
+- Hybridgateway: fix `KongRoute` name collisions when an `HTTPRoute` attaches
+  to multiple listener-scoped `ParentRef`s on the same `Gateway`, enabling the
+  `HTTPRouteListenerHostnameMatching` Gateway API conformance test for Hybrid
+  Gateway. Only affected multi-parent translated routes are renamed.
+  [#4423](https://github.com/Kong/kong-operator/pull/4423)
 - Hybridgateway: fix `KongCertificate` name collisions when a `Gateway` has
   multiple listeners using the same port by including listener identity in
   generated certificate names.

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -388,6 +388,10 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 		pRef := pRefData.parentRef
 		cp := pRefData.cpRef
 		hostnames := pRefData.hostnames
+		var namingParentRef *gwtypes.ParentReference
+		if len(supportedParentRefs) > 1 {
+			namingParentRef = &pRef
+		}
 
 		log.Debug(logger, "Processing parent reference",
 			"parentRef", pRef,
@@ -441,7 +445,7 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 			// Gateway API semantics require OR across matches within a rule
 			// and AND within a single match. Generating a route per match
 			// preserves the OR semantics for Hybrid Gateway.
-			routes, err := kongroute.RoutesForRule(ctx, logger, c.Client, c.route, rule, &pRef, cp, serviceName, hostnames)
+			routes, err := kongroute.RoutesForRule(ctx, logger, c.Client, c.route, rule, &pRef, cp, namingParentRef, serviceName, hostnames)
 			if err != nil {
 				log.Error(logger, err, "Failed to translate KongRoute resources for rule, skipping rule",
 					"ruleIndex", ruleIndex,

--- a/controller/hybridgateway/converter/http_route_test.go
+++ b/controller/hybridgateway/converter/http_route_test.go
@@ -139,6 +139,71 @@ func TestHostnamesIntersection(t *testing.T) {
 	}
 }
 
+func TestTranslateHTTPRouteWithMultipleListenerParentRefs(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, gatewayv1.Install(scheme))
+	require.NoError(t, configurationv1.AddToScheme(scheme))
+	require.NoError(t, configurationv1alpha1.AddToScheme(scheme))
+	require.NoError(t, konnectv1alpha2.AddToScheme(scheme))
+	require.NoError(t, gatewayoperatorv1alpha1.AddToScheme(scheme))
+	require.NoError(t, operatorv2beta1.AddToScheme(scheme))
+
+	route := newHTTPRouteWithHostnames()
+	listener0 := gwtypes.SectionName("listener-0")
+	listener1 := gwtypes.SectionName("listener-1")
+	route.Spec.ParentRefs = []gwtypes.ParentReference{
+		{
+			Name:        "test-gateway",
+			Namespace:   new(gatewayv1.Namespace("default")),
+			SectionName: &listener0,
+			Kind:        new(gwtypes.Kind("Gateway")),
+			Group:       new(gwtypes.Group(gwtypes.GroupName)),
+		},
+		{
+			Name:        "test-gateway",
+			Namespace:   new(gatewayv1.Namespace("default")),
+			SectionName: &listener1,
+			Kind:        new(gwtypes.Kind("Gateway")),
+			Group:       new(gwtypes.Group(gwtypes.GroupName)),
+		},
+	}
+
+	gateway := newGatewayWithListenerHostnames("*.bar.com", "*.foo.com")
+	objects := newKonnectGatewayStandardObjects(gateway)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+
+	converter := newHTTPRouteConverter(route, fakeClient, false, "")
+	_, err := converter.Translate(context.Background(), logr.Discard())
+	require.NoError(t, err)
+
+	output, err := converter.GetOutputStore(context.Background(), logr.Discard())
+	require.NoError(t, err)
+
+	var kongRoutes []*configurationv1alpha1.KongRoute
+	for _, obj := range output {
+		kongroute := &configurationv1alpha1.KongRoute{}
+		err := runtime.DefaultUnstructuredConverter.FromUnstructuredWithValidation(obj.Object, kongroute, true)
+		if err != nil || kongroute.Kind != "KongRoute" {
+			continue
+		}
+		kongRoutes = append(kongRoutes, kongroute)
+	}
+
+	require.Len(t, kongRoutes, 2)
+	assert.NotEqual(t, kongRoutes[0].Name, kongRoutes[1].Name)
+
+	hostnames := map[string]struct{}{}
+	for _, kongRoute := range kongRoutes {
+		require.Len(t, kongRoute.Spec.Hosts, 1)
+		hostnames[kongRoute.Spec.Hosts[0]] = struct{}{}
+	}
+
+	_, ok := hostnames["*.bar.com"]
+	assert.True(t, ok)
+	_, ok = hostnames["*.foo.com"]
+	assert.True(t, ok)
+}
+
 func newHTTPRouteWithHostnames(hostnames ...string) *gwtypes.HTTPRoute {
 	var gwHostnames []gatewayv1.Hostname
 	for _, h := range hostnames {

--- a/controller/hybridgateway/converter/tls_route.go
+++ b/controller/hybridgateway/converter/tls_route.go
@@ -282,6 +282,10 @@ func (c *tlsRouteConverter) translate(ctx context.Context, logger logr.Logger) e
 		pRef := pRefData.parentRef
 		cp := pRefData.cpRef
 		hostnames := pRefData.hostnames
+		var namingParentRef *gwtypes.ParentReference
+		if len(supportedParentRefs) > 1 {
+			namingParentRef = &pRef
+		}
 
 		log.Debug(logger, "Processing parent reference",
 			"parentRef", pRef,
@@ -329,7 +333,7 @@ func (c *tlsRouteConverter) translate(ctx context.Context, logger logr.Logger) e
 			log.Debug(logger, "Successfully translated KongService resource", "service", serviceName)
 
 			// Build the KongRoute resource.
-			routes, err := kongroute.RoutesForRule(ctx, logger, c.Client, c.route, rule, &pRef, cp, serviceName, hostnames)
+			routes, err := kongroute.RoutesForRule(ctx, logger, c.Client, c.route, rule, &pRef, cp, namingParentRef, serviceName, hostnames)
 			if err != nil {
 				log.Error(logger, err, "Failed to translate KongRoute resource, skipping rule",
 					"service", serviceName,

--- a/controller/hybridgateway/kongroute/route.go
+++ b/controller/hybridgateway/kongroute/route.go
@@ -48,6 +48,7 @@ func RoutesForRule[
 	rule R,
 	pRef *gwtypes.ParentReference,
 	cp *commonv1alpha1.ControlPlaneRef,
+	namingParentRef *gwtypes.ParentReference,
 	serviceName string,
 	hostnames []string,
 ) (kongRoutes []*configurationv1alpha1.KongRoute, err error) {
@@ -57,13 +58,13 @@ func RoutesForRule[
 		if !ok {
 			return nil, fmt.Errorf("failed to build KongRoute: unmatched route type and rule type: %T and %T", route, rule)
 		}
-		return RoutesForHTTPRouteRule(ctx, logger, cl, r, httpRule, pRef, cp, serviceName, hostnames)
+		return RoutesForHTTPRouteRule(ctx, logger, cl, r, httpRule, pRef, cp, namingParentRef, serviceName, hostnames)
 	case *gwtypes.TLSRoute:
 		tlsRule, ok := any(rule).(gwtypes.TLSRouteRule)
 		if !ok {
 			return nil, fmt.Errorf("failed to build KongRoute: unmatched route type and rule type: %T and %T", route, rule)
 		}
-		return routesForTLSRouteRule(ctx, logger, cl, r, tlsRule, pRef, cp, serviceName, hostnames)
+		return routesForTLSRouteRule(ctx, logger, cl, r, tlsRule, pRef, cp, namingParentRef, serviceName, hostnames)
 	}
 	return nil, fmt.Errorf("failed to build KongRoute: unsupported route type: %T", route)
 }
@@ -87,6 +88,7 @@ func RoutesForHTTPRouteRule(
 	rule gwtypes.HTTPRouteRule,
 	pRef *gwtypes.ParentReference,
 	cp *commonv1alpha1.ControlPlaneRef,
+	namingParentRef *gwtypes.ParentReference,
 	serviceName string,
 	hostnames []string,
 ) ([]*configurationv1alpha1.KongRoute, error) {
@@ -124,7 +126,7 @@ func RoutesForHTTPRouteRule(
 	}
 
 	for i, match := range rule.Matches {
-		routeName := namegen.NewKongRouteNameForMatch(httpRoute, cp, match, i)
+		routeName := namegen.NewKongRouteNameForMatch(httpRoute, cp, namingParentRef, match, i)
 		mLog := logger.WithValues("kongroute", routeName, "matchIndex", i)
 		log.Debug(mLog, "Creating KongRoute for HTTPRoute match")
 
@@ -194,10 +196,11 @@ func routesForTLSRouteRule(
 	rule gwtypes.TLSRouteRule,
 	pRef *gwtypes.ParentReference,
 	cp *commonv1alpha1.ControlPlaneRef,
+	namingParentRef *gwtypes.ParentReference,
 	serviceName string,
 	hostnames []string,
 ) ([]*configurationv1alpha1.KongRoute, error) {
-	routeName := namegen.NewKongRouteNameForTLSRouteRule(tlsRoute, cp, rule)
+	routeName := namegen.NewKongRouteNameForTLSRouteRule(tlsRoute, cp, namingParentRef, rule)
 	logger = logger.WithValues("kongroute", routeName)
 
 	var protocol sdkkonnectcomp.RouteJSONProtocols

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -161,7 +161,7 @@ func TestRoutesForRule(t *testing.T) {
 			}
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
 
-			results, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, rule, tt.parentRef, cpRef, tt.serviceName, tt.hostnames)
+			results, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, rule, tt.parentRef, cpRef, nil, tt.serviceName, tt.hostnames)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -268,7 +268,7 @@ func TestRoutesForRule_ExactPathMatch(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gateway).Build()
 
-	results, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, rule, pRef, cpRef, "test-service", nil)
+	results, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, rule, pRef, cpRef, nil, "test-service", nil)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 

--- a/controller/hybridgateway/namegen/name.go
+++ b/controller/hybridgateway/namegen/name.go
@@ -21,6 +21,9 @@ const (
 	// defaultCPPrefix is the prefix used when including a control-plane identifier.
 	defaultCPPrefix = "cp"
 
+	// parentRefPrefix is the prefix used when including a ParentRef identifier.
+	parentRefPrefix = "pr"
+
 	// namegenPrefix is used as the prefix for hashed names when concatenated
 	// components exceed the maximum Kubernetes resource name length.
 	namegenPrefix = "ngn"
@@ -158,47 +161,50 @@ func hashElementsForServiceLikeNameTLSRouteRule(
 	}
 }
 
-// NewKongRouteName generates a KongRoute name based on the HTTPRoute, ControlPlaneRef, and HTTPRouteRule passed as arguments.
-func NewKongRouteName(route *gwtypes.HTTPRoute, cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTPRouteRule) string {
-	readableElements := []string{
-		httpProcolPrefix,
-		route.Namespace + "-" + route.Name,
-	}
-	hashElements := []string{
-		defaultCPPrefix + utils.Hash32(cp),
-		utils.Hash32(rule.Matches),
-	}
-	return newNameWithHashSuffix(readableElements, hashElements)
-}
-
 // NewKongRouteNameForMatch generates a KongRoute name based on HTTPRoute, ControlPlaneRef,
-// and a single HTTPRouteMatch. The optional index is included to avoid collisions when
-// multiple matches are identical.
-func NewKongRouteNameForMatch(route *gwtypes.HTTPRoute, cp *commonv1alpha1.ControlPlaneRef, match gatewayv1.HTTPRouteMatch, index int) string {
+// ParentRef, and a single HTTPRouteMatch. The optional index is included to avoid collisions
+// when multiple matches are identical.
+func NewKongRouteNameForMatch(
+	route *gwtypes.HTTPRoute,
+	cp *commonv1alpha1.ControlPlaneRef,
+	parentRef *gwtypes.ParentReference,
+	match gatewayv1.HTTPRouteMatch,
+	index int,
+) string {
 	readableElements := []string{
 		httpProcolPrefix,
 		route.Namespace + "-" + route.Name,
 	}
-	hashElements := []string{
-		defaultCPPrefix + utils.Hash32(cp),
-		utils.Hash32(match),
-		fmt.Sprintf("m%02d", index),
+	hashElements := []string{defaultCPPrefix + utils.Hash32(cp)}
+	if parentRef != nil {
+		hashElements = append(hashElements, parentRefHashElement(parentRef))
 	}
+	hashElements = append(hashElements, utils.Hash32(match), fmt.Sprintf("m%02d", index))
 	return newNameWithHashSuffix(readableElements, hashElements)
 }
 
-// NewKongRouteNameForTLSRouteRule generates a KongRoute name based on the TLSRoute rule, ControlPlaneRef and its parent TLSRoute.
-func NewKongRouteNameForTLSRouteRule(route *gwtypes.TLSRoute, cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.TLSRouteRule) string {
+// NewKongRouteNameForTLSRouteRule generates a KongRoute name based on the TLSRoute rule,
+// ControlPlaneRef, ParentRef, and its parent TLSRoute.
+func NewKongRouteNameForTLSRouteRule(
+	route *gwtypes.TLSRoute,
+	cp *commonv1alpha1.ControlPlaneRef,
+	parentRef *gwtypes.ParentReference,
+	rule gatewayv1.TLSRouteRule,
+) string {
 	readableElements := []string{
 		tlsProtocolPrefix,
 		route.Namespace + "-" + route.Name,
 	}
-	hashElements := []string{
-		// Since there can be only one rule in TLSRoute, we do not need to consider identical rules within the same TLSRoute.
-		defaultCPPrefix + utils.Hash32(cp),
-		utils.Hash32(rule),
+	hashElements := []string{defaultCPPrefix + utils.Hash32(cp)}
+	if parentRef != nil {
+		hashElements = append(hashElements, parentRefHashElement(parentRef))
 	}
+	hashElements = append(hashElements, utils.Hash32(rule))
 	return newNameWithHashSuffix(readableElements, hashElements)
+}
+
+func parentRefHashElement(parentRef *gwtypes.ParentReference) string {
+	return parentRefPrefix + utils.Hash32(*parentRef)
 }
 
 // NewKongPluginName generates a KongPlugin name based on the HTTPRouteFilter passed as argument.

--- a/controller/hybridgateway/namegen/name_test.go
+++ b/controller/hybridgateway/namegen/name_test.go
@@ -32,6 +32,14 @@ func testControlPlaneRef(name string) *commonv1alpha1.ControlPlaneRef {
 	}
 }
 
+func testParentRef(sectionName *gatewayv1.SectionName) *gwtypes.ParentReference {
+	return &gwtypes.ParentReference{
+		Name:        gatewayv1.ObjectName("test-gateway"),
+		Namespace:   new(gatewayv1.Namespace("default")),
+		SectionName: sectionName,
+	}
+}
+
 func testPathMatch(path string) []gatewayv1.HTTPRouteMatch {
 	matchType := gatewayv1.PathMatchPathPrefix
 	return []gatewayv1.HTTPRouteMatch{
@@ -412,86 +420,88 @@ func TestNewKongServiceName_BackendDisplayLimit(t *testing.T) {
 	}
 }
 
-func TestNewKongRouteName(t *testing.T) {
-	tests := []struct {
-		name  string
-		route *gwtypes.HTTPRoute
-		cp    *commonv1alpha1.ControlPlaneRef
-		rule  gatewayv1.HTTPRouteRule
-	}{
-		{
-			name: "basic route name generation",
-			route: &gwtypes.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-route",
-					Namespace: "default",
-				},
-			},
-			cp: &commonv1alpha1.ControlPlaneRef{
-				Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
-				KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
-					Name: "test-cp",
-				},
-			},
-			rule: gatewayv1.HTTPRouteRule{
-				Matches: []gatewayv1.HTTPRouteMatch{
-					{
-						Path: &gatewayv1.HTTPPathMatch{
-							Type:  func() *gatewayv1.PathMatchType { t := gatewayv1.PathMatchPathPrefix; return &t }(),
-							Value: func() *string { s := "/api"; return &s }(),
-						},
-					},
-				},
-			},
+func TestNewKongRouteNameForMatch_DiffersByParentRef(t *testing.T) {
+	route := testRoute("default", "test-route")
+	cp := testControlPlaneRef("test-cp")
+	matchType := gatewayv1.PathMatchPathPrefix
+	match := gatewayv1.HTTPRouteMatch{
+		Path: &gatewayv1.HTTPPathMatch{
+			Type:  &matchType,
+			Value: new("/"),
 		},
-		{
-			name: "route with multiple matches",
-			route: &gwtypes.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "complex-route",
-					Namespace: "test-ns",
-				},
-			},
-			cp: &commonv1alpha1.ControlPlaneRef{
-				Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
-				KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
-					Name: "complex-cp",
-				},
-			},
-			rule: gatewayv1.HTTPRouteRule{
-				Matches: []gatewayv1.HTTPRouteMatch{
-					{
-						Path: &gatewayv1.HTTPPathMatch{
-							Type:  func() *gatewayv1.PathMatchType { t := gatewayv1.PathMatchPathPrefix; return &t }(),
-							Value: func() *string { s := "/api/v1"; return &s }(),
-						},
-						Headers: []gatewayv1.HTTPHeaderMatch{
-							{
-								Name:  "X-API-Version",
-								Value: "v1",
-							},
-						},
-					},
-					{
-						Path: &gatewayv1.HTTPPathMatch{
-							Type:  func() *gatewayv1.PathMatchType { t := gatewayv1.PathMatchExact; return &t }(),
-							Value: func() *string { s := "/health"; return &s }(),
-						},
-					},
-				},
-			},
+	}
+	listener1 := gatewayv1.SectionName("listener-1")
+	listener2 := gatewayv1.SectionName("listener-2")
+
+	name1 := NewKongRouteNameForMatch(route, cp, testParentRef(&listener1), match, 0)
+	name2 := NewKongRouteNameForMatch(route, cp, testParentRef(&listener2), match, 0)
+
+	assert.NotEqual(t, name1, name2)
+	assert.Equal(t, name1, NewKongRouteNameForMatch(route, cp, testParentRef(&listener1), match, 0))
+}
+
+func TestNewKongRouteNameForMatch_WithoutParentRefKeepsLegacyFormat(t *testing.T) {
+	route := testRoute("default", "test-route")
+	cp := testControlPlaneRef("test-cp")
+	matchType := gatewayv1.PathMatchPathPrefix
+	match := gatewayv1.HTTPRouteMatch{
+		Path: &gatewayv1.HTTPPathMatch{
+			Type:  &matchType,
+			Value: new("/"),
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := NewKongRouteName(tt.route, tt.cp, tt.rule)
-			cpHash := utils.Hash32(tt.cp)
-			matchesHash := utils.Hash32(tt.rule.Matches)
-			expected := "http." + tt.route.Namespace + "-" + tt.route.Name + ".cp" + cpHash + "." + matchesHash
-			assert.Equal(t, expected, result)
-		})
+	result := NewKongRouteNameForMatch(route, cp, nil, match, 0)
+	expected := "http.default-test-route.cp" + utils.Hash32(cp) + "." + utils.Hash32(match) + ".m00"
+	assert.Equal(t, expected, result)
+}
+
+func TestNewKongRouteNameForTLSRouteRule_DiffersByParentRef(t *testing.T) {
+	route := &gwtypes.TLSRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "default",
+		},
 	}
+	cp := testControlPlaneRef("test-cp")
+	rule := gwtypes.TLSRouteRule{
+		BackendRefs: []gwtypes.BackendRef{{
+			BackendObjectReference: gwtypes.BackendObjectReference{
+				Name: "backend",
+				Port: new(gatewayv1.PortNumber(443)),
+			},
+		}},
+	}
+	listener1 := gatewayv1.SectionName("listener-1")
+	listener2 := gatewayv1.SectionName("listener-2")
+
+	name1 := NewKongRouteNameForTLSRouteRule(route, cp, testParentRef(&listener1), rule)
+	name2 := NewKongRouteNameForTLSRouteRule(route, cp, testParentRef(&listener2), rule)
+
+	assert.NotEqual(t, name1, name2)
+	assert.Equal(t, name1, NewKongRouteNameForTLSRouteRule(route, cp, testParentRef(&listener1), rule))
+}
+
+func TestNewKongRouteNameForTLSRouteRule_WithoutParentRefKeepsLegacyFormat(t *testing.T) {
+	route := &gwtypes.TLSRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "default",
+		},
+	}
+	cp := testControlPlaneRef("test-cp")
+	rule := gwtypes.TLSRouteRule{
+		BackendRefs: []gwtypes.BackendRef{{
+			BackendObjectReference: gwtypes.BackendObjectReference{
+				Name: "backend",
+				Port: new(gatewayv1.PortNumber(443)),
+			},
+		}},
+	}
+
+	result := NewKongRouteNameForTLSRouteRule(route, cp, nil, rule)
+	expected := "tls.default-test-route.cp" + utils.Hash32(cp) + "." + utils.Hash32(rule)
+	assert.Equal(t, expected, result)
 }
 
 func TestNewKongPluginName(t *testing.T) {
@@ -701,22 +711,6 @@ func TestNameGenerationConsistency(t *testing.T) {
 	t.Run("service name consistency", func(t *testing.T) {
 		result1 := NewKongServiceNameForHTTPRouteRule(route, cp, rule)
 		result2 := NewKongServiceNameForHTTPRouteRule(route, cp, rule)
-		assert.Equal(t, result1, result2)
-	})
-
-	t.Run("route name consistency", func(t *testing.T) {
-		ruleWithMatches := gatewayv1.HTTPRouteRule{
-			Matches: []gatewayv1.HTTPRouteMatch{
-				{
-					Path: &gatewayv1.HTTPPathMatch{
-						Type:  func() *gatewayv1.PathMatchType { t := gatewayv1.PathMatchPathPrefix; return &t }(),
-						Value: func() *string { s := "/api"; return &s }(),
-					},
-				},
-			},
-		}
-		result1 := NewKongRouteName(route, cp, ruleWithMatches)
-		result2 := NewKongRouteName(route, cp, ruleWithMatches)
 		assert.Equal(t, result1, result2)
 	})
 

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -37,7 +37,6 @@ var skippedTestsForHybrid = []string{
 
 	// Core profile.
 	tests.HTTPRouteInvalidNonExistentBackendRef.ShortName,
-	tests.HTTPRouteListenerHostnameMatching.ShortName,
 	tests.HTTPRouteMethodMatching.ShortName,
 	tests.HTTPRoutePathMatchOrder.ShortName,
 	tests.HTTPRouteQueryParamMatching.ShortName,


### PR DESCRIPTION


**What this PR does / why we need it**:

Enable the `HTTPRouteListenerHostnameMatching` conformance test for HybridGateway. Limit hybrid route renames to actual name collisions instead of renaming unconditionally, and drop the now-unused route name helper.

**Which issue this PR fixes**

Fixes #3449

**Special notes for your reviewer**:

This PR will involve renaming some resources, and I have minimized its impact as much as possible.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
