### PR TITLE
[backport v2.2.x]fix: normalize HTTPRoute header and query matches (#4597)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@
 
 ### Fixes
 
+- HTTPRoute: traditional route translation now treats header match names
+  case-insensitively and ignores later equivalent duplicates, aligning with
+  Gateway API matching semantics.
+  [#4597](https://github.com/Kong/kong-operator/pull/4597)
 - Hybridgateway: release Gateway API route finalizers once generated Kong
   resource delete requests have been issued, so immediate same-name route
   re-creates are not blocked by child resource finalizers.

--- a/ingress-controller/internal/dataplane/translator/subtranslator/httproute.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/httproute.go
@@ -849,11 +849,18 @@ func convertGatewayMatchHeadersToKongRouteMatchHeaders(headers []gatewayapi.HTTP
 	// iterate through each provided header match checking for invalid
 	// options and otherwise converting to kong type format.
 	convertedHeaders := make(map[string][]string)
+	// Header names are case-insensitive, and only the first match for an equivalent
+	// header name is considered:
+	// https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPHeaderMatch
+	// The original casing of the first occurrence is kept since Kong matches header
+	// names case-insensitively either way.
+	seenHeaderNames := make(map[string]struct{}, len(headers))
 	for _, header := range headers {
-		if _, exists := convertedHeaders[string(header.Name)]; exists {
-			return nil, fmt.Errorf("multiple header matches for the same header are not allowed: %s",
-				string(header.Name))
+		lowercaseHeaderName := strings.ToLower(string(header.Name))
+		if _, exists := seenHeaderNames[lowercaseHeaderName]; exists {
+			continue
 		}
+		seenHeaderNames[lowercaseHeaderName] = struct{}{}
 		switch {
 		case header.Type != nil && *header.Type == gatewayapi.HeaderMatchRegularExpression:
 			convertedHeaders[string(header.Name)] = []string{KongHeaderRegexPrefix + header.Value}

--- a/ingress-controller/internal/dataplane/translator/subtranslator/httproute_atc.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/httproute_atc.go
@@ -294,13 +294,37 @@ func calculateHTTPRouteMatchPriorityTraits(match SplitHTTPRouteMatch) HTTPRouteP
 		traits.HasMethodMatch = true
 	}
 
-	// fill number of header matches.
-	traits.HeaderCount = len(match.Match.Headers)
+	// fill number of effective header matches.
+	traits.HeaderCount = countEffectiveHTTPHeaderMatches(match.Match.Headers)
 
-	// fill number of query parameters.
-	traits.QueryParamCount = len(match.Match.QueryParams)
+	// fill number of effective query parameters.
+	traits.QueryParamCount = countEffectiveHTTPQueryParamMatches(match.Match.QueryParams)
 
 	return traits
+}
+
+func countEffectiveHTTPHeaderMatches(headers []gatewayapi.HTTPHeaderMatch) int {
+	seenHeaders := make(map[string]struct{}, len(headers))
+	for _, header := range headers {
+		name := strings.ToLower(string(header.Name))
+		if _, ok := seenHeaders[name]; ok {
+			continue
+		}
+		seenHeaders[name] = struct{}{}
+	}
+	return len(seenHeaders)
+}
+
+func countEffectiveHTTPQueryParamMatches(queryParams []gatewayapi.HTTPQueryParamMatch) int {
+	seenQueryParams := make(map[string]struct{}, len(queryParams))
+	for _, queryParam := range queryParams {
+		name := string(queryParam.Name)
+		if _, ok := seenQueryParams[name]; ok {
+			continue
+		}
+		seenQueryParams[name] = struct{}{}
+	}
+	return len(seenQueryParams)
 }
 
 // EncodeToPriority turns HTTPRoute priority traits into the integer expressed priority.

--- a/ingress-controller/internal/dataplane/translator/subtranslator/httproute_atc_test.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/httproute_atc_test.go
@@ -214,6 +214,32 @@ func TestCalculateHTTPRoutePriorityTraits(t *testing.T) {
 				QueryParamCount: 1,
 			},
 		},
+		{
+			name: "equivalent duplicate header and query parameter names count once",
+			match: SplitHTTPRouteMatch{
+				Source: &gatewayapi.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "duplicate-match-names",
+					},
+				},
+				Match: gatewayapi.HTTPRouteMatch{
+					Headers: []gatewayapi.HTTPHeaderMatch{
+						{Name: "X-Foo", Value: "one"},
+						{Name: "x-foo", Value: "two"},
+						{Name: "X-Bar", Value: "three"},
+					},
+					QueryParams: []gatewayapi.HTTPQueryParamMatch{
+						{Name: "version", Value: "one"},
+						{Name: "version", Value: "two"},
+					},
+				},
+			},
+			expectedTraits: HTTPRoutePriorityTraits{
+				HeaderCount:     2,
+				QueryParamCount: 1,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/ingress-controller/internal/dataplane/translator/subtranslator/httproute_test.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/httproute_test.go
@@ -771,7 +771,7 @@ func TestConvertGatewayMatchHeadersToKongRouteMatchHeaders(t *testing.T) {
 			},
 		},
 		{
-			msg: "multiple header matches for the same header are rejected",
+			msg: "multiple identical header names only use the first match",
 			input: []gatewayapi.HTTPHeaderMatch{
 				{
 					Name:  "Content-Type",
@@ -782,8 +782,25 @@ func TestConvertGatewayMatchHeadersToKongRouteMatchHeaders(t *testing.T) {
 					Value: "audio/flac",
 				},
 			},
-			output: nil,
-			err:    fmt.Errorf("multiple header matches for the same header are not allowed: Content-Type"),
+			output: map[string][]string{
+				"Content-Type": {"audio/vorbis"},
+			},
+		},
+		{
+			msg: "multiple equivalent header names only use the first match",
+			input: []gatewayapi.HTTPHeaderMatch{
+				{
+					Name:  "Content-Type",
+					Value: "audio/vorbis",
+				},
+				{
+					Name:  "content-type",
+					Value: "audio/flac",
+				},
+			},
+			output: map[string][]string{
+				"Content-Type": {"audio/vorbis"},
+			},
 		},
 		{
 			msg: "multiple header matches convert properly",


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

backport #4597

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
