### PR TITLE
[Backport release/2.1.x]: fix(konnect): resolve cross-namespace KongRoute→KongService references correctly (#4212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,14 @@
   parent ref (`KongRoute` via `serviceRef`, `KongCredential*` via `consumerRef`) to
   silently fail when the parent's `controlPlaneRef` was cross-namespace.
   [#4210](https://github.com/Kong/kong-operator/pull/4210)
+- Fix cross-namespace `KongRoute → KongService` reference resolution: `handleKongServiceRef`
+  and `GetAPIAuthRefNN` (serviceRef branch) now derive the `KongService` namespace from
+  `serviceRef.namespace` instead of always using the route's namespace, so a cross-namespace
+  serviceRef with a valid `KongReferenceGrant` correctly reaches `Programmed=True`.
+  The `kongRouteRefersToKongService` index key and `enqueueKongRouteForKongService` watch
+  handler are also fixed to use the service's namespace, ensuring cross-namespace routes are
+  re-queued immediately when the referenced service changes rather than waiting for a full resync.
+  [#4212](https://github.com/Kong/kong-operator/pull/4212)
   
 ## [v2.1.6]
 

--- a/controller/konnect/reconciler_apiauthref.go
+++ b/controller/konnect/reconciler_apiauthref.go
@@ -51,7 +51,8 @@ func getCPAuthRefForRef(
 	}, nil
 }
 
-func getAPIAuthRefNN[T constraints.SupportedKonnectEntityType, TEnt constraints.EntityType[T]](
+// GetAPIAuthRefNN returns the NamespacedName of the KonnectAPIAuthConfiguration referenced by the entity.
+func GetAPIAuthRefNN[T constraints.SupportedKonnectEntityType, TEnt constraints.EntityType[T]](
 	ctx context.Context,
 	cl client.Client,
 	ent TEnt,

--- a/controller/konnect/reconciler_apiauthref.go
+++ b/controller/konnect/reconciler_apiauthref.go
@@ -102,10 +102,15 @@ func getAPIAuthRefNN[T constraints.SupportedKonnectEntityType, TEnt constraints.
 		if svcRef.Type != configurationv1alpha1.ServiceRefNamespacedRef {
 			return types.NamespacedName{}, fmt.Errorf("unsupported KongService ref type %q", svcRef.Type)
 		}
-		// TODO(pmalek): handle cross namespace refs
+		// Cross-namespace grant validation for the serviceRef is performed by
+		// handleKongServiceRef before this function is reached; see reconciler_generic.go.
+		svcNamespace := ent.GetNamespace()
+		if svcRef.NamespacedRef.Namespace != nil {
+			svcNamespace = *svcRef.NamespacedRef.Namespace
+		}
 		nn := types.NamespacedName{
 			Name:      svcRef.NamespacedRef.Name,
-			Namespace: ent.GetNamespace(),
+			Namespace: svcNamespace,
 		}
 
 		var svc configurationv1alpha1.KongService
@@ -117,7 +122,7 @@ func getAPIAuthRefNN[T constraints.SupportedKonnectEntityType, TEnt constraints.
 		if !ok {
 			return types.NamespacedName{}, fmt.Errorf("KongService %s does not have a ControlPlaneRef", nn)
 		}
-		return getCPAuthRefForRef(ctx, cl, cpRef, ent.GetNamespace())
+		return getCPAuthRefForRef(ctx, cl, cpRef, svc.Namespace)
 	}
 
 	// If the entity has a KongConsumerRef, get the KonnectAPIAuthConfiguration

--- a/controller/konnect/reconciler_apiauthref_test.go
+++ b/controller/konnect/reconciler_apiauthref_test.go
@@ -43,14 +43,14 @@ func populateGVKOnGet(scheme *runtime.Scheme) interceptor.Funcs {
 }
 
 // TestGetCPAuthRefForRef covers all branches of getCPAuthRefForRef:
-//   - GetCPForRef error (CP missing)
-//   - same-namespace authRef (Namespace nil) verifies the resolved namespace
-//     is the CP's own namespace, not the namespace argument passed by the caller
-//     (this is the bug Fix 1 addresses)
-//   - same-namespace authRef (Namespace explicitly equal to CP's), guards the
-//     "!= cpNamespace" condition
-//   - cross-namespace authRef without a grant, surfaces ReferenceNotGrantedError
-//   - cross-namespace authRef with a valid grant, returns the authRef's namespace
+//   - CP missing: GetCPForRef returns an error and it is propagated.
+//   - Same-namespace authRef (Namespace nil): the returned namespace is the CP's
+//     namespace, regardless of which namespace the caller passed in.
+//   - Same-namespace authRef (Namespace explicitly equal to the CP's): the
+//     cross-namespace branch is skipped (covers the `!= cpNamespace` condition).
+//   - Cross-namespace authRef without a grant: ReferenceNotGrantedError is returned.
+//   - Cross-namespace authRef with a valid grant: the returned namespace is the
+//     authRef's namespace.
 func TestGetCPAuthRefForRef(t *testing.T) {
 	const (
 		cpName        = "cp"
@@ -180,6 +180,167 @@ func TestGetCPAuthRefForRef(t *testing.T) {
 					require.ErrorAs(t, err, &notGranted)
 				}
 				require.Equal(t, types.NamespacedName{}, nn)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantNN, nn)
+		})
+	}
+}
+
+// TestGetAPIAuthRefNN_ServiceRef covers the serviceRef branch of GetAPIAuthRefNN.
+// It is the path that resolves a KongRoute -> KongService -> CP -> auth chain.
+//
+// The branch must:
+//   - look up the KongService using the namespace from `serviceRef.namespace` (falling
+//     back to the route's namespace when not set), not the route's namespace unconditionally.
+//   - call getCPAuthRefForRef with the resolved service's namespace, not the route's.
+func TestGetAPIAuthRefNN_ServiceRef(t *testing.T) {
+	const (
+		routeNs   = "route-ns"
+		serviceNs = "svc-ns"
+		cpName    = "cp"
+		svcName   = "cross-ns-service"
+		authName  = "konnect-api-auth"
+	)
+
+	cp := &konnectv1alpha2.KonnectGatewayControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cpName,
+			Namespace: serviceNs,
+		},
+		Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+			KonnectConfiguration: konnectv1alpha2.ControlPlaneKonnectConfiguration{
+				APIAuthConfigurationRef: konnectv1alpha2.ControlPlaneKonnectAPIAuthConfigurationRef{
+					Name: authName,
+				},
+			},
+		},
+	}
+
+	svc := &configurationv1alpha1.KongService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcName,
+			Namespace: serviceNs,
+		},
+		Spec: configurationv1alpha1.KongServiceSpec{
+			ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+				Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+				KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+					Name:      cpName,
+					Namespace: serviceNs,
+				},
+			},
+		},
+	}
+
+	svcNoCPRef := &configurationv1alpha1.KongService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcName,
+			Namespace: serviceNs,
+		},
+	}
+
+	makeRoute := func(svcRefNamespace *string) *configurationv1alpha1.KongRoute {
+		return &configurationv1alpha1.KongRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "route",
+				Namespace: routeNs,
+			},
+			Spec: configurationv1alpha1.KongRouteSpec{
+				ServiceRef: &configurationv1alpha1.ServiceRef{
+					Type: configurationv1alpha1.ServiceRefNamespacedRef,
+					NamespacedRef: &commonv1alpha1.NamespacedRef{
+						Name:      svcName,
+						Namespace: svcRefNamespace,
+					},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name              string
+		route             *configurationv1alpha1.KongRoute
+		objects           []client.Object
+		wantNN            types.NamespacedName
+		wantErrorContains string
+	}{
+		{
+			name:  "cross-namespace serviceRef resolves auth from service's namespace",
+			route: makeRoute(new(serviceNs)),
+			objects: []client.Object{
+				// Service lives in serviceNs, not the route's namespace. Verifies that
+				// the lookup uses serviceRef.namespace rather than the route's namespace.
+				svc, cp,
+			},
+			wantNN: types.NamespacedName{
+				Name:      authName,
+				Namespace: serviceNs,
+			},
+		},
+		{
+			name:  "same-namespace serviceRef (Namespace nil) falls back to entity's namespace",
+			route: makeRoute(nil),
+			objects: []client.Object{
+				// In the same-namespace case the service is co-located with the route.
+				&configurationv1alpha1.KongService{
+					ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: routeNs},
+					Spec: configurationv1alpha1.KongServiceSpec{
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+								Name:      cpName,
+								Namespace: routeNs,
+							},
+						},
+					},
+				},
+				&konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: metav1.ObjectMeta{Name: cpName, Namespace: routeNs},
+					Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+						KonnectConfiguration: konnectv1alpha2.ControlPlaneKonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha2.ControlPlaneKonnectAPIAuthConfigurationRef{
+								Name: authName,
+							},
+						},
+					},
+				},
+			},
+			wantNN: types.NamespacedName{
+				Name:      authName,
+				Namespace: routeNs,
+			},
+		},
+		{
+			name:              "service not found returns error",
+			route:             makeRoute(new(serviceNs)),
+			objects:           nil,
+			wantErrorContains: "failed to get KongService",
+		},
+		{
+			name:              "service without ControlPlaneRef returns error",
+			route:             makeRoute(new(serviceNs)),
+			objects:           []client.Object{svcNoCPRef},
+			wantErrorContains: "does not have a ControlPlaneRef",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := scheme.Get()
+			cl := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(append(tc.objects, tc.route)...).
+				WithInterceptorFuncs(populateGVKOnGet(s)).
+				Build()
+
+			nn, err := GetAPIAuthRefNN(t.Context(), cl, tc.route)
+
+			if tc.wantErrorContains != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.wantErrorContains)
 				return
 			}
 

--- a/controller/konnect/reconciler_apiauthref_test.go
+++ b/controller/konnect/reconciler_apiauthref_test.go
@@ -269,7 +269,7 @@ func TestGetAPIAuthRefNN_ServiceRef(t *testing.T) {
 	}{
 		{
 			name:  "cross-namespace serviceRef resolves auth from service's namespace",
-			route: makeRoute(new(serviceNs)),
+			route: makeRoute(lo.ToPtr(serviceNs)),
 			objects: []client.Object{
 				// Service lives in serviceNs, not the route's namespace. Verifies that
 				// the lookup uses serviceRef.namespace rather than the route's namespace.
@@ -315,13 +315,13 @@ func TestGetAPIAuthRefNN_ServiceRef(t *testing.T) {
 		},
 		{
 			name:              "service not found returns error",
-			route:             makeRoute(new(serviceNs)),
+			route:             makeRoute(lo.ToPtr(serviceNs)),
 			objects:           nil,
 			wantErrorContains: "failed to get KongService",
 		},
 		{
 			name:              "service without ControlPlaneRef returns error",
-			route:             makeRoute(new(serviceNs)),
+			route:             makeRoute(lo.ToPtr(serviceNs)),
 			objects:           []client.Object{svcNoCPRef},
 			wantErrorContains: "does not have a ControlPlaneRef",
 		},

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -407,7 +407,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(
 		Message: "Some conditions have status set to False",
 	}
 
-	apiAuthRef, err := getAPIAuthRefNN(ctx, r.Client, ent)
+	apiAuthRef, err := GetAPIAuthRefNN(ctx, r.Client, ent)
 	if err != nil {
 		if crossnamespace.IsReferenceNotGranted(err) {
 			log.Info(logger, "cross-namespace reference to KonnectAPIAuthConfiguration is not granted", "error", err.Error())

--- a/controller/konnect/reconciler_serviceref.go
+++ b/controller/konnect/reconciler_serviceref.go
@@ -74,8 +74,7 @@ func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constra
 	nsEnt := ent.GetNamespace()
 	kongSvc := configurationv1alpha1.KongService{}
 	nn := types.NamespacedName{
-		Name: kongServiceRef.NamespacedRef.Name,
-		// TODO: handle cross namespace refs
+		Name:      kongServiceRef.NamespacedRef.Name,
 		Namespace: nsEnt,
 	}
 	ref := kongServiceRef.NamespacedRef
@@ -199,7 +198,7 @@ func handleKongServiceRef[T constraints.SupportedKonnectEntityType, TEnt constra
 			client.ObjectKeyFromObject(&kongSvc),
 		)
 	}
-	cp, err := controlplane.GetCPForRef(ctx, cl, kongSvcCPRef, ent.GetNamespace())
+	cp, err := controlplane.GetCPForRef(ctx, cl, kongSvcCPRef, kongSvc.GetNamespace())
 	if err != nil {
 		if res, errStatus := patch.StatusWithCondition(
 			ctx, cl, ent,

--- a/controller/konnect/reconciler_serviceref_test.go
+++ b/controller/konnect/reconciler_serviceref_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
@@ -116,6 +117,81 @@ var testKongServiceBeingDeleted = &configurationv1alpha1.KongService{
 	},
 }
 
+// Cross-namespace fixtures: service and its CP both live in svc-ns,
+// while the route consuming the service lives in default.
+const svcNamespace = "svc-ns"
+
+var testKongServiceCrossNs = &configurationv1alpha1.KongService{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "svc-cross-ns",
+		Namespace: svcNamespace,
+	},
+	Spec: configurationv1alpha1.KongServiceSpec{
+		ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+			Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+			KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+				Name:      "cp-cross-ns",
+				Namespace: svcNamespace,
+			},
+		},
+	},
+	Status: configurationv1alpha1.KongServiceStatus{
+		Konnect: &konnectv1alpha2.KonnectEntityStatusWithControlPlaneRef{
+			KonnectEntityStatus: konnectv1alpha2.KonnectEntityStatus{
+				ID: "svc-cross-ns-id",
+			},
+			ControlPlaneID: "cp-cross-ns-id",
+		},
+		Conditions: []metav1.Condition{
+			{
+				Type:   konnectv1alpha1.KonnectEntityProgrammedConditionType,
+				Status: metav1.ConditionTrue,
+			},
+		},
+	},
+}
+
+var testControlPlaneCrossNs = &konnectv1alpha2.KonnectGatewayControlPlane{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "cp-cross-ns",
+		Namespace: svcNamespace,
+	},
+	Status: konnectv1alpha2.KonnectGatewayControlPlaneStatus{
+		KonnectEntityStatus: konnectv1alpha2.KonnectEntityStatus{
+			ID: "cp-cross-ns-id",
+		},
+		Conditions: []metav1.Condition{
+			{
+				Type:   konnectv1alpha1.KonnectEntityProgrammedConditionType,
+				Status: metav1.ConditionTrue,
+			},
+		},
+	},
+}
+
+// testKongRouteToSvcGrant allows KongRoute in `default` to reference KongService in `svc-ns`.
+var testKongRouteToSvcGrant = &configurationv1alpha1.KongReferenceGrant{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "route-to-svc",
+		Namespace: svcNamespace,
+	},
+	Spec: configurationv1alpha1.KongReferenceGrantSpec{
+		From: []configurationv1alpha1.ReferenceGrantFrom{
+			{
+				Group:     configurationv1alpha1.Group(configurationv1alpha1.GroupVersion.Group),
+				Kind:      "KongRoute",
+				Namespace: "default",
+			},
+		},
+		To: []configurationv1alpha1.ReferenceGrantTo{
+			{
+				Group: configurationv1alpha1.Group(configurationv1alpha1.GroupVersion.Group),
+				Kind:  "KongService",
+			},
+		},
+	},
+}
+
 func TestHandleServiceRef(t *testing.T) {
 	testCases := []handleServiceRefTestCase[configurationv1alpha1.KongRoute, *configurationv1alpha1.KongRoute]{
 		{
@@ -219,6 +295,138 @@ func TestHandleServiceRef(t *testing.T) {
 			},
 		},
 		{
+			// Regression test: on the 2nd+ reconciliation the KongRoute already has both the
+			// KongServiceRefValid=False condition AND Status.Konnect initialized (from the 1st
+			// reconciliation's SetKonnectID("") call). In that state, patch.ApplyStatusPatchIfNotEmpty
+			// returns op.Noop (nothing changed), causing a fall-through to the ServiceID assignment.
+			// If KongService.Status.Konnect is nil, the old code panicked with a nil pointer dereference
+			// on kongSvc.Status.Konnect.GetKonnectID().
+			// The fix uses kongSvc.GetKonnectID() which is nil-safe.
+			name: "has service ref to an unprogrammed service with nil Konnect status (2nd reconciliation, regression for nil panic)",
+			ent: &configurationv1alpha1.KongRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "route-1",
+					Namespace: "default",
+				},
+				Spec: configurationv1alpha1.KongRouteSpec{
+					ServiceRef: &configurationv1alpha1.ServiceRef{
+						Type: configurationv1alpha1.ServiceRefNamespacedRef,
+						NamespacedRef: &commonv1alpha1.NamespacedRef{
+							Name: "svc-not-programmed-with-cp-ref",
+						},
+					},
+				},
+				Status: configurationv1alpha1.KongRouteStatus{
+					// Both Konnect and condition are pre-set as they would be after the 1st reconciliation.
+					Konnect: &konnectv1alpha2.KonnectEntityStatusWithControlPlaneAndServiceRefs{},
+					Conditions: []metav1.Condition{
+						{
+							Type:               konnectv1alpha1.KongServiceRefValidConditionType,
+							Status:             metav1.ConditionFalse,
+							Reason:             konnectv1alpha1.KongServiceRefReasonInvalid,
+							Message:            "Referenced KongService default/svc-not-programmed-with-cp-ref is not programmed yet",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			objects: []client.Object{
+				testKongServiceNotProgrammedWithCPRef,
+				testControlPlaneOK,
+			},
+			expectResult: ctrl.Result{},
+			expectError:  false,
+			updatedEntAssertions: []func(*configurationv1alpha1.KongRoute) (bool, string){
+				func(ks *configurationv1alpha1.KongRoute) (bool, string) {
+					if ks.Status.Konnect == nil {
+						return false, "KongRoute.Status.Konnect is nil"
+					}
+					return ks.Status.Konnect.ServiceID == "",
+						fmt.Sprintf(
+							"KongRoute.Status.Konnect.ServiceID should be empty (KongService has no Konnect ID), got %q",
+							ks.Status.Konnect.ServiceID,
+						)
+				},
+			},
+		},
+		{
+			// Cross-namespace serviceRef with a valid KongReferenceGrant.
+			// Verifies that handleKongServiceRef resolves both the KongService and its CP
+			// using the service's namespace (from serviceRef.namespace), not the route's.
+			name: "has cross-namespace service ref with valid grant",
+			ent: &configurationv1alpha1.KongRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: configurationv1alpha1.GroupVersion.String(),
+					Kind:       "KongRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "route-cross-ns",
+					Namespace: "default",
+				},
+				Spec: configurationv1alpha1.KongRouteSpec{
+					ServiceRef: &configurationv1alpha1.ServiceRef{
+						Type: configurationv1alpha1.ServiceRefNamespacedRef,
+						NamespacedRef: &commonv1alpha1.NamespacedRef{
+							Name:      "svc-cross-ns",
+							Namespace: new(svcNamespace),
+						},
+					},
+				},
+			},
+			objects: []client.Object{
+				testKongServiceCrossNs,
+				testControlPlaneCrossNs,
+				testKongRouteToSvcGrant,
+			},
+			expectResult: ctrl.Result{},
+			expectError:  false,
+			updatedEntAssertions: []func(*configurationv1alpha1.KongRoute) (bool, string){
+				func(ks *configurationv1alpha1.KongRoute) (bool, string) {
+					return lo.ContainsBy(ks.Status.Conditions, func(c metav1.Condition) bool {
+						return c.Type == konnectv1alpha1.KongServiceRefValidConditionType &&
+							c.Status == metav1.ConditionTrue
+					}), "KongRoute does not have KongServiceRefValid=True after cross-namespace serviceRef resolution"
+				},
+				func(ks *configurationv1alpha1.KongRoute) (bool, string) {
+					return ks.Status.Konnect != nil && ks.Status.Konnect.ServiceID == "svc-cross-ns-id",
+						"KongRoute does not have ServiceID propagated from the cross-namespace service"
+				},
+			},
+		},
+		{
+			// Cross-namespace serviceRef without a KongReferenceGrant.
+			// handleKongServiceRef propagates the ReferenceNotGrantedError so the
+			// reconciliation does not proceed.
+			name: "has cross-namespace service ref without grant returns ReferenceNotGrantedError",
+			ent: &configurationv1alpha1.KongRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: configurationv1alpha1.GroupVersion.String(),
+					Kind:       "KongRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "route-cross-ns-no-grant",
+					Namespace: "default",
+				},
+				Spec: configurationv1alpha1.KongRouteSpec{
+					ServiceRef: &configurationv1alpha1.ServiceRef{
+						Type: configurationv1alpha1.ServiceRefNamespacedRef,
+						NamespacedRef: &commonv1alpha1.NamespacedRef{
+							Name:      "svc-cross-ns",
+							Namespace: new(svcNamespace),
+						},
+					},
+				},
+			},
+			objects: []client.Object{
+				testKongServiceCrossNs,
+				testControlPlaneCrossNs,
+				// no grant
+			},
+			expectResult:        ctrl.Result{},
+			expectError:         true,
+			expectErrorContains: "is not granted",
+		},
+		{
 			name: "has service ref which has an unprogrammed cp",
 			ent: &configurationv1alpha1.KongRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -292,6 +500,13 @@ func testHandleServiceRef[
 				WithStatusSubresource(tc.ent).
 				Build()
 			require.NoError(t, fakeClient.SubResource("status").Update(t.Context(), tc.ent))
+
+			// fake client's Update strips TypeMeta. handleKongServiceRef reads
+			// ent.GetObjectKind().GroupVersionKind() when checking cross-namespace grants,
+			// so restore the GVK from the scheme before invoking the function.
+			if gvk, gvkErr := apiutil.GVKForObject(tc.ent, scheme); gvkErr == nil {
+				tc.ent.GetObjectKind().SetGroupVersionKind(gvk)
+			}
 
 			res, err := handleKongServiceRef(t.Context(), fakeClient, tc.ent)
 

--- a/controller/konnect/reconciler_serviceref_test.go
+++ b/controller/konnect/reconciler_serviceref_test.go
@@ -1,6 +1,7 @@
 package konnect
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -99,6 +100,33 @@ var testKongServiceNotProgrammed = &configurationv1alpha1.KongService{
 		Namespace: "default",
 	},
 	Status: configurationv1alpha1.KongServiceStatus{
+		Conditions: []metav1.Condition{
+			{
+				Type:   konnectv1alpha1.KonnectEntityProgrammedConditionType,
+				Status: metav1.ConditionFalse,
+			},
+		},
+	},
+}
+
+// testKongServiceNotProgrammedWithCPRef is a KongService with KonnectEntityProgrammed=False,
+// a ControlPlane ref, and Status.Konnect == nil (never synced to Konnect).
+// Used to test the nil pointer dereference regression in handleKongServiceRef.
+var testKongServiceNotProgrammedWithCPRef = &configurationv1alpha1.KongService{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "svc-not-programmed-with-cp-ref",
+		Namespace: "default",
+	},
+	Spec: configurationv1alpha1.KongServiceSpec{
+		ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+			Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+			KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+				Name: "cp-ok",
+			},
+		},
+	},
+	Status: configurationv1alpha1.KongServiceStatus{
+		// Status.Konnect is intentionally nil to simulate a service not yet synced to Konnect.
 		Conditions: []metav1.Condition{
 			{
 				Type:   konnectv1alpha1.KonnectEntityProgrammedConditionType,
@@ -368,7 +396,7 @@ func TestHandleServiceRef(t *testing.T) {
 						Type: configurationv1alpha1.ServiceRefNamespacedRef,
 						NamespacedRef: &commonv1alpha1.NamespacedRef{
 							Name:      "svc-cross-ns",
-							Namespace: new(svcNamespace),
+							Namespace: lo.ToPtr(svcNamespace),
 						},
 					},
 				},
@@ -412,7 +440,7 @@ func TestHandleServiceRef(t *testing.T) {
 						Type: configurationv1alpha1.ServiceRefNamespacedRef,
 						NamespacedRef: &commonv1alpha1.NamespacedRef{
 							Name:      "svc-cross-ns",
-							Namespace: new(svcNamespace),
+							Namespace: lo.ToPtr(svcNamespace),
 						},
 					},
 				},

--- a/controller/konnect/watch_kongroute.go
+++ b/controller/konnect/watch_kongroute.go
@@ -96,8 +96,12 @@ func kongRouteRefersToKonnectGatewayControlPlane(cl client.Client) func(obj clie
 		if scvRef == nil || scvRef.Type != configurationv1alpha1.ServiceRefNamespacedRef {
 			return false
 		}
+		svcNamespace := kongRoute.Namespace
+		if scvRef.NamespacedRef.Namespace != nil {
+			svcNamespace = *scvRef.NamespacedRef.Namespace
+		}
 		nn := types.NamespacedName{
-			Namespace: kongRoute.Namespace,
+			Namespace: svcNamespace,
 			Name:      scvRef.NamespacedRef.Name,
 		}
 		kongSvc := configurationv1alpha1.KongService{}
@@ -125,8 +129,6 @@ func enqueueKongRouteForKongService(
 
 		var l configurationv1alpha1.KongRouteList
 		if err := cl.List(ctx, &l,
-			// TODO: change this when cross namespace refs are allowed.
-			client.InNamespace(kongSvc.GetNamespace()),
 			client.MatchingFields{
 				index.IndexFieldKongRouteOnReferencedKongService: kongSvc.Namespace + "/" + kongSvc.Name,
 			},

--- a/internal/utils/index/kongroute.go
+++ b/internal/utils/index/kongroute.go
@@ -57,8 +57,9 @@ func kongRouteRefersToKongService(object client.Object) []string {
 		return nil
 	}
 
-	// NOTE: We currently do not allow cross namespace references between KongRoute and KongService.
-	// https://github.com/Kong/kubernetes-configuration/issues/106 tracks the implementation.
-
-	return []string{route.Namespace + "/" + svcRef.NamespacedRef.Name}
+	svcNamespace := route.Namespace
+	if svcRef.NamespacedRef.Namespace != nil {
+		svcNamespace = *svcRef.NamespacedRef.Namespace
+	}
+	return []string{svcNamespace + "/" + svcRef.NamespacedRef.Name}
 }

--- a/internal/utils/index/kongroute_test.go
+++ b/internal/utils/index/kongroute_test.go
@@ -1,0 +1,103 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+)
+
+// TestKongRouteRefersToKongService covers the index key builder for the
+// KongRoute -> KongService relation. The key must be "<svcNamespace>/<svcName>"
+// so that lookups match cross-namespace services as well as same-namespace ones.
+func TestKongRouteRefersToKongService(t *testing.T) {
+	const (
+		routeNamespace = "route-ns"
+		serviceName    = "svc"
+	)
+	otherNamespace := "svc-ns"
+
+	testCases := []struct {
+		name string
+		obj  client.Object
+		want []string
+	}{
+		{
+			name: "non-route object returns nil",
+			obj:  &configurationv1alpha1.KongService{},
+			want: nil,
+		},
+		{
+			name: "route without serviceRef returns nil",
+			obj: &configurationv1alpha1.KongRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: routeNamespace},
+			},
+			want: nil,
+		},
+		{
+			name: "route with non-namespacedRef type returns nil",
+			obj: &configurationv1alpha1.KongRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: routeNamespace},
+				Spec: configurationv1alpha1.KongRouteSpec{
+					ServiceRef: &configurationv1alpha1.ServiceRef{
+						Type: "konnectID",
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "route with nil NamespacedRef returns nil",
+			obj: &configurationv1alpha1.KongRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: routeNamespace},
+				Spec: configurationv1alpha1.KongRouteSpec{
+					ServiceRef: &configurationv1alpha1.ServiceRef{
+						Type: configurationv1alpha1.ServiceRefNamespacedRef,
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "same-namespace serviceRef (no namespace field) keys with route's namespace",
+			obj: &configurationv1alpha1.KongRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: routeNamespace},
+				Spec: configurationv1alpha1.KongRouteSpec{
+					ServiceRef: &configurationv1alpha1.ServiceRef{
+						Type: configurationv1alpha1.ServiceRefNamespacedRef,
+						NamespacedRef: &commonv1alpha1.NamespacedRef{
+							Name: serviceName,
+						},
+					},
+				},
+			},
+			want: []string{routeNamespace + "/" + serviceName},
+		},
+		{
+			name: "cross-namespace serviceRef keys with serviceRef's namespace",
+			obj: &configurationv1alpha1.KongRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: routeNamespace},
+				Spec: configurationv1alpha1.KongRouteSpec{
+					ServiceRef: &configurationv1alpha1.ServiceRef{
+						Type: configurationv1alpha1.ServiceRefNamespacedRef,
+						NamespacedRef: &commonv1alpha1.NamespacedRef{
+							Name:      serviceName,
+							Namespace: &otherNamespace,
+						},
+					},
+				},
+			},
+			want: []string{otherNamespace + "/" + serviceName},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, kongRouteRefersToKongService(tc.obj))
+		})
+	}
+}


### PR DESCRIPTION




**What this PR does / why we need it**:

(cherry picked from commit dc4911ebe1b9d6bda1a10560882dc6b917937fb0)

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
