### PR TITLE
test(chainsaw): add Event Gateway proxy-roundtrip and SNI routing tests

### DIFF
--- a/.github/workflows/__e2e_chainsaw_tests.yaml
+++ b/.github/workflows/__e2e_chainsaw_tests.yaml
@@ -69,6 +69,7 @@ jobs:
           --set image.repository=${{ env.IMG }} \
           --set image.tag=${{ env.TAG }} \
           --set env.enable_controller_konnect=true \
+          --set env.enable_controller_kegdataplane=true \
           --wait
 
     - name: run chainsaw e2e tests

--- a/test/e2e/chainsaw/common/_step_templates/apply-assert-kafka-cluster.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/apply-assert-kafka-cluster.yaml
@@ -1,0 +1,158 @@
+# Template for deploying and asserting a 3-broker Apache Kafka cluster
+# (KRaft, combined controller+broker mode, no Strimzi).
+#
+# Deployed resources:
+#   - Service/kafka-headless  (ClusterIP None, for inter-broker + advertised listeners)
+#   - Service/kafka-bootstrap (ClusterIP, for in-cluster client bootstrap)
+#   - StatefulSet/kafka       (3 replicas, Parallel pod management, apache/kafka:4.2.0)
+#
+# No required bindings — all resource names are fixed.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: apply-assert-kafka-cluster
+spec:
+  try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: kafka-headless
+          spec:
+            clusterIP: None
+            publishNotReadyAddresses: true
+            selector:
+              app: kafka
+            ports:
+              - name: client
+                port: 9092
+                targetPort: 9092
+              - name: controller
+                port: 9093
+                targetPort: 9093
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: kafka-bootstrap
+          spec:
+            type: ClusterIP
+            selector:
+              app: kafka
+            ports:
+              - name: client
+                port: 9092
+                targetPort: 9092
+    - apply:
+        resource:
+          apiVersion: apps/v1
+          kind: StatefulSet
+          metadata:
+            name: kafka
+          spec:
+            serviceName: kafka-headless
+            replicas: 3
+            # Parallel is required: with the default OrderedReady policy pod-1 and
+            # pod-2 are never created while pod-0 waits for a quorum it can never form
+            # alone, causing a permanent deadlock.
+            podManagementPolicy: Parallel
+            selector:
+              matchLabels:
+                app: kafka
+            template:
+              metadata:
+                labels:
+                  app: kafka
+              spec:
+                terminationGracePeriodSeconds: 10
+                containers:
+                  - name: kafka
+                    image: apache/kafka:4.2.0
+                    imagePullPolicy: IfNotPresent
+                    ports:
+                      - name: client
+                        containerPort: 9092
+                      - name: controller
+                        containerPort: 9093
+                    env:
+                      - name: POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      # Stable cluster ID: must be a 22-char base64url string (no padding).
+                      # Pre-computed so we don't depend on a runtime base64 utility.
+                      # Value decodes to the 16-byte ASCII sequence "abcdefghijklmnop".
+                      - name: CLUSTER_ID
+                        value: "YWJjZGVmZ2hpamtsbW5vcA"
+                    command:
+                      - /bin/bash
+                      - -c
+                      - |
+                        set -euo pipefail
+                        ORDINAL=${HOSTNAME##*-}
+                        SERVICE=kafka-headless
+                        cat <<EOF > /tmp/kraft.properties
+                        process.roles=broker,controller
+                        node.id=${ORDINAL}
+                        controller.quorum.voters=0@kafka-0.${SERVICE}.${POD_NAMESPACE}.svc:9093,1@kafka-1.${SERVICE}.${POD_NAMESPACE}.svc:9093,2@kafka-2.${SERVICE}.${POD_NAMESPACE}.svc:9093
+                        listeners=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+                        advertised.listeners=PLAINTEXT://${HOSTNAME}.${SERVICE}.${POD_NAMESPACE}.svc:9092
+                        listener.security.protocol.map=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+                        controller.listener.names=CONTROLLER
+                        inter.broker.listener.name=PLAINTEXT
+                        log.dirs=/var/lib/kafka/data
+                        offsets.topic.replication.factor=3
+                        transaction.state.log.replication.factor=3
+                        transaction.state.log.min.isr=2
+                        default.replication.factor=3
+                        min.insync.replicas=2
+                        num.partitions=3
+                        EOF
+                        if [ ! -f /var/lib/kafka/data/meta.properties ]; then
+                          /opt/kafka/bin/kafka-storage.sh format \
+                            -t "${CLUSTER_ID}" \
+                            -c /tmp/kraft.properties
+                        fi
+                        exec /opt/kafka/bin/kafka-server-start.sh /tmp/kraft.properties
+                    readinessProbe:
+                      tcpSocket:
+                        port: 9092
+                      initialDelaySeconds: 20
+                      periodSeconds: 5
+                      timeoutSeconds: 3
+                      # Allow ~2 min for all three pods to discover each other, elect a
+                      # KRaft controller leader, and open the client listener.
+                      failureThreshold: 24
+                    volumeMounts:
+                      - name: data
+                        mountPath: /var/lib/kafka/data
+                volumes:
+                  - name: data
+                    emptyDir: {}
+    - assert:
+        resource:
+          apiVersion: apps/v1
+          kind: StatefulSet
+          metadata:
+            name: kafka
+          status:
+            replicas: 3
+            readyReplicas: 3
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: kafka-bootstrap
+          spec:
+            type: ClusterIP
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: kafka-headless
+          spec:
+            clusterIP: None

--- a/test/e2e/chainsaw/common/scripts/debug_snapshot.sh
+++ b/test/e2e/chainsaw/common/scripts/debug_snapshot.sh
@@ -102,7 +102,7 @@ for ns in ${ALL_NAMESPACES}; do
 
   # Konnect resources (excluding KonnectAPIAuthConfiguration - captured separately with redaction)
   capture_resource_group "${RESOURCES_FILE}" "${ns}" "Konnect Resources" \
-    "konnectgatewaycontrolplanes.konnect.konghq.com,konnectextensions.konnect.konghq.com"
+    "konnectgatewaycontrolplanes.konnect.konghq.com,konnectextensions.konnect.konghq.com,konnecteventgateways.konnect.konghq.com"
 
   # KonnectAPIAuthConfiguration with token redaction
   {
@@ -125,6 +125,10 @@ for ns in ${ALL_NAMESPACES}; do
   # Gateway Operator resources
   capture_resource_group "${RESOURCES_FILE}" "${ns}" "Gateway Operator Resources" \
     "gatewayconfigurations.gateway-operator.konghq.com,controlplanes.gateway-operator.konghq.com,dataplanes.gateway-operator.konghq.com,aigateways.gateway-operator.konghq.com,dataplanemetricsextensions.gateway-operator.konghq.com"
+
+  # Event Gateway resources
+  capture_resource_group "${RESOURCES_FILE}" "${ns}" "Event Gateway Resources" \
+    "kegdataplanes.eventgateway.konghq.com,eventgatewaybackendclusters.configuration.konghq.com,eventgatewayvirtualclusters.configuration.konghq.com,eventgatewaylisteners.configuration.konghq.com,eventgatewaylistenerpolicies.configuration.konghq.com,eventgatewayvirtualclusterconsumepolicies.configuration.konghq.com"
 
   # Core Kubernetes resources
   capture_resource_group "${RESOURCES_FILE}" "${ns}" "Core Kubernetes Resources" \
@@ -177,7 +181,7 @@ for ns in ${ALL_NAMESPACES}; do
     echo ""
   } >> "${DESCRIBED_FILE}"
 
-  safe_kubectl "${DESCRIBED_FILE}" describe konnectgatewaycontrolplanes,konnectextensions -n "${ns}"
+  safe_kubectl "${DESCRIBED_FILE}" describe konnectgatewaycontrolplanes,konnectextensions,konnecteventgateways -n "${ns}"
 
   # Describe KonnectAPIAuthConfigurations with token redaction
   {
@@ -201,6 +205,14 @@ for ns in ${ALL_NAMESPACES}; do
   } >> "${DESCRIBED_FILE}"
 
   safe_kubectl "${DESCRIBED_FILE}" describe gatewayconfigurations -n "${ns}"
+
+  {
+    echo ""
+    echo "=== Event Gateway Resources in ${ns} ==="
+    echo ""
+  } >> "${DESCRIBED_FILE}"
+
+  safe_kubectl "${DESCRIBED_FILE}" describe kegdataplanes.eventgateway.konghq.com,eventgatewaybackendclusters,eventgatewayvirtualclusters,eventgatewaylisteners,eventgatewaylistenerpolicies,eventgatewayvirtualclusterconsumepolicies -n "${ns}"
 done
 
 # 3. Capture events in test namespaces

--- a/test/e2e/chainsaw/common/scripts/get_ca_cert.sh
+++ b/test/e2e/chainsaw/common/scripts/get_ca_cert.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Retrieve the CA certificate stored in a ConfigMap during cert generation
+# and output it as a base64-encoded JSON field for use in kafkactl TLS config.
+#
+# Required env:
+#   NAMESPACE    Kubernetes namespace.
+#   CA_CM_NAME   Name of the ConfigMap holding the CA cert (key: ca.crt).
+set -o errexit
+set -o nounset
+set -o pipefail
+
+NAMESPACE="${NAMESPACE}"
+CA_CM_NAME="${CA_CM_NAME}"
+
+CA_CRT=$(kubectl -n "${NAMESPACE}" get configmap "${CA_CM_NAME}" \
+  -o jsonpath='{.data.ca\.crt}' 2>/dev/null || true)
+
+if [[ -z "${CA_CRT}" ]]; then
+  cat <<EOF
+{
+  "success": false,
+  "error": "CA cert not found in ConfigMap ${CA_CM_NAME} in namespace ${NAMESPACE}",
+  "configmap": "${CA_CM_NAME}",
+  "namespace": "${NAMESPACE}"
+}
+EOF
+  exit 1
+fi
+
+CA_CERT_B64=$(printf '%s' "${CA_CRT}" | base64 | tr -d '\n')
+cat <<EOF
+{
+  "success": true,
+  "ca_cert_b64": "${CA_CERT_B64}",
+  "configmap": "${CA_CM_NAME}",
+  "namespace": "${NAMESPACE}"
+}
+EOF

--- a/test/e2e/chainsaw/common/scripts/get_lb_address.sh
+++ b/test/e2e/chainsaw/common/scripts/get_lb_address.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Wait for the KegDataPlane's Kafka LoadBalancer Service to be assigned an
+# external address and output the result as a JSON blob to stdout.
+# Chainsaw captures the address via: json_parse($stdout).address
+#
+# Required env:
+#   NAMESPACE     Namespace the resources live in.
+#   KEG_DP_NAME   Name of the KegDataPlane (its Service is <KEG_DP_NAME>-kafka).
+# Optional env:
+#   MAX_RETRIES   Maximum retry attempts. Default: 60.
+#   RETRY_DELAY   Seconds between retries. Default: 5.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+NAMESPACE="${NAMESPACE}"
+KEG_DP_NAME="${KEG_DP_NAME}"
+MAX_RETRIES="${MAX_RETRIES:-60}"
+RETRY_DELAY="${RETRY_DELAY:-5}"
+
+SVC="${KEG_DP_NAME}-kafka"
+ADDR=""
+
+for ATTEMPT in $(seq 1 "${MAX_RETRIES}"); do
+  IP=$(kubectl -n "${NAMESPACE}" get svc "${SVC}" \
+    -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+  HOSTNAME=$(kubectl -n "${NAMESPACE}" get svc "${SVC}" \
+    -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || true)
+  ADDR="${IP:-${HOSTNAME}}"
+  if [[ -n "${ADDR}" ]]; then
+    cat <<EOF
+{
+  "success": true,
+  "address": "${ADDR}",
+  "service": "${SVC}",
+  "retry_attempt": ${ATTEMPT},
+  "max_retries": ${MAX_RETRIES}
+}
+EOF
+    exit 0
+  fi
+  if [[ ${ATTEMPT} -lt ${MAX_RETRIES} ]]; then
+    sleep "${RETRY_DELAY}"
+  fi
+done
+
+cat <<EOF
+{
+  "success": false,
+  "error": "Service ${SVC} never got a LoadBalancer address after ${MAX_RETRIES} attempts",
+  "service": "${SVC}",
+  "retry_attempt": ${ATTEMPT},
+  "max_retries": ${MAX_RETRIES}
+}
+EOF
+exit 1

--- a/test/e2e/chainsaw/common/scripts/seed_topics.sh
+++ b/test/e2e/chainsaw/common/scripts/seed_topics.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Outer script: spins up a disposable kafkactl pod via kubectl run and
+# pre-seeds all Kafka topics needed by the SNI routing validation steps.
+# Connects directly to Kafka (no TLS, in-cluster DNS) via the bootstrap Service.
+#
+# Required env:
+#   NAMESPACE    Kubernetes namespace for the test pod and Kafka Service.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+: "${NAMESPACE:?must be set}"
+
+KAFKA_BOOTSTRAP="kafka-bootstrap.${NAMESPACE}.svc:9092"
+POD_NAME="kafkactl-seed-$(date +%s)"
+SCRIPT_DIR="$(dirname "$0")"
+
+cat "${SCRIPT_DIR}/seed_topics_inner.sh" | kubectl run "${POD_NAME}" \
+  --image=deviceinsight/kafkactl:latest \
+  --rm -i --restart=Never \
+  --env="KAFKA_BOOTSTRAP=${KAFKA_BOOTSTRAP}" \
+  -n "${NAMESPACE}" \
+  --command -- sh -s 2>/dev/null | grep -v '^pod "'

--- a/test/e2e/chainsaw/common/scripts/seed_topics_inner.sh
+++ b/test/e2e/chainsaw/common/scripts/seed_topics_inner.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# Inner script executed inside a disposable kafkactl pod.
+# Connects directly to Kafka (no TLS, in-cluster DNS) and pre-seeds all topics
+# that the SNI routing validation steps will verify through the virtual clusters.
+#
+# Topics created (matching the docs scenario):
+#   analytics_pageviews, analytics_clicks, analytics_orders  — analytics VC namespace
+#   payments_transactions, payments_refunds, payments_orders  — payments VC namespace
+#   user_actions                                              — shared additional topic
+#
+# Env vars provided by kubectl run --env:
+#   KAFKA_BOOTSTRAP  Direct Kafka bootstrap server (e.g. kafka-bootstrap.<ns>.svc:9092).
+#   MAX_RETRIES      (optional) Default: 60.
+#   RETRY_DELAY      (optional) Default: 5.
+set -eu
+
+KAFKA_BOOTSTRAP="${KAFKA_BOOTSTRAP}"
+MAX_RETRIES="${MAX_RETRIES:-60}"
+RETRY_DELAY="${RETRY_DELAY:-5}"
+
+cat > /tmp/kafkactl.yml <<EOF
+contexts:
+  backend:
+    brokers:
+      - ${KAFKA_BOOTSTRAP}
+EOF
+
+TOPICS="analytics_pageviews analytics_clicks analytics_orders \
+        payments_transactions payments_refunds payments_orders \
+        user_actions"
+
+ATTEMPT=0
+while [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+
+  ALL_OK=true
+  for TOPIC in ${TOPICS}; do
+    if ! kafkactl -C /tmp/kafkactl.yml --context backend \
+        create topic "${TOPIC}" \
+        --partitions 3 --replication-factor 3 >/dev/null 2>&1; then
+      ALL_OK=false
+    fi
+  done
+
+  if [ "${ALL_OK}" = "true" ]; then
+    # Verify topics are visible.
+    LISTED=$(kafkactl -C /tmp/kafkactl.yml --context backend \
+      list topics 2>/dev/null || true)
+    MISSING=""
+    for TOPIC in ${TOPICS}; do
+      if ! echo "${LISTED}" | grep -qF "${TOPIC}"; then
+        MISSING="${MISSING} ${TOPIC}"
+      fi
+    done
+
+    if [ -z "${MISSING}" ]; then
+      cat <<EOF
+{
+  "success": true,
+  "message": "All topics created successfully",
+  "retry_attempt": ${ATTEMPT},
+  "max_retries": ${MAX_RETRIES}
+}
+EOF
+      exit 0
+    fi
+  fi
+
+  if [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; then sleep "${RETRY_DELAY}"; fi
+done
+
+cat <<EOF
+{
+  "success": false,
+  "error": "Failed to create/verify all topics after ${MAX_RETRIES} attempts",
+  "retry_attempt": ${ATTEMPT},
+  "max_retries": ${MAX_RETRIES}
+}
+EOF
+exit 1

--- a/test/e2e/chainsaw/eventgateway/proxy-roundtrip/02-event-gateway-assert.yaml
+++ b/test/e2e/chainsaw/eventgateway/proxy-roundtrip/02-event-gateway-assert.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: konnect.konghq.com/v1alpha1
+kind: KonnectEventGateway
+metadata:
+  name: ($keg_cp_name)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: "True"
+---
+apiVersion: eventgateway.konghq.com/v1alpha1
+kind: KegDataPlane
+metadata:
+  name: ($keg_dp_name)
+status:
+  (conditions[?type == 'Ready']):
+    - status: "True"
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayBackendCluster
+metadata:
+  name: ($backend_cluster_name)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: "True"
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayVirtualCluster
+metadata:
+  name: ($virtual_cluster_name)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: "True"
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayListener
+metadata:
+  name: ($listener_name)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: "True"
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayListenerPolicy
+metadata:
+  name: ($listener_policy_name)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: "True"
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayVirtualClusterConsumePolicy
+metadata:
+  name: ($consume_policy_name)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: "True"

--- a/test/e2e/chainsaw/eventgateway/proxy-roundtrip/02-event-gateway.yaml
+++ b/test/e2e/chainsaw/eventgateway/proxy-roundtrip/02-event-gateway.yaml
@@ -1,0 +1,145 @@
+# Event Gateway resources for the proxy-roundtrip test.
+#
+# advertisedHost on the EventGatewayListenerPolicy starts as a placeholder
+# and is patched to the LoadBalancer external IP in a later step, after the
+# Service has been assigned an address.
+---
+apiVersion: konnect.konghq.com/v1alpha1
+kind: KonnectEventGateway
+metadata:
+  name: ($keg_cp_name)
+spec:
+  apiSpec:
+    name: ($keg_cp_name)
+    description: proxy-roundtrip chainsaw test control plane
+    labels:
+      test: proxy-roundtrip
+  konnect:
+    authRef:
+      name: ($konnect_auth_name)
+---
+apiVersion: eventgateway.konghq.com/v1alpha1
+kind: KegDataPlane
+metadata:
+  name: ($keg_dp_name)
+spec:
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: ($keg_cp_name)
+  network:
+    services:
+      kafka:
+        type: LoadBalancer
+        ports:
+          - name: kafka
+            port: 19092
+            targetPort: 19092
+          - name: kafka-broker-0
+            port: 19093
+            targetPort: 19093
+          - name: kafka-broker-1
+            port: 19094
+            targetPort: 19094
+          - name: kafka-broker-2
+            port: 19095
+            targetPort: 19095
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayBackendCluster
+metadata:
+  name: ($backend_cluster_name)
+spec:
+  gatewayRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($keg_cp_name)
+  apiSpec:
+    name: ($backend_cluster_name)
+    description: proxy-roundtrip backend (in-namespace Kafka)
+    bootstrapServers:
+      - (join('', ['kafka-bootstrap.', ($namespace), '.svc:9092']))
+    authentication:
+      type: anonymous
+      anonymous: {}
+    insecureAllowAnonymousVirtualClusterAuth: Enabled
+    tls:
+      enabled: Disabled
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayVirtualCluster
+metadata:
+  name: ($virtual_cluster_name)
+spec:
+  eventGatewayBackendClusterRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($backend_cluster_name)
+  apiSpec:
+    name: ($virtual_cluster_name)
+    description: proxy-roundtrip virtual cluster
+    dnsLabel: vcluster-1
+    aclMode: passthrough
+    authentication:
+      - type: anonymous
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayListener
+metadata:
+  name: ($listener_name)
+spec:
+  gatewayRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($keg_cp_name)
+  apiSpec:
+    name: ($listener_name)
+    description: proxy-roundtrip listener
+    addresses:
+      - "0.0.0.0"
+    ports:
+      - "19092-19095"
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayListenerPolicy
+metadata:
+  name: ($listener_policy_name)
+spec:
+  eventGatewayListenerRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($listener_name)
+  apiSpec:
+    type: forwardToVirtualCluster
+    forwardToVirtualCluster:
+      name: forward
+      enabled: Enabled
+      config:
+        type: portMapping
+        portMapping:
+          bootstrapPort: at_start
+          # Placeholder. Patched to the LoadBalancer IP after the Service is
+          # assigned an external address.
+          advertisedHost: placeholder.invalid
+          destination:
+            name: ($virtual_cluster_name)
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayVirtualClusterConsumePolicy
+metadata:
+  name: ($consume_policy_name)
+spec:
+  eventGatewayVirtualClusterRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($virtual_cluster_name)
+  apiSpec:
+    type: modifyHeaders
+    modifyHeaders:
+      name: add-test-header
+      config:
+        actions:
+          - op: set
+            set:
+              key: ($injected_header_key)
+              value: ($injected_header_value)

--- a/test/e2e/chainsaw/eventgateway/proxy-roundtrip/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/eventgateway/proxy-roundtrip/chainsaw-test.yaml
@@ -1,0 +1,214 @@
+# Event Gateway proxy round-trip test.
+#
+# Provisions an in-namespace 3-broker Apache Kafka cluster (no Strimzi), wires
+# it up to a Konnect-managed Event Gateway via the operator's CRDs, then runs
+# kafkactl from inside the cluster (disposable kubectl-run pod) to assert that:
+#   - keg accepts client connections and proxies admin + produce + consume to
+#     the in-namespace Kafka cluster.
+#   - the EventGatewayVirtualClusterConsumePolicy (modifyHeaders) injects the
+#     expected header on the consume path.
+#   - a direct read from Kafka (bypassing keg) does NOT see the injected
+#     header, proving the policy is applied by keg and not the producer.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: eventgateway-proxy-roundtrip
+spec:
+  description: |
+    Validates the Event Gateway proxy round-trip end-to-end against a
+    3-broker Apache Kafka cluster deployed without Strimzi.
+
+  # Test cluster must provide a LoadBalancer implementation (MetalLB,
+  # cloud-provider-kind, real cloud LB, etc.) so the keg Kafka Service can
+  # be reached from inside the cluster at its external IP.
+
+  bindings:
+    - name: test_name
+      value: ($namespace)
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
+
+    - name: keg_cp_name
+      value: (join('-', [($test_name), 'cp']))
+    - name: keg_dp_name
+      value: (join('-', [($test_name), 'dp']))
+    - name: backend_cluster_name
+      value: (join('-', [($test_name), 'backend']))
+    - name: virtual_cluster_name
+      value: (join('-', [($test_name), 'vcluster']))
+    - name: listener_name
+      value: (join('-', [($test_name), 'listener']))
+    - name: listener_policy_name
+      value: (join('-', [($test_name), 'forward']))
+    - name: consume_policy_name
+      value: (join('-', [($test_name), 'modify-headers']))
+
+    - name: injected_header_key
+      value: My-New-Header
+    - name: injected_header_value
+      value: header_value
+
+    - name: inside_topic
+      value: roundtrip-inside
+    - name: inside_record_value
+      value: hello-from-inside
+
+  steps:
+    # Konnect auth.
+    - name: Create-auth-secret
+      description: Create Secret with Konnect token for KonnectAPIAuthConfiguration.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    - name: Create-konnect-api-auth
+      description: Create KonnectAPIAuthConfiguration referencing the auth secret.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
+
+    # Kafka (3-broker KRaft, no Strimzi).
+    - name: Create-kafka-cluster
+      description: Deploy 3-broker Apache Kafka cluster (KRaft, combined mode).
+      use:
+        template: ../../common/_step_templates/apply-assert-kafka-cluster.yaml
+
+    # Event Gateway CRs (advertisedHost is a placeholder at this point).
+    - name: Create-event-gateway-resources
+      description: Create KonnectEventGateway, KegDataPlane, and Event Gateway config CRDs.
+      try:
+        - apply:
+            file: 02-event-gateway.yaml
+        - assert:
+            file: 02-event-gateway-assert.yaml
+
+    # Patch advertisedHost to the LB external address and confirm Konnect
+    # accepted the change. All three operations live in one step so that the
+    # lb_address output from the script is in scope for the patch: and assert:
+    # operations that follow (Chainsaw outputs only survive within the step).
+    - name: Patch-advertised-host
+      description: |
+        Discover the LoadBalancer address, patch advertisedHost via Chainsaw's
+        native patch: operation, then assert the policy is Programmed with the
+        updated value.
+      try:
+        # 1. Wait for the LB address; output JSON is parsed via json_parse($stdout).address.
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: KEG_DP_NAME
+                value: ($keg_dp_name)
+            content: |
+              bash ../../common/scripts/get_lb_address.sh
+            outputs:
+              - name: lb_address
+                value: (json_parse($stdout).address)
+        # 2. Patch the policy with the discovered address.
+        - patch:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: EventGatewayListenerPolicy
+              metadata:
+                name: ($listener_policy_name)
+                namespace: ($namespace)
+              spec:
+                apiSpec:
+                  forwardToVirtualCluster:
+                    config:
+                      portMapping:
+                        advertisedHost: ($lb_address)
+        # 3. Assert Konnect accepted the patch and is back to Programmed=True.
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: EventGatewayListenerPolicy
+              metadata:
+                name: ($listener_policy_name)
+              spec:
+                apiSpec:
+                  forwardToVirtualCluster:
+                    config:
+                      portMapping:
+                        advertisedHost: ($lb_address)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: "True"
+
+    # In-cluster validation: spin up a disposable kafkactl pod via kubectl run,
+    # produce a record through keg, consume it back and assert the
+    # modify-headers policy injected the expected header.
+    - name: Test-inside-cluster
+      description: Produce + consume through the gateway from inside the cluster.
+      try:
+        # Re-discover the LB address within this step (outputs don't cross steps).
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: KEG_DP_NAME
+                value: ($keg_dp_name)
+            content: |
+              bash ../../common/scripts/get_lb_address.sh
+            outputs:
+              - name: lb_address
+                value: (json_parse($stdout).address)
+        - script:
+            env:
+              - name: GATEWAY_ADDR
+                value: (join(':', [($lb_address), '19092']))
+              - name: TOPIC
+                value: ($inside_topic)
+              - name: HEADER_KEY
+                value: ($injected_header_key)
+              - name: HEADER_VALUE
+                value: ($injected_header_value)
+              - name: RECORD_VALUE
+                value: ($inside_record_value)
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              bash scripts/kafkactl_roundtrip.sh
+
+    # Negative test: spin up a disposable kafkactl pod that reads the topic
+    # directly from Kafka (bypassing keg). The modifyHeaders policy is
+    # gateway-only, so a direct read must NOT carry the injected header.
+    - name: Test-direct-read-no-injected-header
+      description: |
+        Consume the inside-cluster topic directly from Kafka (bypassing keg).
+        The modifyHeaders policy is gateway-only, so a direct read must NOT
+        carry the injected header.
+      try:
+        - script:
+            env:
+              - name: KAFKA_DIRECT
+                value: (join('', ['kafka-bootstrap.', ($namespace), '.svc:9092']))
+              - name: TOPIC
+                value: ($inside_topic)
+              - name: HEADER_KEY
+                value: ($injected_header_key)
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              bash scripts/kafkactl_direct_read.sh
+
+  catch:
+    - description: Capture debug snapshot on test failure.
+      script:
+        env:
+          - name: TEST_NAME
+            value: eventgateway-proxy-roundtrip
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_direct_read.sh
+++ b/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_direct_read.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Consume a topic directly from Kafka (bypassing keg) from inside the cluster.
+# Spins up a disposable kafkactl pod via `kubectl run --rm`, pipes the inner
+# script into it, and streams output back to the Chainsaw script step.
+#
+# Required env:
+#   KAFKA_DIRECT    host:port of the Kafka bootstrap Service (bypasses gateway).
+#   TOPIC           Kafka topic to consume.
+#   HEADER_KEY      Header that must NOT appear on directly-consumed records.
+#   NAMESPACE       Kubernetes namespace for the test pod.
+set -euo pipefail
+
+: "${KAFKA_DIRECT:?must be set}"
+: "${TOPIC:?must be set}"
+: "${HEADER_KEY:?must be set}"
+: "${NAMESPACE:?must be set}"
+
+POD_NAME="kafkactl-direct-$(date +%s)"
+
+cat scripts/kafkactl_direct_read_inner.sh | kubectl run "${POD_NAME}" \
+  --image=deviceinsight/kafkactl:latest \
+  --rm -i --restart=Never \
+  --env="KAFKA_DIRECT=${KAFKA_DIRECT}" \
+  --env="TOPIC=${TOPIC}" \
+  --env="HEADER_KEY=${HEADER_KEY}" \
+  -n "${NAMESPACE}" \
+  --command -- sh -s 2>/dev/null | grep -v '^pod "'

--- a/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_direct_read_inner.sh
+++ b/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_direct_read_inner.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+# Runs inside the kafkactl pod (piped via stdin by kafkactl_direct_read.sh).
+# Consumes a topic directly from Kafka (bypassing keg) and asserts that the
+# modify-headers policy is NOT present — proving it is gateway-only.
+#
+# Env vars (set by kubectl run --env):
+#   KAFKA_DIRECT    host:port of the Kafka bootstrap Service (bypasses gateway).
+#   TOPIC           Kafka topic to consume.
+#   HEADER_KEY      Header that must NOT appear on directly-consumed records.
+#   MAX_RETRIES     (optional) Maximum retry attempts. Default: 60.
+#   RETRY_DELAY     (optional) Seconds between retries. Default: 5.
+set -eu
+
+KAFKA_DIRECT="${KAFKA_DIRECT}"
+TOPIC="${TOPIC}"
+HEADER_KEY="${HEADER_KEY}"
+MAX_RETRIES="${MAX_RETRIES:-60}"
+RETRY_DELAY="${RETRY_DELAY:-5}"
+
+cat > /tmp/kafkactl.yml <<EOF
+contexts:
+  direct:
+    brokers:
+      - ${KAFKA_DIRECT}
+EOF
+
+# Retry loop: wait for the topic (created by the roundtrip step) to appear.
+ATTEMPT=0
+TOPIC_FOUND=0
+while [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  if kafkactl -C /tmp/kafkactl.yml --context direct \
+       get topics 2>/dev/null | grep -q "^${TOPIC}[[:space:]]"; then
+    TOPIC_FOUND=1
+    break
+  fi
+  if [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; then sleep "${RETRY_DELAY}"; fi
+done
+
+if [ "${TOPIC_FOUND}" -eq 0 ]; then
+  cat <<EOF
+{
+  "success": false,
+  "error": "Topic ${TOPIC} not found after ${MAX_RETRIES} attempts",
+  "kafka_direct": "${KAFKA_DIRECT}",
+  "retry_attempt": ${ATTEMPT},
+  "max_retries": ${MAX_RETRIES}
+}
+EOF
+  exit 1
+fi
+
+# Consume directly from Kafka (bypassing keg).
+OUT=$(kafkactl -C /tmp/kafkactl.yml --context direct \
+  consume "${TOPIC}" --print-headers --from-beginning --exit 2>/dev/null || echo "")
+
+if echo "${OUT}" | grep -q "${HEADER_KEY}:"; then
+  cat <<EOF
+{
+  "success": false,
+  "error": "Header ${HEADER_KEY} found on direct read; gateway-only policy leaked",
+  "topic": "${TOPIC}",
+  "kafka_direct": "${KAFKA_DIRECT}",
+  "retry_attempt": ${ATTEMPT},
+  "max_retries": ${MAX_RETRIES}
+}
+EOF
+  exit 1
+fi
+
+cat <<EOF
+{
+  "success": true,
+  "message": "Direct read has no injected header ${HEADER_KEY} (gateway-only policy confirmed)",
+  "topic": "${TOPIC}",
+  "kafka_direct": "${KAFKA_DIRECT}",
+  "retry_attempt": ${ATTEMPT},
+  "max_retries": ${MAX_RETRIES}
+}
+EOF
+exit 0

--- a/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_roundtrip.sh
+++ b/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_roundtrip.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Produce+consume round-trip through the keg gateway from inside the cluster.
+# Spins up a disposable kafkactl pod via `kubectl run --rm`, pipes the inner
+# script into it, and streams output back to the Chainsaw script step.
+#
+# Required env:
+#   GATEWAY_ADDR    host:port bootstrap address (LB IP + listener port).
+#   TOPIC           Kafka topic name.
+#   HEADER_KEY      Header expected on consumed records.
+#   HEADER_VALUE    Expected header value.
+#   RECORD_VALUE    Record payload to produce.
+#   NAMESPACE       Kubernetes namespace for the test pod.
+set -euo pipefail
+
+: "${GATEWAY_ADDR:?must be set}"
+: "${TOPIC:?must be set}"
+: "${HEADER_KEY:?must be set}"
+: "${HEADER_VALUE:?must be set}"
+: "${RECORD_VALUE:?must be set}"
+: "${NAMESPACE:?must be set}"
+
+POD_NAME="kafkactl-roundtrip-$(date +%s)"
+
+cat scripts/kafkactl_roundtrip_inner.sh | kubectl run "${POD_NAME}" \
+  --image=deviceinsight/kafkactl:latest \
+  --rm -i --restart=Never \
+  --env="GATEWAY_ADDR=${GATEWAY_ADDR}" \
+  --env="TOPIC=${TOPIC}" \
+  --env="HEADER_KEY=${HEADER_KEY}" \
+  --env="HEADER_VALUE=${HEADER_VALUE}" \
+  --env="RECORD_VALUE=${RECORD_VALUE}" \
+  -n "${NAMESPACE}" \
+  --command -- sh -s 2>/dev/null | grep -v '^pod "'

--- a/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_roundtrip_inner.sh
+++ b/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_roundtrip_inner.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+# Runs inside the kafkactl pod (piped via stdin by kafkactl_roundtrip.sh).
+# Produces a record through the keg gateway and consumes it back, asserting
+# that the modify-headers consume policy injected the expected header.
+# Retries until success or MAX_RETRIES attempts are exhausted.
+#
+# Env vars (set by kubectl run --env):
+#   GATEWAY_ADDR    host:port bootstrap address (LB IP + listener port).
+#   TOPIC           Kafka topic name.
+#   HEADER_KEY      Header expected on every consumed record.
+#   HEADER_VALUE    Expected header value.
+#   RECORD_VALUE    Record payload to produce.
+#   MAX_RETRIES     (optional) Maximum retry attempts. Default: 60.
+#   RETRY_DELAY     (optional) Seconds between retries. Default: 5.
+set -eu
+
+GATEWAY_ADDR="${GATEWAY_ADDR}"
+TOPIC="${TOPIC}"
+HEADER_KEY="${HEADER_KEY}"
+HEADER_VALUE="${HEADER_VALUE}"
+RECORD_VALUE="${RECORD_VALUE}"
+MAX_RETRIES="${MAX_RETRIES:-60}"
+RETRY_DELAY="${RETRY_DELAY:-5}"
+
+cat > /tmp/kafkactl.yml <<EOF
+contexts:
+  vc:
+    brokers:
+      - ${GATEWAY_ADDR}
+EOF
+
+# Retry loop: retry until produce succeeds and the consumed record carries the
+# expected header, or retries are exhausted.
+ATTEMPT=0
+LAST_OUT=""
+while [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+
+  # Create topic (idempotent; ignore errors if already exists or not ready).
+  kafkactl -C /tmp/kafkactl.yml --context vc \
+    create topic "${TOPIC}" --partitions 3 --replication-factor 3 >/dev/null 2>&1 || true
+
+  # Produce; skip to next attempt if gateway is not yet ready.
+  if ! kafkactl -C /tmp/kafkactl.yml --context vc \
+      produce "${TOPIC}" --value "${RECORD_VALUE}" >/dev/null 2>&1; then
+    if [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; then sleep "${RETRY_DELAY}"; fi
+    continue
+  fi
+
+  # Consume and check for the injected header.
+  if LAST_OUT=$(kafkactl -C /tmp/kafkactl.yml --context vc \
+      consume "${TOPIC}" --print-headers --from-beginning --exit 2>/dev/null); then
+    if echo "${LAST_OUT}" | grep -q "${HEADER_KEY}:${HEADER_VALUE}"; then
+      cat <<EOF
+{
+  "success": true,
+  "message": "Header ${HEADER_KEY}:${HEADER_VALUE} found in consumed record",
+  "topic": "${TOPIC}",
+  "gateway_addr": "${GATEWAY_ADDR}",
+  "retry_attempt": ${ATTEMPT},
+  "max_retries": ${MAX_RETRIES}
+}
+EOF
+      exit 0
+    fi
+  fi
+
+  if [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; then sleep "${RETRY_DELAY}"; fi
+done
+
+cat <<EOF
+{
+  "success": false,
+  "error": "Header ${HEADER_KEY}:${HEADER_VALUE} not found after ${MAX_RETRIES} attempts",
+  "topic": "${TOPIC}",
+  "gateway_addr": "${GATEWAY_ADDR}",
+  "retry_attempt": ${ATTEMPT},
+  "max_retries": ${MAX_RETRIES}
+}
+EOF
+exit 1

--- a/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/produce_consume_outside.sh
+++ b/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/produce_consume_outside.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Drive a produce + consume round-trip against the keg gateway from outside
+# the cluster, using a kafkactl container scheduled on the host's Docker
+# runtime. Asserts that the modify-headers consume policy injected the
+# expected header on the way back out.
+#
+# Required env:
+#   GATEWAY_ADDR      host:port of the gateway's bootstrap listener (LB IP + 19092).
+#   TOPIC             Kafka topic name to produce/consume on.
+#   HEADER_KEY        Header expected to be present on the consumed record.
+#   HEADER_VALUE      Header value expected.
+#   RECORD_VALUE      Record payload to produce.
+set -euo pipefail
+
+: "${GATEWAY_ADDR:?must be set}"
+: "${TOPIC:?must be set}"
+: "${HEADER_KEY:?must be set}"
+: "${HEADER_VALUE:?must be set}"
+: "${RECORD_VALUE:?must be set}"
+
+IMG="deviceinsight/kafkactl:latest"
+CFG=$(mktemp)
+trap 'rm -f "${CFG}"' EXIT
+cat > "${CFG}" <<EOF
+contexts:
+  vc:
+    brokers:
+      - ${GATEWAY_ADDR}
+EOF
+
+run() {
+  docker run --rm -i \
+    --network host \
+    -v "${CFG}:/etc/kafkactl/config.yml:ro" \
+    "${IMG}" --context vc "$@"
+}
+
+echo "[outside] get brokers"
+run get brokers
+
+echo "[outside] create topic ${TOPIC}"
+run create topic "${TOPIC}" --partitions 3 --replication-factor 3 || true
+
+echo "[outside] produce"
+run produce "${TOPIC}" --value "${RECORD_VALUE}"
+
+echo "[outside] consume (expect header)"
+OUT=$(run consume "${TOPIC}" --print-headers --from-beginning --exit)
+echo "${OUT}"
+
+if ! grep -q "${HEADER_KEY}:${HEADER_VALUE}" <<<"${OUT}"; then
+  echo "FAIL: expected header ${HEADER_KEY}:${HEADER_VALUE} not found in consumer output" >&2
+  exit 1
+fi
+echo "[outside] header present, OK"

--- a/test/e2e/chainsaw/eventgateway/sni-routing/02-event-gateway-assert.yaml
+++ b/test/e2e/chainsaw/eventgateway/sni-routing/02-event-gateway-assert.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: konnect.konghq.com/v1alpha1
+kind: KonnectEventGateway
+metadata:
+  name: ($keg_cp_name)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: "True"
+---
+apiVersion: eventgateway.konghq.com/v1alpha1
+kind: KegDataPlane
+metadata:
+  name: ($keg_dp_name)
+status:
+  (conditions[?type == 'Ready']):
+    - status: "True"
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayBackendCluster
+metadata:
+  name: ($backend_cluster_name)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: "True"
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayVirtualCluster
+metadata:
+  name: ($analytics_vc_name)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: "True"
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayVirtualCluster
+metadata:
+  name: ($payments_vc_name)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: "True"
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayListener
+metadata:
+  name: ($listener_name)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: "True"

--- a/test/e2e/chainsaw/eventgateway/sni-routing/02-event-gateway.yaml
+++ b/test/e2e/chainsaw/eventgateway/sni-routing/02-event-gateway.yaml
@@ -1,0 +1,138 @@
+# Event Gateway resources for the sni-routing test.
+#
+# Creates:
+#   - KonnectEventGateway (control plane)
+#   - KegDataPlane (single port 19092 — SNI routing uses one port for all VCs)
+#   - EventGatewayBackendCluster (in-namespace Kafka)
+#   - EventGatewayVirtualCluster "analytics" (namespace prefix analytics_)
+#   - EventGatewayVirtualCluster "payments"  (namespace prefix payments_)
+#   - EventGatewayListener (port 19092)
+#
+# Note: TLS server policy and SNI forward policy are applied in a later step,
+# after the LoadBalancer IP is known and the TLS certificate has been generated.
+---
+apiVersion: konnect.konghq.com/v1alpha1
+kind: KonnectEventGateway
+metadata:
+  name: ($keg_cp_name)
+spec:
+  apiSpec:
+    name: ($keg_cp_name)
+    description: sni-routing chainsaw test control plane
+    labels:
+      test: sni-routing
+  konnect:
+    authRef:
+      name: ($konnect_auth_name)
+---
+apiVersion: eventgateway.konghq.com/v1alpha1
+kind: KegDataPlane
+metadata:
+  name: ($keg_dp_name)
+spec:
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: ($keg_cp_name)
+  network:
+    services:
+      kafka:
+        type: LoadBalancer
+        ports:
+          - name: kafka
+            port: 19092
+            targetPort: 19092
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayBackendCluster
+metadata:
+  name: ($backend_cluster_name)
+spec:
+  gatewayRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($keg_cp_name)
+  apiSpec:
+    name: ($backend_cluster_name)
+    description: sni-routing backend (in-namespace Kafka)
+    bootstrapServers:
+      - (join('', ['kafka-bootstrap.', ($namespace), '.svc:9092']))
+    authentication:
+      type: anonymous
+      anonymous: {}
+    insecureAllowAnonymousVirtualClusterAuth: Enabled
+    tls:
+      enabled: Disabled
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayVirtualCluster
+metadata:
+  name: ($analytics_vc_name)
+spec:
+  eventGatewayBackendClusterRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($backend_cluster_name)
+  apiSpec:
+    name: ($analytics_vc_name)
+    description: analytics virtual cluster (SNI routing test)
+    dnsLabel: ($analytics_dns_label)
+    aclMode: passthrough
+    authentication:
+      - type: anonymous
+        anonymous: {}
+    namespace:
+      mode: hide_prefix
+      prefix: ($analytics_prefix)
+      additional:
+        topics:
+          - type: exactList
+            exactList:
+              conflict: warn
+              exactList:
+                - backend: user_actions
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayVirtualCluster
+metadata:
+  name: ($payments_vc_name)
+spec:
+  eventGatewayBackendClusterRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($backend_cluster_name)
+  apiSpec:
+    name: ($payments_vc_name)
+    description: payments virtual cluster (SNI routing test)
+    dnsLabel: ($payments_dns_label)
+    aclMode: passthrough
+    authentication:
+      - type: anonymous
+        anonymous: {}
+    namespace:
+      mode: hide_prefix
+      prefix: ($payments_prefix)
+      additional:
+        topics:
+          - type: exactList
+            exactList:
+              conflict: warn
+              exactList:
+                - backend: user_actions
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayListener
+metadata:
+  name: ($listener_name)
+spec:
+  gatewayRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($keg_cp_name)
+  apiSpec:
+    name: ($listener_name)
+    description: sni-routing listener (single port, SNI differentiates VCs)
+    addresses:
+      - "0.0.0.0"
+    ports:
+      - "19092"

--- a/test/e2e/chainsaw/eventgateway/sni-routing/03-tls-server-policy-assert.yaml
+++ b/test/e2e/chainsaw/eventgateway/sni-routing/03-tls-server-policy-assert.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayListenerPolicy
+metadata:
+  name: ($tls_server_policy_name)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: "True"

--- a/test/e2e/chainsaw/eventgateway/sni-routing/03-tls-server-policy.yaml
+++ b/test/e2e/chainsaw/eventgateway/sni-routing/03-tls-server-policy.yaml
@@ -1,0 +1,32 @@
+# TLS server policy for the SNI routing test.
+#
+# Configures the listener to terminate TLS using a certificate sourced from
+# the Kubernetes Secret created by the gen_certs.sh script.
+# The operator reads tls.crt and tls.key from the referenced Secret.
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayListenerPolicy
+metadata:
+  name: ($tls_server_policy_name)
+spec:
+  eventGatewayListenerRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($listener_name)
+  apiSpec:
+    type: tlsServer
+    tlsServer:
+      name: tls-server
+      enabled: Enabled
+      config:
+        certificates:
+          - certificate:
+              type: secretRef
+              secretRef:
+                name: ($tls_secret_name)
+                namespace: ($namespace)
+            key:
+              type: secretRef
+              secretRef:
+                name: ($tls_secret_name)
+                namespace: ($namespace)

--- a/test/e2e/chainsaw/eventgateway/sni-routing/04-sni-forward-policy-assert.yaml
+++ b/test/e2e/chainsaw/eventgateway/sni-routing/04-sni-forward-policy-assert.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayListenerPolicy
+metadata:
+  name: ($sni_forward_policy_name)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: "True"

--- a/test/e2e/chainsaw/eventgateway/sni-routing/04-sni-forward-policy.yaml
+++ b/test/e2e/chainsaw/eventgateway/sni-routing/04-sni-forward-policy.yaml
@@ -1,0 +1,32 @@
+# SNI forward policy for the SNI routing test.
+#
+# Routes incoming TLS connections to virtual clusters based on SNI hostname.
+# The sniSuffix is derived at runtime from the LoadBalancer IP:
+#   bootstrap-{dns_label}.{LB-IP-dashes}.sslip.io:19092
+# resolves to the LoadBalancer IP via sslip.io wildcard DNS.
+#
+# brokerHostFormat: shared_suffix puts all brokers from every virtual cluster
+# at the same DNS level: broker-{node_id}-{dns_label}{sni_suffix}
+# making it easy to cover with one wildcard certificate.
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayListenerPolicy
+metadata:
+  name: ($sni_forward_policy_name)
+spec:
+  eventGatewayListenerRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($listener_name)
+  apiSpec:
+    type: forwardToVirtualCluster
+    forwardToVirtualCluster:
+      name: sni-forward
+      enabled: Enabled
+      config:
+        type: sni
+        sni:
+          advertisedPort: 19092
+          sniSuffix: ($sni_suffix)
+          brokerHostFormat:
+            type: shared_suffix

--- a/test/e2e/chainsaw/eventgateway/sni-routing/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/eventgateway/sni-routing/chainsaw-test.yaml
@@ -1,0 +1,321 @@
+# Event Gateway SNI routing test.
+#
+# Mirrors the scenario from the official docs:
+# https://developer.konghq.com/event-gateway/configure-sni-routing/
+#
+# Provisions an in-namespace 3-broker Apache Kafka cluster (KRaft, no Strimzi),
+# configures two virtual clusters (analytics, payments) behind a single keg
+# listener port (19092), and validates SNI-based routing + namespace isolation by:
+#
+#   1. Pre-seeding Kafka topics directly (analytics_pageviews, analytics_clicks,
+#      analytics_orders, payments_transactions, payments_refunds, payments_orders,
+#      user_actions).
+#   2. Generating a self-signed wildcard TLS certificate for
+#      *.{LB-IP-dashes}.sslip.io (resolved via sslip.io).
+#   3. Applying a TLS server policy (terminates TLS on port 19092).
+#   4. Applying an SNI forward policy (routes to VCs by TLS hostname).
+#   5. Listing topics through the analytics VC and asserting:
+#        PRESENT:  clicks, orders, pageviews, user_actions
+#        ABSENT:   transactions, refunds  (payments namespace — must not leak)
+#   6. Listing topics through the payments VC and asserting:
+#        PRESENT:  orders, refunds, transactions, user_actions
+#        ABSENT:   pageviews, clicks  (analytics namespace — must not leak)
+#
+# Prerequisites:
+#   - A running Kubernetes cluster with LoadBalancer support.
+#   - Pods must be able to resolve *.{IP-dashes}.sslip.io (public DNS).
+#   - KONNECT_TOKEN env var set.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: eventgateway-sni-routing
+spec:
+  description: |
+    Validates Event Gateway SNI-based virtual cluster routing and namespace
+    isolation against a 3-broker Apache Kafka cluster deployed without Strimzi.
+
+  bindings:
+    - name: test_name
+      value: ($namespace)
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
+
+    - name: keg_cp_name
+      value: (join('-', [($test_name), 'cp']))
+    - name: keg_dp_name
+      value: (join('-', [($test_name), 'dp']))
+    - name: backend_cluster_name
+      value: (join('-', [($test_name), 'backend']))
+    - name: listener_name
+      value: (join('-', [($test_name), 'listener']))
+
+    # Virtual clusters.
+    - name: analytics_vc_name
+      value: (join('-', [($test_name), 'analytics']))
+    - name: analytics_dns_label
+      value: analytics
+    - name: analytics_prefix
+      value: analytics_
+
+    - name: payments_vc_name
+      value: (join('-', [($test_name), 'payments']))
+    - name: payments_dns_label
+      value: payments
+    - name: payments_prefix
+      value: payments_
+
+    # TLS / policies.
+    - name: tls_secret_name
+      value: (join('-', [($test_name), 'tls']))
+    - name: ca_cm_name
+      value: (join('-', [($test_name), 'tls-ca']))
+    - name: tls_server_policy_name
+      value: (join('-', [($test_name), 'tls-server']))
+    - name: sni_forward_policy_name
+      value: (join('-', [($test_name), 'sni-forward']))
+
+    # Expected topics per VC (namespace prefix hidden by hide_prefix mode).
+    # analytics VC: analytics_* topics stripped of prefix + shared user_actions.
+    - name: analytics_expected
+      value: clicks orders pageviews user_actions
+    # Topics that must NOT be visible in the analytics VC (payments namespace isolation).
+    - name: analytics_unexpected
+      value: transactions refunds
+
+    # payments VC: payments_* topics stripped of prefix + shared user_actions.
+    - name: payments_expected
+      value: orders refunds transactions user_actions
+    # Topics that must NOT be visible in the payments VC (analytics namespace isolation).
+    - name: payments_unexpected
+      value: pageviews clicks
+
+    # Topic used for produce+consume data-path validation per VC.
+    - name: analytics_produce_topic
+      value: pageviews
+    - name: payments_produce_topic
+      value: transactions
+
+  steps:
+    # Konnect auth.
+    - name: Create-auth-secret
+      description: Create Secret with Konnect token for KonnectAPIAuthConfiguration.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    - name: Create-konnect-api-auth
+      description: Create KonnectAPIAuthConfiguration referencing the auth secret.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
+
+    # Kafka (3-broker KRaft, no Strimzi).
+    - name: Create-kafka-cluster
+      description: Deploy 3-broker Apache Kafka cluster (KRaft, combined mode).
+      use:
+        template: ../../common/_step_templates/apply-assert-kafka-cluster.yaml
+
+    # Event Gateway control plane, data plane, backend cluster, virtual clusters,
+    # and listener. Both VCs have additional.topics for the shared user_actions topic.
+    - name: Create-event-gateway-resources
+      description: |
+        Create KonnectEventGateway, KegDataPlane, EventGatewayBackendCluster,
+        two EventGatewayVirtualClusters (analytics, payments) with namespace
+        prefixes and shared additional topic, and EventGatewayListener.
+      try:
+        - apply:
+            file: 02-event-gateway.yaml
+        - assert:
+            file: 02-event-gateway-assert.yaml
+
+    # Pre-seed all Kafka topics directly (no gateway, no TLS).
+    # This mirrors the docs step "Create Kafka topics" where topics are created
+    # via the backend context before validating the VC views.
+    - name: Seed-kafka-topics
+      description: |
+        Create all test topics directly in Kafka via the in-cluster bootstrap
+        Service (kafka-bootstrap.<ns>.svc:9092) before validating SNI routing.
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              bash ../../common/scripts/seed_topics.sh
+
+    # Generate TLS certificate and apply policies.
+    # All three operations are in one step so that lb_address (from
+    # get_lb_address.sh) and sni_suffix (from gen_certs.sh) are in scope for
+    # the apply operations that follow (Chainsaw outputs only survive within
+    # the same step).
+    - name: Generate-certs-and-apply-tls-policies
+      description: |
+        Discover the LoadBalancer IP, generate a wildcard TLS certificate for
+        *.{IP-dashes}.sslip.io, create the TLS Secret and CA ConfigMap, then
+        apply the TLS server and SNI forward policies.
+      try:
+        # 1. Wait for the LB address.
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: KEG_DP_NAME
+                value: ($keg_dp_name)
+            content: |
+              bash ../../common/scripts/get_lb_address.sh
+            outputs:
+              - name: lb_address
+                value: (json_parse($stdout).address)
+        # 2. Generate certs, create TLS Secret (labelled konghq.com/secret=true)
+        #    and CA ConfigMap.
+        - script:
+            env:
+              - name: LB_IP
+                value: ($lb_address)
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: SECRET_NAME
+                value: ($tls_secret_name)
+            content: |
+              bash scripts/gen_certs.sh
+            outputs:
+              - name: sni_suffix
+                value: (json_parse($stdout).sni_suffix)
+        # 3. Apply the TLS server policy (references the Secret by name).
+        - apply:
+            file: 03-tls-server-policy.yaml
+        # 4. Apply the SNI forward policy (sni_suffix comes from step 2 above).
+        - apply:
+            file: 04-sni-forward-policy.yaml
+            bindings:
+              - name: sni_suffix
+                value: ($sni_suffix)
+        # 5. Assert both policies are accepted by Konnect.
+        - assert:
+            file: 03-tls-server-policy-assert.yaml
+        - assert:
+            file: 04-sni-forward-policy-assert.yaml
+
+    # Validate the analytics virtual cluster.
+    # Mirrors docs validation: kafkactl list topics via bootstrap-analytics.<IP>.sslip.io
+    # Expected topics: clicks, orders, pageviews, user_actions
+    # Must NOT see: transactions, refunds (payments namespace)
+    - name: Validate-analytics-virtual-cluster
+      description: |
+        Connect to the analytics VC via SNI routing and assert:
+          PRESENT  - clicks, orders, pageviews, user_actions
+          ABSENT   - transactions, refunds (payments namespace must not leak)
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: KEG_DP_NAME
+                value: ($keg_dp_name)
+            content: |
+              bash ../../common/scripts/get_lb_address.sh
+            outputs:
+              - name: lb_address
+                value: (json_parse($stdout).address)
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: CA_CM_NAME
+                value: ($ca_cm_name)
+            content: |
+              bash ../../common/scripts/get_ca_cert.sh
+            outputs:
+              - name: ca_cert_b64
+                value: (json_parse($stdout).ca_cert_b64)
+        - script:
+            env:
+              - name: LB_IP
+                value: ($lb_address)
+              - name: DNS_LABEL
+                value: ($analytics_dns_label)
+              - name: CA_CERT_B64
+                value: ($ca_cert_b64)
+              - name: EXPECTED_TOPICS
+                value: ($analytics_expected)
+              - name: UNEXPECTED_TOPICS
+                value: ($analytics_unexpected)
+              - name: PRODUCE_TOPIC
+                value: ($analytics_produce_topic)
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              bash scripts/kafkactl_sni_validate.sh
+
+    # Validate the payments virtual cluster.
+    # Mirrors docs validation: kafkactl list topics via bootstrap-payments.<IP>.sslip.io
+    # Expected topics: orders, refunds, transactions, user_actions
+    # Must NOT see: pageviews, clicks (analytics namespace)
+    - name: Validate-payments-virtual-cluster
+      description: |
+        Connect to the payments VC via SNI routing and assert:
+          PRESENT  - orders, refunds, transactions, user_actions
+          ABSENT   - pageviews, clicks (analytics namespace must not leak)
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: KEG_DP_NAME
+                value: ($keg_dp_name)
+            content: |
+              bash ../../common/scripts/get_lb_address.sh
+            outputs:
+              - name: lb_address
+                value: (json_parse($stdout).address)
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: CA_CM_NAME
+                value: ($ca_cm_name)
+            content: |
+              bash ../../common/scripts/get_ca_cert.sh
+            outputs:
+              - name: ca_cert_b64
+                value: (json_parse($stdout).ca_cert_b64)
+        - script:
+            env:
+              - name: LB_IP
+                value: ($lb_address)
+              - name: DNS_LABEL
+                value: ($payments_dns_label)
+              - name: CA_CERT_B64
+                value: ($ca_cert_b64)
+              - name: EXPECTED_TOPICS
+                value: ($payments_expected)
+              - name: UNEXPECTED_TOPICS
+                value: ($payments_unexpected)
+              - name: PRODUCE_TOPIC
+                value: ($payments_produce_topic)
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              bash scripts/kafkactl_sni_validate.sh
+
+  catch:
+    - description: Capture debug snapshot on test failure.
+      script:
+        env:
+          - name: TEST_NAME
+            value: eventgateway-sni-routing
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh
+

--- a/test/e2e/chainsaw/eventgateway/sni-routing/scripts/gen_certs.sh
+++ b/test/e2e/chainsaw/eventgateway/sni-routing/scripts/gen_certs.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Generate a self-signed CA and wildcard TLS certificate for SNI routing,
+# then create or replace the Kubernetes TLS Secret and a ConfigMap holding
+# the CA certificate (base64-encoded) for use by test pods.
+#
+# The wildcard cert covers *.{LB-IP-dashes}.sslip.io, which sslip.io resolves
+# to the LoadBalancer IP. This means clients can reach
+#   bootstrap-{dns_label}.{LB-IP-dashes}.sslip.io:19092
+# and the SNI hostname is used by keg to route to the correct virtual cluster.
+#
+# Required env:
+#   LB_IP         LoadBalancer external IP address.
+#   NAMESPACE     Kubernetes namespace for the Secret and ConfigMap.
+#   SECRET_NAME   Name of the Kubernetes TLS Secret to create/replace.
+# Optional env:
+#   RETRY_DELAY   Not used; script fails fast on any error.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+LB_IP="${LB_IP}"
+NAMESPACE="${NAMESPACE}"
+SECRET_NAME="${SECRET_NAME}"
+
+# Derive the sslip.io-based SNI suffix from the LB IP.
+# e.g. 10.96.1.5 -> .10-96-1-5.sslip.io
+IP_DASHES="${LB_IP//./-}"
+SNI_SUFFIX=".${IP_DASHES}.sslip.io"
+WILDCARD_CN="*.${IP_DASHES}.sslip.io"
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "${WORKDIR}"' EXIT
+pushd "${WORKDIR}" >/dev/null
+
+# Root CA.
+openssl genrsa -out rootCA.key 4096 2>/dev/null
+openssl req -x509 -new -nodes -key rootCA.key \
+  -sha256 -days 3650 \
+  -subj "/C=US/ST=Local/L=Local/O=Dev CA/CN=Dev Root CA" \
+  -out rootCA.crt 2>/dev/null
+
+# Gateway TLS key + CSR.
+openssl genrsa -out tls.key 2048 2>/dev/null
+openssl req -new -key tls.key \
+  -subj "/C=US/ST=Local/L=Local/O=Dev/CN=${WILDCARD_CN}" \
+  -out tls.csr 2>/dev/null
+
+# SAN extension (required for modern TLS clients).
+cat > tls.ext <<EOF
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+authorityKeyIdentifier = keyid,issuer
+
+[alt_names]
+DNS.1 = ${WILDCARD_CN}
+EOF
+
+# Sign with the CA.
+openssl x509 -req -in tls.csr \
+  -CA rootCA.crt -CAkey rootCA.key -CAcreateserial \
+  -out tls.crt -days 825 -sha256 \
+  -extfile tls.ext 2>/dev/null
+
+# Create/replace TLS Secret.
+# The label konghq.com/secret=true is required so the operator's Secret
+# informer cache (filtered by --secret-label-selector) picks up this Secret.
+kubectl create secret tls "${SECRET_NAME}" \
+  --cert=tls.crt --key=tls.key \
+  -n "${NAMESPACE}" \
+  --dry-run=client -o yaml | \
+kubectl label -f - "konghq.com/secret=true" --local -o yaml | \
+kubectl apply -f - >/dev/null 2>&1
+
+# Create/replace ConfigMap holding the CA cert for test pods.
+CA_CM_NAME="${SECRET_NAME}-ca"
+CA_CERT=$(cat rootCA.crt)
+kubectl create configmap "${CA_CM_NAME}" \
+  --from-literal=ca.crt="${CA_CERT}" \
+  -n "${NAMESPACE}" \
+  --dry-run=client -o yaml | kubectl apply -f - >/dev/null 2>&1
+
+CA_CERT_B64=$(base64 < rootCA.crt | tr -d '\n')
+popd >/dev/null
+
+cat <<EOF
+{
+  "success": true,
+  "sni_suffix": "${SNI_SUFFIX}",
+  "wildcard_cn": "${WILDCARD_CN}",
+  "ca_cert_b64": "${CA_CERT_B64}",
+  "secret_name": "${SECRET_NAME}",
+  "ca_cm_name": "${CA_CM_NAME}"
+}
+EOF

--- a/test/e2e/chainsaw/eventgateway/sni-routing/scripts/kafkactl_sni_validate.sh
+++ b/test/e2e/chainsaw/eventgateway/sni-routing/scripts/kafkactl_sni_validate.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Outer script: spins up a disposable kafkactl pod via kubectl run,
+# connects to a keg virtual cluster via SNI routing (TLS), and validates
+# the visible topics match the expected set (namespace isolation + shared topics).
+#
+# The --command flag is required because deviceinsight/kafkactl has
+# ENTRYPOINT ["kafkactl"]; without it, sh would be passed as args to kafkactl.
+#
+# Required env:
+#   LB_IP              LoadBalancer external IP (e.g. 10.96.1.5).
+#   DNS_LABEL          Virtual cluster DNS label (e.g. analytics or payments).
+#   CA_CERT_B64        Base64-encoded PEM CA certificate.
+#   EXPECTED_TOPICS    Space-separated list of topics that MUST be visible.
+#   UNEXPECTED_TOPICS  Space-separated list of topics that MUST NOT be visible.
+#   PRODUCE_TOPIC      Topic to produce+consume through for data-path validation.
+#   NAMESPACE          Kubernetes namespace for the test pod.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+: "${LB_IP:?must be set}"
+: "${DNS_LABEL:?must be set}"
+: "${CA_CERT_B64:?must be set}"
+: "${EXPECTED_TOPICS:?must be set}"
+: "${PRODUCE_TOPIC:?must be set}"
+: "${NAMESPACE:?must be set}"
+
+UNEXPECTED_TOPICS="${UNEXPECTED_TOPICS:-}"
+
+# Compute bootstrap address: replace dots with dashes and use sslip.io.
+IP_DASHES="${LB_IP//./-}"
+GATEWAY_BOOTSTRAP="bootstrap-${DNS_LABEL}.${IP_DASHES}.sslip.io:19092"
+
+POD_NAME="kafkactl-sni-$(date +%s)"
+
+cat scripts/kafkactl_sni_validate_inner.sh | kubectl run "${POD_NAME}" \
+  --image=deviceinsight/kafkactl:latest \
+  --rm -i --restart=Never \
+  --env="GATEWAY_BOOTSTRAP=${GATEWAY_BOOTSTRAP}" \
+  --env="CA_CERT_B64=${CA_CERT_B64}" \
+  --env="EXPECTED_TOPICS=${EXPECTED_TOPICS}" \
+  --env="UNEXPECTED_TOPICS=${UNEXPECTED_TOPICS}" \
+  --env="PRODUCE_TOPIC=${PRODUCE_TOPIC}" \
+  -n "${NAMESPACE}" \
+  --command -- sh -s 2>/dev/null | grep -v '^pod "'

--- a/test/e2e/chainsaw/eventgateway/sni-routing/scripts/kafkactl_sni_validate_inner.sh
+++ b/test/e2e/chainsaw/eventgateway/sni-routing/scripts/kafkactl_sni_validate_inner.sh
@@ -1,0 +1,157 @@
+#!/bin/sh
+# Inner script executed inside a disposable kafkactl pod.
+# Connects to a keg virtual cluster via SNI routing (TLS) and validates the
+# docs scenario from https://developer.konghq.com/event-gateway/configure-sni-routing/:
+#
+#   1. List topics visible through the virtual cluster.
+#   2. Assert every EXPECTED_TOPICS is present (namespace prefix hidden + shared topic).
+#   3. Assert every UNEXPECTED_TOPICS is absent (namespace isolation).
+#   4. Produce a record to PRODUCE_TOPIC and consume it back (data-path validation).
+#
+# Env vars provided by kubectl run --env:
+#   GATEWAY_BOOTSTRAP    bootstrap-{dns_label}{sni_suffix}:{port}
+#   CA_CERT_B64          Base64-encoded PEM CA certificate.
+#   EXPECTED_TOPICS      Space-separated list of topics that MUST be visible.
+#   UNEXPECTED_TOPICS    Space-separated list of topics that MUST NOT be visible.
+#   PRODUCE_TOPIC        Topic to produce+consume through (must be in EXPECTED_TOPICS).
+#   MAX_RETRIES          (optional) Default: 60.
+#   RETRY_DELAY          (optional) Default: 5.
+set -eu
+
+GATEWAY_BOOTSTRAP="${GATEWAY_BOOTSTRAP}"
+CA_CERT_B64="${CA_CERT_B64}"
+EXPECTED_TOPICS="${EXPECTED_TOPICS}"
+UNEXPECTED_TOPICS="${UNEXPECTED_TOPICS:-}"
+PRODUCE_TOPIC="${PRODUCE_TOPIC}"
+MAX_RETRIES="${MAX_RETRIES:-60}"
+RETRY_DELAY="${RETRY_DELAY:-5}"
+
+# Write CA certificate so kafkactl can verify the gateway's TLS cert.
+printf '%s' "${CA_CERT_B64}" | base64 -d > /tmp/ca.crt
+
+cat > /tmp/kafkactl.yml <<EOF
+contexts:
+  vc:
+    brokers:
+      - ${GATEWAY_BOOTSTRAP}
+    tls:
+      enabled: true
+      ca: /tmp/ca.crt
+      insecure: false
+EOF
+
+# --- Phase 1: topic listing + isolation ---
+ATTEMPT=0
+while [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+
+  LISTED=$(kafkactl -C /tmp/kafkactl.yml --context vc \
+    list topics 2>/dev/null || true)
+
+  if [ -z "${LISTED}" ]; then
+    if [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; then sleep "${RETRY_DELAY}"; fi
+    continue
+  fi
+
+  # Verify all expected topics are present.
+  MISSING=""
+  for TOPIC in ${EXPECTED_TOPICS}; do
+    if ! echo "${LISTED}" | grep -qF "${TOPIC}"; then
+      MISSING="${MISSING} ${TOPIC}"
+    fi
+  done
+
+  if [ -n "${MISSING}" ]; then
+    if [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; then sleep "${RETRY_DELAY}"; fi
+    continue
+  fi
+
+  # Verify isolation: unexpected topics must not appear.
+  LEAKED=""
+  for TOPIC in ${UNEXPECTED_TOPICS}; do
+    if echo "${LISTED}" | grep -qF "${TOPIC}"; then
+      LEAKED="${LEAKED} ${TOPIC}"
+    fi
+  done
+
+  if [ -n "${LEAKED}" ]; then
+    cat <<EOF
+{
+  "success": false,
+  "error": "Namespace isolation violated: unexpected topics visible through VC",
+  "leaked_topics": "${LEAKED}",
+  "gateway_bootstrap": "${GATEWAY_BOOTSTRAP}",
+  "retry_attempt": ${ATTEMPT},
+  "max_retries": ${MAX_RETRIES}
+}
+EOF
+    exit 1
+  fi
+
+  # Topic listing passed — break out for data-path phase.
+  break
+done
+
+if [ "${ATTEMPT}" -ge "${MAX_RETRIES}" ]; then
+  cat <<EOF
+{
+  "success": false,
+  "error": "Expected topics not visible after ${MAX_RETRIES} attempts",
+  "missing_topics": "${MISSING:-unknown}",
+  "expected_topics": "${EXPECTED_TOPICS}",
+  "gateway_bootstrap": "${GATEWAY_BOOTSTRAP}",
+  "retry_attempt": ${ATTEMPT},
+  "max_retries": ${MAX_RETRIES}
+}
+EOF
+  exit 1
+fi
+
+# --- Phase 2: produce + consume (data-path validation) ---
+RECORD_VALUE="sni-test-${ATTEMPT}-$(date +%s)"
+
+PRODUCE_ATTEMPT=0
+while [ "${PRODUCE_ATTEMPT}" -lt "${MAX_RETRIES}" ]; do
+  PRODUCE_ATTEMPT=$((PRODUCE_ATTEMPT + 1))
+
+  if ! kafkactl -C /tmp/kafkactl.yml --context vc \
+      produce "${PRODUCE_TOPIC}" --value "${RECORD_VALUE}" >/dev/null 2>&1; then
+    if [ "${PRODUCE_ATTEMPT}" -lt "${MAX_RETRIES}" ]; then sleep "${RETRY_DELAY}"; fi
+    continue
+  fi
+
+  if CONSUME_OUT=$(kafkactl -C /tmp/kafkactl.yml --context vc \
+      consume "${PRODUCE_TOPIC}" --from-beginning --exit 2>/dev/null); then
+    if echo "${CONSUME_OUT}" | grep -qF "${RECORD_VALUE}"; then
+      cat <<EOF
+{
+  "success": true,
+  "message": "Topic listing and data-path validation passed",
+  "expected_topics": "${EXPECTED_TOPICS}",
+  "produce_topic": "${PRODUCE_TOPIC}",
+  "gateway_bootstrap": "${GATEWAY_BOOTSTRAP}",
+  "retry_attempt": ${ATTEMPT},
+  "produce_attempt": ${PRODUCE_ATTEMPT},
+  "max_retries": ${MAX_RETRIES}
+}
+EOF
+      exit 0
+    fi
+  fi
+
+  if [ "${PRODUCE_ATTEMPT}" -lt "${MAX_RETRIES}" ]; then sleep "${RETRY_DELAY}"; fi
+done
+
+cat <<EOF
+{
+  "success": false,
+  "error": "Produce+consume failed after ${MAX_RETRIES} attempts",
+  "produce_topic": "${PRODUCE_TOPIC}",
+  "gateway_bootstrap": "${GATEWAY_BOOTSTRAP}",
+  "retry_attempt": ${ATTEMPT},
+  "produce_attempt": ${PRODUCE_ATTEMPT},
+  "max_retries": ${MAX_RETRIES}
+}
+EOF
+exit 1
+


### PR DESCRIPTION


**What this PR does / why we need it**:

Add two Chainsaw E2E tests for the Event Gateway:

- **proxy-roundtrip**: deploys a 3-broker KRaft Kafka cluster, wires it to a Konnect-managed KegDataPlane, then runs kafkactl inside the cluster to produce/consume through the gateway and assert that the EventGatewayVirtualClusterConsumePolicy (modifyHeaders) injects the expected header. A second step consumes the same topic directly from Kafka (bypassing keg) and asserts the header is absent.

- **sni-routing**: mirrors the official docs scenario. Pre-seeds Kafka topics, generates a wildcard TLS cert for `*.{LB-IP}.sslip.io`, applies TLS server and SNI forward policies, then validates per-virtual-cluster topic isolation (analytics vs. payments) and produce/consume via SNI-routed bootstrap hostnames.

Shared infrastructure extracted to `common/`:
- `_step_templates/apply-assert-kafka-cluster.yaml` — inline 3-broker Kafka StatefulSet + Services step template
- `scripts/get_lb_address.sh` — waits for KegDataPlane LB IP
- `scripts/get_ca_cert.sh` — reads CA cert from a ConfigMap
- `scripts/seed_topics.sh` + `seed_topics_inner.sh` — pre-seeds Kafka topics

Also:
- `.chainsaw.yaml`: include eventgateway test directory
- CI: add `--set env.enable_controller_kegdataplane=true` to Helm install in the chainsaw E2E workflow


**Which issue this PR fixes**

Fixes #4083 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
