### PR TITLE
[Backport release/2.1.x]: fix(konnect): add KongReferenceGrant watch to KongVault and KongConsumerGroup (#4219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,11 @@
   handler are also fixed to use the service's namespace, ensuring cross-namespace routes are
   re-queued immediately when the referenced service changes rather than waiting for a full resync.
   [#4212](https://github.com/Kong/kong-operator/pull/4212)
+- Add `KongReferenceGrant` watch to `KongVault` and `KongConsumerGroup` reconcilers.
+  Previously, creating or deleting a grant would not trigger re-reconciliation of these
+  resources until the next full resync cycle. Grant changes now immediately re-queue
+  affected objects.
+  [#4219](https://github.com/Kong/kong-operator/pull/4219)
   
 ## [v2.1.6]
 

--- a/controller/konnect/watch_kongconsumergroup.go
+++ b/controller/konnect/watch_kongconsumergroup.go
@@ -7,6 +7,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	configurationv1beta1 "github.com/kong/kong-operator/v2/api/configuration/v1beta1"
 	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
@@ -51,6 +52,14 @@ func KongConsumerGroupReconciliationWatchOptions(
 					enqueueObjectForKonnectGatewayControlPlane[configurationv1beta1.KongConsumerGroupList](
 						cl, index.IndexFieldKongConsumerGroupOnKonnectGatewayControlPlane,
 					),
+				),
+			)
+		},
+		func(b *ctrl.Builder) *ctrl.Builder {
+			return b.Watches(
+				&configurationv1alpha1.KongReferenceGrant{},
+				handler.EnqueueRequestsFromMapFunc(
+					enqueueObjectsForKongReferenceGrant[configurationv1beta1.KongConsumerGroupList](cl),
 				),
 			)
 		},

--- a/controller/konnect/watch_kongvault.go
+++ b/controller/konnect/watch_kongvault.go
@@ -49,6 +49,14 @@ func KongVaultReconciliationWatchOptions(cl client.Client) []func(*ctrl.Builder)
 				),
 			)
 		},
+		func(b *ctrl.Builder) *ctrl.Builder {
+			return b.Watches(
+				&configurationv1alpha1.KongReferenceGrant{},
+				handler.EnqueueRequestsFromMapFunc(
+					enqueueObjectsForKongReferenceGrant[configurationv1alpha1.KongVaultList](cl),
+				),
+			)
+		},
 	}
 }
 


### PR DESCRIPTION




**What this PR does / why we need it**:

(cherry picked from commit 5b1b6f4af96df2f98c1a6955623b9f7d66c81f3f)

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
