### PR TITLE
chore(gateway api): migrate TCPRoute, UDPRoute to gateway v1

### DIFF
--- a/ingress-controller/internal/controllers/gateway/referencegrant_controller.go
+++ b/ingress-controller/internal/controllers/gateway/referencegrant_controller.go
@@ -65,7 +65,7 @@ func (r *ReferenceGrantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *ReferenceGrantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("GatewayV1Alpha2ReferenceGrant", req.NamespacedName)
+	log := r.Log.WithValues("GatewayV1ReferenceGrant", req.NamespacedName)
 	grant := new(gatewayapi.ReferenceGrant)
 	if err := r.Get(ctx, req.NamespacedName, grant); err != nil {
 		// if the queued object is no longer present in the proxy cache we need

--- a/ingress-controller/internal/controllers/gateway/tcproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tcproute_controller.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/controllers"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/gatewayapi"
@@ -84,8 +84,8 @@ func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		blder.WatchesRawSource(
 			source.Channel(
 				r.StatusQueue.Subscribe(schema.GroupVersionKind{
-					Group:   gatewayv1alpha2.GroupVersion.Group,
-					Version: gatewayv1alpha2.GroupVersion.Version,
+					Group:   gatewayv1.GroupVersion.Group,
+					Version: gatewayv1.GroupVersion.Version,
 					Kind:    "TCPRoute",
 				}),
 				&handler.EnqueueRequestForObject{},
@@ -261,7 +261,7 @@ func (r *TCPRouteReconciler) listTCPRoutesForGateway(ctx context.Context, obj cl
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("GatewayV1Alpha2TCPRoute", req.NamespacedName)
+	log := r.Log.WithValues("GatewayV1TCPRoute", req.NamespacedName)
 
 	tcproute := new(gatewayapi.TCPRoute)
 	if err := r.Get(ctx, req.NamespacedName, tcproute); err != nil {

--- a/ingress-controller/internal/controllers/gateway/udproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/udproute_controller.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/controllers"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/gatewayapi"
@@ -84,8 +84,8 @@ func (r *UDPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		blder.WatchesRawSource(
 			source.Channel(
 				r.StatusQueue.Subscribe(schema.GroupVersionKind{
-					Group:   gatewayv1alpha2.GroupVersion.Group,
-					Version: gatewayv1alpha2.GroupVersion.Version,
+					Group:   gatewayv1.GroupVersion.Group,
+					Version: gatewayv1.GroupVersion.Version,
 					Kind:    "UDPRoute",
 				}),
 				&handler.EnqueueRequestForObject{},
@@ -261,7 +261,7 @@ func (r *UDPRouteReconciler) listUDPRoutesForGateway(ctx context.Context, obj cl
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *UDPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("GatewayV1Alpha2UDPRoute", req.NamespacedName)
+	log := r.Log.WithValues("GatewayV1UDPRoute", req.NamespacedName)
 
 	udproute := new(gatewayapi.UDPRoute)
 	if err := r.Get(ctx, req.NamespacedName, udproute); err != nil {

--- a/ingress-controller/internal/dataplane/translator/translate_tcproute_test.go
+++ b/ingress-controller/internal/dataplane/translator/translate_tcproute_test.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/dataplane/failures"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/dataplane/kongstate"
@@ -21,7 +21,7 @@ import (
 )
 
 func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
-	tcpRouteTypeMeta := metav1.TypeMeta{Kind: "TCPRoute", APIVersion: gatewayv1alpha2.GroupVersion.String()}
+	tcpRouteTypeMeta := metav1.TypeMeta{Kind: "TCPRoute", APIVersion: gatewayv1.GroupVersion.String()}
 
 	testCases := []struct {
 		name                 string

--- a/ingress-controller/internal/dataplane/translator/translate_utils_test.go
+++ b/ingress-controller/internal/dataplane/translator/translate_utils_test.go
@@ -131,7 +131,7 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 				// normally the k8s api call populates TypeMeta properly, but we have no such luxuries here
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "HTTPRoute",
-					APIVersion: "gateway.networking.k8s.io/v1alpha2",
+					APIVersion: "gateway.networking.k8s.io/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tong-sirlari",
@@ -184,7 +184,7 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 					},
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "HTTPRoute",
-						APIVersion: "gateway.networking.k8s.io/v1alpha2",
+						APIVersion: "gateway.networking.k8s.io/v1",
 					},
 				},
 			},
@@ -195,7 +195,7 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 			route: &gatewayapi.UDPRoute{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "UDPRoute",
-					APIVersion: "gateway.networking.k8s.io/v1alpha2",
+					APIVersion: "gateway.networking.k8s.io/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "padarkush",
@@ -249,7 +249,7 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 					},
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "UDPRoute",
-						APIVersion: "gateway.networking.k8s.io/v1alpha2",
+						APIVersion: "gateway.networking.k8s.io/v1",
 					},
 				},
 			},
@@ -260,7 +260,7 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 			route: &gatewayapi.TCPRoute{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "TCPRoute",
-					APIVersion: "gateway.networking.k8s.io/v1alpha2",
+					APIVersion: "gateway.networking.k8s.io/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kitab-ul-atfol",
@@ -306,7 +306,7 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 					},
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "TCPRoute",
-						APIVersion: "gateway.networking.k8s.io/v1alpha2",
+						APIVersion: "gateway.networking.k8s.io/v1",
 					},
 				},
 			},
@@ -317,7 +317,7 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 			route: &gatewayapi.TCPRoute{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "TCPRoute",
-					APIVersion: "gateway.networking.k8s.io/v1alpha2",
+					APIVersion: "gateway.networking.k8s.io/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "muntaxabi-jugrofiyai-umumiy",
@@ -367,7 +367,7 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 					},
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "TCPRoute",
-						APIVersion: "gateway.networking.k8s.io/v1alpha2",
+						APIVersion: "gateway.networking.k8s.io/v1",
 					},
 				},
 			},

--- a/ingress-controller/internal/gatewayapi/typemeta.go
+++ b/ingress-controller/internal/gatewayapi/typemeta.go
@@ -3,7 +3,6 @@ package gatewayapi
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -23,7 +22,7 @@ var V1HTTPRouteTypeMeta = metav1.TypeMeta{
 }
 
 var ReferenceGrantTypeMeta = metav1.TypeMeta{
-	APIVersion: gatewayv1beta1.GroupVersion.String(),
+	APIVersion: gatewayv1.GroupVersion.String(),
 	Kind:       "ReferenceGrant",
 }
 
@@ -33,17 +32,17 @@ var GRPCRouteTypeMeta = metav1.TypeMeta{
 }
 
 var TCPRouteTypeMeta = metav1.TypeMeta{
-	APIVersion: gatewayv1alpha2.GroupVersion.String(),
+	APIVersion: gatewayv1.GroupVersion.String(),
 	Kind:       "TCPRoute",
 }
 
 var TLSRouteTypeMeta = metav1.TypeMeta{
-	APIVersion: gatewayv1alpha2.GroupVersion.String(),
+	APIVersion: gatewayv1.GroupVersion.String(),
 	Kind:       "TLSRoute",
 }
 
 var UDPRouteTypeMeta = metav1.TypeMeta{
-	APIVersion: gatewayv1alpha2.GroupVersion.String(),
+	APIVersion: gatewayv1.GroupVersion.String(),
 	Kind:       "UDPRoute",
 }
 

--- a/ingress-controller/internal/manager/controllerdef.go
+++ b/ingress-controller/internal/manager/controllerdef.go
@@ -8,7 +8,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1alpha3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -406,8 +405,8 @@ func setupControllers(
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Dynamic/UDPRoute"),
 				CacheSyncTimeout: c.CacheSyncTimeout,
 				RequiredCRDs: append(baseGatewayCRDs(), schema.GroupVersionResource{
-					Group:    gatewayv1alpha2.GroupVersion.Group,
-					Version:  gatewayv1alpha2.GroupVersion.Version,
+					Group:    gatewayv1.GroupVersion.Group,
+					Version:  gatewayv1.GroupVersion.Version,
 					Resource: "udproutes",
 				}),
 				Controller: &gateway.UDPRouteReconciler{
@@ -428,8 +427,8 @@ func setupControllers(
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Dynamic/TCPRoute"),
 				CacheSyncTimeout: c.CacheSyncTimeout,
 				RequiredCRDs: append(baseGatewayCRDs(), schema.GroupVersionResource{
-					Group:    gatewayv1alpha2.GroupVersion.Group,
-					Version:  gatewayv1alpha2.GroupVersion.Version,
+					Group:    gatewayv1.GroupVersion.Group,
+					Version:  gatewayv1.GroupVersion.Version,
 					Resource: "tcproutes",
 				}),
 				Controller: &gateway.TCPRouteReconciler{

--- a/ingress-controller/test/helpers/gatewayapi.go
+++ b/ingress-controller/test/helpers/gatewayapi.go
@@ -131,7 +131,7 @@ func gatewayLinkStatusMatches(
 			}
 		}
 	case gatewayapi.TCPProtocolType:
-		route, err := c.GatewayV1alpha2().TCPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
+		route, err := c.GatewayV1().TCPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("error getting tcp route: %v", err)
 		} else {
@@ -139,7 +139,7 @@ func gatewayLinkStatusMatches(
 				check(verifyLinked, string(mgrconsts.GetControllerName()))
 		}
 	case gatewayapi.UDPProtocolType:
-		route, err := c.GatewayV1alpha2().UDPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
+		route, err := c.GatewayV1().UDPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("error getting udp route: %v", err)
 		} else {
@@ -224,7 +224,7 @@ func verifyProgrammedConditionStatus(t *testing.T,
 			}
 		}
 	case gatewayapi.TCPProtocolType:
-		route, err := c.GatewayV1alpha2().TCPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
+		route, err := c.GatewayV1().TCPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("error getting tcp route: %v", err)
 		} else {
@@ -238,7 +238,7 @@ func verifyProgrammedConditionStatus(t *testing.T,
 			return parentStatusContainsProgrammedCondition(route.Status.Parents, mgrconsts.GetControllerName(), expectedStatus)
 		}
 	case gatewayapi.UDPProtocolType:
-		route, err := c.GatewayV1alpha2().UDPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
+		route, err := c.GatewayV1().UDPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("error getting udp route: %v", err)
 		} else {

--- a/pkg/utils/test/clients.go
+++ b/pkg/utils/test/clients.go
@@ -6,7 +6,6 @@ import (
 	kubernetesclient "k8s.io/client-go/kubernetes"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
@@ -85,12 +84,6 @@ func NewK8sClients(env environments.Environment) (K8sClients, error) {
 		return clients, err
 	}
 	if err := configurationv1beta1.AddToScheme(clients.MgrClient.Scheme()); err != nil {
-		return clients, err
-	}
-
-	// TODO: remove this when support for v1alpha2 is dropped in GW API. For now
-	// we need to add it to the scheme so that we can pass conformance tests.
-	if err := gatewayv1alpha2.Install(clients.MgrClient.Scheme()); err != nil {
 		return clients, err
 	}
 

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance"
 	conformancev1 "sigs.k8s.io/gateway-api/conformance/apis/v1"
@@ -216,7 +215,7 @@ func waitForConformanceResourcesCleanup(ctx context.Context, cl client.Client, l
 			}
 		}
 
-		var tlsRoutes gatewayv1alpha2.TLSRouteList
+		var tlsRoutes gatewayv1.TLSRouteList
 		if err := cl.List(ctx, &tlsRoutes); err != nil {
 			return false, nil //nolint:nilerr
 		}

--- a/test/envtest/scheme.go
+++ b/test/envtest/scheme.go
@@ -7,7 +7,6 @@ import (
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
@@ -23,7 +22,6 @@ type SchemeOption func(t *testing.T, s *k8sruntime.Scheme)
 func WithGatewayAPI(t *testing.T, s *k8sruntime.Scheme) {
 	require.NoError(t, gatewayv1.Install(s))
 	require.NoError(t, gatewayv1beta1.Install(s))
-	require.NoError(t, gatewayv1alpha2.Install(s))
 }
 
 // WithKong registers the Kong types with the scheme.

--- a/test/integration/kic/isolated/udproute_test.go
+++ b/test/integration/kic/isolated/udproute_test.go
@@ -189,10 +189,10 @@ func TestUDPRouteEssentials(t *testing.T) {
 
 			oldParentRefs := udpRoute.Spec.ParentRefs
 			assert.Eventually(t, func() bool {
-				udpRoute, err := gatewayClient.GatewayV1alpha2().UDPRoutes(namespace).Get(ctx, udpRoute.Name, metav1.GetOptions{})
+				udpRoute, err := gatewayClient.GatewayV1().UDPRoutes(namespace).Get(ctx, udpRoute.Name, metav1.GetOptions{})
 				assert.NoError(t, err)
 				udpRoute.Spec.ParentRefs = nil
-				_, err = gatewayClient.GatewayV1alpha2().UDPRoutes(namespace).Update(ctx, udpRoute, metav1.UpdateOptions{})
+				_, err = gatewayClient.GatewayV1().UDPRoutes(namespace).Update(ctx, udpRoute, metav1.UpdateOptions{})
 				return err == nil
 			}, time.Minute, time.Second)
 
@@ -212,10 +212,10 @@ func TestUDPRouteEssentials(t *testing.T) {
 
 			t.Log("putting the parentRefs back")
 			assert.Eventually(t, func() bool {
-				udpRoute, err := gatewayClient.GatewayV1alpha2().UDPRoutes(namespace).Get(ctx, udpRoute.Name, metav1.GetOptions{})
+				udpRoute, err := gatewayClient.GatewayV1().UDPRoutes(namespace).Get(ctx, udpRoute.Name, metav1.GetOptions{})
 				assert.NoError(t, err)
 				udpRoute.Spec.ParentRefs = oldParentRefs
-				_, err = gatewayClient.GatewayV1alpha2().UDPRoutes(namespace).Update(ctx, udpRoute, metav1.UpdateOptions{})
+				_, err = gatewayClient.GatewayV1().UDPRoutes(namespace).Update(ctx, udpRoute, metav1.UpdateOptions{})
 				return err == nil
 			}, time.Minute, time.Second)
 
@@ -326,7 +326,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 
 			t.Log("adding an additional backendRef to the UDPRoute")
 			assert.Eventually(t, func() bool {
-				udpRoute, err := gatewayClient.GatewayV1alpha2().UDPRoutes(namespace).Get(ctx, udpRoute.Name, metav1.GetOptions{})
+				udpRoute, err := gatewayClient.GatewayV1().UDPRoutes(namespace).Get(ctx, udpRoute.Name, metav1.GetOptions{})
 				assert.NoError(t, err)
 				udpRoute.Spec.Rules[0].BackendRefs = []gatewayapi.BackendRef{
 					{
@@ -343,7 +343,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 					},
 				}
 
-				_, err = gatewayClient.GatewayV1alpha2().UDPRoutes(namespace).Update(ctx, udpRoute, metav1.UpdateOptions{})
+				_, err = gatewayClient.GatewayV1().UDPRoutes(namespace).Update(ctx, udpRoute, metav1.UpdateOptions{})
 				return err == nil
 			}, consts.IngressWait, consts.WaitTick)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Change all the `gatewayv1alpha2` version for `HTTPRoute`, `TLSRoute`, `TCPRoute`, `UDPRoute` to gateway v1.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

Should we also include https://github.com/Kong/kong-operator/issues/4674 to bump `PolicyStatus` in the PR?

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
