### PR TITLE
Revert "test/envtest: fix spurious UpsertX failures caused by pendingKonnectIDs stale-cache path"

### DIFF
--- a/test/envtest/kongpluginbinding_managed_test.go
+++ b/test/envtest/kongpluginbinding_managed_test.go
@@ -92,14 +92,6 @@ func TestKongPluginBindingManaged(t *testing.T) {
 	require.NoError(t, clientNamespaced.Create(ctx, rateLimitingkongPlugin))
 	t.Logf("deployed %s KongPlugin (%s) resource", client.ObjectKeyFromObject(rateLimitingkongPlugin), rateLimitingkongPlugin.PluginName)
 
-	// The stale-cache reconcile (driven by pendingKonnectIDs after any CreatePlugin call) reaches
-	// ops.Update which calls UpsertPlugin. Register a single optional expectation here to absorb
-	// those calls across all subtests. No subtest has a strict UpsertPlugin expectation, so there
-	// is no FIFO ordering conflict.
-	sdk.PluginSDK.EXPECT().UpsertPlugin(mock.Anything, mock.Anything).
-		Return(&sdkkonnectops.UpsertPluginResponse{}, nil).
-		Maybe()
-
 	t.Run("binding to KongService", func(t *testing.T) {
 		serviceID := uuid.NewString()
 

--- a/test/envtest/konnect_entities_konnectcloudgatewaynetwork_test.go
+++ b/test/envtest/konnect_entities_konnectcloudgatewaynetwork_test.go
@@ -74,20 +74,6 @@ func TestKonnectCloudGatewayNetwork(t *testing.T) {
 			},
 		}, nil)
 
-		// Networks are immutable, so the enforcement reconcile "updates" by reading
-		// the network back via GetNetwork. Whether this read fires before the delete
-		// is reconcile-timing dependent, so allow it optionally with .Maybe() to keep
-		// the test from flaking on a benign, idempotent call.
-		sdk.CloudGatewaysSDK.EXPECT().GetNetwork(mock.Anything, networkID).Return(
-			&sdkkonnectops.GetNetworkResponse{
-				Network: &sdkkonnectcomp.Network{
-					ID:    networkID,
-					Name:  networkName,
-					State: sdkkonnectcomp.NetworkStateInitializing,
-				},
-			}, nil,
-		).Maybe()
-
 		t.Log("Creating KonnectAPIAuthConfiguration")
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 


### PR DESCRIPTION
Reverts Kong/kong-operator#4677

Fixed by: https://github.com/Kong/kong-operator/pull/4678