### PR TITLE
test/envtest: fix spurious UpsertX failures caused by pendingKonnectIDs stale-cache path

### DIFF
--- a/test/envtest/kongpluginbinding_managed_test.go
+++ b/test/envtest/kongpluginbinding_managed_test.go
@@ -92,6 +92,14 @@ func TestKongPluginBindingManaged(t *testing.T) {
 	require.NoError(t, clientNamespaced.Create(ctx, rateLimitingkongPlugin))
 	t.Logf("deployed %s KongPlugin (%s) resource", client.ObjectKeyFromObject(rateLimitingkongPlugin), rateLimitingkongPlugin.PluginName)
 
+	// The stale-cache reconcile (driven by pendingKonnectIDs after any CreatePlugin call) reaches
+	// ops.Update which calls UpsertPlugin. Register a single optional expectation here to absorb
+	// those calls across all subtests. No subtest has a strict UpsertPlugin expectation, so there
+	// is no FIFO ordering conflict.
+	sdk.PluginSDK.EXPECT().UpsertPlugin(mock.Anything, mock.Anything).
+		Return(&sdkkonnectops.UpsertPluginResponse{}, nil).
+		Maybe()
+
 	t.Run("binding to KongService", func(t *testing.T) {
 		serviceID := uuid.NewString()
 

--- a/test/envtest/konnect_entities_konnectcloudgatewaynetwork_test.go
+++ b/test/envtest/konnect_entities_konnectcloudgatewaynetwork_test.go
@@ -74,6 +74,20 @@ func TestKonnectCloudGatewayNetwork(t *testing.T) {
 			},
 		}, nil)
 
+		// Networks are immutable, so the enforcement reconcile "updates" by reading
+		// the network back via GetNetwork. Whether this read fires before the delete
+		// is reconcile-timing dependent, so allow it optionally with .Maybe() to keep
+		// the test from flaking on a benign, idempotent call.
+		sdk.CloudGatewaysSDK.EXPECT().GetNetwork(mock.Anything, networkID).Return(
+			&sdkkonnectops.GetNetworkResponse{
+				Network: &sdkkonnectcomp.Network{
+					ID:    networkID,
+					Name:  networkName,
+					State: sdkkonnectcomp.NetworkStateInitializing,
+				},
+			}, nil,
+		).Maybe()
+
 		t.Log("Creating KonnectAPIAuthConfiguration")
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 


### PR DESCRIPTION
…


**What this PR does / why we need it**:


The pendingKonnectIDs store was introduced to prevent duplicate entity creates when the controller's cache still shows a stale, ID-less status after a successful CreateX call. It does this by patching the Konnect ID back onto the object in reconcilePendingKonnectID and, critically, returning stop=false, so the reconcile loop continues into ops.Update instead of returning early.

This means every entity create now produces a second reconcile that takes the UPDATE path (UpsertX, GetTransitGateway, etc.) before the test has had a chance to register any expectation for it. The existing tests were written assuming only one reconcile per create, so these stale-cache UPDATE calls hit testify as unexpected method calls, failing the tests.

Fix pattern applied across all affected envtest files:

- For entities that use UpsertX (most Konnect entities): register a .Maybe() UpsertX(mock.Anything, mock.Anything) before entity creation to absorb any stale-cache update calls. Where a strict UpsertX expectation is needed later (e.g. to assert a spec-change update), register .Once() first (consumed by whichever call arrives first) followed by .Maybe() for extras.

- For entities that use a read-based update (KonnectCloudGatewayTransitGateway uses GetTransitGateway): register .Once() + .Maybe() both returning the target state. The .Once() asserts the call is made at least once; .Maybe() absorbs any additional stale-cache calls.

- For the KongConsumer "detaching and reattaching" subtest: the stale-cache UpsertConsumer fires before the re-attachment strict expectation is registered. Use .Maybe() with .Unset() to absorb the stale-cache window, then register the strict expectation cleanly for the re-attachment call.

- For TestKongPluginBindingManaged: register a single top-level .Maybe() UpsertPlugin before all subtests. No subtest has a strict UpsertPlugin expectation, so there is no FIFO ordering conflict.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

@tao12345666333 this should part of : https://github.com/Kong/kong-operator/issues/4666

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
