### PR TITLE
fix(konnect): prevent orphaned and duplicate Konnect entities on create/delete race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,16 @@
 
 ### Fixes
 
+- Konnect: prevent orphaned and duplicate Konnect entities when reconciliation
+  races with the cached client. The cleanup finalizer is now added before the entity
+  is created in Konnect, and the freshly created Konnect ID is kept in an in-memory
+  store until the cached status reflects it. This lets deletion recover a missing
+  Konnect ID (falling back to probing Konnect by Kubernetes UID, or by name for the
+  tag-less Cloud Gateway types `KonnectCloudGatewayNetwork` and
+  `KonnectCloudGatewayTransitGateway`) so an entity can still be cleaned up after an
+  operator restart, and prevents creating a duplicate entity when a stale cached
+  status has not yet caught up to the persisted Konnect ID.
+  [#4650](https://github.com/Kong/kong-operator/pull/4650)
 - Hybridgateway: merge duplicate `KongTarget`s when multiple `backendRef`s in
   an `HTTPRoute` or `TLSRoute` rule resolve to the same pod IP and port.
   Previously one target per backendRef per endpoint was created, causing Konnect

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -140,62 +140,7 @@ func Create[
 		// If there was a conflict on the create request, we can assume the entity already exists.
 		// We'll get its Konnect ID by listing all entities of its type filtered by the Kubernetes object UID.
 		var id string
-		switch ent := any(e).(type) {
-		case *konnectv1alpha2.KonnectGatewayControlPlane:
-			id, errGet = getControlPlaneForUID(ctx, sdk.GetControlPlaneSDK(), sdk.GetControlPlaneGroupSDK(), cl, ent)
-		case *konnectv1alpha1.KonnectCloudGatewayNetwork:
-			// NOTE: since Cloud Gateways resource do not support labels/tags,
-			// we can't reliably get the Konnect ID for a Cloud Gateway Network
-			// given a K8s object UID.
-			// For now this code uses a list, using a name filter, to get the Konnect ID.
-			id, err = getKonnectNetworkMatchingSpecName(ctx, sdk.GetCloudGatewaysSDK(), ent)
-		case *konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration:
-			// TODO: can't get the ID for a DataPlaneGroupConfiguration
-			// as this resource type does not support labels/tags.
-		case *konnectv1alpha1.KonnectCloudGatewayTransitGateway:
-			id, err = getKonnectTransitGatewayMatchingSpecName(ctx, sdk.GetCloudGatewaysSDK(), ent)
-		case *configurationv1alpha1.KongService:
-			id, errGet = getKongServiceForUID(ctx, sdk.GetServicesSDK(), ent)
-		case *configurationv1alpha1.KongRoute:
-			id, errGet = getKongRouteForUID(ctx, sdk.GetRoutesSDK(), ent)
-		case *configurationv1alpha1.KongSNI:
-			id, errGet = getKongSNIForUID(ctx, sdk.GetSNIsSDK(), ent)
-		case *configurationv1.KongConsumer:
-			id, errGet = getKongConsumerForUID(ctx, sdk.GetConsumersSDK(), ent)
-		case *configurationv1beta1.KongConsumerGroup:
-			id, errGet = getKongConsumerGroupForUID(ctx, sdk.GetConsumerGroupsSDK(), ent)
-		case *configurationv1alpha1.KongKeySet:
-			id, errGet = getKongKeySetForUID(ctx, sdk.GetKeySetsSDK(), ent)
-		case *configurationv1alpha1.KongKey:
-			id, errGet = getKongKeyForUID(ctx, sdk.GetKeysSDK(), ent)
-		case *configurationv1alpha1.KongUpstream:
-			id, errGet = getKongUpstreamForUID(ctx, sdk.GetUpstreamsSDK(), ent)
-		case *configurationv1alpha1.KongTarget:
-			id, errGet = getKongTargetForUID(ctx, sdk.GetTargetsSDK(), ent)
-		case *configurationv1alpha1.KongPluginBinding:
-			id, errGet = getPluginForUID(ctx, sdk.GetPluginSDK(), ent)
-		case *configurationv1alpha1.KongVault:
-			id, errGet = getKongVaultForUID(ctx, sdk.GetVaultSDK(), ent)
-		case *configurationv1alpha1.KongCredentialHMAC:
-			id, errGet = getKongCredentialHMACForUID(ctx, sdk.GetHMACCredentialsSDK(), ent)
-		case *configurationv1alpha1.KongCredentialJWT:
-			id, errGet = getKongCredentialJWTForUID(ctx, sdk.GetJWTCredentialsSDK(), ent)
-		case *configurationv1alpha1.KongCredentialBasicAuth:
-			id, errGet = getKongCredentialBasicAuthForUID(ctx, sdk.GetBasicAuthCredentialsSDK(), ent)
-		case *configurationv1alpha1.KongCredentialAPIKey:
-			id, errGet = getKongCredentialAPIKeyForUID(ctx, sdk.GetAPIKeyCredentialsSDK(), ent)
-		case *configurationv1alpha1.KongCredentialACL:
-			id, errGet = getKongCredentialACLForUID(ctx, sdk.GetACLCredentialsSDK(), ent)
-		case *configurationv1alpha1.KongCertificate:
-			id, errGet = getKongCertificateForUID(ctx, sdk.GetCertificatesSDK(), ent)
-		case *configurationv1alpha1.KongCACertificate:
-			id, errGet = getKongCACertificateForUID(ctx, sdk.GetCACertificatesSDK(), ent)
-
-		// ---------------------------------------------------------------------
-		// TODO: add other manually maintained Konnect types here
-		default:
-			id, errGet = getForUID(ctx, sdk, e)
-		}
+		id, errGet = getKonnectIDForUID(ctx, sdk, cl, e)
 
 		if errConflict, ok := errors.AsType[ConflictOnCreateButNoConflifctHandlingImplementedError](errGet); ok {
 			return e, errConflict
@@ -266,6 +211,83 @@ func Create[
 	return e, err
 }
 
+// getKonnectIDForUID locates an existing Konnect entity that corresponds to the
+// given Kubernetes object and returns its Konnect ID. For most entity types the
+// lookup filters by the Kubernetes object UID tag; Cloud Gateway types that do
+// not support tags are looked up by spec name where a name-based lookup exists.
+//
+// It is used both during create-conflict resolution (the entity already exists in
+// Konnect) and during deletion to recover a Konnect ID that was never persisted to
+// the object status, so the entity can still be cleaned up. It returns an empty ID
+// (and nil error) when no matching entity exists or no lookup is possible for the
+// type.
+func getKonnectIDForUID[
+	T constraints.SupportedKonnectEntityType,
+	TEnt constraints.EntityType[T],
+](
+	ctx context.Context,
+	sdk sdkops.SDKWrapper,
+	cl client.Client,
+	e TEnt,
+) (string, error) {
+	switch ent := any(e).(type) {
+	case *konnectv1alpha2.KonnectGatewayControlPlane:
+		return getControlPlaneForUID(ctx, sdk.GetControlPlaneSDK(), sdk.GetControlPlaneGroupSDK(), cl, ent)
+	case *konnectv1alpha1.KonnectCloudGatewayNetwork:
+		// NOTE: since Cloud Gateways resources do not support labels/tags,
+		// we can't reliably get the Konnect ID for a Cloud Gateway Network
+		// given a K8s object UID. This uses a list, with a name filter, instead.
+		return getKonnectNetworkMatchingSpecName(ctx, sdk.GetCloudGatewaysSDK(), ent)
+	case *konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration:
+		// NOTE: can't get the ID for a DataPlaneGroupConfiguration as this
+		// resource type does not support labels/tags nor a name-based lookup.
+		return "", nil
+	case *konnectv1alpha1.KonnectCloudGatewayTransitGateway:
+		return getKonnectTransitGatewayMatchingSpecName(ctx, sdk.GetCloudGatewaysSDK(), ent)
+	case *configurationv1alpha1.KongService:
+		return getKongServiceForUID(ctx, sdk.GetServicesSDK(), ent)
+	case *configurationv1alpha1.KongRoute:
+		return getKongRouteForUID(ctx, sdk.GetRoutesSDK(), ent)
+	case *configurationv1alpha1.KongSNI:
+		return getKongSNIForUID(ctx, sdk.GetSNIsSDK(), ent)
+	case *configurationv1.KongConsumer:
+		return getKongConsumerForUID(ctx, sdk.GetConsumersSDK(), ent)
+	case *configurationv1beta1.KongConsumerGroup:
+		return getKongConsumerGroupForUID(ctx, sdk.GetConsumerGroupsSDK(), ent)
+	case *configurationv1alpha1.KongKeySet:
+		return getKongKeySetForUID(ctx, sdk.GetKeySetsSDK(), ent)
+	case *configurationv1alpha1.KongKey:
+		return getKongKeyForUID(ctx, sdk.GetKeysSDK(), ent)
+	case *configurationv1alpha1.KongUpstream:
+		return getKongUpstreamForUID(ctx, sdk.GetUpstreamsSDK(), ent)
+	case *configurationv1alpha1.KongTarget:
+		return getKongTargetForUID(ctx, sdk.GetTargetsSDK(), ent)
+	case *configurationv1alpha1.KongPluginBinding:
+		return getPluginForUID(ctx, sdk.GetPluginSDK(), ent)
+	case *configurationv1alpha1.KongVault:
+		return getKongVaultForUID(ctx, sdk.GetVaultSDK(), ent)
+	case *configurationv1alpha1.KongCredentialHMAC:
+		return getKongCredentialHMACForUID(ctx, sdk.GetHMACCredentialsSDK(), ent)
+	case *configurationv1alpha1.KongCredentialJWT:
+		return getKongCredentialJWTForUID(ctx, sdk.GetJWTCredentialsSDK(), ent)
+	case *configurationv1alpha1.KongCredentialBasicAuth:
+		return getKongCredentialBasicAuthForUID(ctx, sdk.GetBasicAuthCredentialsSDK(), ent)
+	case *configurationv1alpha1.KongCredentialAPIKey:
+		return getKongCredentialAPIKeyForUID(ctx, sdk.GetAPIKeyCredentialsSDK(), ent)
+	case *configurationv1alpha1.KongCredentialACL:
+		return getKongCredentialACLForUID(ctx, sdk.GetACLCredentialsSDK(), ent)
+	case *configurationv1alpha1.KongCertificate:
+		return getKongCertificateForUID(ctx, sdk.GetCertificatesSDK(), ent)
+	case *configurationv1alpha1.KongCACertificate:
+		return getKongCACertificateForUID(ctx, sdk.GetCACertificatesSDK(), ent)
+
+	// ---------------------------------------------------------------------
+	// TODO: add other manually maintained Konnect types here
+	default:
+		return getForUID(ctx, sdk, e)
+	}
+}
+
 // Delete deletes a Konnect entity.
 // It returns an error if the entity does not have a Konnect ID or if the operation fails.
 func Delete[
@@ -273,14 +295,37 @@ func Delete[
 	TEnt constraints.EntityType[T],
 ](ctx context.Context, sdk sdkops.SDKWrapper, cl client.Client, metricRecorder metrics.Recorder, ent TEnt) error {
 	if ent.GetKonnectStatus().GetKonnectID() == "" && EntityPersistsKonnectID(ent) {
-		cond, ok := k8sutils.GetCondition(konnectv1alpha1.KonnectEntityProgrammedConditionType, ent)
-		if ok && cond.Status == metav1.ConditionTrue {
-			return fmt.Errorf(
-				"can't delete %T %s when it does not have the Konnect ID",
-				ent, client.ObjectKeyFromObject(ent),
-			)
+		// The Konnect ID was never persisted to the status. This can happen if the
+		// operator created the entity in Konnect but was interrupted before writing
+		// the ID to the status (and the in-memory record was lost, e.g. on restart).
+		// Probe Konnect to recover the ID so the entity can still be cleaned up.
+		id, errGet := getKonnectIDForUID(ctx, sdk, cl, ent)
+		if errGet != nil {
+			_, uidNotFound := errors.AsType[EntityWithMatchingUIDNotFoundError](errGet)
+			_, idNotFound := errors.AsType[EntityWithMatchingIDNotFoundError](errGet)
+			_, noConflictHandling := errors.AsType[ConflictOnCreateButNoConflifctHandlingImplementedError](errGet)
+			switch {
+			// No matching entity exists in Konnect (it was never created or is
+			// already gone), so there is nothing to delete.
+			case uidNotFound, idNotFound:
+				return nil
+			// No lookup is implemented for this type, so we can't determine whether a
+			// Konnect entity exists. There's nothing we can safely delete.
+			case noConflictHandling:
+				return nil
+			default:
+				return fmt.Errorf(
+					"failed to look up Konnect ID for %T %s during deletion: %w",
+					ent, client.ObjectKeyFromObject(ent), errGet,
+				)
+			}
 		}
-		return nil
+		if id == "" {
+			// No matching Konnect entity exists (it was never created or is already
+			// gone), so there is nothing to delete.
+			return nil
+		}
+		ent.SetKonnectID(id)
 	}
 
 	var (

--- a/controller/konnect/ops/ops.go
+++ b/controller/konnect/ops/ops.go
@@ -304,6 +304,7 @@ func Delete[
 			_, uidNotFound := errors.AsType[EntityWithMatchingUIDNotFoundError](errGet)
 			_, idNotFound := errors.AsType[EntityWithMatchingIDNotFoundError](errGet)
 			_, noConflictHandling := errors.AsType[ConflictOnCreateButNoConflifctHandlingImplementedError](errGet)
+			relationsFailed, okRelationsFailed := errors.AsType[KonnectEntityCreatedButRelationsFailedError](errGet)
 			switch {
 			// No matching entity exists in Konnect (it was never created or is
 			// already gone), so there is nothing to delete.
@@ -313,6 +314,12 @@ func Delete[
 			// Konnect entity exists. There's nothing we can safely delete.
 			case noConflictHandling:
 				return nil
+			// The entity was found (its Konnect ID is known) but a side effect of the
+			// lookup failed, e.g. setting control plane group membership. That side
+			// effect is irrelevant when the entity is being deleted, so proceed with
+			// the recovered ID instead of getting stuck requeueing on the error.
+			case okRelationsFailed && relationsFailed.KonnectID != "":
+				id = relationsFailed.KonnectID
 			default:
 				return fmt.Errorf(
 					"failed to look up Konnect ID for %T %s during deletion: %w",

--- a/controller/konnect/ops/ops_test.go
+++ b/controller/konnect/ops/ops_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -357,6 +358,46 @@ func TestDelete(t *testing.T) {
 					}, nil)
 				sdk.ControlPlaneSDK.EXPECT().
 					DeleteControlPlane(mock.Anything, "recovered-12345").
+					Return(&sdkkonnectops.DeleteControlPlaneResponse{}, nil).
+					Once()
+				return sdk
+			},
+		},
+		{
+			name: "no Konnect ID in status, UID probe returns the ID wrapped in a group-membership error but delete proceeds with that ID",
+			entity: &konnectv1alpha2.KonnectGatewayControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp-group",
+					Namespace: "test-ns",
+				},
+				Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+					CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+						Name:        "test-cp-group",
+						ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup.ToPointer(),
+					},
+					// The group references a member that does not exist in the cluster,
+					// so resolving group membership during the UID lookup fails.
+					Members: []corev1.LocalObjectReference{{Name: "missing-member"}},
+					Source:  new(commonv1alpha1.EntitySourceOrigin),
+				},
+			},
+			sdkFunc: func(t *testing.T, sdk *sdkmocks.MockSDKWrapper) *sdkmocks.MockSDKWrapper {
+				// The probe finds the control plane by UID and returns its ID, but
+				// setting group membership fails (the member is missing). Deletion must
+				// still proceed using the recovered ID rather than getting stuck.
+				sdk.ControlPlaneSDK.EXPECT().
+					ListControlPlanes(mock.Anything, mock.Anything).
+					Return(&sdkkonnectops.ListControlPlanesResponse{
+						ListControlPlanesResponse: &sdkkonnectcomp.ListControlPlanesResponse{
+							Data: []sdkkonnectcomp.ControlPlane{
+								{
+									ID: "recovered-group-12345",
+								},
+							},
+						},
+					}, nil)
+				sdk.ControlPlaneSDK.EXPECT().
+					DeleteControlPlane(mock.Anything, "recovered-group-12345").
 					Return(&sdkkonnectops.DeleteControlPlaneResponse{}, nil).
 					Once()
 				return sdk

--- a/controller/konnect/ops/ops_test.go
+++ b/controller/konnect/ops/ops_test.go
@@ -271,12 +271,25 @@ func TestDelete(t *testing.T) {
 		*konnectv1alpha2.KonnectGatewayControlPlane,
 	]{
 		{
-			name: "no Konnect ID and no Programmed status condition - delete is not called",
+			name: "no Konnect ID and entity not found in Konnect - delete is not called",
 			entity: &konnectv1alpha2.KonnectGatewayControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cp",
 					Namespace: "test-ns",
 				},
+			},
+			sdkFunc: func(t *testing.T, sdk *sdkmocks.MockSDKWrapper) *sdkmocks.MockSDKWrapper {
+				// With no Konnect ID in the status, Delete probes Konnect by UID to
+				// recover a possibly-orphaned entity. There's no matching entity, so
+				// nothing is deleted (DeleteControlPlane is never expected).
+				sdk.ControlPlaneSDK.EXPECT().
+					ListControlPlanes(mock.Anything, mock.Anything).
+					Return(&sdkkonnectops.ListControlPlanesResponse{
+						ListControlPlanesResponse: &sdkkonnectcomp.ListControlPlanesResponse{
+							Data: []sdkkonnectcomp.ControlPlane{},
+						},
+					}, nil)
+				return sdk
 			},
 		},
 		{
@@ -300,6 +313,53 @@ func TestDelete(t *testing.T) {
 						},
 					},
 				},
+			},
+			sdkFunc: func(t *testing.T, sdk *sdkmocks.MockSDKWrapper) *sdkmocks.MockSDKWrapper {
+				// Same as above: the probe finds no matching Konnect entity.
+				sdk.ControlPlaneSDK.EXPECT().
+					ListControlPlanes(mock.Anything, mock.Anything).
+					Return(&sdkkonnectops.ListControlPlanesResponse{
+						ListControlPlanesResponse: &sdkkonnectcomp.ListControlPlanesResponse{
+							Data: []sdkkonnectcomp.ControlPlane{},
+						},
+					}, nil)
+				return sdk
+			},
+		},
+		{
+			name: "no Konnect ID but entity found in Konnect by UID - delete recovers ID and deletes it",
+			entity: &konnectv1alpha2.KonnectGatewayControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cp",
+					Namespace: "test-ns",
+				},
+				Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+					CreateControlPlaneRequest: &sdkkonnectcomp.CreateControlPlaneRequest{
+						Name: "test-cp",
+					},
+					Source: new(commonv1alpha1.EntitySourceOrigin),
+				},
+			},
+			sdkFunc: func(t *testing.T, sdk *sdkmocks.MockSDKWrapper) *sdkmocks.MockSDKWrapper {
+				// The Konnect ID was never persisted to the status (e.g. status update
+				// failed after creation). Delete probes Konnect by UID, recovers the ID
+				// and deletes the entity so it is not orphaned.
+				sdk.ControlPlaneSDK.EXPECT().
+					ListControlPlanes(mock.Anything, mock.Anything).
+					Return(&sdkkonnectops.ListControlPlanesResponse{
+						ListControlPlanesResponse: &sdkkonnectcomp.ListControlPlanesResponse{
+							Data: []sdkkonnectcomp.ControlPlane{
+								{
+									ID: "recovered-12345",
+								},
+							},
+						},
+					}, nil)
+				sdk.ControlPlaneSDK.EXPECT().
+					DeleteControlPlane(mock.Anything, "recovered-12345").
+					Return(&sdkkonnectops.DeleteControlPlaneResponse{}, nil).
+					Once()
+				return sdk
 			},
 		},
 		{

--- a/controller/konnect/pending_konnect_ids.go
+++ b/controller/konnect/pending_konnect_ids.go
@@ -1,0 +1,63 @@
+package konnect
+
+import (
+	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// pendingKonnectIDStore is a concurrency-safe, in-memory store of the Konnect ID
+// of entities that have been created in Konnect but whose ID may not yet be
+// persisted to their status.
+//
+// It bridges the window between creating an entity in Konnect and persisting its
+// ID to the Kubernetes object status: if the status update fails (or the operator
+// is interrupted), the cleanup logic can still recover the Konnect ID from this
+// store and delete the entity, avoiding orphaned Konnect entities.
+//
+// Only the entity's own Konnect ID is stored. The parent references needed to
+// delete an entity (control plane, consumer, service, upstream, key set, network,
+// ...) are persisted to the status by their dedicated reference handlers in
+// earlier reconcile passes, so they are already present on the object that the
+// deletion logic operates on; the create pass only ever risks losing the entity's
+// own ID.
+//
+// Entries are keyed by the Kubernetes object's namespace/name and are purged once
+// the ID has been persisted to the status or the entity has been deleted. Keying
+// by namespace/name is safe because the cleanup finalizer is added before the
+// entity is created in Konnect, so an object is never removed from the API server
+// (and a same-namespace/name successor can never be created) until its own
+// deletion reconcile has run and purged the entry.
+type pendingKonnectIDStore struct {
+	mu  sync.RWMutex
+	ids map[client.ObjectKey]string
+}
+
+// newPendingKonnectIDStore returns an initialized pendingKonnectIDStore.
+func newPendingKonnectIDStore() *pendingKonnectIDStore {
+	return &pendingKonnectIDStore{
+		ids: make(map[client.ObjectKey]string),
+	}
+}
+
+// Store saves the Konnect ID for the given object key.
+func (s *pendingKonnectIDStore) Store(key client.ObjectKey, id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ids[key] = id
+}
+
+// Get returns the Konnect ID stored for the given object key, if any.
+func (s *pendingKonnectIDStore) Get(key client.ObjectKey) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	id, ok := s.ids[key]
+	return id, ok
+}
+
+// Delete removes any Konnect ID stored for the given object key.
+func (s *pendingKonnectIDStore) Delete(key client.ObjectKey) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.ids, key)
+}

--- a/controller/konnect/pending_konnect_ids_test.go
+++ b/controller/konnect/pending_konnect_ids_test.go
@@ -1,0 +1,52 @@
+package konnect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestPendingKonnectIDStore(t *testing.T) {
+	s := newPendingKonnectIDStore()
+
+	key := client.ObjectKey{Namespace: "ns", Name: "foo"}
+
+	t.Run("Get on empty store returns not found", func(t *testing.T) {
+		_, ok := s.Get(key)
+		assert.False(t, ok)
+	})
+
+	t.Run("Store then Get returns the stored ID", func(t *testing.T) {
+		s.Store(key, "konnect-id")
+		got, ok := s.Get(key)
+		assert.True(t, ok)
+		assert.Equal(t, "konnect-id", got)
+	})
+
+	t.Run("Delete removes the entry", func(t *testing.T) {
+		s.Delete(key)
+		_, ok := s.Get(key)
+		assert.False(t, ok)
+	})
+
+	t.Run("entries are isolated per key", func(t *testing.T) {
+		k1 := client.ObjectKey{Namespace: "ns", Name: "a"}
+		k2 := client.ObjectKey{Namespace: "ns", Name: "b"}
+		s.Store(k1, "id-a")
+		s.Store(k2, "id-b")
+
+		got1, ok1 := s.Get(k1)
+		got2, ok2 := s.Get(k2)
+		assert.True(t, ok1)
+		assert.True(t, ok2)
+		assert.Equal(t, "id-a", got1)
+		assert.Equal(t, "id-b", got2)
+
+		s.Delete(k1)
+		_, ok1 = s.Get(k1)
+		_, ok2 = s.Get(k2)
+		assert.False(t, ok1)
+		assert.True(t, ok2)
+	})
+}

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -53,6 +53,12 @@ type KonnectEntityReconciler[T constraints.SupportedKonnectEntityType, TEnt cons
 	SyncPeriod        time.Duration
 
 	MetricRecorder metrics.Recorder
+
+	// pendingKonnectIDs holds the Konnect ID of entities created in Konnect whose
+	// ID has not yet been persisted to their status. It lets the cleanup logic
+	// recover and delete a Konnect entity even if the status update that would
+	// persist its ID fails, preventing orphaned entities.
+	pendingKonnectIDs *pendingKonnectIDStore
 }
 
 // KonnectEntityReconcilerOption is a functional option for the KonnectEntityReconciler.
@@ -100,11 +106,12 @@ func NewKonnectEntityReconciler[
 	opts ...KonnectEntityReconcilerOption[T, TEnt],
 ) *KonnectEntityReconciler[T, TEnt] {
 	r := &KonnectEntityReconciler[T, TEnt]{
-		sdkFactory:     sdkFactory,
-		LoggingMode:    loggingMode,
-		Client:         client,
-		SyncPeriod:     consts.DefaultKonnectSyncPeriod,
-		MetricRecorder: nil,
+		sdkFactory:        sdkFactory,
+		LoggingMode:       loggingMode,
+		Client:            client,
+		SyncPeriod:        consts.DefaultKonnectSyncPeriod,
+		MetricRecorder:    nil,
+		pendingKonnectIDs: newPendingKonnectIDStore(),
 	}
 	for _, opt := range opts {
 		opt(r)
@@ -556,6 +563,11 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(ctx context.Context, ent TE
 		}
 
 		if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
+			// If the Konnect ID was never persisted to the status (e.g. the status
+			// update failed after the entity was created in Konnect), try to recover
+			// it from the in-memory store so the entity can still be cleaned up.
+			r.restorePendingKonnectIDForDeletion(ent)
+
 			if err := ops.Delete(ctx, sdk, r.Client, r.MetricRecorder, ent); err != nil {
 				// If the error was a network error, handle it here, there's no need to proceed,
 				// as no state has changed.
@@ -581,6 +593,10 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(ctx context.Context, ent TE
 				}
 				return ctrl.Result{}, err
 			}
+
+			// The Konnect entity has been deleted (or there was nothing to delete);
+			// drop any in-memory copy of its ID.
+			r.pendingKonnectIDs.Delete(client.ObjectKeyFromObject(ent))
 		}
 
 		// For KonnectGatewayControlPlane resources, also remove the finalizer added
@@ -603,6 +619,14 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(ctx context.Context, ent TE
 		}
 
 		return ctrl.Result{}, nil
+	}
+
+	// Add the cleanup finalizer before creating anything in Konnect. This
+	// guarantees that, even if the operator is interrupted right after the
+	// Konnect entity is created, there is always a finalizer that triggers the
+	// cleanup logic on deletion, so the Konnect entity can never be orphaned.
+	if _, res, err := patch.WithFinalizer(ctx, r.Client, ent, KonnectCleanupFinalizer); err != nil || !res.IsZero() {
+		return res, err
 	}
 
 	// Handle type specific operations and stop reconciliation if needed.
@@ -632,12 +656,12 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(ctx context.Context, ent TE
 		return res, nil
 	}
 
-	// TODO: relying on status ID is OK but we need to rethink this because
-	// we're using a cached client so after creating the resource on Konnect it might
-	// happen that we've just created the resource but the status ID is not there yet.
-	//
-	// We should look at the "expectations" for this:
-	// https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/controller_utils.go
+	// Reconcile the cached view of the object with what we know we have already
+	// created in Konnect, so a stale cache cannot drive a duplicate create.
+	if res, stop, err := r.reconcilePendingKonnectID(ctx, ent); stop {
+		return res, err
+	}
+
 	if shouldCreateKonnectEntity(ent) {
 
 		// Check if the object is adopting an existing Konnect entity.
@@ -651,23 +675,24 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(ctx context.Context, ent TE
 
 		_, err := ops.Create(ctx, sdk, r.Client, r.MetricRecorder, ent)
 
-		// TODO: this is actually not 100% error prone because when status
-		// update fails we don't store the Konnect ID and hence the reconciler
-		// will try to create the resource again on next reconciliation.
+		// Add the Org ID and Server URL to the status so that the status can
+		// indicate where the corresponding Konnect entity is located. The cleanup
+		// finalizer has already been added before the create above.
+		setStatusServerURLAndOrgID(ent, server, apiAuth.Status.OrganizationID)
 
-		// Regardless of the error reported from Create(), if the Konnect ID has been
-		// set then:
-		// - add the finalizer so that the resource can be cleaned up from Konnect on deletion...
-		if shouldAttachKonnectFinalizerAfterCreate(ent) {
-			if _, res, err := patch.WithFinalizer(ctx, r.Client, ent, KonnectCleanupFinalizer); err != nil || !res.IsZero() {
-				return res, err
-			}
-
-			// ...
-			// - add the Org ID and Server URL to the status so that the resource can be
-			//   cleaned up from Konnect on deletion and also so that the status can
-			//   indicate where the corresponding Konnect entity is located.
-			setStatusServerURLAndOrgID(ent, server, apiAuth.Status.OrganizationID)
+		// If the entity was created in Konnect, record its Konnect ID in the
+		// in-memory store. The entry is intentionally kept (not purged here) until a
+		// later reconcile observes the persisted ID on the cached status (see the
+		// reconciliation block above) or the entity is deleted. This serves two
+		// purposes:
+		//   - cleanup: the deletion logic can find and delete the Konnect entity even
+		//     if the status update below fails (preventing orphaned entities);
+		//   - de-duplication: a subsequent reconcile reading a stale, ID-less cached
+		//     status will restore the ID from here instead of creating a duplicate.
+		// Only the entity's own ID can be lost here; parent references are persisted
+		// by their reference handlers in earlier reconcile passes.
+		if id := ent.GetKonnectStatus().GetKonnectID(); id != "" {
+			r.pendingKonnectIDs.Store(client.ObjectKeyFromObject(ent), id)
 		}
 
 		// Regardless of the error, patch the status as it can contain the Konnect ID,
@@ -767,20 +792,67 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(ctx context.Context, ent TE
 		return res, nil
 	}
 
-	// Ensure that successfully reconciled object has the cleanup finalizer.
-	// This can happen when the finalizer was removed e.g. when the referenced
-	// object was removed, breaking the reference chain in Konnect and thus making
-	// the delete operation on the Konnect side impossible.
-	if _, res, err := patch.WithFinalizer(ctx, r.Client, ent, KonnectCleanupFinalizer); err != nil || !res.IsZero() {
-		return res, err
-	}
-
 	// NOTE: We requeue here to keep enforcing the state of the resource in Konnect.
 	// Konnect does not allow subscribing to changes so we need to keep pushing the
 	// desired state periodically.
 	return ctrl.Result{
 		RequeueAfter: r.SyncPeriod,
 	}, nil
+}
+
+// reconcilePendingKonnectID reconciles the cached view of the object with the
+// in-memory record of Konnect entities we have already created. Reads go through
+// a cache, so right after creating an entity and persisting its Konnect ID to the
+// status, a later reconcile may still observe a stale, ID-less status; creating
+// again on that basis would produce a duplicate Konnect entity. The in-memory
+// store records the Konnect ID as soon as the entity is created, so:
+//   - if the cached status lacks the ID but the store has it, restore and persist
+//     it. ApplyStatusPatchIfNotEmpty writes through to the API server and refreshes
+//     ent from the response, so the rest of the loop runs on a consistent object.
+//     Re-persisting is idempotent and also heals the case where the post-create
+//     status write failed.
+//   - once the status carries the ID, the bridge entry has served its purpose and
+//     is dropped.
+//
+// It returns stop=true when the caller should return the provided result/error (a
+// conflict requeue or a persist error); otherwise reconciliation continues with a
+// consistent ent.
+func (r *KonnectEntityReconciler[T, TEnt]) reconcilePendingKonnectID(
+	ctx context.Context,
+	ent TEnt,
+) (ctrl.Result, bool, error) {
+	pendingKey := client.ObjectKeyFromObject(ent)
+	if ent.GetKonnectStatus().GetKonnectID() == "" {
+		if id, ok := r.pendingKonnectIDs.Get(pendingKey); ok {
+			old := ent.DeepCopyObject().(client.Object)
+			ent.SetKonnectID(id)
+			if _, err := patch.ApplyStatusPatchIfNotEmpty(ctx, r.Client, ctrllog.FromContext(ctx), any(ent).(client.Object), old); err != nil {
+				if apierrors.IsConflict(err) {
+					return ctrl.Result{Requeue: true}, true, nil
+				}
+				return ctrl.Result{}, true, fmt.Errorf("failed to persist recovered Konnect ID for %s: %w", pendingKey, err)
+			}
+		}
+	}
+	if ent.GetKonnectStatus().GetKonnectID() != "" {
+		r.pendingKonnectIDs.Delete(pendingKey)
+	}
+	return ctrl.Result{}, false, nil
+}
+
+// restorePendingKonnectIDForDeletion restores the Konnect ID from the in-memory
+// store onto the object when its status does not carry one, so the deletion logic
+// can clean up the corresponding Konnect entity. If the ID is not in memory either
+// (e.g. after an operator restart), ops.Delete falls back to probing Konnect by
+// Kubernetes UID. Parent references needed for deletion are already on the object,
+// persisted by their reference handlers in earlier reconcile passes.
+func (r *KonnectEntityReconciler[T, TEnt]) restorePendingKonnectIDForDeletion(ent TEnt) {
+	if ent.GetKonnectStatus().GetKonnectID() != "" {
+		return
+	}
+	if id, ok := r.pendingKonnectIDs.Get(client.ObjectKeyFromObject(ent)); ok {
+		ent.SetKonnectID(id)
+	}
 }
 
 func shouldCreateKonnectEntity[
@@ -798,17 +870,6 @@ func shouldCreateKonnectEntity[
 		return true
 	}
 	return !entityHasProgrammedStatusTrue(ent)
-}
-
-func shouldAttachKonnectFinalizerAfterCreate[
-	T constraints.SupportedKonnectEntityType,
-	TEnt constraints.EntityType[T],
-](ent TEnt) bool {
-	status := ent.GetKonnectStatus()
-	if status != nil && status.GetKonnectID() != "" {
-		return true
-	}
-	return !ops.EntityPersistsKonnectID(ent) && entityHasProgrammedStatusTrue(ent)
 }
 
 func entityHasProgrammedStatusTrue[

--- a/controller/konnect/reconciler_generic_pending_konnect_id_test.go
+++ b/controller/konnect/reconciler_generic_pending_konnect_id_test.go
@@ -1,0 +1,138 @@
+package konnect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
+	"github.com/kong/kong-operator/v2/modules/manager/logging"
+	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+)
+
+// newKongServiceForPendingTest returns a KongService named ns/svc. When id is
+// non-empty the Konnect status (ID + ControlPlaneID) is populated, simulating an
+// object whose status already reflects the persisted Konnect ID.
+func newKongServiceForPendingTest(id string) *configurationv1alpha1.KongService {
+	svc := &configurationv1alpha1.KongService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc",
+			Namespace: "ns",
+		},
+	}
+	if id != "" {
+		svc.Status.Konnect = &konnectv1alpha2.KonnectEntityStatusWithControlPlaneAndCertificateAndCACertificatesRefs{
+			KonnectEntityStatus: konnectv1alpha2.KonnectEntityStatus{ID: id},
+			ControlPlaneID:      "cp-id",
+		}
+	}
+	return svc
+}
+
+func newReconcilerForPendingTest(
+	objs ...client.Object,
+) *KonnectEntityReconciler[configurationv1alpha1.KongService, *configurationv1alpha1.KongService] {
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme.Get()).
+		WithObjects(objs...).
+		WithStatusSubresource(&configurationv1alpha1.KongService{}).
+		Build()
+	return NewKonnectEntityReconciler[configurationv1alpha1.KongService](
+		nil, logging.DevelopmentMode, cl,
+	)
+}
+
+func TestReconcilePendingKonnectID(t *testing.T) {
+	const konnectID = "service-12345"
+
+	t.Run("restores and persists the ID when the cached status lacks it but the store has it", func(t *testing.T) {
+		// The API server copy does not carry the ID yet - this models both the
+		// cache-lag case and the case where the post-create status write failed.
+		r := newReconcilerForPendingTest(newKongServiceForPendingTest(""))
+
+		ent := newKongServiceForPendingTest("")
+		key := client.ObjectKeyFromObject(ent)
+		r.pendingKonnectIDs.Store(key, konnectID)
+
+		res, stop, err := r.reconcilePendingKonnectID(t.Context(), ent)
+		require.NoError(t, err)
+		assert.False(t, stop, "reconciliation should continue, not return early")
+		assert.True(t, res.IsZero())
+
+		// The ID is restored onto ent, so we no longer create (no duplicate).
+		assert.Equal(t, konnectID, ent.GetKonnectStatus().GetKonnectID())
+		assert.False(t, shouldCreateKonnectEntity(ent), "must not create a duplicate Konnect entity")
+
+		// The ID is written through to the API server.
+		var fetched configurationv1alpha1.KongService
+		require.NoError(t, r.Client.Get(t.Context(), key, &fetched))
+		assert.Equal(t, konnectID, fetched.GetKonnectStatus().GetKonnectID())
+
+		// The bridge entry is purged once the status carries the ID.
+		_, ok := r.pendingKonnectIDs.Get(key)
+		assert.False(t, ok)
+	})
+
+	t.Run("does nothing and allows create when there is no store entry", func(t *testing.T) {
+		r := newReconcilerForPendingTest(newKongServiceForPendingTest(""))
+		ent := newKongServiceForPendingTest("")
+
+		res, stop, err := r.reconcilePendingKonnectID(t.Context(), ent)
+		require.NoError(t, err)
+		assert.False(t, stop)
+		assert.True(t, res.IsZero())
+		assert.Empty(t, ent.GetKonnectStatus().GetKonnectID())
+		assert.True(t, shouldCreateKonnectEntity(ent), "a first-time create must proceed")
+	})
+
+	t.Run("purges the store entry once the cached status already carries the ID", func(t *testing.T) {
+		r := newReconcilerForPendingTest(newKongServiceForPendingTest(konnectID))
+		ent := newKongServiceForPendingTest(konnectID)
+		key := client.ObjectKeyFromObject(ent)
+		r.pendingKonnectIDs.Store(key, konnectID)
+
+		_, stop, err := r.reconcilePendingKonnectID(t.Context(), ent)
+		require.NoError(t, err)
+		assert.False(t, stop)
+
+		_, ok := r.pendingKonnectIDs.Get(key)
+		assert.False(t, ok, "entry must be purged once the status reflects the ID")
+	})
+}
+
+func TestRestorePendingKonnectIDForDeletion(t *testing.T) {
+	const konnectID = "service-12345"
+
+	t.Run("restores the ID from the store when the status has none", func(t *testing.T) {
+		r := newReconcilerForPendingTest()
+		ent := newKongServiceForPendingTest("")
+		key := client.ObjectKeyFromObject(ent)
+		r.pendingKonnectIDs.Store(key, konnectID)
+
+		r.restorePendingKonnectIDForDeletion(ent)
+		assert.Equal(t, konnectID, ent.GetKonnectStatus().GetKonnectID())
+	})
+
+	t.Run("keeps the existing status ID and ignores the store", func(t *testing.T) {
+		r := newReconcilerForPendingTest()
+		ent := newKongServiceForPendingTest(konnectID)
+		key := client.ObjectKeyFromObject(ent)
+		r.pendingKonnectIDs.Store(key, "a-different-id")
+
+		r.restorePendingKonnectIDForDeletion(ent)
+		assert.Equal(t, konnectID, ent.GetKonnectStatus().GetKonnectID(), "the persisted status ID must win")
+	})
+
+	t.Run("no-op when neither the status nor the store has an ID", func(t *testing.T) {
+		r := newReconcilerForPendingTest()
+		ent := newKongServiceForPendingTest("")
+
+		r.restorePendingKonnectIDForDeletion(ent)
+		assert.Empty(t, ent.GetKonnectStatus().GetKonnectID())
+	})
+}

--- a/test/envtest/konnect_entities_kongservice_test.go
+++ b/test/envtest/konnect_entities_kongservice_test.go
@@ -641,8 +641,13 @@ func TestKongService(t *testing.T) {
 			if !ok {
 				return false
 			}
-			return c.Status == metav1.ConditionFalse && c.Reason == "FailedToCreate"
-		}, "KongService should get the Programmed condition set to status=False due to network error")
+			// The cleanup finalizer must be present even though the Konnect create
+			// failed: it is added before the create (finalizer-first), so the entity
+			// can always be cleaned up. The previous behaviour (finalizer added only
+			// after a successful create) would leave no finalizer here.
+			return c.Status == metav1.ConditionFalse && c.Reason == "FailedToCreate" &&
+				objectHasFinalizer[*configurationv1alpha1.KongService](konnect.KonnectCleanupFinalizer)(ks)
+		}, "KongService should get Programmed=False on network error and still carry the cleanup finalizer")
 
 		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 	})


### PR DESCRIPTION


**What this PR does / why we need it**:

Creating a Konnect entity and persisting its Konnect ID to the resource status are two non-atomic steps. If the resource was deleted, the operator restarted, or the status write failed within that window, the operator lost track of the entity: it had no Konnect ID and could neither clean it up (orphan) nor avoid re-creating it from a stale cached status (duplicate).

- Add the cleanup finalizer before creating the entity in Konnect, so cleanup is always possible regardless of when the create is interrupted.
- Keep the freshly created Konnect ID in an in-memory store until the cached status reflects it, so the create/status-persist window is bridged.
- On deletion, recover a missing Konnect ID from the in-memory store, falling back to probing Konnect by Kubernetes UID (or by name for the tag-less Cloud Gateway types) so entities are cleaned up even after an operator restart.
- Use the in-memory store as the authoritative "already created" signal to avoid creating a duplicate when the cached status has not yet caught up.
- Add unit tests for the store, the de-dup guard, the delete-time recovery and the Konnect ID probe, plus an envtest asserting the finalizer is present even when the Konnect create fails.

**Which issue this PR fixes**

Fixes #4649 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
