### PR TITLE
[Backport release/2.1.x] fix(hybridgateway): merge HTTPRoute filters mapping to the same Kong plugin type (#4658)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@
 - Prevent recreating consumer credentials on every Konnect sync when running in
   "KIC in Konnect" mode with on prem `ControlPlane`.
   [#4623](https://github.com/Kong/kong-operator/pull/4622) [#4624](https://github.com/Kong/kong-operator/pull/4624)
+- Hybridgateway: merge `HTTPRoute` filters that map to the same Kong plugin type
+  (for example a `URLRewrite` and a `RequestHeaderModifier`, both of which
+  translate to `request-transformer`) into a single `KongPlugin` per rule. This
+  avoids attaching two plugins of the same type to the same route, which Konnect
+  rejects with a `unique-plugin-per-entity` constraint error.
+  [#4658](https://github.com/Kong/kong-operator/pull/4658)
 
 ## [v2.1.7]
 

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -439,47 +439,50 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 				"route", routeName)
 
 			// Build the KongPlugin and KongPluginBinding resources.
+			// Translate the rule's filters into KongPlugins. Filters that map to the same Kong
+			// plugin type (e.g. URLRewrite and RequestHeaderModifier both map to
+			// request-transformer) are merged into a single KongPlugin so that a route never gets
+			// two plugins of the same type bound to it (Kong's unique-plugin-per-entity constraint).
 			log.Debug(logger, "Processing filters for rule",
 				"kongRoute", routeName,
 				"filterCount", len(rule.Filters))
 
-			for _, filter := range rule.Filters {
-				plugins, err := plugin.PluginsForFilter(ctx, logger, c.Client, c.route, rule, filter, &pRef)
+			plugins, err := plugin.PluginsForRule(ctx, logger, c.Client, c.route, rule, &pRef)
+			if err != nil {
+				log.Error(logger, err, "Failed to translate KongPlugin resources for rule, skipping plugins",
+					"ruleIndex", ruleIndex)
+				translationErrors = append(translationErrors, fmt.Errorf("failed to translate KongPlugins for rule %d: %w", ruleIndex, err))
+				plugins = nil
+			}
+
+			for i := range plugins {
+				pluginObj := &plugins[i]
+				pluginName := pluginObj.Name
+				c.outputStore = append(c.outputStore, pluginObj)
+				// Create a KongPluginBinding to bind the KongPlugin to the KongRoute.
+				bindingPtr, err := pluginbinding.BindingForPluginAndRoute(
+					ctx,
+					logger,
+					c.Client,
+					c.route,
+					&pRef,
+					cp,
+					pluginName,
+					routeName,
+				)
 				if err != nil {
-					log.Error(logger, err, "Failed to translate KongPlugin resource, skipping filter",
-						"filter", filter.Type)
-					translationErrors = append(translationErrors, fmt.Errorf("failed to translate KongPlugin for filter: %w", err))
+					log.Error(logger, err, "Failed to build KongPluginBinding resource, skipping binding",
+						"plugin", pluginName,
+						"kongRoute", routeName)
+					translationErrors = append(translationErrors, fmt.Errorf("failed to build KongPluginBinding for plugin %s: %w", pluginName, err))
 					continue
 				}
+				bindingName := bindingPtr.Name
+				c.outputStore = append(c.outputStore, bindingPtr)
 
-				for _, plugin := range plugins {
-					pluginName := plugin.Name
-					c.outputStore = append(c.outputStore, &plugin)
-					// Create a KongPluginBinding to bind the KongPlugin to each KongRoute.
-					bindingPtr, err := pluginbinding.BindingForPluginAndRoute(
-						ctx,
-						logger,
-						c.Client,
-						c.route,
-						&pRef,
-						cp,
-						pluginName,
-						routeName,
-					)
-					if err != nil {
-						log.Error(logger, err, "Failed to build KongPluginBinding resource, skipping binding",
-							"plugin", pluginName,
-							"kongRoute", routeName)
-						translationErrors = append(translationErrors, fmt.Errorf("failed to build KongPluginBinding for plugin %s: %w", pluginName, err))
-						continue
-					}
-					bindingName := bindingPtr.Name
-					c.outputStore = append(c.outputStore, bindingPtr)
-
-					log.Debug(logger, "Successfully translated KongPlugin and KongPluginBinding resources",
-						"plugin", pluginName,
-						"binding", bindingName)
-				}
+				log.Debug(logger, "Successfully translated KongPlugin and KongPluginBinding resources",
+					"plugin", pluginName,
+					"binding", bindingName)
 			}
 
 			// Build the KongTarget resources.

--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -329,6 +329,63 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 			wantStoreLen: 8,
 		},
 		{
+			// Regression test: a rule combining a URLRewrite and a RequestHeaderModifier filter
+			// must produce a single request-transformer KongPlugin (and a single binding per
+			// route) instead of two plugins of the same type bound to the same route, which Kong
+			// rejects with a unique-plugin-per-entity constraint error.
+			name: "merges filters mapping to the same plugin type into a single request-transformer",
+			setup: func() *httpRouteConverter {
+				route := newHTTPRouteForTranslation([]string{"api.example.com"}, []gwtypes.HTTPBackendRef{
+					newBackendRef(""),
+				}, []gwtypes.HTTPRouteFilter{
+					{
+						Type: gatewayv1.HTTPRouteFilterURLRewrite,
+						URLRewrite: &gatewayv1.HTTPURLRewriteFilter{
+							Path: &gatewayv1.HTTPPathModifier{
+								Type:               gatewayv1.PrefixMatchHTTPPathModifier,
+								ReplacePrefixMatch: lo.ToPtr("/echo"),
+							},
+						},
+					},
+					newRequestHeaderFilter("x-test", "true"),
+				})
+				gateway := baseGateway()
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(baseObjects(gateway)...).Build()
+				return newHTTPRouteConverter(route, fakeClient, false, "").(*httpRouteConverter)
+			},
+			wantCount: 6,
+			wantOutputs: outputCount{
+				upstreams: 1,
+				services:  1,
+				routes:    1,
+				targets:   1,
+				bindings:  1,
+				plugins:   1,
+			},
+			wantStoreLen: 6,
+			assertFn: func(t *testing.T, store []client.Object) {
+				t.Helper()
+
+				var pluginObj *configurationv1.KongPlugin
+				for _, obj := range store {
+					if p, ok := obj.(*configurationv1.KongPlugin); ok {
+						pluginObj = p
+					}
+				}
+				require.NotNil(t, pluginObj)
+				assert.Equal(t, "request-transformer", pluginObj.PluginName)
+
+				// The merged config must carry both the URLRewrite (replace.uri) and the
+				// RequestHeaderModifier (the Set header lands in add+replace) contributions.
+				var config map[string]any
+				require.NoError(t, json.Unmarshal(pluginObj.Config.Raw, &config))
+				replace, ok := config["replace"].(map[string]any)
+				require.True(t, ok, "merged config must contain a replace block")
+				assert.NotEmpty(t, replace["uri"], "URLRewrite contribution (replace.uri) must be present")
+				assert.Contains(t, replace["headers"], "x-test:true", "RequestHeaderModifier contribution must be present")
+			},
+		},
+		{
 			name: "translates multi rule redirect only route end to end",
 			setup: func() *httpRouteConverter {
 				route := newHTTPRouteWithRules(
@@ -444,7 +501,7 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 				return newHTTPRouteConverter(route, fakeClient, false, "").(*httpRouteConverter)
 			},
 			wantErr:    true,
-			wantErrSub: "failed to translate KongPlugin for filter",
+			wantErrSub: "failed to translate KongPlugins for rule",
 			wantOutputs: outputCount{
 				upstreams: 1,
 				services:  1,

--- a/controller/hybridgateway/namegen/name.go
+++ b/controller/hybridgateway/namegen/name.go
@@ -140,6 +140,23 @@ func NewKongPluginName(filter gatewayv1.HTTPRouteFilter, namespace string, plugi
 	return newName(namespace, pluginName, utils.Hash32(filter))
 }
 
+// NewKongPluginNameForFilters generates a KongPlugin name for a plugin produced by one or more
+// HTTPRoute filters. When several filters map to the same Kong plugin type (e.g. URLRewrite and
+// RequestHeaderModifier both map to request-transformer) they are merged into a single KongPlugin,
+// so the name must be derived from the whole set of contributing filters. The single-filter case
+// is kept identical to NewKongPluginName to avoid renaming existing resources.
+func NewKongPluginNameForFilters(filters []gatewayv1.HTTPRouteFilter, namespace string, pluginName string) string {
+	if len(filters) == 1 {
+		return NewKongPluginName(filters[0], namespace, pluginName)
+	}
+	return newName(namespace, pluginName, utils.Hash32(filters))
+}
+
+// NewKongPluginNameForService generates a KongPlugin name tied to a KongService.
+func NewKongPluginNameForService(serviceName, pluginName string) string {
+	return newName(serviceName, pluginName)
+}
+
 // NewKongPluginBindingName generates a KongPlugin name based on the KongRoute and the KongPlugin names.
 func NewKongPluginBindingName(routeID, pluginId string) string {
 	return newName(routeID, pluginId)

--- a/controller/hybridgateway/namegen/name_test.go
+++ b/controller/hybridgateway/namegen/name_test.go
@@ -543,6 +543,79 @@ func TestNewKongPluginName(t *testing.T) {
 	}
 }
 
+func TestNewKongPluginNameForFilters(t *testing.T) {
+	headerModifier := gatewayv1.HTTPRouteFilter{
+		Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+		RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+			Set: []gatewayv1.HTTPHeader{{Name: "X-Test", Value: "test-value"}},
+		},
+	}
+	urlRewrite := gatewayv1.HTTPRouteFilter{
+		Type: gatewayv1.HTTPRouteFilterURLRewrite,
+		URLRewrite: &gatewayv1.HTTPURLRewriteFilter{
+			Path: &gatewayv1.HTTPPathModifier{
+				Type:               gatewayv1.PrefixMatchHTTPPathModifier,
+				ReplacePrefixMatch: lo.ToPtr("/echo"),
+			},
+		},
+	}
+
+	const ns, pluginName = "default", "request-transformer"
+
+	tests := []struct {
+		name    string
+		filters []gatewayv1.HTTPRouteFilter
+		// want is the name to compare against; wantEqual decides whether the generated name must
+		// equal it or differ from it.
+		want      string
+		wantEqual bool
+	}{
+		{
+			// Critical: renaming an existing single-filter plugin would momentarily leave two
+			// plugins of the same type on a route, reintroducing the unique-plugin-per-entity error.
+			name:      "single filter is backward compatible with NewKongPluginName",
+			filters:   []gatewayv1.HTTPRouteFilter{headerModifier},
+			want:      NewKongPluginName(headerModifier, ns, pluginName),
+			wantEqual: true,
+		},
+		{
+			name:      "merged name differs from the URLRewrite single-filter name",
+			filters:   []gatewayv1.HTTPRouteFilter{urlRewrite, headerModifier},
+			want:      NewKongPluginName(urlRewrite, ns, pluginName),
+			wantEqual: false,
+		},
+		{
+			name:      "merged name differs from the RequestHeaderModifier single-filter name",
+			filters:   []gatewayv1.HTTPRouteFilter{urlRewrite, headerModifier},
+			want:      NewKongPluginName(headerModifier, ns, pluginName),
+			wantEqual: false,
+		},
+		{
+			name:      "merged name changes when filter order changes",
+			filters:   []gatewayv1.HTTPRouteFilter{urlRewrite, headerModifier},
+			want:      NewKongPluginNameForFilters([]gatewayv1.HTTPRouteFilter{headerModifier, urlRewrite}, ns, pluginName),
+			wantEqual: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewKongPluginNameForFilters(tt.filters, ns, pluginName)
+
+			// The name must be deterministic and carry the readable namespace.pluginType prefix.
+			again := NewKongPluginNameForFilters(tt.filters, ns, pluginName)
+			assert.Equal(t, got, again)
+			assert.True(t, strings.HasPrefix(got, "default.request-transformer."))
+
+			if tt.wantEqual {
+				assert.Equal(t, tt.want, got)
+			} else {
+				assert.NotEqual(t, tt.want, got)
+			}
+		})
+	}
+}
+
 func TestNewKongPluginBindingName(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/controller/hybridgateway/plugin/converter.go
+++ b/controller/hybridgateway/plugin/converter.go
@@ -12,6 +12,118 @@ import (
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 )
 
+// Kong plugin type names produced from HTTPRoute filters.
+const (
+	pluginRequestTransformer  = "request-transformer"
+	pluginResponseTransformer = "response-transformer"
+	pluginRedirect            = "redirect"
+	pluginPreFunction         = "pre-function"
+)
+
+type kongPluginConfig struct {
+	name   string
+	config json.RawMessage
+}
+
+// ruleKongPluginConfig is a KongPlugin configuration together with the filters that produced it.
+// The contributing filters are used to derive a stable KongPlugin name.
+type ruleKongPluginConfig struct {
+	kongPluginConfig
+
+	filters []gwtypes.HTTPRouteFilter
+}
+
+// translateRuleFilters translates all non-ExtensionRef filters of a rule into KongPlugin
+// configurations, merging filters that map to the same Kong plugin type into a single
+// configuration. This is required because Kong enforces a unique-plugin-per-entity constraint:
+// a route cannot have two plugins of the same type bound to it. The most common case is a rule
+// combining a URLRewrite and a RequestHeaderModifier filter, both of which translate to a
+// request-transformer plugin.
+//
+// The order in which plugin types are first encountered is preserved to keep the output
+// deterministic.
+func translateRuleFilters(rule gwtypes.HTTPRouteRule) ([]ruleKongPluginConfig, error) {
+	order := []string{}
+	byName := map[string]*ruleKongPluginConfig{}
+
+	for _, filter := range rule.Filters {
+		// ExtensionRef filters reference user-managed KongPlugins and are handled by the caller.
+		if filter.Type == gatewayv1.HTTPRouteFilterExtensionRef {
+			continue
+		}
+
+		confs, err := translateFromFilter(rule, filter)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, conf := range confs {
+			existing, ok := byName[conf.name]
+			if !ok {
+				order = append(order, conf.name)
+				byName[conf.name] = &ruleKongPluginConfig{
+					kongPluginConfig: conf,
+					filters:          []gwtypes.HTTPRouteFilter{filter},
+				}
+				continue
+			}
+
+			merged, err := mergePluginConfig(conf.name, existing.config, conf.config)
+			if err != nil {
+				return nil, err
+			}
+			existing.config = merged
+			existing.filters = append(existing.filters, filter)
+		}
+	}
+
+	result := make([]ruleKongPluginConfig, 0, len(order))
+	for _, name := range order {
+		result = append(result, *byName[name])
+	}
+	return result, nil
+}
+
+// mergePluginConfig merges two KongPlugin JSON configurations of the same Kong plugin type.
+// Both transformer plugins carry a transformerData config and are mergeable. Today only
+// request-transformer is actually produced by more than one filter type within a rule
+// (RequestHeaderModifier + URLRewrite); response-transformer comes from a single, non-repeatable
+// filter and is included defensively in case a future filter also maps to it. Any other same-type
+// collision is treated as an error rather than silently dropping a configuration.
+func mergePluginConfig(pluginName string, a, b json.RawMessage) (json.RawMessage, error) {
+	switch pluginName {
+	case pluginRequestTransformer, pluginResponseTransformer:
+		var da, db transformerData
+		if err := json.Unmarshal(a, &da); err != nil {
+			return nil, fmt.Errorf("unmarshaling %q config: %w", pluginName, err)
+		}
+		if err := json.Unmarshal(b, &db); err != nil {
+			return nil, fmt.Errorf("unmarshaling %q config: %w", pluginName, err)
+		}
+		merged, err := json.Marshal(mergeTransformerData(da, db))
+		if err != nil {
+			return nil, fmt.Errorf("marshaling merged %q config: %w", pluginName, err)
+		}
+		return merged, nil
+	default:
+		return nil, fmt.Errorf("cannot merge multiple %q plugins generated for the same rule", pluginName)
+	}
+}
+
+// mergeTransformerData combines two transformer plugin configurations by appending their header
+// operations. The URI replacement is only set by URLRewrite filters (at most one per rule), so the
+// first non-empty value wins.
+func mergeTransformerData(a, b transformerData) transformerData {
+	a.Add.Headers = append(a.Add.Headers, b.Add.Headers...)
+	a.Append.Headers = append(a.Append.Headers, b.Append.Headers...)
+	a.Remove.Headers = append(a.Remove.Headers, b.Remove.Headers...)
+	a.Replace.Headers = append(a.Replace.Headers, b.Replace.Headers...)
+	if a.Replace.Uri == "" {
+		a.Replace.Uri = b.Replace.Uri
+	}
+	return a
+}
+
 // translateFromFilter translates a HTTPRouteFilter into one or more KongPlugin resources.
 // The generated KongPlugin(s) are filled with the pluginName and json config only leaving to the caller
 // the responsibility to set metadata (name, namespace, labels, annotations) as needed.
@@ -29,18 +141,12 @@ import (
 // Returns:
 //   - []KongPlugin: Slice of translated KongPlugin resources.
 //   - error: Any error encountered during translation.
-
-type kongPluginConfig struct {
-	name   string
-	config json.RawMessage
-}
-
 func translateFromFilter(rule gwtypes.HTTPRouteRule, filter gwtypes.HTTPRouteFilter) ([]kongPluginConfig, error) {
 	pluginConfs := []kongPluginConfig{}
 
 	switch filter.Type {
 	case gatewayv1.HTTPRouteFilterRequestHeaderModifier:
-		pConf := kongPluginConfig{name: "request-transformer"}
+		pConf := kongPluginConfig{name: pluginRequestTransformer}
 
 		config, err := translateRequestModifier(filter)
 		if err != nil {
@@ -53,7 +159,7 @@ func translateFromFilter(rule gwtypes.HTTPRouteRule, filter gwtypes.HTTPRouteFil
 		pConf.config = configJSON
 		pluginConfs = append(pluginConfs, pConf)
 	case gatewayv1.HTTPRouteFilterResponseHeaderModifier:
-		pData := kongPluginConfig{name: "response-transformer"}
+		pData := kongPluginConfig{name: pluginResponseTransformer}
 
 		config, err := translateResponseModifier(filter)
 		if err != nil {
@@ -76,10 +182,10 @@ func translateFromFilter(rule gwtypes.HTTPRouteRule, filter gwtypes.HTTPRouteFil
 		// otherwise we can use the standard redirect plugin.
 		if rr.Path != nil && rr.Path.Type == gatewayv1.PrefixMatchHTTPPathModifier {
 			config, err = translateRequestRedirectPreFunction(filter, rule)
-			pluginName = "pre-function"
+			pluginName = pluginPreFunction
 		} else {
 			config, err = translateRequestRedirect(filter)
-			pluginName = "redirect"
+			pluginName = pluginRedirect
 		}
 
 		// From here on
@@ -94,7 +200,7 @@ func translateFromFilter(rule gwtypes.HTTPRouteRule, filter gwtypes.HTTPRouteFil
 		pData.config = configJSON
 		pluginConfs = append(pluginConfs, pData)
 	case gatewayv1.HTTPRouteFilterURLRewrite:
-		pData := kongPluginConfig{name: "request-transformer"}
+		pData := kongPluginConfig{name: pluginRequestTransformer}
 
 		path := getPathPrefixMatchValue(rule)
 

--- a/controller/hybridgateway/plugin/converter_test.go
+++ b/controller/hybridgateway/plugin/converter_test.go
@@ -1018,3 +1018,188 @@ func TestTranslateURLRewrite(t *testing.T) {
 		})
 	}
 }
+
+func TestTranslateRuleFilters(t *testing.T) {
+	prefix := lo.ToPtr(gatewayv1.PathMatchPathPrefix)
+
+	requestHeaderModifier := gwtypes.HTTPRouteFilter{
+		Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+		RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+			Add: []gatewayv1.HTTPHeader{{Name: "X-Api-Version", Value: "v2"}},
+		},
+	}
+	urlRewrite := gwtypes.HTTPRouteFilter{
+		Type: gatewayv1.HTTPRouteFilterURLRewrite,
+		URLRewrite: &gatewayv1.HTTPURLRewriteFilter{
+			Path: &gatewayv1.HTTPPathModifier{
+				Type:               gatewayv1.PrefixMatchHTTPPathModifier,
+				ReplacePrefixMatch: lo.ToPtr("/echo"),
+			},
+		},
+	}
+	responseHeaderModifier := gwtypes.HTTPRouteFilter{
+		Type: gatewayv1.HTTPRouteFilterResponseHeaderModifier,
+		ResponseHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+			Add: []gatewayv1.HTTPHeader{{Name: "X-Backend", Value: "echo"}},
+		},
+	}
+	extensionRef := gwtypes.HTTPRouteFilter{
+		Type: gatewayv1.HTTPRouteFilterExtensionRef,
+		ExtensionRef: &gatewayv1.LocalObjectReference{
+			Group: "configuration.konghq.com",
+			Kind:  "KongPlugin",
+			Name:  "rate-limiting",
+		},
+	}
+
+	secondHeaderModifier := gwtypes.HTTPRouteFilter{
+		Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+		RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+			Add: []gatewayv1.HTTPHeader{{Name: "X-Second", Value: "2"}},
+		},
+	}
+
+	newRule := func(filters ...gwtypes.HTTPRouteFilter) gwtypes.HTTPRouteRule {
+		return gwtypes.HTTPRouteRule{
+			Matches: []gatewayv1.HTTPRouteMatch{
+				{Path: &gatewayv1.HTTPPathMatch{Type: prefix, Value: lo.ToPtr("/echo/v2")}},
+			},
+			Filters: filters,
+		}
+	}
+
+	// wantConf is the expected outcome for one generated KongPlugin: its plugin type, the number
+	// of filters that contributed to it, and its merged configuration.
+	type wantConf struct {
+		name        string
+		filterCount int
+		config      transformerData
+	}
+
+	tests := []struct {
+		name    string
+		filters []gwtypes.HTTPRouteFilter
+		want    []wantConf
+	}{
+		{
+			name:    "URLRewrite and RequestHeaderModifier merge into a single request-transformer",
+			filters: []gwtypes.HTTPRouteFilter{urlRewrite, requestHeaderModifier},
+			want: []wantConf{{
+				name:        "request-transformer",
+				filterCount: 2,
+				// URLRewrite contributes the URI rewrite, RequestHeaderModifier the header append.
+				config: transformerData{
+					Append:  transformerTargetSlice{Headers: []string{"X-Api-Version:v2"}},
+					Replace: transformerTargetSliceReplace{Uri: `/echo$(uri_captures[1])`},
+				},
+			}},
+		},
+		{
+			name:    "different plugin types are kept separate",
+			filters: []gwtypes.HTTPRouteFilter{requestHeaderModifier, responseHeaderModifier},
+			want: []wantConf{
+				{
+					name:        "request-transformer",
+					filterCount: 1,
+					config:      transformerData{Append: transformerTargetSlice{Headers: []string{"X-Api-Version:v2"}}},
+				},
+				{
+					name:        "response-transformer",
+					filterCount: 1,
+					config:      transformerData{Append: transformerTargetSlice{Headers: []string{"X-Backend:echo"}}},
+				},
+			},
+		},
+		{
+			name:    "ExtensionRef filters are skipped",
+			filters: []gwtypes.HTTPRouteFilter{extensionRef, requestHeaderModifier},
+			want: []wantConf{{
+				name:        "request-transformer",
+				filterCount: 1,
+				config:      transformerData{Append: transformerTargetSlice{Headers: []string{"X-Api-Version:v2"}}},
+			}},
+		},
+		{
+			// Future-proofing: the Gateway API forbids repeating these filters today, but the
+			// merge engine must not rely on that. If the API ever makes a filter repeatable (or
+			// adds a new filter that maps to an already-generated plugin type), multiple
+			// contributors of the same Kong plugin type must collapse into a single plugin rather
+			// than collide on the route.
+			name:    "multiple filters mapping to the same plugin type collapse into one",
+			filters: []gwtypes.HTTPRouteFilter{requestHeaderModifier, secondHeaderModifier},
+			want: []wantConf{{
+				name:        "request-transformer",
+				filterCount: 2,
+				config:      transformerData{Append: transformerTargetSlice{Headers: []string{"X-Api-Version:v2", "X-Second:2"}}},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			confs, err := translateRuleFilters(newRule(tt.filters...))
+			require.NoError(t, err)
+			require.Len(t, confs, len(tt.want))
+
+			for i, w := range tt.want {
+				assert.Equal(t, w.name, confs[i].name)
+				assert.Len(t, confs[i].filters, w.filterCount, "all contributing filters must be recorded so the name is stable")
+
+				var data transformerData
+				require.NoError(t, json.Unmarshal(confs[i].config, &data))
+				assert.Equal(t, w.config, data)
+			}
+		})
+	}
+}
+
+func TestMergePluginConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		pluginName string
+		a, b       transformerData
+		wantErr    bool
+		want       transformerData
+	}{
+		{
+			name:       "merges request-transformer header lists and keeps the first uri",
+			pluginName: "request-transformer",
+			a:          transformerData{Add: transformerTargetSlice{Headers: []string{"a:1"}}, Replace: transformerTargetSliceReplace{Uri: "/echo"}},
+			b:          transformerData{Add: transformerTargetSlice{Headers: []string{"b:2"}}, Replace: transformerTargetSliceReplace{Uri: "/other"}},
+			want:       transformerData{Add: transformerTargetSlice{Headers: []string{"a:1", "b:2"}}, Replace: transformerTargetSliceReplace{Uri: "/echo"}},
+		},
+		{
+			name:       "merges response-transformer header lists",
+			pluginName: "response-transformer",
+			a:          transformerData{Append: transformerTargetSlice{Headers: []string{"X-A:1"}}},
+			b:          transformerData{Append: transformerTargetSlice{Headers: []string{"X-B:2"}}},
+			want:       transformerData{Append: transformerTargetSlice{Headers: []string{"X-A:1", "X-B:2"}}},
+		},
+		{
+			name:       "returns an error for non-mergeable plugin types",
+			pluginName: "rate-limiting",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			aJSON, err := json.Marshal(tt.a)
+			require.NoError(t, err)
+			bJSON, err := json.Marshal(tt.b)
+			require.NoError(t, err)
+
+			merged, err := mergePluginConfig(tt.pluginName, aJSON, bJSON)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "cannot merge multiple")
+				return
+			}
+			require.NoError(t, err)
+
+			var got transformerData
+			require.NoError(t, json.Unmarshal(merged, &got))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/controller/hybridgateway/plugin/plugin.go
+++ b/controller/hybridgateway/plugin/plugin.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -20,16 +20,19 @@ import (
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 )
 
-// PluginsForFilter creates or retrieves KongPlugins for the given HTTPRoute filter.
+// PluginsForRule creates or retrieves the KongPlugins for all filters of the given HTTPRoute rule.
 //
 // Workflow:
-//  1. If the filter type is ExtensionRef retrieve the referenced KongPlugin.
-//  2. Otherwise, translates the filter into one or more plugin configurations.
-//  3. For each plugin configuration:
-//     - Derives the KongPlugin name using namegen.
+//  1. Translates the rule's built-in filters into plugin configurations, merging filters that map
+//     to the same Kong plugin type into a single configuration. This is required because Kong
+//     enforces a unique-plugin-per-entity constraint: a route cannot have two plugins of the same
+//     type bound to it (e.g. URLRewrite and RequestHeaderModifier both map to request-transformer).
+//  2. For each resulting plugin configuration:
+//     - Derives the KongPlugin name using namegen (from the contributing filters).
 //     - Builds a new KongPlugin resource with appropriate name, namespace, labels, annotations, and config.
 //     - Calls translator.VerifyAndUpdate to handle existing plugin reconciliation.
-//  4. Returns all translated plugins.
+//  3. Retrieves the KongPlugin referenced by each ExtensionRef filter.
+//  4. Returns all plugins.
 //
 // Self-managed plugin:
 //
@@ -44,61 +47,31 @@ import (
 //   - cl: Kubernetes client.
 //   - httpRoute: Source HTTPRoute.
 //   - rule: The HTTPRouteRule being processed.
-//   - filter: The HTTPRouteFilter being processed.
 //   - pRef: Parent (Gateway) reference.
 //
 // Returns:
 //   - kongPlugins: The translated plugin(s).
 //   - err: Any error encountered.
-func PluginsForFilter(
+func PluginsForRule(
 	ctx context.Context,
 	logger logr.Logger,
 	cl client.Client,
 	httpRoute *gwtypes.HTTPRoute,
 	rule gwtypes.HTTPRouteRule,
-	filter gwtypes.HTTPRouteFilter,
 	pRef *gwtypes.ParentReference,
 ) ([]configurationv1.KongPlugin, error) {
-	logger = logger.WithValues("filter-type", filter.Type)
 	plugins := []configurationv1.KongPlugin{}
 
-	// In case the filter is an ExtensionRef, retrieve the referenced KongPlugin and return early
-	if filter.Type == gatewayv1.HTTPRouteFilterExtensionRef {
-		log.Debug(logger, "Filter is an ExtensionRef, retrieving referenced KongPlugin")
-		plugin, err := getReferencedKongPlugin(ctx, cl, httpRoute.Namespace, filter)
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				log.Debug(logger, "Referenced KongPlugin not found")
-				return plugins, nil
-			}
-			return nil, fmt.Errorf("failed to retrieve referenced KongPlugin: %w", err)
-		}
-		pluginName := plugin.Name
-		log.Debug(logger, "Successfully retrieved referenced KongPlugin")
-		pluginCopy, err := builder.NewKongPlugin().
-			WithName(namegen.NewKongPluginName(filter, httpRoute.Namespace, plugin.PluginName)).
-			WithNamespace(metadata.NamespaceFromParentRef(httpRoute, pRef)).
-			WithLabels(httpRoute, pRef).
-			WithPluginName(plugin.PluginName).
-			WithPluginConfig(plugin.Config.Raw).
-			WithAnnotations(httpRoute, pRef).
-			Build()
-		if err != nil {
-			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)
-		}
-		plugins = append(plugins, pluginCopy)
-		return plugins, nil
-	}
-
-	pluginConfs, err := translateFromFilter(rule, filter)
+	// Translate the built-in filters, merging filters that map to the same Kong plugin type.
+	pluginConfs, err := translateRuleFilters(rule)
 	if err != nil {
-		return nil, fmt.Errorf("translating filter to KongPlugins: %w", err)
+		return nil, fmt.Errorf("translating filters to KongPlugins: %w", err)
 	}
 	for i := range pluginConfs {
 		pConf := &pluginConfs[i]
-		pluginName := namegen.NewKongPluginName(filter, httpRoute.Namespace, pConf.name)
+		pluginName := namegen.NewKongPluginNameForFilters(pConf.filters, httpRoute.Namespace, pConf.name)
 		logger := logger.WithValues("kongplugin", pluginName)
-		log.Debug(logger, "Generating KongPlugin for HTTPRoute filter")
+		log.Debug(logger, "Generating KongPlugin for HTTPRoute filters")
 
 		plugin, err := builder.NewKongPlugin().
 			WithName(pluginName).
@@ -116,6 +89,38 @@ func PluginsForFilter(
 			return nil, err
 		}
 		plugins = append(plugins, plugin)
+	}
+
+	// ExtensionRef filters reference user-managed KongPlugins; retrieve each one as-is.
+	for _, filter := range rule.Filters {
+		if filter.Type != gatewayv1.HTTPRouteFilterExtensionRef {
+			continue
+		}
+
+		logger := logger.WithValues("filter-type", filter.Type)
+		log.Debug(logger, "Filter is an ExtensionRef, retrieving referenced KongPlugin")
+		plugin, err := getReferencedKongPlugin(ctx, cl, httpRoute.Namespace, filter)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Debug(logger, "Referenced KongPlugin not found")
+				continue
+			}
+			return nil, fmt.Errorf("failed to retrieve referenced KongPlugin: %w", err)
+		}
+		pluginName := plugin.Name
+		log.Debug(logger, "Successfully retrieved referenced KongPlugin")
+		pluginCopy, err := builder.NewKongPlugin().
+			WithName(namegen.NewKongPluginName(filter, httpRoute.Namespace, plugin.PluginName)).
+			WithNamespace(metadata.NamespaceFromParentRef(httpRoute, pRef)).
+			WithLabels(httpRoute, pRef).
+			WithPluginName(plugin.PluginName).
+			WithPluginConfig(plugin.Config.Raw).
+			WithAnnotations(httpRoute, pRef).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)
+		}
+		plugins = append(plugins, pluginCopy)
 	}
 
 	return plugins, nil

--- a/controller/hybridgateway/plugin/plugin_test.go
+++ b/controller/hybridgateway/plugin/plugin_test.go
@@ -188,7 +188,9 @@ func TestPluginForFilter(t *testing.T) {
 				WithRuntimeObjects(objects...).
 				Build()
 
-			plugins, err := PluginsForFilter(ctx, logger, fakeClient, tt.httpRoute, tt.rule, tt.filter, tt.parentRef)
+			rule := tt.rule
+			rule.Filters = append(rule.Filters, tt.filter)
+			plugins, err := PluginsForRule(ctx, logger, fakeClient, tt.httpRoute, rule, tt.parentRef)
 
 			if tt.expectedError {
 				require.Error(t, err)

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/07-httproute-filter-url-rewrite-and-header-modifier.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/07-httproute-filter-url-rewrite-and-header-modifier.yaml
@@ -1,0 +1,57 @@
+##
+# HTTPRoute whose single rule combines a URLRewrite and a RequestHeaderModifier filter.
+# Both filters translate to a Kong `request-transformer` plugin, so they MUST be merged into a
+# single KongPlugin/KongPluginBinding bound to the route. Emitting two `request-transformer`
+# plugins on the same route is rejected by Konnect with a `unique-plugin-per-entity` error.
+#
+# Required bindings:
+#   - http_route_name: Name of the HTTPRoute resource
+#   - http_route_namespace: Namespace of the HTTPRoute resource
+#   - test_name: The test name label to match (used for labels)
+#   - route_hosts: List of hostnames for the HTTPRoute
+#   - gateway_name: Name of the Gateway parent resource
+#   - httpbin_deployment_name: Name of the httpbin backend service
+#   - httpbin_deployment_namespace: Namespace of the httpbin backend service
+
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
+  labels:
+    chainsaw/test: ($test_name)
+  annotations:
+    konghq.com/strip-path: "false"
+spec:
+  hostnames: ($route_hosts)
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /get
+      # Both filters map to a request-transformer plugin and must be merged into one.
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /anything
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+            - name: X-Merge-Set
+              value: "foo"
+            add:
+            - name: X-Merge-Add
+              value: "bar"
+            remove:
+            - X-Merge-Remove
+      backendRefs:
+        - name: ($httpbin_deployment_name)
+          port: 80
+          namespace: ($httpbin_deployment_namespace)

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/08-httproute-filter-url-rewrite-and-header-modifier-assert.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/08-httproute-filter-url-rewrite-and-header-modifier-assert.yaml
@@ -1,0 +1,76 @@
+---
+# Assert the HTTPRoute combining URLRewrite + RequestHeaderModifier is accepted and fully
+# programmed. KongPluginBindingProgrammed=True is the key signal: under the unique-plugin-per-entity
+# bug the second request-transformer binding would fail and this condition would be False.
+#
+# Required bindings:
+#   - test_name: The test name label to match (used for labels)
+#   - http_route_name: Name of the HTTPRoute resource
+#   - http_route_namespace: Namespace of the HTTPRoute resource
+#   - gateway_name: Name of the Gateway parent resource
+#   - httpbin_deployment_name: Name of the httpbin backend service
+#   - httpbin_deployment_namespace: Namespace of the httpbin backend service
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  (labels."chainsaw/test" == ($test_name)): true
+  name: ($http_route_name)
+  namespace: ($http_route_namespace)
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name)
+  rules:
+    - backendRefs:
+        - name: ($httpbin_deployment_name)
+          namespace: ($httpbin_deployment_namespace)
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /get
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /anything
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+            - name: X-Merge-Set
+              value: "foo"
+            add:
+            - name: X-Merge-Add
+              value: "bar"
+            remove:
+            - X-Merge-Remove
+status:
+  parents:
+    - parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: ($gateway_name)
+      (conditions[?type == 'Accepted']):
+        - status: "True"
+          reason: Accepted
+      (conditions[?type == 'ResolvedRefs']):
+        - status: "True"
+          reason: ResolvedRefs
+      (conditions[?type == 'KongRouteProgrammed']):
+        - status: "True"
+          reason: KongRouteProgrammed
+      (conditions[?type == 'KongServiceProgrammed']):
+        - status: "True"
+          reason: KongServiceProgrammed
+      (conditions[?type == 'KongUpstreamProgrammed']):
+        - status: "True"
+          reason: KongUpstreamProgrammed
+      (conditions[?type == 'KongTargetProgrammed']):
+        - status: "True"
+          reason: KongTargetProgrammed
+      (conditions[?type == 'KongPluginBindingProgrammed']):
+        - status: "True"
+          reason: KongPluginBindingProgrammed

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
@@ -7,7 +7,13 @@ spec:
   description: |
     This test validates that the hybrid gateway controller correctly
     processes the currently supported filters in HTTPRoute, including:
-    `RequestHeaderModifier`, `ResponseHeaderModifier`.
+    `RequestHeaderModifier`, `ResponseHeaderModifier`, and `URLRewrite`.
+    It also validates that multiple filters in a single rule that map to the
+    same Kong plugin type (e.g. `URLRewrite` + `RequestHeaderModifier`, both
+    of which translate to `request-transformer`) are merged into a single
+    KongPlugin/KongPluginBinding, instead of producing two plugins of the same
+    type on the same route (which Konnect rejects with a
+    `unique-plugin-per-entity` constraint error).
 
   timeouts:
     apply: 120s
@@ -56,6 +62,12 @@ spec:
     - name: http_route_combined_filters_name
       value: (join('-', [($test_name), 'httpbin-combined-filters']))
     - name: http_route_combined_filters_namespace
+      value: ($namespace)
+    - name: merged_filters_fqdn
+      value: (join('.', ['httpbin-merged', ($test_name), 'example.com']))
+    - name: http_route_merged_filters_name
+      value: (join('-', [($test_name), 'httpbin-merged-filters']))
+    - name: http_route_merged_filters_namespace
       value: ($namespace)
     - name: httpbin_deployment_name
       value: (join('-', [($test_name), 'httpbin']))
@@ -842,6 +854,146 @@ spec:
           value: "https"
         - name: insecure
           value: "true"
+
+    # Step 50: Create an HTTPRoute whose single rule combines a URLRewrite and a
+    # RequestHeaderModifier filter. Both map to a request-transformer plugin and must be merged.
+    - name: Create-httproute-with-url-rewrite-and-header-modifier
+      description: Create HTTPRoute combining URLRewrite and RequestHeaderModifier filters (both map to request-transformer).
+      try:
+        - apply:
+            file: 07-httproute-filter-url-rewrite-and-header-modifier.yaml
+        - assert:
+            file: 08-httproute-filter-url-rewrite-and-header-modifier-assert.yaml
+      bindings:
+        - name: http_route_name
+          value: ($http_route_merged_filters_name)
+        - name: http_route_namespace
+          value: ($http_route_merged_filters_namespace)
+        - name: route_hosts
+          value:
+            - ($merged_filters_fqdn)
+
+    # Step 51: Assert the backend is translated into a KongService resource (merged filters).
+    - name: Assert-kong-service-merged-filters
+      description: Assert that the KongService resource is created for the HTTPRoute with merged filters.
+      use:
+        template: ../../common/_step_templates/assert-kongService.yaml
+      bindings:
+        - name: http_route_name
+          value: ($http_route_merged_filters_name)
+        - name: http_route_namespace
+          value: ($http_route_merged_filters_namespace)
+
+    # Step 52: Assert the backend is translated into a KongUpstream resource (merged filters).
+    - name: Assert-kong-upstream-merged-filters
+      description: Assert that the KongUpstream resource is created for the HTTPRoute with merged filters.
+      use:
+        template: ../../common/_step_templates/assert-kongUpstream.yaml
+      bindings:
+        - name: http_route_name
+          value: ($http_route_merged_filters_name)
+        - name: http_route_namespace
+          value: ($http_route_merged_filters_namespace)
+
+    # Step 53: Assert the KongUpstream has a KongTarget resource (merged filters).
+    - name: Assert-kong-target-merged-filters
+      description: Assert that the KongTarget resource is created for the KongUpstream (merged filters).
+      use:
+        template: ../../common/_step_templates/assert-kongTarget.yaml
+      bindings:
+        - name: http_route_name
+          value: ($http_route_merged_filters_name)
+        - name: http_route_namespace
+          value: ($http_route_merged_filters_namespace)
+        - name: resource_type
+          value: "kongupstreams.configuration.konghq.com"
+        - name: target_weight
+          value: 1
+
+    # Step 54: Assert that a SINGLE request-transformer plugin is created carrying the merged
+    # configuration of BOTH filters: the URLRewrite contributes replace.uri and the
+    # RequestHeaderModifier contributes the header operations. If the filters were not merged,
+    # there would be two request-transformer plugins each with a partial config and neither would
+    # match this exact configuration.
+    - name: Assert-Request-Transformer-Plugin-for-Merged-Filters
+      description: Assert that a single request-transformer plugin carries the merged configuration of both filters.
+      use:
+        template: ../../common/_step_templates/assert-kongPlugin.yaml
+      bindings:
+        - name: http_route_name
+          value: ($http_route_merged_filters_name)
+        - name: http_route_namespace
+          value: ($http_route_merged_filters_namespace)
+        - name: namespace
+          value: ($namespace)
+        - name: gateway_name
+          value: ($gateway_name)
+        - name: plugin_type
+          value: request-transformer
+        - name: plugin_config
+          value: '{"add":{"headers":["X-Merge-Set:foo"]},"append":{"headers":["X-Merge-Add:bar"]},"remove":{"headers":["X-Merge-Remove"]},"replace":{"headers":["X-Merge-Set:foo"],"uri":"/anything$(uri_captures[1])"}}'
+
+    # Step 55: Assert the single KongPluginBinding for the merged plugin is Programmed in Konnect.
+    # The assert template resolves the (single) request-transformer plugin name and requires the
+    # binding's Programmed condition to be True - this is what fails under the unique-plugin bug.
+    - name: Assert-KongPluginBinding-for-Merged-Filters
+      description: Assert that a single KongPluginBinding is created for the merged request-transformer plugin and is Programmed.
+      use:
+        template: ../../common/_step_templates/assert-kongPluginBinding.yaml
+      bindings:
+        - name: http_route_name
+          value: ($http_route_merged_filters_name)
+        - name: http_route_namespace
+          value: ($http_route_merged_filters_namespace)
+
+    # Step 56: Verify GET /get works from the host (merged filters). The URLRewrite rewrites the
+    # prefix to /anything, which go-httpbin echoes back.
+    - name: Verify-GET-traffic-from-host-merged-filters
+      description: Verify that GET requests to /get work from the host (merged filters).
+      use:
+        template: ../../common/_step_templates/verify-http-traffic-from-host.yaml
+      bindings:
+        - name: http_route_name
+          value: ($http_route_merged_filters_name)
+        - name: http_route_namespace
+          value: ($http_route_merged_filters_namespace)
+        - name: route_path
+          value: "/get"
+        - name: http_method
+          value: "GET"
+        - name: listener_http_port
+          value: "80"
+        - name: host_header
+          value: ($merged_filters_fqdn)
+
+    # Step 57: Verify the RequestHeaderModifier half of the merged plugin still applies over HTTP.
+    - name: Verify-request-header-modifier-merged-filters-over-http
+      description: Validate that the RequestHeaderModifier contribution of the merged plugin modifies headers correctly over HTTP.
+      use:
+        template: ../../common/_step_templates/verify-request-header-modifier.yaml
+      bindings:
+        - name: gateway_name
+          value: ($gateway_name)
+        - name: gateway_namespace
+          value: ($gateway_namespace)
+        - name: route_path
+          value: "/get"
+        - name: namespace
+          value: ($http_route_merged_filters_namespace)
+        - name: host_header
+          value: ($merged_filters_fqdn)
+        - name: proxy_port
+          value: "80"
+        - name: headers_to_send
+          value: "X-Merge-Remove:to-be-removed,X-Merge-Set:existing-value"
+        - name: expected_headers_present
+          value: "X-Merge-Set:foo,X-Merge-Add:bar"
+        - name: expected_headers_absent
+          value: "X-Merge-Remove,X-Merge-Set:existing-value"
+        - name: protocol
+          value: "http"
+        - name: insecure
+          value: "false"
 
   catch:
     # Capture and describe all relevant Kubernetes resources for debugging on test failure.


### PR DESCRIPTION




**What this PR does / why we need it**:

(cherry picked from commit b5761b35945142d2f15a9cb0dd1bb7f21a6578f4)

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
