### PR TITLE
test: re-enable HTTPRouteReferenceGrant conformance test for HybridGateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,20 @@
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
 
+## Unreleased
+
+### Fixes
+
+- Hybridgateway: release Gateway API route finalizers once generated Kong
+  resource delete requests have been issued, so immediate same-name route
+  re-creates are not blocked by child resource finalizers.
+  [#4465](https://github.com/Kong/kong-operator/pull/4465)
+- Hybridgateway: use route-scoped `KongService` names for `HTTPRoute` rules
+  whose backendRefs resolve to no valid targets. This avoids Konnect name
+  conflicts with valid backend services while keeping normally generated service
+  names unchanged.
+  [#4437](https://github.com/Kong/kong-operator/pull/4437)
+
 ## [v2.2.0]
 
 > Release date: 2026-06-05
@@ -253,15 +267,6 @@
 
 ### Fixes
 
-- Hybridgateway: release Gateway API route finalizers once generated Kong
-  resource delete requests have been issued, so immediate same-name route
-  re-creates are not blocked by child resource finalizers.
-  [#4465](https://github.com/Kong/kong-operator/pull/4465)
-- Hybridgateway: use route-scoped `KongService` names for `HTTPRoute` rules
-  whose backendRefs resolve to no valid targets. This avoids Konnect name
-  conflicts with valid backend services while keeping normally generated service
-  names unchanged.
-  [#4437](https://github.com/Kong/kong-operator/pull/4437)
 - Hybridgateway: fix `KongRoute` name collisions when an `HTTPRoute` attaches
   to multiple listener-scoped `ParentRef`s on the same `Gateway`, enabling the
   `HTTPRouteListenerHostnameMatching` Gateway API conformance test for Hybrid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,6 +257,11 @@
   resource delete requests have been issued, so immediate same-name route
   re-creates are not blocked by child resource finalizers.
   [#4465](https://github.com/Kong/kong-operator/pull/4465)
+- Hybridgateway: use route-scoped `KongService` names for `HTTPRoute` rules
+  whose backendRefs resolve to no valid targets. This avoids Konnect name
+  conflicts with valid backend services while keeping normally generated service
+  names unchanged.
+  [#4437](https://github.com/Kong/kong-operator/pull/4437)
 - Hybridgateway: fix `KongRoute` name collisions when an `HTTPRoute` attaches
   to multiple listener-scoped `ParentRef`s on the same `Gateway`, enabling the
   `HTTPRouteListenerHostnameMatching` Gateway API conformance test for Hybrid

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -408,8 +408,36 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 
 			upstreamName := namegen.NewKongUpstreamNameForHTTPRouteRule(c.route, cp, rule)
 
+			// Build the KongTarget resources before the service so fallback services for
+			// invalid backends can use a route-scoped name and avoid colliding with normal backend services.
+			targets, err := target.TargetsForBackendRefs(
+				ctx,
+				logger.WithValues("upstream", upstreamName),
+				c.Client,
+				c.route,
+				rule.BackendRefs,
+				&pRef,
+				upstreamName,
+				c.fqdnMode,
+				c.clusterDomain,
+			)
+			if err != nil {
+				log.Error(logger, err, "Failed to translate KongTarget resources for rule, skipping rule",
+					"upstream", upstreamName,
+					"backendRefs", rule.BackendRefs,
+					"parentRef", pRef)
+				translationErrors = append(translationErrors, fmt.Errorf("failed to translate KongTarget resources for upstream %s: %w", upstreamName, err))
+				continue
+			}
+			log.Debug(logger, "Successfully translated KongTarget resources", "upstream", upstreamName, "targetCount", len(targets))
+
+			serviceNameOverride := ""
+			if len(rule.BackendRefs) > 0 && len(targets) == 0 {
+				serviceNameOverride = namegen.NewKongServiceNameForHTTPRouteRuleBackendNotFound(c.route, cp, rule)
+			}
+
 			// Build the KongService resource (and optionally a KongCertificate + KongReferenceGrant for client-cert).
-			servicePtr, certPtr, grantPtr, err := service.ServiceForRule(ctx, logger, c.Client, c.route, rule, &pRef, cp, upstreamName)
+			servicePtr, certPtr, grantPtr, err := service.ServiceForRuleWithName(ctx, logger, c.Client, c.route, rule, &pRef, cp, upstreamName, serviceNameOverride)
 			if err != nil {
 				log.Error(logger, err, "Failed to translate KongService resource, skipping rule",
 					"controlPlane", cp.KonnectNamespacedRef,
@@ -479,29 +507,6 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 					}
 				}
 			}
-
-			// Build the KongTarget resources.
-			// Leave them as the last step since we want everything fully configured before enabling the traffic to the backends.
-			targets, err := target.TargetsForBackendRefs(
-				ctx,
-				logger.WithValues("upstream", upstreamName),
-				c.Client,
-				c.route,
-				rule.BackendRefs,
-				&pRef,
-				upstreamName,
-				c.fqdnMode,
-				c.clusterDomain,
-			)
-			if err != nil {
-				log.Error(logger, err, "Failed to translate KongTarget resources for rule, skipping rule",
-					"upstream", upstreamName,
-					"backendRefs", rule.BackendRefs,
-					"parentRef", pRef)
-				translationErrors = append(translationErrors, fmt.Errorf("failed to translate KongTarget resources for upstream %s: %w", upstreamName, err))
-				continue
-			}
-			log.Debug(logger, "Successfully translated KongTarget resources", "upstream", upstreamName, "targetCount", len(targets))
 
 			ruleOutputs := make([]client.Object, 0, 1+len(routes)+len(filterOutputs)+len(targets)+4)
 			if len(rule.BackendRefs) == 0 || len(targets) > 0 {

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -18,6 +18,7 @@ import (
 	hybridgatewayerrors "github.com/kong/kong-operator/v2/controller/hybridgateway/errors"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/kongroute"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/namegen"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/plugin"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/pluginbinding"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/refs"
@@ -405,18 +406,7 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 				"matchCount", len(rule.Matches),
 				"filterCount", len(rule.Filters))
 
-			// Build the KongUpstream resource.
-			upstreamPtr, err := upstream.UpstreamForRule(ctx, logger, c.Client, c.route, rule, &pRef, cp)
-			if err != nil {
-				log.Error(logger, err, "Failed to translate KongUpstream resource for rule, skipping rule",
-					"controlPlane", cp.KonnectNamespacedRef)
-				translationErrors = append(translationErrors, fmt.Errorf("failed to translate KongUpstream resource: %w", err))
-				continue
-			}
-			upstreamName := upstreamPtr.Name
-			c.outputStore = append(c.outputStore, upstreamPtr)
-			log.Debug(logger, "Successfully translated KongUpstream resource",
-				"upstream", upstreamName)
+			upstreamName := namegen.NewKongUpstreamNameForHTTPRouteRule(c.route, cp, rule)
 
 			// Build the KongService resource (and optionally a KongCertificate + KongReferenceGrant for client-cert).
 			servicePtr, certPtr, grantPtr, err := service.ServiceForRule(ctx, logger, c.Client, c.route, rule, &pRef, cp, upstreamName)
@@ -427,19 +417,7 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 				translationErrors = append(translationErrors, fmt.Errorf("failed to translate KongService for rule: %w", err))
 				continue
 			}
-			// Append KongReferenceGrant before KongCertificate so the grant exists when the cert is applied.
-			if grantPtr != nil {
-				c.outputStore = append(c.outputStore, grantPtr)
-				log.Debug(logger, "Successfully translated KongReferenceGrant resource", "grant", grantPtr.Name)
-			}
-			if certPtr != nil {
-				c.outputStore = append(c.outputStore, certPtr)
-				log.Debug(logger, "Successfully translated KongCertificate resource", "cert", certPtr.Name)
-			}
 			serviceName := servicePtr.Name
-			c.outputStore = append(c.outputStore, servicePtr)
-			log.Debug(logger, "Successfully translated KongService resource",
-				"service", serviceName)
 
 			// Build one KongRoute per match in the rule.
 			// Gateway API semantics require OR across matches within a rule
@@ -454,16 +432,10 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 				translationErrors = append(translationErrors, fmt.Errorf("failed to translate KongRoutes for rule %d: %w", ruleIndex, err))
 				continue
 			}
-			for _, r := range routes {
-				routeName := r.Name
-				c.outputStore = append(c.outputStore, r)
-				log.Debug(logger, "Successfully translated KongRoute resource",
-					"route", routeName)
-			}
-
 			// Build the KongPlugin and KongPluginBinding resources.
 			log.Debug(logger, "Processing filters for rule",
 				"filterCount", len(rule.Filters))
+			filterOutputs := make([]client.Object, 0)
 
 			for _, filter := range rule.Filters {
 				plugins, err := plugin.PluginsForFilter(ctx, logger, c.Client, c.route, rule, filter, &pRef)
@@ -474,9 +446,10 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 					continue
 				}
 
-				for _, plugin := range plugins {
-					pluginName := plugin.Name
-					c.outputStore = append(c.outputStore, &plugin)
+				for i := range plugins {
+					pluginObj := &plugins[i]
+					pluginName := pluginObj.Name
+					filterOutputs = append(filterOutputs, pluginObj)
 					// Create a KongPluginBinding to bind the KongPlugin to each KongRoute generated for the rule.
 					for _, r := range routes {
 						bindingPtr, err := pluginbinding.BindingForPluginAndRoute(
@@ -497,7 +470,7 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 							continue
 						}
 						bindingName := bindingPtr.Name
-						c.outputStore = append(c.outputStore, bindingPtr)
+						filterOutputs = append(filterOutputs, bindingPtr)
 
 						log.Debug(logger, "Successfully translated KongPlugin and KongPluginBinding resources",
 							"plugin", pluginName,
@@ -528,12 +501,42 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 				translationErrors = append(translationErrors, fmt.Errorf("failed to translate KongTarget resources for upstream %s: %w", upstreamName, err))
 				continue
 			}
-			log.Debug(logger, "Successfully translated KongTarget resources",
-				"upstream", upstreamName,
-				"targetCount", len(targets))
-			for _, tgt := range targets {
-				c.outputStore = append(c.outputStore, &tgt)
+			log.Debug(logger, "Successfully translated KongTarget resources", "upstream", upstreamName, "targetCount", len(targets))
+
+			ruleOutputs := make([]client.Object, 0, 1+len(routes)+len(filterOutputs)+len(targets)+4)
+			if len(rule.BackendRefs) == 0 || len(targets) > 0 {
+				upstreamPtr, err := upstream.UpstreamForRule(ctx, logger, c.Client, c.route, rule, &pRef, cp)
+				if err != nil {
+					log.Error(logger, err, "Failed to translate KongUpstream resource for rule, skipping rule",
+						"controlPlane", cp.KonnectNamespacedRef)
+					translationErrors = append(translationErrors, fmt.Errorf("failed to translate KongUpstream resource: %w", err))
+					continue
+				}
+				ruleOutputs = append(ruleOutputs, upstreamPtr)
+				log.Debug(logger, "Successfully translated KongUpstream resource", "upstream", upstreamName)
+			} else {
+				log.Debug(logger, "Skipping KongUpstream translation because no valid backend targets were produced",
+					"upstream", upstreamName,
+					"backendRefCount", len(rule.BackendRefs))
 			}
+
+			// Append KongReferenceGrant before KongCertificate so the grant exists when the cert is applied.
+			if grantPtr != nil {
+				ruleOutputs = append(ruleOutputs, grantPtr)
+				log.Debug(logger, "Successfully translated KongReferenceGrant resource", "grant", grantPtr.Name)
+			}
+			if certPtr != nil {
+				ruleOutputs = append(ruleOutputs, certPtr)
+				log.Debug(logger, "Successfully translated KongCertificate resource", "cert", certPtr.Name)
+			}
+			ruleOutputs = append(ruleOutputs, servicePtr)
+			log.Debug(logger, "Successfully translated KongService resource", "service", serviceName)
+			for _, r := range routes {
+				routeName := r.Name
+				ruleOutputs = append(ruleOutputs, r)
+				log.Debug(logger, "Successfully translated KongRoute resource", "route", routeName)
+			}
+			ruleOutputs = append(ruleOutputs, filterOutputs...)
 
 			if len(rule.BackendRefs) > 0 && len(targets) == 0 {
 				terminationPlugin, err := plugin.RequestTerminationForBackendNotFound(
@@ -551,7 +554,6 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 					translationErrors = append(translationErrors, fmt.Errorf("failed to translate request-termination plugin for service %s: %w", serviceName, err))
 					continue
 				}
-				c.outputStore = append(c.outputStore, terminationPlugin)
 
 				bindingPtr, err := pluginbinding.BindingForPluginAndService(
 					ctx,
@@ -570,8 +572,14 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 					translationErrors = append(translationErrors, fmt.Errorf("failed to bind request-termination plugin %s to service %s: %w", terminationPlugin.Name, serviceName, err))
 					continue
 				}
-				c.outputStore = append(c.outputStore, bindingPtr)
+				ruleOutputs = append(ruleOutputs, terminationPlugin, bindingPtr)
 			}
+
+			for i := range targets {
+				ruleOutputs = append(ruleOutputs, &targets[i])
+			}
+
+			c.outputStore = append(c.outputStore, ruleOutputs...)
 		}
 	}
 

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -508,7 +508,7 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 				}
 			}
 
-			ruleOutputs := make([]client.Object, 0, 1+len(routes)+len(filterOutputs)+len(targets)+4)
+			var ruleOutputs []client.Object
 			if len(rule.BackendRefs) == 0 || len(targets) > 0 {
 				upstreamPtr, err := upstream.UpstreamForRule(ctx, logger, c.Client, c.route, rule, &pRef, cp)
 				if err != nil {

--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -24,6 +24,7 @@ import (
 
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/namegen"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	"github.com/kong/kong-operator/v2/pkg/consts"
@@ -352,15 +353,15 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 				t.Helper()
 
 				var (
-					serviceName string
-					pluginObj   *configurationv1.KongPlugin
-					bindingObj  *configurationv1alpha1.KongPluginBinding
+					serviceObj *configurationv1alpha1.KongService
+					pluginObj  *configurationv1.KongPlugin
+					bindingObj *configurationv1alpha1.KongPluginBinding
 				)
 
 				for _, obj := range store {
 					switch typed := obj.(type) {
 					case *configurationv1alpha1.KongService:
-						serviceName = typed.Name
+						serviceObj = typed
 					case *configurationv1.KongPlugin:
 						pluginObj = typed
 					case *configurationv1alpha1.KongPluginBinding:
@@ -368,7 +369,14 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 					}
 				}
 
+				require.NotNil(t, serviceObj)
+				serviceName := serviceObj.Name
+				normalRoute := newHTTPRouteForTranslation([]string{"api.example.com"}, []gwtypes.HTTPBackendRef{
+					newBackendRef("backend"),
+				}, nil)
+				normalServiceName := namegen.NewKongServiceNameForHTTPRouteRule(normalRoute, serviceObj.Spec.ControlPlaneRef, normalRoute.Spec.Rules[0])
 				require.NotEmpty(t, serviceName)
+				assert.NotEqual(t, normalServiceName, serviceName)
 				require.NotNil(t, pluginObj)
 				require.NotNil(t, bindingObj)
 				assert.Equal(t, "request-termination", pluginObj.PluginName)

--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -338,16 +338,16 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 				fakeClient := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(objects...).Build()
 				return newHTTPRouteConverter(route, fakeClient, false, "").(*httpRouteConverter)
 			},
-			wantCount: 5,
+			wantCount: 4,
 			wantOutputs: outputCount{
-				upstreams: 1,
+				upstreams: 0,
 				services:  1,
 				routes:    1,
 				targets:   0,
 				bindings:  1,
 				plugins:   1,
 			},
-			wantStoreLen: 5,
+			wantStoreLen: 4,
 			assertFn: func(t *testing.T, store []client.Object) {
 				t.Helper()
 
@@ -397,16 +397,16 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 				fakeClient := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(objects...).Build()
 				return newHTTPRouteConverter(route, fakeClient, false, "").(*httpRouteConverter)
 			},
-			wantCount: 5,
+			wantCount: 4,
 			wantOutputs: outputCount{
-				upstreams: 1,
+				upstreams: 0,
 				services:  1,
 				routes:    1,
 				targets:   0,
 				bindings:  1,
 				plugins:   1,
 			},
-			wantStoreLen: 5,
+			wantStoreLen: 4,
 			assertFn: func(t *testing.T, store []client.Object) {
 				t.Helper()
 
@@ -545,16 +545,16 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 				fakeClient := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(objects...).Build()
 				return newHTTPRouteConverter(route, fakeClient, false, "").(*httpRouteConverter)
 			},
-			wantCount: 9,
+			wantCount: 8,
 			wantOutputs: outputCount{
-				upstreams: 2,
+				upstreams: 1,
 				services:  2,
 				routes:    2,
 				targets:   1,
 				bindings:  1,
 				plugins:   1,
 			},
-			wantStoreLen: 9,
+			wantStoreLen: 8,
 			assertFn: func(t *testing.T, store []client.Object) {
 				t.Helper()
 
@@ -603,16 +603,16 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 				fakeClient := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(objects...).Build()
 				return newHTTPRouteConverter(route, fakeClient, false, "").(*httpRouteConverter)
 			},
-			wantCount: 5,
+			wantCount: 4,
 			wantOutputs: outputCount{
-				upstreams: 1,
+				upstreams: 0,
 				services:  1,
 				routes:    1,
 				targets:   0,
 				bindings:  1,
 				plugins:   1,
 			},
-			wantStoreLen: 5,
+			wantStoreLen: 4,
 			assertFn: func(t *testing.T, store []client.Object) {
 				t.Helper()
 
@@ -980,12 +980,9 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 					Build()
 				return newHTTPRouteConverter(route, fakeClient, false, "").(*httpRouteConverter)
 			},
-			wantErr:    true,
-			wantErrSub: "failed to translate KongService for rule",
-			wantOutputs: outputCount{
-				upstreams: 1,
-			},
-			wantStoreLen: 1,
+			wantErr:      true,
+			wantErrSub:   "failed to translate KongService for rule",
+			wantStoreLen: 0,
 		},
 		{
 			name: "returns error when route translation fails",
@@ -1006,13 +1003,9 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 					Build()
 				return newHTTPRouteConverter(route, fakeClient, false, "").(*httpRouteConverter)
 			},
-			wantErr:    true,
-			wantErrSub: "failed to translate KongRoutes for rule",
-			wantOutputs: outputCount{
-				upstreams: 1,
-				services:  1,
-			},
-			wantStoreLen: 2,
+			wantErr:      true,
+			wantErrSub:   "failed to translate KongRoutes for rule",
+			wantStoreLen: 0,
 		},
 		{
 			name: "returns error when plugin binding fails",
@@ -1068,14 +1061,9 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 					Build()
 				return newHTTPRouteConverter(route, fakeClient, false, "").(*httpRouteConverter)
 			},
-			wantErr:    true,
-			wantErrSub: "failed to translate KongTarget resources for upstream",
-			wantOutputs: outputCount{
-				upstreams: 1,
-				services:  1,
-				routes:    1,
-			},
-			wantStoreLen: 3,
+			wantErr:      true,
+			wantErrSub:   "failed to translate KongTarget resources for upstream",
+			wantStoreLen: 0,
 		},
 	}
 

--- a/controller/hybridgateway/namegen/name.go
+++ b/controller/hybridgateway/namegen/name.go
@@ -24,6 +24,10 @@ const (
 	// parentRefPrefix is the prefix used when including a ParentRef identifier.
 	parentRefPrefix = "pr"
 
+	// backendNotFoundPrefix is the prefix used for service names that intentionally
+	// route to request-termination because no backend target could be produced.
+	backendNotFoundPrefix = "bnf"
+
 	// namegenPrefix is used as the prefix for hashed names when concatenated
 	// components exceed the maximum Kubernetes resource name length.
 	namegenPrefix = "ngn"
@@ -109,6 +113,32 @@ func NewKongServiceNameForHTTPRouteRule(route *gwtypes.HTTPRoute, cp *commonv1al
 	return newNameWithHashSuffix(readableElements, hashElements)
 }
 
+// NewKongServiceNameForHTTPRouteRuleBackendNotFound generates a route-scoped KongService name
+// for rules that have BackendRefs but no valid backend targets. These services get a
+// request-termination plugin, so they must not share the normal backend service name.
+func NewKongServiceNameForHTTPRouteRuleBackendNotFound(
+	route *gwtypes.HTTPRoute,
+	cp *commonv1alpha1.ControlPlaneRef,
+	rule gatewayv1.HTTPRouteRule,
+) string {
+	readableElements := append(
+		[]string{httpProcolPrefix},
+		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
+	)
+	hashElements := []string{
+		defaultCPPrefix + utils.Hash32(cp),
+		backendNotFoundPrefix + utils.Hash32(struct {
+			Namespace string
+			Name      string
+		}{
+			Namespace: route.Namespace,
+			Name:      route.Name,
+		}),
+		hashForHTTPRouteRuleServiceLikeName(route, rule),
+	}
+	return newNameWithHashSuffix(readableElements, hashElements)
+}
+
 // NewKongServiceNameForTLSRouteRule generates a KongService name based on the ControlPlaneRef and TLSRouteRule passed as arguments.
 func NewKongServiceNameForTLSRouteRule(route *gwtypes.TLSRoute, cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.TLSRouteRule) string {
 	readableElements := append(
@@ -124,6 +154,14 @@ func hashElementsForServiceLikeName(
 	cp *commonv1alpha1.ControlPlaneRef,
 	rule gatewayv1.HTTPRouteRule,
 ) []string {
+	hash := hashForHTTPRouteRuleServiceLikeName(route, rule)
+	return []string{
+		defaultCPPrefix + utils.Hash32(cp),
+		hash,
+	}
+}
+
+func hashForHTTPRouteRuleServiceLikeName(route *gwtypes.HTTPRoute, rule gatewayv1.HTTPRouteRule) string {
 	var hash string
 	if len(rule.BackendRefs) > 0 {
 		hash = utils.Hash32(rule.BackendRefs)
@@ -142,10 +180,7 @@ func hashElementsForServiceLikeName(
 		hash = utils.Hash32(zeroBackendRuleIdentity)
 	}
 
-	return []string{
-		defaultCPPrefix + utils.Hash32(cp),
-		hash,
-	}
+	return hash
 }
 
 func hashElementsForServiceLikeNameTLSRouteRule(

--- a/controller/hybridgateway/namegen/name_test.go
+++ b/controller/hybridgateway/namegen/name_test.go
@@ -276,6 +276,27 @@ func TestNewKongServiceName(t *testing.T) {
 	}
 }
 
+func TestNewKongServiceNameForHTTPRouteRuleBackendNotFound(t *testing.T) {
+	backendNS := gatewayv1.Namespace("gateway-conformance-web-backend")
+	port := gatewayv1.PortNumber(8080)
+	rule := gatewayv1.HTTPRouteRule{
+		BackendRefs: []gatewayv1.HTTPBackendRef{
+			testBackendRef("web-backend", &backendNS, &port),
+		},
+	}
+	routeA := testRoute("gateway-conformance-infra", "invalid-cross-namespace-backend-ref")
+	routeB := testRoute("gateway-conformance-infra", "reference-grant")
+	cp := testControlPlaneRef("same-namespace")
+
+	normalName := NewKongServiceNameForHTTPRouteRule(routeA, cp, rule)
+	fallbackNameA := NewKongServiceNameForHTTPRouteRuleBackendNotFound(routeA, cp, rule)
+	fallbackNameB := NewKongServiceNameForHTTPRouteRuleBackendNotFound(routeB, cp, rule)
+
+	assert.NotEqual(t, normalName, fallbackNameA)
+	assert.NotEqual(t, fallbackNameA, fallbackNameB)
+	assert.Contains(t, fallbackNameA, backendNotFoundPrefix)
+}
+
 func TestNewKongServiceName_Equality(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/controller/hybridgateway/service/service.go
+++ b/controller/hybridgateway/service/service.go
@@ -60,7 +60,25 @@ func ServiceForRule[
 	cp *commonv1alpha1.ControlPlaneRef,
 	upstreamName string,
 ) (kongService *configurationv1alpha1.KongService, kongCertificate *configurationv1alpha1.KongCertificate, kongReferenceGrant *configurationv1alpha1.KongReferenceGrant, err error) {
+	return ServiceForRuleWithName(ctx, logger, cl, parentRoute, rule, pRef, cp, upstreamName, "")
+}
 
+// ServiceForRuleWithName behaves like ServiceForRule but uses serviceName when it is not empty.
+func ServiceForRuleWithName[
+	T gwtypes.SupportedRoute,
+	TPtr gwtypes.SupportedRoutePtr[T],
+	R gwtypes.SupportedRouteRule,
+](
+	ctx context.Context,
+	logger logr.Logger,
+	cl client.Client,
+	parentRoute TPtr,
+	rule R,
+	pRef *gwtypes.ParentReference,
+	cp *commonv1alpha1.ControlPlaneRef,
+	upstreamName string,
+	serviceNameOverride string,
+) (kongService *configurationv1alpha1.KongService, kongCertificate *configurationv1alpha1.KongCertificate, kongReferenceGrant *configurationv1alpha1.KongReferenceGrant, err error) {
 	var serviceName string
 	var namespace string
 	var backendRefs []gwtypes.BackendRef
@@ -92,6 +110,10 @@ func ServiceForRule[
 	// Should be unreachable.
 	default:
 		return nil, nil, nil, fmt.Errorf("failed to build KongService: unsupported route type: %T", parentRoute)
+	}
+
+	if serviceNameOverride != "" {
+		serviceName = serviceNameOverride
 	}
 
 	// Resolve service attributes once, outside the switch — future route types only add a case above.

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -125,6 +125,9 @@ func runConformance(
 	timeoutConfig.GatewayStatusMustHaveListeners = conformanceLooserTimeout
 	timeoutConfig.GatewayListenersMustHaveConditions = conformanceLooserTimeout
 	timeoutConfig.HTTPRouteMustHaveCondition = conformanceLooserTimeout
+	if gwType == hybridGateway {
+		timeoutConfig.MaxTimeToConsistency = conformanceLooserTimeout
+	}
 
 	opts := conformance.DefaultOptions(t)
 	// It takes default conformance suite configuration manifests from provided location.

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -38,10 +38,6 @@ var skippedTestsForHybrid = []string{
 	// Extended profile.
 	tests.HTTPRouteRewriteHost.ShortName,
 	tests.HTTPRouteRewritePath.ShortName,
-
-	// This test is skipped because it proven to be flaky.
-	// TODO: https://github.com/Kong/kong-operator/issues/2793
-	tests.HTTPRouteReferenceGrant.ShortName,
 }
 
 // skippedTestsForConfig returns the list of skipped tests for the given router flavor and gateway type.


### PR DESCRIPTION
**What this PR does / why we need it**:

Re-enables the `HTTPRouteReferenceGrant` Gateway API conformance test for Hybrid Gateway and fixes the hybrid HTTPRoute translation path that made the test flaky in CI.

When an `HTTPRoute` rule has backendRefs but none resolve to valid targets, the translator now uses a route-scoped fallback `KongService` name for the backend-not-found/request-termination path. This avoids reusing the normal backend-derived service name, which could collide in Konnect with a later valid backend service after ReferenceGrant changes.

Normal generated service names for valid backends are unchanged; only invalid-backend fallback services are renamed.

Also increases the Hybrid conformance timeout to account for slower Konnect/data-plane convergence.


**Which issue this PR fixes**

Fixes #2793

**Special notes for your reviewer**:

The user-visible resource name change is intentionally narrow: it only affects generated fallback `KongService` resources for `HTTPRoute` rules whose backendRefs resolve to no valid targets. Existing/normal valid backend generated service names remain unchanged.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
