### PR TITLE
tests: remove unused client param from GetResponseBodyContains

### DIFF
--- a/pkg/utils/test/predicates.go
+++ b/pkg/utils/test/predicates.go
@@ -881,9 +881,10 @@ func GatewayClassHasSupportedFeatures(t *testing.T, ctx context.Context, gateway
 }
 
 // GetResponseBodyContains issues an HTTP request and checks if a response body contains a string.
-func GetResponseBodyContains(t *testing.T, clients K8sClients, httpc *http.Client, request *http.Request, responseContains string) func() bool {
+func GetResponseBodyContains(t *testing.T, httpc *http.Client, request *http.Request, responseContains string) func() bool {
 	return func() bool {
-		resp, err := httpc.Do(request)
+		ctx := request.Context()
+		resp, err := httpc.Do(request.WithContext(ctx))
 		if err != nil {
 			return false
 		}

--- a/test/integration/ko/httproute_test.go
+++ b/test/integration/ko/httproute_test.go
@@ -104,7 +104,7 @@ func TestHTTPRoute(t *testing.T) {
 	request := helpers.MustBuildRequest(t, ctx, http.MethodGet, "http://"+gatewayIPAddress+"/test", "")
 	require.Eventually(
 		t,
-		testutils.GetResponseBodyContains(t, clients, httpClient, request, "<title>httpbin.org</title>"),
+		testutils.GetResponseBodyContains(t, httpClient, request, "<title>httpbin.org</title>"),
 		httpRouteAccessTimeout,
 		time.Second,
 	)
@@ -113,7 +113,7 @@ func TestHTTPRoute(t *testing.T) {
 	request = helpers.MustBuildRequest(t, ctx, http.MethodGet, "http://"+gatewayIPAddress+"/test/1234", "")
 	require.Eventually(
 		t,
-		testutils.GetResponseBodyContains(t, clients, httpClient, request, "<h1>Not Found</h1>"),
+		testutils.GetResponseBodyContains(t, httpClient, request, "<h1>Not Found</h1>"),
 		httpRouteAccessTimeout,
 		time.Second,
 	)
@@ -236,7 +236,7 @@ func TestHTTPRouteWithTLS(t *testing.T) {
 	request := helpers.MustBuildRequest(t, ctx, http.MethodGet, "https://"+gatewayIPAddress+"/test", host)
 	require.Eventually(
 		t,
-		testutils.GetResponseBodyContains(t, clients, httpClient, request, "<title>httpbin.org</title>"),
+		testutils.GetResponseBodyContains(t, httpClient, request, "<title>httpbin.org</title>"),
 		httpRouteAccessTimeout,
 		time.Second,
 	)
@@ -244,7 +244,7 @@ func TestHTTPRouteWithTLS(t *testing.T) {
 	request = helpers.MustBuildRequest(t, ctx, http.MethodGet, "https://"+gatewayIPAddress+"/test/1234", host)
 	require.Eventually(
 		t,
-		testutils.GetResponseBodyContains(t, clients, httpClient, request, "<h1>Not Found</h1>"),
+		testutils.GetResponseBodyContains(t, httpClient, request, "<h1>Not Found</h1>"),
 		httpRouteAccessTimeout,
 		time.Second,
 	)

--- a/test/integration/konnect/gateway_hybrid_test.go
+++ b/test/integration/konnect/gateway_hybrid_test.go
@@ -182,7 +182,7 @@ func TestGatewayHybridFull(t *testing.T) {
 		request := helpers.MustBuildRequest(t, ctx, http.MethodGet, "http://"+gatewayIPAddress+"/test", "")
 		require.Eventually(
 			t,
-			testutils.GetResponseBodyContains(t, integration.GetClients(), httpClient, request, "<title>httpbin.org</title>"),
+			testutils.GetResponseBodyContains(t, httpClient, request, "<title>httpbin.org</title>"),
 			httpRouteAccessTimeout,
 			time.Second,
 		)
@@ -191,7 +191,7 @@ func TestGatewayHybridFull(t *testing.T) {
 		request = helpers.MustBuildRequest(t, ctx, http.MethodGet, "http://"+gatewayIPAddress+"/test/1234", "")
 		require.Eventually(
 			t,
-			testutils.GetResponseBodyContains(t, integration.GetClients(), httpClient, request, "<h1>Not Found</h1>"),
+			testutils.GetResponseBodyContains(t, httpClient, request, "<h1>Not Found</h1>"),
 			httpRouteAccessTimeout,
 			time.Second,
 		)

--- a/test/integration/konnect/konnect_extension_test.go
+++ b/test/integration/konnect/konnect_extension_test.go
@@ -537,7 +537,7 @@ func konnectExtensionTestBody(t *testing.T, cl client.Client, p KonnectExtension
 	request := helpers.MustBuildRequest(t, ctx, http.MethodGet, "http://"+dpIngressIP+"/test", "")
 	require.Eventually(
 		t,
-		testutils.GetResponseBodyContains(t, integration.GetClients(), httpClient, request, "<title>httpbin.org</title>"),
+		testutils.GetResponseBodyContains(t, httpClient, request, "<title>httpbin.org</title>"),
 		routeAccessTimeout,
 		time.Second,
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
