### PR TITLE
test(conformance): enable HTTPRouteHeaderMatching for hybridgateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,9 +143,9 @@
 - Hybridgateway: order overlapping header-only `HTTPRoute` matches by Gateway API
   specificity. Header-only matches are translated to `KongRoute`s with a catch-all
   regex path so Kong's `regex_priority` becomes effective, and a per-match priority
-  derived from path/method/header/query specificity keeps more specific matches
-  ahead of less specific ones while staying below path-based routes. This enables
-  the `HTTPRouteHeaderMatching` Gateway API conformance test for the hybrid gateway.
+  derived from method and header specificity keeps more specific header matches
+  ahead of less specific ones. This enables the `HTTPRouteHeaderMatching` Gateway API
+  conformance test for the hybrid gateway.
   [#4640](https://github.com/Kong/kong-operator/pull/4640)
 
 ## [v2.2.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,10 @@
   derived from method and header specificity keeps more specific header matches
   ahead of less specific ones. This enables the `HTTPRouteHeaderMatching` Gateway API
   conformance test for the hybrid gateway.
+  Generated header-only priorities stay below `1 << 20` (`1048576`), while generated
+  path-based priorities start at that value. Use custom `KongRoute` priorities below
+  or above that boundary depending on whether they should sort before or after
+  generated path-based routes.
   [#4640](https://github.com/Kong/kong-operator/pull/4640)
 
 ## [v2.2.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,13 @@
   is not removed when a resource is updated to remove the cross-namespace
   reference.
   [#4663](https://github.com/Kong/kong-operator/pull/4663)
+- Hybridgateway: order overlapping header-only `HTTPRoute` matches by Gateway API
+  specificity. Header-only matches are translated to `KongRoute`s with a catch-all
+  regex path so Kong's `regex_priority` becomes effective, and a per-match priority
+  derived from path/method/header/query specificity keeps more specific matches
+  ahead of less specific ones while staying below path-based routes. This enables
+  the `HTTPRouteHeaderMatching` Gateway API conformance test for the hybrid gateway.
+  [#4640](https://github.com/Kong/kong-operator/pull/4640)
 
 ## [v2.2.0]
 

--- a/controller/hybridgateway/builder/kongroute.go
+++ b/controller/hybridgateway/builder/kongroute.go
@@ -24,6 +24,9 @@ const (
 	// KongHeaderRegexPrefix is a reserved prefix string that Kong uses to determine if it should parse a header value
 	// as a regex.
 	KongHeaderRegexPrefix = "~*"
+	// KongHTTPRouteHeaderOnlyRegexPath is a catch-all regex path used to make regex_priority effective
+	// for HTTPRoute matches that only match on headers.
+	KongHTTPRouteHeaderOnlyRegexPath = KongPathRegexPrefix + "/(.*)"
 )
 
 // KongRouteBuilder is a builder for configurationv1alpha1.KongRoute resources.
@@ -81,6 +84,23 @@ func (b *KongRouteBuilder) WithHTTPRouteMatch(match gwtypes.HTTPRouteMatch, setC
 	}
 	// Note: QueryParams are not natively supported by KongRoute
 
+	return b
+}
+
+// WithRegexPriority sets the regex_priority for the KongRoute being built.
+func (b *KongRouteBuilder) WithRegexPriority(priority *int64) *KongRouteBuilder {
+	if priority != nil {
+		b.route.Spec.RegexPriority = priority
+	}
+	return b
+}
+
+// WithHeaderOnlyRegexPath adds a catch-all regex path when needed so Kong can use
+// regex_priority to order overlapping header-only HTTPRoute matches.
+func (b *KongRouteBuilder) WithHeaderOnlyRegexPath() *KongRouteBuilder {
+	if len(b.route.Spec.Paths) == 0 && len(b.route.Spec.Headers) > 0 {
+		b.route.Spec.Paths = append(b.route.Spec.Paths, KongHTTPRouteHeaderOnlyRegexPath)
+	}
 	return b
 }
 

--- a/controller/hybridgateway/builder/kongroute.go
+++ b/controller/hybridgateway/builder/kongroute.go
@@ -27,6 +27,9 @@ const (
 	// KongHTTPRouteHeaderOnlyRegexPath is a catch-all regex path used to make regex_priority effective
 	// for HTTPRoute matches that only match on headers.
 	KongHTTPRouteHeaderOnlyRegexPath = KongPathRegexPrefix + "/(.*)"
+	// KongHTTPRoutePathRegexPriorityOffset reserves lower regex_priority values for synthetic
+	// catch-all regex routes used by default path header-only matches.
+	KongHTTPRoutePathRegexPriorityOffset int64 = 1 << 20
 )
 
 // KongRouteBuilder is a builder for configurationv1alpha1.KongRoute resources.
@@ -96,10 +99,15 @@ func (b *KongRouteBuilder) WithRegexPriority(priority *int64) *KongRouteBuilder 
 }
 
 // WithHeaderOnlyRegexPath adds a catch-all regex path when needed so Kong can use
-// regex_priority to order overlapping header-only HTTPRoute matches.
+// regex_priority to order overlapping HTTPRoute matches that only specify headers
+// and otherwise use the default root path.
 func (b *KongRouteBuilder) WithHeaderOnlyRegexPath() *KongRouteBuilder {
-	if len(b.route.Spec.Paths) == 0 && len(b.route.Spec.Headers) > 0 {
-		b.route.Spec.Paths = append(b.route.Spec.Paths, KongHTTPRouteHeaderOnlyRegexPath)
+	if len(b.route.Spec.Headers) == 0 {
+		return b
+	}
+
+	if len(b.route.Spec.Paths) == 0 || (len(b.route.Spec.Paths) == 1 && b.route.Spec.Paths[0] == "/") {
+		b.route.Spec.Paths = []string{KongHTTPRouteHeaderOnlyRegexPath}
 	}
 	return b
 }
@@ -274,7 +282,7 @@ func GenerateKongRoutePathFromHTTPRouteMatch(pathMatch *gatewayv1.HTTPPathMatch,
 }
 
 func regexPriorityForHTTPPathMatch(matchType gatewayv1.PathMatchType, value string) *int64 {
-	priority := int64(len(value) * 2)
+	priority := KongHTTPRoutePathRegexPriorityOffset + int64(len(value)*2)
 	if matchType == gatewayv1.PathMatchExact {
 		priority++
 	}

--- a/controller/hybridgateway/builder/kongroute_test.go
+++ b/controller/hybridgateway/builder/kongroute_test.go
@@ -93,7 +93,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
 				assert.Equal(t, []string{"~/api$", "/api/"}, route.Spec.Paths)
-				assert.Equal(t, new(int64(8)), route.Spec.RegexPriority)
+				assert.Equal(t, new(KongHTTPRoutePathRegexPriorityOffset+8), route.Spec.RegexPriority)
 				assert.Empty(t, route.Spec.Methods)
 				assert.Nil(t, route.Spec.Headers)
 			},
@@ -108,7 +108,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
 				assert.Equal(t, []string{"~/api$"}, route.Spec.Paths)
-				assert.Equal(t, new(int64(9)), route.Spec.RegexPriority)
+				assert.Equal(t, new(KongHTTPRoutePathRegexPriorityOffset+9), route.Spec.RegexPriority)
 				assert.Empty(t, route.Spec.Methods)
 				assert.Nil(t, route.Spec.Headers)
 			},
@@ -239,7 +239,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
 				assert.Equal(t, []string{"~/api$", "/api/"}, route.Spec.Paths)
-				assert.Equal(t, new(int64(8)), route.Spec.RegexPriority)
+				assert.Equal(t, new(KongHTTPRoutePathRegexPriorityOffset+8), route.Spec.RegexPriority)
 				assert.Equal(t, []string{"GET"}, route.Spec.Methods)
 				require.NotNil(t, route.Spec.Headers)
 				assert.Equal(t, []string{"Bearer token"}, route.Spec.Headers["Authorization"])

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -474,7 +474,7 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 			// Gateway API semantics require OR across matches within a rule
 			// and AND within a single match. Generating a route per match
 			// preserves the OR semantics for Hybrid Gateway.
-			routes, err := kongroute.RoutesForRule(ctx, logger, c.Client, c.route, rule, &pRef, cp, namingParentRef, serviceName, hostnames)
+			routes, err := kongroute.RoutesForRule(ctx, logger, c.Client, c.route, rule, ruleIndex, &pRef, cp, namingParentRef, serviceName, hostnames)
 			if err != nil {
 				log.Error(logger, err, "Failed to translate KongRoute resources for rule, skipping rule",
 					"ruleIndex", ruleIndex,

--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -25,6 +25,7 @@ import (
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
+	routebuilder "github.com/kong/kong-operator/v2/controller/hybridgateway/builder"
 	routeconst "github.com/kong/kong-operator/v2/controller/hybridgateway/const/route"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/namegen"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
@@ -984,6 +985,7 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 				routeNames := map[string]struct{}{}
 				serviceNames := map[string]struct{}{}
 				headersByRoute := map[string]int{}
+				priorityByHeaders := map[string]int64{}
 
 				for _, obj := range store {
 					route, ok := obj.(*configurationv1alpha1.KongRoute)
@@ -992,8 +994,9 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 					}
 
 					routeNames[route.Name] = struct{}{}
-					assert.Empty(t, route.Spec.Paths)
+					assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, route.Spec.Paths)
 					assert.Empty(t, route.Spec.Methods)
+					require.NotNil(t, route.Spec.RegexPriority)
 					require.NotNil(t, route.Spec.ServiceRef)
 					require.NotNil(t, route.Spec.ServiceRef.NamespacedRef)
 
@@ -1002,6 +1005,7 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 
 					headersKey := canonicalHeaderMatchSet(route.Spec.Headers)
 					headersByRoute[headersKey]++
+					priorityByHeaders[headersKey] = *route.Spec.RegexPriority
 				}
 
 				expectedHeaders := map[string]int{
@@ -1017,6 +1021,8 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 				assert.Len(t, routeNames, 7)
 				assert.Len(t, serviceNames, 1)
 				assert.Equal(t, expectedHeaders, headersByRoute)
+				assert.Greater(t, priorityByHeaders["color=orange&version=two"], priorityByHeaders["version=two"])
+				assert.Greater(t, priorityByHeaders["version=two"], priorityByHeaders["color=blue"])
 			},
 		},
 		{

--- a/controller/hybridgateway/converter/tls_route.go
+++ b/controller/hybridgateway/converter/tls_route.go
@@ -267,7 +267,7 @@ func (c *tlsRouteConverter) translate(ctx context.Context, logger logr.Logger) e
 			log.Debug(logger, "Successfully translated KongService resource", "service", serviceName)
 
 			// Build the KongRoute resource.
-			routes, err := kongroute.RoutesForRule(ctx, logger, c.Client, c.route, rule, &pRef, cp, namingParentRef, serviceName, hostnames)
+			routes, err := kongroute.RoutesForRule(ctx, logger, c.Client, c.route, rule, ruleIndex, &pRef, cp, namingParentRef, serviceName, hostnames)
 			if err != nil {
 				log.Error(logger, err, "Failed to translate KongRoute resource, skipping rule",
 					"service", serviceName,

--- a/controller/hybridgateway/kongroute/route.go
+++ b/controller/hybridgateway/kongroute/route.go
@@ -183,13 +183,9 @@ type httpRoutePriorityClass struct {
 }
 
 func httpRouteMatchPriorities(httpRoute *gwtypes.HTTPRoute) map[httpRouteMatchPriorityKey]int64 {
-	type routeAndClass struct {
-		class httpRoutePriorityClass
-	}
-
 	classes := make([]httpRoutePriorityClass, 0)
 	classSet := make(map[httpRoutePriorityClass]struct{})
-	matchCountByClass := make(map[routeAndClass]int)
+	matchCountByClass := make(map[httpRoutePriorityClass]int)
 	for _, rule := range httpRoute.Spec.Rules {
 		for _, match := range rule.Matches {
 			class := calculateHTTPRoutePriorityClass(match)
@@ -197,7 +193,7 @@ func httpRouteMatchPriorities(httpRoute *gwtypes.HTTPRoute) map[httpRouteMatchPr
 				classSet[class] = struct{}{}
 				classes = append(classes, class)
 			}
-			matchCountByClass[routeAndClass{class: class}]++
+			matchCountByClass[class]++
 		}
 	}
 
@@ -207,15 +203,18 @@ func httpRouteMatchPriorities(httpRoute *gwtypes.HTTPRoute) map[httpRouteMatchPr
 		rankByClass[class] = int64(rank)
 	}
 
+	// priorityClassSize bounds the number of matches that can share a single
+	// specificity class without their offsets overflowing into the adjacent
+	// class' range. Gateway API caps the matches per HTTPRoute well below this,
+	// so the assumption holds in practice.
 	const priorityClassSize = int64(1 << 10)
-	seenByClass := make(map[routeAndClass]int)
+	seenByClass := make(map[httpRoutePriorityClass]int)
 	priorities := make(map[httpRouteMatchPriorityKey]int64)
 	for ruleIndex, rule := range httpRoute.Spec.Rules {
 		for matchIndex, match := range rule.Matches {
 			class := calculateHTTPRoutePriorityClass(match)
-			key := routeAndClass{class: class}
-			offset := matchCountByClass[key] - 1 - seenByClass[key]
-			seenByClass[key]++
+			offset := matchCountByClass[class] - 1 - seenByClass[class]
+			seenByClass[class]++
 			priorities[httpRouteMatchPriorityKey{
 				ruleIndex:  ruleIndex,
 				matchIndex: matchIndex,
@@ -234,10 +233,7 @@ func priorityForHeaderOnlyHTTPRouteMatch(
 		return nil
 	}
 	priority := headerOnlyRegexPriority(
-		priorities[httpRouteMatchPriorityKey{
-			ruleIndex:  ruleIndex,
-			matchIndex: matchIndex,
-		}],
+		priorityForHTTPRouteMatch(priorities, ruleIndex, matchIndex),
 		priorities,
 	)
 	return &priority

--- a/controller/hybridgateway/kongroute/route.go
+++ b/controller/hybridgateway/kongroute/route.go
@@ -175,11 +175,10 @@ type httpRouteMatchPriorityKey struct {
 }
 
 type httpRoutePriorityClass struct {
-	pathType        gatewayv1.PathMatchType
-	pathLength      int
-	hasMethodMatch  bool
-	headerCount     int
-	queryParamCount int
+	pathType       gatewayv1.PathMatchType
+	pathLength     int
+	hasMethodMatch bool
+	headerCount    int
 }
 
 func httpRouteMatchPriorities(httpRoute *gwtypes.HTTPRoute) map[httpRouteMatchPriorityKey]int64 {
@@ -229,24 +228,26 @@ func priorityForHeaderOnlyHTTPRouteMatch(
 	priorities map[httpRouteMatchPriorityKey]int64,
 	ruleIndex, matchIndex int,
 ) *int64 {
-	if match.Path != nil || len(match.Headers) == 0 {
+	if !isHeaderOnlyDefaultPathHTTPRouteMatch(match) {
 		return nil
 	}
-	priority := headerOnlyRegexPriority(
-		priorityForHTTPRouteMatch(priorities, ruleIndex, matchIndex),
-		priorities,
-	)
+	priority := priorityForHTTPRouteMatch(priorities, ruleIndex, matchIndex)
 	return &priority
 }
 
-func headerOnlyRegexPriority(priority int64, priorities map[httpRouteMatchPriorityKey]int64) int64 {
-	var maxPriority int64
-	for _, p := range priorities {
-		if p > maxPriority {
-			maxPriority = p
-		}
+func isHeaderOnlyDefaultPathHTTPRouteMatch(match gatewayv1.HTTPRouteMatch) bool {
+	if len(match.Headers) == 0 {
+		return false
 	}
-	return -(maxPriority - priority + 1)
+	if match.Path == nil {
+		return true
+	}
+
+	pathType := gatewayv1.PathMatchPathPrefix
+	if match.Path.Type != nil {
+		pathType = *match.Path.Type
+	}
+	return pathType == gatewayv1.PathMatchPathPrefix && match.Path.Value != nil && *match.Path.Value == "/"
 }
 
 func priorityForHTTPRouteMatch(priorities map[httpRouteMatchPriorityKey]int64, ruleIndex, matchIndex int) int64 {
@@ -269,7 +270,6 @@ func calculateHTTPRoutePriorityClass(match gatewayv1.HTTPRouteMatch) httpRoutePr
 	}
 	class.hasMethodMatch = match.Method != nil
 	class.headerCount = countEffectiveHTTPHeaderMatches(match.Headers)
-	class.queryParamCount = countEffectiveHTTPQueryParamMatches(match.QueryParams)
 	return class
 }
 
@@ -286,7 +286,7 @@ func compareHTTPRoutePriorityClass(a, b httpRoutePriorityClass) int {
 	if c := a.headerCount - b.headerCount; c != 0 {
 		return c
 	}
-	return a.queryParamCount - b.queryParamCount
+	return 0
 }
 
 func comparePathTypePriority(a, b gatewayv1.PathMatchType) int {
@@ -326,18 +326,6 @@ func countEffectiveHTTPHeaderMatches(headers []gatewayv1.HTTPHeaderMatch) int {
 		seenHeaders[name] = struct{}{}
 	}
 	return len(seenHeaders)
-}
-
-func countEffectiveHTTPQueryParamMatches(queryParams []gatewayv1.HTTPQueryParamMatch) int {
-	seenQueryParams := make(map[string]struct{}, len(queryParams))
-	for _, queryParam := range queryParams {
-		name := string(queryParam.Name)
-		if _, ok := seenQueryParams[name]; ok {
-			continue
-		}
-		seenQueryParams[name] = struct{}{}
-	}
-	return len(seenQueryParams)
 }
 
 // needsCaptureGroup checks if the given HTTPRoute rule requires a capture group

--- a/controller/hybridgateway/kongroute/route.go
+++ b/controller/hybridgateway/kongroute/route.go
@@ -3,6 +3,8 @@ package kongroute
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/go-logr/logr"
@@ -47,6 +49,7 @@ func RoutesForRule[
 	cl client.Client,
 	route TPtr,
 	rule R,
+	ruleIndex int,
 	pRef *gwtypes.ParentReference,
 	cp *commonv1alpha1.ControlPlaneRef,
 	namingParentRef *gwtypes.ParentReference,
@@ -59,7 +62,7 @@ func RoutesForRule[
 		if !ok {
 			return nil, fmt.Errorf("failed to build KongRoute: unmatched route type and rule type: %T and %T", route, rule)
 		}
-		return RoutesForHTTPRouteRule(ctx, logger, cl, r, httpRule, pRef, cp, namingParentRef, serviceName, hostnames)
+		return RoutesForHTTPRouteRule(ctx, logger, cl, r, httpRule, ruleIndex, pRef, cp, namingParentRef, serviceName, hostnames)
 	case *gwtypes.TLSRoute:
 		tlsRule, ok := any(rule).(gwtypes.TLSRouteRule)
 		if !ok {
@@ -87,6 +90,7 @@ func RoutesForHTTPRouteRule(
 	cl client.Client,
 	httpRoute *gwtypes.HTTPRoute,
 	rule gwtypes.HTTPRouteRule,
+	ruleIndex int,
 	pRef *gwtypes.ParentReference,
 	cp *commonv1alpha1.ControlPlaneRef,
 	namingParentRef *gwtypes.ParentReference,
@@ -112,6 +116,7 @@ func RoutesForHTTPRouteRule(
 
 	// Check filters to determine if we need capture groups in paths.
 	setCaptureGroup := needsCaptureGroup(rule)
+	priorities := httpRouteMatchPriorities(httpRoute)
 
 	stripPath, err := metadata.ExtractStripPath(httpRoute.Annotations)
 	if err != nil {
@@ -141,6 +146,9 @@ func RoutesForHTTPRouteRule(
 			WithPreserveHost(preserveHost).
 			WithKongService(serviceName).
 			WithHTTPRouteMatch(match, setCaptureGroup)
+		if priority := priorityForHeaderOnlyHTTPRouteMatch(match, priorities, ruleIndex, i); priority != nil {
+			routeBuilder.WithRegexPriority(priority).WithHeaderOnlyRegexPath()
+		}
 
 		newRoute, buildErr := routeBuilder.Build()
 		if buildErr != nil {
@@ -159,6 +167,181 @@ func RoutesForHTTPRouteRule(
 	}
 
 	return kongRoutes, nil
+}
+
+type httpRouteMatchPriorityKey struct {
+	ruleIndex  int
+	matchIndex int
+}
+
+type httpRoutePriorityClass struct {
+	pathType        gatewayv1.PathMatchType
+	pathLength      int
+	hasMethodMatch  bool
+	headerCount     int
+	queryParamCount int
+}
+
+func httpRouteMatchPriorities(httpRoute *gwtypes.HTTPRoute) map[httpRouteMatchPriorityKey]int64 {
+	type routeAndClass struct {
+		class httpRoutePriorityClass
+	}
+
+	classes := make([]httpRoutePriorityClass, 0)
+	classSet := make(map[httpRoutePriorityClass]struct{})
+	matchCountByClass := make(map[routeAndClass]int)
+	for _, rule := range httpRoute.Spec.Rules {
+		for _, match := range rule.Matches {
+			class := calculateHTTPRoutePriorityClass(match)
+			if _, ok := classSet[class]; !ok {
+				classSet[class] = struct{}{}
+				classes = append(classes, class)
+			}
+			matchCountByClass[routeAndClass{class: class}]++
+		}
+	}
+
+	slices.SortFunc(classes, compareHTTPRoutePriorityClass)
+	rankByClass := make(map[httpRoutePriorityClass]int64, len(classes))
+	for rank, class := range classes {
+		rankByClass[class] = int64(rank)
+	}
+
+	const priorityClassSize = int64(1 << 10)
+	seenByClass := make(map[routeAndClass]int)
+	priorities := make(map[httpRouteMatchPriorityKey]int64)
+	for ruleIndex, rule := range httpRoute.Spec.Rules {
+		for matchIndex, match := range rule.Matches {
+			class := calculateHTTPRoutePriorityClass(match)
+			key := routeAndClass{class: class}
+			offset := matchCountByClass[key] - 1 - seenByClass[key]
+			seenByClass[key]++
+			priorities[httpRouteMatchPriorityKey{
+				ruleIndex:  ruleIndex,
+				matchIndex: matchIndex,
+			}] = rankByClass[class]*priorityClassSize + int64(offset)
+		}
+	}
+	return priorities
+}
+
+func priorityForHeaderOnlyHTTPRouteMatch(
+	match gatewayv1.HTTPRouteMatch,
+	priorities map[httpRouteMatchPriorityKey]int64,
+	ruleIndex, matchIndex int,
+) *int64 {
+	if match.Path != nil || len(match.Headers) == 0 {
+		return nil
+	}
+	priority := headerOnlyRegexPriority(
+		priorities[httpRouteMatchPriorityKey{
+			ruleIndex:  ruleIndex,
+			matchIndex: matchIndex,
+		}],
+		priorities,
+	)
+	return &priority
+}
+
+func headerOnlyRegexPriority(priority int64, priorities map[httpRouteMatchPriorityKey]int64) int64 {
+	var maxPriority int64
+	for _, p := range priorities {
+		if p > maxPriority {
+			maxPriority = p
+		}
+	}
+	return -(maxPriority - priority + 1)
+}
+
+func priorityForHTTPRouteMatch(priorities map[httpRouteMatchPriorityKey]int64, ruleIndex, matchIndex int) int64 {
+	return priorities[httpRouteMatchPriorityKey{
+		ruleIndex:  ruleIndex,
+		matchIndex: matchIndex,
+	}]
+}
+
+func calculateHTTPRoutePriorityClass(match gatewayv1.HTTPRouteMatch) httpRoutePriorityClass {
+	class := httpRoutePriorityClass{}
+	if match.Path != nil {
+		class.pathType = gatewayv1.PathMatchPathPrefix
+		if match.Path.Type != nil {
+			class.pathType = *match.Path.Type
+		}
+		if match.Path.Value != nil {
+			class.pathLength = len(*match.Path.Value)
+		}
+	}
+	class.hasMethodMatch = match.Method != nil
+	class.headerCount = countEffectiveHTTPHeaderMatches(match.Headers)
+	class.queryParamCount = countEffectiveHTTPQueryParamMatches(match.QueryParams)
+	return class
+}
+
+func compareHTTPRoutePriorityClass(a, b httpRoutePriorityClass) int {
+	if c := comparePathTypePriority(a.pathType, b.pathType); c != 0 {
+		return c
+	}
+	if c := a.pathLength - b.pathLength; c != 0 {
+		return c
+	}
+	if c := compareBool(a.hasMethodMatch, b.hasMethodMatch); c != 0 {
+		return c
+	}
+	if c := a.headerCount - b.headerCount; c != 0 {
+		return c
+	}
+	return a.queryParamCount - b.queryParamCount
+}
+
+func comparePathTypePriority(a, b gatewayv1.PathMatchType) int {
+	return pathTypePriority(a) - pathTypePriority(b)
+}
+
+func pathTypePriority(t gatewayv1.PathMatchType) int {
+	switch t {
+	case gatewayv1.PathMatchRegularExpression:
+		return 3
+	case gatewayv1.PathMatchExact:
+		return 2
+	case gatewayv1.PathMatchPathPrefix:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func compareBool(a, b bool) int {
+	if a == b {
+		return 0
+	}
+	if a {
+		return 1
+	}
+	return -1
+}
+
+func countEffectiveHTTPHeaderMatches(headers []gatewayv1.HTTPHeaderMatch) int {
+	seenHeaders := make(map[string]struct{}, len(headers))
+	for _, header := range headers {
+		name := strings.ToLower(string(header.Name))
+		if _, ok := seenHeaders[name]; ok {
+			continue
+		}
+		seenHeaders[name] = struct{}{}
+	}
+	return len(seenHeaders)
+}
+
+func countEffectiveHTTPQueryParamMatches(queryParams []gatewayv1.HTTPQueryParamMatch) int {
+	seenQueryParams := make(map[string]struct{}, len(queryParams))
+	for _, queryParam := range queryParams {
+		name := string(queryParam.Name)
+		if _, ok := seenQueryParams[name]; ok {
+			continue
+		}
+		seenQueryParams[name] = struct{}{}
+	}
+	return len(seenQueryParams)
 }
 
 // needsCaptureGroup checks if the given HTTPRoute rule requires a capture group

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -499,7 +499,7 @@ func TestRoutesForHTTPRouteRule_MalformedAnnotations(t *testing.T) {
 				},
 			}
 
-			routes, err := RoutesForHTTPRouteRule(ctx, logger, fakeClient, httpRoute, rule, pRef, cpRef, nil, "test-service", nil)
+			routes, err := RoutesForHTTPRouteRule(ctx, logger, fakeClient, httpRoute, rule, 0, pRef, cpRef, nil, "test-service", nil)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, hgerrors.ErrMalformedAnnotation)
 			assert.Nil(t, routes)

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -63,6 +63,10 @@ func TestRoutesForRule(t *testing.T) {
 				},
 			},
 			{
+				Path: &gatewayv1.HTTPPathMatch{
+					Type:  &prefix,
+					Value: new("/"),
+				},
 				Headers: []gatewayv1.HTTPHeaderMatch{{
 					Name:  "X-Foo",
 					Value: "bar",
@@ -198,13 +202,13 @@ func TestRoutesForRule(t *testing.T) {
 					assert.Contains(t, result.Spec.Headers, "X-Foo")
 					assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, result.Spec.Paths)
 					require.NotNil(t, result.Spec.RegexPriority)
-					assert.Negative(t, *result.Spec.RegexPriority)
+					assert.GreaterOrEqual(t, *result.Spec.RegexPriority, int64(0))
 					continue
 				}
 
 				// Verify path-only route.
 				require.NotNil(t, result.Spec.RegexPriority)
-				assert.Equal(t, int64(10), *result.Spec.RegexPriority)
+				assert.Equal(t, routebuilder.KongHTTPRoutePathRegexPriorityOffset+10, *result.Spec.RegexPriority)
 			}
 		})
 	}
@@ -231,16 +235,19 @@ func TestRoutesForRule_PrioritizesHeaderOnlyHTTPRouteMatches(t *testing.T) {
 			Rules: []gatewayv1.HTTPRouteRule{
 				{
 					Matches: []gatewayv1.HTTPRouteMatch{{
+						Path:    defaultRootPathMatch(),
 						Headers: []gatewayv1.HTTPHeaderMatch{{Name: "version", Value: "one"}},
 					}},
 				},
 				{
 					Matches: []gatewayv1.HTTPRouteMatch{{
+						Path:    defaultRootPathMatch(),
 						Headers: []gatewayv1.HTTPHeaderMatch{{Name: "version", Value: "two"}},
 					}},
 				},
 				{
 					Matches: []gatewayv1.HTTPRouteMatch{{
+						Path: defaultRootPathMatch(),
 						Headers: []gatewayv1.HTTPHeaderMatch{
 							{Name: "version", Value: "two"},
 							{Name: "color", Value: "orange"},
@@ -249,6 +256,7 @@ func TestRoutesForRule_PrioritizesHeaderOnlyHTTPRouteMatches(t *testing.T) {
 				},
 				{
 					Matches: []gatewayv1.HTTPRouteMatch{{
+						Path:    defaultRootPathMatch(),
 						Headers: []gatewayv1.HTTPHeaderMatch{{Name: "color", Value: "blue"}},
 					}},
 				},
@@ -297,29 +305,36 @@ func TestRoutesForRule_PrioritizesHeaderOnlyHTTPRouteMatches(t *testing.T) {
 	require.NotNil(t, colorBlueRoute.Spec.RegexPriority)
 	assert.Greater(t, *twoHeaderRoute.Spec.RegexPriority, *versionTwoRoute.Spec.RegexPriority)
 	assert.Greater(t, *versionTwoRoute.Spec.RegexPriority, *colorBlueRoute.Spec.RegexPriority)
-	assert.Negative(t, *twoHeaderRoute.Spec.RegexPriority)
-	assert.Negative(t, *versionTwoRoute.Spec.RegexPriority)
-	assert.Negative(t, *colorBlueRoute.Spec.RegexPriority)
+	assert.GreaterOrEqual(t, *twoHeaderRoute.Spec.RegexPriority, int64(0))
+	assert.GreaterOrEqual(t, *versionTwoRoute.Spec.RegexPriority, int64(0))
+	assert.GreaterOrEqual(t, *colorBlueRoute.Spec.RegexPriority, int64(0))
+	assert.Less(t, *twoHeaderRoute.Spec.RegexPriority, routebuilder.KongHTTPRoutePathRegexPriorityOffset)
 	assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, versionTwoRoute.Spec.Paths)
 	assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, twoHeaderRoute.Spec.Paths)
 	assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, colorBlueRoute.Spec.Paths)
 }
 
-func TestHTTPRouteMatchPrioritiesKeepHeaderOnlyBelowPathRoutes(t *testing.T) {
+func TestHTTPRouteMatchPrioritiesIgnoreUnsupportedQueryParams(t *testing.T) {
 	httpRoute := &gwtypes.HTTPRoute{
 		Spec: gatewayv1.HTTPRouteSpec{
 			Rules: []gatewayv1.HTTPRouteRule{
 				{
 					Matches: []gatewayv1.HTTPRouteMatch{{
-						Path: &gatewayv1.HTTPPathMatch{
-							Type:  new(gatewayv1.PathMatchExact),
-							Value: new("/"),
-						},
+						Path: defaultRootPathMatch(),
+						Headers: []gatewayv1.HTTPHeaderMatch{{
+							Name:  "version",
+							Value: "two",
+						}},
 					}},
 				},
 				{
 					Matches: []gatewayv1.HTTPRouteMatch{{
+						Path:    defaultRootPathMatch(),
 						Headers: []gatewayv1.HTTPHeaderMatch{{Name: "version", Value: "two"}},
+						QueryParams: []gatewayv1.HTTPQueryParamMatch{{
+							Name:  "animal",
+							Value: "whale",
+						}},
 					}},
 				},
 			},
@@ -327,9 +342,15 @@ func TestHTTPRouteMatchPrioritiesKeepHeaderOnlyBelowPathRoutes(t *testing.T) {
 	}
 
 	priorities := httpRouteMatchPriorities(httpRoute)
-	headerPriority := headerOnlyRegexPriority(priorityForHTTPRouteMatch(priorities, 1, 0), priorities)
 
-	require.Negative(t, headerPriority)
+	assert.Greater(t, priorityForHTTPRouteMatch(priorities, 0, 0), priorityForHTTPRouteMatch(priorities, 1, 0))
+}
+
+func defaultRootPathMatch() *gatewayv1.HTTPPathMatch {
+	return &gatewayv1.HTTPPathMatch{
+		Type:  new(gatewayv1.PathMatchPathPrefix),
+		Value: new("/"),
+	}
 }
 
 func TestRoutesForRule_ExactPathMatch(t *testing.T) {
@@ -398,7 +419,7 @@ func TestRoutesForRule_ExactPathMatch(t *testing.T) {
 
 	assert.Equal(t, []string{"~/one$"}, results[0].Spec.Paths)
 	require.NotNil(t, results[0].Spec.RegexPriority)
-	assert.Equal(t, int64(9), *results[0].Spec.RegexPriority)
+	assert.Equal(t, routebuilder.KongHTTPRoutePathRegexPriorityOffset+9, *results[0].Spec.RegexPriority)
 	assert.ElementsMatch(t,
 		[]sdkkonnectcomp.RouteJSONProtocols{
 			sdkkonnectcomp.RouteJSONProtocols("http"),

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -16,6 +16,7 @@ import (
 
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+	routebuilder "github.com/kong/kong-operator/v2/controller/hybridgateway/builder"
 	hgerrors "github.com/kong/kong-operator/v2/controller/hybridgateway/errors"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/pkg/consts"
@@ -162,7 +163,7 @@ func TestRoutesForRule(t *testing.T) {
 			}
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
 
-			results, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, rule, tt.parentRef, cpRef, nil, tt.serviceName, tt.hostnames)
+			results, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, rule, 0, tt.parentRef, cpRef, nil, tt.serviceName, tt.hostnames)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -193,20 +194,142 @@ func TestRoutesForRule(t *testing.T) {
 				expectedAnnotation := httpRoute.Namespace + "/" + httpRoute.Name
 				assert.Contains(t, result.Annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation], expectedAnnotation)
 
-				// Verify at least one path/header/method is set based on the match.
-				// For the first match with path, we expect Paths to be non-empty.
-				// For the second header-only match, Paths may be empty; Headers must be set.
-				if len(result.Spec.Paths) == 0 {
-					// header-only route
+				if len(result.Spec.Headers) > 0 {
 					assert.Contains(t, result.Spec.Headers, "X-Foo")
-					assert.Nil(t, result.Spec.RegexPriority)
+					assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, result.Spec.Paths)
+					require.NotNil(t, result.Spec.RegexPriority)
+					assert.Negative(t, *result.Spec.RegexPriority)
 					continue
 				}
 
-				assert.Equal(t, new(int64(10)), result.Spec.RegexPriority)
+				// Verify path-only route.
+				require.NotNil(t, result.Spec.RegexPriority)
+				assert.Equal(t, int64(10), *result.Spec.RegexPriority)
 			}
 		})
 	}
+}
+
+func TestRoutesForRule_PrioritizesHeaderOnlyHTTPRouteMatches(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, configurationv1alpha1.AddToScheme(scheme))
+	require.NoError(t, gatewayv1.Install(scheme))
+
+	httpRoute := &gwtypes.HTTPRoute{
+		TypeMeta: httpRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "header-matching",
+			Namespace: "gateway-conformance-infra",
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "same-namespace"}},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Headers: []gatewayv1.HTTPHeaderMatch{{Name: "version", Value: "one"}},
+					}},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Headers: []gatewayv1.HTTPHeaderMatch{{Name: "version", Value: "two"}},
+					}},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Headers: []gatewayv1.HTTPHeaderMatch{
+							{Name: "version", Value: "two"},
+							{Name: "color", Value: "orange"},
+						},
+					}},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Headers: []gatewayv1.HTTPHeaderMatch{{Name: "color", Value: "blue"}},
+					}},
+				},
+			},
+		},
+	}
+	pRef := &gwtypes.ParentReference{
+		Name:      "same-namespace",
+		Namespace: (*gatewayv1.Namespace)(new("gateway-conformance-infra")),
+	}
+	cpRef := &commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: "test-cp",
+		},
+	}
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "same-namespace",
+			Namespace: "gateway-conformance-infra",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "test-class",
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Protocol: gatewayv1.HTTPProtocolType, Port: 80},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gateway).Build()
+
+	versionTwoRoutes, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, httpRoute.Spec.Rules[1], 1, pRef, cpRef, nil, "version-two-service", nil)
+	require.NoError(t, err)
+	require.Len(t, versionTwoRoutes, 1)
+	twoHeaderRoutes, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, httpRoute.Spec.Rules[2], 2, pRef, cpRef, nil, "two-header-service", nil)
+	require.NoError(t, err)
+	require.Len(t, twoHeaderRoutes, 1)
+	colorBlueRoutes, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, httpRoute.Spec.Rules[3], 3, pRef, cpRef, nil, "color-blue-service", nil)
+	require.NoError(t, err)
+	require.Len(t, colorBlueRoutes, 1)
+
+	versionTwoRoute := versionTwoRoutes[0]
+	twoHeaderRoute := twoHeaderRoutes[0]
+	colorBlueRoute := colorBlueRoutes[0]
+	require.NotNil(t, versionTwoRoute.Spec.RegexPriority)
+	require.NotNil(t, twoHeaderRoute.Spec.RegexPriority)
+	require.NotNil(t, colorBlueRoute.Spec.RegexPriority)
+	assert.Greater(t, *twoHeaderRoute.Spec.RegexPriority, *versionTwoRoute.Spec.RegexPriority)
+	assert.Greater(t, *versionTwoRoute.Spec.RegexPriority, *colorBlueRoute.Spec.RegexPriority)
+	assert.Negative(t, *twoHeaderRoute.Spec.RegexPriority)
+	assert.Negative(t, *versionTwoRoute.Spec.RegexPriority)
+	assert.Negative(t, *colorBlueRoute.Spec.RegexPriority)
+	assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, versionTwoRoute.Spec.Paths)
+	assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, twoHeaderRoute.Spec.Paths)
+	assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, colorBlueRoute.Spec.Paths)
+}
+
+func TestHTTPRouteMatchPrioritiesKeepHeaderOnlyBelowPathRoutes(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  new(gatewayv1.PathMatchExact),
+							Value: new("/"),
+						},
+					}},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Headers: []gatewayv1.HTTPHeaderMatch{{Name: "version", Value: "two"}},
+					}},
+				},
+			},
+		},
+	}
+
+	priorities := httpRouteMatchPriorities(httpRoute)
+	headerPriority := headerOnlyRegexPriority(priorityForHTTPRouteMatch(priorities, 1, 0), priorities)
+
+	require.Negative(t, headerPriority)
 }
 
 func TestRoutesForRule_ExactPathMatch(t *testing.T) {
@@ -269,12 +392,13 @@ func TestRoutesForRule_ExactPathMatch(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gateway).Build()
 
-	results, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, rule, pRef, cpRef, nil, "test-service", nil)
+	results, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, rule, 0, pRef, cpRef, nil, "test-service", nil)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
 	assert.Equal(t, []string{"~/one$"}, results[0].Spec.Paths)
-	assert.Equal(t, new(int64(9)), results[0].Spec.RegexPriority)
+	require.NotNil(t, results[0].Spec.RegexPriority)
+	assert.Equal(t, int64(9), *results[0].Spec.RegexPriority)
 	assert.ElementsMatch(t,
 		[]sdkkonnectcomp.RouteJSONProtocols{
 			sdkkonnectcomp.RouteJSONProtocols("http"),

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -33,8 +33,7 @@ var skippedTestsShared = []string{
 
 var skippedTestsForExpressionsRouter = []string{}
 
-var skippedTestsForTraditionalCompatibleRouter = []string{
-	// HTTPRoute
+var skippedTestsForStandardTraditionalCompatibleRouter = []string{
 	tests.HTTPRouteHeaderMatching.ShortName,
 }
 
@@ -55,8 +54,8 @@ func skippedTestsForConfig(routerFlavor consts.RouterFlavor, gwType gatewayType)
 
 	switch routerFlavor {
 	case consts.RouterFlavorTraditionalCompatible:
-		skipped = append(skipped, skippedTestsForTraditionalCompatibleRouter...)
 		if gwType == standardGateway {
+			skipped = append(skipped, skippedTestsForStandardTraditionalCompatibleRouter...)
 			skipped = append(skipped, tests.HTTPRouteInvalidBackendRefUnknownKind.ShortName)
 		}
 	case consts.RouterFlavorExpressions:


### PR DESCRIPTION
**What this PR does / why we need it**:

Order overlapping header-only `HTTPRoute` matches by Gateway API 
   specificity. Header-only matches are translated to `KongRoute`s with a catch-all 
   regex path so Kong's `regex_priority` becomes effective, and a per-match priority derived from path/method/header/query specificity keeps more specific matches  ahead of less specific ones while staying below path-based routes. This enables   the `HTTPRouteHeaderMatching` Gateway API conformance test for the hybrid gateway.

**Which issue this PR fixes**

part of #4454

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
