### PR TITLE
fix: fix routes become unaccepted and removed from dataplane unexpectly

### DIFF
--- a/ingress-controller/internal/controllers/gateway/grpcroute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/grpcroute_controller.go
@@ -329,7 +329,7 @@ func (r *GRPCRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, grpcroute, "Checking if the grpcroute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayProgrammed(gateway.gateway) {
+		if !isGatewayProgrammedForRoute(grpcroute, gateway) {
 			debug(log, grpcroute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/ingress-controller/internal/controllers/gateway/grpcroute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/grpcroute_controller.go
@@ -329,7 +329,7 @@ func (r *GRPCRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, grpcroute, "Checking if the grpcroute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayProgrammedForRoute(grpcroute, gateway) {
+		if !isGatewayProgrammedForRoute(gateway) {
 			debug(log, grpcroute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/ingress-controller/internal/controllers/gateway/httproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/httproute_controller.go
@@ -452,7 +452,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, httproute, "Checking if the httproute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayProgrammedForRoute(httproute, gateway) {
+		if !isGatewayProgrammedForRoute(gateway) {
 			debug(log, httproute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/ingress-controller/internal/controllers/gateway/httproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/httproute_controller.go
@@ -452,7 +452,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, httproute, "Checking if the httproute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayProgrammed(gateway.gateway) {
+		if !isGatewayProgrammedForRoute(httproute, gateway) {
 			debug(log, httproute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/ingress-controller/internal/controllers/gateway/route_utils.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils.go
@@ -687,6 +687,39 @@ func isRouteAccepted(gateways []supportedGatewayWithCondition) bool {
 	return false
 }
 
+func isGatewayProgrammedForRoute[T gatewayapi.RouteT](route T, gateway supportedGatewayWithCondition) bool {
+	if !isGatewayProgrammed(gateway.gateway) {
+		return false
+	}
+
+	matchingListeners := make([]gatewayapi.Listener, 0, len(gateway.gateway.Spec.Listeners))
+	for _, listener := range gateway.gateway.Spec.Listeners {
+		if gateway.listenerName != "" && gatewayapi.SectionName(gateway.listenerName) != listener.Name {
+			continue
+		}
+		if !routeTypeMatchesListenerType(route, listener) {
+			continue
+		}
+		matchingListeners = append(matchingListeners, listener)
+	}
+
+	// If the Gateway spec has no listener that could match this route, let normal
+	// route acceptance handling set the terminal status. This readiness check is
+	// only intended to wait for listener status to catch up when the spec listener
+	// exists but its status is not programmed yet.
+	if len(matchingListeners) == 0 {
+		return true
+	}
+
+	for _, listener := range matchingListeners {
+		if err := listenerProgrammedInStatus(listener.Name, gateway.gateway.Status.Listeners); err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
 // isHTTPReferenceGranted checks that the backendRef referenced by the HTTPRoute is granted by a ReferenceGrant.
 func isHTTPReferenceGranted(grantSpec gatewayapi.ReferenceGrantSpec, backendRef gatewayapi.HTTPBackendRef, fromNamespace string) bool {
 	var backendRefGroup gatewayapi.Group

--- a/ingress-controller/internal/controllers/gateway/route_utils.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils.go
@@ -43,9 +43,10 @@ var (
 // supportedGatewayWithCondition is a struct that wraps a gateway and some further info
 // such as the condition Status condition Accepted of the gateway and the listenerName.
 type supportedGatewayWithCondition struct {
-	gateway      *gatewayapi.Gateway
-	condition    metav1.Condition
-	listenerName string
+	gateway               *gatewayapi.Gateway
+	condition             metav1.Condition
+	listenerName          string
+	attachedListenerNames []gatewayapi.SectionName
 }
 
 func (g supportedGatewayWithCondition) GetName() string {
@@ -186,6 +187,8 @@ func getSupportedGatewayForRoute[T gatewayapi.RouteT](
 			allowedBySupportedKinds = false
 			allowedByListenerName   = false
 			listenerReady           = false
+
+			attachedListenerNames []gatewayapi.SectionName
 		)
 
 		for _, listener := range gateway.Spec.Listeners {
@@ -264,6 +267,7 @@ func getSupportedGatewayForRoute[T gatewayapi.RouteT](
 			}
 
 			matched = true
+			attachedListenerNames = append(attachedListenerNames, listener.Name)
 		}
 
 		if matched {
@@ -273,8 +277,9 @@ func getSupportedGatewayForRoute[T gatewayapi.RouteT](
 			}
 
 			gateways = append(gateways, supportedGatewayWithCondition{
-				gateway:      &gateway,
-				listenerName: listenerName,
+				gateway:               &gateway,
+				listenerName:          listenerName,
+				attachedListenerNames: attachedListenerNames,
 				condition: metav1.Condition{
 					Type:               string(gatewayapi.RouteConditionAccepted),
 					Status:             metav1.ConditionTrue,
@@ -312,8 +317,9 @@ func getSupportedGatewayForRoute[T gatewayapi.RouteT](
 			}
 
 			gateways = append(gateways, supportedGatewayWithCondition{
-				gateway:      &gateway,
-				listenerName: listenerName,
+				gateway:               &gateway,
+				listenerName:          listenerName,
+				attachedListenerNames: attachedListenerNames,
 				condition: metav1.Condition{
 					Type:               string(gatewayapi.RouteConditionAccepted),
 					Status:             metav1.ConditionFalse,
@@ -687,32 +693,21 @@ func isRouteAccepted(gateways []supportedGatewayWithCondition) bool {
 	return false
 }
 
-func isGatewayProgrammedForRoute[T gatewayapi.RouteT](route T, gateway supportedGatewayWithCondition) bool {
+func isGatewayProgrammedForRoute(gateway supportedGatewayWithCondition) bool {
 	if !isGatewayProgrammed(gateway.gateway) {
 		return false
 	}
 
-	matchingListeners := make([]gatewayapi.Listener, 0, len(gateway.gateway.Spec.Listeners))
-	for _, listener := range gateway.gateway.Spec.Listeners {
-		if gateway.listenerName != "" && gatewayapi.SectionName(gateway.listenerName) != listener.Name {
-			continue
-		}
-		if !routeTypeMatchesListenerType(route, listener) {
-			continue
-		}
-		matchingListeners = append(matchingListeners, listener)
-	}
-
-	// If the Gateway spec has no listener that could match this route, let normal
+	// If the Gateway spec has no listener that could attach this route, let normal
 	// route acceptance handling set the terminal status. This readiness check is
-	// only intended to wait for listener status to catch up when the spec listener
-	// exists but its status is not programmed yet.
-	if len(matchingListeners) == 0 {
+	// only intended to wait for listener status to catch up when an attached spec
+	// listener exists but its status is not programmed yet.
+	if len(gateway.attachedListenerNames) == 0 {
 		return true
 	}
 
-	for _, listener := range matchingListeners {
-		if err := listenerProgrammedInStatus(listener.Name, gateway.gateway.Status.Listeners); err == nil {
+	for _, listenerName := range gateway.attachedListenerNames {
+		if err := listenerProgrammedInStatus(listenerName, gateway.gateway.Status.Listeners); err == nil {
 			return true
 		}
 	}

--- a/ingress-controller/internal/controllers/gateway/route_utils_test.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils_test.go
@@ -36,6 +36,130 @@ func init() {
 	}
 }
 
+func TestIsGatewayProgrammedForRoute(t *testing.T) {
+	udpRoute := &gatewayapi.UDPRoute{}
+	udpListener := gatewayapi.Listener{
+		Name:     "udp",
+		Protocol: gatewayapi.UDPProtocolType,
+		Port:     9999,
+	}
+
+	testCases := []struct {
+		name      string
+		gateway   *gatewayapi.Gateway
+		listener  string
+		wantReady bool
+	}{
+		{
+			name: "gateway programmed and matching listener programmed",
+			gateway: programmedGatewayForRouteReadinessTest(
+				[]gatewayapi.Listener{udpListener},
+				[]gatewayapi.ListenerStatus{programmedListenerStatusForRouteReadinessTest("udp", metav1.ConditionTrue)},
+			),
+			listener:  "udp",
+			wantReady: true,
+		},
+		{
+			name: "gateway programmed but matching listener status missing",
+			gateway: programmedGatewayForRouteReadinessTest(
+				[]gatewayapi.Listener{udpListener},
+				nil,
+			),
+			listener:  "udp",
+			wantReady: false,
+		},
+		{
+			name: "gateway programmed but matching listener not programmed",
+			gateway: programmedGatewayForRouteReadinessTest(
+				[]gatewayapi.Listener{udpListener},
+				[]gatewayapi.ListenerStatus{programmedListenerStatusForRouteReadinessTest("udp", metav1.ConditionFalse)},
+			),
+			listener:  "udp",
+			wantReady: false,
+		},
+		{
+			name: "gateway not programmed even when matching listener is programmed",
+			gateway: &gatewayapi.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec: gatewayapi.GatewaySpec{
+					Listeners: []gatewayapi.Listener{udpListener},
+				},
+				Status: gatewayapi.GatewayStatus{
+					Listeners: []gatewayapi.ListenerStatus{programmedListenerStatusForRouteReadinessTest("udp", metav1.ConditionTrue)},
+				},
+			},
+			listener:  "udp",
+			wantReady: false,
+		},
+		{
+			name: "specified listener absent from spec is terminal not transient",
+			gateway: programmedGatewayForRouteReadinessTest(
+				[]gatewayapi.Listener{{Name: "other", Protocol: gatewayapi.UDPProtocolType, Port: 9999}},
+				nil,
+			),
+			listener:  "udp",
+			wantReady: true,
+		},
+		{
+			name: "no section name waits for matching route protocol listener, ignoring unrelated programmed listener",
+			gateway: programmedGatewayForRouteReadinessTest(
+				[]gatewayapi.Listener{
+					{Name: "http", Protocol: gatewayapi.HTTPProtocolType, Port: 80},
+					udpListener,
+				},
+				[]gatewayapi.ListenerStatus{programmedListenerStatusForRouteReadinessTest("http", metav1.ConditionTrue)},
+			),
+			wantReady: false,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			gateway := supportedGatewayWithCondition{
+				gateway:      tt.gateway,
+				listenerName: tt.listener,
+			}
+			assert.Equal(t, tt.wantReady, isGatewayProgrammedForRoute(udpRoute, gateway))
+		})
+	}
+}
+
+func programmedGatewayForRouteReadinessTest(
+	listeners []gatewayapi.Listener,
+	listenerStatuses []gatewayapi.ListenerStatus,
+) *gatewayapi.Gateway {
+	return &gatewayapi.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Generation: 1},
+		Spec: gatewayapi.GatewaySpec{
+			Listeners: listeners,
+		},
+		Status: gatewayapi.GatewayStatus{
+			Conditions: []metav1.Condition{{
+				Type:               string(gatewayapi.GatewayConditionProgrammed),
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: 1,
+				Reason:             string(gatewayapi.GatewayReasonProgrammed),
+			}},
+			Listeners: listenerStatuses,
+		},
+	}
+}
+
+func programmedListenerStatusForRouteReadinessTest(
+	name gatewayapi.SectionName,
+	conditionStatus metav1.ConditionStatus,
+) gatewayapi.ListenerStatus {
+	return gatewayapi.ListenerStatus{
+		Name: name,
+		Conditions: []metav1.Condition{{
+			Type:               string(gatewayapi.ListenerConditionProgrammed),
+			Status:             conditionStatus,
+			ObservedGeneration: 1,
+			Reason:             string(gatewayapi.ListenerReasonProgrammed),
+		}},
+	}
+}
+
 func TestFilterHostnames(t *testing.T) {
 	commonGateway := &gatewayapi.Gateway{
 		Spec: gatewayapi.GatewaySpec{

--- a/ingress-controller/internal/controllers/gateway/route_utils_test.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils_test.go
@@ -37,7 +37,6 @@ func init() {
 }
 
 func TestIsGatewayProgrammedForRoute(t *testing.T) {
-	udpRoute := &gatewayapi.UDPRoute{}
 	udpListener := gatewayapi.Listener{
 		Name:     "udp",
 		Protocol: gatewayapi.UDPProtocolType,
@@ -45,10 +44,11 @@ func TestIsGatewayProgrammedForRoute(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name      string
-		gateway   *gatewayapi.Gateway
-		listener  string
-		wantReady bool
+		name                  string
+		gateway               *gatewayapi.Gateway
+		listener              string
+		attachedListenerNames []gatewayapi.SectionName
+		wantReady             bool
 	}{
 		{
 			name: "gateway programmed and matching listener programmed",
@@ -56,8 +56,9 @@ func TestIsGatewayProgrammedForRoute(t *testing.T) {
 				[]gatewayapi.Listener{udpListener},
 				[]gatewayapi.ListenerStatus{programmedListenerStatusForRouteReadinessTest("udp", metav1.ConditionTrue)},
 			),
-			listener:  "udp",
-			wantReady: true,
+			listener:              "udp",
+			attachedListenerNames: []gatewayapi.SectionName{"udp"},
+			wantReady:             true,
 		},
 		{
 			name: "gateway programmed but matching listener status missing",
@@ -65,8 +66,9 @@ func TestIsGatewayProgrammedForRoute(t *testing.T) {
 				[]gatewayapi.Listener{udpListener},
 				nil,
 			),
-			listener:  "udp",
-			wantReady: false,
+			listener:              "udp",
+			attachedListenerNames: []gatewayapi.SectionName{"udp"},
+			wantReady:             false,
 		},
 		{
 			name: "gateway programmed but matching listener not programmed",
@@ -74,8 +76,9 @@ func TestIsGatewayProgrammedForRoute(t *testing.T) {
 				[]gatewayapi.Listener{udpListener},
 				[]gatewayapi.ListenerStatus{programmedListenerStatusForRouteReadinessTest("udp", metav1.ConditionFalse)},
 			),
-			listener:  "udp",
-			wantReady: false,
+			listener:              "udp",
+			attachedListenerNames: []gatewayapi.SectionName{"udp"},
+			wantReady:             false,
 		},
 		{
 			name: "gateway not programmed even when matching listener is programmed",
@@ -88,8 +91,9 @@ func TestIsGatewayProgrammedForRoute(t *testing.T) {
 					Listeners: []gatewayapi.ListenerStatus{programmedListenerStatusForRouteReadinessTest("udp", metav1.ConditionTrue)},
 				},
 			},
-			listener:  "udp",
-			wantReady: false,
+			listener:              "udp",
+			attachedListenerNames: []gatewayapi.SectionName{"udp"},
+			wantReady:             false,
 		},
 		{
 			name: "specified listener absent from spec is terminal not transient",
@@ -109,17 +113,31 @@ func TestIsGatewayProgrammedForRoute(t *testing.T) {
 				},
 				[]gatewayapi.ListenerStatus{programmedListenerStatusForRouteReadinessTest("http", metav1.ConditionTrue)},
 			),
-			wantReady: false,
+			attachedListenerNames: []gatewayapi.SectionName{"udp"},
+			wantReady:             false,
+		},
+		{
+			name: "no section name ignores same protocol listener that did not attach",
+			gateway: programmedGatewayForRouteReadinessTest(
+				[]gatewayapi.Listener{
+					{Name: "udp-attached", Protocol: gatewayapi.UDPProtocolType, Port: 9999},
+					{Name: "udp-unattached", Protocol: gatewayapi.UDPProtocolType, Port: 9998},
+				},
+				[]gatewayapi.ListenerStatus{programmedListenerStatusForRouteReadinessTest("udp-unattached", metav1.ConditionTrue)},
+			),
+			attachedListenerNames: []gatewayapi.SectionName{"udp-attached"},
+			wantReady:             false,
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			gateway := supportedGatewayWithCondition{
-				gateway:      tt.gateway,
-				listenerName: tt.listener,
+				gateway:               tt.gateway,
+				listenerName:          tt.listener,
+				attachedListenerNames: tt.attachedListenerNames,
 			}
-			assert.Equal(t, tt.wantReady, isGatewayProgrammedForRoute(udpRoute, gateway))
+			assert.Equal(t, tt.wantReady, isGatewayProgrammedForRoute(gateway))
 		})
 	}
 }
@@ -520,8 +538,9 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 	}
 
 	type expected struct {
-		condition    metav1.Condition
-		listenerName string
+		condition             metav1.Condition
+		listenerName          string
+		attachedListenerNames []gatewayapi.SectionName
 	}
 
 	goodGroup := gatewayapi.Group(gatewayv1.GroupName)
@@ -660,6 +679,50 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 				expected: []expected{
 					{
 						condition: routeConditionAccepted(metav1.ConditionTrue, gatewayapi.RouteReasonAccepted),
+					},
+				},
+			},
+			{
+				name: "basic HTTPRoute without section name tracks only attached listeners",
+				route: func() *gatewayapi.HTTPRoute {
+					r := basicHTTPRoute()
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = new(gatewayapi.PortNumber(80))
+					return r
+				}(),
+				objects: []client.Object{
+					func() *gatewayapi.Gateway {
+						gw := gatewayWithHTTP80Ready()
+						gw.Spec.Listeners = []gatewayapi.Listener{
+							{Name: "http", Port: 80, Protocol: gatewayapi.HTTPProtocolType},
+							{Name: "http-unattached", Port: 81, Protocol: gatewayapi.HTTPProtocolType},
+						}
+						gw.Status.Listeners = []gatewayapi.ListenerStatus{
+							{
+								Name: "http",
+								Conditions: []metav1.Condition{{
+									Type:   string(gatewayapi.ListenerConditionProgrammed),
+									Status: metav1.ConditionTrue,
+								}},
+								SupportedKinds: supportedRouteGroupKinds,
+							},
+							{
+								Name: "http-unattached",
+								Conditions: []metav1.Condition{{
+									Type:   string(gatewayapi.ListenerConditionProgrammed),
+									Status: metav1.ConditionTrue,
+								}},
+								SupportedKinds: supportedRouteGroupKinds,
+							},
+						}
+						return gw
+					}(),
+					gatewayClass,
+					namespace,
+				},
+				expected: []expected{
+					{
+						condition:             routeConditionAccepted(metav1.ConditionTrue, gatewayapi.RouteReasonAccepted),
+						attachedListenerNames: []gatewayapi.SectionName{"http"},
 					},
 				},
 			},
@@ -858,6 +921,9 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 					assert.Equalf(t, "test-namespace", got[i].gateway.Namespace, "gateway namespace #%d", i)
 					assert.Equalf(t, "test-gateway", got[i].gateway.Name, "gateway name #%d", i)
 					assert.Equalf(t, tt.expected[i].listenerName, got[i].listenerName, "listenerName #%d", i)
+					if tt.expected[i].attachedListenerNames != nil {
+						assert.Equalf(t, tt.expected[i].attachedListenerNames, got[i].attachedListenerNames, "attachedListenerNames #%d", i)
+					}
 					assert.Equalf(t, tt.expected[i].condition, got[i].condition, "condition #%d", i)
 				}
 			})

--- a/ingress-controller/internal/controllers/gateway/tcproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tcproute_controller.go
@@ -324,7 +324,7 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, tcproute, "Checking if the tcproute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayProgrammed(gateway.gateway) {
+		if !isGatewayProgrammedForRoute(tcproute, gateway) {
 			debug(log, tcproute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/ingress-controller/internal/controllers/gateway/tcproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tcproute_controller.go
@@ -324,7 +324,7 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, tcproute, "Checking if the tcproute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayProgrammedForRoute(tcproute, gateway) {
+		if !isGatewayProgrammedForRoute(gateway) {
 			debug(log, tcproute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
@@ -396,7 +396,7 @@ func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, tlsroute, "Checking if the tlsroute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayProgrammedForRoute(tlsroute, gateway) {
+		if !isGatewayProgrammedForRoute(gateway) {
 			debug(log, tlsroute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
@@ -396,7 +396,7 @@ func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, tlsroute, "Checking if the tlsroute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayProgrammed(gateway.gateway) {
+		if !isGatewayProgrammedForRoute(tlsroute, gateway) {
 			debug(log, tlsroute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/ingress-controller/internal/controllers/gateway/udproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/udproute_controller.go
@@ -325,7 +325,7 @@ func (r *UDPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, udproute, "Checking if the udproute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayProgrammed(gateway.gateway) {
+		if !isGatewayProgrammedForRoute(udproute, gateway) {
 			debug(log, udproute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/ingress-controller/internal/controllers/gateway/udproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/udproute_controller.go
@@ -325,7 +325,7 @@ func (r *UDPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, udproute, "Checking if the udproute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayProgrammedForRoute(udproute, gateway) {
+		if !isGatewayProgrammedForRoute(gateway) {
 			debug(log, udproute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #4507 
In this pr, besides checking programmed in the gateway level, we added checking if there are any programmed listener could attach to the route. If there are listeners attachable but none programmed, return requeue.
So when gateway's listeners' statuses are wiped, *route_controller will return requeue instead of continuing the reconciliation and then causing DataplaneClient.DeleteObject

p.s
if wiping listener conditions on every reconciliation in gateway controller is not by design, we don't have to fix the issue in the way of this pr.

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
