### PR TITLE
chore: exclude docker/docker CVEs with no fixed version in govulncheck

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -211,7 +211,7 @@ require (
 	github.com/itchyny/timefmt-go v0.1.6 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.7.2 // indirect
+	github.com/jackc/pgx/v5 v5.10.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 // indirect
 	github.com/jmoiron/sqlx v1.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -364,8 +364,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.7.2 h1:mLoDLV6sonKlvjIEsV56SkWNCnuNv531l94GaIzO+XI=
-github.com/jackc/pgx/v5 v5.7.2/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
+github.com/jackc/pgx/v5 v5.10.0 h1:VhSvgU2jSli8o3AqIEOTJr7rZwAEUVo4E4XhR94Zfr0=
+github.com/jackc/pgx/v5 v5.10.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=

--- a/hack/govulncheck-with-excludes.sh
+++ b/hack/govulncheck-with-excludes.sh
@@ -27,7 +27,16 @@ excludeVulns="$(jq -nc '[
   "GO-2026-4771",
 
   # Memory-safety vulnerability in github.com/jackc/pgx/v5.
-  "GO-2026-4772"
+  "GO-2026-4772",
+
+  # Race condition in docker cp / PUT /containers/{id}/archive in github.com/docker/docker.
+  # docker/docker is an indirect dependency pulled in by kubernetes-testing-framework and
+  # go-containerregistry. There is no fixed version of github.com/docker/docker for these CVEs
+  # (the fix only exists in the separate github.com/moby/moby/v2 module).
+  # The affected docker cp and archive code paths are not used by the operator.
+  "GO-2026-5617",
+  "GO-2026-5668",
+  "GO-2026-5746"
 
 ]')"
 export excludeVulns

--- a/hack/govulncheck-with-excludes.sh
+++ b/hack/govulncheck-with-excludes.sh
@@ -23,12 +23,6 @@ excludeVulns="$(jq -nc '[
   # Moby has AuthZ plugin bypass when provided oversized request bodies in github.com/docker/docker
   "GO-2026-4887",
 
-  # Memory-safety vulnerability in github.com/jackc/pgx/v5.
-  "GO-2026-4771",
-
-  # Memory-safety vulnerability in github.com/jackc/pgx/v5.
-  "GO-2026-4772",
-
   # Race condition in docker cp / PUT /containers/{id}/archive in github.com/docker/docker.
   # docker/docker is an indirect dependency pulled in by kubernetes-testing-framework and
   # go-containerregistry. There is no fixed version of github.com/docker/docker for these CVEs


### PR DESCRIPTION


**What this PR does / why we need it**:

Exclude GO-2026-5617, GO-2026-5668, and GO-2026-5746 from govulncheck. These CVEs affect docker cp and archive operations in github.com/docker/docker, which is an indirect dependency pulled in by kubernetes-testing-framework and go-containerregistry. There is no fixed version available for the github.com/docker/docker module path, the upstream fix only exists in the separate github.com/moby/moby/v2 module. The affected code paths are not used by the operator.

Bonus commit: 63d785c7df5ab40e7c3ad04b78ec683b3cce9daa
**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
