### PR TITLE
test: re-enable HTTPRouteInvalidNonExistentBackendRef conformance test for HybridGateway

### DIFF
--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -1161,6 +1161,33 @@ func TestHTTPRouteConverter_UpdateRootObjectStatus(t *testing.T) {
 			},
 		},
 		{
+			name: "nonexistent backend sets BackendNotFound without stop",
+			setup: func() (*httpRouteConverter, *gwtypes.HTTPRoute) {
+				route := newHTTPRouteForTranslation([]string{"api.example.com"}, []gwtypes.HTTPBackendRef{
+					newBackendRef(""),
+				}, nil)
+				gateway := baseGateway()
+				objects := append(newKonnectGatewayStandardObjects(gateway), newNamespace(), route)
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme.Get()).WithStatusSubresource(route).WithObjects(objects...).Build()
+				return newHTTPRouteConverter(route, fakeClient, false, "").(*httpRouteConverter), route
+			},
+			wantUpdated: true,
+			assertFn: func(t *testing.T, route *gwtypes.HTTPRoute) {
+				require.Len(t, route.Status.Parents, 1)
+				conditions := route.Status.Parents[0].Conditions
+				assertConditionStatus(t, conditions, string(gwtypes.RouteConditionAccepted), metav1.ConditionTrue)
+				assertConditionStatus(t, conditions, string(gwtypes.RouteConditionResolvedRefs), metav1.ConditionFalse)
+
+				for _, condition := range conditions {
+					if condition.Type == string(gwtypes.RouteConditionResolvedRefs) {
+						assert.Equal(t, string(gwtypes.RouteReasonBackendNotFound), condition.Reason)
+						return
+					}
+				}
+				t.Fatalf("missing %s condition", gwtypes.RouteConditionResolvedRefs)
+			},
+		},
+		{
 			name: "accepted false sets stop",
 			setup: func() (*httpRouteConverter, *gwtypes.HTTPRoute) {
 				route := newHTTPRouteForTranslation([]string{"api.example.com"}, []gwtypes.HTTPBackendRef{

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -32,7 +32,6 @@ var skippedTestsForTraditionalCompatibleRouter = []string{
 var skippedTestsForHybrid = []string{
 
 	// Core profile.
-	tests.HTTPRouteInvalidNonExistentBackendRef.ShortName,
 	tests.HTTPRouteMethodMatching.ShortName,
 	tests.HTTPRouteQueryParamMatching.ShortName,
 	tests.GatewayWithAttachedRoutes.ShortName,


### PR DESCRIPTION
…

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #4455

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
