### PR TITLE
[Backport release/2.2.x] fix(hybridgateway): prevent traffic drops when HTTPRoute spec changesrotate resource names (#4577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,24 @@
 - Prevent recreating consumer credentials on every Konnect sync when running in
   "KIC in Konnect" mode with on prem `ControlPlane`.
   [#4622](https://github.com/Kong/kong-operator/pull/4622)
+- Hybridgateway: fix `KongTarget` stuck in `Programmed=False` when multiple
+  backendRef Services in an HTTPRoute or TLSRoute rule resolve to the same pod
+  IP and port. The operator now creates one `KongTarget` per unique endpoint
+  address across all backendRefs in a rule, merging duplicate endpoints and
+  summing their weights, instead of attempting to create one per backendRef per
+  endpoint which violated Konnect's upstream/target uniqueness constraint.
+  **Note:** the `KongTarget` naming scheme has changed and the backendRef is no
+  longer part of the name hash. All existing `KongTarget` resources will be
+  orphaned and recreated on the first reconciliation after upgrading. During
+  the transition, both old and new entries may be present in Konnect
+  simultaneously as creation and orphan cleanup are not synchronized.
+  [#4509](https://github.com/Kong/kong-operator/pull/4509)
+- Hybridgateway: prevent traffic drops when an `HTTPRoute` spec change rotates
+  resource names. A cleanup-time gate defers orphan deletion until every desired
+  `KongRoute` is confirmed bound to its new `KongService` in Konnect, and an
+  enforce-time gate delays `KongService` creation until its `KongUpstream` and
+  all desired `KongTarget`s are Programmed.
+  [#4577](https://github.com/Kong/kong-operator/pull/4577)
 
 ## [v2.2.0]
 
@@ -349,18 +367,6 @@
   Users are suggested to block network access to debug endpoints (which are disabled
   by default) if plugin configuration can contain sensitive information.
   [#4467](https://github.com/Kong/kong-operator/pull/4467)
-- Hybridgateway: fix `KongTarget` stuck in `Programmed=False` when multiple
-  backendRef Services in an HTTPRoute or TLSRoute rule resolve to the same pod
-  IP and port. The operator now creates one `KongTarget` per unique endpoint
-  address across all backendRefs in a rule, merging duplicate endpoints and
-  summing their weights, instead of attempting to create one per backendRef per
-  endpoint which violated Konnect's upstream/target uniqueness constraint.
-  **Note:** the `KongTarget` naming scheme has changed and the backendRef is no
-  longer part of the name hash. All existing `KongTarget` resources will be
-  orphaned and recreated on the first reconciliation after upgrading. During
-  the transition, both old and new entries may be present in Konnect
-  simultaneously as creation and orphan cleanup are not synchronized.
-  [#4509](https://github.com/Kong/kong-operator/pull/4509)
 
 ## [v2.1.7]
 

--- a/controller/hybridgateway/controller.go
+++ b/controller/hybridgateway/controller.go
@@ -266,6 +266,22 @@ func (r *HybridGatewayReconciler[t, tPtr]) Reconcile(ctx context.Context, obj tP
 		return ctrl.Result{RequeueAfter: requeueWhileWaiting}, nil
 	}
 
+	// Phase 4.5: Readiness gate before orphan cleanup.
+	// For converters that opt in (currently HTTPRoute), defer deleting orphaned resources
+	// until all desired resources are Programmed. This prevents removing stale resources
+	// before their replacements are live in the data plane, which would otherwise open a
+	// traffic gap when a spec change rotates the desired resource names.
+	if checker, ok := any(conv).(converter.DesiredStateReadinessChecker); ok {
+		ready, err := checker.DesiredResourcesReady(ctx, logger)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if !ready {
+			log.Debug(logger, "Desired resources not ready yet, deferring orphan cleanup")
+			return ctrl.Result{RequeueAfter: requeueWhileWaiting}, nil
+		}
+	}
+
 	// Phase 5: Orphan Cleanup.
 	orphansDeleted, err := cleanOrphanedResources[t, tPtr](ctx, r.Client, logger, conv)
 	if err != nil {

--- a/controller/hybridgateway/converter/converter.go
+++ b/controller/hybridgateway/converter/converter.go
@@ -41,6 +41,18 @@ type OrphanedResourceHandler interface {
 	HandleOrphanedResource(ctx context.Context, logger logr.Logger, resource *unstructured.Unstructured) (skipDelete bool, err error)
 }
 
+// DesiredStateReadinessChecker is an optional interface that converters can implement to
+// defer orphan cleanup until the resources they desire are ready (Programmed in Konnect).
+// When a converter implements it and DesiredResourcesReady returns false, the reconciler
+// requeues without deleting orphaned resources. This ensures stale resources are pruned
+// only after their replacements are live, avoiding a data-plane gap during a cutover
+// (e.g. when a spec change rotates the desired KongUpstream/KongService/KongRoute names).
+type DesiredStateReadinessChecker interface {
+	// DesiredResourcesReady reports whether all desired resources produced by the converter
+	// are Programmed. Resource kinds without a Programmed condition are ignored.
+	DesiredResourcesReady(ctx context.Context, logger logr.Logger) (ready bool, err error)
+}
+
 // RootObject is an interface that represents all resource types that can be loaded
 // as root by the APIConverter.
 type RootObject interface {

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -15,6 +16,7 @@ import (
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
 	hybridgatewayerrors "github.com/kong/kong-operator/v2/controller/hybridgateway/errors"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/kongroute"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
@@ -32,7 +34,10 @@ import (
 	"github.com/kong/kong-operator/v2/pkg/vars"
 )
 
-var _ APIConverter[gwtypes.HTTPRoute] = &httpRouteConverter{}
+var (
+	_ APIConverter[gwtypes.HTTPRoute] = &httpRouteConverter{}
+	_ DesiredStateReadinessChecker    = &httpRouteConverter{}
+)
 
 // httpRouteConverter is a concrete implementation of the APIConverter interface for HTTPRoute.
 type httpRouteConverter struct {
@@ -294,6 +299,88 @@ func (c *httpRouteConverter) UpdateRootObjectStatus(ctx context.Context, logger 
 
 	log.Debug(logger, "Finished UpdateRootObjectStatus", "updated", updated)
 	return updated, stop, nil
+}
+
+// DesiredResourcesReady implements DesiredStateReadinessChecker. It decides whether orphan cleanup may
+// proceed for this HTTPRoute.
+//
+// THE GATE is a single rule: every desired KongRoute must be bound, in Konnect, to its desired
+// KongService — verified via the authoritative status.konnect.serviceID, NOT the route's Programmed
+// condition. After a rollout repoints a route's serviceRef, the route can keep reporting Programmed=True
+// against the OLD service until the Konnect controller actually reprograms it; deleting the old chain
+// (KongTargets/KongUpstream/KongService) in that window drops traffic. Only the serviceID matching the
+// desired service tells us the route has truly moved and the old chain is safe to remove.
+//
+// We deliberately do NOT gate on the Programmed condition of the desired resources: the enforce-time chain
+// gating (KongService waits for its KongUpstream and KongTargets; KongRoute waits for the service)
+// already builds and programs the whole chain before a route is ever repointed, so a Programmed
+// check here would be redundant. The route serviceID is the only condition that actually makes deleting
+// the old chain safe.
+func (c *httpRouteConverter) DesiredResourcesReady(ctx context.Context, logger logr.Logger) (bool, error) {
+	desired, err := c.GetOutputStore(ctx, logger)
+	if err != nil {
+		return false, fmt.Errorf("failed to get desired objects for readiness check: %w", err)
+	}
+
+	// THE GATE: for each desired KongRoute, the service named in its spec.serviceRef must be the one it is
+	// actually bound to in Konnect. spec.serviceRef is a name and status.konnect.serviceID is a Konnect ID,
+	// so we fetch that one referenced KongService to resolve its Konnect ID and compare. The route's
+	// Programmed condition is not used: it lags on the old service right after a serviceRef repoint.
+	for i := range desired {
+		d := &desired[i]
+		if d.GetKind() != "KongRoute" {
+			continue
+		}
+
+		r := &unstructured.Unstructured{}
+		r.SetGroupVersionKind(d.GroupVersionKind())
+		if err := c.Get(ctx, client.ObjectKeyFromObject(d), r); err != nil {
+			if apierrors.IsNotFound(err) {
+				// Route not applied yet: it cannot be confirmed on its desired service, so defer.
+				log.Debug(logger, "Desired KongRoute not found yet, deferring orphan cleanup", "obj", client.ObjectKeyFromObject(d))
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to get KongRoute %s: %w", client.ObjectKeyFromObject(d), err)
+		}
+
+		serviceRefName, _, _ := unstructured.NestedString(r.Object, "spec", "serviceRef", "namespacedRef", "name")
+		if serviceRefName == "" {
+			log.Debug(logger, "KongRoute has no serviceRef, skipping readiness check", "obj", client.ObjectKeyFromObject(r))
+			continue
+		}
+		boundServiceID, _, _ := unstructured.NestedString(r.Object, "status", "konnect", "serviceID")
+
+		// Fetch the referenced KongService: it must be Programmed (ready) and the route must be bound to
+		// its Konnect ID. spec.serviceRef is a name; the service's Konnect ID lives in its status.
+		var svc configurationv1alpha1.KongService
+		if err := c.Get(ctx, client.ObjectKey{Namespace: d.GetNamespace(), Name: serviceRefName}, &svc); err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Debug(logger, "Referenced KongService not found yet, deferring orphan cleanup", "route", client.ObjectKeyFromObject(r), "service", serviceRefName)
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to get KongService %s for route %s: %w", serviceRefName, client.ObjectKeyFromObject(r), err)
+		}
+		if !meta.IsStatusConditionTrue(svc.Status.Conditions, konnectv1alpha1.KonnectEntityProgrammedConditionType) {
+			log.Debug(logger, "Referenced KongService not Programmed yet, deferring orphan cleanup", "route", client.ObjectKeyFromObject(r), "service", serviceRefName)
+			return false, nil
+		}
+
+		var desiredServiceID string
+		if svc.Status.Konnect != nil {
+			desiredServiceID = svc.Status.Konnect.ID
+		}
+		if desiredServiceID == "" || boundServiceID != desiredServiceID {
+			log.Debug(logger, "KongRoute not yet bound to its referenced KongService in Konnect, deferring orphan cleanup",
+				"route", client.ObjectKeyFromObject(r),
+				"service", serviceRefName,
+				"boundServiceID", boundServiceID,
+				"desiredServiceID", desiredServiceID)
+			return false, nil
+		}
+	}
+
+	log.Debug(logger, "All routes are bound to their referenced KongService in Konnect, orphan cleanup may proceed")
+	return true, nil
 }
 
 // HandleOrphanedResource implements OrphanedResourceHandler.

--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -24,6 +24,7 @@ import (
 
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/namegen"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
@@ -2148,4 +2149,220 @@ func newUnstructuredResource(routesAnnotation string) *unstructured.Unstructured
 		})
 	}
 	return resource
+}
+
+func TestHTTPRouteConverter_DesiredResourcesReady(t *testing.T) {
+	ctx := t.Context()
+	const (
+		ns           = "default"
+		routeName    = "route-1"
+		svcName      = "svc-1"
+		konnectSvcID = "konnect-svc-id-abc"
+	)
+
+	routeGVK := configurationv1alpha1.GroupVersion.WithKind("KongRoute")
+
+	// desiredRoute builds a KongRoute for the converter's outputStore.
+	desiredRoute := func(name string) *configurationv1alpha1.KongRoute {
+		r := &configurationv1alpha1.KongRoute{}
+		r.Name = name
+		r.Namespace = ns
+		r.SetGroupVersionKind(routeGVK)
+		return r
+	}
+
+	// clusterRoute builds an unstructured KongRoute representing what is in the cluster.
+	clusterRoute := func(name, serviceRefName, boundServiceID string) *unstructured.Unstructured {
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(routeGVK)
+		u.SetName(name)
+		u.SetNamespace(ns)
+		if serviceRefName != "" {
+			_ = unstructured.SetNestedField(u.Object, serviceRefName, "spec", "serviceRef", "namespacedRef", "name")
+		}
+		if boundServiceID != "" {
+			_ = unstructured.SetNestedField(u.Object, boundServiceID, "status", "konnect", "serviceID")
+		}
+		return u
+	}
+
+	// kongService builds a typed KongService with configurable Programmed status and Konnect ID.
+	kongService := func(name string, programmed bool, konnectID string) *configurationv1alpha1.KongService {
+		svc := &configurationv1alpha1.KongService{}
+		svc.Name = name
+		svc.Namespace = ns
+		if programmed {
+			svc.Status.Conditions = []metav1.Condition{{
+				Type:               "Programmed",
+				Status:             metav1.ConditionTrue,
+				Reason:             "Programmed",
+				LastTransitionTime: metav1.Now(),
+			}}
+		}
+		if konnectID != "" {
+			svc.Status.Konnect = &konnectv1alpha2.KonnectEntityStatusWithControlPlaneAndCertificateAndCACertificatesRefs{
+				KonnectEntityStatus: konnectv1alpha2.KonnectEntityStatus{ID: konnectID},
+			}
+		}
+		return svc
+	}
+
+	baseRoute := &gwtypes.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "test-route", Namespace: ns}}
+
+	tests := []struct {
+		name            string
+		outputStore     []client.Object
+		existingObjs    []client.Object
+		interceptorFn   *interceptor.Funcs
+		wantReady       bool
+		wantErrContains string
+	}{
+		{
+			name:            "GetOutputStore error is propagated",
+			outputStore:     []client.Object{&badObject{Name: "bad"}},
+			wantReady:       false,
+			wantErrContains: "failed to get desired objects for readiness check",
+		},
+		{
+			name:        "empty output store → ready",
+			outputStore: nil,
+			wantReady:   true,
+		},
+		{
+			name: "no KongRoutes in output store → ready",
+			outputStore: []client.Object{
+				func() *configurationv1alpha1.KongService {
+					s := &configurationv1alpha1.KongService{}
+					s.Name = "svc-only"
+					s.Namespace = ns
+					s.SetGroupVersionKind(configurationv1alpha1.GroupVersion.WithKind("KongService"))
+					return s
+				}(),
+			},
+			wantReady: true,
+		},
+		{
+			name:        "desired KongRoute not yet in cluster → defer (NotFound)",
+			outputStore: []client.Object{desiredRoute(routeName)},
+			wantReady:   false,
+		},
+		{
+			name:        "Get KongRoute returns non-NotFound error → propagate",
+			outputStore: []client.Object{desiredRoute(routeName)},
+			interceptorFn: &interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*unstructured.Unstructured); ok && key.Name == routeName {
+						return fmt.Errorf("simulated get error")
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+			wantReady:       false,
+			wantErrContains: "failed to get KongRoute",
+		},
+		{
+			name:         "KongRoute found, no serviceRef (serviceless route) → ready",
+			outputStore:  []client.Object{desiredRoute(routeName)},
+			existingObjs: []client.Object{clusterRoute(routeName, "", "")},
+			wantReady:    true,
+		},
+		{
+			name:         "KongRoute found with serviceRef, KongService not found → defer",
+			outputStore:  []client.Object{desiredRoute(routeName)},
+			existingObjs: []client.Object{clusterRoute(routeName, svcName, "")},
+			wantReady:    false,
+		},
+		{
+			name:         "Get KongService returns non-NotFound error → propagate",
+			outputStore:  []client.Object{desiredRoute(routeName)},
+			existingObjs: []client.Object{clusterRoute(routeName, svcName, "")},
+			interceptorFn: &interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*configurationv1alpha1.KongService); ok {
+						return fmt.Errorf("simulated service get error")
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+			wantReady:       false,
+			wantErrContains: "failed to get KongService",
+		},
+		{
+			name:         "KongService found but not Programmed → defer",
+			outputStore:  []client.Object{desiredRoute(routeName)},
+			existingObjs: []client.Object{clusterRoute(routeName, svcName, ""), kongService(svcName, false, "")},
+			wantReady:    false,
+		},
+		{
+			name:        "KongService Programmed but Konnect status nil (no Konnect ID) → defer",
+			outputStore: []client.Object{desiredRoute(routeName)},
+			existingObjs: []client.Object{
+				clusterRoute(routeName, svcName, konnectSvcID),
+				kongService(svcName, true, ""), // Programmed but Konnect == nil
+			},
+			wantReady: false,
+		},
+		{
+			name:        "KongService Programmed, Konnect ID set, but route bound to old service ID → defer",
+			outputStore: []client.Object{desiredRoute(routeName)},
+			existingObjs: []client.Object{
+				clusterRoute(routeName, svcName, "old-service-id"),
+				kongService(svcName, true, konnectSvcID),
+			},
+			wantReady: false,
+		},
+		{
+			name:        "KongRoute bound to correct service ID → ready",
+			outputStore: []client.Object{desiredRoute(routeName)},
+			existingObjs: []client.Object{
+				clusterRoute(routeName, svcName, konnectSvcID),
+				kongService(svcName, true, konnectSvcID),
+			},
+			wantReady: true,
+		},
+		{
+			name:         "multiple routes: first not ready → defer immediately",
+			outputStore:  []client.Object{desiredRoute("route-a"), desiredRoute("route-b")},
+			existingObjs: []client.Object{
+				// route-a not in cluster → defers before even checking route-b
+			},
+			wantReady: false,
+		},
+		{
+			name:        "multiple routes: all bound to correct service → ready",
+			outputStore: []client.Object{desiredRoute("route-a"), desiredRoute("route-b")},
+			existingObjs: []client.Object{
+				clusterRoute("route-a", svcName, konnectSvcID),
+				clusterRoute("route-b", svcName, konnectSvcID),
+				kongService(svcName, true, konnectSvcID),
+			},
+			wantReady: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(scheme.Get())
+			if len(tt.existingObjs) > 0 {
+				builder = builder.WithObjects(tt.existingObjs...)
+			}
+			if tt.interceptorFn != nil {
+				builder = builder.WithInterceptorFuncs(*tt.interceptorFn)
+			}
+			cl := builder.Build()
+
+			conv := newHTTPRouteConverter(baseRoute, cl, false, "").(*httpRouteConverter)
+			conv.outputStore = tt.outputStore
+
+			ready, err := conv.DesiredResourcesReady(ctx, logr.Discard())
+
+			if tt.wantErrContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantReady, ready)
+		})
+	}
 }

--- a/controller/hybridgateway/reconciler_utils.go
+++ b/controller/hybridgateway/reconciler_utils.go
@@ -72,6 +72,20 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 
 	log.Debug(logger, "Retrieved desired objects for enforcement", "objectCount", len(desiredObjects))
 
+	// Build lookup maps once so that per-object gating checks are O(1) instead of O(n).
+	desiredUpstreamNames := make(map[string]struct{}, len(desiredObjects))
+	desiredTargetsByUpstream := make(map[string][]unstructured.Unstructured, len(desiredObjects))
+	for _, obj := range desiredObjects {
+		switch obj.GetKind() {
+		case "KongUpstream":
+			desiredUpstreamNames[obj.GetName()] = struct{}{}
+		case "KongTarget":
+			if upName, _, _ := unstructured.NestedString(obj.Object, "spec", "upstreamRef", "name"); upName != "" {
+				desiredTargetsByUpstream[upName] = append(desiredTargetsByUpstream[upName], obj)
+			}
+		}
+	}
+
 	var (
 		objectsCreated = 0
 		objectsUpdated = 0
@@ -100,6 +114,40 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 		// "can't create target without a Konnect Upstream ID".
 		switch desired.GetKind() {
 		case "KongService":
+			// KongService.Spec.Host is the KongUpstream name. Do not create/program the service before its
+			// upstream exists and is Programmed in Konnect. Otherwise Konnect can hold a service whose host
+			// has no matching upstream, and once a request hits it the dataplane falls back to DNS-resolving
+			// the (hashed) upstream name -> NXDOMAIN. Only gate when the host actually refers to a desired
+			// KongUpstream (in hybrid gateway it always does; the guard avoids waiting forever on a service
+			// that legitimately points at an external hostname).
+			if host, _, _ := unstructured.NestedString(desired.Object, "spec", "host"); host != "" && desiredHasUpstreamNamed(desiredUpstreamNames, host) {
+				var up configurationv1alpha1.KongUpstream
+				if err := cl.Get(ctx, client.ObjectKey{Namespace: desired.GetNamespace(), Name: host}, &up); err != nil {
+					log.Debug(logger, "Upstream not found yet for service, waiting", "upstream", host)
+					objectsSkipped++
+					stopAtKind = "KongUpstream"
+					continue
+				}
+				if !k8sutils.HasConditionTrue(konnectv1alpha1.KonnectEntityProgrammedConditionType, &up) {
+					log.Debug(logger, "Upstream not Programmed yet for service, waiting", "upstream", host)
+					objectsSkipped++
+					stopAtKind = "KongUpstream"
+					continue
+				}
+				// Also wait until the upstream's targets are Programmed before creating the service, so the
+				// service is only ever live once it can actually serve traffic. Anything that depends on the
+				// service (the KongRoute) then transitively waits for a servable backend.
+				targetsReady, err := upstreamTargetsProgrammed(ctx, cl, desiredTargetsByUpstream[host])
+				if err != nil {
+					return false, false, fmt.Errorf("failed to check upstream targets readiness for service %s: %w", desired.GetName(), err)
+				}
+				if !targetsReady {
+					log.Debug(logger, "Upstream targets not Programmed yet for service, waiting", "service", desired.GetName(), "upstream", host)
+					objectsSkipped++
+					stopAtKind = "KongTarget"
+					continue
+				}
+			}
 			// KongService with a clientCertificateRef depends on the referenced KongCertificate being Programmed.
 			certName, _, _ := unstructured.NestedString(desired.Object, "spec", "clientCertificateRef", "name")
 			if certName != "" {
@@ -288,6 +336,36 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 	applied = (objectsCreated + objectsUpdated) > 0
 	waiting = objectsSkipped > 0
 	return applied, waiting, nil
+}
+
+// desiredHasUpstreamNamed reports whether the pre-built upstream name set contains the given name.
+// Used to decide whether a KongService's host refers to a managed upstream (and should therefore be gated
+// on it) versus an external hostname (which must not gate).
+func desiredHasUpstreamNamed(desiredUpstreamNames map[string]struct{}, name string) bool {
+	_, ok := desiredUpstreamNames[name]
+	return ok
+}
+
+// upstreamTargetsProgrammed reports whether every KongTarget in the pre-filtered targets slice is present
+// in the cluster and Programmed. The caller is responsible for passing only the targets that belong to the
+// upstream being checked (use the desiredTargetsByUpstream map built in enforceState). An empty/nil slice
+// means no targets exist for that upstream and is considered ready.
+func upstreamTargetsProgrammed(ctx context.Context, cl client.Client, targets []unstructured.Unstructured) (bool, error) {
+	for i := range targets {
+		d := &targets[i]
+		var tgt configurationv1alpha1.KongTarget
+		if err := cl.Get(ctx, client.ObjectKey{Namespace: d.GetNamespace(), Name: d.GetName()}, &tgt); err != nil {
+			if apierrors.IsNotFound(err) {
+				// Not created yet (targets are appended after the route): not ready.
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to get KongTarget %s/%s: %w", d.GetNamespace(), d.GetName(), err)
+		}
+		if !k8sutils.HasConditionTrue(konnectv1alpha1.KonnectEntityProgrammedConditionType, &tgt) {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // enforceStatus updates the status of the root object managed by the provided APIConverter.

--- a/controller/hybridgateway/reconciler_utils_test.go
+++ b/controller/hybridgateway/reconciler_utils_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"slices"
 	"testing"
-	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
@@ -92,7 +91,7 @@ func TestPruneDesiredObj(t *testing.T) {
 }
 
 func TestEnforceState_DependencyGating(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	logger := logr.Discard()
 
 	// Prepare Scheme with needed types.
@@ -253,7 +252,7 @@ func TestTranslate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			conv := &fakeHTTPRouteConverter{translateRet: tt.translateRet, translateErr: tt.translateErr}
 
-			count, err := translate[gwtypes.HTTPRoute](conv, context.Background(), logr.Discard())
+			count, err := translate[gwtypes.HTTPRoute](conv, t.Context(), logr.Discard())
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -293,7 +292,7 @@ func TestEnforceStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			conv := &fakeHTTPRouteConverter{statusUpdated: tt.statusUpdated, statusStop: tt.statusStop, statusErr: tt.statusErr}
 
-			updated, stop, err := enforceStatus[gwtypes.HTTPRoute](context.Background(), logr.Discard(), conv)
+			updated, stop, err := enforceStatus[gwtypes.HTTPRoute](t.Context(), logr.Discard(), conv)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -307,7 +306,7 @@ func TestEnforceStatus(t *testing.T) {
 }
 
 func TestEnforceState_CoreAndErrorPaths(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	logger := logr.Discard()
 	kongServiceGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongService"}
 
@@ -476,264 +475,300 @@ func TestEnforceState_CoreAndErrorPaths(t *testing.T) {
 }
 
 func TestCleanOrphanedResources(t *testing.T) {
-	gvks := []schema.GroupVersionKind{
-		{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongRoute"},
-		{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongService"},
+	ctx := t.Context()
+	logger := logr.Discard()
+
+	routeGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongRoute"}
+	serviceGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongService"}
+
+	root := &gwtypes.HTTPRoute{
+		TypeMeta:   metav1.TypeMeta{APIVersion: gatewayv1.GroupVersion.String(), Kind: "HTTPRoute"},
+		ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "ns"},
 	}
-	root := &gwtypes.HTTPRoute{}
-	root.SetName("httproute-owner")
-	root.SetNamespace("ns")
-	root.SetGroupVersionKind(schema.GroupVersionKind{Group: gwtypes.GroupName, Version: "v1alpha2", Kind: "HTTPRoute"})
 	ownerLabels := metadata.BuildLabels(root, nil)
+	ownerAnnotation := fmt.Sprintf("%s/%s", root.Namespace, root.Name)
+
+	// makeOrphan creates an object that is owned (has owner labels) and has the route
+	// annotation that the fake HandleOrphanedResource uses to allow deletion.
+	makeOrphan := func(name string, gvk schema.GroupVersionKind) unstructured.Unstructured {
+		obj := newUnstructured("ns", name, gvk, ownerLabels)
+		obj.SetAnnotations(map[string]string{
+			consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: ownerAnnotation,
+		})
+		return obj
+	}
+
+	// makeDeletingOrphan is an orphan that is already being deleted (has DeletionTimestamp).
+	makeDeletingOrphan := func(name string, gvk schema.GroupVersionKind) unstructured.Unstructured {
+		obj := makeOrphan(name, gvk)
+		ts := metav1.Now()
+		obj.SetDeletionTimestamp(&ts)
+		obj.SetFinalizers([]string{"example.com/test"})
+		return obj
+	}
+
+	// makeDesired creates an object that represents a desired resource in the cluster.
+	makeDesired := func(name string, gvk schema.GroupVersionKind) unstructured.Unstructured {
+		return newUnstructured("ns", name, gvk, ownerLabels)
+	}
+
+	// listNames returns the names of all objects in the cluster for a given GVK.
+	listNames := func(t *testing.T, cl client.Client, gvk schema.GroupVersionKind) []string {
+		t.Helper()
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(gvk)
+		require.NoError(t, cl.List(ctx, list))
+		names := make([]string, len(list.Items))
+		for i, item := range list.Items {
+			names[i] = item.GetName()
+		}
+		return names
+	}
 
 	tests := []struct {
-		name         string
-		desiredNames map[schema.GroupVersionKind][]string
-		orphanNames  map[schema.GroupVersionKind][]string
-		wantNames    map[schema.GroupVersionKind][]string
-		gvks         []schema.GroupVersionKind
+		name                 string
+		gvks                 []schema.GroupVersionKind
+		desired              []unstructured.Unstructured // what the converter reports as desired
+		existing             []unstructured.Unstructured // what's in the cluster
+		noWait               bool                        // true → cleanOrphanedResourcesWithoutWaitingForDeletes
+		runUntilDone         bool                        // loop until requeue=false
+		outputStoreErr       error
+		interceptorFn        *interceptor.Funcs
+		handleOrphanedResErr bool
+		wantRequeue          bool
+		wantErrContains      string
+		wantRemaining        map[schema.GroupVersionKind][]string
 	}{
+		// --- basic cleanup ---
 		{
-			name:         "KongRoute orphans cleaned",
-			gvks:         []schema.GroupVersionKind{gvks[0]},
-			desiredNames: map[schema.GroupVersionKind][]string{gvks[0]: {"route1"}},
-			orphanNames:  map[schema.GroupVersionKind][]string{gvks[0]: {"route2"}},
-			wantNames:    map[schema.GroupVersionKind][]string{gvks[0]: {"route1"}},
+			name:        "no objects → requeue=false",
+			gvks:        []schema.GroupVersionKind{routeGVK},
+			wantRequeue: false,
 		},
 		{
-			name:         "KongService orphans cleaned",
-			gvks:         []schema.GroupVersionKind{gvks[1]},
-			desiredNames: map[schema.GroupVersionKind][]string{gvks[1]: {"service1"}},
-			orphanNames:  map[schema.GroupVersionKind][]string{gvks[1]: {"service2"}},
-			wantNames:    map[schema.GroupVersionKind][]string{gvks[1]: {"service1"}},
+			name:          "no orphans → requeue=false",
+			gvks:          []schema.GroupVersionKind{routeGVK},
+			desired:       []unstructured.Unstructured{makeDesired("r1", routeGVK)},
+			existing:      []unstructured.Unstructured{makeDesired("r1", routeGVK)},
+			wantRequeue:   false,
+			wantRemaining: map[schema.GroupVersionKind][]string{routeGVK: {"r1"}},
 		},
 		{
-			name:         "No orphans present",
-			gvks:         []schema.GroupVersionKind{gvks[0]},
-			desiredNames: map[schema.GroupVersionKind][]string{gvks[0]: {"route1"}},
-			orphanNames:  map[schema.GroupVersionKind][]string{gvks[0]: {}},
-			wantNames:    map[schema.GroupVersionKind][]string{gvks[0]: {"route1"}},
+			name:          "single orphan is deleted",
+			gvks:          []schema.GroupVersionKind{routeGVK},
+			desired:       []unstructured.Unstructured{makeDesired("r1", routeGVK)},
+			existing:      []unstructured.Unstructured{makeDesired("r1", routeGVK), makeOrphan("r-orphan", routeGVK)},
+			runUntilDone:  true,
+			wantRequeue:   false,
+			wantRemaining: map[schema.GroupVersionKind][]string{routeGVK: {"r1"}},
 		},
 		{
-			name:         "Multiple orphans and multiple desired resources",
-			gvks:         []schema.GroupVersionKind{gvks[0]},
-			desiredNames: map[schema.GroupVersionKind][]string{gvks[0]: {"route1", "route2", "route3"}},
-			orphanNames:  map[schema.GroupVersionKind][]string{gvks[0]: {"route4", "route5"}},
-			wantNames:    map[schema.GroupVersionKind][]string{gvks[0]: {"route1", "route2", "route3"}},
+			name:          "multiple orphans in one GVK are all deleted",
+			gvks:          []schema.GroupVersionKind{routeGVK},
+			desired:       []unstructured.Unstructured{makeDesired("r1", routeGVK)},
+			existing:      []unstructured.Unstructured{makeDesired("r1", routeGVK), makeOrphan("orphan-a", routeGVK), makeOrphan("orphan-b", routeGVK)},
+			runUntilDone:  true,
+			wantRequeue:   false,
+			wantRemaining: map[schema.GroupVersionKind][]string{routeGVK: {"r1"}},
 		},
 		{
-			name:         "No desired, only orphans",
-			gvks:         []schema.GroupVersionKind{gvks[0]},
-			desiredNames: map[schema.GroupVersionKind][]string{gvks[0]: {}},
-			orphanNames:  map[schema.GroupVersionKind][]string{gvks[0]: {"route1", "route2"}},
-			wantNames:    map[schema.GroupVersionKind][]string{gvks[0]: {}},
+			name:          "all cluster objects are orphans → all deleted",
+			gvks:          []schema.GroupVersionKind{routeGVK},
+			existing:      []unstructured.Unstructured{makeOrphan("orphan-a", routeGVK), makeOrphan("orphan-b", routeGVK)},
+			runUntilDone:  true,
+			wantRequeue:   false,
+			wantRemaining: map[schema.GroupVersionKind][]string{routeGVK: {}},
 		},
 		{
-			name:         "Desired and orphan have overlapping names",
-			gvks:         []schema.GroupVersionKind{gvks[0]},
-			desiredNames: map[schema.GroupVersionKind][]string{gvks[0]: {"route1", "route2"}},
-			orphanNames:  map[schema.GroupVersionKind][]string{gvks[0]: {"route2", "route3"}},
-			wantNames:    map[schema.GroupVersionKind][]string{gvks[0]: {"route1", "route2"}},
-		},
-		{
-			name:         "Orphan with label mismatch is not deleted",
-			gvks:         []schema.GroupVersionKind{gvks[0]},
-			desiredNames: map[schema.GroupVersionKind][]string{gvks[0]: {"route1"}},
-			orphanNames:  map[schema.GroupVersionKind][]string{gvks[0]: {"route2"}},
-			wantNames:    map[schema.GroupVersionKind][]string{gvks[0]: {"route1", "route2"}}, // route2 has wrong labels, should not be deleted
-		},
-		{
-			name: "Multiple GVKs in one test",
-			gvks: []schema.GroupVersionKind{gvks[0], gvks[1]},
-			desiredNames: map[schema.GroupVersionKind][]string{
-				gvks[0]: {"routeA"},
-				gvks[1]: {"serviceA"},
+			name:    "desired name overlaps with orphan name: desired-set object is kept",
+			gvks:    []schema.GroupVersionKind{routeGVK},
+			desired: []unstructured.Unstructured{makeDesired("r1", routeGVK), makeDesired("r2", routeGVK)},
+			existing: []unstructured.Unstructured{
+				makeDesired("r1", routeGVK),
+				makeDesired("r2", routeGVK),
+				makeOrphan("r3", routeGVK), // orphan not in desired
 			},
-			orphanNames: map[schema.GroupVersionKind][]string{
-				gvks[0]: {"routeB"},
-				gvks[1]: {"serviceB"},
+			runUntilDone:  true,
+			wantRequeue:   false,
+			wantRemaining: map[schema.GroupVersionKind][]string{routeGVK: {"r1", "r2"}},
+		},
+		{
+			name:    "object without owner labels is not matched by selector and not deleted",
+			gvks:    []schema.GroupVersionKind{routeGVK},
+			desired: []unstructured.Unstructured{makeDesired("r1", routeGVK)},
+			existing: []unstructured.Unstructured{
+				makeDesired("r1", routeGVK),
+				newUnstructured("ns", "unrelated", routeGVK, map[string]string{"other": "label"}),
 			},
-			wantNames: map[schema.GroupVersionKind][]string{
-				gvks[0]: {"routeA"},
-				gvks[1]: {"serviceA"},
+			wantRequeue:   false,
+			wantRemaining: map[schema.GroupVersionKind][]string{routeGVK: {"r1", "unrelated"}},
+		},
+		// --- multi-GVK eventual cleanup ---
+		{
+			name: "multiple GVKs: all orphans are eventually cleaned",
+			gvks: []schema.GroupVersionKind{routeGVK, serviceGVK},
+			desired: []unstructured.Unstructured{
+				makeDesired("r1", routeGVK),
+				makeDesired("svc1", serviceGVK),
+			},
+			existing: []unstructured.Unstructured{
+				makeDesired("r1", routeGVK), makeOrphan("r-orphan", routeGVK),
+				makeDesired("svc1", serviceGVK), makeOrphan("svc-orphan", serviceGVK),
+			},
+			runUntilDone: true,
+			wantRequeue:  false,
+			wantRemaining: map[schema.GroupVersionKind][]string{
+				routeGVK:   {"r1"},
+				serviceGVK: {"svc1"},
+			},
+		},
+		// --- gating: noWait=false (cleanOrphanedResources, waitForDeletedResources=true) ---
+		{
+			// After deleting the orphan in GVK1, the function returns immediately without
+			// processing GVK2. A second call is needed to clean GVK2 orphans.
+			name:        "noWait=false: orphan deleted in GVK1 stops processing GVK2 in same pass",
+			gvks:        []schema.GroupVersionKind{routeGVK, serviceGVK},
+			existing:    []unstructured.Unstructured{makeOrphan("r-orphan", routeGVK), makeOrphan("svc-orphan", serviceGVK)},
+			wantRequeue: true,
+			wantRemaining: map[schema.GroupVersionKind][]string{
+				routeGVK:   {},
+				serviceGVK: {"svc-orphan"},
 			},
 		},
 		{
-			name:         "No resources at all",
-			gvks:         []schema.GroupVersionKind{gvks[0]},
-			desiredNames: map[schema.GroupVersionKind][]string{gvks[0]: {}},
-			orphanNames:  map[schema.GroupVersionKind][]string{gvks[0]: {}},
-			wantNames:    map[schema.GroupVersionKind][]string{gvks[0]: {}},
+			// An in-deletion object in GVK1 also triggers an early return, blocking GVK2.
+			name:        "noWait=false: in-deletion orphan in GVK1 stops processing GVK2",
+			gvks:        []schema.GroupVersionKind{routeGVK, serviceGVK},
+			existing:    []unstructured.Unstructured{makeDeletingOrphan("r-deleting", routeGVK), makeOrphan("svc-orphan", serviceGVK)},
+			wantRequeue: true,
+			wantRemaining: map[schema.GroupVersionKind][]string{
+				routeGVK:   {"r-deleting"},
+				serviceGVK: {"svc-orphan"},
+			},
+		},
+		// --- gating: noWait=true (cleanOrphanedResourcesWithoutWaitingForDeletes, waitForDeletedResources=false) ---
+		{
+			// With noWait=true, GVK2 is processed even when GVK1 had orphans to delete.
+			name:        "noWait=true: orphan deleted in GVK1 continues to GVK2 in same pass",
+			gvks:        []schema.GroupVersionKind{routeGVK, serviceGVK},
+			existing:    []unstructured.Unstructured{makeOrphan("r-orphan", routeGVK), makeOrphan("svc-orphan", serviceGVK)},
+			noWait:      true,
+			wantRequeue: true,
+			wantRemaining: map[schema.GroupVersionKind][]string{
+				routeGVK:   {},
+				serviceGVK: {},
+			},
 		},
 		{
-			name:         "Orphan with extra fields is deleted",
-			gvks:         []schema.GroupVersionKind{gvks[0]},
-			desiredNames: map[schema.GroupVersionKind][]string{gvks[0]: {"route1"}},
-			orphanNames:  map[schema.GroupVersionKind][]string{gvks[0]: {"route2"}},
-			wantNames:    map[schema.GroupVersionKind][]string{gvks[0]: {"route1"}},
+			// With noWait=true, an in-deletion GVK1 orphan does not block GVK2.
+			name:        "noWait=true: in-deletion orphan in GVK1 does not block GVK2",
+			gvks:        []schema.GroupVersionKind{routeGVK, serviceGVK},
+			existing:    []unstructured.Unstructured{makeDeletingOrphan("r-deleting", routeGVK), makeOrphan("svc-orphan", serviceGVK)},
+			noWait:      true,
+			wantRequeue: true,
+			wantRemaining: map[schema.GroupVersionKind][]string{
+				routeGVK:   {"r-deleting"},
+				serviceGVK: {},
+			},
+		},
+		// --- error paths ---
+		{
+			name:            "GetOutputStore error is propagated",
+			gvks:            []schema.GroupVersionKind{routeGVK},
+			outputStoreErr:  assert.AnError,
+			wantErrContains: "failed to get desired objects from converter for cleanup",
+		},
+		{
+			name: "cl.List error is propagated",
+			gvks: []schema.GroupVersionKind{routeGVK},
+			interceptorFn: &interceptor.Funcs{
+				List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					return assert.AnError
+				},
+			},
+			wantErrContains: "unable to list objects with gvk",
+		},
+		{
+			name:     "cl.Delete error is propagated",
+			gvks:     []schema.GroupVersionKind{routeGVK},
+			existing: []unstructured.Unstructured{makeOrphan("r-orphan", routeGVK)},
+			interceptorFn: &interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					return assert.AnError
+				},
+			},
+			wantErrContains: "failed to delete orphaned resource",
+		},
+		{
+			name:                 "HandleOrphanedResource error is propagated",
+			gvks:                 []schema.GroupVersionKind{routeGVK},
+			existing:             []unstructured.Unstructured{makeOrphan("r-orphan", routeGVK)},
+			handleOrphanedResErr: true,
+			wantErrContains:      "failed to handle orphaned resource",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var desired, orphans []unstructured.Unstructured
-			for _, gvk := range tt.gvks {
-				desiredSet := make(map[string]struct{})
-				for _, name := range tt.desiredNames[gvk] {
-					desired = append(desired, newUnstructured("ns", name, gvk, ownerLabels))
-					desiredSet[name] = struct{}{}
-				}
-				for _, name := range tt.orphanNames[gvk] {
-					ns := "ns"
-					labels := ownerLabels
-					extraFields := false
-					if tt.name == "Orphans in different namespace are not deleted" {
-						ns = "other-ns"
-					}
-					if tt.name == "Orphan with label mismatch is not deleted" {
-						labels = map[string]string{"unrelated": "true"}
-					}
-					if tt.name == "Orphan with extra fields is deleted" && name == "route2" {
-						extraFields = true
-					}
-					if _, exists := desiredSet[name]; !exists {
-						obj := newUnstructured(ns, name, gvk, labels)
+			allObjs := make([]client.Object, len(tt.existing))
+			for i := range tt.existing {
+				allObjs[i] = &tt.existing[i]
+			}
+			builder := fake.NewClientBuilder().WithScheme(runtime.NewScheme()).WithObjects(allObjs...)
+			if tt.interceptorFn != nil {
+				builder = builder.WithInterceptorFuncs(*tt.interceptorFn)
+			}
+			cl := builder.Build()
 
-						annotations := obj.GetAnnotations()
-						if annotations == nil {
-							annotations = make(map[string]string)
-						}
-						annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation] = "ns/httproute-owner"
-						obj.SetAnnotations(annotations)
-
-						if extraFields {
-							annotations["extra"] = "field"
-							obj.SetAnnotations(annotations)
-						}
-						orphans = append(orphans, obj)
-					}
-				}
-			}
-			var allObjs []client.Object
-			for i := range desired {
-				allObjs = append(allObjs, &desired[i])
-			}
-			for i := range orphans {
-				allObjs = append(allObjs, &orphans[i])
-			}
-			scheme := runtime.NewScheme()
-			cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(allObjs...).Build()
-			fakeConv := &fakeHTTPRouteConverter{
-				desired: desired,
-				gvks:    tt.gvks,
-				root:    *root,
-			}
-			logger := logr.Discard()
+			var requeue bool
 			var err error
-			requeue := true
-			for requeue {
-				requeue, err = cleanOrphanedResources(context.Background(), cl, logger, fakeConv)
-				assert.NoError(t, err)
-			}
-			for _, gvk := range tt.gvks {
-				list := &unstructured.UnstructuredList{}
-				list.SetGroupVersionKind(gvk)
-				err = cl.List(context.Background(), list)
-				assert.NoError(t, err)
-				var nsNames, otherNsNames []string
-				for _, item := range list.Items {
-					if item.GetNamespace() == "ns" {
-						nsNames = append(nsNames, item.GetName())
-					} else if item.GetNamespace() == "other-ns" {
-						otherNsNames = append(otherNsNames, item.GetName())
+			for {
+				if tt.handleOrphanedResErr {
+					conv := &fakeHTTPRouteConverterWithHandleErr{
+						fakeHTTPRouteConverter: fakeHTTPRouteConverter{
+							gvks:           tt.gvks,
+							root:           *root,
+							desired:        tt.desired,
+							outputStoreErr: tt.outputStoreErr,
+						},
+					}
+					if tt.noWait {
+						requeue, err = cleanOrphanedResourcesWithoutWaitingForDeletes(ctx, cl, logger, conv)
+					} else {
+						requeue, err = cleanOrphanedResources(ctx, cl, logger, conv)
+					}
+				} else {
+					conv := &fakeHTTPRouteConverter{
+						gvks:           tt.gvks,
+						root:           *root,
+						desired:        tt.desired,
+						outputStoreErr: tt.outputStoreErr,
+					}
+					if tt.noWait {
+						requeue, err = cleanOrphanedResourcesWithoutWaitingForDeletes(ctx, cl, logger, conv)
+					} else {
+						requeue, err = cleanOrphanedResources(ctx, cl, logger, conv)
 					}
 				}
-				switch tt.name {
-				case "Orphans in different namespace are not deleted":
-					assert.ElementsMatch(t, tt.wantNames[gvk][:1], nsNames)
-					assert.ElementsMatch(t, tt.wantNames[gvk][1:], otherNsNames)
-				case "Orphan with label mismatch is not deleted":
-					assert.ElementsMatch(t, tt.wantNames[gvk], nsNames)
-				default:
-					assert.ElementsMatch(t, tt.wantNames[gvk], nsNames)
+				if !tt.runUntilDone || !requeue || err != nil {
+					break
 				}
+			}
+
+			if tt.wantErrContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantRequeue, requeue)
+
+			for gvk, wantNames := range tt.wantRemaining {
+				assert.ElementsMatch(t, wantNames, listNames(t, cl, gvk),
+					"remaining names for GVK %s", gvk)
 			}
 		})
 	}
-}
-
-func TestCleanOrphanedResourcesForRootDeletionDoesNotWaitForDeletingChildren(t *testing.T) {
-	ctx := context.Background()
-	logger := logr.Discard()
-	gvks := []schema.GroupVersionKind{
-		{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongRoute"},
-		{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongService"},
-	}
-	root := &gwtypes.HTTPRoute{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: gatewayv1.GroupVersion.String(),
-			Kind:       "HTTPRoute",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "httproute-owner",
-			Namespace: "ns",
-		},
-	}
-	ownerLabels := metadata.BuildLabels(root, nil)
-
-	deletingRoute := newUnstructured("ns", "deleting-route", gvks[0], ownerLabels)
-	deletingTimestamp := metav1.NewTime(time.Now())
-	deletingRoute.SetDeletionTimestamp(&deletingTimestamp)
-	deletingRoute.SetFinalizers([]string{"example.com/finalizer"})
-
-	service := newUnstructured("ns", "service", gvks[1], ownerLabels)
-	for _, obj := range []*unstructured.Unstructured{&deletingRoute, &service} {
-		annotations := obj.GetAnnotations()
-		if annotations == nil {
-			annotations = make(map[string]string)
-		}
-		annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation] = "ns/httproute-owner"
-		obj.SetAnnotations(annotations)
-	}
-
-	newClient := func() client.Client {
-		return fake.NewClientBuilder().
-			WithScheme(runtime.NewScheme()).
-			WithObjects(deletingRoute.DeepCopy(), service.DeepCopy()).
-			Build()
-	}
-	fakeConv := &fakeHTTPRouteConverter{
-		gvks: gvks,
-		root: *root,
-	}
-
-	t.Run("normal cleanup waits for deleting child before later GVKs", func(t *testing.T) {
-		cl := newClient()
-		requeue, err := cleanOrphanedResources[gwtypes.HTTPRoute, *gwtypes.HTTPRoute](ctx, cl, logger, fakeConv)
-		require.NoError(t, err)
-		require.True(t, requeue)
-
-		serviceList := &unstructured.UnstructuredList{}
-		serviceList.SetGroupVersionKind(gvks[1])
-		require.NoError(t, cl.List(ctx, serviceList))
-		require.Len(t, serviceList.Items, 1)
-	})
-
-	t.Run("root deletion cleanup deletes later GVKs before releasing root finalizer", func(t *testing.T) {
-		cl := newClient()
-		requeue, err := cleanOrphanedResourcesWithoutWaitingForDeletes[gwtypes.HTTPRoute, *gwtypes.HTTPRoute](ctx, cl, logger, fakeConv)
-		require.NoError(t, err)
-		require.True(t, requeue)
-
-		serviceList := &unstructured.UnstructuredList{}
-		serviceList.SetGroupVersionKind(gvks[1])
-		require.NoError(t, cl.List(ctx, serviceList))
-		require.Empty(t, serviceList.Items)
-
-		requeue, err = cleanOrphanedResourcesWithoutWaitingForDeletes[gwtypes.HTTPRoute, *gwtypes.HTTPRoute](ctx, cl, logger, fakeConv)
-		require.NoError(t, err)
-		require.False(t, requeue)
-	})
 }
 
 // Minimal fake converter for HTTPRoute
@@ -806,7 +841,7 @@ func (f *fakeHTTPRouteConverter) HandleOrphanedResource(ctx context.Context, log
 }
 
 func TestShouldProcessObject_HTTPRoute(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	logger := logr.Discard()
 
 	// Create a test Gateway with KonnectExtension (managed by us).
@@ -1124,7 +1159,7 @@ func TestShouldProcessObject_HTTPRoute(t *testing.T) {
 }
 
 func TestShouldProcessObject_Gateway(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	logger := logr.Discard()
 
 	// KonnectExtension for managed Gateway
@@ -1323,7 +1358,7 @@ func TestShouldProcessObject_Gateway(t *testing.T) {
 }
 
 func TestRemoveFinalizerIfNotManaged_HTTPRoute(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	logger := logr.Discard()
 
 	// Create a supported Gateway (managed by KonnectExtension)
@@ -1621,8 +1656,377 @@ func TestRemoveFinalizerIfNotManaged_HTTPRoute(t *testing.T) {
 	}
 }
 
+func TestDesiredHasUpstreamNamed(t *testing.T) {
+	upstream := func(name string) unstructured.Unstructured {
+		u := unstructured.Unstructured{}
+		u.SetName(name)
+		u.SetGroupVersionKind(schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongUpstream"})
+		return u
+	}
+	notUpstream := func(name string) unstructured.Unstructured {
+		u := unstructured.Unstructured{}
+		u.SetName(name)
+		u.SetGroupVersionKind(schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongService"})
+		return u
+	}
+
+	tests := []struct {
+		name    string
+		desired []unstructured.Unstructured
+		search  string
+		want    bool
+	}{
+		{
+			name:    "empty list returns false",
+			desired: nil,
+			search:  "u1",
+			want:    false,
+		},
+		{
+			name:    "matching upstream returns true",
+			desired: []unstructured.Unstructured{upstream("u1"), upstream("u2")},
+			search:  "u1",
+			want:    true,
+		},
+		{
+			name:    "name present under different kind returns false",
+			desired: []unstructured.Unstructured{notUpstream("u1")},
+			search:  "u1",
+			want:    false,
+		},
+		{
+			name:    "name not in list returns false",
+			desired: []unstructured.Unstructured{upstream("u2")},
+			search:  "u1",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			names := make(map[string]struct{}, len(tt.desired))
+			for _, obj := range tt.desired {
+				if obj.GetKind() == "KongUpstream" {
+					names[obj.GetName()] = struct{}{}
+				}
+			}
+			assert.Equal(t, tt.want, desiredHasUpstreamNamed(names, tt.search))
+		})
+	}
+}
+
+func TestUpstreamTargetsProgrammed(t *testing.T) {
+	ctx := t.Context()
+	s := scheme.Get()
+	ns := "ns"
+
+	programmedCondition := metav1.Condition{
+		Type:               "Programmed",
+		Status:             metav1.ConditionTrue,
+		Reason:             "Programmed",
+		LastTransitionTime: metav1.Now(),
+	}
+
+	makeDesiredTarget := func(name, upstreamName string) unstructured.Unstructured {
+		u := unstructured.Unstructured{}
+		u.SetName(name)
+		u.SetNamespace(ns)
+		u.SetGroupVersionKind(schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongTarget"})
+		_ = unstructured.SetNestedField(u.Object, map[string]any{"name": upstreamName}, "spec", "upstreamRef")
+		return u
+	}
+
+	makeTarget := func(name string, programmed bool) *configurationv1alpha1.KongTarget {
+		tgt := &configurationv1alpha1.KongTarget{}
+		tgt.SetName(name)
+		tgt.SetNamespace(ns)
+		if programmed {
+			tgt.Status.Conditions = []metav1.Condition{programmedCondition}
+		}
+		return tgt
+	}
+
+	tests := []struct {
+		name            string
+		targets         []unstructured.Unstructured // pre-filtered targets for the upstream under test
+		existing        []client.Object
+		wantReady       bool
+		wantErrContains string
+		interceptorFn   *interceptor.Funcs
+	}{
+		{
+			name:      "nil targets returns ready",
+			targets:   nil,
+			wantReady: true,
+		},
+		{
+			name:      "empty targets slice returns ready",
+			targets:   []unstructured.Unstructured{},
+			wantReady: true,
+		},
+		{
+			name:      "target not in cluster returns not ready",
+			targets:   []unstructured.Unstructured{makeDesiredTarget("t1", "my-upstream")},
+			existing:  nil,
+			wantReady: false,
+		},
+		{
+			name:      "target in cluster but not Programmed returns not ready",
+			targets:   []unstructured.Unstructured{makeDesiredTarget("t1", "my-upstream")},
+			existing:  []client.Object{makeTarget("t1", false)},
+			wantReady: false,
+		},
+		{
+			name:      "target in cluster and Programmed returns ready",
+			targets:   []unstructured.Unstructured{makeDesiredTarget("t1", "my-upstream")},
+			existing:  []client.Object{makeTarget("t1", true)},
+			wantReady: true,
+		},
+		{
+			name: "multiple targets all Programmed returns ready",
+			targets: []unstructured.Unstructured{
+				makeDesiredTarget("t1", "my-upstream"),
+				makeDesiredTarget("t2", "my-upstream"),
+			},
+			existing:  []client.Object{makeTarget("t1", true), makeTarget("t2", true)},
+			wantReady: true,
+		},
+		{
+			name: "multiple targets, one not Programmed returns not ready",
+			targets: []unstructured.Unstructured{
+				makeDesiredTarget("t1", "my-upstream"),
+				makeDesiredTarget("t2", "my-upstream"),
+			},
+			existing:  []client.Object{makeTarget("t1", true), makeTarget("t2", false)},
+			wantReady: false,
+		},
+		{
+			name:    "Get error for existing target is propagated",
+			targets: []unstructured.Unstructured{makeDesiredTarget("t1", "my-upstream")},
+			interceptorFn: &interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*configurationv1alpha1.KongTarget); ok {
+						return assert.AnError
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+			wantReady:       false,
+			wantErrContains: "failed to get KongTarget",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(s)
+			if len(tt.existing) > 0 {
+				builder = builder.WithObjects(tt.existing...)
+			}
+			if tt.interceptorFn != nil {
+				builder = builder.WithInterceptorFuncs(*tt.interceptorFn)
+			}
+			cl := builder.Build()
+
+			ready, err := upstreamTargetsProgrammed(ctx, cl, tt.targets)
+
+			if tt.wantErrContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantReady, ready)
+		})
+	}
+}
+
+func TestEnforceState_UpstreamGating(t *testing.T) {
+	ctx := t.Context()
+	logger := logr.Discard()
+	s := scheme.Get()
+	ns := "ns"
+
+	programmedCondition := metav1.Condition{
+		Type:               "Programmed",
+		Status:             metav1.ConditionTrue,
+		Reason:             "Programmed",
+		LastTransitionTime: metav1.Now(),
+	}
+
+	svcGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongService"}
+	tgtGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongTarget"}
+	upGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongUpstream"}
+	routeGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongRoute"}
+	kpbGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongPluginBinding"}
+
+	makeObj := func(name string, gvk schema.GroupVersionKind, spec map[string]any) unstructured.Unstructured {
+		u := newUnstructured(ns, name, gvk, nil)
+		if spec != nil {
+			_ = unstructured.SetNestedField(u.Object, spec, "spec")
+		}
+		return u
+	}
+
+	tests := []struct {
+		name        string
+		desired     []unstructured.Unstructured
+		existing    []client.Object
+		wantApplied bool
+		wantWaiting bool
+		wantErr     bool
+	}{
+		{
+			// The service is gated (waiting=true) but the upstream prerequisite itself is
+			// still created in the same pass (applied=true): the loop skips the service
+			// but processes the upstream object that follows it.
+			name: "KongService waits when its host upstream is missing from cluster",
+			desired: []unstructured.Unstructured{
+				makeObj("svc1", svcGVK, map[string]any{"host": "upstream1"}),
+				makeObj("upstream1", upGVK, nil),
+			},
+			existing:    nil,
+			wantApplied: true,
+			wantWaiting: true,
+		},
+		{
+			// Upstream exists but isn't Programmed yet. The service is gated; the
+			// upstream is updated (no managed-fields yet → apply), so applied=true.
+			name: "KongService waits when its host upstream is not Programmed",
+			desired: []unstructured.Unstructured{
+				makeObj("svc1", svcGVK, map[string]any{"host": "upstream1"}),
+				makeObj("upstream1", upGVK, nil),
+			},
+			existing: func() []client.Object {
+				up := &configurationv1alpha1.KongUpstream{}
+				up.SetName("upstream1")
+				up.SetNamespace(ns)
+				return []client.Object{up}
+			}(),
+			wantApplied: true,
+			wantWaiting: true,
+		},
+		{
+			// Upstream is Programmed but targets are not yet. The service is gated on
+			// targets; the target itself is still processed in the same pass (applied=true).
+			name: "KongService waits when upstream is Programmed but targets are not",
+			desired: []unstructured.Unstructured{
+				makeObj("svc1", svcGVK, map[string]any{"host": "upstream1"}),
+				makeObj("upstream1", upGVK, nil),
+				makeObj("tgt1", tgtGVK, map[string]any{"upstreamRef": map[string]any{"name": "upstream1"}}),
+			},
+			existing: func() []client.Object {
+				up := &configurationv1alpha1.KongUpstream{}
+				up.SetName("upstream1")
+				up.SetNamespace(ns)
+				up.Status.Conditions = []metav1.Condition{programmedCondition}
+				// KongTarget exists but is not Programmed.
+				tgt := &configurationv1alpha1.KongTarget{}
+				tgt.SetName("tgt1")
+				tgt.SetNamespace(ns)
+				return []client.Object{up, tgt}
+			}(),
+			wantApplied: true,
+			wantWaiting: true,
+		},
+		{
+			name: "KongService skips upstream gate when host is not a desired upstream (external)",
+			desired: []unstructured.Unstructured{
+				makeObj("svc1", svcGVK, map[string]any{"host": "external.example.com"}),
+			},
+			existing:    nil,
+			wantApplied: true, // proceeds immediately, no upstream to wait for
+			wantWaiting: false,
+		},
+		{
+			name: "KongTarget waits when upstream exists but is not Programmed",
+			desired: []unstructured.Unstructured{
+				makeObj("tgt1", tgtGVK, map[string]any{"upstreamRef": map[string]any{"name": "upstream1"}}),
+			},
+			existing: func() []client.Object {
+				up := &configurationv1alpha1.KongUpstream{}
+				up.SetName("upstream1")
+				up.SetNamespace(ns)
+				return []client.Object{up}
+			}(),
+			wantApplied: false,
+			wantWaiting: true,
+		},
+		{
+			name: "KongRoute waits when service is missing",
+			desired: []unstructured.Unstructured{
+				makeObj("r1", routeGVK, map[string]any{
+					"serviceRef": map[string]any{"namespacedRef": map[string]any{"name": "svc1"}},
+				}),
+			},
+			existing:    nil,
+			wantApplied: false,
+			wantWaiting: true,
+		},
+		{
+			name: "KongPluginBinding waits when route is missing",
+			desired: []unstructured.Unstructured{
+				makeObj("b1", kpbGVK, map[string]any{
+					"targets": map[string]any{"routeRef": map[string]any{"name": "r1"}},
+				}),
+			},
+			existing:    nil,
+			wantApplied: false,
+			wantWaiting: true,
+		},
+		{
+			name: "KongPluginBinding waits when referenced KongService is not Programmed",
+			desired: []unstructured.Unstructured{
+				makeObj("b1", kpbGVK, map[string]any{
+					"targets": map[string]any{
+						"serviceRef": map[string]any{"name": "svc1", "kind": "KongService"},
+					},
+				}),
+			},
+			existing: func() []client.Object {
+				svc := &configurationv1alpha1.KongService{}
+				svc.SetName("svc1")
+				svc.SetNamespace(ns)
+				return []client.Object{svc}
+			}(),
+			wantApplied: false,
+			wantWaiting: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(s)
+			if len(tt.existing) > 0 {
+				builder = builder.WithObjects(tt.existing...)
+			}
+			cl := builder.Build()
+
+			fakeConv := &fakeHTTPRouteConverter{desired: tt.desired}
+			applied, waiting, err := enforceState(ctx, cl, logger, fakeConv)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantApplied, applied)
+			assert.Equal(t, tt.wantWaiting, waiting)
+		})
+	}
+}
+
+// fakeHTTPRouteConverterWithHandleErr wraps fakeHTTPRouteConverter and returns an error
+// from HandleOrphanedResource so we can test error propagation in cleanOrphanedResources.
+type fakeHTTPRouteConverterWithHandleErr struct {
+	fakeHTTPRouteConverter
+}
+
+func (f *fakeHTTPRouteConverterWithHandleErr) HandleOrphanedResource(_ context.Context, _ logr.Logger, _ *unstructured.Unstructured) (bool, error) {
+	return false, assert.AnError
+}
+
 func TestRemoveFinalizerIfNotManaged_Gateway(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	logger := logr.Discard()
 
 	// KonnectExtension for the managed Gateway (with UID test-gateway-uid)


### PR DESCRIPTION




**What this PR does / why we need it**:

(cherry picked from commit ed7f7787d6f27fa3f44617aae3a73e18cd09e1ca)

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
