### PR TITLE
fix(konnect): defer reconcile after recovering pending Konnect ID

### DIFF
--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -807,16 +807,23 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(ctx context.Context, ent TE
 // again on that basis would produce a duplicate Konnect entity. The in-memory
 // store records the Konnect ID as soon as the entity is created, so:
 //   - if the cached status lacks the ID but the store has it, restore and persist
-//     it. ApplyStatusPatchIfNotEmpty writes through to the API server and refreshes
-//     ent from the response, so the rest of the loop runs on a consistent object.
-//     Re-persisting is idempotent and also heals the case where the post-create
-//     status write failed.
+//     it. When the status is actually patched (op.Updated), reconciliation stops
+//     for this pass so the watch event from the status write triggers a fresh
+//     reconcile with a fully-consistent cached object. The status patch refreshes
+//     ent from the server response, so continuing here would run the rest of the
+//     loop and issue an enforcement Konnect update (e.g. ops.Update) on an object
+//     stitched together from a stale cache plus the targeted ID patch — an extra,
+//     timing-dependent API call. Deferring to a fresh reconcile matches the
+//     create path's convention (the status write drives the next pass) and keeps
+//     the behaviour deterministic. The store entry is purged in that fresh
+//     reconcile (see the block below). Re-persisting is idempotent and also heals
+//     the case where the post-create status write failed.
 //   - once the status carries the ID, the bridge entry has served its purpose and
 //     is dropped.
 //
 // It returns stop=true when the caller should return the provided result/error (a
-// conflict requeue or a persist error); otherwise reconciliation continues with a
-// consistent ent.
+// conflict requeue, a persist error, or a successful ID recovery that needs a
+// fresh reconcile); otherwise reconciliation continues with a consistent ent.
 func (r *KonnectEntityReconciler[T, TEnt]) reconcilePendingKonnectID(
 	ctx context.Context,
 	ent TEnt,
@@ -826,11 +833,22 @@ func (r *KonnectEntityReconciler[T, TEnt]) reconcilePendingKonnectID(
 		if id, ok := r.pendingKonnectIDs.Get(pendingKey); ok {
 			old := ent.DeepCopyObject().(client.Object)
 			ent.SetKonnectID(id)
-			if _, err := patch.ApplyStatusPatchIfNotEmpty(ctx, r.Client, ctrllog.FromContext(ctx), any(ent).(client.Object), old); err != nil {
+			result, err := patch.ApplyStatusPatchIfNotEmpty(ctx, r.Client, ctrllog.FromContext(ctx), any(ent).(client.Object), old)
+			if err != nil {
 				if apierrors.IsConflict(err) {
 					return ctrl.Result{Requeue: true}, true, nil
 				}
 				return ctrl.Result{}, true, fmt.Errorf("failed to persist recovered Konnect ID for %s: %w", pendingKey, err)
+			}
+			if result == op.Updated {
+				// ID was recovered and written to the cluster. Stop this reconcile
+				// pass so the status-update watch event triggers a fresh reconcile
+				// from a consistent cache. Continuing would run the enforcement
+				// ops.Update on an object built from a stale cache plus the targeted
+				// ID patch, issuing an extra, timing-dependent Konnect call. The
+				// store entry is purged in that subsequent reconcile once the cached
+				// status reflects the ID.
+				return ctrl.Result{}, true, nil
 			}
 		}
 	}

--- a/controller/konnect/reconciler_generic_pending_konnect_id_test.go
+++ b/controller/konnect/reconciler_generic_pending_konnect_id_test.go
@@ -61,7 +61,11 @@ func TestReconcilePendingKonnectID(t *testing.T) {
 
 		res, stop, err := r.reconcilePendingKonnectID(t.Context(), ent)
 		require.NoError(t, err)
-		assert.False(t, stop, "reconciliation should continue, not return early")
+		// stop=true: the ID was written to the cluster so this reconcile pass
+		// ends here. The watch event from the status write triggers a fresh
+		// reconcile with a consistent object, avoiding a spurious Konnect
+		// update call (e.g. UpsertPlugin).
+		assert.True(t, stop, "reconciliation should stop to let a fresh reconcile proceed with consistent state")
 		assert.True(t, res.IsZero())
 
 		// The ID is restored onto ent, so we no longer create (no duplicate).
@@ -73,9 +77,19 @@ func TestReconcilePendingKonnectID(t *testing.T) {
 		require.NoError(t, r.Client.Get(t.Context(), key, &fetched))
 		assert.Equal(t, konnectID, fetched.GetKonnectStatus().GetKonnectID())
 
-		// The bridge entry is purged once the status carries the ID.
+		// The bridge entry is NOT yet purged on this pass. It is cleaned up in
+		// the subsequent reconcile (triggered by the status watch event) once
+		// the cached status reflects the ID.
 		_, ok := r.pendingKonnectIDs.Get(key)
-		assert.False(t, ok)
+		assert.True(t, ok, "entry must remain in store until the next reconcile")
+
+		// Simulate the next reconcile: the cache now reflects the persisted ID.
+		ent2 := newKongServiceForPendingTest(konnectID)
+		_, stop2, err2 := r.reconcilePendingKonnectID(t.Context(), ent2)
+		require.NoError(t, err2)
+		assert.False(t, stop2, "second pass should continue normally")
+		_, ok2 := r.pendingKonnectIDs.Get(key)
+		assert.False(t, ok2, "entry must be purged once the cached status reflects the ID")
 	})
 
 	t.Run("does nothing and allows create when there is no store entry", func(t *testing.T) {

--- a/ingress-controller/test/kongintegration/containers/kong.go
+++ b/ingress-controller/test/kongintegration/containers/kong.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"testing"
@@ -153,16 +154,22 @@ func NewKong(ctx context.Context, t *testing.T, opts ...KongOpt) Kong {
 
 // AdminURL returns the admin API URL of the Kong container reachable from the host machine.
 func (c Kong) AdminURL(ctx context.Context, t *testing.T) string {
+	host, err := c.container.Host(ctx)
+	require.NoError(t, err)
+
 	port, err := c.container.MappedPort(ctx, kongAdminPort)
 	require.NoError(t, err)
-	return fmt.Sprintf("http://localhost:%s", port.Port())
+	return fmt.Sprintf("http://%s", net.JoinHostPort(host, port.Port()))
 }
 
 // ProxyURL returns the proxy URL of the Kong container reachable from the host machine.
 func (c Kong) ProxyURL(ctx context.Context, t *testing.T) string {
+	host, err := c.container.Host(ctx)
+	require.NoError(t, err)
+
 	port, err := c.container.MappedPort(ctx, kongProxyPort)
 	require.NoError(t, err)
-	return fmt.Sprintf("http://localhost:%s", port.Port())
+	return fmt.Sprintf("http://%s", net.JoinHostPort(host, port.Port()))
 }
 
 // Terminate stops and removes the Kong container.


### PR DESCRIPTION


**What this PR does / why we need it**:

When the informer cache serves a stale, ID-less status after a create, reconcilePendingKonnectID restores the ID from the in-memory store and patches the status. The patch refreshes ent from the server response, so continuing the loop would issue an enforcement Konnect call (e.g. ops.Update / UpsertPlugin) on an object stitched together from a stale cache plus the targeted ID patch — an extra, timing-dependent API call.

Stop the reconcile pass once the ID is written (op.Updated) and let the status-write watch event drive a fresh reconcile from a consistent cache, matching the create path's convention. The bridge store entry is purged on that subsequent pass. This keeps Konnect call counts deterministic.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
