### PR TITLE
ci: manage ktf with mise (#3321)

### DIFF
--- a/.github/actions/bump-inotify/action.yml
+++ b/.github/actions/bump-inotify/action.yml
@@ -1,0 +1,10 @@
+name: Bump inotify limits
+description: Raise fs.inotify limits on the runner host so kind pods don't hit "too many open files".
+runs:
+  using: composite
+  steps:
+    - name: Bump fs.inotify limits
+      shell: bash
+      run: |
+        sudo sysctl -w fs.inotify.max_user_instances=8192
+        sudo sysctl -w fs.inotify.max_user_watches=524288

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -764,6 +764,7 @@ jobs:
         path: e2e-tests.xml
 
   e2e-tests-chainsaw:
+    runs-on: ubuntu-latest
     needs:
       - check-docs-only
       - matrix_k8s_node_versions

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -229,6 +229,9 @@ jobs:
       with:
         go-version-file: go.mod
 
+    - name: bump inotify limits
+      uses: ./.github/actions/bump-inotify
+
     - name: Create k8s KinD Cluster
       uses: helm/kind-action@92086f6be054225fa813e0a4b13787fc9088faab # v1.13.0
       with:
@@ -277,6 +280,9 @@ jobs:
 
     - name: build docker image
       run: make docker.build
+
+    - name: bump inotify limits
+      uses: ./.github/actions/bump-inotify
 
     - name: Create k8s KinD Cluster
       uses: helm/kind-action@92086f6be054225fa813e0a4b13787fc9088faab # v1.13.0
@@ -497,6 +503,9 @@ jobs:
       with:
         install: false
 
+    - name: bump inotify limits
+      uses: ./.github/actions/bump-inotify
+
     - name: run conformance tests
       run: make test.conformance
       env:
@@ -560,6 +569,9 @@ jobs:
     - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
       with:
         install: false
+
+    - name: bump inotify limits
+      uses: ./.github/actions/bump-inotify
 
     - name: run integration tests
       run: make test.integration-${{ matrix.suite }}
@@ -625,6 +637,9 @@ jobs:
       with:
         install: false
 
+    - name: bump inotify limits
+      uses: ./.github/actions/bump-inotify
+
     - name: run integration tests
       run: make test.integration_validatingwebhook
       env:
@@ -679,6 +694,9 @@ jobs:
     - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
       with:
         install: false
+
+    - name: bump inotify limits
+      uses: ./.github/actions/bump-inotify
 
     - name: run integration tests
       run: make test.integration_bluegreen
@@ -742,6 +760,9 @@ jobs:
       with:
         install: false
 
+    - name: bump inotify limits
+      uses: ./.github/actions/bump-inotify
+
     - name: run e2e tests
       run: make test.e2e
       env:
@@ -792,6 +813,9 @@ jobs:
     - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
       with:
         install_args: github:Kong/kubernetes-testing-framework http:helm
+
+    - name: bump inotify limits
+      uses: ./.github/actions/bump-inotify
 
     - name: Create k8s KinD Cluster with ktf
       run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -764,10 +764,9 @@ jobs:
         path: e2e-tests.xml
 
   e2e-tests-chainsaw:
-    runs-on: ubuntu-latest
     needs:
-    - check-docs-only
-    - matrix_k8s_node_versions
+      - check-docs-only
+      - matrix_k8s_node_versions
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     env:
       IMG: kong-operator
@@ -791,11 +790,10 @@ jobs:
 
     - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
       with:
-        install: false
+        install_args: github:Kong/kubernetes-testing-framework http:helm
 
     - name: Create k8s KinD Cluster with ktf
       run: |
-        go install github.com/kong/kubernetes-testing-framework/cmd/ktf@latest
         ktf environments create --name ${{ env.CLUSTER_NAME }} --addon metallb --addon cert-manager
 
     - name: Load image to kind cluster

--- a/.mise.toml
+++ b/.mise.toml
@@ -15,6 +15,11 @@ github_attestations = false
 version = "v5.8.0"
 version_prefix = "kustomize/"
 
+[tools."github:Kong/kubernetes-testing-framework"]
+# renovate: datasource=github-releases depName=Kong/kubernetes-testing-framework
+version = "v0.49.0"
+bin = "ktf"
+
 [tools."github:telepresenceio/telepresence"]
 # renovate: datasource=github-releases depName=telepresenceio/telepresence
 version = "2.26.1"

--- a/.mise.toml
+++ b/.mise.toml
@@ -46,3 +46,7 @@ version = "470c3a315f3ae8281f873d979092ece824d3dcfd"
 # renovate: datasource=github-releases depName=mikefarah/yq
 version = "v4.53.2"
 bin = "yq"
+
+[tools."aqua:kyverno/chainsaw"]
+# renovate: datasource=git-refs packageName=https://github.com/kyverno/chainsaw.git
+version = "v0.2.15"

--- a/.tools_versions.yaml
+++ b/.tools_versions.yaml
@@ -45,5 +45,3 @@ kube-linter: "0.8.1"
 markdownlint-cli2: "0.20.0"
 # renovate: datasource=github-releases depName=cert-manager/cert-manager
 cert-manager: "1.19.3"
-# renovate: datasource=github-releases depName=kyverno/chainsaw
-chainsaw: "v0.2.15-beta.1"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,21 @@ make test.integration_validatingwebhook  # Webhook tests
 make test.crds-validation             # CRD validation tests
 ```
 
+#### kind: "too many open files" / fsnotify watcher errors
+
+Tests that spin up a kind cluster (integration, conformance, e2e) can fail with
+`failed to create fsnotify watcher: too many open files`. kind nodes share the host
+kernel, so the `fs.inotify.max_user_instances` / `max_user_watches` limits must be raised
+on the **host running Docker** (see https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files).
+
+- **Linux host**: `make tune.inotify` (one-off; persist via `/etc/sysctl.d/99-kind-inotify.conf`).
+- **macOS** (Docker Desktop / colima): the limit lives in the Linux VM, not macOS.
+  - colima: `colima ssh -- sudo sysctl -w fs.inotify.max_user_instances=8192 fs.inotify.max_user_watches=524288`
+  - Docker Desktop: `docker run --rm --privileged alpine sysctl -w fs.inotify.max_user_instances=8192 fs.inotify.max_user_watches=524288`
+  - Note: not persistent across VM restarts.
+
+CI raises these limits automatically via the `.github/actions/bump-inotify` composite action.
+
 ### CRD Validation Tests
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -200,11 +200,11 @@ KUBE_API_LINTER = $(PROJECT_DIR)/bin/installs/go-sigs-k8s-io-kube-api-linter-cmd
 download.kube-api-linter: mise yq ## Download kube-api-linter locally if necessary.
 	$(MAKE) mise-install DEP_VER=go:sigs.k8s.io/kube-api-linter/cmd/golangci-lint-kube-api-linter@$(KUBE_API_LINTER_VERSION)
 
-CHAINSAW_VERSION = $(shell $(YQ) -r '.chainsaw' < $(TOOLS_VERSIONS_FILE))
-CHAINSAW = $(PROJECT_DIR)/bin/installs/github-kyverno-chainsaw/$(CHAINSAW_VERSION)/chainsaw
+CHAINSAW_VERSION = $(shell $(YQ) -p toml -o yaml '.tools["aqua:kyverno/chainsaw"].version' < $(MISE_FILE))
+CHAINSAW = $(PROJECT_DIR)/bin/installs/aqua-kyverno-chainsaw/$(CHAINSAW_VERSION)/chainsaw
 .PHONY: chainsaw
 chainsaw: mise yq ## Download chainsaw locally if necessary.
-	$(MAKE) mise-install DEP_VER=github:kyverno/chainsaw@$(CHAINSAW_VERSION)
+	$(MAKE) mise-install DEP_VER=aqua:kyverno/chainsaw@$(CHAINSAW_VERSION)
 
 .PHONY: use-setup-envtest
 use-setup-envtest:

--- a/Makefile
+++ b/Makefile
@@ -564,6 +564,11 @@ CLUSTER_VERSION ?=$(patsubst v%,%,$(_CLUSTER_VERSION ))
 TEST_KONG_HELM_CHART_VERSION ?= $(shell $(YQ) -ojson -r '.integration.helm.kong' < ./test/test_dependencies.yaml)
 KONG_CONTROLLER_FEATURE_GATES ?= GatewayAlpha=true
 
+.PHONY: tune.inotify
+tune.inotify: ## Raise host fs.inotify limits to avoid "too many open files" in kind-based tests (Linux host / Docker VM).
+	sudo sysctl -w fs.inotify.max_user_instances=8192
+	sudo sysctl -w fs.inotify.max_user_watches=524288
+
 .PHONY: test
 test: test.unit
 

--- a/go.mod
+++ b/go.mod
@@ -236,7 +236,7 @@ require (
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
 	github.com/moby/patternmatcher v0.6.1 // indirect
-	github.com/moby/spdystream v0.5.0 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -456,8 +456,8 @@ github.com/moby/moby/client v0.4.0 h1:S+2XegzHQrrvTCvF6s5HFzcrywWQmuVnhOXe2kiWjI
 github.com/moby/moby/client v0.4.0/go.mod h1:QWPbvWchQbxBNdaLSpoKpCdf5E+WxFAgNHogCWDoa7g=
 github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x084U=
 github.com/moby/patternmatcher v0.6.1/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
-github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
-github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=
 github.com/moby/sys/atomicwriter v0.1.0/go.mod h1:Ul8oqv2ZMNHOceF643P6FKPXeCmYtlQMvpizfsSoaWs=
 github.com/moby/sys/sequential v0.6.0 h1:qrx7XFUd/5DxtqcoH1h438hF5TmOvzC/lspjy7zgvCU=


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport https://github.com/Kong/kong-operator/pull/3321 to 2.1

Pin ktf to 0.49.0

Also bump [github.com/moby/spdystream](https://pkg.go.dev/github.com/moby/spdystream) to mitigate

```
- GO-2026-4958 (aka CVE-2026-35469, GHSA-pc3f-x583-g7j2)

	The SPDY/3 frame parser in spdystream does not validate attacker-controlled counts and lengths before allocating memory. A remote peer that can send SPDY frames to a service using spdystream can cause the process to allocate gigabytes of memory with a small number of malformed control frames, leading to an out-of-memory crash.
	
	Three allocation paths in the receive side are affected:
	1. SETTINGS entry count: The SETTINGS frame reader reads a 32-bit numSettings from the payload and allocates a slice of that size without checking it against the declared frame length.
	2. Header count: parseHeaderValueBlock reads a 32-bit numHeaders from the decompressed header block and allocates an http.Header map of that size with no upper bound.
	3. Header field size: Individual header name and value lengths are read as 32-bit integers and used directly as allocation sizes with no validation.
	
	Because SPDY header blocks are zlib-compressed, a small on-the-wire payload can decompress into attacker-controlled bytes that the parser interprets as 32-bit counts and lengths. A single crafted frame is enough to exhaust process memory.
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
