### PR TITLE
tests: fix getting kong image tags in kongintegration

### DIFF
--- a/ingress-controller/test/helpers/konnect/system_accounts.go
+++ b/ingress-controller/test/helpers/konnect/system_accounts.go
@@ -27,7 +27,7 @@ func CreateTestSystemAccount(ctx context.Context, t *testing.T) string {
 
 	var (
 		systemAccountID   string
-		systemAccountName = fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixMilli())
+		systemAccountName = fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixMicro())
 	)
 	err := retry.New(
 		retry.Attempts(5),

--- a/ingress-controller/test/kongintegration/containers/kong.go
+++ b/ingress-controller/test/kongintegration/containers/kong.go
@@ -61,7 +61,7 @@ type Kong struct {
 // It sets up a cleanup function that will terminate the container when the test finishes.
 func NewKong(ctx context.Context, t *testing.T, opts ...KongOpt) Kong {
 	req := testcontainers.ContainerRequest{
-		Image: kongImageUnderTest(),
+		Image: kongImageUnderTest(t),
 		Env: map[string]string{
 			"KONG_DATABASE":      "off",
 			"KONG_ADMIN_LISTEN":  fmt.Sprintf("0.0.0.0:%s", kongAdminPort),
@@ -173,13 +173,19 @@ func (c Kong) Terminate(ctx context.Context) error {
 // kongImageUnderTest returns the Kong image to be used for integration tests. If both TEST_KONG_IMAGE and
 // TEST_KONG_TAG are set, it will return the image and tag specified by them. Otherwise, it will return
 // the default image (kong:latest or kong/kong-gateway if EE tests enabled).
-func kongImageUnderTest() string {
+func kongImageUnderTest(t *testing.T) string {
+	t.Helper()
+
 	if testenv.KongImage() != "" && testenv.KongTag() != "" {
 		return fmt.Sprintf("%s:%s", testenv.KongImage(), testenv.KongTag())
 	}
 
 	if testenv.KongEnterpriseEnabled() {
-		return "kong/kong-gateway:latest"
+		gatewayTag, err := testenv.GetDependencyVersion("kongintegration.kong-ee")
+		require.NoError(t, err)
+		return "kong/kong-gateway:" + gatewayTag
 	}
-	return "kong:latest"
+	gatewayTag, err := testenv.GetDependencyVersion("kongintegration.kong-oss")
+	require.NoError(t, err)
+	return "kong:" + gatewayTag
 }

--- a/ingress-controller/test/kongintegration/containers/kong_postgres.go
+++ b/ingress-controller/test/kongintegration/containers/kong_postgres.go
@@ -74,7 +74,7 @@ func runKongDBMigrations(ctx context.Context, t *testing.T, networkName string) 
 	// Run Kong migrations bootstrap command in a container.
 	kongMigrationsC, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image: kongImageUnderTest(),
+			Image: kongImageUnderTest(t),
 			Env: map[string]string{
 				"KONG_DATABASE":    "postgres",
 				"KONG_PG_HOST":     postgresContainerNetworkAlias,

--- a/ingress-controller/test/kongintegration/dbmode_update_strategy_test.go
+++ b/ingress-controller/test/kongintegration/dbmode_update_strategy_test.go
@@ -43,8 +43,7 @@ func TestUpdateStrategyDBMode(t *testing.T) {
 	kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), managercfg.AdminAPIClientConfig{}, "")
 	require.NoError(t, err)
 
-	gatewayTag, err := testenv.GetDependencyVersion("kongintegration.kong-ee")
-	require.NoError(t, err)
+	gatewayTag := testenv.KongTag()
 	gatewayTag = trimEnterpriseTagToSemver(gatewayTag)
 
 	logbase, err := zap.NewDevelopment()

--- a/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
+++ b/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
@@ -105,12 +105,14 @@ func TestKongClientGoldenTestsOutputs_Konnect(t *testing.T) {
 	if test.KonnectAccessToken() == "" {
 		t.Skip("Konnect token is not available, skipping test")
 	}
+	if testenv.KongImage() != "kong/kong-gateway" {
+		t.Skip("Non EE image is used, skipping Konnect test")
+	}
 	t.Parallel()
 
 	ctx := t.Context()
 
-	gatewayTag, err := testenv.GetDependencyVersion("kongintegration.kong-ee")
-	require.NoError(t, err)
+	gatewayTag := testenv.KongTag()
 	gatewayTag = trimEnterpriseTagToSemver(gatewayTag)
 
 	systemAccountID := konnect.CreateTestSystemAccount(ctx, t)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes 2 issues with kongintegration tests:

1. system account name collisions

    In this [enterprise run](https://github.com/Kong/kong-operator/actions/runs/27343495854/job/80786134948#step:16:163) the system account creation succeeded but oss didn't:
    
    ```
      kong_client_golden_tests_outputs_test.go:116: 
        	  Error Trace:	/home/runner/work/kong-operator/kong-operator/ingress-controller/test/helpers/konnect/system_accounts.go:73
        	            				  /home/runner/work/kong-operator/kong-operator/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go:116
        	  Error:      	Received unexpected error:
        	            	  All attempts fail:
        	            	  #1: {"status":409,"title":"Resource Conflict","instance":"konnect:trace:14006457785058173005","detail":"A system account with the name [TestKongClientGoldenTestsOutputs_Konnect-1781177294968] already exists"}
        	            	  #2: {"status":409,"title":"Resource Conflict","instance":"konnect:trace:15542941733464467744","detail":"A system account with the name [TestKongClientGoldenTestsOutputs_Konnect-1781177294968] already exists"}
        	            	  #3: {"status":409,"title":"Resource Conflict","instance":"konnect:trace:10875147118887355837","detail":"A system account with the name [TestKongClientGoldenTestsOutputs_Konnect-1781177294968] already exists"}
        	            	  #4: {"status":409,"title":"Resource Conflict","instance":"konnect:trace:12333443368701451875","detail":"A system account with the name [TestKongClientGoldenTestsOutputs_Konnect-1781177294968] already exists"}
        	            	  #5: {"status":409,"title":"Resource Conflict","instance":"konnect:trace:4299601389959045047","detail":"A system account with the name [TestKongClientGoldenTestsOutputs_Konnect-1781177294968] already exists"}
        	  Test:       	TestKongClientGoldenTestsOutputs_Konnect
    ```

    This PR changes the system account name generation to rely on micro instead of milliseconds.

2. Getting kong image tags 

    With this PR the kongintegration tests will not get the tags directly from `.github/workflows/__kongintegration_tests.yaml` but they will rely on the injected tags via `TEST_KONG_IMAGE` and `TEST_KONG_TAG`.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
