### PR TITLE
test(envtest): refactor to cleanup duplicate code

### DIFF
--- a/test/envtest/kongpluginbinding_managed_test.go
+++ b/test/envtest/kongpluginbinding_managed_test.go
@@ -128,6 +128,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 	}
 	require.NoError(t, clientNamespaced.Create(ctx, rateLimitingkongPlugin))
 	t.Logf("deployed %s KongPlugin (%s) resource", client.ObjectKeyFromObject(rateLimitingkongPlugin), rateLimitingkongPlugin.PluginName)
+	managedPluginReference := rateLimitingkongPlugin.Namespace + "/" + rateLimitingkongPlugin.Name
 	sdk.PluginSDK.EXPECT().UpsertPlugin(
 		mock.Anything,
 		mock.MatchedBy(func(req sdkkonnectops.UpsertPluginRequest) bool {
@@ -181,6 +182,27 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		)
 		require.NotNil(t, found)
 		return found
+	}
+
+	assertMatchingKongPluginBindings := func(
+		t *testing.T,
+		message string,
+		matchingFields client.MatchingFields,
+		assertions func(*assert.CollectT, []configurationv1alpha1.KongPluginBinding),
+	) {
+		t.Helper()
+
+		assert.EventuallyWithT(t,
+			func(c *assert.CollectT) {
+				var list configurationv1alpha1.KongPluginBindingList
+				if !assert.NoError(c, clientNamespaced.List(ctx, &list, matchingFields)) {
+					return
+				}
+				assertions(c, list.Items)
+			},
+			waitTime, tickTime,
+			message,
+		)
 	}
 
 	// The stale-cache reconcile (driven by pendingKonnectIDs after any CreatePlugin call) reaches
@@ -265,12 +287,8 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			"checking that managed KongPluginBinding %s gets deleted",
 			client.ObjectKeyFromObject(kongPluginBinding),
 		)
-		assert.EventuallyWithT(t,
-			func(c *assert.CollectT) {
-				assert.True(c, apierrors.IsNotFound(
-					clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongPluginBinding), kongPluginBinding),
-				))
-			}, waitTime, tickTime,
+		eventually.WaitForObjectToNotExist(
+			t, ctx, clientNamespaced, kongPluginBinding, waitTime, tickTime,
 			"KongPluginBinding wasn't deleted after removing annotation from KongService",
 		)
 
@@ -348,12 +366,8 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			"checking that managed KongPluginBinding %s gets deleted",
 			client.ObjectKeyFromObject(kongPluginBinding),
 		)
-		assert.EventuallyWithT(t,
-			func(c *assert.CollectT) {
-				assert.True(c, apierrors.IsNotFound(
-					clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongPluginBinding), kongPluginBinding),
-				))
-			}, waitTime, tickTime,
+		eventually.WaitForObjectToNotExist(
+			t, ctx, clientNamespaced, kongPluginBinding, waitTime, tickTime,
 			"KongPluginBinding wasn't deleted after removing annotation from KongRoute",
 		)
 
@@ -443,12 +457,8 @@ func TestKongPluginBindingManaged(t *testing.T) {
 
 		delete(kongRoute.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongRoute))
-		assert.EventuallyWithT(t,
-			func(c *assert.CollectT) {
-				assert.True(c, apierrors.IsNotFound(
-					clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpbRoute), kpbRoute),
-				))
-			}, waitTime, tickTime,
+		eventually.WaitForObjectToNotExist(
+			t, ctx, clientNamespaced, kpbRoute, waitTime, tickTime,
 			"KongPluginBinding bound to Route wasn't deleted after removing annotation from KongRoute",
 		)
 
@@ -461,12 +471,8 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		delete(kongService.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongService))
 
-		assert.EventuallyWithT(t,
-			func(c *assert.CollectT) {
-				assert.True(c, apierrors.IsNotFound(
-					clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpbService), kpbService),
-				))
-			}, waitTime, tickTime,
+		eventually.WaitForObjectToNotExist(
+			t, ctx, clientNamespaced, kpbService, waitTime, tickTime,
 			"KongPluginBinding bound to Service wasn't deleted after removing annotation from KongService",
 		)
 
@@ -588,29 +594,20 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		delete(kongRoute.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongRoute))
 
-		assert.EventuallyWithT(t,
-			func(t *assert.CollectT) {
-				var l configurationv1alpha1.KongPluginBindingList
-				if !assert.NoError(t, clientNamespaced.List(ctx, &l,
-					client.MatchingFields{
-						index.IndexFieldKongPluginBindingKongPluginReference:   rateLimitingkongPlugin.Namespace + "/" + rateLimitingkongPlugin.Name,
-						index.IndexFieldKongPluginBindingKongServiceReference:  kongService.Name,
-						index.IndexFieldKongPluginBindingKongConsumerReference: kongConsumer.Name,
-					},
-				)) {
-					return
-				}
-				assert.Len(t, l.Items, 1)
-			}, waitTime, tickTime,
+		assertMatchingKongPluginBindings(t,
 			"KongPluginBinding bound to Consumer and Service doesn't exist but it should",
+			client.MatchingFields{
+				index.IndexFieldKongPluginBindingKongPluginReference:   managedPluginReference,
+				index.IndexFieldKongPluginBindingKongServiceReference:  kongService.Name,
+				index.IndexFieldKongPluginBindingKongConsumerReference: kongConsumer.Name,
+			},
+			func(c *assert.CollectT, bindings []configurationv1alpha1.KongPluginBinding) {
+				assert.Len(c, bindings, 1)
+			},
 		)
 
-		assert.EventuallyWithT(t,
-			func(c *assert.CollectT) {
-				assert.True(c, apierrors.IsNotFound(
-					clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpbRoute), kpbRoute),
-				))
-			}, waitTime, tickTime,
+		eventually.WaitForObjectToNotExist(
+			t, ctx, clientNamespaced, kpbRoute, waitTime, tickTime,
 			"KongPluginBinding bound to Route wasn't deleted after removing annotation from KongRoute",
 		)
 
@@ -623,28 +620,23 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		delete(kongService.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongService))
 
-		assert.EventuallyWithT(t,
-			func(c *assert.CollectT) {
-				var l configurationv1alpha1.KongPluginBindingList
-				if !assert.NoError(c, clientNamespaced.List(ctx, &l,
-					client.MatchingFields{
-						index.IndexFieldKongPluginBindingKongPluginReference:   rateLimitingkongPlugin.Namespace + "/" + rateLimitingkongPlugin.Name,
-						index.IndexFieldKongPluginBindingKongConsumerReference: kongConsumer.Name,
-					},
-				)) {
+		assertMatchingKongPluginBindings(t,
+			"KongConsumer bound KongPluginBinding wasn't created",
+			client.MatchingFields{
+				index.IndexFieldKongPluginBindingKongPluginReference:   managedPluginReference,
+				index.IndexFieldKongPluginBindingKongConsumerReference: kongConsumer.Name,
+			},
+			func(c *assert.CollectT, bindings []configurationv1alpha1.KongPluginBinding) {
+				if !assert.Len(c, bindings, 1) {
 					return
 				}
-				if !assert.Len(c, l.Items, 1) {
-					return
-				}
-				targets := l.Items[0].Spec.Targets
+				targets := bindings[0].Spec.Targets
 				assert.Nil(c, targets.RouteReference)
 				assert.Nil(c, targets.ServiceReference)
 				if assert.NotNil(c, targets.ConsumerReference) {
 					assert.Equal(c, kongConsumer.Name, targets.ConsumerReference.Name)
 				}
-			}, waitTime, tickTime,
-			"KongConsumer bound KongPluginBinding wasn't created",
+			},
 		)
 
 		t.Logf(
@@ -657,20 +649,15 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		delete(kongConsumer.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongConsumer))
 
-		assert.EventuallyWithT(t,
-			func(c *assert.CollectT) {
-				var l configurationv1alpha1.KongPluginBindingList
-				if !assert.NoError(c, clientNamespaced.List(ctx, &l,
-					client.MatchingFields{
-						index.IndexFieldKongPluginBindingKongPluginReference:   rateLimitingkongPlugin.Namespace + "/" + rateLimitingkongPlugin.Name,
-						index.IndexFieldKongPluginBindingKongConsumerReference: kongConsumer.Name,
-					},
-				)) {
-					return
-				}
-				assert.Empty(c, l.Items)
-			}, waitTime, tickTime,
+		assertMatchingKongPluginBindings(t,
 			"KongConsumer bound KongPluginBinding wasn't deleted",
+			client.MatchingFields{
+				index.IndexFieldKongPluginBindingKongPluginReference:   managedPluginReference,
+				index.IndexFieldKongPluginBindingKongConsumerReference: kongConsumer.Name,
+			},
+			func(c *assert.CollectT, bindings []configurationv1alpha1.KongPluginBinding) {
+				assert.Empty(c, bindings)
+			},
 		)
 
 		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
@@ -791,29 +778,20 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		delete(kongRoute.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongRoute))
 
-		assert.EventuallyWithT(t,
-			func(t *assert.CollectT) {
-				var l configurationv1alpha1.KongPluginBindingList
-				if !assert.NoError(t, clientNamespaced.List(ctx, &l,
-					client.MatchingFields{
-						index.IndexFieldKongPluginBindingKongPluginReference:        rateLimitingkongPlugin.Namespace + "/" + rateLimitingkongPlugin.Name,
-						index.IndexFieldKongPluginBindingKongServiceReference:       kongService.Name,
-						index.IndexFieldKongPluginBindingKongConsumerGroupReference: kongConsumerGroup.Name,
-					},
-				)) {
-					return
-				}
-				assert.Len(t, l.Items, 1)
-			}, waitTime, tickTime,
+		assertMatchingKongPluginBindings(t,
 			"KongPluginBinding bound to ConsumerGroup and Service doesn't exist but it should",
+			client.MatchingFields{
+				index.IndexFieldKongPluginBindingKongPluginReference:        managedPluginReference,
+				index.IndexFieldKongPluginBindingKongServiceReference:       kongService.Name,
+				index.IndexFieldKongPluginBindingKongConsumerGroupReference: kongConsumerGroup.Name,
+			},
+			func(c *assert.CollectT, bindings []configurationv1alpha1.KongPluginBinding) {
+				assert.Len(c, bindings, 1)
+			},
 		)
 
-		assert.EventuallyWithT(t,
-			func(c *assert.CollectT) {
-				assert.True(c, apierrors.IsNotFound(
-					clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpbRoute), kpbRoute),
-				))
-			}, waitTime, tickTime,
+		eventually.WaitForObjectToNotExist(
+			t, ctx, clientNamespaced, kpbRoute, waitTime, tickTime,
 			"KongPluginBinding bound to Route wasn't deleted after removing annotation from KongRoute",
 		)
 
@@ -826,28 +804,23 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		delete(kongService.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongService))
 
-		assert.EventuallyWithT(t,
-			func(c *assert.CollectT) {
-				var l configurationv1alpha1.KongPluginBindingList
-				if !assert.NoError(c, clientNamespaced.List(ctx, &l,
-					client.MatchingFields{
-						index.IndexFieldKongPluginBindingKongPluginReference:        rateLimitingkongPlugin.Namespace + "/" + rateLimitingkongPlugin.Name,
-						index.IndexFieldKongPluginBindingKongConsumerGroupReference: kongConsumerGroup.Name,
-					},
-				)) {
+		assertMatchingKongPluginBindings(t,
+			"KongConsumerGroup bound KongPluginBinding wasn't created",
+			client.MatchingFields{
+				index.IndexFieldKongPluginBindingKongPluginReference:        managedPluginReference,
+				index.IndexFieldKongPluginBindingKongConsumerGroupReference: kongConsumerGroup.Name,
+			},
+			func(c *assert.CollectT, bindings []configurationv1alpha1.KongPluginBinding) {
+				if !assert.Len(c, bindings, 1) {
 					return
 				}
-				if !assert.Len(c, l.Items, 1) {
-					return
-				}
-				targets := l.Items[0].Spec.Targets
+				targets := bindings[0].Spec.Targets
 				assert.Nil(c, targets.RouteReference)
 				assert.Nil(c, targets.ServiceReference)
 				if assert.NotNil(c, targets.ConsumerGroupReference) {
 					assert.Equal(c, kongConsumerGroup.Name, targets.ConsumerGroupReference.Name)
 				}
-			}, waitTime, tickTime,
-			"KongConsumerGroup bound KongPluginBinding wasn't created",
+			},
 		)
 
 		t.Logf(
@@ -860,20 +833,15 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		delete(kongConsumerGroup.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongConsumerGroup))
 
-		assert.EventuallyWithT(t,
-			func(c *assert.CollectT) {
-				var l configurationv1alpha1.KongPluginBindingList
-				if !assert.NoError(c, clientNamespaced.List(ctx, &l,
-					client.MatchingFields{
-						index.IndexFieldKongPluginBindingKongPluginReference:        rateLimitingkongPlugin.Namespace + "/" + rateLimitingkongPlugin.Name,
-						index.IndexFieldKongPluginBindingKongConsumerGroupReference: kongConsumerGroup.Name,
-					},
-				)) {
-					return
-				}
-				assert.Empty(c, l.Items)
-			}, waitTime, tickTime,
+		assertMatchingKongPluginBindings(t,
 			"KongConsumerGroup bound KongPluginBinding wasn't deleted",
+			client.MatchingFields{
+				index.IndexFieldKongPluginBindingKongPluginReference:        managedPluginReference,
+				index.IndexFieldKongPluginBindingKongConsumerGroupReference: kongConsumerGroup.Name,
+			},
+			func(c *assert.CollectT, bindings []configurationv1alpha1.KongPluginBinding) {
+				assert.Empty(c, bindings)
+			},
 		)
 
 		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)

--- a/test/envtest/kongpluginbinding_managed_test.go
+++ b/test/envtest/kongpluginbinding_managed_test.go
@@ -184,27 +184,6 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		return found
 	}
 
-	assertMatchingKongPluginBindings := func(
-		t *testing.T,
-		message string,
-		matchingFields client.MatchingFields,
-		assertions func(*assert.CollectT, []configurationv1alpha1.KongPluginBinding),
-	) {
-		t.Helper()
-
-		assert.EventuallyWithT(t,
-			func(c *assert.CollectT) {
-				var list configurationv1alpha1.KongPluginBindingList
-				if !assert.NoError(c, clientNamespaced.List(ctx, &list, matchingFields)) {
-					return
-				}
-				assertions(c, list.Items)
-			},
-			waitTime, tickTime,
-			message,
-		)
-	}
-
 	// The stale-cache reconcile (driven by pendingKonnectIDs after any CreatePlugin call) reaches
 	// ops.Update which calls UpsertPlugin. Register a single optional expectation here to absorb
 	// those calls across all subtests. No subtest has a strict UpsertPlugin expectation, so there
@@ -594,16 +573,17 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		delete(kongRoute.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongRoute))
 
-		assertMatchingKongPluginBindings(t,
-			"KongPluginBinding bound to Consumer and Service doesn't exist but it should",
+		eventually.AssertMatchingKongPluginBindings(t, ctx, clientNamespaced,
 			client.MatchingFields{
 				index.IndexFieldKongPluginBindingKongPluginReference:   managedPluginReference,
 				index.IndexFieldKongPluginBindingKongServiceReference:  kongService.Name,
 				index.IndexFieldKongPluginBindingKongConsumerReference: kongConsumer.Name,
 			},
+			waitTime, tickTime,
 			func(c *assert.CollectT, bindings []configurationv1alpha1.KongPluginBinding) {
 				assert.Len(c, bindings, 1)
 			},
+			"KongPluginBinding bound to Consumer and Service doesn't exist but it should",
 		)
 
 		eventually.WaitForObjectToNotExist(
@@ -620,12 +600,12 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		delete(kongService.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongService))
 
-		assertMatchingKongPluginBindings(t,
-			"KongConsumer bound KongPluginBinding wasn't created",
+		eventually.AssertMatchingKongPluginBindings(t, ctx, clientNamespaced,
 			client.MatchingFields{
 				index.IndexFieldKongPluginBindingKongPluginReference:   managedPluginReference,
 				index.IndexFieldKongPluginBindingKongConsumerReference: kongConsumer.Name,
 			},
+			waitTime, tickTime,
 			func(c *assert.CollectT, bindings []configurationv1alpha1.KongPluginBinding) {
 				if !assert.Len(c, bindings, 1) {
 					return
@@ -637,6 +617,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 					assert.Equal(c, kongConsumer.Name, targets.ConsumerReference.Name)
 				}
 			},
+			"KongConsumer bound KongPluginBinding wasn't created",
 		)
 
 		t.Logf(
@@ -649,15 +630,16 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		delete(kongConsumer.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongConsumer))
 
-		assertMatchingKongPluginBindings(t,
-			"KongConsumer bound KongPluginBinding wasn't deleted",
+		eventually.AssertMatchingKongPluginBindings(t, ctx, clientNamespaced,
 			client.MatchingFields{
 				index.IndexFieldKongPluginBindingKongPluginReference:   managedPluginReference,
 				index.IndexFieldKongPluginBindingKongConsumerReference: kongConsumer.Name,
 			},
+			waitTime, tickTime,
 			func(c *assert.CollectT, bindings []configurationv1alpha1.KongPluginBinding) {
 				assert.Empty(c, bindings)
 			},
+			"KongConsumer bound KongPluginBinding wasn't deleted",
 		)
 
 		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
@@ -778,16 +760,17 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		delete(kongRoute.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongRoute))
 
-		assertMatchingKongPluginBindings(t,
-			"KongPluginBinding bound to ConsumerGroup and Service doesn't exist but it should",
+		eventually.AssertMatchingKongPluginBindings(t, ctx, clientNamespaced,
 			client.MatchingFields{
 				index.IndexFieldKongPluginBindingKongPluginReference:        managedPluginReference,
 				index.IndexFieldKongPluginBindingKongServiceReference:       kongService.Name,
 				index.IndexFieldKongPluginBindingKongConsumerGroupReference: kongConsumerGroup.Name,
 			},
+			waitTime, tickTime,
 			func(c *assert.CollectT, bindings []configurationv1alpha1.KongPluginBinding) {
 				assert.Len(c, bindings, 1)
 			},
+			"KongPluginBinding bound to ConsumerGroup and Service doesn't exist but it should",
 		)
 
 		eventually.WaitForObjectToNotExist(
@@ -804,12 +787,12 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		delete(kongService.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongService))
 
-		assertMatchingKongPluginBindings(t,
-			"KongConsumerGroup bound KongPluginBinding wasn't created",
+		eventually.AssertMatchingKongPluginBindings(t, ctx, clientNamespaced,
 			client.MatchingFields{
 				index.IndexFieldKongPluginBindingKongPluginReference:        managedPluginReference,
 				index.IndexFieldKongPluginBindingKongConsumerGroupReference: kongConsumerGroup.Name,
 			},
+			waitTime, tickTime,
 			func(c *assert.CollectT, bindings []configurationv1alpha1.KongPluginBinding) {
 				if !assert.Len(c, bindings, 1) {
 					return
@@ -821,6 +804,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 					assert.Equal(c, kongConsumerGroup.Name, targets.ConsumerGroupReference.Name)
 				}
 			},
+			"KongConsumerGroup bound KongPluginBinding wasn't created",
 		)
 
 		t.Logf(
@@ -833,15 +817,16 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		delete(kongConsumerGroup.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongConsumerGroup))
 
-		assertMatchingKongPluginBindings(t,
-			"KongConsumerGroup bound KongPluginBinding wasn't deleted",
+		eventually.AssertMatchingKongPluginBindings(t, ctx, clientNamespaced,
 			client.MatchingFields{
 				index.IndexFieldKongPluginBindingKongPluginReference:        managedPluginReference,
 				index.IndexFieldKongPluginBindingKongConsumerGroupReference: kongConsumerGroup.Name,
 			},
+			waitTime, tickTime,
 			func(c *assert.CollectT, bindings []configurationv1alpha1.KongPluginBinding) {
 				assert.Empty(c, bindings)
 			},
+			"KongConsumerGroup bound KongPluginBinding wasn't deleted",
 		)
 
 		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)

--- a/test/helpers/eventually/kongpluginbinding.go
+++ b/test/helpers/eventually/kongpluginbinding.go
@@ -1,0 +1,39 @@
+package eventually
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+)
+
+// AssertMatchingKongPluginBindings lists KongPluginBindings matching the
+// provided fields until the supplied assertions pass.
+func AssertMatchingKongPluginBindings(
+	t *testing.T,
+	ctx context.Context,
+	cl client.Client,
+	matchingFields client.MatchingFields,
+	waitTime time.Duration,
+	tickTime time.Duration,
+	assertions func(*assert.CollectT, []configurationv1alpha1.KongPluginBinding),
+	msgAndArgs ...any,
+) bool {
+	t.Helper()
+
+	return assert.EventuallyWithT(t,
+		func(c *assert.CollectT) {
+			var list configurationv1alpha1.KongPluginBindingList
+			if !assert.NoError(c, cl.List(ctx, &list, matchingFields)) {
+				return
+			}
+			assertions(c, list.Items)
+		},
+		waitTime, tickTime,
+		msgAndArgs...,
+	)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

follow-up for @pmalek 's comments

https://github.com/Kong/kong-operator/pull/4667#discussion_r3474316544

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
