### PR TITLE
fix(gateway): patch controlplane when extensions differ

### DIFF
--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -759,7 +759,7 @@ func (r *Reconciler) provisionControlPlane(
 	}
 
 	if !controlPlaneSpecDeepEqual(&controlPlane.Spec.ControlPlaneOptions, &expectedControlPlaneOptions) ||
-		reflect.DeepEqual(controlPlane.Spec.Extensions, expectedExtensions) {
+		!reflect.DeepEqual(controlPlane.Spec.Extensions, expectedExtensions) {
 		log.Trace(logger, "controlplane config is out of date")
 		controlplaneOld := controlPlane.DeepCopy()
 		controlPlane.Spec.ControlPlaneOptions = expectedControlPlaneOptions

--- a/controller/gateway/controller_test.go
+++ b/controller/gateway/controller_test.go
@@ -439,6 +439,72 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 	}
 }
 
+func TestProvisionControlPlane_UpdatesExtensionsWhenOnlyExtensionsDiffer(t *testing.T) {
+	ctx := t.Context()
+
+	gateway := &gwtypes.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gateway",
+			Namespace: "test-namespace",
+			UID:       types.UID(uuid.NewString()),
+		},
+	}
+
+	controlPlane := &gwtypes.ControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-controlplane",
+			Namespace: "test-namespace",
+		},
+		Spec: gwtypes.ControlPlaneSpec{
+			ControlPlaneOptions: gwtypes.ControlPlaneOptions{},
+			Extensions: []commonv1alpha1.ExtensionRef{
+				{
+					Group: "sample.group",
+					Kind:  "SampleExtension",
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "old-extension",
+					},
+				},
+			},
+		},
+	}
+	k8sutils.SetOwnerForObject(controlPlane, gateway)
+	gatewayutils.LabelObjectAsGatewayManaged(controlPlane, gateway.Name)
+
+	fakeClient := fakectrlruntimeclient.
+		NewClientBuilder().
+		WithScheme(scheme.Get()).
+		WithObjects(controlPlane).
+		Build()
+
+	reconciler := Reconciler{
+		Client: fakeClient,
+	}
+
+	gatewayConfig := &GatewayConfiguration{
+		Spec: GatewayConfigurationSpec{
+			Extensions: []commonv1alpha1.ExtensionRef{
+				{
+					Group: "sample.group",
+					Kind:  "SampleExtension",
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: "new-extension",
+					},
+				},
+			},
+		},
+	}
+
+	reconciler.provisionControlPlane(ctx, logr.Discard(), gateway, gatewayConfig)
+
+	var updatedControlPlane gwtypes.ControlPlane
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{
+		Name:      controlPlane.Name,
+		Namespace: controlPlane.Namespace,
+	}, &updatedControlPlane))
+	require.Equal(t, gatewayConfig.Spec.Extensions, updatedControlPlane.Spec.Extensions)
+}
+
 func Test_setDataPlaneOptionsDefaults(t *testing.T) {
 	testcases := []struct {
 		name     string


### PR DESCRIPTION
**What this PR does / why we need it**:

Porting https://github.com/Kong/kong-operator/pull/3769 to overcome CI limitations ( no secrets ).

Correct the ControlPlane spec comparison to update when Extensions actually differ, and add a unit test that covers extensions-only drift to prevent regression.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
