### PR TITLE
test(conformance): enable HTTPRouteMethodMatching for hybrid gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,11 @@
 - Gateway: Support watching both `v1` and `v1beta1` versions of `ReferenceGrant`
   to ensure compatability with gateway API 1.3 and 1.4.
   [#5091](https://github.com/Kong/kong-operator/pull/5091)
+- Hybridgateway: translate method-only `HTTPRoute` matches with the default root
+  path and avoid promoting method-less header-only matches above them, enabling
+  the `HTTPRouteMethodMatching` Gateway API conformance test for the hybrid
+  gateway.
+  [#4715](https://github.com/Kong/kong-operator/pull/4715)
 
 ### Added
   
@@ -402,11 +407,6 @@
   or above that boundary depending on whether they should sort before or after
   generated path-based routes.
   [#4640](https://github.com/Kong/kong-operator/pull/4640)
-- Hybridgateway: translate method-only `HTTPRoute` matches with the default root
-  path and avoid promoting method-less header-only matches above them, enabling
-  the `HTTPRouteMethodMatching` Gateway API conformance test for the hybrid
-  gateway.
-  [#4715](https://github.com/Kong/kong-operator/pull/4715)
 - Fix routes become unaccepted and removed from DataPlane unexpectedly
   [#4521](https://github.com/Kong/kong-operator/pull/4521)
 - EventGateway / MCPServer: fix Server-Side Apply (SSA) permanently failing with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -402,6 +402,11 @@
   or above that boundary depending on whether they should sort before or after
   generated path-based routes.
   [#4640](https://github.com/Kong/kong-operator/pull/4640)
+- Hybridgateway: translate method-only `HTTPRoute` matches with the default root
+  path and avoid promoting method-less header-only matches above them, enabling
+  the `HTTPRouteMethodMatching` Gateway API conformance test for the hybrid
+  gateway.
+  [#4715](https://github.com/Kong/kong-operator/pull/4715)
 - Fix routes become unaccepted and removed from DataPlane unexpectedly
   [#4521](https://github.com/Kong/kong-operator/pull/4521)
 - EventGateway / MCPServer: fix Server-Side Apply (SSA) permanently failing with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,10 +85,10 @@
 - Gateway: Support watching both `v1` and `v1beta1` versions of `ReferenceGrant`
   to ensure compatability with gateway API 1.3 and 1.4.
   [#5091](https://github.com/Kong/kong-operator/pull/5091)
-- Hybridgateway: translate method-only `HTTPRoute` matches with the default root
-  path and avoid promoting method-less header-only matches above them, enabling
-  the `HTTPRouteMethodMatching` Gateway API conformance test for the hybrid
-  gateway.
+- Hybridgateway: preserve Gateway API precedence for overlapping path, method,
+  and header matches by retaining native PathPrefix matching and generating
+  specialized Kong Routes for conflicting match combinations. This enables the
+  `HTTPRouteMethodMatching` Gateway API conformance test for the hybrid gateway.
   [#4715](https://github.com/Kong/kong-operator/pull/4715)
 
 ### Added
@@ -402,10 +402,9 @@
   derived from method and header specificity keeps more specific header matches
   ahead of less specific ones. This enables the `HTTPRouteHeaderMatching` Gateway API
   conformance test for the hybrid gateway.
-  Generated header-only priorities stay below `1 << 20` (`1048576`), while generated
-  path-based priorities start at that value. Use custom `KongRoute` priorities below
-  or above that boundary depending on whether they should sort before or after
-  generated path-based routes.
+  Generated priorities stay below `1 << 20` (`1048576`) because Kong's
+  traditional-compatible router only retains the low 20 bits when calculating
+  route precedence.
   [#4640](https://github.com/Kong/kong-operator/pull/4640)
 - Fix routes become unaccepted and removed from DataPlane unexpectedly
   [#4521](https://github.com/Kong/kong-operator/pull/4521)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,12 @@
   patch instead of an optimistic-locked update. A stale cached `resourceVersion`
   could previously make that write conflict, which silently requeued the
   reconcile and deleted the same entity from Konnect a second time.
+- Hybridgateway: preserve Gateway API precedence for overlapping path, method,
+  and header matches by retaining native PathPrefix matching and generating
+  specialized Kong Routes for conflicting match combinations. This enables the
+  `HTTPRouteMethodMatching` Gateway API conformance test for the hybrid
+  gateway.
+  [#4715](https://github.com/Kong/kong-operator/pull/4715)
 
 ## [v2.3.1]
 
@@ -538,10 +544,9 @@
   derived from method and header specificity keeps more specific header matches
   ahead of less specific ones. This enables the `HTTPRouteHeaderMatching` Gateway API
   conformance test for the hybrid gateway.
-  Generated header-only priorities stay below `1 << 20` (`1048576`), while generated
-  path-based priorities start at that value. Use custom `KongRoute` priorities below
-  or above that boundary depending on whether they should sort before or after
-  generated path-based routes.
+  Generated priorities stay below `1 << 20` (`1048576`) because Kong's
+  traditional-compatible router only retains the low 20 bits when calculating
+  route precedence.
   [#4640](https://github.com/Kong/kong-operator/pull/4640)
 - Fix routes become unaccepted and removed from `DataPlane` unexpectedly
   [#4521](https://github.com/Kong/kong-operator/pull/4521)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,9 @@
   and header matches by retaining native PathPrefix matching and generating
   specialized Kong Routes for conflicting match combinations. This enables the
   `HTTPRouteMethodMatching` Gateway API conformance test for the hybrid
-  gateway.
+  gateway. Generated priorities stay below `1 << 20` (`1048576`) because Kong's
+  traditional-compatible router only retains the low 20 bits when calculating
+  route precedence.
   [#4715](https://github.com/Kong/kong-operator/pull/4715)
 
 ## [v2.3.1]
@@ -544,9 +546,10 @@
   derived from method and header specificity keeps more specific header matches
   ahead of less specific ones. This enables the `HTTPRouteHeaderMatching` Gateway API
   conformance test for the hybrid gateway.
-  Generated priorities stay below `1 << 20` (`1048576`) because Kong's
-  traditional-compatible router only retains the low 20 bits when calculating
-  route precedence.
+  Generated header-only priorities stay below `1 << 20` (`1048576`), while generated
+  path-based priorities start at that value. Use custom `KongRoute` priorities below
+  or above that boundary depending on whether they should sort before or after
+  generated path-based routes.
   [#4640](https://github.com/Kong/kong-operator/pull/4640)
 - Fix routes become unaccepted and removed from `DataPlane` unexpectedly
   [#4521](https://github.com/Kong/kong-operator/pull/4521)

--- a/controller/hybridgateway/builder/kongroute.go
+++ b/controller/hybridgateway/builder/kongroute.go
@@ -70,6 +70,11 @@ func (b *KongRouteBuilder) WithHTTPRouteMatch(match gwtypes.HTTPRouteMatch, setC
 	// Method
 	if match.Method != nil {
 		b.route.Spec.Methods = append(b.route.Spec.Methods, string(*match.Method))
+		if len(b.route.Spec.Paths) == 0 {
+			// Gateway API treats an omitted path as PathPrefix "/". Materialize it so
+			// Kong's traditional router prioritizes method-only matches over header-only matches.
+			b.route.Spec.Paths = append(b.route.Spec.Paths, "/")
+		}
 	}
 
 	// Headers

--- a/controller/hybridgateway/builder/kongroute.go
+++ b/controller/hybridgateway/builder/kongroute.go
@@ -24,11 +24,11 @@ const (
 	// KongHeaderRegexPrefix is a reserved prefix string that Kong uses to determine if it should parse a header value
 	// as a regex.
 	KongHeaderRegexPrefix = "~*"
-	// KongHTTPRouteHeaderOnlyRegexPath is a catch-all regex path used to make regex_priority effective
-	// for HTTPRoute matches that only match on headers.
-	KongHTTPRouteHeaderOnlyRegexPath = KongPathRegexPrefix + "/(.*)"
+	// KongHTTPRouteDefaultPathRegexPath is a catch-all regex path used to make regex_priority effective
+	// for HTTPRoute matches that otherwise use the default root path.
+	KongHTTPRouteDefaultPathRegexPath = KongPathRegexPrefix + "/(.*)"
 	// KongHTTPRoutePathRegexPriorityOffset reserves lower regex_priority values for synthetic
-	// catch-all regex routes used by default path header-only matches.
+	// catch-all regex routes used by default-path method/header matches.
 	KongHTTPRoutePathRegexPriorityOffset int64 = 1 << 20
 )
 
@@ -103,16 +103,11 @@ func (b *KongRouteBuilder) WithRegexPriority(priority *int64) *KongRouteBuilder 
 	return b
 }
 
-// WithHeaderOnlyRegexPath adds a catch-all regex path when needed so Kong can use
-// regex_priority to order overlapping HTTPRoute matches that only specify headers
-// and otherwise use the default root path.
-func (b *KongRouteBuilder) WithHeaderOnlyRegexPath() *KongRouteBuilder {
-	if len(b.route.Spec.Headers) == 0 {
-		return b
-	}
-
+// WithDefaultPathRegexPath replaces the default root path with a catch-all regex
+// path so regex_priority can order default-path HTTPRoute matches.
+func (b *KongRouteBuilder) WithDefaultPathRegexPath() *KongRouteBuilder {
 	if len(b.route.Spec.Paths) == 0 || (len(b.route.Spec.Paths) == 1 && b.route.Spec.Paths[0] == "/") {
-		b.route.Spec.Paths = []string{KongHTTPRouteHeaderOnlyRegexPath}
+		b.route.Spec.Paths = []string{KongHTTPRouteDefaultPathRegexPath}
 	}
 	return b
 }

--- a/controller/hybridgateway/builder/kongroute.go
+++ b/controller/hybridgateway/builder/kongroute.go
@@ -24,12 +24,6 @@ const (
 	// KongHeaderRegexPrefix is a reserved prefix string that Kong uses to determine if it should parse a header value
 	// as a regex.
 	KongHeaderRegexPrefix = "~*"
-	// KongHTTPRouteDefaultPathRegexPath is a catch-all regex path used to make regex_priority effective
-	// for HTTPRoute matches that otherwise use the default root path.
-	KongHTTPRouteDefaultPathRegexPath = KongPathRegexPrefix + "/(.*)"
-	// KongHTTPRoutePathRegexPriorityOffset reserves lower regex_priority values for synthetic
-	// catch-all regex routes used by default-path method/header matches.
-	KongHTTPRoutePathRegexPriorityOffset int64 = 1 << 20
 )
 
 // KongRouteBuilder is a builder for configurationv1alpha1.KongRoute resources.
@@ -62,19 +56,13 @@ func (b *KongRouteBuilder) WithProtocols(protocols ...sdkkonnectcomp.Protocols) 
 func (b *KongRouteBuilder) WithHTTPRouteMatch(match gwtypes.HTTPRouteMatch, setCaptureGroup bool) *KongRouteBuilder {
 	// Path.
 	if match.Path != nil && match.Path.Value != nil {
-		paths, regexPriority := GenerateKongRoutePathFromHTTPRouteMatch(match.Path, setCaptureGroup)
+		paths := GenerateKongRoutePathFromHTTPRouteMatch(match.Path, setCaptureGroup)
 		b.route.Spec.Paths = append(b.route.Spec.Paths, paths...)
-		b.route.Spec.RegexPriority = regexPriority
 	}
 
 	// Method
 	if match.Method != nil {
 		b.route.Spec.Methods = append(b.route.Spec.Methods, string(*match.Method))
-		if len(b.route.Spec.Paths) == 0 {
-			// Gateway API treats an omitted path as PathPrefix "/". Materialize it so
-			// Kong's traditional router prioritizes method-only matches over header-only matches.
-			b.route.Spec.Paths = append(b.route.Spec.Paths, "/")
-		}
 	}
 
 	// Headers
@@ -99,20 +87,6 @@ func (b *KongRouteBuilder) WithHTTPRouteMatch(match gwtypes.HTTPRouteMatch, setC
 func (b *KongRouteBuilder) WithRegexPriority(priority *int64) *KongRouteBuilder {
 	if priority != nil {
 		b.route.Spec.RegexPriority = priority
-	}
-	return b
-}
-
-// WithDefaultPathRegexPath replaces the default root path with a catch-all regex
-// path so regex_priority can order default-path HTTPRoute matches.
-func (b *KongRouteBuilder) WithDefaultPathRegexPath() *KongRouteBuilder {
-	isDefaultRootPath := len(b.route.Spec.Paths) == 0 ||
-		(len(b.route.Spec.Paths) == 1 && b.route.Spec.Paths[0] == "/")
-	isRootCaptureGroupPath := len(b.route.Spec.Paths) == 2 &&
-		b.route.Spec.Paths[0] == KongPathRegexPrefix+"/$" &&
-		b.route.Spec.Paths[1] == KongHTTPRouteDefaultPathRegexPath
-	if isDefaultRootPath || isRootCaptureGroupPath {
-		b.route.Spec.Paths = []string{KongHTTPRouteDefaultPathRegexPath}
 	}
 	return b
 }
@@ -244,12 +218,9 @@ func (b *KongRouteBuilder) MustBuild() configurationv1alpha1.KongRoute {
 }
 
 // GenerateKongRoutePathFromHTTPRouteMatch translates the value in HTTPRoute's path match
-// to the path used in KongRoute and returns any RegexPriority needed for the KongRoute.
-// RegexPriority is set for Exact and non-root PathPrefix translations whose generated regex
-// paths must preserve Gateway API path precedence in Kong's traditional-compatible router.
-// Root capture-group translations and user-supplied RegularExpression matches keep Kong's
-// default priority because they remain catch-all or implementation-specific cases.
-func GenerateKongRoutePathFromHTTPRouteMatch(pathMatch *gatewayv1.HTTPPathMatch, setCaptureGroup bool) (paths []string, regexPriority *int64) {
+// to the path used in KongRoute. The caller assigns regex_priority using the complete
+// HTTPRoute so that path, method, and header precedence share one compact priority space.
+func GenerateKongRoutePathFromHTTPRouteMatch(pathMatch *gatewayv1.HTTPPathMatch, setCaptureGroup bool) []string {
 	// The default match type is PathMatchPathPrefix.
 	matchType := gatewayv1.PathMatchPathPrefix
 	if pathMatch.Type != nil {
@@ -268,17 +239,17 @@ func GenerateKongRoutePathFromHTTPRouteMatch(pathMatch *gatewayv1.HTTPPathMatch,
 	switch matchType {
 	// Since the path matches request in prefix way, we need to use a regex with the '$' suffix to do the exact match.
 	case gatewayv1.PathMatchExact:
-		return []string{KongPathRegexPrefix + value + "$"}, regexPriorityForHTTPPathMatch(matchType, value)
+		return []string{KongPathRegexPrefix + value + "$"}
 
 	// In HTTPRoute, the prefix match is specified in the "directory" manner but not simple string prefix.
 	// For example, '/abc' should match '/abc', '/abc/', '/abc/123' but not '/abcd'.
 	// So we split it into 2 items:
 	// - One using regex to match the exact path without the trailing '/', e.g: '~/abc$'
-	// - The other to match the prefix with the trailing '/', e.g: '/abc/'.
+	// - The other native prefix path with the trailing '/', e.g: '/abc/'.
 	case gatewayv1.PathMatchPathPrefix:
 		// For the '/' path to match all, we just return the item in KongRoute to do the same catch-all match.
 		if value == "/" && !setCaptureGroup {
-			return []string{"/"}, nil
+			return []string{"/"}
 		}
 
 		paths := make([]string, 0, 2)
@@ -291,30 +262,21 @@ func GenerateKongRoutePathFromHTTPRouteMatch(pathMatch *gatewayv1.HTTPPathMatch,
 		if setCaptureGroup {
 			// If the path is "/", we have to skip capturing the slash as Kong Route's path must begin with a slash.
 			if value == "/" {
-				// Keep the default priority for the root capture-group form: it remains the catch-all route.
-				return append(paths, fmt.Sprintf("%s/(.*)", KongPathRegexPrefix)), nil
+				return append(paths, fmt.Sprintf("%s/(.*)", KongPathRegexPrefix))
 			}
 			// When there is a prefix in the route path, we capture the slash and the rest of the path after the prefix.
-			return append(paths, fmt.Sprintf("%s%s%s", KongPathRegexPrefix, path, "(/.*)")), regexPriorityForHTTPPathMatch(matchType, value)
+			return append(paths, fmt.Sprintf("%s%s%s", KongPathRegexPrefix, path, "(/.*)"))
 		}
 
 		if !strings.HasSuffix(path, "/") {
 			path = fmt.Sprintf("%s/", path)
 		}
-		return append(paths, path), regexPriorityForHTTPPathMatch(matchType, value)
+		return append(paths, path)
 
 	// For RegularExpression path match, we simply use the same regex in the paths of KongRoute.
 	case gatewayv1.PathMatchRegularExpression:
 		// Gateway API leaves the precedence of regular-expression path matches implementation-specific.
-		return []string{KongPathRegexPrefix + value}, nil
+		return []string{KongPathRegexPrefix + value}
 	}
-	return nil, nil // Should never be reached.
-}
-
-func regexPriorityForHTTPPathMatch(matchType gatewayv1.PathMatchType, value string) *int64 {
-	priority := KongHTTPRoutePathRegexPriorityOffset + int64(len(value)*2)
-	if matchType == gatewayv1.PathMatchExact {
-		priority++
-	}
-	return &priority
+	return nil // Should never be reached.
 }

--- a/controller/hybridgateway/builder/kongroute.go
+++ b/controller/hybridgateway/builder/kongroute.go
@@ -106,7 +106,12 @@ func (b *KongRouteBuilder) WithRegexPriority(priority *int64) *KongRouteBuilder 
 // WithDefaultPathRegexPath replaces the default root path with a catch-all regex
 // path so regex_priority can order default-path HTTPRoute matches.
 func (b *KongRouteBuilder) WithDefaultPathRegexPath() *KongRouteBuilder {
-	if len(b.route.Spec.Paths) == 0 || (len(b.route.Spec.Paths) == 1 && b.route.Spec.Paths[0] == "/") {
+	isDefaultRootPath := len(b.route.Spec.Paths) == 0 ||
+		(len(b.route.Spec.Paths) == 1 && b.route.Spec.Paths[0] == "/")
+	isRootCaptureGroupPath := len(b.route.Spec.Paths) == 2 &&
+		b.route.Spec.Paths[0] == KongPathRegexPrefix+"/$" &&
+		b.route.Spec.Paths[1] == KongHTTPRouteDefaultPathRegexPath
+	if isDefaultRootPath || isRootCaptureGroupPath {
 		b.route.Spec.Paths = []string{KongHTTPRouteDefaultPathRegexPath}
 	}
 	return b

--- a/controller/hybridgateway/builder/kongroute.go
+++ b/controller/hybridgateway/builder/kongroute.go
@@ -25,13 +25,6 @@ const (
 	// KongHeaderRegexPrefix is a reserved prefix string that Kong uses to determine if it should parse a header value
 	// as a regex.
 	KongHeaderRegexPrefix = "~*"
-	// KongHTTPRouteHeaderOnlyRegexPath is a catch-all regex path used to make regex_priority effective
-	// for HTTPRoute matches that only match on headers.
-	KongHTTPRouteHeaderOnlyRegexPath = KongPathRegexPrefix + "/(.*)"
-	// KongHTTPRoutePathRegexPriorityOffset reserves lower regex_priority values for synthetic
-	// catch-all regex routes used by default path header-only matches.
-	KongHTTPRoutePathRegexPriorityOffset int64 = 1 << 20
-
 	// KongGRPCRouteCatchAllPath is the synthetic regex path used for GRPCRoute matches that
 	// specify no method matcher at all (Method == nil), which per Gateway API must match every
 	// service and method. GRPCRouteMatch has no path field, so regex_priority (not path
@@ -69,9 +62,8 @@ func (b *KongRouteBuilder) WithProtocols(protocols ...sdkkonnectcomp.Protocols) 
 func (b *KongRouteBuilder) WithHTTPRouteMatch(match gwtypes.HTTPRouteMatch, setCaptureGroup bool) *KongRouteBuilder {
 	// Path.
 	if match.Path != nil && match.Path.Value != nil {
-		paths, regexPriority := GenerateKongRoutePathFromHTTPRouteMatch(match.Path, setCaptureGroup)
+		paths := GenerateKongRoutePathFromHTTPRouteMatch(match.Path, setCaptureGroup)
 		b.route.Spec.Paths = append(b.route.Spec.Paths, paths...)
-		b.route.Spec.RegexPriority = regexPriority
 	}
 
 	// Method
@@ -124,20 +116,6 @@ func (b *KongRouteBuilder) WithGRPCRouteMatch(match gatewayv1.GRPCRouteMatch) *K
 func (b *KongRouteBuilder) WithRegexPriority(priority *int64) *KongRouteBuilder {
 	if priority != nil {
 		b.route.Spec.RegexPriority = priority
-	}
-	return b
-}
-
-// WithHeaderOnlyRegexPath adds a catch-all regex path when needed so Kong can use
-// regex_priority to order overlapping HTTPRoute matches that only specify headers
-// and otherwise use the default root path.
-func (b *KongRouteBuilder) WithHeaderOnlyRegexPath() *KongRouteBuilder {
-	if len(b.route.Spec.Headers) == 0 {
-		return b
-	}
-
-	if len(b.route.Spec.Paths) == 0 || (len(b.route.Spec.Paths) == 1 && b.route.Spec.Paths[0] == "/") {
-		b.route.Spec.Paths = []string{KongHTTPRouteHeaderOnlyRegexPath}
 	}
 	return b
 }
@@ -269,12 +247,9 @@ func (b *KongRouteBuilder) MustBuild() configurationv1alpha1.KongRoute {
 }
 
 // GenerateKongRoutePathFromHTTPRouteMatch translates the value in HTTPRoute's path match
-// to the path used in KongRoute and returns any RegexPriority needed for the KongRoute.
-// RegexPriority is set for Exact and non-root PathPrefix translations whose generated regex
-// paths must preserve Gateway API path precedence in Kong's traditional-compatible router.
-// Root capture-group translations and user-supplied RegularExpression matches keep Kong's
-// default priority because they remain catch-all or implementation-specific cases.
-func GenerateKongRoutePathFromHTTPRouteMatch(pathMatch *gatewayv1.HTTPPathMatch, setCaptureGroup bool) (paths []string, regexPriority *int64) {
+// to the path used in KongRoute. The caller assigns regex_priority using the complete
+// HTTPRoute so that path, method, and header precedence share one compact priority space.
+func GenerateKongRoutePathFromHTTPRouteMatch(pathMatch *gatewayv1.HTTPPathMatch, setCaptureGroup bool) []string {
 	// The default match type is PathMatchPathPrefix.
 	matchType := gatewayv1.PathMatchPathPrefix
 	if pathMatch.Type != nil {
@@ -293,17 +268,17 @@ func GenerateKongRoutePathFromHTTPRouteMatch(pathMatch *gatewayv1.HTTPPathMatch,
 	switch matchType {
 	// Since the path matches request in prefix way, we need to use a regex with the '$' suffix to do the exact match.
 	case gatewayv1.PathMatchExact:
-		return []string{KongPathRegexPrefix + value + "$"}, regexPriorityForHTTPPathMatch(matchType, value)
+		return []string{KongPathRegexPrefix + value + "$"}
 
 	// In HTTPRoute, the prefix match is specified in the "directory" manner but not simple string prefix.
 	// For example, '/abc' should match '/abc', '/abc/', '/abc/123' but not '/abcd'.
 	// So we split it into 2 items:
 	// - One using regex to match the exact path without the trailing '/', e.g: '~/abc$'
-	// - The other to match the prefix with the trailing '/', e.g: '/abc/'.
+	// - The other native prefix path with the trailing '/', e.g: '/abc/'.
 	case gatewayv1.PathMatchPathPrefix:
 		// For the '/' path to match all, we just return the item in KongRoute to do the same catch-all match.
 		if value == "/" && !setCaptureGroup {
-			return []string{"/"}, nil
+			return []string{"/"}
 		}
 
 		paths := make([]string, 0, 2)
@@ -316,32 +291,23 @@ func GenerateKongRoutePathFromHTTPRouteMatch(pathMatch *gatewayv1.HTTPPathMatch,
 		if setCaptureGroup {
 			// If the path is "/", we have to skip capturing the slash as Kong Route's path must begin with a slash.
 			if value == "/" {
-				// Keep the default priority for the root capture-group form: it remains the catch-all route.
-				return append(paths, fmt.Sprintf("%s/(.*)", KongPathRegexPrefix)), nil
+				return append(paths, fmt.Sprintf("%s/(.*)", KongPathRegexPrefix))
 			}
 			// When there is a prefix in the route path, we capture the slash and the rest of the path after the prefix.
-			return append(paths, fmt.Sprintf("%s%s%s", KongPathRegexPrefix, path, "(/.*)")), regexPriorityForHTTPPathMatch(matchType, value)
+			return append(paths, fmt.Sprintf("%s%s%s", KongPathRegexPrefix, path, "(/.*)"))
 		}
 
 		if !strings.HasSuffix(path, "/") {
 			path = fmt.Sprintf("%s/", path)
 		}
-		return append(paths, path), regexPriorityForHTTPPathMatch(matchType, value)
+		return append(paths, path)
 
 	// For RegularExpression path match, we simply use the same regex in the paths of KongRoute.
 	case gatewayv1.PathMatchRegularExpression:
 		// Gateway API leaves the precedence of regular-expression path matches implementation-specific.
-		return []string{KongPathRegexPrefix + value}, nil
+		return []string{KongPathRegexPrefix + value}
 	}
-	return nil, nil // Should never be reached.
-}
-
-func regexPriorityForHTTPPathMatch(matchType gatewayv1.PathMatchType, value string) *int64 {
-	priority := KongHTTPRoutePathRegexPriorityOffset + int64(len(value)*2)
-	if matchType == gatewayv1.PathMatchExact {
-		priority++
-	}
-	return &priority
+	return nil // Should never be reached.
 }
 
 // GenerateKongRoutePathFromGRPCMethodMatch translates a GRPCRouteMatch's method matcher into the

--- a/controller/hybridgateway/builder/kongroute.go
+++ b/controller/hybridgateway/builder/kongroute.go
@@ -25,16 +25,14 @@ const (
 	// KongHeaderRegexPrefix is a reserved prefix string that Kong uses to determine if it should parse a header value
 	// as a regex.
 	KongHeaderRegexPrefix = "~*"
+	// KongHTTPRouteHeaderOnlyRegexPath is a catch-all regex path used to make regex_priority effective
+	// for HTTPRoute matches that only match on headers.
+	KongHTTPRouteHeaderOnlyRegexPath = KongPathRegexPrefix + "/(.*)"
 	// KongGRPCRouteCatchAllPath is the synthetic regex path used for GRPCRoute matches that
 	// specify no method matcher at all (Method == nil), which per Gateway API must match every
 	// service and method. GRPCRouteMatch has no path field, so regex_priority (not path
 	// specificity) is what Kong uses to order these against more specific matches.
 	KongGRPCRouteCatchAllPath = KongPathRegexPrefix + "/(.*)"
-	// KongHTTPRouteDefaultPathRegexPath is a catch-all regex path used for HTTPRoute matches
-	// that specify no path or the root path "/". Kong's traditional_compatible router only
-	// applies regex_priority to regex paths, so default-path matches need a regex path to
-	// preserve Gateway API precedence via regex_priority.
-	KongHTTPRouteDefaultPathRegexPath = KongPathRegexPrefix + "/"
 )
 
 // KongRouteBuilder is a builder for configurationv1alpha1.KongRoute resources.
@@ -65,11 +63,8 @@ func (b *KongRouteBuilder) WithProtocols(protocols ...sdkkonnectcomp.Protocols) 
 
 // WithHTTPRouteMatch sets the match criteria (path, method, headers) for the KongRoute.
 func (b *KongRouteBuilder) WithHTTPRouteMatch(match gwtypes.HTTPRouteMatch, setCaptureGroup bool) *KongRouteBuilder {
-	// Path. Nil path (the default match) translates to a catch-all regex path so
-	// Kong's traditional_compatible router applies regex_priority for precedence.
-	if match.Path == nil || match.Path.Value == nil {
-		b.route.Spec.Paths = append(b.route.Spec.Paths, KongHTTPRouteDefaultPathRegexPath)
-	} else {
+	// Path.
+	if match.Path != nil && match.Path.Value != nil {
 		paths := GenerateKongRoutePathFromHTTPRouteMatch(match.Path, setCaptureGroup)
 		b.route.Spec.Paths = append(b.route.Spec.Paths, paths...)
 	}
@@ -124,6 +119,20 @@ func (b *KongRouteBuilder) WithGRPCRouteMatch(match gatewayv1.GRPCRouteMatch) *K
 func (b *KongRouteBuilder) WithRegexPriority(priority *int64) *KongRouteBuilder {
 	if priority != nil {
 		b.route.Spec.RegexPriority = priority
+	}
+	return b
+}
+
+// WithHeaderOnlyRegexPath adds a catch-all regex path when needed so Kong can use
+// regex_priority to order overlapping HTTPRoute matches that only specify headers
+// and otherwise use the default root path.
+func (b *KongRouteBuilder) WithHeaderOnlyRegexPath() *KongRouteBuilder {
+	if len(b.route.Spec.Headers) == 0 {
+		return b
+	}
+
+	if len(b.route.Spec.Paths) == 0 || (len(b.route.Spec.Paths) == 1 && b.route.Spec.Paths[0] == "/") {
+		b.route.Spec.Paths = []string{KongHTTPRouteHeaderOnlyRegexPath}
 	}
 	return b
 }

--- a/controller/hybridgateway/builder/kongroute.go
+++ b/controller/hybridgateway/builder/kongroute.go
@@ -30,6 +30,11 @@ const (
 	// service and method. GRPCRouteMatch has no path field, so regex_priority (not path
 	// specificity) is what Kong uses to order these against more specific matches.
 	KongGRPCRouteCatchAllPath = KongPathRegexPrefix + "/(.*)"
+	// KongHTTPRouteDefaultPathRegexPath is a catch-all regex path used for HTTPRoute matches
+	// that specify no path or the root path "/". Kong's traditional_compatible router only
+	// applies regex_priority to regex paths, so default-path matches need a regex path to
+	// preserve Gateway API precedence via regex_priority.
+	KongHTTPRouteDefaultPathRegexPath = KongPathRegexPrefix + "/"
 )
 
 // KongRouteBuilder is a builder for configurationv1alpha1.KongRoute resources.
@@ -60,8 +65,11 @@ func (b *KongRouteBuilder) WithProtocols(protocols ...sdkkonnectcomp.Protocols) 
 
 // WithHTTPRouteMatch sets the match criteria (path, method, headers) for the KongRoute.
 func (b *KongRouteBuilder) WithHTTPRouteMatch(match gwtypes.HTTPRouteMatch, setCaptureGroup bool) *KongRouteBuilder {
-	// Path.
-	if match.Path != nil && match.Path.Value != nil {
+	// Path. Nil path (the default match) translates to a catch-all regex path so
+	// Kong's traditional_compatible router applies regex_priority for precedence.
+	if match.Path == nil || match.Path.Value == nil {
+		b.route.Spec.Paths = append(b.route.Spec.Paths, KongHTTPRouteDefaultPathRegexPath)
+	} else {
 		paths := GenerateKongRoutePathFromHTTPRouteMatch(match.Path, setCaptureGroup)
 		b.route.Spec.Paths = append(b.route.Spec.Paths, paths...)
 	}

--- a/controller/hybridgateway/builder/kongroute_test.go
+++ b/controller/hybridgateway/builder/kongroute_test.go
@@ -165,9 +165,10 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 				Method: &method,
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
-				assert.Empty(t, route.Spec.Paths)
+				assert.Equal(t, []string{"/"}, route.Spec.Paths)
 				assert.Equal(t, []string{"GET"}, route.Spec.Methods)
 				assert.Nil(t, route.Spec.Headers)
+				assert.Nil(t, route.Spec.RegexPriority)
 			},
 		},
 		{

--- a/controller/hybridgateway/builder/kongroute_test.go
+++ b/controller/hybridgateway/builder/kongroute_test.go
@@ -93,7 +93,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
 				assert.Equal(t, []string{"~/api$", "/api/"}, route.Spec.Paths)
-				assert.Equal(t, new(KongHTTPRoutePathRegexPriorityOffset+8), route.Spec.RegexPriority)
+				assert.Nil(t, route.Spec.RegexPriority)
 				assert.Empty(t, route.Spec.Methods)
 				assert.Nil(t, route.Spec.Headers)
 			},
@@ -108,7 +108,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
 				assert.Equal(t, []string{"~/api$"}, route.Spec.Paths)
-				assert.Equal(t, new(KongHTTPRoutePathRegexPriorityOffset+9), route.Spec.RegexPriority)
+				assert.Nil(t, route.Spec.RegexPriority)
 				assert.Empty(t, route.Spec.Methods)
 				assert.Nil(t, route.Spec.Headers)
 			},
@@ -165,7 +165,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 				Method: &method,
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
-				assert.Equal(t, []string{"/"}, route.Spec.Paths)
+				assert.Empty(t, route.Spec.Paths)
 				assert.Equal(t, []string{"GET"}, route.Spec.Methods)
 				assert.Nil(t, route.Spec.Headers)
 				assert.Nil(t, route.Spec.RegexPriority)
@@ -240,7 +240,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
 				assert.Equal(t, []string{"~/api$", "/api/"}, route.Spec.Paths)
-				assert.Equal(t, new(KongHTTPRoutePathRegexPriorityOffset+8), route.Spec.RegexPriority)
+				assert.Nil(t, route.Spec.RegexPriority)
 				assert.Equal(t, []string{"GET"}, route.Spec.Methods)
 				require.NotNil(t, route.Spec.Headers)
 				assert.Equal(t, []string{"Bearer token"}, route.Spec.Headers["Authorization"])
@@ -280,44 +280,22 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 	}
 }
 
-func TestKongRouteBuilder_WithDefaultPathRegexPathNormalizesRootCaptureGroup(t *testing.T) {
-	match := gwtypes.HTTPRouteMatch{
-		Path: &gatewayv1.HTTPPathMatch{
-			Type:  new(gatewayv1.PathMatchPathPrefix),
-			Value: new("/"),
-		},
-		Method: new(gatewayv1.HTTPMethodGet),
-	}
-	priority := int64(1)
-
-	route, err := NewKongRoute().
-		WithHTTPRouteMatch(match, true).
-		WithRegexPriority(&priority).
-		WithDefaultPathRegexPath().
-		Build()
-	require.NoError(t, err)
-
-	assert.Equal(t, []string{KongHTTPRouteDefaultPathRegexPath}, route.Spec.Paths)
-	assert.Equal(t, []string{"GET"}, route.Spec.Methods)
-	assert.Equal(t, &priority, route.Spec.RegexPriority)
-}
-
-func TestGenerateKongRoutePathFromHTTPRouteMatch_RegexPriorityFollowsSpecificity(t *testing.T) {
-	shortPrefixPaths, shortPrefixPriority := GenerateKongRoutePathFromHTTPRouteMatch(
+func TestGenerateKongRoutePathFromHTTPRouteMatch(t *testing.T) {
+	shortPrefixPaths := GenerateKongRoutePathFromHTTPRouteMatch(
 		&gatewayv1.HTTPPathMatch{
 			Type:  new(gatewayv1.PathMatchPathPrefix),
 			Value: new("/match"),
 		},
 		false,
 	)
-	longPrefixPaths, longPrefixPriority := GenerateKongRoutePathFromHTTPRouteMatch(
+	longPrefixPaths := GenerateKongRoutePathFromHTTPRouteMatch(
 		&gatewayv1.HTTPPathMatch{
 			Type:  new(gatewayv1.PathMatchPathPrefix),
 			Value: new("/match/prefix/one"),
 		},
 		false,
 	)
-	exactPaths, exactPriority := GenerateKongRoutePathFromHTTPRouteMatch(
+	exactPaths := GenerateKongRoutePathFromHTTPRouteMatch(
 		&gatewayv1.HTTPPathMatch{
 			Type:  new(gatewayv1.PathMatchExact),
 			Value: new("/match"),
@@ -328,12 +306,6 @@ func TestGenerateKongRoutePathFromHTTPRouteMatch_RegexPriorityFollowsSpecificity
 	require.Equal(t, []string{"~/match$", "/match/"}, shortPrefixPaths)
 	require.Equal(t, []string{"~/match/prefix/one$", "/match/prefix/one/"}, longPrefixPaths)
 	require.Equal(t, []string{"~/match$"}, exactPaths)
-	require.NotNil(t, shortPrefixPriority)
-	require.NotNil(t, longPrefixPriority)
-	require.NotNil(t, exactPriority)
-
-	assert.Greater(t, *longPrefixPriority, *shortPrefixPriority)
-	assert.Greater(t, *exactPriority, *shortPrefixPriority)
 }
 
 func TestKongRouteBuilder_WithKongService(t *testing.T) {

--- a/controller/hybridgateway/builder/kongroute_test.go
+++ b/controller/hybridgateway/builder/kongroute_test.go
@@ -280,6 +280,28 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 	}
 }
 
+func TestKongRouteBuilder_WithDefaultPathRegexPathNormalizesRootCaptureGroup(t *testing.T) {
+	match := gwtypes.HTTPRouteMatch{
+		Path: &gatewayv1.HTTPPathMatch{
+			Type:  new(gatewayv1.PathMatchPathPrefix),
+			Value: new("/"),
+		},
+		Method: new(gatewayv1.HTTPMethodGet),
+	}
+	priority := int64(1)
+
+	route, err := NewKongRoute().
+		WithHTTPRouteMatch(match, true).
+		WithRegexPriority(&priority).
+		WithDefaultPathRegexPath().
+		Build()
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{KongHTTPRouteDefaultPathRegexPath}, route.Spec.Paths)
+	assert.Equal(t, []string{"GET"}, route.Spec.Methods)
+	assert.Equal(t, &priority, route.Spec.RegexPriority)
+}
+
 func TestGenerateKongRoutePathFromHTTPRouteMatch_RegexPriorityFollowsSpecificity(t *testing.T) {
 	shortPrefixPaths, shortPrefixPriority := GenerateKongRoutePathFromHTTPRouteMatch(
 		&gatewayv1.HTTPPathMatch{

--- a/controller/hybridgateway/builder/kongroute_test.go
+++ b/controller/hybridgateway/builder/kongroute_test.go
@@ -93,7 +93,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
 				assert.Equal(t, []string{"~/api$", "/api/"}, route.Spec.Paths)
-				assert.Equal(t, new(KongHTTPRoutePathRegexPriorityOffset+8), route.Spec.RegexPriority)
+				assert.Nil(t, route.Spec.RegexPriority)
 				assert.Empty(t, route.Spec.Methods)
 				assert.Nil(t, route.Spec.Headers)
 			},
@@ -108,7 +108,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
 				assert.Equal(t, []string{"~/api$"}, route.Spec.Paths)
-				assert.Equal(t, new(KongHTTPRoutePathRegexPriorityOffset+9), route.Spec.RegexPriority)
+				assert.Nil(t, route.Spec.RegexPriority)
 				assert.Empty(t, route.Spec.Methods)
 				assert.Nil(t, route.Spec.Headers)
 			},
@@ -168,6 +168,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 				assert.Empty(t, route.Spec.Paths)
 				assert.Equal(t, []string{"GET"}, route.Spec.Methods)
 				assert.Nil(t, route.Spec.Headers)
+				assert.Nil(t, route.Spec.RegexPriority)
 			},
 		},
 		{
@@ -239,7 +240,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
 				assert.Equal(t, []string{"~/api$", "/api/"}, route.Spec.Paths)
-				assert.Equal(t, new(KongHTTPRoutePathRegexPriorityOffset+8), route.Spec.RegexPriority)
+				assert.Nil(t, route.Spec.RegexPriority)
 				assert.Equal(t, []string{"GET"}, route.Spec.Methods)
 				require.NotNil(t, route.Spec.Headers)
 				assert.Equal(t, []string{"Bearer token"}, route.Spec.Headers["Authorization"])
@@ -279,22 +280,22 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 	}
 }
 
-func TestGenerateKongRoutePathFromHTTPRouteMatch_RegexPriorityFollowsSpecificity(t *testing.T) {
-	shortPrefixPaths, shortPrefixPriority := GenerateKongRoutePathFromHTTPRouteMatch(
+func TestGenerateKongRoutePathFromHTTPRouteMatch(t *testing.T) {
+	shortPrefixPaths := GenerateKongRoutePathFromHTTPRouteMatch(
 		&gatewayv1.HTTPPathMatch{
 			Type:  new(gatewayv1.PathMatchPathPrefix),
 			Value: new("/match"),
 		},
 		false,
 	)
-	longPrefixPaths, longPrefixPriority := GenerateKongRoutePathFromHTTPRouteMatch(
+	longPrefixPaths := GenerateKongRoutePathFromHTTPRouteMatch(
 		&gatewayv1.HTTPPathMatch{
 			Type:  new(gatewayv1.PathMatchPathPrefix),
 			Value: new("/match/prefix/one"),
 		},
 		false,
 	)
-	exactPaths, exactPriority := GenerateKongRoutePathFromHTTPRouteMatch(
+	exactPaths := GenerateKongRoutePathFromHTTPRouteMatch(
 		&gatewayv1.HTTPPathMatch{
 			Type:  new(gatewayv1.PathMatchExact),
 			Value: new("/match"),
@@ -305,12 +306,6 @@ func TestGenerateKongRoutePathFromHTTPRouteMatch_RegexPriorityFollowsSpecificity
 	require.Equal(t, []string{"~/match$", "/match/"}, shortPrefixPaths)
 	require.Equal(t, []string{"~/match/prefix/one$", "/match/prefix/one/"}, longPrefixPaths)
 	require.Equal(t, []string{"~/match$"}, exactPaths)
-	require.NotNil(t, shortPrefixPriority)
-	require.NotNil(t, longPrefixPriority)
-	require.NotNil(t, exactPriority)
-
-	assert.Greater(t, *longPrefixPriority, *shortPrefixPriority)
-	assert.Greater(t, *exactPriority, *shortPrefixPriority)
 }
 
 func TestKongRouteBuilder_WithKongService(t *testing.T) {

--- a/controller/hybridgateway/builder/kongroute_test.go
+++ b/controller/hybridgateway/builder/kongroute_test.go
@@ -165,7 +165,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 				Method: &method,
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
-				assert.Equal(t, []string{"~/"}, route.Spec.Paths)
+				assert.Empty(t, route.Spec.Paths)
 				assert.Equal(t, []string{"GET"}, route.Spec.Methods)
 				assert.Nil(t, route.Spec.Headers)
 				assert.Nil(t, route.Spec.RegexPriority)
@@ -193,7 +193,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 				},
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
-				assert.Equal(t, []string{"~/"}, route.Spec.Paths)
+				assert.Empty(t, route.Spec.Paths)
 				assert.Empty(t, route.Spec.Methods)
 				require.NotNil(t, route.Spec.Headers)
 				assert.Equal(t, []string{"Bearer token"}, route.Spec.Headers["Authorization"])
@@ -255,14 +255,14 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 				},
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
-				assert.Equal(t, []string{"~/"}, route.Spec.Paths)
+				assert.Empty(t, route.Spec.Paths)
 			},
 		},
 		{
 			name:  "empty match",
 			match: gwtypes.HTTPRouteMatch{},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
-				assert.Equal(t, []string{"~/"}, route.Spec.Paths)
+				assert.Empty(t, route.Spec.Paths)
 				assert.Empty(t, route.Spec.Methods)
 				assert.Nil(t, route.Spec.Headers)
 			},

--- a/controller/hybridgateway/builder/kongroute_test.go
+++ b/controller/hybridgateway/builder/kongroute_test.go
@@ -165,7 +165,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 				Method: &method,
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
-				assert.Empty(t, route.Spec.Paths)
+				assert.Equal(t, []string{"~/"}, route.Spec.Paths)
 				assert.Equal(t, []string{"GET"}, route.Spec.Methods)
 				assert.Nil(t, route.Spec.Headers)
 				assert.Nil(t, route.Spec.RegexPriority)
@@ -193,7 +193,7 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 				},
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
-				assert.Empty(t, route.Spec.Paths)
+				assert.Equal(t, []string{"~/"}, route.Spec.Paths)
 				assert.Empty(t, route.Spec.Methods)
 				require.NotNil(t, route.Spec.Headers)
 				assert.Equal(t, []string{"Bearer token"}, route.Spec.Headers["Authorization"])
@@ -255,14 +255,14 @@ func TestKongRouteBuilder_WithHTTPRouteMatch(t *testing.T) {
 				},
 			},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
-				assert.Empty(t, route.Spec.Paths)
+				assert.Equal(t, []string{"~/"}, route.Spec.Paths)
 			},
 		},
 		{
 			name:  "empty match",
 			match: gwtypes.HTTPRouteMatch{},
 			validate: func(t *testing.T, route configurationv1alpha1.KongRoute) {
-				assert.Empty(t, route.Spec.Paths)
+				assert.Equal(t, []string{"~/"}, route.Spec.Paths)
 				assert.Empty(t, route.Spec.Methods)
 				assert.Nil(t, route.Spec.Headers)
 			},

--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -1055,7 +1055,7 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 					}
 
 					routeNames[route.Name] = struct{}{}
-					assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, route.Spec.Paths)
+					assert.Equal(t, []string{routebuilder.KongHTTPRouteDefaultPathRegexPath}, route.Spec.Paths)
 					assert.Empty(t, route.Spec.Methods)
 					require.NotNil(t, route.Spec.RegexPriority)
 					require.NotNil(t, route.Spec.ServiceRef)

--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -25,7 +25,6 @@ import (
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
-	routebuilder "github.com/kong/kong-operator/v2/controller/hybridgateway/builder"
 	routeconst "github.com/kong/kong-operator/v2/controller/hybridgateway/const/route"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/namegen"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
@@ -1046,7 +1045,6 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 				routeNames := map[string]struct{}{}
 				serviceNames := map[string]struct{}{}
 				headersByRoute := map[string]int{}
-				priorityByHeaders := map[string]int64{}
 
 				for _, obj := range store {
 					route, ok := obj.(*configurationv1alpha1.KongRoute)
@@ -1055,9 +1053,9 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 					}
 
 					routeNames[route.Name] = struct{}{}
-					assert.Equal(t, []string{routebuilder.KongHTTPRouteDefaultPathRegexPath}, route.Spec.Paths)
+					assert.Empty(t, route.Spec.Paths)
 					assert.Empty(t, route.Spec.Methods)
-					require.NotNil(t, route.Spec.RegexPriority)
+					assert.Nil(t, route.Spec.RegexPriority)
 					require.NotNil(t, route.Spec.ServiceRef)
 					require.NotNil(t, route.Spec.ServiceRef.NamespacedRef)
 
@@ -1066,7 +1064,6 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 
 					headersKey := canonicalHeaderMatchSet(route.Spec.Headers)
 					headersByRoute[headersKey]++
-					priorityByHeaders[headersKey] = *route.Spec.RegexPriority
 				}
 
 				expectedHeaders := map[string]int{
@@ -1082,8 +1079,6 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 				assert.Len(t, routeNames, 7)
 				assert.Len(t, serviceNames, 1)
 				assert.Equal(t, expectedHeaders, headersByRoute)
-				assert.Greater(t, priorityByHeaders["color=orange&version=two"], priorityByHeaders["version=two"])
-				assert.Greater(t, priorityByHeaders["version=two"], priorityByHeaders["color=blue"])
 			},
 		},
 		{

--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -1043,7 +1043,9 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 					routeNames[route.Name] = struct{}{}
 					assert.Empty(t, route.Spec.Paths)
 					assert.Empty(t, route.Spec.Methods)
-					assert.Nil(t, route.Spec.RegexPriority)
+					// Header-only matches on the default path get an explicit
+					// regex_priority to preserve Gateway API precedence.
+					assert.NotNil(t, route.Spec.RegexPriority)
 					require.NotNil(t, route.Spec.ServiceRef)
 					require.NotNil(t, route.Spec.ServiceRef.NamespacedRef)
 

--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -1041,7 +1041,7 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 					}
 
 					routeNames[route.Name] = struct{}{}
-					assert.Equal(t, []string{"~/"}, route.Spec.Paths)
+					assert.Equal(t, []string{"~/(.*)"}, route.Spec.Paths)
 					assert.Empty(t, route.Spec.Methods)
 					// Header-only matches on the default path get an explicit
 					// regex_priority to preserve Gateway API precedence.

--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -25,7 +25,6 @@ import (
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
-	routebuilder "github.com/kong/kong-operator/v2/controller/hybridgateway/builder"
 	routeconst "github.com/kong/kong-operator/v2/controller/hybridgateway/const/route"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/namegen"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
@@ -1034,7 +1033,6 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 				routeNames := map[string]struct{}{}
 				serviceNames := map[string]struct{}{}
 				headersByRoute := map[string]int{}
-				priorityByHeaders := map[string]int64{}
 
 				for _, obj := range store {
 					route, ok := obj.(*configurationv1alpha1.KongRoute)
@@ -1043,9 +1041,9 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 					}
 
 					routeNames[route.Name] = struct{}{}
-					assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, route.Spec.Paths)
+					assert.Empty(t, route.Spec.Paths)
 					assert.Empty(t, route.Spec.Methods)
-					require.NotNil(t, route.Spec.RegexPriority)
+					assert.Nil(t, route.Spec.RegexPriority)
 					require.NotNil(t, route.Spec.ServiceRef)
 					require.NotNil(t, route.Spec.ServiceRef.NamespacedRef)
 
@@ -1054,7 +1052,6 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 
 					headersKey := canonicalHeaderMatchSet(route.Spec.Headers)
 					headersByRoute[headersKey]++
-					priorityByHeaders[headersKey] = *route.Spec.RegexPriority
 				}
 
 				expectedHeaders := map[string]int{
@@ -1070,8 +1067,6 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 				assert.Len(t, routeNames, 7)
 				assert.Len(t, serviceNames, 1)
 				assert.Equal(t, expectedHeaders, headersByRoute)
-				assert.Greater(t, priorityByHeaders["color=orange&version=two"], priorityByHeaders["version=two"])
-				assert.Greater(t, priorityByHeaders["version=two"], priorityByHeaders["color=blue"])
 			},
 		},
 		{

--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -1041,7 +1041,7 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 					}
 
 					routeNames[route.Name] = struct{}{}
-					assert.Empty(t, route.Spec.Paths)
+					assert.Equal(t, []string{"~/"}, route.Spec.Paths)
 					assert.Empty(t, route.Spec.Methods)
 					// Header-only matches on the default path get an explicit
 					// regex_priority to preserve Gateway API precedence.

--- a/controller/hybridgateway/kongroute/route.go
+++ b/controller/hybridgateway/kongroute/route.go
@@ -124,6 +124,7 @@ func RoutesForHTTPRouteRule(
 	// Check filters to determine if we need capture groups in paths.
 	setCaptureGroup := needsCaptureGroup(rule)
 	priorities := httpRouteMatchPriorities(httpRoute)
+	hasDefaultPathMethodOnlyMatch := hasDefaultPathMethodOnlyHTTPRouteMatch(httpRoute)
 
 	stripPath, err := metadata.ExtractStripPath(httpRoute.Annotations)
 	if err != nil {
@@ -155,7 +156,9 @@ func RoutesForHTTPRouteRule(
 			WithSpecTags(tags).
 			WithKongService(serviceName).
 			WithHTTPRouteMatch(match, setCaptureGroup)
-		if priority := priorityForHeaderOnlyHTTPRouteMatch(match, priorities, ruleIndex, i); priority != nil {
+		if priority := priorityForHeaderOnlyHTTPRouteMatch(
+			match, priorities, ruleIndex, i, hasDefaultPathMethodOnlyMatch,
+		); priority != nil {
 			routeBuilder.WithRegexPriority(priority).WithHeaderOnlyRegexPath()
 		}
 
@@ -236,8 +239,16 @@ func priorityForHeaderOnlyHTTPRouteMatch(
 	match gatewayv1.HTTPRouteMatch,
 	priorities map[httpRouteMatchPriorityKey]int64,
 	ruleIndex, matchIndex int,
+	hasDefaultPathMethodOnlyMatch bool,
 ) *int64 {
 	if !isHeaderOnlyDefaultPathHTTPRouteMatch(match) {
+		return nil
+	}
+	if hasDefaultPathMethodOnlyMatch && match.Method == nil {
+		// Keep method-less header routes below default-path method-only routes:
+		// adding the synthetic path would give both routes the same Kong match
+		// weight, after which Kong's header-count tie breaker would pick the
+		// header route instead of the Gateway API method-precedence route.
 		return nil
 	}
 	priority := priorityForHTTPRouteMatch(priorities, ruleIndex, matchIndex)
@@ -248,6 +259,26 @@ func isHeaderOnlyDefaultPathHTTPRouteMatch(match gatewayv1.HTTPRouteMatch) bool 
 	if len(match.Headers) == 0 {
 		return false
 	}
+	return isDefaultPathHTTPRouteMatch(match)
+}
+
+func hasDefaultPathMethodOnlyHTTPRouteMatch(httpRoute *gwtypes.HTTPRoute) bool {
+	for _, rule := range httpRoute.Spec.Rules {
+		if slices.ContainsFunc(rule.Matches, isDefaultPathMethodOnlyHTTPRouteMatch) {
+			return true
+		}
+	}
+	return false
+}
+
+func isDefaultPathMethodOnlyHTTPRouteMatch(match gatewayv1.HTTPRouteMatch) bool {
+	return match.Method != nil &&
+		len(match.Headers) == 0 &&
+		len(match.QueryParams) == 0 &&
+		isDefaultPathHTTPRouteMatch(match)
+}
+
+func isDefaultPathHTTPRouteMatch(match gatewayv1.HTTPRouteMatch) bool {
 	if match.Path == nil {
 		return true
 	}

--- a/controller/hybridgateway/kongroute/route.go
+++ b/controller/hybridgateway/kongroute/route.go
@@ -124,7 +124,6 @@ func RoutesForHTTPRouteRule(
 	// Check filters to determine if we need capture groups in paths.
 	setCaptureGroup := needsCaptureGroup(rule)
 	priorities := httpRouteMatchPriorities(httpRoute)
-	hasDefaultPathMethodOnlyMatch := hasDefaultPathMethodOnlyHTTPRouteMatch(httpRoute)
 
 	stripPath, err := metadata.ExtractStripPath(httpRoute.Annotations)
 	if err != nil {
@@ -156,10 +155,8 @@ func RoutesForHTTPRouteRule(
 			WithSpecTags(tags).
 			WithKongService(serviceName).
 			WithHTTPRouteMatch(match, setCaptureGroup)
-		if priority := priorityForHeaderOnlyHTTPRouteMatch(
-			match, priorities, ruleIndex, i, hasDefaultPathMethodOnlyMatch,
-		); priority != nil {
-			routeBuilder.WithRegexPriority(priority).WithHeaderOnlyRegexPath()
+		if priority := priorityForDefaultPathHTTPRouteMatch(match, priorities, ruleIndex, i); priority != nil {
+			routeBuilder.WithRegexPriority(priority).WithDefaultPathRegexPath()
 		}
 
 		newRoute, buildErr := routeBuilder.Build()
@@ -235,47 +232,16 @@ func httpRouteMatchPriorities(httpRoute *gwtypes.HTTPRoute) map[httpRouteMatchPr
 	return priorities
 }
 
-func priorityForHeaderOnlyHTTPRouteMatch(
+func priorityForDefaultPathHTTPRouteMatch(
 	match gatewayv1.HTTPRouteMatch,
 	priorities map[httpRouteMatchPriorityKey]int64,
 	ruleIndex, matchIndex int,
-	hasDefaultPathMethodOnlyMatch bool,
 ) *int64 {
-	if !isHeaderOnlyDefaultPathHTTPRouteMatch(match) {
-		return nil
-	}
-	if hasDefaultPathMethodOnlyMatch && match.Method == nil {
-		// Keep method-less header routes below default-path method-only routes:
-		// adding the synthetic path would give both routes the same Kong match
-		// weight, after which Kong's header-count tie breaker would pick the
-		// header route instead of the Gateway API method-precedence route.
+	if !isDefaultPathHTTPRouteMatch(match) || (match.Method == nil && len(match.Headers) == 0) {
 		return nil
 	}
 	priority := priorityForHTTPRouteMatch(priorities, ruleIndex, matchIndex)
 	return &priority
-}
-
-func isHeaderOnlyDefaultPathHTTPRouteMatch(match gatewayv1.HTTPRouteMatch) bool {
-	if len(match.Headers) == 0 {
-		return false
-	}
-	return isDefaultPathHTTPRouteMatch(match)
-}
-
-func hasDefaultPathMethodOnlyHTTPRouteMatch(httpRoute *gwtypes.HTTPRoute) bool {
-	for _, rule := range httpRoute.Spec.Rules {
-		if slices.ContainsFunc(rule.Matches, isDefaultPathMethodOnlyHTTPRouteMatch) {
-			return true
-		}
-	}
-	return false
-}
-
-func isDefaultPathMethodOnlyHTTPRouteMatch(match gatewayv1.HTTPRouteMatch) bool {
-	return match.Method != nil &&
-		len(match.Headers) == 0 &&
-		len(match.QueryParams) == 0 &&
-		isDefaultPathHTTPRouteMatch(match)
 }
 
 func isDefaultPathHTTPRouteMatch(match gatewayv1.HTTPRouteMatch) bool {
@@ -299,7 +265,10 @@ func priorityForHTTPRouteMatch(priorities map[httpRouteMatchPriorityKey]int64, r
 
 func calculateHTTPRoutePriorityClass(match gatewayv1.HTTPRouteMatch) httpRoutePriorityClass {
 	class := httpRoutePriorityClass{}
-	if match.Path != nil {
+	if isDefaultPathHTTPRouteMatch(match) {
+		class.pathType = gatewayv1.PathMatchPathPrefix
+		class.pathLength = len("/")
+	} else if match.Path != nil {
 		class.pathType = gatewayv1.PathMatchPathPrefix
 		if match.Path.Type != nil {
 			class.pathType = *match.Path.Type

--- a/controller/hybridgateway/kongroute/route.go
+++ b/controller/hybridgateway/kongroute/route.go
@@ -3,6 +3,7 @@ package kongroute
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -150,41 +151,42 @@ func RoutesForHTTPRouteRule(
 	tags := pkgmetadata.ExtractTags(httpRoute)
 
 	for i, match := range rule.Matches {
-		routeName := namegen.NewKongRouteNameForMatch(httpRoute, cp, namingParentRef, match, i)
-		mLog := logger.WithValues("kongroute", routeName, "matchIndex", i)
-		log.Debug(mLog, "Creating KongRoute for HTTPRoute match")
+		variants := precedenceVariantsForHTTPRouteMatch(httpRoute, match, priorities, ruleIndex, i)
+		for variantIndex, variant := range variants {
+			nameIndex := i + variantIndex*len(rule.Matches)
+			routeName := namegen.NewKongRouteNameForMatch(httpRoute, cp, namingParentRef, variant, nameIndex)
+			mLog := logger.WithValues("kongroute", routeName, "matchIndex", i, "precedenceVariant", variantIndex)
+			log.Debug(mLog, "Creating KongRoute for HTTPRoute match")
 
-		routeBuilder := builder.NewKongRoute().
-			WithName(routeName).
-			WithNamespace(metadata.NamespaceFromParentRef(httpRoute, pRef)).
-			WithLabels(httpRoute, pRef).
-			WithAnnotations(httpRoute, pRef).
-			WithSpecName(routeName).
-			WithProtocols(protocols...).
-			WithHosts(hostnames).
-			WithStripPath(stripPath).
-			WithPreserveHost(preserveHost).
-			WithSpecTags(tags).
-			WithKongService(serviceName).
-			WithHTTPRouteMatch(match, setCaptureGroup)
-		if priority := priorityForHeaderOnlyHTTPRouteMatch(match, priorities, ruleIndex, i); priority != nil {
-			routeBuilder.WithRegexPriority(priority).WithHeaderOnlyRegexPath()
+			routeBuilder := builder.NewKongRoute().
+				WithName(routeName).
+				WithNamespace(metadata.NamespaceFromParentRef(httpRoute, pRef)).
+				WithLabels(httpRoute, pRef).
+				WithAnnotations(httpRoute, pRef).
+				WithSpecName(routeName).
+				WithProtocols(protocols...).
+				WithHosts(hostnames).
+				WithStripPath(stripPath).
+				WithPreserveHost(preserveHost).
+				WithSpecTags(tags).
+				WithKongService(serviceName).
+				WithHTTPRouteMatch(variant, setCaptureGroup)
+			if priority := priorityForTraditionalHTTPRouteMatch(match, priorities, ruleIndex, i); priority != nil {
+				routeBuilder.WithRegexPriority(priority)
+			}
+
+			newRoute, buildErr := routeBuilder.Build()
+			if buildErr != nil {
+				log.Error(mLog, buildErr, "Failed to build KongRoute resource")
+				return nil, fmt.Errorf("failed to build KongRoute %s: %w", routeName, buildErr)
+			}
+
+			if _, updErr := translator.VerifyAndUpdate(ctx, mLog, cl, &newRoute, httpRoute, true); updErr != nil {
+				return nil, updErr
+			}
+
+			kongRoutes = append(kongRoutes, newRoute.DeepCopy())
 		}
-
-		newRoute, buildErr := routeBuilder.Build()
-		if buildErr != nil {
-			log.Error(mLog, buildErr, "Failed to build KongRoute resource")
-			return nil, fmt.Errorf("failed to build KongRoute %s: %w", routeName, buildErr)
-		}
-
-		if _, updErr := translator.VerifyAndUpdate(ctx, mLog, cl, &newRoute, httpRoute, true); updErr != nil {
-			return nil, updErr
-		}
-
-		// Add to result slice as an explicit copy for clarity.
-		// Using DeepCopy expresses the intent that each match yields an
-		// independent KongRoute object.
-		kongRoutes = append(kongRoutes, newRoute.DeepCopy())
 	}
 
 	return kongRoutes, nil
@@ -425,22 +427,177 @@ func httpRouteMatchPriorities(httpRoute *gwtypes.HTTPRoute) map[httpRouteMatchPr
 	return priorities
 }
 
-func priorityForHeaderOnlyHTTPRouteMatch(
+func priorityForTraditionalHTTPRouteMatch(
 	match gatewayv1.HTTPRouteMatch,
 	priorities map[httpRouteMatchPriorityKey]int64,
 	ruleIndex, matchIndex int,
 ) *int64 {
-	if !isHeaderOnlyDefaultPathHTTPRouteMatch(match) {
+	if isDefaultPathHTTPRouteMatch(match) || match.Path == nil || match.Path.Value == nil {
+		return nil
+	}
+	pathType := gatewayv1.PathMatchPathPrefix
+	if match.Path.Type != nil {
+		pathType = *match.Path.Type
+	}
+	// Gateway API leaves RegularExpression precedence implementation-specific.
+	if pathType == gatewayv1.PathMatchRegularExpression {
 		return nil
 	}
 	priority := priorityForHTTPRouteMatch(priorities, ruleIndex, matchIndex)
 	return &priority
 }
 
-func isHeaderOnlyDefaultPathHTTPRouteMatch(match gatewayv1.HTTPRouteMatch) bool {
-	if len(match.Headers) == 0 {
-		return false
+// precedenceVariantsForHTTPRouteMatch returns the original match plus specialized copies that
+// include the non-path constraints of lower-priority matches it can overlap. Kong's traditional
+// router considers the number of populated match fields before regex_priority. Without these
+// copies a less-specific method or header match can beat a more-specific path match regardless of
+// regex_priority. The specialized copy has at least the same native Kong specificity as the lower
+// match, after which path length/type and regex_priority preserve Gateway API precedence. The
+// original copy remains necessary for requests that do not satisfy any lower match's constraints.
+func precedenceVariantsForHTTPRouteMatch(
+	httpRoute *gwtypes.HTTPRoute,
+	match gatewayv1.HTTPRouteMatch,
+	priorities map[httpRouteMatchPriorityKey]int64,
+	ruleIndex, matchIndex int,
+) []gatewayv1.HTTPRouteMatch {
+	variants := []gatewayv1.HTTPRouteMatch{*match.DeepCopy()}
+	priority := priorityForHTTPRouteMatch(priorities, ruleIndex, matchIndex)
+
+	for lowerRuleIndex, rule := range httpRoute.Spec.Rules {
+		for lowerMatchIndex, lower := range rule.Matches {
+			if priorityForHTTPRouteMatch(priorities, lowerRuleIndex, lowerMatchIndex) >= priority {
+				continue
+			}
+			if !needsPrecedenceVariant(match, lower) {
+				continue
+			}
+			variant, changed, overlaps := augmentHTTPRouteMatch(match, lower)
+			if !changed || !overlaps || slices.ContainsFunc(variants, func(existing gatewayv1.HTTPRouteMatch) bool {
+				return reflect.DeepEqual(existing, variant)
+			}) {
+				continue
+			}
+			variants = append(variants, variant)
+		}
 	}
+
+	return variants
+}
+
+func needsPrecedenceVariant(higher, lower gatewayv1.HTTPRouteMatch) bool {
+	higherWeight := traditionalKongMatchWeight(higher)
+	lowerWeight := traditionalKongMatchWeight(lower)
+	if lowerWeight != higherWeight {
+		return lowerWeight > higherWeight
+	}
+	return countEffectiveHTTPHeaderMatches(lower.Headers) > countEffectiveHTTPHeaderMatches(higher.Headers)
+}
+
+// traditionalKongMatchWeight returns the portion of Kong's traditional-compatible priority that
+// is determined before regex_priority for the fields produced from an HTTPRouteMatch. Hostnames
+// and protocols are omitted because they are identical for every match of the parent HTTPRoute.
+func traditionalKongMatchWeight(match gatewayv1.HTTPRouteMatch) int {
+	weight := 0
+	if match.Path != nil && match.Path.Value != nil {
+		weight++
+	}
+	if match.Method != nil {
+		weight++
+	}
+	if len(match.Headers) > 0 {
+		weight++
+	}
+	return weight
+}
+
+func augmentHTTPRouteMatch(
+	higher gatewayv1.HTTPRouteMatch,
+	lower gatewayv1.HTTPRouteMatch,
+) (gatewayv1.HTTPRouteMatch, bool, bool) {
+	if !httpRoutePathsCanOverlap(higher.Path, lower.Path) {
+		return gatewayv1.HTTPRouteMatch{}, false, false
+	}
+
+	variant := *higher.DeepCopy()
+	changed := false
+	if variant.Method != nil && lower.Method != nil && *variant.Method != *lower.Method {
+		return gatewayv1.HTTPRouteMatch{}, false, false
+	}
+	if variant.Method == nil && lower.Method != nil {
+		variant.Method = new(*lower.Method)
+		changed = true
+	}
+
+	for _, lowerHeader := range lower.Headers {
+		matchingHeader := slices.IndexFunc(variant.Headers, func(h gatewayv1.HTTPHeaderMatch) bool {
+			return strings.EqualFold(string(h.Name), string(lowerHeader.Name))
+		})
+		if matchingHeader < 0 {
+			variant.Headers = append(variant.Headers, *lowerHeader.DeepCopy())
+			changed = true
+			continue
+		}
+		if !httpHeaderMatchesEqual(variant.Headers[matchingHeader], lowerHeader) {
+			// Exact matches with different values cannot overlap. Intersections involving
+			// regular-expression header matches cannot be represented by a KongRoute header
+			// value list (which is ORed), so leave those implementation-specific cases alone.
+			return gatewayv1.HTTPRouteMatch{}, false, false
+		}
+	}
+
+	return variant, changed, true
+}
+
+func httpHeaderMatchesEqual(a, b gatewayv1.HTTPHeaderMatch) bool {
+	aType := gatewayv1.HeaderMatchExact
+	if a.Type != nil {
+		aType = *a.Type
+	}
+	bType := gatewayv1.HeaderMatchExact
+	if b.Type != nil {
+		bType = *b.Type
+	}
+	return strings.EqualFold(string(a.Name), string(b.Name)) && aType == bType && a.Value == b.Value
+}
+
+func httpRoutePathsCanOverlap(a, b *gatewayv1.HTTPPathMatch) bool {
+	aType, aValue := normalizedHTTPPathMatch(a)
+	bType, bValue := normalizedHTTPPathMatch(b)
+	if aType == gatewayv1.PathMatchRegularExpression || bType == gatewayv1.PathMatchRegularExpression {
+		return true
+	}
+	if aType == gatewayv1.PathMatchExact && bType == gatewayv1.PathMatchExact {
+		return aValue == bValue
+	}
+	if aType == gatewayv1.PathMatchExact {
+		return httpPathPrefixMatches(bValue, aValue)
+	}
+	if bType == gatewayv1.PathMatchExact {
+		return httpPathPrefixMatches(aValue, bValue)
+	}
+	return httpPathPrefixMatches(aValue, bValue) || httpPathPrefixMatches(bValue, aValue)
+}
+
+func normalizedHTTPPathMatch(path *gatewayv1.HTTPPathMatch) (gatewayv1.PathMatchType, string) {
+	if path == nil || path.Value == nil {
+		return gatewayv1.PathMatchPathPrefix, "/"
+	}
+	pathType := gatewayv1.PathMatchPathPrefix
+	if path.Type != nil {
+		pathType = *path.Type
+	}
+	return pathType, *path.Value
+}
+
+func httpPathPrefixMatches(prefix, path string) bool {
+	if prefix == "/" || prefix == path {
+		return true
+	}
+	prefix = strings.TrimSuffix(prefix, "/")
+	return strings.HasPrefix(path, prefix+"/")
+}
+
+func isDefaultPathHTTPRouteMatch(match gatewayv1.HTTPRouteMatch) bool {
 	if match.Path == nil {
 		return true
 	}
@@ -461,7 +618,10 @@ func priorityForHTTPRouteMatch(priorities map[httpRouteMatchPriorityKey]int64, r
 
 func calculateHTTPRoutePriorityClass(match gatewayv1.HTTPRouteMatch) httpRoutePriorityClass {
 	class := httpRoutePriorityClass{}
-	if match.Path != nil {
+	if isDefaultPathHTTPRouteMatch(match) {
+		class.pathType = gatewayv1.PathMatchPathPrefix
+		class.pathLength = len("/")
+	} else if match.Path != nil {
 		class.pathType = gatewayv1.PathMatchPathPrefix
 		if match.Path.Type != nil {
 			class.pathType = *match.Path.Type

--- a/controller/hybridgateway/kongroute/route.go
+++ b/controller/hybridgateway/kongroute/route.go
@@ -3,6 +3,7 @@ package kongroute
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -138,41 +139,42 @@ func RoutesForHTTPRouteRule(
 	tags := pkgmetadata.ExtractTags(httpRoute)
 
 	for i, match := range rule.Matches {
-		routeName := namegen.NewKongRouteNameForMatch(httpRoute, cp, namingParentRef, match, i)
-		mLog := logger.WithValues("kongroute", routeName, "matchIndex", i)
-		log.Debug(mLog, "Creating KongRoute for HTTPRoute match")
+		variants := precedenceVariantsForHTTPRouteMatch(httpRoute, match, priorities, ruleIndex, i)
+		for variantIndex, variant := range variants {
+			nameIndex := i + variantIndex*len(rule.Matches)
+			routeName := namegen.NewKongRouteNameForMatch(httpRoute, cp, namingParentRef, variant, nameIndex)
+			mLog := logger.WithValues("kongroute", routeName, "matchIndex", i, "precedenceVariant", variantIndex)
+			log.Debug(mLog, "Creating KongRoute for HTTPRoute match")
 
-		routeBuilder := builder.NewKongRoute().
-			WithName(routeName).
-			WithNamespace(metadata.NamespaceFromParentRef(httpRoute, pRef)).
-			WithLabels(httpRoute, pRef).
-			WithAnnotations(httpRoute, pRef).
-			WithSpecName(routeName).
-			WithProtocols(protocols...).
-			WithHosts(hostnames).
-			WithStripPath(stripPath).
-			WithPreserveHost(preserveHost).
-			WithSpecTags(tags).
-			WithKongService(serviceName).
-			WithHTTPRouteMatch(match, setCaptureGroup)
-		if priority := priorityForDefaultPathHTTPRouteMatch(match, priorities, ruleIndex, i); priority != nil {
-			routeBuilder.WithRegexPriority(priority).WithDefaultPathRegexPath()
+			routeBuilder := builder.NewKongRoute().
+				WithName(routeName).
+				WithNamespace(metadata.NamespaceFromParentRef(httpRoute, pRef)).
+				WithLabels(httpRoute, pRef).
+				WithAnnotations(httpRoute, pRef).
+				WithSpecName(routeName).
+				WithProtocols(protocols...).
+				WithHosts(hostnames).
+				WithStripPath(stripPath).
+				WithPreserveHost(preserveHost).
+				WithSpecTags(tags).
+				WithKongService(serviceName).
+				WithHTTPRouteMatch(variant, setCaptureGroup)
+			if priority := priorityForTraditionalHTTPRouteMatch(match, priorities, ruleIndex, i); priority != nil {
+				routeBuilder.WithRegexPriority(priority)
+			}
+
+			newRoute, buildErr := routeBuilder.Build()
+			if buildErr != nil {
+				log.Error(mLog, buildErr, "Failed to build KongRoute resource")
+				return nil, fmt.Errorf("failed to build KongRoute %s: %w", routeName, buildErr)
+			}
+
+			if _, updErr := translator.VerifyAndUpdate(ctx, mLog, cl, &newRoute, httpRoute, true); updErr != nil {
+				return nil, updErr
+			}
+
+			kongRoutes = append(kongRoutes, newRoute.DeepCopy())
 		}
-
-		newRoute, buildErr := routeBuilder.Build()
-		if buildErr != nil {
-			log.Error(mLog, buildErr, "Failed to build KongRoute resource")
-			return nil, fmt.Errorf("failed to build KongRoute %s: %w", routeName, buildErr)
-		}
-
-		if _, updErr := translator.VerifyAndUpdate(ctx, mLog, cl, &newRoute, httpRoute, true); updErr != nil {
-			return nil, updErr
-		}
-
-		// Add to result slice as an explicit copy for clarity.
-		// Using DeepCopy expresses the intent that each match yields an
-		// independent KongRoute object.
-		kongRoutes = append(kongRoutes, newRoute.DeepCopy())
 	}
 
 	return kongRoutes, nil
@@ -232,16 +234,174 @@ func httpRouteMatchPriorities(httpRoute *gwtypes.HTTPRoute) map[httpRouteMatchPr
 	return priorities
 }
 
-func priorityForDefaultPathHTTPRouteMatch(
+func priorityForTraditionalHTTPRouteMatch(
 	match gatewayv1.HTTPRouteMatch,
 	priorities map[httpRouteMatchPriorityKey]int64,
 	ruleIndex, matchIndex int,
 ) *int64 {
-	if !isDefaultPathHTTPRouteMatch(match) || (match.Method == nil && len(match.Headers) == 0) {
+	if isDefaultPathHTTPRouteMatch(match) || match.Path == nil || match.Path.Value == nil {
+		return nil
+	}
+	pathType := gatewayv1.PathMatchPathPrefix
+	if match.Path.Type != nil {
+		pathType = *match.Path.Type
+	}
+	// Gateway API leaves RegularExpression precedence implementation-specific.
+	if pathType == gatewayv1.PathMatchRegularExpression {
 		return nil
 	}
 	priority := priorityForHTTPRouteMatch(priorities, ruleIndex, matchIndex)
 	return &priority
+}
+
+// precedenceVariantsForHTTPRouteMatch returns the original match plus specialized copies that
+// include the non-path constraints of lower-priority matches it can overlap. Kong's traditional
+// router considers the number of populated match fields before regex_priority. Without these
+// copies a less-specific method or header match can beat a more-specific path match regardless of
+// regex_priority. The specialized copy has at least the same native Kong specificity as the lower
+// match, after which path length/type and regex_priority preserve Gateway API precedence. The
+// original copy remains necessary for requests that do not satisfy any lower match's constraints.
+func precedenceVariantsForHTTPRouteMatch(
+	httpRoute *gwtypes.HTTPRoute,
+	match gatewayv1.HTTPRouteMatch,
+	priorities map[httpRouteMatchPriorityKey]int64,
+	ruleIndex, matchIndex int,
+) []gatewayv1.HTTPRouteMatch {
+	variants := []gatewayv1.HTTPRouteMatch{*match.DeepCopy()}
+	priority := priorityForHTTPRouteMatch(priorities, ruleIndex, matchIndex)
+
+	for lowerRuleIndex, rule := range httpRoute.Spec.Rules {
+		for lowerMatchIndex, lower := range rule.Matches {
+			if priorityForHTTPRouteMatch(priorities, lowerRuleIndex, lowerMatchIndex) >= priority {
+				continue
+			}
+			if !needsPrecedenceVariant(match, lower) {
+				continue
+			}
+			variant, changed, overlaps := augmentHTTPRouteMatch(match, lower)
+			if !changed || !overlaps || slices.ContainsFunc(variants, func(existing gatewayv1.HTTPRouteMatch) bool {
+				return reflect.DeepEqual(existing, variant)
+			}) {
+				continue
+			}
+			variants = append(variants, variant)
+		}
+	}
+
+	return variants
+}
+
+func needsPrecedenceVariant(higher, lower gatewayv1.HTTPRouteMatch) bool {
+	higherWeight := traditionalKongMatchWeight(higher)
+	lowerWeight := traditionalKongMatchWeight(lower)
+	if lowerWeight != higherWeight {
+		return lowerWeight > higherWeight
+	}
+	return countEffectiveHTTPHeaderMatches(lower.Headers) > countEffectiveHTTPHeaderMatches(higher.Headers)
+}
+
+// traditionalKongMatchWeight returns the portion of Kong's traditional-compatible priority that
+// is determined before regex_priority for the fields produced from an HTTPRouteMatch. Hostnames
+// and protocols are omitted because they are identical for every match of the parent HTTPRoute.
+func traditionalKongMatchWeight(match gatewayv1.HTTPRouteMatch) int {
+	weight := 0
+	if match.Path != nil && match.Path.Value != nil {
+		weight++
+	}
+	if match.Method != nil {
+		weight++
+	}
+	if len(match.Headers) > 0 {
+		weight++
+	}
+	return weight
+}
+
+func augmentHTTPRouteMatch(
+	higher gatewayv1.HTTPRouteMatch,
+	lower gatewayv1.HTTPRouteMatch,
+) (gatewayv1.HTTPRouteMatch, bool, bool) {
+	if !httpRoutePathsCanOverlap(higher.Path, lower.Path) {
+		return gatewayv1.HTTPRouteMatch{}, false, false
+	}
+
+	variant := *higher.DeepCopy()
+	changed := false
+	if variant.Method != nil && lower.Method != nil && *variant.Method != *lower.Method {
+		return gatewayv1.HTTPRouteMatch{}, false, false
+	}
+	if variant.Method == nil && lower.Method != nil {
+		variant.Method = new(*lower.Method)
+		changed = true
+	}
+
+	for _, lowerHeader := range lower.Headers {
+		matchingHeader := slices.IndexFunc(variant.Headers, func(h gatewayv1.HTTPHeaderMatch) bool {
+			return strings.EqualFold(string(h.Name), string(lowerHeader.Name))
+		})
+		if matchingHeader < 0 {
+			variant.Headers = append(variant.Headers, *lowerHeader.DeepCopy())
+			changed = true
+			continue
+		}
+		if !httpHeaderMatchesEqual(variant.Headers[matchingHeader], lowerHeader) {
+			// Exact matches with different values cannot overlap. Intersections involving
+			// regular-expression header matches cannot be represented by a KongRoute header
+			// value list (which is ORed), so leave those implementation-specific cases alone.
+			return gatewayv1.HTTPRouteMatch{}, false, false
+		}
+	}
+
+	return variant, changed, true
+}
+
+func httpHeaderMatchesEqual(a, b gatewayv1.HTTPHeaderMatch) bool {
+	aType := gatewayv1.HeaderMatchExact
+	if a.Type != nil {
+		aType = *a.Type
+	}
+	bType := gatewayv1.HeaderMatchExact
+	if b.Type != nil {
+		bType = *b.Type
+	}
+	return strings.EqualFold(string(a.Name), string(b.Name)) && aType == bType && a.Value == b.Value
+}
+
+func httpRoutePathsCanOverlap(a, b *gatewayv1.HTTPPathMatch) bool {
+	aType, aValue := normalizedHTTPPathMatch(a)
+	bType, bValue := normalizedHTTPPathMatch(b)
+	if aType == gatewayv1.PathMatchRegularExpression || bType == gatewayv1.PathMatchRegularExpression {
+		return true
+	}
+	if aType == gatewayv1.PathMatchExact && bType == gatewayv1.PathMatchExact {
+		return aValue == bValue
+	}
+	if aType == gatewayv1.PathMatchExact {
+		return httpPathPrefixMatches(bValue, aValue)
+	}
+	if bType == gatewayv1.PathMatchExact {
+		return httpPathPrefixMatches(aValue, bValue)
+	}
+	return httpPathPrefixMatches(aValue, bValue) || httpPathPrefixMatches(bValue, aValue)
+}
+
+func normalizedHTTPPathMatch(path *gatewayv1.HTTPPathMatch) (gatewayv1.PathMatchType, string) {
+	if path == nil || path.Value == nil {
+		return gatewayv1.PathMatchPathPrefix, "/"
+	}
+	pathType := gatewayv1.PathMatchPathPrefix
+	if path.Type != nil {
+		pathType = *path.Type
+	}
+	return pathType, *path.Value
+}
+
+func httpPathPrefixMatches(prefix, path string) bool {
+	if prefix == "/" || prefix == path {
+		return true
+	}
+	prefix = strings.TrimSuffix(prefix, "/")
+	return strings.HasPrefix(path, prefix+"/")
 }
 
 func isDefaultPathHTTPRouteMatch(match gatewayv1.HTTPRouteMatch) bool {

--- a/controller/hybridgateway/kongroute/route.go
+++ b/controller/hybridgateway/kongroute/route.go
@@ -171,7 +171,9 @@ func RoutesForHTTPRouteRule(
 				WithSpecTags(tags).
 				WithKongService(serviceName).
 				WithHTTPRouteMatch(variant, setCaptureGroup)
-			if priority := priorityForTraditionalHTTPRouteMatch(match, priorities, ruleIndex, i); priority != nil {
+			if priority := priorityForHeaderOnlyHTTPRouteMatch(match, priorities, ruleIndex, i); priority != nil {
+				routeBuilder.WithRegexPriority(priority).WithHeaderOnlyRegexPath()
+			} else if priority := priorityForTraditionalHTTPRouteMatch(match, priorities, ruleIndex, i); priority != nil {
 				routeBuilder.WithRegexPriority(priority)
 			}
 
@@ -427,6 +429,18 @@ func httpRouteMatchPriorities(httpRoute *gwtypes.HTTPRoute) map[httpRouteMatchPr
 	return priorities
 }
 
+func priorityForHeaderOnlyHTTPRouteMatch(
+	match gatewayv1.HTTPRouteMatch,
+	priorities map[httpRouteMatchPriorityKey]int64,
+	ruleIndex, matchIndex int,
+) *int64 {
+	if !isHeaderOnlyDefaultPathHTTPRouteMatch(match) {
+		return nil
+	}
+	priority := priorityForHTTPRouteMatch(priorities, ruleIndex, matchIndex)
+	return &priority
+}
+
 func priorityForTraditionalHTTPRouteMatch(
 	match gatewayv1.HTTPRouteMatch,
 	priorities map[httpRouteMatchPriorityKey]int64,
@@ -606,6 +620,21 @@ func httpPathPrefixMatches(prefix, path string) bool {
 }
 
 func isDefaultPathHTTPRouteMatch(match gatewayv1.HTTPRouteMatch) bool {
+	if match.Path == nil {
+		return true
+	}
+
+	pathType := gatewayv1.PathMatchPathPrefix
+	if match.Path.Type != nil {
+		pathType = *match.Path.Type
+	}
+	return pathType == gatewayv1.PathMatchPathPrefix && match.Path.Value != nil && *match.Path.Value == "/"
+}
+
+func isHeaderOnlyDefaultPathHTTPRouteMatch(match gatewayv1.HTTPRouteMatch) bool {
+	if len(match.Headers) == 0 {
+		return false
+	}
 	if match.Path == nil {
 		return true
 	}

--- a/controller/hybridgateway/kongroute/route.go
+++ b/controller/hybridgateway/kongroute/route.go
@@ -432,7 +432,15 @@ func priorityForTraditionalHTTPRouteMatch(
 	priorities map[httpRouteMatchPriorityKey]int64,
 	ruleIndex, matchIndex int,
 ) *int64 {
-	if isDefaultPathHTTPRouteMatch(match) || match.Path == nil || match.Path.Value == nil {
+	// Matches on the default path (nil or "/") need an explicit regex_priority to
+	// preserve Gateway API precedence, since Kong weighs populated match fields
+	// before regex_priority and would otherwise treat all default-path matches as
+	// equally specific regardless of their method or header constraints.
+	if isDefaultPathHTTPRouteMatch(match) {
+		priority := priorityForHTTPRouteMatch(priorities, ruleIndex, matchIndex)
+		return &priority
+	}
+	if match.Path == nil || match.Path.Value == nil {
 		return nil
 	}
 	pathType := gatewayv1.PathMatchPathPrefix

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -549,6 +549,69 @@ func TestRoutesForRule_ExactPathMatch(t *testing.T) {
 	)
 }
 
+func TestRoutesForRule_MethodOnlyMatch(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, configurationv1alpha1.AddToScheme(scheme))
+	require.NoError(t, gatewayv1.Install(scheme))
+
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Name: "test-gateway"},
+				},
+			},
+		},
+	}
+
+	method := gatewayv1.HTTPMethodGet
+	rule := gwtypes.HTTPRouteRule{
+		Matches: []gatewayv1.HTTPRouteMatch{{
+			Method: &method,
+		}},
+	}
+	pRef := &gwtypes.ParentReference{
+		Name:      "test-gateway",
+		Namespace: (*gatewayv1.Namespace)(new("test-namespace")),
+	}
+	cpRef := &commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: "test-cp",
+		},
+	}
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gateway",
+			Namespace: "test-namespace",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "test-class",
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Protocol: gatewayv1.HTTPProtocolType, Port: 80},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gateway).Build()
+
+	results, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, rule, 0, pRef, cpRef, nil, "test-service", []string{"example.com"})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Equal(t, []string{"GET"}, results[0].Spec.Methods)
+	assert.Equal(t, []string{"/"}, results[0].Spec.Paths)
+	assert.Nil(t, results[0].Spec.Headers)
+	assert.Nil(t, results[0].Spec.RegexPriority)
+	assert.Equal(t, []string{"example.com"}, results[0].Spec.Hosts)
+}
+
 func TestRoutesForHTTPRouteRule_TagsAnnotation(t *testing.T) {
 	ctx := context.Background()
 	logger := logr.Discard()

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -200,7 +200,7 @@ func TestRoutesForRule(t *testing.T) {
 
 				if len(result.Spec.Headers) > 0 {
 					assert.Contains(t, result.Spec.Headers, "X-Foo")
-					assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, result.Spec.Paths)
+					assert.Equal(t, []string{routebuilder.KongHTTPRouteDefaultPathRegexPath}, result.Spec.Paths)
 					require.NotNil(t, result.Spec.RegexPriority)
 					assert.GreaterOrEqual(t, *result.Spec.RegexPriority, int64(0))
 					continue
@@ -429,12 +429,12 @@ func TestRoutesForRule_PrioritizesHeaderOnlyHTTPRouteMatches(t *testing.T) {
 	assert.GreaterOrEqual(t, *versionTwoRoute.Spec.RegexPriority, int64(0))
 	assert.GreaterOrEqual(t, *colorBlueRoute.Spec.RegexPriority, int64(0))
 	assert.Less(t, *twoHeaderRoute.Spec.RegexPriority, routebuilder.KongHTTPRoutePathRegexPriorityOffset)
-	assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, versionTwoRoute.Spec.Paths)
-	assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, twoHeaderRoute.Spec.Paths)
-	assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, colorBlueRoute.Spec.Paths)
+	assert.Equal(t, []string{routebuilder.KongHTTPRouteDefaultPathRegexPath}, versionTwoRoute.Spec.Paths)
+	assert.Equal(t, []string{routebuilder.KongHTTPRouteDefaultPathRegexPath}, twoHeaderRoute.Spec.Paths)
+	assert.Equal(t, []string{routebuilder.KongHTTPRouteDefaultPathRegexPath}, colorBlueRoute.Spec.Paths)
 }
 
-func TestRoutesForRule_DoesNotPrioritizeHeaderOnlyMatchOverDefaultPathMethodOnlyMatch(t *testing.T) {
+func TestRoutesForRule_PrioritizesDefaultPathMethodMatchesOverHeaderOnlyMatches(t *testing.T) {
 	ctx := context.Background()
 	logger := logr.Discard()
 
@@ -507,16 +507,17 @@ func TestRoutesForRule_DoesNotPrioritizeHeaderOnlyMatchOverDefaultPathMethodOnly
 
 	methodOnlyRoute := methodOnlyRoutes[0]
 	assert.Equal(t, []string{"PATCH"}, methodOnlyRoute.Spec.Methods)
-	assert.Equal(t, []string{"/"}, methodOnlyRoute.Spec.Paths)
-	assert.Nil(t, methodOnlyRoute.Spec.RegexPriority)
+	assert.Equal(t, []string{routebuilder.KongHTTPRouteDefaultPathRegexPath}, methodOnlyRoute.Spec.Paths)
+	require.NotNil(t, methodOnlyRoute.Spec.RegexPriority)
 	assert.Nil(t, methodOnlyRoute.Spec.Headers)
 
 	headerOnlyRoute := headerOnlyRoutes[0]
-	assert.Empty(t, headerOnlyRoute.Spec.Paths)
+	assert.Equal(t, []string{routebuilder.KongHTTPRouteDefaultPathRegexPath}, headerOnlyRoute.Spec.Paths)
 	assert.Empty(t, headerOnlyRoute.Spec.Methods)
-	assert.Nil(t, headerOnlyRoute.Spec.RegexPriority)
+	require.NotNil(t, headerOnlyRoute.Spec.RegexPriority)
 	require.NotNil(t, headerOnlyRoute.Spec.Headers)
 	assert.Equal(t, map[string][]string{"version": {"four"}}, headerOnlyRoute.Spec.Headers)
+	assert.Greater(t, *methodOnlyRoute.Spec.RegexPriority, *headerOnlyRoute.Spec.RegexPriority)
 }
 
 func TestHTTPRouteMatchPrioritiesIgnoreUnsupportedQueryParams(t *testing.T) {
@@ -549,6 +550,53 @@ func TestHTTPRouteMatchPrioritiesIgnoreUnsupportedQueryParams(t *testing.T) {
 	priorities := httpRouteMatchPriorities(httpRoute)
 
 	assert.Greater(t, priorityForHTTPRouteMatch(priorities, 0, 0), priorityForHTTPRouteMatch(priorities, 1, 0))
+}
+
+func TestHTTPRouteMatchPrioritiesForDefaultPathMethodMatching(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Method: new(gatewayv1.HTTPMethodPost),
+					}},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Method: new(gatewayv1.HTTPMethodGet),
+					}},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Headers: []gatewayv1.HTTPHeaderMatch{{Name: "version", Value: "one"}},
+						Method:  new(gatewayv1.HTTPMethodPut),
+					}},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Method: new(gatewayv1.HTTPMethodPatch),
+					}},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Headers: []gatewayv1.HTTPHeaderMatch{{Name: "version", Value: "four"}},
+					}},
+				},
+			},
+		},
+	}
+
+	priorities := httpRouteMatchPriorities(httpRoute)
+
+	postOnly := priorityForHTTPRouteMatch(priorities, 0, 0)
+	getOnly := priorityForHTTPRouteMatch(priorities, 1, 0)
+	putWithHeader := priorityForHTTPRouteMatch(priorities, 2, 0)
+	patchOnly := priorityForHTTPRouteMatch(priorities, 3, 0)
+	headerOnly := priorityForHTTPRouteMatch(priorities, 4, 0)
+
+	assert.Greater(t, postOnly, getOnly)
+	assert.Greater(t, putWithHeader, patchOnly)
+	assert.Greater(t, patchOnly, headerOnly)
 }
 
 func defaultRootPathMatch() *gatewayv1.HTTPPathMatch {
@@ -691,9 +739,9 @@ func TestRoutesForRule_MethodOnlyMatch(t *testing.T) {
 	require.Len(t, results, 1)
 
 	assert.Equal(t, []string{"GET"}, results[0].Spec.Methods)
-	assert.Equal(t, []string{"/"}, results[0].Spec.Paths)
+	assert.Equal(t, []string{routebuilder.KongHTTPRouteDefaultPathRegexPath}, results[0].Spec.Paths)
 	assert.Nil(t, results[0].Spec.Headers)
-	assert.Nil(t, results[0].Spec.RegexPriority)
+	require.NotNil(t, results[0].Spec.RegexPriority)
 	assert.Equal(t, []string{"example.com"}, results[0].Spec.Hosts)
 }
 

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -16,7 +16,6 @@ import (
 
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
-	routebuilder "github.com/kong/kong-operator/v2/controller/hybridgateway/builder"
 	hgerrors "github.com/kong/kong-operator/v2/controller/hybridgateway/errors"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/pkg/consts"
@@ -74,6 +73,7 @@ func TestRoutesForRule(t *testing.T) {
 			},
 		},
 	}
+	httpRoute.Spec.Rules = []gwtypes.HTTPRouteRule{rule}
 
 	// Create test parent reference
 	pRef := &gwtypes.ParentReference{
@@ -122,7 +122,7 @@ func TestRoutesForRule(t *testing.T) {
 			parentRef:    pRef,
 			serviceName:  "test-service",
 			hostnames:    []string{"example.com"},
-			expectRoutes: 2,
+			expectRoutes: 3,
 			expectProtocols: []sdkkonnectcomp.Protocols{
 				sdkkonnectcomp.Protocols("http"),
 				sdkkonnectcomp.Protocols("https"),
@@ -137,7 +137,7 @@ func TestRoutesForRule(t *testing.T) {
 			},
 			serviceName:  "test-service",
 			hostnames:    []string{"example.com"},
-			expectRoutes: 2,
+			expectRoutes: 3,
 			expectProtocols: []sdkkonnectcomp.Protocols{
 				sdkkonnectcomp.Protocols("http"),
 			},
@@ -151,7 +151,7 @@ func TestRoutesForRule(t *testing.T) {
 			},
 			serviceName:  "test-service",
 			hostnames:    []string{"example.com"},
-			expectRoutes: 2,
+			expectRoutes: 3,
 			expectProtocols: []sdkkonnectcomp.Protocols{
 				sdkkonnectcomp.Protocols("https"),
 			},
@@ -198,17 +198,15 @@ func TestRoutesForRule(t *testing.T) {
 				expectedAnnotation := httpRoute.Namespace + "/" + httpRoute.Name
 				assert.Contains(t, result.Annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation], expectedAnnotation)
 
-				if len(result.Spec.Headers) > 0 {
-					assert.Contains(t, result.Spec.Headers, "X-Foo")
-					assert.Equal(t, []string{routebuilder.KongHTTPRouteDefaultPathRegexPath}, result.Spec.Paths)
-					require.NotNil(t, result.Spec.RegexPriority)
-					assert.GreaterOrEqual(t, *result.Spec.RegexPriority, int64(0))
+				if result.Spec.Paths[0] == "/" {
+					assert.Equal(t, map[string][]string{"X-Foo": {"bar"}}, result.Spec.Headers)
+					assert.Nil(t, result.Spec.RegexPriority)
 					continue
 				}
 
-				// Verify path-only route.
+				assert.Equal(t, []string{"~/test$", "/test/"}, result.Spec.Paths)
 				require.NotNil(t, result.Spec.RegexPriority)
-				assert.Equal(t, routebuilder.KongHTTPRoutePathRegexPriorityOffset+10, *result.Spec.RegexPriority)
+				assert.Equal(t, int64(1<<10), *result.Spec.RegexPriority)
 			}
 		})
 	}
@@ -420,18 +418,15 @@ func TestRoutesForRule_PrioritizesHeaderOnlyHTTPRouteMatches(t *testing.T) {
 	versionTwoRoute := versionTwoRoutes[0]
 	twoHeaderRoute := twoHeaderRoutes[0]
 	colorBlueRoute := colorBlueRoutes[0]
-	require.NotNil(t, versionTwoRoute.Spec.RegexPriority)
-	require.NotNil(t, twoHeaderRoute.Spec.RegexPriority)
-	require.NotNil(t, colorBlueRoute.Spec.RegexPriority)
-	assert.Greater(t, *twoHeaderRoute.Spec.RegexPriority, *versionTwoRoute.Spec.RegexPriority)
-	assert.Greater(t, *versionTwoRoute.Spec.RegexPriority, *colorBlueRoute.Spec.RegexPriority)
-	assert.GreaterOrEqual(t, *twoHeaderRoute.Spec.RegexPriority, int64(0))
-	assert.GreaterOrEqual(t, *versionTwoRoute.Spec.RegexPriority, int64(0))
-	assert.GreaterOrEqual(t, *colorBlueRoute.Spec.RegexPriority, int64(0))
-	assert.Less(t, *twoHeaderRoute.Spec.RegexPriority, routebuilder.KongHTTPRoutePathRegexPriorityOffset)
-	assert.Equal(t, []string{routebuilder.KongHTTPRouteDefaultPathRegexPath}, versionTwoRoute.Spec.Paths)
-	assert.Equal(t, []string{routebuilder.KongHTTPRouteDefaultPathRegexPath}, twoHeaderRoute.Spec.Paths)
-	assert.Equal(t, []string{routebuilder.KongHTTPRouteDefaultPathRegexPath}, colorBlueRoute.Spec.Paths)
+	assert.Equal(t, map[string][]string{"version": {"two"}}, versionTwoRoute.Spec.Headers)
+	assert.Equal(t, map[string][]string{"version": {"two"}, "color": {"orange"}}, twoHeaderRoute.Spec.Headers)
+	assert.Equal(t, map[string][]string{"color": {"blue"}}, colorBlueRoute.Spec.Headers)
+	assert.Equal(t, []string{"/"}, versionTwoRoute.Spec.Paths)
+	assert.Equal(t, []string{"/"}, twoHeaderRoute.Spec.Paths)
+	assert.Equal(t, []string{"/"}, colorBlueRoute.Spec.Paths)
+	assert.Nil(t, versionTwoRoute.Spec.RegexPriority)
+	assert.Nil(t, twoHeaderRoute.Spec.RegexPriority)
+	assert.Nil(t, colorBlueRoute.Spec.RegexPriority)
 }
 
 func TestRoutesForRule_PrioritizesDefaultPathMethodMatchesOverHeaderOnlyMatches(t *testing.T) {
@@ -498,26 +493,40 @@ func TestRoutesForRule_PrioritizesDefaultPathMethodMatchesOverHeaderOnlyMatches(
 	}
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gateway).Build()
 
+	pathRoutes, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, httpRoute.Spec.Rules[0], 0, pRef, cpRef, nil, "path-service", nil)
+	require.NoError(t, err)
+	require.Len(t, pathRoutes, 2)
 	methodOnlyRoutes, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, httpRoute.Spec.Rules[1], 1, pRef, cpRef, nil, "method-only-service", nil)
 	require.NoError(t, err)
-	require.Len(t, methodOnlyRoutes, 1)
+	require.Len(t, methodOnlyRoutes, 2)
 	headerOnlyRoutes, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, httpRoute.Spec.Rules[2], 2, pRef, cpRef, nil, "header-only-service", nil)
 	require.NoError(t, err)
 	require.Len(t, headerOnlyRoutes, 1)
 
 	methodOnlyRoute := methodOnlyRoutes[0]
+	methodWithHeaderRoute := methodOnlyRoutes[1]
 	assert.Equal(t, []string{"PATCH"}, methodOnlyRoute.Spec.Methods)
-	assert.Equal(t, []string{routebuilder.KongHTTPRouteDefaultPathRegexPath}, methodOnlyRoute.Spec.Paths)
-	require.NotNil(t, methodOnlyRoute.Spec.RegexPriority)
+	assert.Empty(t, methodOnlyRoute.Spec.Paths)
+	assert.Nil(t, methodOnlyRoute.Spec.RegexPriority)
 	assert.Nil(t, methodOnlyRoute.Spec.Headers)
+	assert.Equal(t, []string{"PATCH"}, methodWithHeaderRoute.Spec.Methods)
+	assert.Equal(t, map[string][]string{"version": {"four"}}, methodWithHeaderRoute.Spec.Headers)
+	assert.Empty(t, methodWithHeaderRoute.Spec.Paths)
 
 	headerOnlyRoute := headerOnlyRoutes[0]
-	assert.Equal(t, []string{routebuilder.KongHTTPRouteDefaultPathRegexPath}, headerOnlyRoute.Spec.Paths)
+	assert.Empty(t, headerOnlyRoute.Spec.Paths)
 	assert.Empty(t, headerOnlyRoute.Spec.Methods)
-	require.NotNil(t, headerOnlyRoute.Spec.RegexPriority)
+	assert.Nil(t, headerOnlyRoute.Spec.RegexPriority)
 	require.NotNil(t, headerOnlyRoute.Spec.Headers)
 	assert.Equal(t, map[string][]string{"version": {"four"}}, headerOnlyRoute.Spec.Headers)
-	assert.Greater(t, *methodOnlyRoute.Spec.RegexPriority, *headerOnlyRoute.Spec.RegexPriority)
+
+	pathOnlyRoute := pathRoutes[0]
+	pathWithHeaderRoute := pathRoutes[1]
+	assert.Equal(t, []string{"~/path5$", "/path5/"}, pathOnlyRoute.Spec.Paths)
+	assert.Empty(t, pathOnlyRoute.Spec.Headers)
+	assert.Equal(t, pathOnlyRoute.Spec.Paths, pathWithHeaderRoute.Spec.Paths)
+	assert.Equal(t, map[string][]string{"version": {"four"}}, pathWithHeaderRoute.Spec.Headers)
+	assert.Equal(t, pathOnlyRoute.Spec.RegexPriority, pathWithHeaderRoute.Spec.RegexPriority)
 }
 
 func TestHTTPRouteMatchPrioritiesIgnoreUnsupportedQueryParams(t *testing.T) {
@@ -550,6 +559,55 @@ func TestHTTPRouteMatchPrioritiesIgnoreUnsupportedQueryParams(t *testing.T) {
 	priorities := httpRouteMatchPriorities(httpRoute)
 
 	assert.Greater(t, priorityForHTTPRouteMatch(priorities, 0, 0), priorityForHTTPRouteMatch(priorities, 1, 0))
+}
+
+func TestPrecedenceVariantsForHTTPRouteMatch(t *testing.T) {
+	prefix := gatewayv1.PathMatchPathPrefix
+	path := func(value string) *gatewayv1.HTTPPathMatch {
+		return &gatewayv1.HTTPPathMatch{Type: &prefix, Value: &value}
+	}
+
+	t.Run("augments a more specific path with a lower path and method match", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{Spec: gatewayv1.HTTPRouteSpec{Rules: []gatewayv1.HTTPRouteRule{
+			{Matches: []gatewayv1.HTTPRouteMatch{{Path: path("/specific")}}},
+			{Matches: []gatewayv1.HTTPRouteMatch{{Path: path("/"), Method: new(gatewayv1.HTTPMethodPatch)}}},
+		}}}
+		priorities := httpRouteMatchPriorities(route)
+
+		variants := precedenceVariantsForHTTPRouteMatch(route, route.Spec.Rules[0].Matches[0], priorities, 0, 0)
+
+		require.Len(t, variants, 2)
+		assert.Nil(t, variants[0].Method)
+		require.NotNil(t, variants[1].Method)
+		assert.Equal(t, gatewayv1.HTTPMethodPatch, *variants[1].Method)
+		assert.Equal(t, "/specific", *variants[1].Path.Value)
+	})
+
+	t.Run("augments a method match with a lower header match", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{Spec: gatewayv1.HTTPRouteSpec{Rules: []gatewayv1.HTTPRouteRule{
+			{Matches: []gatewayv1.HTTPRouteMatch{{Method: new(gatewayv1.HTTPMethodPatch)}}},
+			{Matches: []gatewayv1.HTTPRouteMatch{{Headers: []gatewayv1.HTTPHeaderMatch{{Name: "version", Value: "four"}}}}},
+		}}}
+		priorities := httpRouteMatchPriorities(route)
+
+		variants := precedenceVariantsForHTTPRouteMatch(route, route.Spec.Rules[0].Matches[0], priorities, 0, 0)
+
+		require.Len(t, variants, 2)
+		assert.Empty(t, variants[0].Headers)
+		assert.Equal(t, route.Spec.Rules[1].Matches[0].Headers, variants[1].Headers)
+	})
+
+	t.Run("does not augment matches with disjoint paths", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{Spec: gatewayv1.HTTPRouteSpec{Rules: []gatewayv1.HTTPRouteRule{
+			{Matches: []gatewayv1.HTTPRouteMatch{{Path: path("/one")}}},
+			{Matches: []gatewayv1.HTTPRouteMatch{{Path: path("/two"), Method: new(gatewayv1.HTTPMethodPatch)}}},
+		}}}
+		priorities := httpRouteMatchPriorities(route)
+
+		variants := precedenceVariantsForHTTPRouteMatch(route, route.Spec.Rules[0].Matches[0], priorities, 0, 0)
+
+		require.Len(t, variants, 1)
+	})
 }
 
 func TestHTTPRouteMatchPrioritiesForDefaultPathMethodMatching(t *testing.T) {
@@ -637,6 +695,7 @@ func TestRoutesForRule_ExactPathMatch(t *testing.T) {
 			},
 		}},
 	}
+	httpRoute.Spec.Rules = []gwtypes.HTTPRouteRule{rule}
 
 	pRef := &gwtypes.ParentReference{
 		Name:      "test-gateway",
@@ -672,7 +731,7 @@ func TestRoutesForRule_ExactPathMatch(t *testing.T) {
 
 	assert.Equal(t, []string{"~/one$"}, results[0].Spec.Paths)
 	require.NotNil(t, results[0].Spec.RegexPriority)
-	assert.Equal(t, routebuilder.KongHTTPRoutePathRegexPriorityOffset+9, *results[0].Spec.RegexPriority)
+	assert.Equal(t, int64(0), *results[0].Spec.RegexPriority)
 	assert.ElementsMatch(t,
 		[]sdkkonnectcomp.Protocols{
 			sdkkonnectcomp.Protocols("http"),
@@ -739,9 +798,9 @@ func TestRoutesForRule_MethodOnlyMatch(t *testing.T) {
 	require.Len(t, results, 1)
 
 	assert.Equal(t, []string{"GET"}, results[0].Spec.Methods)
-	assert.Equal(t, []string{routebuilder.KongHTTPRouteDefaultPathRegexPath}, results[0].Spec.Paths)
+	assert.Empty(t, results[0].Spec.Paths)
 	assert.Nil(t, results[0].Spec.Headers)
-	require.NotNil(t, results[0].Spec.RegexPriority)
+	assert.Nil(t, results[0].Spec.RegexPriority)
 	assert.Equal(t, []string{"example.com"}, results[0].Spec.Hosts)
 }
 

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -434,6 +434,91 @@ func TestRoutesForRule_PrioritizesHeaderOnlyHTTPRouteMatches(t *testing.T) {
 	assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, colorBlueRoute.Spec.Paths)
 }
 
+func TestRoutesForRule_DoesNotPrioritizeHeaderOnlyMatchOverDefaultPathMethodOnlyMatch(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, configurationv1alpha1.AddToScheme(scheme))
+	require.NoError(t, gatewayv1.Install(scheme))
+
+	httpRoute := &gwtypes.HTTPRoute{
+		TypeMeta: httpRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "method-matching",
+			Namespace: "gateway-conformance-infra",
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "same-namespace"}},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  new(gatewayv1.PathMatchPathPrefix),
+							Value: new("/path5"),
+						},
+					}},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Method: new(gatewayv1.HTTPMethodPatch),
+					}},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Headers: []gatewayv1.HTTPHeaderMatch{{Name: "version", Value: "four"}},
+					}},
+				},
+			},
+		},
+	}
+	pRef := &gwtypes.ParentReference{
+		Name:      "same-namespace",
+		Namespace: (*gatewayv1.Namespace)(new("gateway-conformance-infra")),
+	}
+	cpRef := &commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: "test-cp",
+		},
+	}
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "same-namespace",
+			Namespace: "gateway-conformance-infra",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "test-class",
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Protocol: gatewayv1.HTTPProtocolType, Port: 80},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gateway).Build()
+
+	methodOnlyRoutes, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, httpRoute.Spec.Rules[1], 1, pRef, cpRef, nil, "method-only-service", nil)
+	require.NoError(t, err)
+	require.Len(t, methodOnlyRoutes, 1)
+	headerOnlyRoutes, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, httpRoute.Spec.Rules[2], 2, pRef, cpRef, nil, "header-only-service", nil)
+	require.NoError(t, err)
+	require.Len(t, headerOnlyRoutes, 1)
+
+	methodOnlyRoute := methodOnlyRoutes[0]
+	assert.Equal(t, []string{"PATCH"}, methodOnlyRoute.Spec.Methods)
+	assert.Equal(t, []string{"/"}, methodOnlyRoute.Spec.Paths)
+	assert.Nil(t, methodOnlyRoute.Spec.RegexPriority)
+	assert.Nil(t, methodOnlyRoute.Spec.Headers)
+
+	headerOnlyRoute := headerOnlyRoutes[0]
+	assert.Empty(t, headerOnlyRoute.Spec.Paths)
+	assert.Empty(t, headerOnlyRoute.Spec.Methods)
+	assert.Nil(t, headerOnlyRoute.Spec.RegexPriority)
+	require.NotNil(t, headerOnlyRoute.Spec.Headers)
+	assert.Equal(t, map[string][]string{"version": {"four"}}, headerOnlyRoute.Spec.Headers)
+}
+
 func TestHTTPRouteMatchPrioritiesIgnoreUnsupportedQueryParams(t *testing.T) {
 	httpRoute := &gwtypes.HTTPRoute{
 		Spec: gatewayv1.HTTPRouteSpec{

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -804,11 +804,9 @@ func TestRoutesForRule_PrioritizesDefaultPathMethodMatchesOverHeaderOnlyMatches(
 	require.NoError(t, gatewayv1.Install(scheme))
 
 	httpRoute := &gwtypes.HTTPRoute{
-		TypeMeta: httpRouteTypeMeta,
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "method-matching",
-			Namespace: "gateway-conformance-infra",
-		},
+		TypeMeta:  httpRouteTypeMeta,
+		Name:      "method-matching",
+		Namespace: "gateway-conformance-infra",
 		Spec: gatewayv1.HTTPRouteSpec{
 			CommonRouteSpec: gatewayv1.CommonRouteSpec{
 				ParentRefs: []gatewayv1.ParentReference{{Name: "same-namespace"}},
@@ -846,10 +844,8 @@ func TestRoutesForRule_PrioritizesDefaultPathMethodMatchesOverHeaderOnlyMatches(
 		},
 	}
 	gateway := &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "same-namespace",
-			Namespace: "gateway-conformance-infra",
-		},
+		Name:      "same-namespace",
+		Namespace: "gateway-conformance-infra",
 		Spec: gatewayv1.GatewaySpec{
 			GatewayClassName: "test-class",
 			Listeners: []gatewayv1.Listener{
@@ -1157,10 +1153,8 @@ func TestRoutesForRule_MethodOnlyMatch(t *testing.T) {
 	require.NoError(t, gatewayv1.Install(scheme))
 
 	httpRoute := &gwtypes.HTTPRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-route",
-			Namespace: "test-namespace",
-		},
+		Name:      "test-route",
+		Namespace: "test-namespace",
 		Spec: gatewayv1.HTTPRouteSpec{
 			CommonRouteSpec: gatewayv1.CommonRouteSpec{
 				ParentRefs: []gatewayv1.ParentReference{
@@ -1187,10 +1181,8 @@ func TestRoutesForRule_MethodOnlyMatch(t *testing.T) {
 		},
 	}
 	gateway := &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-gateway",
-			Namespace: "test-namespace",
-		},
+		Name:      "test-gateway",
+		Namespace: "test-namespace",
 		Spec: gatewayv1.GatewaySpec{
 			GatewayClassName: "test-class",
 			Listeners: []gatewayv1.Listener{

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -872,15 +872,15 @@ func TestRoutesForRule_PrioritizesDefaultPathMethodMatchesOverHeaderOnlyMatches(
 	methodOnlyRoute := methodOnlyRoutes[0]
 	methodWithHeaderRoute := methodOnlyRoutes[1]
 	assert.Equal(t, []string{"PATCH"}, methodOnlyRoute.Spec.Methods)
-	assert.Empty(t, methodOnlyRoute.Spec.Paths)
+	assert.Equal(t, []string{"~/"}, methodOnlyRoute.Spec.Paths)
 	assert.NotNil(t, methodOnlyRoute.Spec.RegexPriority)
 	assert.Nil(t, methodOnlyRoute.Spec.Headers)
 	assert.Equal(t, []string{"PATCH"}, methodWithHeaderRoute.Spec.Methods)
 	assert.Equal(t, map[string][]string{"version": {"four"}}, methodWithHeaderRoute.Spec.Headers)
-	assert.Empty(t, methodWithHeaderRoute.Spec.Paths)
+	assert.Equal(t, []string{"~/"}, methodWithHeaderRoute.Spec.Paths)
 
 	headerOnlyRoute := headerOnlyRoutes[0]
-	assert.Empty(t, headerOnlyRoute.Spec.Paths)
+	assert.Equal(t, []string{"~/"}, headerOnlyRoute.Spec.Paths)
 	assert.Empty(t, headerOnlyRoute.Spec.Methods)
 	assert.NotNil(t, headerOnlyRoute.Spec.RegexPriority)
 	require.NotNil(t, headerOnlyRoute.Spec.Headers)
@@ -1203,7 +1203,7 @@ func TestRoutesForRule_MethodOnlyMatch(t *testing.T) {
 	require.Len(t, results, 1)
 
 	assert.Equal(t, []string{"GET"}, results[0].Spec.Methods)
-	assert.Empty(t, results[0].Spec.Paths)
+	assert.Equal(t, []string{"~/"}, results[0].Spec.Paths)
 	assert.Nil(t, results[0].Spec.Headers)
 	// Method-only matches on the default path get an explicit regex_priority so
 	// Gateway API precedence is preserved relative to header-only matches.

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -72,6 +72,7 @@ func TestRoutesForRule(t *testing.T) {
 			},
 		},
 	}
+	httpRoute.Spec.Rules = []gwtypes.HTTPRouteRule{rule}
 
 	// Create test parent reference
 	pRef := &gwtypes.ParentReference{
@@ -118,7 +119,7 @@ func TestRoutesForRule(t *testing.T) {
 			parentRef:    pRef,
 			serviceName:  "test-service",
 			hostnames:    []string{"example.com"},
-			expectRoutes: 2,
+			expectRoutes: 3,
 			expectProtocols: []sdkkonnectcomp.Protocols{
 				sdkkonnectcomp.Protocols("http"),
 				sdkkonnectcomp.Protocols("https"),
@@ -133,7 +134,7 @@ func TestRoutesForRule(t *testing.T) {
 			},
 			serviceName:  "test-service",
 			hostnames:    []string{"example.com"},
-			expectRoutes: 2,
+			expectRoutes: 3,
 			expectProtocols: []sdkkonnectcomp.Protocols{
 				sdkkonnectcomp.Protocols("http"),
 			},
@@ -147,7 +148,7 @@ func TestRoutesForRule(t *testing.T) {
 			},
 			serviceName:  "test-service",
 			hostnames:    []string{"example.com"},
-			expectRoutes: 2,
+			expectRoutes: 3,
 			expectProtocols: []sdkkonnectcomp.Protocols{
 				sdkkonnectcomp.Protocols("https"),
 			},
@@ -194,17 +195,15 @@ func TestRoutesForRule(t *testing.T) {
 				expectedAnnotation := httpRoute.Namespace + "/" + httpRoute.Name
 				assert.Contains(t, result.Annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation], expectedAnnotation)
 
-				if len(result.Spec.Headers) > 0 {
-					assert.Contains(t, result.Spec.Headers, "X-Foo")
-					assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, result.Spec.Paths)
-					require.NotNil(t, result.Spec.RegexPriority)
-					assert.GreaterOrEqual(t, *result.Spec.RegexPriority, int64(0))
+				if result.Spec.Paths[0] == "/" {
+					assert.Equal(t, map[string][]string{"X-Foo": {"bar"}}, result.Spec.Headers)
+					assert.Nil(t, result.Spec.RegexPriority)
 					continue
 				}
 
-				// Verify path-only route.
+				assert.Equal(t, []string{"~/test$", "/test/"}, result.Spec.Paths)
 				require.NotNil(t, result.Spec.RegexPriority)
-				assert.Equal(t, routebuilder.KongHTTPRoutePathRegexPriorityOffset+10, *result.Spec.RegexPriority)
+				assert.Equal(t, int64(1<<10), *result.Spec.RegexPriority)
 			}
 		})
 	}
@@ -785,18 +784,115 @@ func TestRoutesForRule_PrioritizesHeaderOnlyHTTPRouteMatches(t *testing.T) {
 	versionTwoRoute := versionTwoRoutes[0]
 	twoHeaderRoute := twoHeaderRoutes[0]
 	colorBlueRoute := colorBlueRoutes[0]
-	require.NotNil(t, versionTwoRoute.Spec.RegexPriority)
-	require.NotNil(t, twoHeaderRoute.Spec.RegexPriority)
-	require.NotNil(t, colorBlueRoute.Spec.RegexPriority)
-	assert.Greater(t, *twoHeaderRoute.Spec.RegexPriority, *versionTwoRoute.Spec.RegexPriority)
-	assert.Greater(t, *versionTwoRoute.Spec.RegexPriority, *colorBlueRoute.Spec.RegexPriority)
-	assert.GreaterOrEqual(t, *twoHeaderRoute.Spec.RegexPriority, int64(0))
-	assert.GreaterOrEqual(t, *versionTwoRoute.Spec.RegexPriority, int64(0))
-	assert.GreaterOrEqual(t, *colorBlueRoute.Spec.RegexPriority, int64(0))
-	assert.Less(t, *twoHeaderRoute.Spec.RegexPriority, routebuilder.KongHTTPRoutePathRegexPriorityOffset)
-	assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, versionTwoRoute.Spec.Paths)
-	assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, twoHeaderRoute.Spec.Paths)
-	assert.Equal(t, []string{routebuilder.KongHTTPRouteHeaderOnlyRegexPath}, colorBlueRoute.Spec.Paths)
+	assert.Equal(t, map[string][]string{"version": {"two"}}, versionTwoRoute.Spec.Headers)
+	assert.Equal(t, map[string][]string{"version": {"two"}, "color": {"orange"}}, twoHeaderRoute.Spec.Headers)
+	assert.Equal(t, map[string][]string{"color": {"blue"}}, colorBlueRoute.Spec.Headers)
+	assert.Equal(t, []string{"/"}, versionTwoRoute.Spec.Paths)
+	assert.Equal(t, []string{"/"}, twoHeaderRoute.Spec.Paths)
+	assert.Equal(t, []string{"/"}, colorBlueRoute.Spec.Paths)
+	assert.Nil(t, versionTwoRoute.Spec.RegexPriority)
+	assert.Nil(t, twoHeaderRoute.Spec.RegexPriority)
+	assert.Nil(t, colorBlueRoute.Spec.RegexPriority)
+}
+
+func TestRoutesForRule_PrioritizesDefaultPathMethodMatchesOverHeaderOnlyMatches(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, configurationv1alpha1.AddToScheme(scheme))
+	require.NoError(t, gatewayv1.Install(scheme))
+
+	httpRoute := &gwtypes.HTTPRoute{
+		TypeMeta: httpRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "method-matching",
+			Namespace: "gateway-conformance-infra",
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "same-namespace"}},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  new(gatewayv1.PathMatchPathPrefix),
+							Value: new("/path5"),
+						},
+					}},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Method: new(gatewayv1.HTTPMethodPatch),
+					}},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Headers: []gatewayv1.HTTPHeaderMatch{{Name: "version", Value: "four"}},
+					}},
+				},
+			},
+		},
+	}
+	pRef := &gwtypes.ParentReference{
+		Name:      "same-namespace",
+		Namespace: (*gatewayv1.Namespace)(new("gateway-conformance-infra")),
+	}
+	cpRef := &commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: "test-cp",
+		},
+	}
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "same-namespace",
+			Namespace: "gateway-conformance-infra",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "test-class",
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Protocol: gatewayv1.HTTPProtocolType, Port: 80},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gateway).Build()
+
+	pathRoutes, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, httpRoute.Spec.Rules[0], 0, pRef, cpRef, nil, "path-service", nil)
+	require.NoError(t, err)
+	require.Len(t, pathRoutes, 2)
+	methodOnlyRoutes, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, httpRoute.Spec.Rules[1], 1, pRef, cpRef, nil, "method-only-service", nil)
+	require.NoError(t, err)
+	require.Len(t, methodOnlyRoutes, 2)
+	headerOnlyRoutes, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, httpRoute.Spec.Rules[2], 2, pRef, cpRef, nil, "header-only-service", nil)
+	require.NoError(t, err)
+	require.Len(t, headerOnlyRoutes, 1)
+
+	methodOnlyRoute := methodOnlyRoutes[0]
+	methodWithHeaderRoute := methodOnlyRoutes[1]
+	assert.Equal(t, []string{"PATCH"}, methodOnlyRoute.Spec.Methods)
+	assert.Empty(t, methodOnlyRoute.Spec.Paths)
+	assert.Nil(t, methodOnlyRoute.Spec.RegexPriority)
+	assert.Nil(t, methodOnlyRoute.Spec.Headers)
+	assert.Equal(t, []string{"PATCH"}, methodWithHeaderRoute.Spec.Methods)
+	assert.Equal(t, map[string][]string{"version": {"four"}}, methodWithHeaderRoute.Spec.Headers)
+	assert.Empty(t, methodWithHeaderRoute.Spec.Paths)
+
+	headerOnlyRoute := headerOnlyRoutes[0]
+	assert.Empty(t, headerOnlyRoute.Spec.Paths)
+	assert.Empty(t, headerOnlyRoute.Spec.Methods)
+	assert.Nil(t, headerOnlyRoute.Spec.RegexPriority)
+	require.NotNil(t, headerOnlyRoute.Spec.Headers)
+	assert.Equal(t, map[string][]string{"version": {"four"}}, headerOnlyRoute.Spec.Headers)
+
+	pathOnlyRoute := pathRoutes[0]
+	pathWithHeaderRoute := pathRoutes[1]
+	assert.Equal(t, []string{"~/path5$", "/path5/"}, pathOnlyRoute.Spec.Paths)
+	assert.Empty(t, pathOnlyRoute.Spec.Headers)
+	assert.Equal(t, pathOnlyRoute.Spec.Paths, pathWithHeaderRoute.Spec.Paths)
+	assert.Equal(t, map[string][]string{"version": {"four"}}, pathWithHeaderRoute.Spec.Headers)
+	assert.Equal(t, pathOnlyRoute.Spec.RegexPriority, pathWithHeaderRoute.Spec.RegexPriority)
 }
 
 func TestHTTPRouteMatchPrioritiesIgnoreUnsupportedQueryParams(t *testing.T) {
@@ -829,6 +925,102 @@ func TestHTTPRouteMatchPrioritiesIgnoreUnsupportedQueryParams(t *testing.T) {
 	priorities := httpRouteMatchPriorities(httpRoute)
 
 	assert.Greater(t, priorityForHTTPRouteMatch(priorities, 0, 0), priorityForHTTPRouteMatch(priorities, 1, 0))
+}
+
+func TestPrecedenceVariantsForHTTPRouteMatch(t *testing.T) {
+	prefix := gatewayv1.PathMatchPathPrefix
+	path := func(value string) *gatewayv1.HTTPPathMatch {
+		return &gatewayv1.HTTPPathMatch{Type: &prefix, Value: &value}
+	}
+
+	t.Run("augments a more specific path with a lower path and method match", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{Spec: gatewayv1.HTTPRouteSpec{Rules: []gatewayv1.HTTPRouteRule{
+			{Matches: []gatewayv1.HTTPRouteMatch{{Path: path("/specific")}}},
+			{Matches: []gatewayv1.HTTPRouteMatch{{Path: path("/"), Method: new(gatewayv1.HTTPMethodPatch)}}},
+		}}}
+		priorities := httpRouteMatchPriorities(route)
+
+		variants := precedenceVariantsForHTTPRouteMatch(route, route.Spec.Rules[0].Matches[0], priorities, 0, 0)
+
+		require.Len(t, variants, 2)
+		assert.Nil(t, variants[0].Method)
+		require.NotNil(t, variants[1].Method)
+		assert.Equal(t, gatewayv1.HTTPMethodPatch, *variants[1].Method)
+		assert.Equal(t, "/specific", *variants[1].Path.Value)
+	})
+
+	t.Run("augments a method match with a lower header match", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{Spec: gatewayv1.HTTPRouteSpec{Rules: []gatewayv1.HTTPRouteRule{
+			{Matches: []gatewayv1.HTTPRouteMatch{{Method: new(gatewayv1.HTTPMethodPatch)}}},
+			{Matches: []gatewayv1.HTTPRouteMatch{{Headers: []gatewayv1.HTTPHeaderMatch{{Name: "version", Value: "four"}}}}},
+		}}}
+		priorities := httpRouteMatchPriorities(route)
+
+		variants := precedenceVariantsForHTTPRouteMatch(route, route.Spec.Rules[0].Matches[0], priorities, 0, 0)
+
+		require.Len(t, variants, 2)
+		assert.Empty(t, variants[0].Headers)
+		assert.Equal(t, route.Spec.Rules[1].Matches[0].Headers, variants[1].Headers)
+	})
+
+	t.Run("does not augment matches with disjoint paths", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{Spec: gatewayv1.HTTPRouteSpec{Rules: []gatewayv1.HTTPRouteRule{
+			{Matches: []gatewayv1.HTTPRouteMatch{{Path: path("/one")}}},
+			{Matches: []gatewayv1.HTTPRouteMatch{{Path: path("/two"), Method: new(gatewayv1.HTTPMethodPatch)}}},
+		}}}
+		priorities := httpRouteMatchPriorities(route)
+
+		variants := precedenceVariantsForHTTPRouteMatch(route, route.Spec.Rules[0].Matches[0], priorities, 0, 0)
+
+		require.Len(t, variants, 1)
+	})
+}
+
+func TestHTTPRouteMatchPrioritiesForDefaultPathMethodMatching(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Method: new(gatewayv1.HTTPMethodPost),
+					}},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Method: new(gatewayv1.HTTPMethodGet),
+					}},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Headers: []gatewayv1.HTTPHeaderMatch{{Name: "version", Value: "one"}},
+						Method:  new(gatewayv1.HTTPMethodPut),
+					}},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Method: new(gatewayv1.HTTPMethodPatch),
+					}},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Headers: []gatewayv1.HTTPHeaderMatch{{Name: "version", Value: "four"}},
+					}},
+				},
+			},
+		},
+	}
+
+	priorities := httpRouteMatchPriorities(httpRoute)
+
+	postOnly := priorityForHTTPRouteMatch(priorities, 0, 0)
+	getOnly := priorityForHTTPRouteMatch(priorities, 1, 0)
+	putWithHeader := priorityForHTTPRouteMatch(priorities, 2, 0)
+	patchOnly := priorityForHTTPRouteMatch(priorities, 3, 0)
+	headerOnly := priorityForHTTPRouteMatch(priorities, 4, 0)
+
+	assert.Greater(t, postOnly, getOnly)
+	assert.Greater(t, putWithHeader, patchOnly)
+	assert.Greater(t, patchOnly, headerOnly)
 }
 
 func defaultRootPathMatch() *gatewayv1.HTTPPathMatch {
@@ -867,6 +1059,7 @@ func TestRoutesForRule_ExactPathMatch(t *testing.T) {
 			},
 		}},
 	}
+	httpRoute.Spec.Rules = []gwtypes.HTTPRouteRule{rule}
 
 	pRef := &gwtypes.ParentReference{
 		Name:      "test-gateway",
@@ -900,7 +1093,7 @@ func TestRoutesForRule_ExactPathMatch(t *testing.T) {
 
 	assert.Equal(t, []string{"~/one$"}, results[0].Spec.Paths)
 	require.NotNil(t, results[0].Spec.RegexPriority)
-	assert.Equal(t, routebuilder.KongHTTPRoutePathRegexPriorityOffset+9, *results[0].Spec.RegexPriority)
+	assert.Equal(t, int64(0), *results[0].Spec.RegexPriority)
 	assert.ElementsMatch(t,
 		[]sdkkonnectcomp.Protocols{
 			sdkkonnectcomp.Protocols("http"),
@@ -908,6 +1101,69 @@ func TestRoutesForRule_ExactPathMatch(t *testing.T) {
 		},
 		results[0].Spec.Protocols,
 	)
+}
+
+func TestRoutesForRule_MethodOnlyMatch(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, configurationv1alpha1.AddToScheme(scheme))
+	require.NoError(t, gatewayv1.Install(scheme))
+
+	httpRoute := &gwtypes.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Name: "test-gateway"},
+				},
+			},
+		},
+	}
+
+	method := gatewayv1.HTTPMethodGet
+	rule := gwtypes.HTTPRouteRule{
+		Matches: []gatewayv1.HTTPRouteMatch{{
+			Method: &method,
+		}},
+	}
+	pRef := &gwtypes.ParentReference{
+		Name:      "test-gateway",
+		Namespace: (*gatewayv1.Namespace)(new("test-namespace")),
+	}
+	cpRef := &commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: "test-cp",
+		},
+	}
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gateway",
+			Namespace: "test-namespace",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "test-class",
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Protocol: gatewayv1.HTTPProtocolType, Port: 80},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gateway).Build()
+
+	results, err := RoutesForRule(ctx, logger, fakeClient, httpRoute, rule, 0, pRef, cpRef, nil, "test-service", []string{"example.com"})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Equal(t, []string{"GET"}, results[0].Spec.Methods)
+	assert.Empty(t, results[0].Spec.Paths)
+	assert.Nil(t, results[0].Spec.Headers)
+	assert.Nil(t, results[0].Spec.RegexPriority)
+	assert.Equal(t, []string{"example.com"}, results[0].Spec.Hosts)
 }
 
 func TestRoutesForHTTPRouteRule_TagsAnnotation(t *testing.T) {

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -195,7 +195,15 @@ func TestRoutesForRule(t *testing.T) {
 				expectedAnnotation := httpRoute.Namespace + "/" + httpRoute.Name
 				assert.Contains(t, result.Annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation], expectedAnnotation)
 
-				if result.Spec.Paths[0] == "/" {
+				if len(result.Spec.Paths) == 0 {
+					// Header-only match on default path: no paths, only headers.
+					assert.Equal(t, map[string][]string{"X-Foo": {"bar"}}, result.Spec.Headers)
+					assert.NotNil(t, result.Spec.RegexPriority)
+					continue
+				}
+
+				if len(result.Spec.Paths) == 1 && result.Spec.Paths[0] == "~/(.*)" {
+					// Header-only match with regex path.
 					assert.Equal(t, map[string][]string{"X-Foo": {"bar"}}, result.Spec.Headers)
 					assert.NotNil(t, result.Spec.RegexPriority)
 					continue
@@ -787,9 +795,9 @@ func TestRoutesForRule_PrioritizesHeaderOnlyHTTPRouteMatches(t *testing.T) {
 	assert.Equal(t, map[string][]string{"version": {"two"}}, versionTwoRoute.Spec.Headers)
 	assert.Equal(t, map[string][]string{"version": {"two"}, "color": {"orange"}}, twoHeaderRoute.Spec.Headers)
 	assert.Equal(t, map[string][]string{"color": {"blue"}}, colorBlueRoute.Spec.Headers)
-	assert.Equal(t, []string{"/"}, versionTwoRoute.Spec.Paths)
-	assert.Equal(t, []string{"/"}, twoHeaderRoute.Spec.Paths)
-	assert.Equal(t, []string{"/"}, colorBlueRoute.Spec.Paths)
+	assert.Equal(t, []string{"~/(.*)"}, versionTwoRoute.Spec.Paths)
+	assert.Equal(t, []string{"~/(.*)"}, twoHeaderRoute.Spec.Paths)
+	assert.Equal(t, []string{"~/(.*)"}, colorBlueRoute.Spec.Paths)
 	// Header-only matches on the default path get an explicit regex_priority so
 	// Gateway API precedence (more headers beat fewer headers) is preserved.
 	assert.NotNil(t, versionTwoRoute.Spec.RegexPriority)
@@ -872,15 +880,15 @@ func TestRoutesForRule_PrioritizesDefaultPathMethodMatchesOverHeaderOnlyMatches(
 	methodOnlyRoute := methodOnlyRoutes[0]
 	methodWithHeaderRoute := methodOnlyRoutes[1]
 	assert.Equal(t, []string{"PATCH"}, methodOnlyRoute.Spec.Methods)
-	assert.Equal(t, []string{"~/"}, methodOnlyRoute.Spec.Paths)
+	assert.Empty(t, methodOnlyRoute.Spec.Paths)
 	assert.NotNil(t, methodOnlyRoute.Spec.RegexPriority)
 	assert.Nil(t, methodOnlyRoute.Spec.Headers)
 	assert.Equal(t, []string{"PATCH"}, methodWithHeaderRoute.Spec.Methods)
 	assert.Equal(t, map[string][]string{"version": {"four"}}, methodWithHeaderRoute.Spec.Headers)
-	assert.Equal(t, []string{"~/"}, methodWithHeaderRoute.Spec.Paths)
+	assert.Empty(t, methodWithHeaderRoute.Spec.Paths)
 
 	headerOnlyRoute := headerOnlyRoutes[0]
-	assert.Equal(t, []string{"~/"}, headerOnlyRoute.Spec.Paths)
+	assert.Equal(t, []string{"~/(.*)"}, headerOnlyRoute.Spec.Paths)
 	assert.Empty(t, headerOnlyRoute.Spec.Methods)
 	assert.NotNil(t, headerOnlyRoute.Spec.RegexPriority)
 	require.NotNil(t, headerOnlyRoute.Spec.Headers)
@@ -1203,7 +1211,8 @@ func TestRoutesForRule_MethodOnlyMatch(t *testing.T) {
 	require.Len(t, results, 1)
 
 	assert.Equal(t, []string{"GET"}, results[0].Spec.Methods)
-	assert.Equal(t, []string{"~/"}, results[0].Spec.Paths)
+	assert.Empty(t, results[0].Spec.Paths)
+	assert.NotNil(t, results[0].Spec.RegexPriority)
 	assert.Nil(t, results[0].Spec.Headers)
 	// Method-only matches on the default path get an explicit regex_priority so
 	// Gateway API precedence is preserved relative to header-only matches.

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -197,7 +197,7 @@ func TestRoutesForRule(t *testing.T) {
 
 				if result.Spec.Paths[0] == "/" {
 					assert.Equal(t, map[string][]string{"X-Foo": {"bar"}}, result.Spec.Headers)
-					assert.Nil(t, result.Spec.RegexPriority)
+					assert.NotNil(t, result.Spec.RegexPriority)
 					continue
 				}
 
@@ -790,9 +790,13 @@ func TestRoutesForRule_PrioritizesHeaderOnlyHTTPRouteMatches(t *testing.T) {
 	assert.Equal(t, []string{"/"}, versionTwoRoute.Spec.Paths)
 	assert.Equal(t, []string{"/"}, twoHeaderRoute.Spec.Paths)
 	assert.Equal(t, []string{"/"}, colorBlueRoute.Spec.Paths)
-	assert.Nil(t, versionTwoRoute.Spec.RegexPriority)
-	assert.Nil(t, twoHeaderRoute.Spec.RegexPriority)
-	assert.Nil(t, colorBlueRoute.Spec.RegexPriority)
+	// Header-only matches on the default path get an explicit regex_priority so
+	// Gateway API precedence (more headers beat fewer headers) is preserved.
+	assert.NotNil(t, versionTwoRoute.Spec.RegexPriority)
+	assert.NotNil(t, twoHeaderRoute.Spec.RegexPriority)
+	assert.NotNil(t, colorBlueRoute.Spec.RegexPriority)
+	assert.Greater(t, *twoHeaderRoute.Spec.RegexPriority, *versionTwoRoute.Spec.RegexPriority)
+	assert.Greater(t, *twoHeaderRoute.Spec.RegexPriority, *colorBlueRoute.Spec.RegexPriority)
 }
 
 func TestRoutesForRule_PrioritizesDefaultPathMethodMatchesOverHeaderOnlyMatches(t *testing.T) {
@@ -869,7 +873,7 @@ func TestRoutesForRule_PrioritizesDefaultPathMethodMatchesOverHeaderOnlyMatches(
 	methodWithHeaderRoute := methodOnlyRoutes[1]
 	assert.Equal(t, []string{"PATCH"}, methodOnlyRoute.Spec.Methods)
 	assert.Empty(t, methodOnlyRoute.Spec.Paths)
-	assert.Nil(t, methodOnlyRoute.Spec.RegexPriority)
+	assert.NotNil(t, methodOnlyRoute.Spec.RegexPriority)
 	assert.Nil(t, methodOnlyRoute.Spec.Headers)
 	assert.Equal(t, []string{"PATCH"}, methodWithHeaderRoute.Spec.Methods)
 	assert.Equal(t, map[string][]string{"version": {"four"}}, methodWithHeaderRoute.Spec.Headers)
@@ -878,9 +882,11 @@ func TestRoutesForRule_PrioritizesDefaultPathMethodMatchesOverHeaderOnlyMatches(
 	headerOnlyRoute := headerOnlyRoutes[0]
 	assert.Empty(t, headerOnlyRoute.Spec.Paths)
 	assert.Empty(t, headerOnlyRoute.Spec.Methods)
-	assert.Nil(t, headerOnlyRoute.Spec.RegexPriority)
+	assert.NotNil(t, headerOnlyRoute.Spec.RegexPriority)
 	require.NotNil(t, headerOnlyRoute.Spec.Headers)
 	assert.Equal(t, map[string][]string{"version": {"four"}}, headerOnlyRoute.Spec.Headers)
+	// Method matches rank above header-only matches per Gateway API precedence.
+	assert.Greater(t, *methodOnlyRoute.Spec.RegexPriority, *headerOnlyRoute.Spec.RegexPriority)
 
 	pathOnlyRoute := pathRoutes[0]
 	pathWithHeaderRoute := pathRoutes[1]
@@ -1199,7 +1205,9 @@ func TestRoutesForRule_MethodOnlyMatch(t *testing.T) {
 	assert.Equal(t, []string{"GET"}, results[0].Spec.Methods)
 	assert.Empty(t, results[0].Spec.Paths)
 	assert.Nil(t, results[0].Spec.Headers)
-	assert.Nil(t, results[0].Spec.RegexPriority)
+	// Method-only matches on the default path get an explicit regex_priority so
+	// Gateway API precedence is preserved relative to header-only matches.
+	assert.NotNil(t, results[0].Spec.RegexPriority)
 	assert.Equal(t, []string{"example.com"}, results[0].Spec.Hosts)
 }
 

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -1023,6 +1023,51 @@ func TestHTTPRouteMatchPrioritiesForDefaultPathMethodMatching(t *testing.T) {
 	assert.Greater(t, patchOnly, headerOnly)
 }
 
+// TestHTTPRouteMatchPrioritiesTreatDefaultPathAsRootPrefix ensures a match with an
+// explicit root path prefix (Path: "/") and a method-less default-path match share
+// the same priority class, so that method-only matches always rank above them. Without
+// normalizing the default path to the root prefix, a method-only match would be ordered
+// below an explicit root prefix match, and precedence variant generation would augment
+// the wrong side.
+func TestHTTPRouteMatchPrioritiesTreatDefaultPathAsRootPrefix(t *testing.T) {
+	httpRoute := &gwtypes.HTTPRoute{
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Path:    defaultRootPathMatch(),
+						Headers: []gatewayv1.HTTPHeaderMatch{{Name: "version", Value: "one"}},
+					}},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Method: new(gatewayv1.HTTPMethodPatch),
+					}},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Headers: []gatewayv1.HTTPHeaderMatch{{Name: "version", Value: "four"}},
+					}},
+				},
+			},
+		},
+	}
+
+	priorities := httpRouteMatchPriorities(httpRoute)
+
+	explicitRootWithHeader := priorityForHTTPRouteMatch(priorities, 0, 0)
+	methodOnly := priorityForHTTPRouteMatch(priorities, 1, 0)
+	headerOnly := priorityForHTTPRouteMatch(priorities, 2, 0)
+
+	// Method matches rank above header matches, and an explicit root prefix path must not
+	// outrank a default (implicit root) path.
+	assert.Greater(t, methodOnly, explicitRootWithHeader)
+	assert.Greater(t, methodOnly, headerOnly)
+	// The explicit root prefix and the default path are the same path, so both matches
+	// share the path class and the header count breaks the tie.
+	assert.Greater(t, explicitRootWithHeader, headerOnly)
+}
+
 func defaultRootPathMatch() *gatewayv1.HTTPPathMatch {
 	return &gatewayv1.HTTPPathMatch{
 		Type:  new(gatewayv1.PathMatchPathPrefix),

--- a/pkg/gatewayapi/supportedfeatures.go
+++ b/pkg/gatewayapi/supportedfeatures.go
@@ -10,7 +10,10 @@ import (
 )
 
 var (
-	traditionalCompatibleRouterSupportedFeatures = slices.Clone(commonSupportedFeatures) // Append here the traditional compatible router specific features.
+	traditionalCompatibleRouterSupportedFeatures = append(slices.Clone(commonSupportedFeatures),
+		// HTTPRoute extended.
+		features.SupportHTTPRouteMethodMatching,
+	)
 
 	expressionsRouterSupportedFeatures = append(slices.Clone(commonSupportedFeatures),
 		// HTTPRoute extended.

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -80,7 +80,7 @@ func TestGatewayConformance(t *testing.T) {
 		t.Fatal("hybrid gateway type requires KONG_TEST_KONNECT_ACCESS_TOKEN to be set")
 	}
 
-	skippedTests := skippedTestsForConfig(gwType)
+	skippedTests := skippedTestsForConfig(kongRouterFlavor, gwType)
 	runConformance(t, gwType, kongRouterFlavor, supportedFeatures, cleanupResources, skippedTests)
 }
 

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -23,7 +23,9 @@ var skippedTestsForStandard = []string{
 
 var skippedTestsForExpressionsRouter = []string{}
 
-var skippedTestsForStandardTraditionalCompatibleRouter = []string{}
+var skippedTestsForStandardTraditionalCompatibleRouter = []string{
+	tests.HTTPRouteMethodMatching.ShortName,
+}
 
 var skippedTestsForHybrid = []string{
 

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -27,11 +27,8 @@ var skippedTestsForStandardTraditionalCompatibleRouter = []string{}
 
 var skippedTestsForHybrid = []string{
 
-	// Core profile.
-	tests.HTTPRouteMethodMatching.ShortName,
-	tests.HTTPRouteQueryParamMatching.ShortName,
-
 	// Extended profile.
+	tests.HTTPRouteQueryParamMatching.ShortName,
 	tests.HTTPRouteRewriteHost.ShortName,
 	tests.HTTPRouteRewritePath.ShortName,
 

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -3,6 +3,7 @@ package conformance
 import (
 	"sigs.k8s.io/gateway-api/conformance/tests"
 
+	"github.com/kong/kong-operator/v2/pkg/consts"
 	"github.com/kong/kong-operator/v2/test"
 )
 
@@ -11,18 +12,30 @@ var skippedTestsShared = []string{}
 
 var skippedTestsForStandard = []string{}
 
+// skippedTestsForStandardTraditionalCompatibleRouter are ShortNames of tests
+// skipped only for the standard gateway with the traditional_compatible router
+// flavor.
+var skippedTestsForStandardTraditionalCompatibleRouter = []string{
+	// The standard gateway does not preserve Gateway API method-over-header
+	// match precedence with the traditional_compatible router flavor, so
+	// HTTPRouteMethodMatching is enabled for the hybrid gateway only.
+	tests.HTTPRouteMethodMatching.ShortName,
+}
+
 var skippedTestsForHybrid = []string{
 
 	// Extended profile.
-	tests.HTTPRouteMethodMatching.ShortName,
 	tests.HTTPRouteQueryParamMatching.ShortName,
 }
 
-// skippedTestsForConfig returns the list of skipped tests for the given gateway type.
-func skippedTestsForConfig(gwType gatewayType) []string {
+// skippedTestsForConfig returns the list of skipped tests for the given router flavor and gateway type.
+func skippedTestsForConfig(routerFlavor consts.RouterFlavor, gwType gatewayType) []string {
 	skipped := append([]string{}, skippedTestsShared...)
 	if gwType == standardGateway {
 		skipped = append(skipped, skippedTestsForStandard...)
+		if routerFlavor == consts.RouterFlavorTraditionalCompatible {
+			skipped = append(skipped, skippedTestsForStandardTraditionalCompatibleRouter...)
+		}
 	}
 
 	if gwType == hybridGateway {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enables the Gateway API `HTTPRouteMethodMatching` conformance test for hybrid gateways and fixes route precedence in Kong's `traditional_compatible` router.

The hybrid gateway previously produced incorrect or transient routing results when method-only, header-only, and path-based matches overlapped. In particular, Kong only retains the low 20 bits of `regex_priority`, and creating catch-all routes before more specific routes could temporarily expose or cache the wrong match.

**Which issue this PR fixes**

Fixes https://github.com/Kong/kong-operator/issues/3445

**Special notes for your reviewer**:

- The priority range intentionally stays below `1 << 20` because Kong's `traditional_compatible` router retains only the low 20 bits when calculating route precedence.
- Precedence for user-provided `RegularExpression` path matches remains implementation-specific, as allowed by the Gateway API specification.
- This change does not introduce any API or CRD changes.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
