### PR TITLE
fix(konnect): stop after recovering pending Konnect IDs

### DIFF
--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -807,16 +807,16 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(ctx context.Context, ent TE
 // again on that basis would produce a duplicate Konnect entity. The in-memory
 // store records the Konnect ID as soon as the entity is created, so:
 //   - if the cached status lacks the ID but the store has it, restore and persist
-//     it. ApplyStatusPatchIfNotEmpty writes through to the API server and refreshes
-//     ent from the response, so the rest of the loop runs on a consistent object.
-//     Re-persisting is idempotent and also heals the case where the post-create
-//     status write failed.
-//   - once the status carries the ID, the bridge entry has served its purpose and
-//     is dropped.
+//     it, then return. A stale cached object can otherwise continue into update
+//     logic with the recovered ID, causing nondeterministic Konnect updates before
+//     the cache has observed the status write. Re-persisting is idempotent and
+//     also heals the case where the post-create status write failed.
+//   - once the cached status carries the ID, the bridge entry has served its
+//     purpose and is dropped.
 //
 // It returns stop=true when the caller should return the provided result/error (a
-// conflict requeue or a persist error); otherwise reconciliation continues with a
-// consistent ent.
+// conflict requeue, a persist error, or a successful pending-ID recovery);
+// otherwise reconciliation continues.
 func (r *KonnectEntityReconciler[T, TEnt]) reconcilePendingKonnectID(
 	ctx context.Context,
 	ent TEnt,
@@ -832,9 +832,9 @@ func (r *KonnectEntityReconciler[T, TEnt]) reconcilePendingKonnectID(
 				}
 				return ctrl.Result{}, true, fmt.Errorf("failed to persist recovered Konnect ID for %s: %w", pendingKey, err)
 			}
+			return ctrl.Result{}, true, nil
 		}
-	}
-	if ent.GetKonnectStatus().GetKonnectID() != "" {
+	} else {
 		r.pendingKonnectIDs.Delete(pendingKey)
 	}
 	return ctrl.Result{}, false, nil

--- a/controller/konnect/reconciler_generic_pending_konnect_id_test.go
+++ b/controller/konnect/reconciler_generic_pending_konnect_id_test.go
@@ -50,7 +50,7 @@ func newReconcilerForPendingTest(
 func TestReconcilePendingKonnectID(t *testing.T) {
 	const konnectID = "service-12345"
 
-	t.Run("restores and persists the ID when the cached status lacks it but the store has it", func(t *testing.T) {
+	t.Run("restores and persists the ID then stops when the cached status lacks it but the store has it", func(t *testing.T) {
 		// The API server copy does not carry the ID yet - this models both the
 		// cache-lag case and the case where the post-create status write failed.
 		r := newReconcilerForPendingTest(newKongServiceForPendingTest(""))
@@ -61,21 +61,28 @@ func TestReconcilePendingKonnectID(t *testing.T) {
 
 		res, stop, err := r.reconcilePendingKonnectID(t.Context(), ent)
 		require.NoError(t, err)
-		assert.False(t, stop, "reconciliation should continue, not return early")
+		assert.True(t, stop, "reconciliation should return early until the cache observes the persisted ID")
 		assert.True(t, res.IsZero())
 
-		// The ID is restored onto ent, so we no longer create (no duplicate).
+		// The ID is restored onto ent before patching status.
 		assert.Equal(t, konnectID, ent.GetKonnectStatus().GetKonnectID())
-		assert.False(t, shouldCreateKonnectEntity(ent), "must not create a duplicate Konnect entity")
 
 		// The ID is written through to the API server.
 		var fetched configurationv1alpha1.KongService
 		require.NoError(t, r.Client.Get(t.Context(), key, &fetched))
 		assert.Equal(t, konnectID, fetched.GetKonnectStatus().GetKonnectID())
 
-		// The bridge entry is purged once the status carries the ID.
+		// The bridge entry remains until a later cached read carries the ID.
 		_, ok := r.pendingKonnectIDs.Get(key)
-		assert.False(t, ok)
+		assert.True(t, ok)
+
+		res, stop, err = r.reconcilePendingKonnectID(t.Context(), &fetched)
+		require.NoError(t, err)
+		assert.False(t, stop)
+		assert.True(t, res.IsZero())
+
+		_, ok = r.pendingKonnectIDs.Get(key)
+		assert.False(t, ok, "entry must be purged once the cached status reflects the ID")
 	})
 
 	t.Run("does nothing and allows create when there is no store entry", func(t *testing.T) {


### PR DESCRIPTION


**What this PR does / why we need it**:

When a Konnect entity is created, we keep its ID in pendingKonnectIDs until the controller cache observes the persisted status. During that cache-lag window, a later reconcile can still read an ID-less object from the cache.

Previously, reconcilePendingKonnectID restored the pending ID and patched status, but then allowed the same reconcile to continue. That prevented duplicate creates, but it could still fall through into the update path with a stale object and make timing-dependent SDK calls, such as KongPluginBinding UpsertPlugin or Cloud Gateway Network GetNetwork. The number of those calls depended on reconcile/cache timing, which made envtests flaky in CI.

Return immediately after successfully patching a recovered pending ID. The pending entry is kept until a later reconcile sees the ID from the cache, then it is deleted. This makes the production reconcile flow deterministic around stale-cache recovery: first persist the recovered ID, then wait for the cache to catch up before enforcing updates.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
