### PR TITLE
fix(multiinstance): shut down diagnostics server on context cancellation

### DIFF
--- a/ingress-controller/pkg/manager/multiinstance/diagnostics.go
+++ b/ingress-controller/pkg/manager/multiinstance/diagnostics.go
@@ -2,6 +2,7 @@ package multiinstance
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/pprof"
@@ -63,14 +64,23 @@ func NewDiagnosticsServer(listenerPort int, opts ...DiagnosticsServerOption) *Di
 
 // Start starts the diagnostics server.
 func (s *DiagnosticsServer) Start(ctx context.Context) error {
-	errg, _ := errgroup.WithContext(ctx)
+	server := http.Server{
+		Addr:              fmt.Sprintf(":%d", s.listenerPort),
+		Handler:           s,
+		ReadHeaderTimeout: diagnosticsServerReadHeaderTimeout,
+	}
+
+	errg, ctx := errgroup.WithContext(ctx)
 	errg.Go(func() error {
-		server := http.Server{
-			Addr:              fmt.Sprintf(":%d", s.listenerPort),
-			Handler:           s,
-			ReadHeaderTimeout: diagnosticsServerReadHeaderTimeout,
+		err := server.ListenAndServe()
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
 		}
-		return server.ListenAndServe()
+		return err
+	})
+	errg.Go(func() error {
+		<-ctx.Done()
+		return server.Shutdown(context.Background())
 	})
 	return errg.Wait()
 }

--- a/ingress-controller/pkg/manager/multiinstance/diagnostics.go
+++ b/ingress-controller/pkg/manager/multiinstance/diagnostics.go
@@ -80,7 +80,9 @@ func (s *DiagnosticsServer) Start(ctx context.Context) error {
 	})
 	errg.Go(func() error {
 		<-ctx.Done()
-		return server.Shutdown(context.Background())
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return server.Shutdown(shutdownCtx) //nolint:contextcheck
 	})
 	return errg.Wait()
 }

--- a/test/envtest/manager_envtest_test.go
+++ b/test/envtest/manager_envtest_test.go
@@ -73,6 +73,8 @@ func TestManagerDoesntStartUntilKubernetesAPIReachable(t *testing.T) {
 }
 
 func TestManager_NoLeakedGoroutinesAfterContextCancellation(t *testing.T) {
+	ignoreExistingGoroutines := goleak.IgnoreCurrent()
+
 	ts := NewTelemetryServer(t)
 	ts.Start(t.Context(), t)
 
@@ -81,6 +83,7 @@ func TestManager_NoLeakedGoroutinesAfterContextCancellation(t *testing.T) {
 		ts.Stop(t)
 		t.Logf("Checking for goroutine leaks")
 		goleak.VerifyNone(t,
+			ignoreExistingGoroutines,
 			goleak.IgnoreTopFunction("sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue.(*priorityqueue[...]).handleReadyItems.func1.1"),
 		)
 	})
@@ -99,9 +102,9 @@ func TestManager_NoLeakedGoroutinesAfterContextCancellation(t *testing.T) {
 		WithDiagnosticsServer(diagnosticsServerPort),
 		WithTelemetry(ts.Endpoint(), 100*time.Millisecond),
 	)
+	managerStopped := make(chan error, 1)
 	go func() {
-		err := m.Run(ctx)
-		assert.NoError(t, err)
+		managerStopped <- m.Run(ctx)
 	}()
 
 	t.Log("Waiting for the manager to become ready")
@@ -129,5 +132,10 @@ func TestManager_NoLeakedGoroutinesAfterContextCancellation(t *testing.T) {
 	t.Logf("Waiting for the manager to stop gracefully, this should happen within %f seconds",
 		consts.DefaultGracefulShutdownTimeout.Seconds(),
 	)
-	<-time.After(consts.DefaultGracefulShutdownTimeout)
+	select {
+	case err := <-managerStopped:
+		require.NoError(t, err)
+	case <-time.After(consts.DefaultGracefulShutdownTimeout):
+		t.Fatal("manager did not stop gracefully before the shutdown timeout")
+	}
 }

--- a/test/envtest/multiinstance_helpers_test.go
+++ b/test/envtest/multiinstance_helpers_test.go
@@ -2,7 +2,6 @@ package envtest
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"github.com/go-logr/logr/testr"
@@ -22,7 +21,7 @@ func setupMultiInstanceDiagnosticsManager(
 	t.Log("Starting the diagnostics server and the multi-instance manager")
 	diagServer := multiinstance.NewDiagnosticsServer(diagPort, opts...)
 	go func() {
-		assert.ErrorIs(t, diagServer.Start(ctx), http.ErrServerClosed)
+		assert.NoError(t, diagServer.Start(ctx))
 	}()
 
 	multimgr := multiinstance.NewManager(testr.New(t), multiinstance.WithDiagnosticsExposer(diagServer))


### PR DESCRIPTION


**What this PR does / why we need it**:

The multi-instance diagnostics server started an HTTP server with
ListenAndServe, but did not shut it down when the parent context was cancelled.
That left the listener blocked in Accept and could keep Start waiting forever on
its errgroup after manager shutdown.

Create the HTTP server outside the serving goroutine, shut it down when the
context is cancelled, and treat http.ErrServerClosed as a clean exit.

Update envtests to match the production shutdown contract: diagnostics server
shutdown now returns nil on normal context cancellation, and the manager leak test
waits for m.Run(ctx) to return before running goleak. The leak test also ignores
goroutines that existed before the test started, so it only checks goroutines
created by this test.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
