### PR TITLE
test(kongintegration): use container host IP instead of hardcoded localhost

### DIFF
--- a/ingress-controller/test/kongintegration/containers/kong.go
+++ b/ingress-controller/test/kongintegration/containers/kong.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"testing"
@@ -153,16 +154,22 @@ func NewKong(ctx context.Context, t *testing.T, opts ...KongOpt) Kong {
 
 // AdminURL returns the admin API URL of the Kong container reachable from the host machine.
 func (c Kong) AdminURL(ctx context.Context, t *testing.T) string {
+	host, err := c.container.Host(ctx)
+	require.NoError(t, err)
+
 	port, err := c.container.MappedPort(ctx, kongAdminPort)
 	require.NoError(t, err)
-	return fmt.Sprintf("http://localhost:%s", port.Port())
+	return fmt.Sprintf("http://%s", net.JoinHostPort(host, port.Port()))
 }
 
 // ProxyURL returns the proxy URL of the Kong container reachable from the host machine.
 func (c Kong) ProxyURL(ctx context.Context, t *testing.T) string {
+	host, err := c.container.Host(ctx)
+	require.NoError(t, err)
+
 	port, err := c.container.MappedPort(ctx, kongProxyPort)
 	require.NoError(t, err)
-	return fmt.Sprintf("http://localhost:%s", port.Port())
+	return fmt.Sprintf("http://%s", net.JoinHostPort(host, port.Port()))
 }
 
 // Terminate stops and removes the Kong container.


### PR DESCRIPTION


**What this PR does / why we need it**:

AdminURL/ProxyURL hardcoded localhost, which breaks when the Docker daemon is remote (e.g. colima, Docker-in-Docker, remote contexts) and the container is not reachable on the host loopback. Resolve the real container host via testcontainers and join it with the mapped port using net.JoinHostPort so it works regardless of where Docker runs.

In my environment with docker on a minikube node i get the following error:

```
=== Failed
=== FAIL: test/envtest TestControlPlaneReferenceHandling (70.84s)
    control_plane_reference_test.go:33: starting envtest environment for test TestControlPlaneReferenceHandling...
    control_plane_reference_test.go:33: envtest environment (v1.36.0) started at https://127.0.0.1:55968/
    kong.go:130: failed validating Kong version: making HTTP request: Get "http://localhost:56181/": dial tcp [::1]:56181: connect: connection refused
    kong.go:122: 
                Error Trace:    /Users/aldo.lacuku/dev/kong-operator/ingress-controller/test/kongintegration/containers/kong.go:122
                                                        /Users/aldo.lacuku/dev/kong-operator/test/envtest/kong.go:26
                                                        /Users/aldo.lacuku/dev/kong-operator/test/envtest/control_plane_reference_test.go:39
                Error:          Received unexpected error:
                                context deadline exceeded
                Test:           TestControlPlaneReferenceHandling
    control_plane_reference_test.go:33: stopping envtest environment for test TestControlPlaneReferenceHandling

```


**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
