### PR TITLE
test: enable GatewayWithAttachedRoutes conformance test for HybridGateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,10 @@
 
 ### Fixes
 
+- Hybridgateway: release Gateway API route finalizers once generated Kong
+  resource delete requests have been issued, so immediate same-name route
+  re-creates are not blocked by child resource finalizers.
+  [#4465](https://github.com/Kong/kong-operator/pull/4465)
 - Hybridgateway: fix `KongRoute` name collisions when an `HTTPRoute` attaches
   to multiple listener-scoped `ParentRef`s on the same `Gateway`, enabling the
   `HTTPRouteListenerHostnameMatching` Gateway API conformance test for Hybrid

--- a/controller/gateway/controller_watch.go
+++ b/controller/gateway/controller_watch.go
@@ -407,16 +407,27 @@ func listGatewaysAttachedByRoute[T gwtypes.SupportedRoute, TPtr gwtypes.Supporte
 	var recs []reconcile.Request
 	for _, gateway := range gateways.Items {
 		for _, parentRef := range gwtypes.GetSpecParentRefs(*route) {
-			if parentRef.Group != nil && string(*parentRef.Group) == gatewayv1.GroupName &&
-				parentRef.Kind != nil && string(*parentRef.Kind) == "Gateway" &&
-				string(parentRef.Name) == gateway.Name {
-				recs = append(recs, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Namespace: gateway.Namespace,
-						Name:      gateway.Name,
-					},
-				})
+			if parentRef.Group != nil && string(*parentRef.Group) != gatewayv1.GroupName {
+				continue
 			}
+			if parentRef.Kind != nil && string(*parentRef.Kind) != "Gateway" {
+				continue
+			}
+			parentRefNamespace := route.GetNamespace()
+			if parentRef.Namespace != nil {
+				parentRefNamespace = string(*parentRef.Namespace)
+			}
+			if parentRefNamespace != gateway.Namespace || string(parentRef.Name) != gateway.Name {
+				continue
+			}
+
+			recs = append(recs, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: gateway.Namespace,
+					Name:      gateway.Name,
+				},
+			})
+			break
 		}
 	}
 	return recs

--- a/controller/gateway/controller_watch.go
+++ b/controller/gateway/controller_watch.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"slices"
 
-	"github.com/go-logr/logr"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -395,40 +394,31 @@ func (r *Reconciler) listManagedGatewaysInNamespace(ctx context.Context, obj cli
 }
 
 // listGatewaysAttachedByRoute is the generic method to list gateways attached to the given route with supported type.
-func listGatewaysAttachedByRoute[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRoutePtr[T]](
-	ctx context.Context, logger logr.Logger, cl client.Client, route TPtr) []reconcile.Request {
-
-	gateways := &gatewayv1.GatewayList{}
-	if err := cl.List(ctx, gateways); err != nil {
-		// Log kind and namespace/name of the object.
-		logger.Error(err, "Failed to list gateways in watch", route.GetObjectKind().GroupVersionKind().Kind, client.ObjectKeyFromObject(route))
-		return nil
-	}
-	var recs []reconcile.Request
-	for _, gateway := range gateways.Items {
-		for _, parentRef := range gwtypes.GetSpecParentRefs(*route) {
-			if parentRef.Group != nil && string(*parentRef.Group) != gatewayv1.GroupName {
-				continue
-			}
-			if parentRef.Kind != nil && string(*parentRef.Kind) != "Gateway" {
-				continue
-			}
-			parentRefNamespace := route.GetNamespace()
-			if parentRef.Namespace != nil {
-				parentRefNamespace = string(*parentRef.Namespace)
-			}
-			if parentRefNamespace != gateway.Namespace || string(parentRef.Name) != gateway.Name {
-				continue
-			}
-
-			recs = append(recs, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: gateway.Namespace,
-					Name:      gateway.Name,
-				},
-			})
-			break
+func listGatewaysAttachedByRoute[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRoutePtr[T]](route TPtr) []reconcile.Request {
+	recs := make([]reconcile.Request, 0, len(gwtypes.GetSpecParentRefs(*route)))
+	seen := make(map[types.NamespacedName]struct{})
+	for _, parentRef := range gwtypes.GetSpecParentRefs(*route) {
+		if parentRef.Group != nil && string(*parentRef.Group) != gatewayv1.GroupName {
+			continue
 		}
+		if parentRef.Kind != nil && string(*parentRef.Kind) != "Gateway" {
+			continue
+		}
+
+		parentRefNamespace := route.GetNamespace()
+		if parentRef.Namespace != nil {
+			parentRefNamespace = string(*parentRef.Namespace)
+		}
+
+		nn := types.NamespacedName{
+			Namespace: parentRefNamespace,
+			Name:      string(parentRef.Name),
+		}
+		if _, ok := seen[nn]; ok {
+			continue
+		}
+		seen[nn] = struct{}{}
+		recs = append(recs, reconcile.Request{NamespacedName: nn})
 	}
 	return recs
 }
@@ -447,7 +437,7 @@ func (r *Reconciler) listGatewaysAttachedByHTTPRoute(ctx context.Context, obj cl
 		)
 		return nil
 	}
-	return listGatewaysAttachedByRoute(ctx, logger, r.Client, httpRoute)
+	return listGatewaysAttachedByRoute(httpRoute)
 }
 
 func (r *Reconciler) listGatewaysAttachedByTLSRoute(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -462,7 +452,7 @@ func (r *Reconciler) listGatewaysAttachedByTLSRoute(ctx context.Context, obj cli
 		)
 		return nil
 	}
-	return listGatewaysAttachedByRoute(ctx, logger, r.Client, tlsRoute)
+	return listGatewaysAttachedByRoute(tlsRoute)
 }
 
 // -----------------------------------------------------------------------------

--- a/controller/gateway/controller_watch_test.go
+++ b/controller/gateway/controller_watch_test.go
@@ -300,6 +300,96 @@ func TestReconciler_listGatewayReconcileRequestsForSecret(t *testing.T) {
 	}
 }
 
+func TestReconciler_listGatewaysAttachedByHTTPRoute(t *testing.T) {
+	makeGateway := func() *gwtypes.Gateway {
+		return &gwtypes.Gateway{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Gateway",
+				APIVersion: gatewayv1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-gateway",
+				Namespace: "default",
+				UID:       types.UID(uuid.NewString()),
+			},
+		}
+	}
+
+	makeRoute := func(parentRef gatewayv1.ParentReference) *gatewayv1.HTTPRoute {
+		return &gatewayv1.HTTPRoute{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "HTTPRoute",
+				APIVersion: gatewayv1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+			},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{parentRef},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name             string
+		parentRef        gatewayv1.ParentReference
+		expectedRequests []reconcile.Request
+	}{
+		{
+			name: "matches gateway when group is omitted",
+			parentRef: gatewayv1.ParentReference{
+				Name:      "test-gateway",
+				Namespace: new(gatewayv1.Namespace("default")),
+				Kind:      new(gatewayv1.Kind("Gateway")),
+			},
+			expectedRequests: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-gateway"}},
+			},
+		},
+		{
+			name: "matches gateway when namespace is omitted and defaults to route namespace",
+			parentRef: gatewayv1.ParentReference{
+				Name: "test-gateway",
+				Kind: new(gatewayv1.Kind("Gateway")),
+			},
+			expectedRequests: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-gateway"}},
+			},
+		},
+		{
+			name: "does not match non-gateway parent refs",
+			parentRef: gatewayv1.ParentReference{
+				Name:  "test-gateway",
+				Group: new(gatewayv1.Group(gatewayv1.GroupName)),
+				Kind:  new(gatewayv1.Kind("Service")),
+			},
+			expectedRequests: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gateway := makeGateway()
+			route := makeRoute(tc.parentRef)
+
+			fakeClient := fakectrlruntimeclient.NewClientBuilder().
+				WithScheme(scheme.Get()).
+				WithObjects(gateway, route).
+				Build()
+
+			reconciler := &Reconciler{
+				Client: fakeClient,
+			}
+
+			requests := reconciler.listGatewaysAttachedByHTTPRoute(t.Context(), route)
+			require.ElementsMatch(t, tc.expectedRequests, requests)
+		})
+	}
+}
+
 func TestReconciler_listGatewaysForKongReferenceGrant(t *testing.T) {
 	gatewayClassWithParamsRef := &gatewayv1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controller/gateway/controller_watch_test.go
+++ b/controller/gateway/controller_watch_test.go
@@ -336,10 +336,11 @@ func TestReconciler_listGatewaysAttachedByHTTPRoute(t *testing.T) {
 	testCases := []struct {
 		name             string
 		parentRef        gatewayv1.ParentReference
+		includeGateway   bool
 		expectedRequests []reconcile.Request
 	}{
 		{
-			name: "matches gateway when group is omitted",
+			name: "matches gateway when group is omitted even if gateway is not yet in cache",
 			parentRef: gatewayv1.ParentReference{
 				Name:      "test-gateway",
 				Namespace: new(gatewayv1.Namespace("default")),
@@ -355,6 +356,7 @@ func TestReconciler_listGatewaysAttachedByHTTPRoute(t *testing.T) {
 				Name: "test-gateway",
 				Kind: new(gatewayv1.Kind("Gateway")),
 			},
+			includeGateway: true,
 			expectedRequests: []reconcile.Request{
 				{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-gateway"}},
 			},
@@ -366,19 +368,22 @@ func TestReconciler_listGatewaysAttachedByHTTPRoute(t *testing.T) {
 				Group: new(gatewayv1.Group(gatewayv1.GroupName)),
 				Kind:  new(gatewayv1.Kind("Service")),
 			},
+			includeGateway:   true,
 			expectedRequests: nil,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gateway := makeGateway()
 			route := makeRoute(tc.parentRef)
 
-			fakeClient := fakectrlruntimeclient.NewClientBuilder().
+			clientBuilder := fakectrlruntimeclient.NewClientBuilder().
 				WithScheme(scheme.Get()).
-				WithObjects(gateway, route).
-				Build()
+				WithObjects(route)
+			if tc.includeGateway {
+				clientBuilder.WithObjects(makeGateway())
+			}
+			fakeClient := clientBuilder.Build()
 
 			reconciler := &Reconciler{
 				Client: fakeClient,

--- a/controller/hybridgateway/controller.go
+++ b/controller/hybridgateway/controller.go
@@ -378,7 +378,9 @@ func (r *HybridGatewayReconciler[t, tPtr]) cleanupGeneratedResources(
 	logger logr.Logger,
 	conv converter.APIConverter[t],
 ) (bool, error) {
-	// Use the existing cleanup logic but with an empty desired set,
-	// which will cause all owned resources to be considered orphans and deleted
-	return cleanOrphanedResources[t, tPtr](ctx, r.Client, logger, conv)
+	// Use the existing cleanup logic but do not wait for generated resources to
+	// fully disappear before releasing the root finalizer. Generated resources
+	// have their own cleanup/finalizer flows; keeping the Gateway API object in
+	// deletion until every child finishes can block immediate same-name re-creates.
+	return cleanOrphanedResourcesWithoutWaitingForDeletes[t, tPtr](ctx, r.Client, logger, conv)
 }

--- a/controller/hybridgateway/converter/http_route_test.go
+++ b/controller/hybridgateway/converter/http_route_test.go
@@ -267,6 +267,10 @@ func newGatewayWithListenerHostnames(hostnames ...string) *gwtypes.Gateway {
 			Name: listenerName,
 			Conditions: []metav1.Condition{
 				{
+					Type:   string(gatewayv1.ListenerConditionAccepted),
+					Status: metav1.ConditionTrue,
+				},
+				{
 					Type:   string(gwtypes.ListenerConditionProgrammed),
 					Status: metav1.ConditionTrue,
 				},
@@ -284,6 +288,10 @@ func newGatewayWithListenerHostnames(hostnames ...string) *gwtypes.Gateway {
 		gwListenerStatuses = append(gwListenerStatuses, gatewayv1.ListenerStatus{
 			Name: listenerName,
 			Conditions: []metav1.Condition{
+				{
+					Type:   string(gatewayv1.ListenerConditionAccepted),
+					Status: metav1.ConditionTrue,
+				},
 				{
 					Type:   string(gwtypes.ListenerConditionProgrammed),
 					Status: metav1.ConditionTrue,

--- a/controller/hybridgateway/reconciler_utils.go
+++ b/controller/hybridgateway/reconciler_utils.go
@@ -343,6 +343,25 @@ func cleanOrphanedResources[t converter.RootObject, tPtr converter.RootObjectPtr
 	logger logr.Logger,
 	conv converter.APIConverter[t],
 ) (bool, error) {
+	return cleanOrphanedResourcesWithOptions[t, tPtr](ctx, cl, logger, conv, true)
+}
+
+func cleanOrphanedResourcesWithoutWaitingForDeletes[t converter.RootObject, tPtr converter.RootObjectPtr[t]](
+	ctx context.Context,
+	cl client.Client,
+	logger logr.Logger,
+	conv converter.APIConverter[t],
+) (bool, error) {
+	return cleanOrphanedResourcesWithOptions[t, tPtr](ctx, cl, logger, conv, false)
+}
+
+func cleanOrphanedResourcesWithOptions[t converter.RootObject, tPtr converter.RootObjectPtr[t]](
+	ctx context.Context,
+	cl client.Client,
+	logger logr.Logger,
+	conv converter.APIConverter[t],
+	waitForDeletedResources bool,
+) (bool, error) {
 	logger = logger.WithValues("phase", "orphan-cleanup")
 	log.Debug(logger, "Starting orphaned resource cleanup")
 
@@ -377,9 +396,12 @@ func cleanOrphanedResources[t converter.RootObject, tPtr converter.RootObjectPtr
 	}
 	log.Debug(logger, "Finished building desired resource key set", "totalKeys", len(desiredSet))
 
-	// For each expected GVK, list resources and delete orphans.
-	// Process one GVK at a time to ensure proper deletion ordering and wait for resources
-	// to be fully deleted before moving to the next type.
+	// For each expected GVK, list resources and delete orphans. Normal reconciliation
+	// processes one GVK at a time and waits for resources to be fully deleted before
+	// moving to the next type. Root deletion cleanup only waits until delete requests
+	// have been issued; child resource controllers own their final cleanup and should
+	// not keep the root object finalizer around.
+	orphansDeleted := 0
 	for _, gvk := range expectedGVKs {
 		log.Debug(logger, "Processing GVK for orphan cleanup", "gvk", gvk.String())
 
@@ -393,8 +415,8 @@ func cleanOrphanedResources[t converter.RootObject, tPtr converter.RootObjectPtr
 
 		log.Debug(logger, "Found existing resources for GVK", "gvk", gvk.String(), "resourceCount", len(list.Items))
 
-		orphansForGVK := 0
-		orphansForGVKInDeletion := 0
+		orphansDeletedForGVK := 0
+		orphansInDeletionForGVK := 0
 
 		for _, item := range list.Items {
 			key := fmt.Sprintf("%s/%s/%s", item.GetNamespace(), item.GetName(), gvk.String())
@@ -416,10 +438,13 @@ func cleanOrphanedResources[t converter.RootObject, tPtr converter.RootObjectPtr
 			}
 
 			// Check if the resource is already being deleted (has deletionTimestamp set).
-			// If so, we need to wait for it to be fully deleted before proceeding to the next GVK.
 			if !item.GetDeletionTimestamp().IsZero() {
-				log.Debug(logger, "Resource is already being deleted, will requeue to wait for deletion", "kind", item.GetKind(), "obj", client.ObjectKeyFromObject(&item))
-				orphansForGVKInDeletion++
+				msg := "Resource is already being deleted"
+				if waitForDeletedResources {
+					msg = "Resource is already being deleted, will requeue to wait for deletion"
+				}
+				log.Debug(logger, msg, "kind", item.GetKind(), "obj", client.ObjectKeyFromObject(&item))
+				orphansInDeletionForGVK++
 				continue
 			}
 
@@ -427,18 +452,33 @@ func cleanOrphanedResources[t converter.RootObject, tPtr converter.RootObjectPtr
 			if err := cl.Delete(ctx, &item); err != nil && !apierrors.IsNotFound(err) {
 				return false, fmt.Errorf("failed to delete orphaned resource kind %s obj %s: %w", item.GetKind(), client.ObjectKeyFromObject(&item), err)
 			}
-			orphansForGVK++
+			orphansDeletedForGVK++
 		}
+		orphansDeleted += orphansDeletedForGVK
 
 		// If we deleted any orphan resource or found any that is currently being deleted, return true to trigger a requeue.
 		// This ensures we wait for the current GVK's resources to be fully deleted before moving to the next GVK, enforcing
 		// deletion order among resource types.
-		if orphansForGVK > 0 || orphansForGVKInDeletion > 0 {
-			log.Debug(logger, "Requeuing to wait for orphaned resources deletion for GVK", "gvk", gvk.String(), "orphansDeleted", orphansForGVK)
+		if waitForDeletedResources && (orphansDeletedForGVK > 0 || orphansInDeletionForGVK > 0) {
+			log.Debug(logger, "Requeuing to wait for orphaned resources deletion for GVK", "gvk", gvk.String(), "orphansDeleted", orphansDeletedForGVK)
 			return true, nil
-		} else {
-			log.Debug(logger, "No orphaned resources found for GVK", "gvk", gvk.String())
 		}
+		if orphansDeletedForGVK > 0 || orphansInDeletionForGVK > 0 {
+			log.Debug(
+				logger,
+				"Finished processing orphaned resources for GVK",
+				"gvk", gvk.String(),
+				"orphansDeleted", orphansDeletedForGVK,
+				"orphansInDeletion", orphansInDeletionForGVK,
+			)
+			continue
+		}
+		log.Debug(logger, "No orphaned resources found for GVK", "gvk", gvk.String())
+	}
+
+	if orphansDeleted > 0 {
+		log.Debug(logger, "Requeuing after deleting orphaned resources", "orphansDeleted", orphansDeleted)
+		return true, nil
 	}
 
 	// No orphans found

--- a/controller/hybridgateway/reconciler_utils_test.go
+++ b/controller/hybridgateway/reconciler_utils_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
@@ -659,6 +660,80 @@ func TestCleanOrphanedResources(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCleanOrphanedResourcesForRootDeletionDoesNotWaitForDeletingChildren(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+	gvks := []schema.GroupVersionKind{
+		{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongRoute"},
+		{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongService"},
+	}
+	root := &gwtypes.HTTPRoute{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gatewayv1.GroupVersion.String(),
+			Kind:       "HTTPRoute",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "httproute-owner",
+			Namespace: "ns",
+		},
+	}
+	ownerLabels := metadata.BuildLabels(root, nil)
+
+	deletingRoute := newUnstructured("ns", "deleting-route", gvks[0], ownerLabels)
+	deletingTimestamp := metav1.NewTime(time.Now())
+	deletingRoute.SetDeletionTimestamp(&deletingTimestamp)
+	deletingRoute.SetFinalizers([]string{"example.com/finalizer"})
+
+	service := newUnstructured("ns", "service", gvks[1], ownerLabels)
+	for _, obj := range []*unstructured.Unstructured{&deletingRoute, &service} {
+		annotations := obj.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation] = "ns/httproute-owner"
+		obj.SetAnnotations(annotations)
+	}
+
+	newClient := func() client.Client {
+		return fake.NewClientBuilder().
+			WithScheme(runtime.NewScheme()).
+			WithObjects(deletingRoute.DeepCopy(), service.DeepCopy()).
+			Build()
+	}
+	fakeConv := &fakeHTTPRouteConverter{
+		gvks: gvks,
+		root: *root,
+	}
+
+	t.Run("normal cleanup waits for deleting child before later GVKs", func(t *testing.T) {
+		cl := newClient()
+		requeue, err := cleanOrphanedResources[gwtypes.HTTPRoute, *gwtypes.HTTPRoute](ctx, cl, logger, fakeConv)
+		require.NoError(t, err)
+		require.True(t, requeue)
+
+		serviceList := &unstructured.UnstructuredList{}
+		serviceList.SetGroupVersionKind(gvks[1])
+		require.NoError(t, cl.List(ctx, serviceList))
+		require.Len(t, serviceList.Items, 1)
+	})
+
+	t.Run("root deletion cleanup deletes later GVKs before releasing root finalizer", func(t *testing.T) {
+		cl := newClient()
+		requeue, err := cleanOrphanedResourcesWithoutWaitingForDeletes[gwtypes.HTTPRoute, *gwtypes.HTTPRoute](ctx, cl, logger, fakeConv)
+		require.NoError(t, err)
+		require.True(t, requeue)
+
+		serviceList := &unstructured.UnstructuredList{}
+		serviceList.SetGroupVersionKind(gvks[1])
+		require.NoError(t, cl.List(ctx, serviceList))
+		require.Empty(t, serviceList.Items)
+
+		requeue, err = cleanOrphanedResourcesWithoutWaitingForDeletes[gwtypes.HTTPRoute, *gwtypes.HTTPRoute](ctx, cl, logger, fakeConv)
+		require.NoError(t, err)
+		require.False(t, requeue)
+	})
 }
 
 // Minimal fake converter for HTTPRoute

--- a/controller/hybridgateway/route/status.go
+++ b/controller/hybridgateway/route/status.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
@@ -736,31 +737,29 @@ func isProgrammed(obj *unstructured.Unstructured) bool {
 }
 
 // FilterMatchingListeners filters the provided listeners to find those that match the given ParentReference
-// based on section name, port, and protocol requirements. Only listeners that are both matching and ready
-// are returned.
+// based on section name, port, and listener acceptance status. Only listeners that are both matching and
+// accepted are returned.
 //
 // The function performs the following checks for each listener:
 // 1. Matches the section name specified in the ParentReference (if any)
 // 2. Matches the port specified in the ParentReference (if any)
-// 3. Supports the protocol with appropriate TLS mode
-// 4. Is in a "Programmed" (ready) state according to the Gateway status
+// 3. Is accepted according to the Gateway status
 //
 // Parameters:
 //   - gw: The Gateway object containing the listeners and their status
-//   - routeKind: The kind of the route
+//   - routeKind: The kind of the route. Currently unused, but kept to preserve the caller shape.
 //   - logger: Logger for debugging information
 //   - pRef: The ParentReference specifying matching criteria
 //   - listeners: The list of listeners from the Gateway spec to filter
 //
 // Returns:
-//   - []gwtypes.Listener: List of listeners that match criteria and are ready
+//   - []gwtypes.Listener: List of listeners that match criteria and are accepted
 //   - *metav1.Condition: Condition indicating why no listeners matched (nil if matches found)
 //
 // The returned condition will have status "False" with reason "NoMatchingParent" if no listeners
-// match the criteria. If listeners match but are not ready, the message will indicate this distinction.
+// match the criteria.
 func FilterMatchingListeners(logger logr.Logger, gw *gwtypes.Gateway, routeKind string, pRef gwtypes.ParentReference, listeners []gwtypes.Listener) ([]gwtypes.Listener, *metav1.Condition) {
 	var matchingListeners []gwtypes.Listener
-	var matchedNotReady bool
 	for _, listener := range listeners {
 		// Check if the listener name matches the section name of the parent reference.
 		if pRef.SectionName != nil && *pRef.SectionName != listener.Name {
@@ -774,18 +773,14 @@ func FilterMatchingListeners(logger logr.Logger, gw *gwtypes.Gateway, routeKind 
 
 		// At this point, the listener matches the parent reference.
 		log.Debug(logger, "Listener matches ParentReference criteria", "listener", listener.Name, "parentRef", pRef)
-		// Now check if the listener is ready.
+		// Now check if the listener is accepted.
 		for _, ls := range gw.Status.Listeners {
 			if ls.Name == listener.Name {
 				for _, cond := range ls.Conditions {
-					if cond.Type == string(gwtypes.ListenerConditionProgrammed) {
+					if cond.Type == string(gatewayv1.ListenerConditionAccepted) {
 						if cond.Status == metav1.ConditionTrue {
-							log.Debug(logger, "Listener is ready (programmed)", "listener", listener.Name)
+							log.Debug(logger, "Listener is accepted", "listener", listener.Name)
 							matchingListeners = append(matchingListeners, listener)
-						} else {
-							log.Debug(logger, "Listener matched but is not ready", "listener", listener.Name)
-							// Listener is not ready, and we track that at least one listener matched but is not ready.
-							matchedNotReady = true
 						}
 					}
 				}
@@ -795,21 +790,16 @@ func FilterMatchingListeners(logger logr.Logger, gw *gwtypes.Gateway, routeKind 
 
 	// If we found no matching listeners, determine the appropriate condition to return.
 	if len(matchingListeners) == 0 {
-		// If we had at least one listener that matched but was not ready, return a condition indicating that.
-		msg := string(gwtypes.RouteReasonNoMatchingParent)
-		if matchedNotReady {
-			msg = "A Gateway Listener matches this route but is not ready"
-		}
-		log.Debug(logger, "No matching listeners found for ParentReference", "parentRef", pRef, "matchedNotReady", matchedNotReady)
+		log.Debug(logger, "No matching listeners found for ParentReference", "parentRef", pRef)
 		return nil, &metav1.Condition{
 			Type:    string(gwtypes.RouteConditionAccepted),
 			Status:  metav1.ConditionFalse,
 			Reason:  string(gwtypes.RouteReasonNoMatchingParent),
-			Message: msg,
+			Message: string(gwtypes.RouteReasonNoMatchingParent),
 		}
 	}
-	// Return the list of matching and ready listeners that can be used for further processing.
-	log.Debug(logger, "Matching and ready listeners found", "parentRef", pRef, "count", len(matchingListeners))
+	// Return the list of matching and accepted listeners that can be used for further processing.
+	log.Debug(logger, "Matching and accepted listeners found", "parentRef", pRef, "count", len(matchingListeners))
 	return matchingListeners, nil
 }
 

--- a/controller/hybridgateway/route/status_test.go
+++ b/controller/hybridgateway/route/status_test.go
@@ -551,7 +551,7 @@ func Test_BuildAcceptedCondition(t *testing.T) {
 		},
 		Status: gatewayv1.GatewayStatus{
 			Listeners: []gatewayv1.ListenerStatus{
-				{Name: "listener1", Conditions: []metav1.Condition{{Type: string(gwtypes.ListenerConditionProgrammed), Status: metav1.ConditionTrue}}},
+				{Name: "listener1", Conditions: []metav1.Condition{{Type: string(gatewayv1.ListenerConditionAccepted), Status: metav1.ConditionTrue}}},
 			},
 		},
 	}
@@ -630,7 +630,7 @@ func Test_BuildAcceptedCondition(t *testing.T) {
 				},
 				Status: gatewayv1.GatewayStatus{
 					Listeners: []gatewayv1.ListenerStatus{
-						{Name: "listener1", Conditions: []metav1.Condition{{Type: string(gatewayv1.ListenerConditionProgrammed), Status: metav1.ConditionTrue}}},
+						{Name: "listener1", Conditions: []metav1.Condition{{Type: string(gatewayv1.ListenerConditionAccepted), Status: metav1.ConditionTrue}}},
 					},
 				},
 			},
@@ -657,12 +657,57 @@ func Test_BuildAcceptedCondition(t *testing.T) {
 				},
 				Status: gatewayv1.GatewayStatus{
 					Listeners: []gatewayv1.ListenerStatus{
-						{Name: "listener1", Conditions: []metav1.Condition{{Type: string(gatewayv1.ListenerConditionProgrammed), Status: metav1.ConditionTrue}}},
+						{Name: "listener1", Conditions: []metav1.Condition{{Type: string(gatewayv1.ListenerConditionAccepted), Status: metav1.ConditionTrue}}},
 					},
 				},
 			},
 			route:      route,
 			pRef:       pRef,
+			client:     cl,
+			wantType:   string(gwtypes.RouteConditionAccepted),
+			wantStatus: metav1.ConditionTrue,
+			wantReason: string(gwtypes.RouteReasonAccepted),
+		},
+		{
+			name: "accepted route through unresolved but accepted listener",
+			gateway: &gwtypes.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "gw"},
+				Spec: gwtypes.GatewaySpec{
+					Listeners: []gatewayv1.Listener{
+						{
+							Name:          "tls",
+							Port:          443,
+							Protocol:      gatewayv1.HTTPSProtocolType,
+							AllowedRoutes: &gatewayv1.AllowedRoutes{Namespaces: &gatewayv1.RouteNamespaces{From: new(gatewayv1.NamespacesFromAll)}},
+							TLS: &gatewayv1.ListenerTLSConfig{
+								Mode: func() *gatewayv1.TLSModeType {
+									mode := gatewayv1.TLSModeTerminate
+									return &mode
+								}(),
+							},
+						},
+					},
+					GatewayClassName: "my-class",
+				},
+				Status: gatewayv1.GatewayStatus{
+					Listeners: []gatewayv1.ListenerStatus{
+						{
+							Name: "tls",
+							Conditions: []metav1.Condition{
+								{Type: string(gatewayv1.ListenerConditionAccepted), Status: metav1.ConditionTrue},
+								{Type: string(gatewayv1.ListenerConditionProgrammed), Status: metav1.ConditionFalse},
+								{Type: string(gatewayv1.ListenerConditionResolvedRefs), Status: metav1.ConditionFalse},
+							},
+						},
+					},
+				},
+			},
+			route: &gwtypes.HTTPRoute{
+				TypeMeta:   httpRouteTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
+				Spec:       gwtypes.HTTPRouteSpec{},
+			},
+			pRef:       gwtypes.ParentReference{Kind: kindPtr("Gateway"), Group: groupPtr(gwtypes.GroupName), Name: "gw", SectionName: sectionPtr("tls")},
 			client:     cl,
 			wantType:   string(gwtypes.RouteConditionAccepted),
 			wantStatus: metav1.ConditionTrue,
@@ -680,7 +725,7 @@ func Test_BuildAcceptedCondition(t *testing.T) {
 				},
 				Status: gatewayv1.GatewayStatus{
 					Listeners: []gatewayv1.ListenerStatus{
-						{Name: "listener1", Conditions: []metav1.Condition{{Type: string(gatewayv1.ListenerConditionProgrammed), Status: metav1.ConditionTrue}}},
+						{Name: "listener1", Conditions: []metav1.Condition{{Type: string(gatewayv1.ListenerConditionAccepted), Status: metav1.ConditionTrue}}},
 					},
 				},
 			},
@@ -706,7 +751,7 @@ func Test_BuildAcceptedCondition(t *testing.T) {
 				},
 				Status: gatewayv1.GatewayStatus{
 					Listeners: []gatewayv1.ListenerStatus{
-						{Name: "listener1", Conditions: []metav1.Condition{{Type: string(gatewayv1.ListenerConditionProgrammed), Status: metav1.ConditionTrue}}},
+						{Name: "listener1", Conditions: []metav1.Condition{{Type: string(gatewayv1.ListenerConditionAccepted), Status: metav1.ConditionTrue}}},
 					},
 				},
 			},
@@ -748,7 +793,7 @@ func Test_BuildAcceptedCondition(t *testing.T) {
 				},
 				Status: gatewayv1.GatewayStatus{
 					Listeners: []gatewayv1.ListenerStatus{
-						{Name: "listener1", Conditions: []metav1.Condition{{Type: string(gatewayv1.ListenerConditionProgrammed), Status: metav1.ConditionTrue}}},
+						{Name: "listener1", Conditions: []metav1.Condition{{Type: string(gatewayv1.ListenerConditionAccepted), Status: metav1.ConditionTrue}}},
 					},
 				},
 			},
@@ -1177,17 +1222,25 @@ func Test_FilterMatchingListeners(t *testing.T) {
 	gw := &gwtypes.Gateway{
 		Status: gatewayv1.GatewayStatus{
 			Listeners: []gatewayv1.ListenerStatus{
-				{Name: "listener1", Conditions: []metav1.Condition{{Type: string(gwtypes.ListenerConditionProgrammed), Status: metav1.ConditionTrue}}},
-				{Name: "listener2", Conditions: []metav1.Condition{{Type: string(gwtypes.ListenerConditionProgrammed), Status: metav1.ConditionFalse}}},
+				{Name: "listener1", Conditions: []metav1.Condition{{Type: string(gatewayv1.ListenerConditionAccepted), Status: metav1.ConditionTrue}}},
+				{Name: "listener2", Conditions: []metav1.Condition{{Type: string(gatewayv1.ListenerConditionAccepted), Status: metav1.ConditionFalse}}},
+				{
+					Name: "tls",
+					Conditions: []metav1.Condition{
+						{Type: string(gatewayv1.ListenerConditionAccepted), Status: metav1.ConditionTrue},
+						{Type: string(gatewayv1.ListenerConditionProgrammed), Status: metav1.ConditionFalse},
+					},
+				},
 			},
 		},
 	}
-	listenerReady := gwtypes.Listener{Name: "listener1", Port: 80, Protocol: gwtypes.HTTPProtocolType}
-	listenerNotReady := gwtypes.Listener{Name: "listener2", Port: 80, Protocol: gwtypes.HTTPProtocolType}
+	listenerAccepted := gwtypes.Listener{Name: "listener1", Port: 80, Protocol: gwtypes.HTTPProtocolType}
+	listenerRejected := gwtypes.Listener{Name: "listener2", Port: 80, Protocol: gwtypes.HTTPProtocolType}
 	tlsModePassthrough := gatewayv1.TLSModePassthrough
 	tlsModeTerminate := gatewayv1.TLSModeTerminate
-	listenerNotReadyTLS := gwtypes.Listener{Name: "listener2", Port: 80, Protocol: gwtypes.TLSProtocolType, TLS: &gatewayv1.ListenerTLSConfig{Mode: &tlsModeTerminate}}
-	listenerProtocolTLS := gwtypes.Listener{Name: "listener1", Port: 80, Protocol: gwtypes.TLSProtocolType, TLS: &gatewayv1.ListenerTLSConfig{Mode: &tlsModePassthrough}}
+	listenerRejectedTLS := gwtypes.Listener{Name: "listener2", Port: 80, Protocol: gwtypes.TLSProtocolType, TLS: &gatewayv1.ListenerTLSConfig{Mode: &tlsModeTerminate}}
+	listenerAcceptedTLS := gwtypes.Listener{Name: "listener1", Port: 80, Protocol: gwtypes.TLSProtocolType, TLS: &gatewayv1.ListenerTLSConfig{Mode: &tlsModePassthrough}}
+	listenerUnresolvedTLS := gwtypes.Listener{Name: "tls", Port: 443, Protocol: gwtypes.HTTPSProtocolType, TLS: &gatewayv1.ListenerTLSConfig{Mode: &tlsModeTerminate}}
 
 	tests := []struct {
 		name      string
@@ -1211,7 +1264,7 @@ func Test_FilterMatchingListeners(t *testing.T) {
 			name:      "section name mismatch",
 			pRef:      gwtypes.ParentReference{Name: "listener1", SectionName: sectionPtr("notfound")},
 			routeKind: "HTTPRoute",
-			listeners: []gwtypes.Listener{listenerReady},
+			listeners: []gwtypes.Listener{listenerAccepted},
 			wantLen:   0,
 			wantCond:  true,
 			condMsg:   string(gwtypes.RouteReasonNoMatchingParent),
@@ -1220,50 +1273,58 @@ func Test_FilterMatchingListeners(t *testing.T) {
 			name:      "port mismatch",
 			pRef:      gwtypes.ParentReference{Name: "listener1", Port: new(int32(81))},
 			routeKind: "HTTPRoute",
-			listeners: []gwtypes.Listener{listenerReady},
+			listeners: []gwtypes.Listener{listenerAccepted},
 			wantLen:   0,
 			wantCond:  true,
 			condMsg:   string(gwtypes.RouteReasonNoMatchingParent),
 		},
 		{
-			name:      "listener matches but not ready",
+			name:      "listener matches but is not accepted",
 			pRef:      gwtypes.ParentReference{Name: "listener2"},
 			routeKind: "HTTPRoute",
-			listeners: []gwtypes.Listener{listenerNotReady},
+			listeners: []gwtypes.Listener{listenerRejected},
 			wantLen:   0,
 			wantCond:  true,
-			condMsg:   "A Gateway Listener matches this route but is not ready",
+			condMsg:   string(gwtypes.RouteReasonNoMatchingParent),
 		},
 		{
-			name:      "listener matches and is ready",
+			name:      "listener matches and is accepted",
 			pRef:      pRef,
 			routeKind: "HTTPRoute",
-			listeners: []gwtypes.Listener{listenerReady},
+			listeners: []gwtypes.Listener{listenerAccepted},
 			wantLen:   1,
 			wantCond:  false,
 		},
 		{
-			name:      "multiple listeners, mixed readiness",
+			name:      "multiple listeners, mixed acceptance",
 			pRef:      gwtypes.ParentReference{Name: "listener1"},
 			routeKind: "HTTPRoute",
-			listeners: []gwtypes.Listener{listenerReady, listenerNotReady},
+			listeners: []gwtypes.Listener{listenerAccepted, listenerRejected},
 			wantLen:   1,
 			wantCond:  false,
 		},
 		{
-			name:      "TLSRoute - no ready listeners",
+			name:      "TLSRoute - no accepted listeners",
 			pRef:      pRef,
 			routeKind: "TLSRoute",
-			listeners: []gwtypes.Listener{listenerNotReadyTLS},
+			listeners: []gwtypes.Listener{listenerRejectedTLS},
 			wantLen:   0,
 			wantCond:  true,
-			condMsg:   "A Gateway Listener matches this route but is not ready",
+			condMsg:   string(gwtypes.RouteReasonNoMatchingParent),
 		},
 		{
-			name:      "TLSRoute - ready and match listener",
+			name:      "TLSRoute - accepted and matching listener",
 			pRef:      pRef,
 			routeKind: "TLSRoute",
-			listeners: []gwtypes.Listener{listenerProtocolTLS},
+			listeners: []gwtypes.Listener{listenerAcceptedTLS},
+			wantLen:   1,
+			wantCond:  false,
+		},
+		{
+			name:      "HTTPS listener can match while unresolved and not programmed",
+			pRef:      gwtypes.ParentReference{Name: "tls", SectionName: sectionPtr("tls")},
+			routeKind: "HTTPRoute",
+			listeners: []gwtypes.Listener{listenerUnresolvedTLS},
 			wantLen:   1,
 			wantCond:  false,
 		},

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -35,7 +35,6 @@ var skippedTestsForHybrid = []string{
 	tests.HTTPRouteInvalidNonExistentBackendRef.ShortName,
 	tests.HTTPRouteMethodMatching.ShortName,
 	tests.HTTPRouteQueryParamMatching.ShortName,
-	tests.GatewayWithAttachedRoutes.ShortName,
 
 	// Extended profile.
 	tests.HTTPRouteRewriteHost.ShortName,


### PR DESCRIPTION


**What this PR does / why we need it**:

- Treat hybrid route parent matching as dependent on listener `Accepted=True` status rather than `Programmed=True` status so unresolved-but-accepted listeners still count for attached route semantics.
- Reconcile Gateways from HTTPRoute/TLSRoute parentRefs directly, including default group/kind/namespace handling, to avoid cache visibility races and missed updates.

**Which issue this PR fixes**

Fixes https://github.com/Kong/kong-operator/issues/3480

**Special notes for your reviewer**:

This PR allows deleting hybrid Gateway API routes to release their root finalizer once generated Kong child resource delete requests have been issued, instead of waiting for child resource finalizers to fully complete.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
