### PR TITLE
chore: Rename builder to prevent conflict with package name

### DIFF
--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -83,7 +83,7 @@ const provisionDataPlaneFailRetryAfter = 5 * time.Second
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
-	builder := ctrl.NewControllerManagedBy(mgr).
+	blder := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(r.ControllerOptions).
 		// watch Gateway objects, filtering out any Gateways which are not configured with
 		// a supported GatewayClass controller name.
@@ -145,7 +145,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 	if r.KonnectEnabled {
 		// Watch for changes in KonnectExtension objects that are referenced by GatewayConfigurations used by Gateways objects.
 		// They may trigger reconciliation of DataPlane resources.
-		builder.WatchesRawSource(
+		blder.WatchesRawSource(
 			source.Kind(
 				mgr.GetCache(),
 				&konnectv1alpha2.KonnectExtension{},
@@ -155,7 +155,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 	}
 
 	// Watch Secrets to requeue Gateways that reference them via listeners.tls.certificateRefs.
-	builder.WatchesRawSource(
+	blder.WatchesRawSource(
 		source.Kind(
 			mgr.GetCache(),
 			&corev1.Secret{},
@@ -163,7 +163,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 		),
 	)
 
-	return builder.Complete(reconcile.AsReconciler[*gwtypes.Gateway](r.Client, r))
+	return blder.Complete(reconcile.AsReconciler(r.Client, r))
 }
 
 // Reconcile moves the current state of an object to the intended state.

--- a/controller/gateway/controller_test.go
+++ b/controller/gateway/controller_test.go
@@ -803,7 +803,7 @@ func BenchmarkGatewayReconciler_Reconcile(b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		_, err := reconcile.AsReconciler[*gwtypes.Gateway](reconciler.Client, &reconciler).Reconcile(b.Context(), gatewayReq)
+		_, err := reconcile.AsReconciler(reconciler.Client, &reconciler).Reconcile(b.Context(), gatewayReq)
 		if err != nil {
 			b.Error(err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Rename variable name `builder` for builder in gateway controller to prevent conflict with package name.

**Which issue this PR fixes**


**Special notes for your reviewer**:

Required for #4445

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
