### PR TITLE
ci: bump inotify limits in CI

### DIFF
--- a/.github/actions/bump-inotify/action.yml
+++ b/.github/actions/bump-inotify/action.yml
@@ -1,0 +1,8 @@
+name: Bump inotify limits
+description: Raise fs.inotify limits on the runner host so kind pods don't hit "too many open files".
+runs:
+  using: composite
+  steps:
+    - name: Bump fs.inotify limits
+      shell: bash
+      run: make tune.inotify

--- a/.github/workflows/__conformance_tests.yaml
+++ b/.github/workflows/__conformance_tests.yaml
@@ -78,6 +78,8 @@ jobs:
           ${{ env.GO_CACHE_KEY }}
           ${{ env.GO_CACHE_KEY_2 }}
 
+    - uses: ./.github/actions/bump-inotify
+
     - name: run conformance tests
       run: make test.conformance
       env:

--- a/.github/workflows/__e2e_chainsaw_tests.yaml
+++ b/.github/workflows/__e2e_chainsaw_tests.yaml
@@ -44,6 +44,8 @@ jobs:
       with:
         install_args: github:Kong/kubernetes-testing-framework aqua:helm/helm
 
+    - uses: ./.github/actions/bump-inotify
+
     - name: Create k8s KinD Cluster with ktf
       env:
         # NOTE: add GITHUB_TOKEN to env to allow ktf to query GitHub API without

--- a/.github/workflows/__e2e_tests.yaml
+++ b/.github/workflows/__e2e_tests.yaml
@@ -71,6 +71,8 @@ jobs:
           ${{ env.GO_CACHE_KEY }}
           ${{ env.GO_CACHE_KEY_2 }}
 
+    - uses: ./.github/actions/bump-inotify
+
     - name: run e2e tests
       run: make test.e2e
       env:

--- a/.github/workflows/__integration_tests.yaml
+++ b/.github/workflows/__integration_tests.yaml
@@ -104,6 +104,8 @@ jobs:
         sudo tcpdump -i any 'dst port 443' -w /tmp/capture-${{ matrix.suite }}-${{ matrix.router_flavor }}.pcap &
         echo $! > /tmp/tcpdump.pid
 
+    - uses: ./.github/actions/bump-inotify
+
     - name: run integration tests
       run: make test.integration-${{ matrix.suite }}
       env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -206,6 +206,8 @@ jobs:
       with:
         go-version-file: go.mod
 
+    - uses: ./.github/actions/bump-inotify
+
     - name: Create k8s KinD Cluster
       uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
       with:
@@ -254,6 +256,8 @@ jobs:
 
     - name: build docker image
       run: make docker.build
+
+    - uses: ./.github/actions/bump-inotify
 
     - name: Create k8s KinD Cluster
       uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,21 @@ make test.integration-bluegreen          # DataPlane upgrade/blue-green tests
 make test.integration-validatingwebhook  # Webhook tests
 ```
 
+#### kind: "too many open files" / fsnotify watcher errors
+
+Tests that spin up a kind cluster (integration, conformance, e2e) can fail with
+`failed to create fsnotify watcher: too many open files`. kind nodes share the host
+kernel, so the `fs.inotify.max_user_instances` / `max_user_watches` limits must be raised
+on the **host running Docker** (see https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files).
+
+- **Linux host**: `make tune.inotify` (one-off; persist via `/etc/sysctl.d/99-kind-inotify.conf`).
+- **macOS** (Docker Desktop / colima): the limit lives in the Linux VM, not macOS.
+  - colima: `colima ssh -- sudo sysctl -w fs.inotify.max_user_instances=8192 fs.inotify.max_user_watches=524288`
+  - Docker Desktop: `docker run --rm --privileged alpine sysctl -w fs.inotify.max_user_instances=8192 fs.inotify.max_user_watches=524288`
+  - Note: not persistent across VM restarts.
+
+CI raises these limits automatically via the `.github/actions/bump-inotify` composite action.
+
 ### CRD Validation Tests
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -561,6 +561,11 @@ CLUSTER_VERSION ?=$(patsubst v%,%,$(_CLUSTER_VERSION ))
 TEST_KONG_HELM_CHART_VERSION ?= $(shell $(YQ) -ojson -r '.integration.helm.kong' < ./test/test_dependencies.yaml)
 KONG_CONTROLLER_FEATURE_GATES ?= GatewayAlpha=true
 
+.PHONY: tune.inotify
+tune.inotify: ## Raise host fs.inotify limits to avoid "too many open files" in kind-based tests (Linux host / Docker VM).
+	sudo sysctl -w fs.inotify.max_user_instances=8192
+	sudo sysctl -w fs.inotify.max_user_watches=524288
+
 .PHONY: test
 test: test.unit
 


### PR DESCRIPTION
**What this PR does / why we need it**:

To prevent errors like:

```
to create fsnotify watcher: too many open files
```

when creating kind clusters, bump inotify limits in CI.

Related: https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
