### PR TITLE
chore(crd): Bump PolicyStatus to v1 in KongUpstreamPolicy CRD

### DIFF
--- a/api/configuration/v1beta1/kongupstreampolicy_types.go
+++ b/api/configuration/v1beta1/kongupstreampolicy_types.go
@@ -2,7 +2,7 @@ package v1beta1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 const (
@@ -59,7 +59,7 @@ type KongUpstreamPolicy struct {
 	Spec KongUpstreamPolicySpec `json:"spec,omitempty"`
 
 	// Status defines the current state of KongUpstreamPolicy
-	Status gatewayv1alpha2.PolicyStatus `json:"status,omitempty"`
+	Status gatewayv1.PolicyStatus `json:"status,omitempty"`
 }
 
 // KongUpstreamPolicyList contains a list of KongUpstreamPolicy.

--- a/docs/all-api-reference.md
+++ b/docs/all-api-reference.md
@@ -5096,7 +5096,7 @@ used instead. This is to allow reusing the same KongUpstreamPolicy for multiple 
 | `kind` _string_ | `KongUpstreamPolicy`
 | `metadata` _k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `spec` _[KongUpstreamPolicySpec](#configuration-konghq-com-v1beta1-types-kongupstreampolicyspec)_ | Spec contains the configuration of the Kong upstream. |
-| `status` _sigs.k8s.io/gateway-api/apis/v1alpha2.PolicyStatus_ | Status defines the current state of KongUpstreamPolicy |
+| `status` _sigs.k8s.io/gateway-api/apis/v1.PolicyStatus_ | Status defines the current state of KongUpstreamPolicy |
 
 ### Types
 

--- a/docs/configuration-api-reference.md
+++ b/docs/configuration-api-reference.md
@@ -5089,7 +5089,7 @@ used instead. This is to allow reusing the same KongUpstreamPolicy for multiple 
 | `kind` _string_ | `KongUpstreamPolicy`
 | `metadata` _k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `spec` _[KongUpstreamPolicySpec](#configuration-konghq-com-v1beta1-types-kongupstreampolicyspec)_ | Spec contains the configuration of the Kong upstream. |
-| `status` _sigs.k8s.io/gateway-api/apis/v1alpha2.PolicyStatus_ | Status defines the current state of KongUpstreamPolicy |
+| `status` _sigs.k8s.io/gateway-api/apis/v1.PolicyStatus_ | Status defines the current state of KongUpstreamPolicy |
 
 ### Types
 

--- a/ingress-controller/internal/gatewayapi/aliases.go
+++ b/ingress-controller/internal/gatewayapi/aliases.go
@@ -2,7 +2,6 @@ package gatewayapi
 
 import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1alpha3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
@@ -101,7 +100,7 @@ type (
 	GRPCRouteStatus                           = gatewayv1.GRPCRouteStatus
 
 	PolicyAncestorStatus = gatewayv1.PolicyAncestorStatus
-	PolicyStatus         = gatewayv1alpha2.PolicyStatus
+	PolicyStatus         = gatewayv1.PolicyStatus
 	TCPRoute             = gatewayv1.TCPRoute
 	TCPRouteList         = gatewayv1.TCPRouteList
 	TCPRouteRule         = gatewayv1.TCPRouteRule


### PR DESCRIPTION
**What this PR does / why we need it**:

`PolicyStatus` in gateway API has been promoted to v1 and the v1alpha2 version is an alias of v1. So we should bump v1alpha2 `PolicyStatus` to v1.

**Which issue this PR fixes**

Fixes #4674 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
