### PR TITLE
test(conformance): wait for resource cleanup to converge

### DIFF
--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -3,6 +3,7 @@ package conformance
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,7 +15,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance"
 	conformancev1 "sigs.k8s.io/gateway-api/conformance/apis/v1"
 	conformanceconfig "sigs.k8s.io/gateway-api/conformance/utils/config"
@@ -156,8 +160,89 @@ func runConformance(
 	opts.TimeoutConfig = timeoutConfig
 	opts.RestConfig.QPS = -1
 
+	// The suite runs top-level tests one at a time. Each test (including its
+	// parallel per-request sub-cases) fully completes before the next starts.
+	// Several tests reuse the same resource names though. For example the
+	// "reference-grant" HTTPRoute is created by both HTTPRouteInvalidReferenceGrant
+	// and HTTPRouteReferenceGrant. A test's per-manifest cleanup only issues the
+	// Delete and returns without waiting, so with the hybrid gateway type, whose
+	// Konnect finalizers make teardown slower, a deleted resource can still be
+	// terminating when a later same-named test applies its manifests, then vanish
+	// mid-test. It returns immediately when nothing is terminating, so it
+	// costs effectively nothing in the common case.
+	opts.Hook = func(t *testing.T, _ suite.ConformanceTest, _ *suite.ConformanceTestSuite) {
+		waitForConformanceResourcesCleanup(ctx, clients.MgrClient, t.Logf)
+	}
+
 	t.Log("running the Gateway API conformance test suite")
 	conformance.RunConformanceWithOptions(t, opts)
+}
+
+// conformanceCleanupTimeout bounds how long the post-test Hook waits for
+// terminating resources to disappear before giving up and letting the next test
+// proceed anyway (so a stuck finalizer can't hang the whole suite).
+const conformanceCleanupTimeout = 90 * time.Second
+
+// waitForConformanceResourcesCleanup blocks until no HTTPRoute, TLSRoute or
+// ReferenceGrant in any conformance namespace still has a deletion timestamp,
+// i.e. the previous test's resources have been fully finalized and removed.
+// These are per-test resources (the base manifests only contribute
+// Gateways/Services), and several tests reuse the same names (for example the
+// "reference-grant" HTTPRoute, the "gateway-conformance-infra-test" TLSRoute,
+// and the "reference-grant-wrong-*" ReferenceGrants shared by the
+// *InvalidReferenceGrant tests), so letting them fully drain prevents the next
+// test from racing a still-finalizing object. HTTPRoutes and TLSRoutes carry
+// the operator's (hybrid/Konnect) finalizers and are the slow case;
+// ReferenceGrants are not finalized and usually clear instantly, but are
+// checked too for robustness. HTTPRoute and TLSRoute are the only route kinds
+// the operator supports. In the common case nothing is terminating and this
+// returns right away. On timeout it logs and returns without failing.
+func waitForConformanceResourcesCleanup(ctx context.Context, cl client.Client, logf func(string, ...any)) {
+	waitCtx, cancel := context.WithTimeout(ctx, conformanceCleanupTimeout)
+	defer cancel()
+
+	isConformanceNS := func(ns string) bool { return strings.HasPrefix(ns, conformanceNamespacePrefix) }
+
+	err := wait.PollUntilContextCancel(waitCtx, 200*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+		var httpRoutes gatewayv1.HTTPRouteList
+		if err := cl.List(ctx, &httpRoutes); err != nil {
+			// Treat transient list errors as "not ready yet" and keep polling
+			// until the context deadline.
+			return false, nil //nolint:nilerr
+		}
+		for i := range httpRoutes.Items {
+			if r := &httpRoutes.Items[i]; isConformanceNS(r.Namespace) && r.DeletionTimestamp != nil {
+				logf("waiting for HTTPRoute %s/%s to finish terminating before next test", r.Namespace, r.Name)
+				return false, nil
+			}
+		}
+
+		var tlsRoutes gatewayv1alpha2.TLSRouteList
+		if err := cl.List(ctx, &tlsRoutes); err != nil {
+			return false, nil //nolint:nilerr
+		}
+		for i := range tlsRoutes.Items {
+			if r := &tlsRoutes.Items[i]; isConformanceNS(r.Namespace) && r.DeletionTimestamp != nil {
+				logf("waiting for TLSRoute %s/%s to finish terminating before next test", r.Namespace, r.Name)
+				return false, nil
+			}
+		}
+
+		var grants gatewayv1beta1.ReferenceGrantList
+		if err := cl.List(ctx, &grants); err != nil {
+			return false, nil //nolint:nilerr
+		}
+		for i := range grants.Items {
+			if g := &grants.Items[i]; isConformanceNS(g.Namespace) && g.DeletionTimestamp != nil {
+				logf("waiting for ReferenceGrant %s/%s to finish terminating before next test", g.Namespace, g.Name)
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		logf("timed out after %s waiting for conformance HTTPRoutes/ReferenceGrants to be cleaned up; proceeding anyway", conformanceCleanupTimeout)
+	}
 }
 
 type gatewayType string

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -137,6 +139,17 @@ func TestMain(m *testing.M) {
 		logf := func(format string, args ...any) { fmt.Printf(format+"\n", args...) }
 		exitOnErr(waitForConformanceGatewaysToCleanup(ctx, clients.GatewayClient.GatewayV1(), logf))
 		exitOnErr(waitForConformanceKonnectGatewayControlPlanesToCleanup(ctx, logf))
+		// Gateways and KonnectGatewayControlPlanes are not the only resources the
+		// operator finalizes. Deleting them cascades to Konnect entity CRs
+		// (KongService, KongRoute, KongUpstream, KongTarget, ...) created in the
+		// conformance namespaces. Those carry their own finalizers, and if the
+		// operator's controller manager is stopped (ctx cancelled below) before
+		// it removes them, the entities are left dangling in the cluster and in
+		// Konnect. A namespace cannot finish terminating while it still holds
+		// finalizer-bearing resources, so waiting for the conformance namespaces
+		// to fully disappear keeps the operator alive until every entity it owns
+		// has been cleaned up.
+		exitOnErr(waitForConformanceNamespacesToCleanup(ctx, clients.MgrClient, logf))
 	}
 
 	if existingCluster == "" && cleanupResources {
@@ -244,6 +257,54 @@ func waitForConformanceKonnectGatewayControlPlanesToCleanup(ctx context.Context,
 				return nil
 			}
 			controlPlanesRemaining = len(controlPlaneList.Items)
+		}
+	}
+}
+
+// conformanceNamespacePrefix is the prefix shared by every namespace the
+// conformance suite creates (gateway-conformance-infra, -app-backend,
+// -web-backend).
+const conformanceNamespacePrefix = "gateway-conformance-"
+
+// conformanceNamespaceCleanupTimeout bounds how long we keep the operator alive
+// waiting for the conformance namespaces to terminate, so a genuinely stuck
+// finalizer surfaces as a failure instead of hanging the suite forever.
+const conformanceNamespaceCleanupTimeout = 5 * time.Minute
+
+// waitForConformanceNamespacesToCleanup blocks until no namespace with the
+// conformance prefix exists anymore. Because a namespace stays in Terminating
+// while it still contains finalizer-bearing resources, this guarantees that all
+// operator-owned Konnect entity CRs (KongService, KongRoute, KongUpstream,
+// KongTarget, ...) created in those namespaces have been fully reconciled away
+// before the controller manager is shut down.
+func waitForConformanceNamespacesToCleanup(ctx context.Context, cl client.Client, logf func(string, ...any)) error {
+	ctx, cancel := context.WithTimeout(ctx, conformanceNamespaceCleanupTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	var remaining []string
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("conformance cleanup failed (namespaces still terminating: %v): %w", remaining, ctx.Err())
+		case <-ticker.C:
+			var nsList corev1.NamespaceList
+			if err := cl.List(ctx, &nsList); err != nil {
+				return fmt.Errorf("failed to list namespaces during cleanup: %w", err)
+			}
+
+			remaining = remaining[:0]
+			for i := range nsList.Items {
+				if strings.HasPrefix(nsList.Items[i].Name, conformanceNamespacePrefix) {
+					remaining = append(remaining, nsList.Items[i].Name)
+				}
+			}
+			if len(remaining) == 0 {
+				return nil
+			}
+			logf("waiting for conformance namespaces to finish terminating (operator still cleaning up owned entities): %v", remaining)
 		}
 	}
 }


### PR DESCRIPTION


**What this PR does / why we need it**:

Gateway API conformance runs top-level tests sequentially and several reuse the same resource names. For example the "reference-grant" HTTPRoute is created by both HTTPRouteInvalidReferenceGrant and HTTPRouteReferenceGrant. A test's per-manifest cleanup only issues the Delete and returns without waiting, so with the hybrid gateway type, whose Konnect finalizers make teardown slower, a deleted resource can still be terminating when a later same-named test applies its manifests, then disappear mid-test. The applier logs "Updating reference-grant HTTPRoute" and the test then fails with "error fetching HTTPRoute ... not found". This is reliably hit when such tests run back to back, for example when narrowed via a -run filter.

Add a post-test suite Hook that waits until the just-deleted HTTPRoutes and ReferenceGrants in the conformance namespaces are fully gone before the next test runs. It returns immediately when nothing is terminating, so it costs effectively nothing in the common case, and it is bounded so a stuck finalizer cannot hang the suite.

Additionally, during suite teardown keep the controller manager alive until the conformance namespaces are fully terminated. Deleting Gateways and KonnectGatewayControlPlanes cascades to Konnect entity CRs such as KongService, KongRoute, KongUpstream and KongTarget, which carry their own finalizers. Previously the manager could be stopped before removing them, leaving the entities dangling in the cluster and in Konnect. A namespace cannot finish terminating while it still holds finalizer-bearing resources, so waiting for the conformance namespaces to disappear guarantees every operator-owned entity has been reconciled away first.


**Which issue this PR fixes**

Fixes #4635

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
