### PR TITLE
test: enable HTTPRoutePathMatchOrder conformance test for HybridGateway

### DIFF
--- a/controller/hybridgateway/builder/kongroute.go
+++ b/controller/hybridgateway/builder/kongroute.go
@@ -56,14 +56,9 @@ func (b *KongRouteBuilder) WithProtocols(protocols ...sdkkonnectcomp.RouteJSONPr
 func (b *KongRouteBuilder) WithHTTPRouteMatch(match gwtypes.HTTPRouteMatch, setCaptureGroup bool) *KongRouteBuilder {
 	// Path.
 	if match.Path != nil && match.Path.Value != nil {
-		paths, setRegexPriority := GenerateKongRoutePathFromHTTPRouteMatch(match.Path, setCaptureGroup)
+		paths, regexPriority := GenerateKongRoutePathFromHTTPRouteMatch(match.Path, setCaptureGroup)
 		b.route.Spec.Paths = append(b.route.Spec.Paths, paths...)
-		if setRegexPriority {
-			// Exact matches and the exact component of non-root prefix matches are emitted as
-			// regex paths. Without a regex priority boost, Kong's "/" catch-all path can win
-			// over those routes in the traditional-compatible router.
-			b.route.Spec.RegexPriority = new(int64(1))
-		}
+		b.route.Spec.RegexPriority = regexPriority
 	}
 
 	// Method
@@ -191,13 +186,12 @@ func (b *KongRouteBuilder) MustBuild() configurationv1alpha1.KongRoute {
 }
 
 // GenerateKongRoutePathFromHTTPRouteMatch translates the value in HTTPRoute's path match
-// to the path used in KongRoute and returns whether to set RegexPriority for the KongRoute.
+// to the path used in KongRoute and returns any RegexPriority needed for the KongRoute.
 // RegexPriority is set for Exact and non-root PathPrefix translations whose generated regex
-// paths must outrank a competing plain "/" catch-all route in Kong's traditional-compatible
-// router. Root capture-group translations and user-supplied RegularExpression matches keep
-// Kong's default priority because they are outside the precedence fix needed for
-// HTTPRouteMatchingAcrossRoutes.
-func GenerateKongRoutePathFromHTTPRouteMatch(pathMatch *gatewayv1.HTTPPathMatch, setCaptureGroup bool) (paths []string, setRegexPriority bool) {
+// paths must preserve Gateway API path precedence in Kong's traditional-compatible router.
+// Root capture-group translations and user-supplied RegularExpression matches keep Kong's
+// default priority because they remain catch-all or implementation-specific cases.
+func GenerateKongRoutePathFromHTTPRouteMatch(pathMatch *gatewayv1.HTTPPathMatch, setCaptureGroup bool) (paths []string, regexPriority *int64) {
 	// The default match type is PathMatchPathPrefix.
 	matchType := gatewayv1.PathMatchPathPrefix
 	if pathMatch.Type != nil {
@@ -216,7 +210,7 @@ func GenerateKongRoutePathFromHTTPRouteMatch(pathMatch *gatewayv1.HTTPPathMatch,
 	switch matchType {
 	// Since the path matches request in prefix way, we need to use a regex with the '$' suffix to do the exact match.
 	case gatewayv1.PathMatchExact:
-		return []string{KongPathRegexPrefix + value + "$"}, true
+		return []string{KongPathRegexPrefix + value + "$"}, regexPriorityForHTTPPathMatch(matchType, value)
 
 	// In HTTPRoute, the prefix match is specified in the "directory" manner but not simple string prefix.
 	// For example, '/abc' should match '/abc', '/abc/', '/abc/123' but not '/abcd'.
@@ -226,7 +220,7 @@ func GenerateKongRoutePathFromHTTPRouteMatch(pathMatch *gatewayv1.HTTPPathMatch,
 	case gatewayv1.PathMatchPathPrefix:
 		// For the '/' path to match all, we just return the item in KongRoute to do the same catch-all match.
 		if value == "/" && !setCaptureGroup {
-			return []string{"/"}, false
+			return []string{"/"}, nil
 		}
 
 		paths := make([]string, 0, 2)
@@ -240,21 +234,29 @@ func GenerateKongRoutePathFromHTTPRouteMatch(pathMatch *gatewayv1.HTTPPathMatch,
 			// If the path is "/", we have to skip capturing the slash as Kong Route's path must begin with a slash.
 			if value == "/" {
 				// Keep the default priority for the root capture-group form: it remains the catch-all route.
-				return append(paths, fmt.Sprintf("%s/(.*)", KongPathRegexPrefix)), false
+				return append(paths, fmt.Sprintf("%s/(.*)", KongPathRegexPrefix)), nil
 			}
 			// When there is a prefix in the route path, we capture the slash and the rest of the path after the prefix.
-			return append(paths, fmt.Sprintf("%s%s%s", KongPathRegexPrefix, path, "(/.*)")), true
+			return append(paths, fmt.Sprintf("%s%s%s", KongPathRegexPrefix, path, "(/.*)")), regexPriorityForHTTPPathMatch(matchType, value)
 		}
 
 		if !strings.HasSuffix(path, "/") {
 			path = fmt.Sprintf("%s/", path)
 		}
-		return append(paths, path), true
+		return append(paths, path), regexPriorityForHTTPPathMatch(matchType, value)
 
 	// For RegularExpression path match, we simply use the same regex in the paths of KongRoute.
 	case gatewayv1.PathMatchRegularExpression:
 		// Gateway API leaves the precedence of regular-expression path matches implementation-specific.
-		return []string{KongPathRegexPrefix + value}, false
+		return []string{KongPathRegexPrefix + value}, nil
 	}
-	return nil, false // Should never be reached.
+	return nil, nil // Should never be reached.
+}
+
+func regexPriorityForHTTPPathMatch(matchType gatewayv1.PathMatchType, value string) *int64 {
+	priority := int64(len(value) * 2)
+	if matchType == gatewayv1.PathMatchExact {
+		priority++
+	}
+	return &priority
 }

--- a/controller/hybridgateway/builder/kongroute_test.go
+++ b/controller/hybridgateway/builder/kongroute_test.go
@@ -93,7 +93,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
 				assert.Equal(t, []string{"~/api$", "/api/"}, route.Spec.Paths)
-				assert.Equal(t, new(int64(1)), route.Spec.RegexPriority)
+				assert.Equal(t, new(int64(8)), route.Spec.RegexPriority)
 				assert.Empty(t, route.Spec.Methods)
 				assert.Nil(t, route.Spec.Headers)
 			},
@@ -108,7 +108,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
 				assert.Equal(t, []string{"~/api$"}, route.Spec.Paths)
-				assert.Equal(t, new(int64(1)), route.Spec.RegexPriority)
+				assert.Equal(t, new(int64(9)), route.Spec.RegexPriority)
 				assert.Empty(t, route.Spec.Methods)
 				assert.Nil(t, route.Spec.Headers)
 			},
@@ -239,7 +239,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
 				assert.Equal(t, []string{"~/api$", "/api/"}, route.Spec.Paths)
-				assert.Equal(t, new(int64(1)), route.Spec.RegexPriority)
+				assert.Equal(t, new(int64(8)), route.Spec.RegexPriority)
 				assert.Equal(t, []string{"GET"}, route.Spec.Methods)
 				require.NotNil(t, route.Spec.Headers)
 				assert.Equal(t, []string{"Bearer token"}, route.Spec.Headers["Authorization"])
@@ -277,6 +277,40 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 			tt.validate(t, route)
 		})
 	}
+}
+
+func TestGenerateKongRoutePathFromHTTPRouteMatch_RegexPriorityFollowsSpecificity(t *testing.T) {
+	shortPrefixPaths, shortPrefixPriority := GenerateKongRoutePathFromHTTPRouteMatch(
+		&gatewayv1.HTTPPathMatch{
+			Type:  new(gatewayv1.PathMatchPathPrefix),
+			Value: new("/match"),
+		},
+		false,
+	)
+	longPrefixPaths, longPrefixPriority := GenerateKongRoutePathFromHTTPRouteMatch(
+		&gatewayv1.HTTPPathMatch{
+			Type:  new(gatewayv1.PathMatchPathPrefix),
+			Value: new("/match/prefix/one"),
+		},
+		false,
+	)
+	exactPaths, exactPriority := GenerateKongRoutePathFromHTTPRouteMatch(
+		&gatewayv1.HTTPPathMatch{
+			Type:  new(gatewayv1.PathMatchExact),
+			Value: new("/match"),
+		},
+		false,
+	)
+
+	require.Equal(t, []string{"~/match$", "/match/"}, shortPrefixPaths)
+	require.Equal(t, []string{"~/match/prefix/one$", "/match/prefix/one/"}, longPrefixPaths)
+	require.Equal(t, []string{"~/match$"}, exactPaths)
+	require.NotNil(t, shortPrefixPriority)
+	require.NotNil(t, longPrefixPriority)
+	require.NotNil(t, exactPriority)
+
+	assert.Greater(t, *longPrefixPriority, *shortPrefixPriority)
+	assert.Greater(t, *exactPriority, *shortPrefixPriority)
 }
 
 func TestKongRouteBuilder_WithKongService(t *testing.T) {

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -202,7 +202,7 @@ func TestRoutesForRule(t *testing.T) {
 					continue
 				}
 
-				assert.Equal(t, new(int64(1)), result.Spec.RegexPriority)
+				assert.Equal(t, new(int64(10)), result.Spec.RegexPriority)
 			}
 		})
 	}
@@ -273,7 +273,7 @@ func TestRoutesForRule_ExactPathMatch(t *testing.T) {
 	require.Len(t, results, 1)
 
 	assert.Equal(t, []string{"~/one$"}, results[0].Spec.Paths)
-	assert.Equal(t, new(int64(1)), results[0].Spec.RegexPriority)
+	assert.Equal(t, new(int64(9)), results[0].Spec.RegexPriority)
 	assert.ElementsMatch(t,
 		[]sdkkonnectcomp.RouteJSONProtocols{
 			sdkkonnectcomp.RouteJSONProtocols("http"),

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -34,7 +34,6 @@ var skippedTestsForHybrid = []string{
 	// Core profile.
 	tests.HTTPRouteInvalidNonExistentBackendRef.ShortName,
 	tests.HTTPRouteMethodMatching.ShortName,
-	tests.HTTPRoutePathMatchOrder.ShortName,
 	tests.HTTPRouteQueryParamMatching.ShortName,
 	tests.GatewayWithAttachedRoutes.ShortName,
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Gateway API requires the `HTTPRoutePathMatchOrder` conformance test to verify that when multiple `HTTPRoute` path matches can all match the same request, the **more specific path match must win over the broader one**. For this scenario, the important precedence rules are:

- `Exact` path matches must take precedence over `PathPrefix`
- when multiple `PathPrefix` matches apply, the **longer and more specific** prefix must win

This PR changes Hybrid `KongRoute` generation so that `regex_priority` is no longer a flat value and is instead **derived from path specificity**.

More specifically, in `controller/hybridgateway/builder/kongroute.go`:

- `Exact` and non-root `PathPrefix` matches no longer all use `regex_priority = 1`
- priority is now computed from path specificity so that:
  - longer, more specific prefixes get higher priority
  - `Exact` matches rank above `PathPrefix` matches for the same path
- the root `/` catch-all behavior remains unchanged

This allows the generated `KongRoute` resources to better reflect Gateway API path precedence and enables the `HTTPRoutePathMatchOrder` conformance test to run successfully for Hybrid Gateway.





**Which issue this PR fixes**

Fixes #3447

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
