### PR TITLE
[Backport release/2.1.x] chore(build): Bump go to 1.26.4 (#4493)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Builder
 # ------------------------------------------------------------------------------
 
-FROM --platform=$BUILDPLATFORM golang:1.25.10@sha256:c138bff780910acf4254ab3a6f7ff0f64bbd841f27bd82bfa986fe122c109538 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4@sha256:68cb6d68bed024785b69195b89af7ac7a444f27791435f98647edff595aa0479 AS builder
 
 WORKDIR /workspace
 ARG GOPATH

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -2,7 +2,7 @@
 # Debug image
 # ------------------------------------------------------------------------------
 
-FROM --platform=$BUILDPLATFORM golang:1.25.10@sha256:c138bff780910acf4254ab3a6f7ff0f64bbd841f27bd82bfa986fe122c109538 AS debug
+FROM --platform=$BUILDPLATFORM golang:1.26.4@sha256:68cb6d68bed024785b69195b89af7ac7a444f27791435f98647edff595aa0479 AS debug
 
 ARG GOPATH
 ARG GOCACHE

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kong-operator/v2
 
-go 1.25.10
+go 1.26.4
 
 require (
 	cloud.google.com/go/container v1.46.0


### PR DESCRIPTION
(cherry picked from commit 4e7651bc62d810b0f260326c34e1b778ed298114)

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
