### PR TITLE
chore(ci): fix chainsaw path

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -68,6 +68,10 @@ version = "3fa174937a6b9f0c1c2203efb312fff4ac8477c8"
 # renovate: datasource=github-releases depName=mikefarah/yq
 version = "v4.53.2"
 
+[tools."aqua:kyverno/chainsaw"]
+# renovate: datasource=git-refs packageName=https://github.com/kyverno/chainsaw.git
+version = "v0.2.15"
+
 ################################################################################
 # Tasks
 

--- a/.tools_versions.yaml
+++ b/.tools_versions.yaml
@@ -49,5 +49,3 @@ kube-linter: "0.8.3"
 markdownlint-cli2: "0.22.1"
 # renovate: datasource=github-releases depName=cert-manager/cert-manager
 cert-manager: "1.20.2"
-# renovate: datasource=github-releases depName=kyverno/chainsaw
-chainsaw: "v0.2.15-beta.1"

--- a/Makefile
+++ b/Makefile
@@ -192,11 +192,11 @@ KUBE_API_LINTER = $(PROJECT_DIR)/bin/installs/go-sigs-k8s-io-kube-api-linter-cmd
 download.kube-api-linter: mise yq ## Download kube-api-linter locally if necessary.
 	$(MAKE) mise-install DEP_VER=go:sigs.k8s.io/kube-api-linter/cmd/golangci-lint-kube-api-linter@$(KUBE_API_LINTER_VERSION)
 
-CHAINSAW_VERSION = $(shell $(YQ) -r '.chainsaw' < $(TOOLS_VERSIONS_FILE))
-CHAINSAW = $(PROJECT_DIR)/bin/installs/github-kyverno-chainsaw/$(CHAINSAW_VERSION)/chainsaw
+CHAINSAW_VERSION = $(shell $(YQ) -p toml -o yaml '.tools["aqua:kyverno/chainsaw"].version' < $(MISE_FILE))
+CHAINSAW = $(PROJECT_DIR)/bin/installs/aqua-kyverno-chainsaw/$(CHAINSAW_VERSION)/chainsaw
 .PHONY: chainsaw
 chainsaw: mise yq ## Download chainsaw locally if necessary.
-	$(MAKE) mise-install DEP_VER=github:kyverno/chainsaw@$(CHAINSAW_VERSION)
+	$(MAKE) mise-install DEP_VER=aqua:kyverno/chainsaw@$(CHAINSAW_VERSION)
 
 .PHONY: use-setup-envtest
 use-setup-envtest:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix:

```
make[1]: Leaving directory '/home/runner/work/kong-operator/kong-operator'
/home/runner/work/kong-operator/kong-operator/bin/installs/github-kyverno-chainsaw/v0.2.15-beta.1/chainsaw test --config ./test/e2e/chainsaw/.chainsaw.yaml --quiet --test-dir ./test/e2e/chainsaw
bash: line 1: /home/runner/work/kong-operator/kong-operator/bin/installs/github-kyverno-chainsaw/v0.2.15-beta.1/chainsaw: No such file or directory
```

https://github.com/Kong/kong-operator/actions/runs/26638436872/job/78505197176?pr=4450#step:11:99

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
