### PR TITLE
tests: skip flaky test for hybridgateway conformance suite: HTTPRoutePathMatchOrder

### DIFF
--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -34,6 +34,8 @@ var skippedTestsForHybrid = []string{
 	// Core profile.
 	tests.HTTPRouteMethodMatching.ShortName,
 	tests.HTTPRouteQueryParamMatching.ShortName,
+	// TODO: https://github.com/Kong/kong-operator/issues/4581
+	tests.HTTPRoutePathMatchOrder.ShortName,
 
 	// Extended profile.
 	tests.HTTPRouteRewriteHost.ShortName,


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Related issue: https://github.com/Kong/kong-operator/issues/4581

WIP PR which is fixing this test: https://github.com/Kong/kong-operator/pull/4567

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
