### PR TITLE
test(chainsaw): add ACL enforcement test to event gateway proxy-roundtrip

### DIFF
--- a/test/e2e/chainsaw/common/scripts/get_lb_address.sh
+++ b/test/e2e/chainsaw/common/scripts/get_lb_address.sh
@@ -7,16 +7,16 @@
 #   NAMESPACE     Namespace the resources live in.
 #   KEG_DP_NAME   Name of the KegDataPlane (its Service is <KEG_DP_NAME>-kafka).
 # Optional env:
-#   MAX_RETRIES   Maximum retry attempts. Default: 60.
-#   RETRY_DELAY   Seconds between retries. Default: 5.
+#   MAX_RETRIES   Maximum retry attempts. Default: 180.
+#   RETRY_DELAY   Seconds between retries. Default: 1.
 set -o errexit
 set -o nounset
 set -o pipefail
 
 NAMESPACE="${NAMESPACE}"
 KEG_DP_NAME="${KEG_DP_NAME}"
-MAX_RETRIES="${MAX_RETRIES:-60}"
-RETRY_DELAY="${RETRY_DELAY:-5}"
+MAX_RETRIES="${MAX_RETRIES:-180}"
+RETRY_DELAY="${RETRY_DELAY:-1}"
 
 SVC="${KEG_DP_NAME}-kafka"
 ADDR=""

--- a/test/e2e/chainsaw/common/scripts/seed_topics_inner.sh
+++ b/test/e2e/chainsaw/common/scripts/seed_topics_inner.sh
@@ -10,13 +10,13 @@
 #
 # Env vars provided by kubectl run --env:
 #   KAFKA_BOOTSTRAP  Direct Kafka bootstrap server (e.g. kafka-bootstrap.<ns>.svc:9092).
-#   MAX_RETRIES      (optional) Default: 60.
-#   RETRY_DELAY      (optional) Default: 5.
+#   MAX_RETRIES      (optional) Default: 180.
+#   RETRY_DELAY      (optional) Default: 1.
 set -eu
 
 KAFKA_BOOTSTRAP="${KAFKA_BOOTSTRAP}"
-MAX_RETRIES="${MAX_RETRIES:-60}"
-RETRY_DELAY="${RETRY_DELAY:-5}"
+MAX_RETRIES="${MAX_RETRIES:-180}"
+RETRY_DELAY="${RETRY_DELAY:-1}"
 
 cat > /tmp/kafkactl.yml <<EOF
 contexts:

--- a/test/e2e/chainsaw/eventgateway/proxy-roundtrip/02-event-gateway-assert.yaml
+++ b/test/e2e/chainsaw/eventgateway/proxy-roundtrip/02-event-gateway-assert.yaml
@@ -48,6 +48,14 @@ status:
     - status: "True"
 ---
 apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayVirtualClusterPolicy
+metadata:
+  name: ($acl_policy_name)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: "True"
+---
+apiVersion: configuration.konghq.com/v1alpha1
 kind: EventGatewayVirtualClusterConsumePolicy
 metadata:
   name: ($consume_policy_name)

--- a/test/e2e/chainsaw/eventgateway/proxy-roundtrip/02-event-gateway.yaml
+++ b/test/e2e/chainsaw/eventgateway/proxy-roundtrip/02-event-gateway.yaml
@@ -79,7 +79,7 @@ spec:
     name: ($virtual_cluster_name)
     description: proxy-roundtrip virtual cluster
     dnsLabel: vcluster-1
-    aclMode: passthrough
+    aclMode: enforce_on_gateway
     authentication:
       - type: anonymous
 ---
@@ -123,6 +123,46 @@ spec:
           advertisedHost: placeholder.invalid
           destination:
             name: ($virtual_cluster_name)
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: EventGatewayVirtualClusterPolicy
+metadata:
+  name: ($acl_policy_name)
+spec:
+  eventGatewayVirtualClusterRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($virtual_cluster_name)
+  apiSpec:
+    type: acls
+    acls:
+      name: ($acl_policy_name)
+      config:
+        rules:
+          - action: allow
+            resourceType: topic
+            operations:
+              - name: all
+            resourceNames:
+              type: stat
+              stat:
+                - match: "*"
+          - action: deny
+            resourceType: topic
+            operations:
+              - name: write
+            resourceNames:
+              type: stat
+              stat:
+                - match: blocked-topic
+          - action: allow
+            resourceType: group
+            operations:
+              - name: all
+            resourceNames:
+              type: stat
+              stat:
+                - match: "*"
 ---
 apiVersion: configuration.konghq.com/v1alpha1
 kind: EventGatewayVirtualClusterConsumePolicy

--- a/test/e2e/chainsaw/eventgateway/proxy-roundtrip/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/eventgateway/proxy-roundtrip/chainsaw-test.yaml
@@ -52,6 +52,8 @@ spec:
       value: (join('-', [($test_name), 'forward']))
     - name: consume_policy_name
       value: (join('-', [($test_name), 'modify-headers']))
+    - name: acl_policy_name
+      value: (join('-', [($test_name), 'acls']))
 
     - name: injected_header_key
       value: My-New-Header
@@ -199,6 +201,38 @@ spec:
                 value: ($namespace)
             content: |
               bash scripts/kafkactl_direct_read.sh
+
+    # ACL enforcement test: create blocked-topic directly on Kafka, then try to
+    # produce through the gateway and assert the ACL policy denies the request.
+    - name: Test-acl-blocked-topic
+      description: |
+        Assert that the ACL policy denies write access to blocked-topic when
+        producing through the gateway (virtual cluster). The topic is first
+        created directly on Kafka so the produce attempt can reach the
+        authorization check, not a "topic not found" error.
+      try:
+        # Re-discover the LB address within this step.
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: KEG_DP_NAME
+                value: ($keg_dp_name)
+            content: |
+              bash ../../common/scripts/get_lb_address.sh
+            outputs:
+              - name: lb_address
+                value: (json_parse($stdout).address)
+        - script:
+            env:
+              - name: GATEWAY_ADDR
+                value: (join(':', [($lb_address), '19092']))
+              - name: KAFKA_DIRECT
+                value: (join('', ['kafka-bootstrap.', ($namespace), '.svc:9092']))
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              bash scripts/kafkactl_acl_blocked.sh
 
   catch:
     - description: Capture debug snapshot on test failure.

--- a/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_acl_blocked.sh
+++ b/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_acl_blocked.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Assert that the ACL policy blocks produce to blocked-topic through the gateway.
+# Creates blocked-topic directly on Kafka, then attempts to produce through keg
+# and expects an authorization error.
+#
+# Required env:
+#   GATEWAY_ADDR    host:port bootstrap address (LB IP + listener port).
+#   KAFKA_DIRECT    host:port of the Kafka bootstrap Service (bypasses gateway).
+#   NAMESPACE       Kubernetes namespace for the test pod.
+set -euo pipefail
+
+: "${GATEWAY_ADDR:?must be set}"
+: "${KAFKA_DIRECT:?must be set}"
+: "${NAMESPACE:?must be set}"
+
+POD_NAME="kafkactl-acl-blocked-$(date +%s)"
+_STDERR=$(mktemp /tmp/kubectl-acl-blocked-stderr.XXXXXX)
+_on_exit() { [ $? -ne 0 ] && cat "${_STDERR}" >&2; rm -f "${_STDERR}"; }
+trap _on_exit EXIT
+
+cat scripts/kafkactl_acl_blocked_inner.sh | kubectl run "${POD_NAME}" \
+  --image=deviceinsight/kafkactl:latest \
+  --rm -i --restart=Never \
+  --env="GATEWAY_ADDR=${GATEWAY_ADDR}" \
+  --env="KAFKA_DIRECT=${KAFKA_DIRECT}" \
+  -n "${NAMESPACE}" \
+  --command -- sh -s 2>"${_STDERR}"

--- a/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_acl_blocked_inner.sh
+++ b/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_acl_blocked_inner.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# Runs inside the kafkactl pod (piped via stdin by kafkactl_acl_blocked.sh).
+# 1. Creates blocked-topic directly on Kafka (bypassing the gateway).
+# 2. Retries producing to blocked-topic through the gateway until the ACL
+#    policy returns an authorization error, confirming enforcement.
+#
+# Produce success → ACL not yet propagated to data plane → retry.
+# "not authorized" error → ACL enforced → exit 0.
+# Any other produce failure → gateway not ready → retry.
+#
+# Env vars (set by kubectl run --env):
+#   GATEWAY_ADDR    host:port bootstrap address (LB IP + listener port).
+#   KAFKA_DIRECT    host:port of the Kafka bootstrap Service (bypasses gateway).
+#   MAX_RETRIES     (optional) Maximum retry attempts. Default: 180.
+#   RETRY_DELAY     (optional) Seconds between retries. Default: 1.
+set -eu
+
+GATEWAY_ADDR="${GATEWAY_ADDR}"
+KAFKA_DIRECT="${KAFKA_DIRECT}"
+MAX_RETRIES="${MAX_RETRIES:-180}"
+RETRY_DELAY="${RETRY_DELAY:-1}"
+
+cat > /tmp/kafkactl.yml <<EOF
+contexts:
+  direct:
+    brokers:
+      - ${KAFKA_DIRECT}
+  vc:
+    brokers:
+      - ${GATEWAY_ADDR}
+EOF
+
+# Create blocked-topic directly on Kafka (idempotent; ignore errors).
+kafkactl -C /tmp/kafkactl.yml --context direct \
+  create topic blocked-topic --partitions 3 --replication-factor 3 >/dev/null 2>&1 || true
+
+# Retry loop: wait until the gateway denies writes to blocked-topic.
+ATTEMPT=0
+LAST_ERR=""
+while [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+
+  LAST_ERR=""
+  if LAST_ERR=$(kafkactl -C /tmp/kafkactl.yml --context vc \
+      produce blocked-topic --value "test message" 2>&1); then
+    # Produce succeeded — ACL not yet enforced, retry.
+    if [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; then sleep "${RETRY_DELAY}"; fi
+    continue
+  fi
+
+  if echo "${LAST_ERR}" | grep -qi "not authorized"; then
+    cat <<EOF
+{
+  "success": true,
+  "message": "ACL policy correctly blocked produce to blocked-topic",
+  "gateway_addr": "${GATEWAY_ADDR}",
+  "retry_attempt": ${ATTEMPT},
+  "max_retries": ${MAX_RETRIES}
+}
+EOF
+    exit 0
+  fi
+
+  # Other failure (connection error, not ready, etc.) — retry.
+  if [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; then sleep "${RETRY_DELAY}"; fi
+done
+
+cat <<EOF
+{
+  "success": false,
+  "error": "produce to blocked-topic was not blocked by ACL after ${MAX_RETRIES} attempts",
+  "last_error": "${LAST_ERR}",
+  "gateway_addr": "${GATEWAY_ADDR}",
+  "retry_attempt": ${ATTEMPT},
+  "max_retries": ${MAX_RETRIES}
+}
+EOF
+exit 1

--- a/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_direct_read.sh
+++ b/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_direct_read.sh
@@ -16,6 +16,9 @@ set -euo pipefail
 : "${NAMESPACE:?must be set}"
 
 POD_NAME="kafkactl-direct-$(date +%s)"
+_STDERR=$(mktemp /tmp/kubectl-direct-stderr.XXXXXX)
+_on_exit() { [ $? -ne 0 ] && cat "${_STDERR}" >&2; rm -f "${_STDERR}"; }
+trap _on_exit EXIT
 
 cat scripts/kafkactl_direct_read_inner.sh | kubectl run "${POD_NAME}" \
   --image=deviceinsight/kafkactl:latest \
@@ -24,4 +27,4 @@ cat scripts/kafkactl_direct_read_inner.sh | kubectl run "${POD_NAME}" \
   --env="TOPIC=${TOPIC}" \
   --env="HEADER_KEY=${HEADER_KEY}" \
   -n "${NAMESPACE}" \
-  --command -- sh -s 2>/dev/null | grep -v '^pod "'
+  --command -- sh -s 2>"${_STDERR}"

--- a/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_direct_read_inner.sh
+++ b/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_direct_read_inner.sh
@@ -7,15 +7,15 @@
 #   KAFKA_DIRECT    host:port of the Kafka bootstrap Service (bypasses gateway).
 #   TOPIC           Kafka topic to consume.
 #   HEADER_KEY      Header that must NOT appear on directly-consumed records.
-#   MAX_RETRIES     (optional) Maximum retry attempts. Default: 60.
-#   RETRY_DELAY     (optional) Seconds between retries. Default: 5.
+#   MAX_RETRIES     (optional) Maximum retry attempts. Default: 180.
+#   RETRY_DELAY     (optional) Seconds between retries. Default: 1.
 set -eu
 
 KAFKA_DIRECT="${KAFKA_DIRECT}"
 TOPIC="${TOPIC}"
 HEADER_KEY="${HEADER_KEY}"
-MAX_RETRIES="${MAX_RETRIES:-60}"
-RETRY_DELAY="${RETRY_DELAY:-5}"
+MAX_RETRIES="${MAX_RETRIES:-180}"
+RETRY_DELAY="${RETRY_DELAY:-1}"
 
 cat > /tmp/kafkactl.yml <<EOF
 contexts:
@@ -30,7 +30,7 @@ TOPIC_FOUND=0
 while [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; do
   ATTEMPT=$((ATTEMPT + 1))
   if kafkactl -C /tmp/kafkactl.yml --context direct \
-       get topics 2>/dev/null | grep -q "^${TOPIC}[[:space:]]"; then
+       get topics 2>&1 | grep -q "^${TOPIC}[[:space:]]"; then
     TOPIC_FOUND=1
     break
   fi
@@ -52,7 +52,7 @@ fi
 
 # Consume directly from Kafka (bypassing keg).
 OUT=$(kafkactl -C /tmp/kafkactl.yml --context direct \
-  consume "${TOPIC}" --print-headers --from-beginning --exit 2>/dev/null || echo "")
+  consume "${TOPIC}" --print-headers --from-beginning --exit 2>&1 || echo "")
 
 if echo "${OUT}" | grep -q "${HEADER_KEY}:"; then
   cat <<EOF
@@ -62,7 +62,8 @@ if echo "${OUT}" | grep -q "${HEADER_KEY}:"; then
   "topic": "${TOPIC}",
   "kafka_direct": "${KAFKA_DIRECT}",
   "retry_attempt": ${ATTEMPT},
-  "max_retries": ${MAX_RETRIES}
+  "max_retries": ${MAX_RETRIES},
+  "consume_output": "${OUT}"
 }
 EOF
   exit 1

--- a/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_roundtrip.sh
+++ b/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_roundtrip.sh
@@ -20,6 +20,9 @@ set -euo pipefail
 : "${NAMESPACE:?must be set}"
 
 POD_NAME="kafkactl-roundtrip-$(date +%s)"
+_STDERR=$(mktemp /tmp/kubectl-roundtrip-stderr.XXXXXX)
+_on_exit() { [ $? -ne 0 ] && cat "${_STDERR}" >&2; rm -f "${_STDERR}"; }
+trap _on_exit EXIT
 
 cat scripts/kafkactl_roundtrip_inner.sh | kubectl run "${POD_NAME}" \
   --image=deviceinsight/kafkactl:latest \
@@ -30,4 +33,4 @@ cat scripts/kafkactl_roundtrip_inner.sh | kubectl run "${POD_NAME}" \
   --env="HEADER_VALUE=${HEADER_VALUE}" \
   --env="RECORD_VALUE=${RECORD_VALUE}" \
   -n "${NAMESPACE}" \
-  --command -- sh -s 2>/dev/null | grep -v '^pod "'
+  --command -- sh -s 2>"${_STDERR}"

--- a/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_roundtrip_inner.sh
+++ b/test/e2e/chainsaw/eventgateway/proxy-roundtrip/scripts/kafkactl_roundtrip_inner.sh
@@ -10,8 +10,8 @@
 #   HEADER_KEY      Header expected on every consumed record.
 #   HEADER_VALUE    Expected header value.
 #   RECORD_VALUE    Record payload to produce.
-#   MAX_RETRIES     (optional) Maximum retry attempts. Default: 60.
-#   RETRY_DELAY     (optional) Seconds between retries. Default: 5.
+#   MAX_RETRIES     (optional) Maximum retry attempts. Default: 180.
+#   RETRY_DELAY     (optional) Seconds between retries. Default: 1.
 set -eu
 
 GATEWAY_ADDR="${GATEWAY_ADDR}"
@@ -19,8 +19,8 @@ TOPIC="${TOPIC}"
 HEADER_KEY="${HEADER_KEY}"
 HEADER_VALUE="${HEADER_VALUE}"
 RECORD_VALUE="${RECORD_VALUE}"
-MAX_RETRIES="${MAX_RETRIES:-60}"
-RETRY_DELAY="${RETRY_DELAY:-5}"
+MAX_RETRIES="${MAX_RETRIES:-180}"
+RETRY_DELAY="${RETRY_DELAY:-1}"
 
 cat > /tmp/kafkactl.yml <<EOF
 contexts:
@@ -32,7 +32,7 @@ EOF
 # Retry loop: retry until produce succeeds and the consumed record carries the
 # expected header, or retries are exhausted.
 ATTEMPT=0
-LAST_OUT=""
+LAST_ERROR=""
 while [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; do
   ATTEMPT=$((ATTEMPT + 1))
 
@@ -40,17 +40,20 @@ while [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; do
   kafkactl -C /tmp/kafkactl.yml --context vc \
     create topic "${TOPIC}" --partitions 3 --replication-factor 3 >/dev/null 2>&1 || true
 
-  # Produce; skip to next attempt if gateway is not yet ready.
-  if ! kafkactl -C /tmp/kafkactl.yml --context vc \
-      produce "${TOPIC}" --value "${RECORD_VALUE}" >/dev/null 2>&1; then
+  # Produce; capture output for diagnostics on failure.
+  PRODUCE_OUT=""
+  if ! PRODUCE_OUT=$(kafkactl -C /tmp/kafkactl.yml --context vc \
+      produce "${TOPIC}" --value "${RECORD_VALUE}" 2>&1); then
+    LAST_ERROR="produce failed: ${PRODUCE_OUT}"
     if [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; then sleep "${RETRY_DELAY}"; fi
     continue
   fi
 
   # Consume and check for the injected header.
-  if LAST_OUT=$(kafkactl -C /tmp/kafkactl.yml --context vc \
-      consume "${TOPIC}" --print-headers --from-beginning --exit 2>/dev/null); then
-    if echo "${LAST_OUT}" | grep -q "${HEADER_KEY}:${HEADER_VALUE}"; then
+  CONSUME_OUT=""
+  if CONSUME_OUT=$(kafkactl -C /tmp/kafkactl.yml --context vc \
+      consume "${TOPIC}" --print-headers --from-beginning --exit 2>&1); then
+    if echo "${CONSUME_OUT}" | grep -q "${HEADER_KEY}:${HEADER_VALUE}"; then
       cat <<EOF
 {
   "success": true,
@@ -63,6 +66,9 @@ while [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; do
 EOF
       exit 0
     fi
+    LAST_ERROR="consume output (header not found): ${CONSUME_OUT}"
+  else
+    LAST_ERROR="consume failed: ${CONSUME_OUT}"
   fi
 
   if [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; then sleep "${RETRY_DELAY}"; fi
@@ -75,7 +81,8 @@ cat <<EOF
   "topic": "${TOPIC}",
   "gateway_addr": "${GATEWAY_ADDR}",
   "retry_attempt": ${ATTEMPT},
-  "max_retries": ${MAX_RETRIES}
+  "max_retries": ${MAX_RETRIES},
+  "last_error": "${LAST_ERROR}"
 }
 EOF
 exit 1

--- a/test/e2e/chainsaw/eventgateway/sni-routing/scripts/kafkactl_sni_validate_inner.sh
+++ b/test/e2e/chainsaw/eventgateway/sni-routing/scripts/kafkactl_sni_validate_inner.sh
@@ -14,8 +14,8 @@
 #   EXPECTED_TOPICS      Space-separated list of topics that MUST be visible.
 #   UNEXPECTED_TOPICS    Space-separated list of topics that MUST NOT be visible.
 #   PRODUCE_TOPIC        Topic to produce+consume through (must be in EXPECTED_TOPICS).
-#   MAX_RETRIES          (optional) Default: 60.
-#   RETRY_DELAY          (optional) Default: 5.
+#   MAX_RETRIES          (optional) Default: 180.
+#   RETRY_DELAY          (optional) Default: 1.
 set -eu
 
 GATEWAY_BOOTSTRAP="${GATEWAY_BOOTSTRAP}"
@@ -23,8 +23,8 @@ CA_CERT_B64="${CA_CERT_B64}"
 EXPECTED_TOPICS="${EXPECTED_TOPICS}"
 UNEXPECTED_TOPICS="${UNEXPECTED_TOPICS:-}"
 PRODUCE_TOPIC="${PRODUCE_TOPIC}"
-MAX_RETRIES="${MAX_RETRIES:-60}"
-RETRY_DELAY="${RETRY_DELAY:-5}"
+MAX_RETRIES="${MAX_RETRIES:-180}"
+RETRY_DELAY="${RETRY_DELAY:-1}"
 
 # Write CA certificate so kafkactl can verify the gateway's TLS cert.
 printf '%s' "${CA_CERT_B64}" | base64 -d > /tmp/ca.crt


### PR DESCRIPTION


**What this PR does / why we need it**:

Add an EventGatewayVirtualClusterPolicy (ACL) to the proxy-roundtrip
Chainsaw test and assert that the gateway correctly enforces it:

- Switch the virtual cluster's aclMode from passthrough to
  enforce_on_gateway.
- Add an EventGatewayVirtualClusterPolicy CR (acls type) with three
  rules: allow all operations on topic "*", deny write on
  "blocked-topic", allow all operations on group "*".
- Add an assert step in 02-event-gateway-assert.yaml that waits for
  the policy to reach Programmed=True.
- Add a new Test-acl-blocked-topic step: creates blocked-topic directly
  on Kafka, then retries producing through the gateway until the ACL
  returns "not authorized", confirming enforcement.
- Add scripts/kafkactl_acl_blocked.sh and
  kafkactl_acl_blocked_inner.sh implementing the above flow with the
  trap-based stderr capture pattern (matches kafkactl_roundtrip.sh).

Tighten retry defaults across all eventgateway Chainsaw scripts:
  MAX_RETRIES 60→180, RETRY_DELAY 5s→1s (180 × 1s = 3 min budget).

Fix outer script output cleanliness: replace 2>&1 | grep -v '^pod '
pipe with trap _on_exit EXIT + stderr redirected to a temp file
(dumped on failure only), keeping stdout as pure JSON.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

ACL was introduced in: https://github.com/Kong/kong-operator/pull/4444

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
