### PR TITLE
conformance: skip flaky HTTPRouteWeight for on-prem

### DIFF
--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -26,6 +26,9 @@ var skippedTestsShared = []string{
 	tests.GatewayListenerUnsupportedProtocol.ShortName,
 	tests.GatewayInvalidParametersRef.ShortName,
 	tests.HTTPRouteNoBackendRefs.ShortName,
+
+	// failed after bumping gateway api to v1.6.0-rc.1, https://github.com/Kong/kong-operator/issues/4661
+	tests.HTTPRouteWeight.ShortName,
 }
 
 var skippedTestsForExpressionsRouter = []string{}
@@ -44,9 +47,6 @@ var skippedTestsForHybrid = []string{
 	// Extended profile.
 	tests.HTTPRouteRewriteHost.ShortName,
 	tests.HTTPRouteRewritePath.ShortName,
-
-	// failed after bumping gateway api to v1.6.0-rc.1, https://github.com/Kong/kong-operator/issues/4661
-	tests.HTTPRouteWeight.ShortName,
 }
 
 // skippedTestsForConfig returns the list of skipped tests for the given router flavor and gateway type.


### PR DESCRIPTION
**What this PR does / why we need it**:

For on-prem, HTTPRouteWeight is flaky, https://github.com/Kong/kong-operator/actions/runs/28232485271/job/83639433186?pr=4668

Programmed condition gated configs pushed to dataplane, but in conformance test, Programmed condition is not waited.  It waits for:
 1. GatewayAndHTTPRoutesMustBeAccepted(...) → route parent status with Accepted=True
 2. HTTPRouteMustHaveResolvedRefsConditionsTrue(...) → ResolvedRefs=True

So at the moment requests sent, the weight route configs probably not synced to dataplane.

The sync period from KIC's memory to dataplane is 3s, 10 re-runs completed in 4s, so unlike continuous failure in hybrid mode, HTTPRouteWeight is flaky for on-prem.

Skip HTTPWeight for all conformance test until this problem solved.

**Which issue this PR fixes**

Fixes #

related to #4661 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
