### PR TITLE
ci: sample tests do not require cert manager

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -218,16 +218,16 @@ jobs:
       with:
         install: false
 
-    # We use install.all to install all CRDs and resources also the ones that are not bundled
+    # We use install.crds to install all CRDs and resources also the ones that are not bundled
     # in base kustomization (e.g. currently AIGateway) but which have samples defined.
     - name: Verify installing CRDs via kustomize works
-      run: make install.all
+      run: make install.gateway-api-crds install.crds
 
     - name: Install and delete each sample one by one
       run: make test.samples
 
     - name: Verify that uninstalling operator CRDs via kustomize works
-      run: make ignore-not-found=true uninstall.all
+      run: make ignore-not-found=true uninstall.gateway-api-crds uninstall.crds
 
   install-with-kustomize:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What this PR does / why we need it**:

`make install.all` installs cert manager but sample tests do not require it so this PR removes the step which installs it.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
