### PR TITLE
test(chainsaw): add cross-namespace controlPlaneRef test for KongPluginBinding

### DIFF
--- a/test/e2e/chainsaw/konnect/kongpluginbinding_controlplaneref_cross-namespace/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/konnect/kongpluginbinding_controlplaneref_cross-namespace/chainsaw-test.yaml
@@ -1,0 +1,643 @@
+# KongPluginBinding cross-namespace controlPlaneRef test.
+#
+# A KongPluginBinding may reference a KonnectGatewayControlPlane in a different
+# namespace via spec.controlPlaneRef.konnectNamespacedRef.namespace. The
+# cross-namespace reference must be permitted by a KongReferenceGrant in the
+# control plane's namespace allowing KongPluginBinding -> KonnectGatewayControlPlane.
+#
+# The KongPlugin referenced by pluginRef is kept in the same namespace as the
+# KongPluginBinding throughout, so the only cross-namespace axis under test is
+# controlPlaneRef.namespace.
+#
+# Scenario A: All resources in the same namespace — baseline, no grants needed.
+#   controlPlaneRef omits namespace; the ResolvedRefs condition is absent.
+#
+# Scenario B: KongPluginBinding+KongPlugin in the test namespace, CP+Auth in cp_namespace.
+#   One controlPlaneRef grant (in cp_namespace) is needed to allow the cross-namespace CP reference.
+#   Includes an intermediate assertion showing the binding fails when the grant is missing.
+#
+# Scenario C: starting from Scenario B (Programmed=True), deleting the
+#   KongReferenceGrant reverts the KongPluginBinding to ResolvedRefs=False/RefNotPermitted.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kongpluginbinding-controlplaneref-cross-namespace
+spec:
+  description: |
+    Tests cross-namespace controlPlaneRef behaviour for KongPluginBinding.
+
+    A KongPluginBinding references a KonnectGatewayControlPlane in a different
+    namespace via spec.controlPlaneRef.konnectNamespacedRef.namespace. The
+    KongPlugin referenced by pluginRef stays in the same namespace as the
+    binding, isolating the controlPlaneRef cross-namespace axis.
+
+    Scenario A: KongPluginBinding, KongPlugin, KonnectGatewayControlPlane and
+    KonnectAPIAuthConfiguration all in the same namespace. controlPlaneRef omits
+    namespace; no grants needed. Baseline sanity check.
+
+    Scenario B: KongPluginBinding+KongPlugin in the test namespace, CP+Auth in
+    cp_namespace. The binding fails until a KongReferenceGrant in cp_namespace
+    permits the cross-namespace KongPluginBinding -> KonnectGatewayControlPlane reference.
+
+    Scenario C: starting from Scenario B (Programmed=True), deleting the
+    KongReferenceGrant reverts the KongPluginBinding to
+    ResolvedRefs=False/RefNotPermitted immediately, validating that the
+    KongReferenceGrant watch is wired correctly. The grant is then recreated to
+    allow clean Konnect deprovisioning.
+
+    Scenario D: both axes cross-namespace at once. KongPluginBinding in the test
+    namespace references a KonnectGatewayControlPlane in cp_namespace AND a
+    KongPlugin in plugin_namespace. Two KongReferenceGrants are required:
+    KongPluginBinding -> KonnectGatewayControlPlane (in cp_namespace) and
+    KongPluginBinding -> KongPlugin (in plugin_namespace). The controlPlaneRef
+    grant is checked first, so with no grants the binding reports
+    ResolvedRefs=False/RefNotPermitted; once the CP grant exists it reports
+    PluginRefValid=False/RefNotPermitted; once both grants exist it becomes
+    Programmed.
+
+  bindings:
+    # Common bindings.
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    # Namespace bindings.
+    - name: cp_namespace
+      value: (join('-', [$namespace, 'cp']))
+    - name: plugin_namespace
+      value: (join('-', [$namespace, 'plugin']))
+    # Scenario A resource names (all in test namespace).
+    - name: cp0_name
+      value: (join('-', [$namespace, 'cp0']))
+    - name: auth0_name
+      value: (join('-', [$namespace, 'auth0-konnect-api-auth']))
+    - name: plugin0_name
+      value: (join('-', [$namespace, 'plugin0']))
+    - name: pb0_name
+      value: (join('-', [$namespace, 'pb0']))
+    # Scenario B resource names (binding+plugin in test namespace, CP+Auth in cp_namespace).
+    - name: cp_name
+      value: (join('-', [$namespace, 'cp']))
+    - name: auth_name
+      value: (join('-', [$namespace, 'konnect-api-auth']))
+    - name: plugin_name
+      value: (join('-', [$namespace, 'plugin']))
+    - name: pb_name
+      value: (join('-', [$namespace, 'pb']))
+    # Scenario D resource names (binding in test namespace, CP+Auth in cp_namespace, plugin in plugin_namespace).
+    - name: cp3_name
+      value: (join('-', [$namespace, 'cp3']))
+    - name: plugin3_name
+      value: (join('-', [$namespace, 'plugin3']))
+    - name: pb3_name
+      value: (join('-', [$namespace, 'pb3']))
+
+  steps:
+    # =========================================================================
+    # Scenario A: All resources in the same namespace. No grants needed.
+    # controlPlaneRef omits namespace, so the ResolvedRefs condition is absent.
+    # =========================================================================
+
+    - name: 1-create-auth-config-same-ns
+      description: Create KonnectAPIAuthConfiguration in the test namespace.
+      bindings:
+        - name: test_name
+          value: (join('-', [$namespace, 'auth0']))
+        - name: namespace
+          value: ($namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    - name: 2-create-control-plane-same-ns
+      description: Create KonnectGatewayControlPlane in the test namespace.
+      bindings:
+        - name: cp_name
+          value: ($cp0_name)
+        - name: cp_namespace
+          value: ($namespace)
+        - name: auth_name
+          value: ($auth0_name)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectGatewayControlPlane.yaml
+
+    - name: 3-create-plugin-same-ns
+      description: Create KongPlugin in the test namespace.
+      bindings:
+        - name: kong_plugin_name
+          value: ($plugin0_name)
+        - name: kong_plugin_namespace
+          value: ($namespace)
+        - name: plugin_type
+          value: rate-limiting
+        - name: plugin_config
+          value: '{"minute": 5, "policy": "local"}'
+      use:
+        template: ../../common/_step_templates/apply-assert-kongPlugin.yaml
+
+    - name: 4-create-binding-same-ns
+      description: Create KongPluginBinding in test namespace with same-namespace controlPlaneRef and pluginRef. No grants needed.
+      try:
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongPluginBinding
+              metadata:
+                name: ($pb0_name)
+                namespace: ($namespace)
+              spec:
+                controlPlaneRef:
+                  type: konnectNamespacedRef
+                  konnectNamespacedRef:
+                    name: ($cp0_name)
+                pluginRef:
+                  name: ($plugin0_name)
+                scope: GlobalInControlPlane
+
+    - name: 5-assert-binding-programmed-same-ns
+      description: Assert KongPluginBinding is Programmed. No ResolvedRefs condition for same-namespace controlPlaneRef.
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongPluginBinding
+              metadata:
+                name: ($pb0_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+
+    - name: 6-cleanup-scenario-a
+      description: Delete binding and CP in order; wait for each to be gone before proceeding.
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongPluginBinding
+              name: ($pb0_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongPluginBinding
+              metadata:
+                name: ($pb0_name)
+                namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              name: ($cp0_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp0_name)
+                namespace: ($namespace)
+
+    # =========================================================================
+    # Scenario B: KongPluginBinding+KongPlugin in the test namespace, CP+Auth in cp_namespace.
+    # A controlPlaneRef grant in cp_namespace is needed.
+    # =========================================================================
+
+    - name: 7-create-cp-namespace
+      description: Create separate namespace for the KonnectGatewayControlPlane and KonnectAPIAuthConfiguration.
+      bindings:
+        - name: namespace_name
+          value: ($cp_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-namespace.yaml
+
+    - name: 8-create-auth-config
+      description: Create KonnectAPIAuthConfiguration in the CP namespace for scenario B.
+      bindings:
+        - name: test_name
+          value: ($namespace)
+        - name: namespace
+          value: ($cp_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    - name: 9-create-control-plane
+      description: Create KonnectGatewayControlPlane in the CP namespace for scenario B.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectGatewayControlPlane.yaml
+
+    - name: 10-create-plugin-same-ns
+      description: Create KongPlugin in the test namespace (same namespace as the binding).
+      bindings:
+        - name: kong_plugin_name
+          value: ($plugin_name)
+        - name: kong_plugin_namespace
+          value: ($namespace)
+        - name: plugin_type
+          value: rate-limiting
+        - name: plugin_config
+          value: '{"minute": 5, "policy": "local"}'
+      use:
+        template: ../../common/_step_templates/apply-assert-kongPlugin.yaml
+
+    - name: 11-create-binding-no-grant
+      description: Create KongPluginBinding in test namespace referencing KonnectGatewayControlPlane in cp_namespace (no grant yet).
+      try:
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongPluginBinding
+              metadata:
+                name: ($pb_name)
+                namespace: ($namespace)
+              spec:
+                controlPlaneRef:
+                  type: konnectNamespacedRef
+                  konnectNamespacedRef:
+                    name: ($cp_name)
+                    namespace: ($cp_namespace)
+                pluginRef:
+                  name: ($plugin_name)
+                scope: GlobalInControlPlane
+
+    - name: 12-assert-binding-grant-missing
+      description: Assert KongPluginBinding has ResolvedRefs=False/RefNotPermitted because no grant exists.
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongPluginBinding
+              metadata:
+                name: ($pb_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    - name: 13-create-binding-to-cp-grant
+      description: Create KongReferenceGrant in cp_namespace allowing KongPluginBinding from test namespace to reference KonnectGatewayControlPlane.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'pb-to-cp']))
+        - name: kong_reference_grant_namespace
+          value: ($cp_namespace)
+        - name: from
+          value:
+            - group: configuration.konghq.com
+              kind: KongPluginBinding
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectGatewayControlPlane
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 14-assert-binding-programmed
+      description: Assert KongPluginBinding is Programmed after the controlPlaneRef grant is in place.
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongPluginBinding
+              metadata:
+                name: ($pb_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'True'
+                    reason: ResolvedRefs
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+
+    # =========================================================================
+    # Scenario C: delete the binding->CP grant and verify the KongPluginBinding
+    # reverts to ResolvedRefs=False/RefNotPermitted (validates grant watch).
+    # =========================================================================
+
+    - name: 15-delete-pb-to-cp-grant
+      description: Delete the binding->CP grant to verify the KongPluginBinding reverts to RefNotPermitted.
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'pb-to-cp']))
+              namespace: ($cp_namespace)
+
+    - name: 16-assert-binding-reverts-to-not-permitted
+      description: Assert KongPluginBinding transitions back to ResolvedRefs=False/RefNotPermitted after grant deletion.
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongPluginBinding
+              metadata:
+                name: ($pb_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    - name: 17-recreate-pb-to-cp-grant
+      description: Recreate the binding->CP grant so the binding can be deprovisioned cleanly during cleanup.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'pb-to-cp']))
+        - name: kong_reference_grant_namespace
+          value: ($cp_namespace)
+        - name: from
+          value:
+            - group: configuration.konghq.com
+              kind: KongPluginBinding
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectGatewayControlPlane
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 18-cleanup-scenario-b
+      description: Delete binding and CP in order; wait for each to be gone before proceeding.
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongPluginBinding
+              name: ($pb_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongPluginBinding
+              metadata:
+                name: ($pb_name)
+                namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'pb-to-cp']))
+              namespace: ($cp_namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              name: ($cp_name)
+              namespace: ($cp_namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp_name)
+                namespace: ($cp_namespace)
+
+    # =========================================================================
+    # Scenario D: both axes cross-namespace at once. KongPluginBinding (test ns)
+    # references a CP in cp_namespace AND a KongPlugin in plugin_namespace.
+    # Two grants are required; the controlPlaneRef grant is evaluated first.
+    # The KonnectAPIAuthConfiguration created for scenario B in cp_namespace is
+    # reused (only its CP was deleted during the scenario B cleanup).
+    # =========================================================================
+
+    - name: 19-create-plugin-namespace
+      description: Create separate namespace for the KongPlugin.
+      bindings:
+        - name: namespace_name
+          value: ($plugin_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-namespace.yaml
+
+    - name: 20-create-control-plane-d
+      description: Create KonnectGatewayControlPlane in cp_namespace for scenario D, reusing the existing auth config.
+      bindings:
+        - name: cp_name
+          value: ($cp3_name)
+        - name: cp_namespace
+          value: ($cp_namespace)
+        - name: auth_name
+          value: ($auth_name)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectGatewayControlPlane.yaml
+
+    - name: 21-create-plugin-cross-ns
+      description: Create KongPlugin in plugin_namespace.
+      bindings:
+        - name: kong_plugin_name
+          value: ($plugin3_name)
+        - name: kong_plugin_namespace
+          value: ($plugin_namespace)
+        - name: plugin_type
+          value: rate-limiting
+        - name: plugin_config
+          value: '{"minute": 5, "policy": "local"}'
+      use:
+        template: ../../common/_step_templates/apply-assert-kongPlugin.yaml
+
+    - name: 22-create-binding-no-grants
+      description: Create KongPluginBinding referencing the CP in cp_namespace and the KongPlugin in plugin_namespace (no grants yet).
+      try:
+        - apply:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongPluginBinding
+              metadata:
+                name: ($pb3_name)
+                namespace: ($namespace)
+              spec:
+                controlPlaneRef:
+                  type: konnectNamespacedRef
+                  konnectNamespacedRef:
+                    name: ($cp3_name)
+                    namespace: ($cp_namespace)
+                pluginRef:
+                  name: ($plugin3_name)
+                  namespace: ($plugin_namespace)
+                scope: GlobalInControlPlane
+
+    - name: 23-assert-cp-grant-missing
+      description: Assert KongPluginBinding has ResolvedRefs=False/RefNotPermitted (controlPlaneRef grant checked first).
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongPluginBinding
+              metadata:
+                name: ($pb3_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    - name: 24-create-binding-to-cp-grant
+      description: Create KongReferenceGrant in cp_namespace allowing KongPluginBinding from test namespace to reference KonnectGatewayControlPlane.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'pb3-to-cp']))
+        - name: kong_reference_grant_namespace
+          value: ($cp_namespace)
+        - name: from
+          value:
+            - group: configuration.konghq.com
+              kind: KongPluginBinding
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectGatewayControlPlane
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 25-assert-plugin-grant-missing
+      description: Assert KongPluginBinding now has ResolvedRefs=True but PluginRefValid=False/RefNotPermitted (plugin grant still missing).
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongPluginBinding
+              metadata:
+                name: ($pb3_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'True'
+                    reason: ResolvedRefs
+                (conditions[?type == 'PluginRefValid']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    - name: 26-create-binding-to-plugin-grant
+      description: Create KongReferenceGrant in plugin_namespace allowing KongPluginBinding from test namespace to reference KongPlugin.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'pb3-to-plugin']))
+        - name: kong_reference_grant_namespace
+          value: ($plugin_namespace)
+        - name: from
+          value:
+            - group: configuration.konghq.com
+              kind: KongPluginBinding
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: configuration.konghq.com
+              kind: KongPlugin
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 27-assert-binding-programmed
+      description: Assert KongPluginBinding is Programmed after both the controlPlaneRef and pluginRef grants are in place.
+      try:
+        - assert:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongPluginBinding
+              metadata:
+                name: ($pb3_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'True'
+                    reason: ResolvedRefs
+                (conditions[?type == 'PluginRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'ControlPlaneRefValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (konnect.controlPlaneID != null): true
+                (konnect.id != null): true
+
+    - name: 28-cleanup-scenario-d
+      description: Delete binding, grants and CP in order; wait for the binding and CP to be gone before proceeding.
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongPluginBinding
+              name: ($pb3_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongPluginBinding
+              metadata:
+                name: ($pb3_name)
+                namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'pb3-to-cp']))
+              namespace: ($cp_namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'pb3-to-plugin']))
+              namespace: ($plugin_namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              name: ($cp3_name)
+              namespace: ($cp_namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                name: ($cp3_name)
+                namespace: ($cp_namespace)
+
+  catch:
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: kongpluginbinding-controlplaneref-cross-namespace
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: ADDITIONAL_NAMESPACES
+            value: (join(',', [$cp_namespace, $plugin_namespace]))
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a chainsaw e2e test covering the cross-namespace controlPlaneRef
support for KongPluginBinding (introduced in https://github.com/Kong/kong-operator/commit/c074d63e77e52710f40091324706321c41922147, which removed the
CRD validation that previously forbade a namespace in controlPlaneRef).

The test exercises every combination of the cross-namespace axes:
- Scenario A: all resources in the same namespace (baseline, no grants).
- Scenario B: controlPlaneRef cross-namespace only; binding is gated on a
  KongPluginBinding -> KonnectGatewayControlPlane grant in the CP namespace
  (ResolvedRefs=False/RefNotPermitted until granted).
- Scenario C: deleting the grant reverts the binding to
  ResolvedRefs=False/RefNotPermitted, validating the grant watch.
- Scenario D: controlPlaneRef and pluginRef both cross-namespace, requiring
  two grants; asserts the controlPlaneRef grant is evaluated first.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

#4452 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
