### PR TITLE
Fix(controller): Copy old object before removing condition in `StatusWithoutCondition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,10 @@
   avoids attaching two plugins of the same type to the same route, which Konnect
   rejects with a `unique-plugin-per-entity` constraint error.
   [#4658](https://github.com/Kong/kong-operator/pull/4658)
+- Fix the issue that the `ResolvedRef` condition for cross-namespace reference
+  is not removed when a resource is updated to remove the cross-namespace
+  reference.
+  [#4663](https://github.com/Kong/kong-operator/pull/4663)
 
 ## [v2.2.0]
 

--- a/controller/konnect/reconciler_controlplaneref.go
+++ b/controller/konnect/reconciler_controlplaneref.go
@@ -137,6 +137,34 @@ func handleControlPlaneRef[T constraints.SupportedKonnectEntityType, TEnt constr
 	return ctrl.Result{}, nil
 }
 
+// entityHasCrossNamespaceRefs reports whether ent has any cross-namespace
+// reference (Secret, KongCACertificate, KongCertificate/ClientCertificate) whose
+// shared ResolvedRefs condition is owned by a dedicated handler. The
+// control-plane-ref handler must not remove the ResolvedRefs condition while any
+// such reference exists, otherwise it would clobber what those handlers set
+// (they run later in Reconcile).
+func entityHasCrossNamespaceRefs[
+	T constraints.SupportedKonnectEntityType, TEnt constraints.EntityType[T],
+](ent TEnt) bool {
+	ns := ent.GetNamespace()
+	isCross := func(n *string) bool { return n != nil && *n != "" && *n != ns }
+
+	for _, r := range getSecretRefs(ent) {
+		if isCross(r.Namespace) {
+			return true
+		}
+	}
+	for _, r := range getKongCACertificateRefs(ent) {
+		if isCross(r.Namespace) {
+			return true
+		}
+	}
+	if r, ok := getKongCertificateRef(ent).Get(); ok && isCross(r.Namespace) {
+		return true
+	}
+	return false
+}
+
 func conditionMessageReferenceKonnectAPIAuthConfigurationInvalid(apiAuthRef types.NamespacedName) string {
 	return fmt.Sprintf("referenced KonnectAPIAuthConfiguration %s is invalid", apiAuthRef)
 }
@@ -162,11 +190,17 @@ func ensureKongReferenceGrant[
 	if cpRef.Type != commonv1alpha1.ControlPlaneRefKonnectNamespacedRef ||
 		toNamespace == "" ||
 		toNamespace == fromNamespace {
-		if res, errStatus := patch.StatusWithoutCondition(
-			ctx, cl, ent,
-			configurationv1alpha1.KongReferenceGrantConditionTypeResolvedRefs,
-		); errStatus != nil || !res.IsZero() {
-			return res, errStatus
+		// The ControlPlane ref doesn't require a grant. Only remove the shared
+		// ResolvedRefs condition if no other cross-namespace reference of this
+		// entity still justifies it, otherwise we'd clobber the condition that
+		// the secret/certificate ref handlers set (they run later in Reconcile).
+		if !entityHasCrossNamespaceRefs(ent) {
+			if res, errStatus := patch.StatusWithoutCondition(
+				ctx, cl, ent,
+				configurationv1alpha1.KongReferenceGrantConditionTypeResolvedRefs,
+			); errStatus != nil || !res.IsZero() {
+				return res, errStatus
+			}
 		}
 		return ctrl.Result{}, nil
 	}

--- a/controller/konnect/reconciler_controlplaneref.go
+++ b/controller/konnect/reconciler_controlplaneref.go
@@ -194,6 +194,10 @@ func ensureKongReferenceGrant[
 		// ResolvedRefs condition if no other cross-namespace reference of this
 		// entity still justifies it, otherwise we'd clobber the condition that
 		// the secret/certificate ref handlers set (they run later in Reconcile).
+
+		// TODO: Unify the place of setting `ResolvedRefs` condition for entities
+		// having multiple references to other resources, so that we don't have to check for each of them here:
+		// https://github.com/Kong/kong-operator/issues/4711
 		if !entityHasCrossNamespaceRefs(ent) {
 			if res, errStatus := patch.StatusWithoutCondition(
 				ctx, cl, ent,

--- a/controller/konnect/reconciler_controlplaneref_test.go
+++ b/controller/konnect/reconciler_controlplaneref_test.go
@@ -857,3 +857,95 @@ func TestKongReferenceGrantAllowsCPRef(t *testing.T) {
 		})
 	}
 }
+
+func TestEntityHasCrossNamespaceRefs(t *testing.T) {
+	const entNamespace = "default"
+
+	kongCert := func(spec configurationv1alpha1.KongCertificateSpec) func() bool {
+		return func() bool {
+			return entityHasCrossNamespaceRefs(&configurationv1alpha1.KongCertificate{
+				ObjectMeta: metav1.ObjectMeta{Namespace: entNamespace},
+				Spec:       spec,
+			})
+		}
+	}
+	kongSvc := func(apiSpec configurationv1alpha1.KongServiceAPISpec) func() bool {
+		return func() bool {
+			return entityHasCrossNamespaceRefs(&configurationv1alpha1.KongService{
+				ObjectMeta: metav1.ObjectMeta{Namespace: entNamespace},
+				Spec:       configurationv1alpha1.KongServiceSpec{KongServiceAPISpec: apiSpec},
+			})
+		}
+	}
+
+	tests := []struct {
+		name     string
+		run      func() bool
+		expected bool
+	}{
+		{
+			name:     "KongCertificate without secret refs",
+			run:      kongCert(configurationv1alpha1.KongCertificateSpec{}),
+			expected: false,
+		},
+		{
+			name: "KongCertificate with same-namespace SecretRef (nil namespace)",
+			run: kongCert(configurationv1alpha1.KongCertificateSpec{
+				SecretRef: &commonv1alpha1.NamespacedRef{Name: "s"},
+			}),
+			expected: false,
+		},
+		{
+			name: "KongCertificate with same-namespace SecretRef (explicit namespace)",
+			run: kongCert(configurationv1alpha1.KongCertificateSpec{
+				SecretRef: &commonv1alpha1.NamespacedRef{Name: "s", Namespace: new(entNamespace)},
+			}),
+			expected: false,
+		},
+		{
+			name: "KongCertificate with cross-namespace SecretRef",
+			run: kongCert(configurationv1alpha1.KongCertificateSpec{
+				SecretRef: &commonv1alpha1.NamespacedRef{Name: "s", Namespace: new("other")},
+			}),
+			expected: true,
+		},
+		{
+			name: "KongCertificate with cross-namespace SecretRefAlt",
+			run: kongCert(configurationv1alpha1.KongCertificateSpec{
+				SecretRef:    &commonv1alpha1.NamespacedRef{Name: "s"},
+				SecretRefAlt: &commonv1alpha1.NamespacedRef{Name: "s-alt", Namespace: new("other")},
+			}),
+			expected: true,
+		},
+		{
+			name: "KongService with cross-namespace CACertificateRef",
+			run: kongSvc(configurationv1alpha1.KongServiceAPISpec{
+				CACertificateRefs: []commonv1alpha1.NamespacedRef{
+					{Name: "ca", Namespace: new("other")},
+				},
+			}),
+			expected: true,
+		},
+		{
+			name: "KongService with cross-namespace ClientCertificateRef",
+			run: kongSvc(configurationv1alpha1.KongServiceAPISpec{
+				ClientCertificateRef: &commonv1alpha1.NamespacedRef{Name: "cc", Namespace: new("other")},
+			}),
+			expected: true,
+		},
+		{
+			name: "KongService with only same-namespace refs",
+			run: kongSvc(configurationv1alpha1.KongServiceAPISpec{
+				CACertificateRefs:    []commonv1alpha1.NamespacedRef{{Name: "ca"}},
+				ClientCertificateRef: &commonv1alpha1.NamespacedRef{Name: "cc", Namespace: new(entNamespace)},
+			}),
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.run())
+		})
+	}
+}

--- a/controller/konnect/reconciler_generic_handle_parentref.go
+++ b/controller/konnect/reconciler_generic_handle_parentref.go
@@ -63,11 +63,17 @@ func ensureKongReferenceGrantForParentRef[
 		ref.NamespacedRef == nil ||
 		ref.NamespacedRef.Namespace == nil ||
 		*ref.NamespacedRef.Namespace == ent.GetNamespace() {
-		if res, errStatus := patch.StatusWithoutCondition(
-			ctx, cl, ent,
-			configurationv1alpha1.KongReferenceGrantConditionTypeResolvedRefs,
-		); errStatus != nil || !res.IsZero() {
-			return res, errStatus
+		// The parent ref doesn't require a grant. Only remove the shared
+		// ResolvedRefs condition if no other cross-namespace reference of this
+		// entity still justifies it, otherwise we'd clobber the condition that
+		// the secret ref handler sets (it runs later in Reconcile).
+		if !parentRefEntityHasCrossNamespaceRefs(ent) {
+			if res, errStatus := patch.StatusWithoutCondition(
+				ctx, cl, ent,
+				configurationv1alpha1.KongReferenceGrantConditionTypeResolvedRefs,
+			); errStatus != nil || !res.IsZero() {
+				return res, errStatus
+			}
 		}
 		return ctrl.Result{}, nil
 	}
@@ -120,6 +126,25 @@ func ensureKongReferenceGrantForParentRef[
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// parentRefEntityHasCrossNamespaceRefs reports whether a parent-ref entity has a
+// cross-namespace sensitive-data secret ref. Such refs are the only cross-namespace
+// reference type a parent-ref entity carries, and the secret ref handler owns the
+// shared ResolvedRefs condition for them. The parent-ref handler must not remove
+// ResolvedRefs while one exists, otherwise it would clobber what that handler sets.
+func parentRefEntityHasCrossNamespaceRefs(ent client.Object) bool {
+	g, ok := any(ent).(sensitiveDataSecretRefsGetter)
+	if !ok {
+		return false
+	}
+	ns := ent.GetNamespace()
+	for _, r := range g.GetSensitiveDataSecretRefs() {
+		if n := r.Ref.Namespace; n != nil && *n != "" && *n != ns {
+			return true
+		}
+	}
+	return false
 }
 
 type parentRefHandler[

--- a/controller/pkg/patch/statuscondition.go
+++ b/controller/pkg/patch/statuscondition.go
@@ -101,6 +101,10 @@ func StatusWithoutCondition[T interface {
 	ent T,
 	conditionType string,
 ) (res ctrl.Result, err error) {
+	// If the condition is not set, return without patching.
+	if !k8sutils.HasCondition(kcfgconsts.ConditionType(conditionType), ent) {
+		return ctrl.Result{}, nil
+	}
 	old := ent.DeepCopyObject().(T)
 	if !k8sutils.RemoveCondition(kcfgconsts.ConditionType(conditionType), ent) {
 		return ctrl.Result{}, nil

--- a/controller/pkg/patch/statuscondition.go
+++ b/controller/pkg/patch/statuscondition.go
@@ -101,11 +101,11 @@ func StatusWithoutCondition[T interface {
 	ent T,
 	conditionType string,
 ) (res ctrl.Result, err error) {
+	old := ent.DeepCopyObject().(T)
 	if !k8sutils.RemoveCondition(kcfgconsts.ConditionType(conditionType), ent) {
 		return ctrl.Result{}, nil
 	}
 
-	old := ent.DeepCopyObject().(T)
 	if err := cl.Status().Patch(ctx, ent, client.MergeFrom(old)); err != nil {
 		if apierrors.IsConflict(err) {
 			return ctrl.Result{Requeue: true}, nil

--- a/controller/pkg/patch/statuscondition_test.go
+++ b/controller/pkg/patch/statuscondition_test.go
@@ -288,3 +288,128 @@ func TestPatchStatusWithCondition(t *testing.T) {
 		})
 	}
 }
+
+func TestPatchStatusWithoutCondition(t *testing.T) {
+	const removedConditionType = kcfgdataplane.ReadyType
+
+	otherCondition := metav1.Condition{
+		Type:               "OtherCondition",
+		Status:             metav1.ConditionTrue,
+		Reason:             string(kcfgkonnect.KonnectExtensionAppliedReason),
+		Message:            "unrelated condition that must be preserved",
+		ObservedGeneration: 1,
+	}
+	removedCondition := metav1.Condition{
+		Type:               string(removedConditionType),
+		Status:             metav1.ConditionFalse,
+		Reason:             string(kcfgdataplane.DependenciesNotReadyReason),
+		Message:            "stale condition that must be removed",
+		ObservedGeneration: 1,
+	}
+
+	newDataPlane := func(conditions ...metav1.Condition) *operatorv1beta1.DataPlane {
+		return &operatorv1beta1.DataPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "dp1",
+				Generation: 1,
+			},
+			Status: operatorv1beta1.DataPlaneStatus{
+				Conditions: conditions,
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		obj  *operatorv1beta1.DataPlane
+		// removedAbsent asserts the condition is gone after the call.
+		removedAbsent bool
+		// remainingTypes lists condition types that must still be present after the call.
+		remainingTypes  []string
+		expectedResult  ctrl.Result
+		expectedError   bool
+		interceptorFunc interceptor.Funcs
+	}{
+		{
+			name:           "condition present is removed and other conditions are preserved",
+			obj:            newDataPlane(otherCondition, removedCondition),
+			removedAbsent:  true,
+			remainingTypes: []string{otherCondition.Type},
+			expectedResult: ctrl.Result{},
+		},
+		{
+			name:           "condition absent is a no-op without error",
+			obj:            newDataPlane(otherCondition),
+			removedAbsent:  true,
+			remainingTypes: []string{otherCondition.Type},
+			expectedResult: ctrl.Result{},
+		},
+		{
+			name:           "conflict triggers requeue",
+			obj:            newDataPlane(removedCondition),
+			expectedResult: ctrl.Result{Requeue: true},
+			interceptorFunc: interceptor.Funcs{
+				SubResourcePatch: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+					return &apierrors.StatusError{
+						ErrStatus: metav1.Status{
+							Status: metav1.StatusFailure,
+							Reason: metav1.StatusReasonConflict,
+						},
+					}
+				},
+			},
+		},
+		{
+			name:          "other error is returned",
+			obj:           newDataPlane(removedCondition),
+			expectedError: true,
+			interceptorFunc: interceptor.Funcs{
+				SubResourcePatch: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+					return &apierrors.StatusError{
+						ErrStatus: metav1.Status{
+							Status: metav1.StatusFailure,
+							Reason: metav1.StatusReason("unknown"),
+						},
+					}
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			cl := fake.NewClientBuilder().
+				WithObjects(tt.obj).
+				WithStatusSubresource(tt.obj).
+				WithScheme(scheme.Get()).
+				WithInterceptorFuncs(tt.interceptorFunc).
+				Build()
+
+			result, err := StatusWithoutCondition(
+				ctx, cl, tt.obj, string(removedConditionType),
+			)
+
+			assert.Equal(t, tt.expectedResult, result)
+			if tt.expectedError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Re-read from the client (not the in-memory object) so the test
+			// catches the empty-patch no-op bug rather than just the in-memory mutation.
+			persisted := &operatorv1beta1.DataPlane{}
+			require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(tt.obj), persisted))
+
+			if tt.removedAbsent {
+				_, ok := k8sutils.GetCondition(removedConditionType, persisted)
+				assert.Falsef(t, ok, "condition %s should have been removed", removedConditionType)
+			}
+			for _, condType := range tt.remainingTypes {
+				_, ok := k8sutils.GetCondition(kcfgconsts.ConditionType(condType), persisted)
+				assert.Truef(t, ok, "condition %s should have been preserved", condType)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the `StatusWithoutCondition` in the utils so that the not required `ResolvedRef` condition in Konnect entities when a cross-namespace reference dissappears can be correctly removed.

**Which issue this PR fixes**

Fixes #4248

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
