### PR TITLE
test(conformance): add KONG_TEST_CONFORMANCE_SKIP_TESTS env var support

### DIFF
--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -4,6 +4,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/tests"
 
 	"github.com/kong/kong-operator/v2/pkg/consts"
+	"github.com/kong/kong-operator/v2/test"
 )
 
 var skippedTestsShared = []string{
@@ -59,6 +60,11 @@ func skippedTestsForConfig(routerFlavor consts.RouterFlavor, gwType gatewayType)
 	if gwType == hybridGateway {
 		skipped = append(skipped, skippedTestsForHybrid...)
 	}
+
+	// Allow excluding extra (e.g. flaky or undesired) tests via the
+	// KONG_TEST_CONFORMANCE_SKIP_TESTS environment variable so a local run can
+	// drop the gotest -run filter and still avoid known-bad tests.
+	skipped = append(skipped, test.ConformanceSkipTests()...)
 
 	return skipped
 }

--- a/test/envvars.go
+++ b/test/envvars.go
@@ -130,3 +130,23 @@ func ConformanceGatewayType() string {
 	}
 	return gt
 }
+
+// ConformanceSkipTests returns an extra list of conformance test short names to
+// skip, on top of the built-in skip lists. It reads the comma separated
+// KONG_TEST_CONFORMANCE_SKIP_TESTS environment variable, e.g.
+// "HTTPRouteReferenceGrant,HTTPRouteRedirectPort". This lets a local run drop
+// the gotest -run filter entirely and instead exclude flaky or undesired tests.
+// Whitespace around each name is trimmed and empty entries are ignored.
+func ConformanceSkipTests() []string {
+	raw := os.Getenv("KONG_TEST_CONFORMANCE_SKIP_TESTS")
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var skip []string
+	for name := range strings.SplitSeq(raw, ",") {
+		if name = strings.TrimSpace(name); name != "" {
+			skip = append(skip, name)
+		}
+	}
+	return skip
+}


### PR DESCRIPTION


**What this PR does / why we need it**:
Reads a comma-separated list of conformance test names to skip at runtime, letting local runs avoid known-flaky tests without a -run filter.
**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
