### PR TITLE
chore: fix issues reported by gopls

### DIFF
--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -113,7 +113,7 @@ func (r *KonnectExtensionReconciler) SetupWithManager(ctx context.Context, mgr c
 			&configurationv1alpha1.KongDataPlaneClientCertificate{},
 			handler.EnqueueRequestForOwner(r.Scheme(), mgr.GetRESTMapper(), &konnectv1alpha2.KonnectExtension{}),
 		).
-		Complete(reconcile.AsReconciler[*konnectv1alpha2.KonnectExtension](r.Client, r))
+		Complete(reconcile.AsReconciler(r.Client, r))
 }
 
 // listExtendableReferencedExtensions returns a list of all the KonnectExtensions referenced by the Extendable object.

--- a/controller/konnect/reconciler_credential_secrets.go
+++ b/controller/konnect/reconciler_credential_secrets.go
@@ -137,7 +137,7 @@ func (r *KongCredentialSecretReconciler) SetupWithManager(_ context.Context, mgr
 		Owns(&configurationv1alpha1.KongCredentialACL{}, builder.MatchEveryOwner).
 		Owns(&configurationv1alpha1.KongCredentialJWT{}, builder.MatchEveryOwner).
 		Owns(&configurationv1alpha1.KongCredentialHMAC{}, builder.MatchEveryOwner).
-		Complete(reconcile.AsReconciler[*corev1.Secret](r.client, r))
+		Complete(reconcile.AsReconciler(r.client, r))
 }
 
 func enqueueSecretsForKongConsumer(ctx context.Context, obj client.Object) []reconcile.Request {

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -127,7 +127,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) SetupWithManager(ctx context.Context,
 	for _, dep := range ReconciliationWatchOptionsForEntity(r.Client, ent) {
 		b = dep(b)
 	}
-	return b.Complete(reconcile.AsReconciler[TEnt](r.Client, r))
+	return b.Complete(reconcile.AsReconciler(r.Client, r))
 }
 
 // Reconcile reconciles the given Konnect entity.

--- a/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
+++ b/controller/konnect/reconciler_generic_pluginbindingfinalizer.go
@@ -67,7 +67,7 @@ func (r *KonnectEntityPluginBindingFinalizerReconciler[T, TEnt]) SetupWithManage
 
 	r.setControllerBuilderOptionsForKongPluginBinding(b)
 
-	return b.Complete(reconcile.AsReconciler[TEnt](r.Client, r))
+	return b.Complete(reconcile.AsReconciler(r.Client, r))
 }
 
 // enqueueObjectReferencedByKongPluginBinding watches for KongPluginBinding objects

--- a/controller/konnect/reconciler_kongplugin.go
+++ b/controller/konnect/reconciler_kongplugin.go
@@ -97,7 +97,7 @@ func (r *KongPluginReconciler) SetupWithManager(_ context.Context, mgr ctrl.Mana
 				predicate.NewPredicateFuncs(objRefersToKonnectGatewayControlPlane[configurationv1beta1.KongConsumerGroup]),
 			),
 		).
-		Complete(reconcile.AsReconciler[*configurationv1.KongPlugin](r.client, r))
+		Complete(reconcile.AsReconciler(r.client, r))
 }
 
 // Reconcile reconciles a KongPlugin object.

--- a/controller/konnect/reconciler_konnectapiauth.go
+++ b/controller/konnect/reconciler_konnectapiauth.go
@@ -105,7 +105,7 @@ func (r *KonnectAPIAuthConfigurationReconciler) SetupWithManager(ctx context.Con
 
 	setKonnectAPIAuthConfigurationRefWatches(b)
 
-	return b.Complete(reconcile.AsReconciler[*konnectv1alpha1.KonnectAPIAuthConfiguration](r.client, r))
+	return b.Complete(reconcile.AsReconciler(r.client, r))
 }
 
 // Reconcile reconciles a KonnectAPIAuthConfiguration object.

--- a/controller/konnect/secret_reference_controller.go
+++ b/controller/konnect/secret_reference_controller.go
@@ -49,7 +49,7 @@ func (r *KonnectSecretReferenceController) SetupWithManager(ctx context.Context,
 
 	setSecretReferenceWatches(b)
 
-	return b.Complete(reconcile.AsReconciler[*corev1.Secret](r.client, r))
+	return b.Complete(reconcile.AsReconciler(r.client, r))
 }
 
 // Reconcile reconciles a Secret object.

--- a/crd-from-oas/pkg/parser/parser.go
+++ b/crd-from-oas/pkg/parser/parser.go
@@ -519,7 +519,8 @@ func deriveSchemaNameFromPath(path string, operationID string) string {
 		var result strings.Builder
 		for _, part := range parts {
 			if len(part) > 0 {
-				result.WriteString(strings.ToUpper(part[:1]) + part[1:])
+				result.WriteString(strings.ToUpper(part[:1]))
+				result.WriteString(part[1:])
 			}
 		}
 		return result.String()

--- a/ingress-controller/internal/dataplane/kongstate/kongstate.go
+++ b/ingress-controller/internal/dataplane/kongstate/kongstate.go
@@ -584,22 +584,26 @@ func buildPlugins(
 			if !rel.Service.IsEmpty() {
 				relSvc := rel.Service.Identifier
 				plugin.Service = &kong.Service{ID: new(relSvc)}
-				toHash.WriteString("_service-" + relSvc)
+				toHash.WriteString("_service-")
+				toHash.WriteString(relSvc)
 			}
 			if !rel.Route.IsEmpty() {
 				relRoute := rel.Route.Identifier
 				plugin.Route = &kong.Route{ID: new(relRoute)}
-				toHash.WriteString("_route-" + relRoute)
+				toHash.WriteString("_route-")
+				toHash.WriteString(relRoute)
 			}
 			if !rel.Consumer.IsEmpty() {
 				relConsumer := rel.Consumer.Identifier
 				plugin.Consumer = &kong.Consumer{ID: new(relConsumer)}
-				toHash.WriteString("_consumer-" + relConsumer)
+				toHash.WriteString("_consumer-")
+				toHash.WriteString(relConsumer)
 			}
 			if !rel.ConsumerGroup.IsEmpty() {
 				relConsumerGroup := rel.ConsumerGroup.Identifier
 				plugin.ConsumerGroup = &kong.ConsumerGroup{ID: new(relConsumerGroup)}
-				toHash.WriteString("_group-" + relConsumerGroup)
+				toHash.WriteString("_group-")
+				toHash.WriteString(relConsumerGroup)
 			}
 
 			// instance_name must be unique. Using the same KongPlugin on multiple resources will result in duplicates

--- a/test/integration/kic/isolated/suite_test.go
+++ b/test/integration/kic/isolated/suite_test.go
@@ -431,7 +431,7 @@ func startControllerManager(
 	var featureGates strings.Builder
 	featureGates.WriteString(consts.DefaultControllerFeatureGates)
 	for gate, value := range setupCfg.controllerManagerFeatureGates {
-		featureGates.WriteString("," + fmt.Sprintf("%s=%s", gate, value))
+		fmt.Fprintf(&featureGates, ",%s=%s", gate, value)
 	}
 	t.Logf("feature gates enabled: %s", featureGates.String())
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix 2 types of issues:

- inefficient string concatenation:

```
kong-operator/crd-from-oas/pkg/parser/parser.go:522:5-61: Inefficient string concatenation in call to WriteString
kong-operator/test/integration/kic/isolated/suite_test.go:434:3-68: Inefficient string concatenation in call to WriteString
kong-operator/ingress-controller/internal/dataplane/kongstate/kongstate.go:587:5-45: Inefficient string concatenation in call to WriteString
kong-operator/ingress-controller/internal/dataplane/kongstate/kongstate.go:592:5-45: Inefficient string concatenation in call to WriteString
kong-operator/ingress-controller/internal/dataplane/kongstate/kongstate.go:597:5-51: Inefficient string concatenation in call to WriteString
kong-operator/ingress-controller/internal/dataplane/kongstate/kongstate.go:602:5-53: Inefficient string concatenation in call to WriteString
```

- `unnecessary type arguments` where type parameters can be inferred

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

It can be considered to run `gopls` in CI but it would have to be done with leveraging the build and gopls cache because that is a rather heavy process computation-wise:

```
time find . -name '*.go' -print0 | xargs -0 -n 20 gopls check
```

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
