### PR TITLE
[Backport release/2.1.x] fix(hybridgateway): prevent traffic drops when HTTPRoute spec changes rotate resource names (#4577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,12 @@
   the transition, both old and new entries may be present in Konnect
   simultaneously as creation and orphan cleanup are not synchronized.
   [#4509](https://github.com/Kong/kong-operator/pull/4509)
+- Hybridgateway: prevent traffic drops when an `HTTPRoute` spec change rotates
+  resource names. A cleanup-time gate defers orphan deletion until every desired
+  `KongRoute` is confirmed bound to its new `KongService` in Konnect, and an
+  enforce-time gate delays `KongService` creation until its `KongUpstream` and
+  all desired `KongTarget`s are Programmed.
+  [#4577](https://github.com/Kong/kong-operator/pull/4577)
 
 ## [v2.1.7]
 

--- a/controller/hybridgateway/controller.go
+++ b/controller/hybridgateway/controller.go
@@ -3,6 +3,7 @@ package hybridgateway
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -25,6 +26,10 @@ import (
 const (
 	// ControllerName is the name used for logging and event recording in the hybrid gateway controller.
 	ControllerName = "hybridgateway"
+
+	// requeueWhileWaiting is a short safety requeue used when we intentionally
+	// wait for prerequisites (e.g., Programmed dependencies) before proceeding.
+	requeueWhileWaiting = time.Second
 )
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongroutes,verbs=get;list;watch;create;update;patch;delete
@@ -196,7 +201,7 @@ func (r *HybridGatewayReconciler[t, tPtr]) Reconcile(ctx context.Context, req ct
 	)
 
 	// Phase 3: State Enforcement.
-	stateChanged, err := enforceState(ctx, r.Client, logger, conv)
+	stateChanged, waiting, err := enforceState(ctx, r.Client, logger, conv)
 	if err != nil {
 		// Record state enforcement failure event.
 		r.eventRecorder.Event(
@@ -220,7 +225,29 @@ func (r *HybridGatewayReconciler[t, tPtr]) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	// Phase 4: Orphan Cleanup.
+	// If we are intentionally waiting for prerequisites (e.g., Programmed deps),
+	// schedule a short requeue as a safety net in case watch events are delayed.
+	if waiting {
+		return ctrl.Result{RequeueAfter: requeueWhileWaiting}, nil
+	}
+
+	// Phase 4.5: Readiness gate before orphan cleanup.
+	// For converters that opt in (currently HTTPRoute), defer deleting orphaned resources
+	// until all desired resources are Programmed. This prevents removing stale resources
+	// before their replacements are live in the data plane, which would otherwise open a
+	// traffic gap when a spec change rotates the desired resource names.
+	if checker, ok := any(conv).(converter.DesiredStateReadinessChecker); ok {
+		ready, err := checker.DesiredResourcesReady(ctx, logger)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if !ready {
+			log.Debug(logger, "Desired resources not ready yet, deferring orphan cleanup")
+			return ctrl.Result{RequeueAfter: requeueWhileWaiting}, nil
+		}
+	}
+
+	// Phase 5: Orphan Cleanup.
 	orphansDeleted, err := cleanOrphanedResources[t, tPtr](ctx, r.Client, logger, conv)
 	if err != nil {
 		// Record orphan cleanup failure event.

--- a/controller/hybridgateway/converter/converter.go
+++ b/controller/hybridgateway/converter/converter.go
@@ -41,6 +41,18 @@ type OrphanedResourceHandler interface {
 	HandleOrphanedResource(ctx context.Context, logger logr.Logger, resource *unstructured.Unstructured) (skipDelete bool, err error)
 }
 
+// DesiredStateReadinessChecker is an optional interface that converters can implement to
+// defer orphan cleanup until the resources they desire are ready (Programmed in Konnect).
+// When a converter implements it and DesiredResourcesReady returns false, the reconciler
+// requeues without deleting orphaned resources. This ensures stale resources are pruned
+// only after their replacements are live, avoiding a data-plane gap during a cutover
+// (e.g. when a spec change rotates the desired KongUpstream/KongService/KongRoute names).
+type DesiredStateReadinessChecker interface {
+	// DesiredResourcesReady reports whether all desired resources produced by the converter
+	// are Programmed. Resource kinds without a Programmed condition are ignored.
+	DesiredResourcesReady(ctx context.Context, logger logr.Logger) (ready bool, err error)
+}
+
 // RootObject is an interface that represents all resource types that can be loaded
 // as root by the APIConverter.
 type RootObject interface {

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -15,6 +16,7 @@ import (
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
 	hybridgatewayerrors "github.com/kong/kong-operator/v2/controller/hybridgateway/errors"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/kongroute"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
@@ -31,7 +33,10 @@ import (
 	"github.com/kong/kong-operator/v2/pkg/vars"
 )
 
-var _ APIConverter[gwtypes.HTTPRoute] = &httpRouteConverter{}
+var (
+	_ APIConverter[gwtypes.HTTPRoute] = &httpRouteConverter{}
+	_ DesiredStateReadinessChecker    = &httpRouteConverter{}
+)
 
 // httpRouteConverter is a concrete implementation of the APIConverter interface for HTTPRoute.
 type httpRouteConverter struct {
@@ -289,6 +294,88 @@ func (c *httpRouteConverter) UpdateRootObjectStatus(ctx context.Context, logger 
 
 	log.Debug(logger, "Finished UpdateRootObjectStatus", "updated", updated)
 	return updated, stop, nil
+}
+
+// DesiredResourcesReady implements DesiredStateReadinessChecker. It decides whether orphan cleanup may
+// proceed for this HTTPRoute.
+//
+// THE GATE is a single rule: every desired KongRoute must be bound, in Konnect, to its desired
+// KongService — verified via the authoritative status.konnect.serviceID, NOT the route's Programmed
+// condition. After a rollout repoints a route's serviceRef, the route can keep reporting Programmed=True
+// against the OLD service until the Konnect controller actually reprograms it; deleting the old chain
+// (KongTargets/KongUpstream/KongService) in that window drops traffic. Only the serviceID matching the
+// desired service tells us the route has truly moved and the old chain is safe to remove.
+//
+// We deliberately do NOT gate on the Programmed condition of the desired resources: the enforce-time chain
+// gating (KongService waits for its KongUpstream and KongTargets; KongRoute waits for the service)
+// already builds and programs the whole chain before a route is ever repointed, so a Programmed
+// check here would be redundant. The route serviceID is the only condition that actually makes deleting
+// the old chain safe.
+func (c *httpRouteConverter) DesiredResourcesReady(ctx context.Context, logger logr.Logger) (bool, error) {
+	desired, err := c.GetOutputStore(ctx, logger)
+	if err != nil {
+		return false, fmt.Errorf("failed to get desired objects for readiness check: %w", err)
+	}
+
+	// THE GATE: for each desired KongRoute, the service named in its spec.serviceRef must be the one it is
+	// actually bound to in Konnect. spec.serviceRef is a name and status.konnect.serviceID is a Konnect ID,
+	// so we fetch that one referenced KongService to resolve its Konnect ID and compare. The route's
+	// Programmed condition is not used: it lags on the old service right after a serviceRef repoint.
+	for i := range desired {
+		d := &desired[i]
+		if d.GetKind() != "KongRoute" {
+			continue
+		}
+
+		r := &unstructured.Unstructured{}
+		r.SetGroupVersionKind(d.GroupVersionKind())
+		if err := c.Get(ctx, client.ObjectKeyFromObject(d), r); err != nil {
+			if k8serrors.IsNotFound(err) {
+				// Route not applied yet: it cannot be confirmed on its desired service, so defer.
+				log.Debug(logger, "Desired KongRoute not found yet, deferring orphan cleanup", "obj", client.ObjectKeyFromObject(d))
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to get KongRoute %s: %w", client.ObjectKeyFromObject(d), err)
+		}
+
+		serviceRefName, _, _ := unstructured.NestedString(r.Object, "spec", "serviceRef", "namespacedRef", "name")
+		if serviceRefName == "" {
+			log.Debug(logger, "KongRoute has no serviceRef, skipping readiness check", "obj", client.ObjectKeyFromObject(r))
+			continue
+		}
+		boundServiceID, _, _ := unstructured.NestedString(r.Object, "status", "konnect", "serviceID")
+
+		// Fetch the referenced KongService: it must be Programmed (ready) and the route must be bound to
+		// its Konnect ID. spec.serviceRef is a name; the service's Konnect ID lives in its status.
+		var svc configurationv1alpha1.KongService
+		if err := c.Get(ctx, client.ObjectKey{Namespace: d.GetNamespace(), Name: serviceRefName}, &svc); err != nil {
+			if k8serrors.IsNotFound(err) {
+				log.Debug(logger, "Referenced KongService not found yet, deferring orphan cleanup", "route", client.ObjectKeyFromObject(r), "service", serviceRefName)
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to get KongService %s for route %s: %w", serviceRefName, client.ObjectKeyFromObject(r), err)
+		}
+		if !meta.IsStatusConditionTrue(svc.Status.Conditions, konnectv1alpha1.KonnectEntityProgrammedConditionType) {
+			log.Debug(logger, "Referenced KongService not Programmed yet, deferring orphan cleanup", "route", client.ObjectKeyFromObject(r), "service", serviceRefName)
+			return false, nil
+		}
+
+		var desiredServiceID string
+		if svc.Status.Konnect != nil {
+			desiredServiceID = svc.Status.Konnect.ID
+		}
+		if desiredServiceID == "" || boundServiceID != desiredServiceID {
+			log.Debug(logger, "KongRoute not yet bound to its referenced KongService in Konnect, deferring orphan cleanup",
+				"route", client.ObjectKeyFromObject(r),
+				"service", serviceRefName,
+				"boundServiceID", boundServiceID,
+				"desiredServiceID", desiredServiceID)
+			return false, nil
+		}
+	}
+
+	log.Debug(logger, "All routes are bound to their referenced KongService in Konnect, orphan cleanup may proceed")
+	return true, nil
 }
 
 // HandleOrphanedResource implements OrphanedResourceHandler.

--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -25,6 +25,7 @@ import (
 
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	"github.com/kong/kong-operator/v2/pkg/consts"
@@ -1626,4 +1627,220 @@ func newUnstructuredResource(routesAnnotation string) *unstructured.Unstructured
 		})
 	}
 	return resource
+}
+
+func TestHTTPRouteConverter_DesiredResourcesReady(t *testing.T) {
+	ctx := context.Background()
+	const (
+		ns           = "default"
+		routeName    = "route-1"
+		svcName      = "svc-1"
+		konnectSvcID = "konnect-svc-id-abc"
+	)
+
+	routeGVK := configurationv1alpha1.GroupVersion.WithKind("KongRoute")
+
+	// desiredRoute builds a KongRoute for the converter's outputStore.
+	desiredRoute := func(name string) *configurationv1alpha1.KongRoute {
+		r := &configurationv1alpha1.KongRoute{}
+		r.Name = name
+		r.Namespace = ns
+		r.SetGroupVersionKind(routeGVK)
+		return r
+	}
+
+	// clusterRoute builds an unstructured KongRoute representing what is in the cluster.
+	clusterRoute := func(name, serviceRefName, boundServiceID string) *unstructured.Unstructured {
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(routeGVK)
+		u.SetName(name)
+		u.SetNamespace(ns)
+		if serviceRefName != "" {
+			_ = unstructured.SetNestedField(u.Object, serviceRefName, "spec", "serviceRef", "namespacedRef", "name")
+		}
+		if boundServiceID != "" {
+			_ = unstructured.SetNestedField(u.Object, boundServiceID, "status", "konnect", "serviceID")
+		}
+		return u
+	}
+
+	// kongService builds a typed KongService with configurable Programmed status and Konnect ID.
+	kongService := func(name string, programmed bool, konnectID string) *configurationv1alpha1.KongService {
+		svc := &configurationv1alpha1.KongService{}
+		svc.Name = name
+		svc.Namespace = ns
+		if programmed {
+			svc.Status.Conditions = []metav1.Condition{{
+				Type:               "Programmed",
+				Status:             metav1.ConditionTrue,
+				Reason:             "Programmed",
+				LastTransitionTime: metav1.Now(),
+			}}
+		}
+		if konnectID != "" {
+			svc.Status.Konnect = &konnectv1alpha2.KonnectEntityStatusWithControlPlaneRef{
+				KonnectEntityStatus: konnectv1alpha2.KonnectEntityStatus{ID: konnectID},
+			}
+		}
+		return svc
+	}
+
+	baseRoute := &gwtypes.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "test-route", Namespace: ns}}
+
+	tests := []struct {
+		name            string
+		outputStore     []client.Object
+		existingObjs    []client.Object
+		interceptorFn   *interceptor.Funcs
+		wantReady       bool
+		wantErrContains string
+	}{
+		{
+			name:            "GetOutputStore error is propagated",
+			outputStore:     []client.Object{&badObject{Name: "bad"}},
+			wantReady:       false,
+			wantErrContains: "failed to get desired objects for readiness check",
+		},
+		{
+			name:        "empty output store → ready",
+			outputStore: nil,
+			wantReady:   true,
+		},
+		{
+			name: "no KongRoutes in output store → ready",
+			outputStore: []client.Object{
+				func() *configurationv1alpha1.KongService {
+					s := &configurationv1alpha1.KongService{}
+					s.Name = "svc-only"
+					s.Namespace = ns
+					s.SetGroupVersionKind(configurationv1alpha1.GroupVersion.WithKind("KongService"))
+					return s
+				}(),
+			},
+			wantReady: true,
+		},
+		{
+			name:        "desired KongRoute not yet in cluster → defer (NotFound)",
+			outputStore: []client.Object{desiredRoute(routeName)},
+			wantReady:   false,
+		},
+		{
+			name:        "Get KongRoute returns non-NotFound error → propagate",
+			outputStore: []client.Object{desiredRoute(routeName)},
+			interceptorFn: &interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*unstructured.Unstructured); ok && key.Name == routeName {
+						return fmt.Errorf("simulated get error")
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+			wantReady:       false,
+			wantErrContains: "failed to get KongRoute",
+		},
+		{
+			name:         "KongRoute found, no serviceRef (serviceless route) → ready",
+			outputStore:  []client.Object{desiredRoute(routeName)},
+			existingObjs: []client.Object{clusterRoute(routeName, "", "")},
+			wantReady:    true,
+		},
+		{
+			name:         "KongRoute found with serviceRef, KongService not found → defer",
+			outputStore:  []client.Object{desiredRoute(routeName)},
+			existingObjs: []client.Object{clusterRoute(routeName, svcName, "")},
+			wantReady:    false,
+		},
+		{
+			name:         "Get KongService returns non-NotFound error → propagate",
+			outputStore:  []client.Object{desiredRoute(routeName)},
+			existingObjs: []client.Object{clusterRoute(routeName, svcName, "")},
+			interceptorFn: &interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*configurationv1alpha1.KongService); ok {
+						return fmt.Errorf("simulated service get error")
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+			wantReady:       false,
+			wantErrContains: "failed to get KongService",
+		},
+		{
+			name:         "KongService found but not Programmed → defer",
+			outputStore:  []client.Object{desiredRoute(routeName)},
+			existingObjs: []client.Object{clusterRoute(routeName, svcName, ""), kongService(svcName, false, "")},
+			wantReady:    false,
+		},
+		{
+			name:        "KongService Programmed but Konnect status nil (no Konnect ID) → defer",
+			outputStore: []client.Object{desiredRoute(routeName)},
+			existingObjs: []client.Object{
+				clusterRoute(routeName, svcName, konnectSvcID),
+				kongService(svcName, true, ""), // Programmed but Konnect == nil
+			},
+			wantReady: false,
+		},
+		{
+			name:        "KongService Programmed, Konnect ID set, but route bound to old service ID → defer",
+			outputStore: []client.Object{desiredRoute(routeName)},
+			existingObjs: []client.Object{
+				clusterRoute(routeName, svcName, "old-service-id"),
+				kongService(svcName, true, konnectSvcID),
+			},
+			wantReady: false,
+		},
+		{
+			name:        "KongRoute bound to correct service ID → ready",
+			outputStore: []client.Object{desiredRoute(routeName)},
+			existingObjs: []client.Object{
+				clusterRoute(routeName, svcName, konnectSvcID),
+				kongService(svcName, true, konnectSvcID),
+			},
+			wantReady: true,
+		},
+		{
+			name:         "multiple routes: first not ready → defer immediately",
+			outputStore:  []client.Object{desiredRoute("route-a"), desiredRoute("route-b")},
+			existingObjs: []client.Object{
+				// route-a not in cluster → defers before even checking route-b
+			},
+			wantReady: false,
+		},
+		{
+			name:        "multiple routes: all bound to correct service → ready",
+			outputStore: []client.Object{desiredRoute("route-a"), desiredRoute("route-b")},
+			existingObjs: []client.Object{
+				clusterRoute("route-a", svcName, konnectSvcID),
+				clusterRoute("route-b", svcName, konnectSvcID),
+				kongService(svcName, true, konnectSvcID),
+			},
+			wantReady: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(scheme.Get())
+			if len(tt.existingObjs) > 0 {
+				builder = builder.WithObjects(tt.existingObjs...)
+			}
+			if tt.interceptorFn != nil {
+				builder = builder.WithInterceptorFuncs(*tt.interceptorFn)
+			}
+			cl := builder.Build()
+
+			conv := newHTTPRouteConverter(baseRoute, cl, false, "").(*httpRouteConverter)
+			conv.outputStore = tt.outputStore
+
+			ready, err := conv.DesiredResourcesReady(ctx, logr.Discard())
+
+			if tt.wantErrContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantReady, ready)
+		})
+	}
 }

--- a/controller/hybridgateway/reconciler_utils.go
+++ b/controller/hybridgateway/reconciler_utils.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
 	finalizerconst "github.com/kong/kong-operator/v2/controller/hybridgateway/const/finalizers"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/converter"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/managedfields"
@@ -18,6 +20,7 @@ import (
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/utils"
 	"github.com/kong/kong-operator/v2/controller/pkg/log"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
+	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
 )
 
 const (
@@ -57,21 +60,35 @@ func translate[t converter.RootObject](conv converter.APIConverter[t], ctx conte
 //
 // The function uses server-side apply with the "gateway-operator" field manager to ensure
 // proper ownership and conflict resolution when multiple controllers manage the same resources.
-func enforceState[t converter.RootObject](ctx context.Context, cl client.Client, logger logr.Logger, conv converter.APIConverter[t]) (bool, error) {
+func enforceState[t converter.RootObject](ctx context.Context, cl client.Client, logger logr.Logger, conv converter.APIConverter[t]) (applied bool, waiting bool, err error) {
 	logger = logger.WithValues("phase", "state-enforcement")
 	log.Debug(logger, "Starting state enforcement")
 
 	// Get the desired state from the converter.
 	desiredObjects, err := conv.GetOutputStore(ctx, logger)
 	if err != nil {
-		return false, fmt.Errorf("failed to get desired objects from converter: %w", err)
+		return false, false, fmt.Errorf("failed to get desired objects from converter: %w", err)
 	}
 	if len(desiredObjects) == 0 {
 		log.Debug(logger, "No desired objects to enforce")
-		return false, nil
+		return false, false, nil
 	}
 
 	log.Debug(logger, "Retrieved desired objects for enforcement", "objectCount", len(desiredObjects))
+
+	// Build lookup maps once so that per-object gating checks are O(1) instead of O(n).
+	desiredUpstreamNames := make(map[string]struct{}, len(desiredObjects))
+	desiredTargetsByUpstream := make(map[string][]unstructured.Unstructured, len(desiredObjects))
+	for _, obj := range desiredObjects {
+		switch obj.GetKind() {
+		case "KongUpstream":
+			desiredUpstreamNames[obj.GetName()] = struct{}{}
+		case "KongTarget":
+			if upName, _, _ := unstructured.NestedString(obj.Object, "spec", "upstreamRef", "name"); upName != "" {
+				desiredTargetsByUpstream[upName] = append(desiredTargetsByUpstream[upName], obj)
+			}
+		}
+	}
 
 	var (
 		objectsCreated = 0
@@ -89,6 +106,107 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 			objectsSkipped++
 			continue
 		}
+
+		// Best-effort dependency gating: avoid creating dependent resources before
+		// their prerequisites are Programmed in Konnect. This reduces transient
+		// 404s during conformance and prevents noisy reconciliation errors like
+		// "can't create target without a Konnect Upstream ID".
+		switch desired.GetKind() {
+		case "KongService":
+			if host, _, _ := unstructured.NestedString(desired.Object, "spec", "host"); host != "" && desiredHasUpstreamNamed(desiredUpstreamNames, host) {
+				var up configurationv1alpha1.KongUpstream
+				if err := cl.Get(ctx, client.ObjectKey{Namespace: desired.GetNamespace(), Name: host}, &up); err != nil {
+					log.Debug(logger, "Upstream not found yet for service, waiting", "upstream", host)
+					objectsSkipped++
+					stopAtKind = "KongUpstream"
+					continue
+				}
+				if !k8sutils.HasConditionTrue(konnectv1alpha1.KonnectEntityProgrammedConditionType, &up) {
+					log.Debug(logger, "Upstream not Programmed yet for service, waiting", "upstream", host)
+					objectsSkipped++
+					stopAtKind = "KongUpstream"
+					continue
+				}
+				targetsReady, err := upstreamTargetsProgrammed(ctx, cl, desiredTargetsByUpstream[host])
+				if err != nil {
+					return false, false, fmt.Errorf("failed to check upstream targets readiness for service %s: %w", desired.GetName(), err)
+				}
+				if !targetsReady {
+					log.Debug(logger, "Upstream targets not Programmed yet for service, waiting", "service", desired.GetName(), "upstream", host)
+					objectsSkipped++
+					stopAtKind = "KongTarget"
+					continue
+				}
+			}
+		case "KongTarget":
+			upstreamName, _, _ := unstructured.NestedString(desired.Object, "spec", "upstreamRef", "name")
+			if upstreamName != "" {
+				var up configurationv1alpha1.KongUpstream
+				if err := cl.Get(ctx, client.ObjectKey{Namespace: desired.GetNamespace(), Name: upstreamName}, &up); err != nil {
+					log.Debug(logger, "Upstream not found yet for target, waiting", "upstream", upstreamName)
+					objectsSkipped++
+					stopAtKind = "KongUpstream"
+					continue
+				}
+				if !k8sutils.HasConditionTrue(konnectv1alpha1.KonnectEntityProgrammedConditionType, &up) {
+					log.Debug(logger, "Upstream not Programmed yet for target, waiting", "upstream", upstreamName)
+					objectsSkipped++
+					stopAtKind = "KongUpstream"
+					continue
+				}
+			}
+		case "KongRoute":
+			svcName, _, _ := unstructured.NestedString(desired.Object, "spec", "serviceRef", "namespacedRef", "name")
+			if svcName != "" {
+				var svc configurationv1alpha1.KongService
+				if err := cl.Get(ctx, client.ObjectKey{Namespace: desired.GetNamespace(), Name: svcName}, &svc); err != nil {
+					log.Debug(logger, "Service not found yet for route, waiting", "service", svcName)
+					objectsSkipped++
+					stopAtKind = "KongService"
+					continue
+				}
+				if !k8sutils.HasConditionTrue(konnectv1alpha1.KonnectEntityProgrammedConditionType, &svc) {
+					log.Debug(logger, "Service not Programmed yet for route, waiting", "service", svcName)
+					objectsSkipped++
+					stopAtKind = "KongService"
+					continue
+				}
+			}
+		case "KongPluginBinding":
+			if routeName, _, _ := unstructured.NestedString(desired.Object, "spec", "targets", "routeRef", "name"); routeName != "" {
+				var route configurationv1alpha1.KongRoute
+				if err := cl.Get(ctx, client.ObjectKey{Namespace: desired.GetNamespace(), Name: routeName}, &route); err != nil {
+					log.Debug(logger, "Route not found yet for plugin binding, waiting", "route", routeName)
+					objectsSkipped++
+					stopAtKind = "KongRoute"
+					continue
+				}
+				if !k8sutils.HasConditionTrue(konnectv1alpha1.KonnectEntityProgrammedConditionType, &route) {
+					log.Debug(logger, "Route not Programmed yet for plugin binding, waiting", "route", routeName)
+					objectsSkipped++
+					stopAtKind = "KongRoute"
+					continue
+				}
+			}
+			if svcName, _, _ := unstructured.NestedString(desired.Object, "spec", "targets", "serviceRef", "name"); svcName != "" {
+				if kind, _, _ := unstructured.NestedString(desired.Object, "spec", "targets", "serviceRef", "kind"); kind == "KongService" {
+					var svc configurationv1alpha1.KongService
+					if err := cl.Get(ctx, client.ObjectKey{Namespace: desired.GetNamespace(), Name: svcName}, &svc); err != nil {
+						log.Debug(logger, "Service not found yet for plugin binding, waiting", "service", svcName)
+						objectsSkipped++
+						stopAtKind = "KongService"
+						continue
+					}
+					if !k8sutils.HasConditionTrue(konnectv1alpha1.KonnectEntityProgrammedConditionType, &svc) {
+						log.Debug(logger, "Service not Programmed yet for plugin binding, waiting", "service", svcName)
+						objectsSkipped++
+						stopAtKind = "KongService"
+						continue
+					}
+				}
+			}
+		}
+
 		log.Debug(logger, "Processing desired object", "index", i, "kind", desired.GetKind(), "name", desired.GetName())
 		// Get the existing object by name from the API server.
 		existing := &unstructured.Unstructured{}
@@ -103,15 +221,15 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 		namespacedNameExisting := client.ObjectKeyFromObject(existing)
 
 		if err != nil {
-			if errors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				// Object doesn't exist, create it using server-side apply.
 				log.Debug(logger, "Creating new object", "kind", desired.GetKind(), "obj", namespacedNameDesired)
 				// Set field manager for server-side apply
 				if err := cl.Apply(ctx, client.ApplyConfigurationFromUnstructured(&desired), client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
-					if errors.IsConflict(err) {
-						return false, fmt.Errorf("conflict during create of object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
+					if apierrors.IsConflict(err) {
+						return false, false, fmt.Errorf("conflict during create of object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 					}
-					return false, fmt.Errorf("failed to create object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
+					return false, false, fmt.Errorf("failed to create object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 				}
 				objectsCreated++
 				log.Debug(logger, "Successfully created object", "kind", desired.GetKind(), "obj", namespacedNameDesired)
@@ -119,7 +237,7 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 				continue
 			} else {
 				// Other error getting the object.
-				return false, fmt.Errorf("failed to get object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
+				return false, false, fmt.Errorf("failed to get object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 			}
 		}
 
@@ -134,16 +252,16 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 		// Object exists, check if we need to update it.
 		managedFieldsObj, err := managedfields.ExtractAsUnstructured(existing, FieldManager, "")
 		if err != nil {
-			return false, fmt.Errorf("failed to extract managed fields for kind %s obj %s: %w", existing.GetKind(), namespacedNameExisting, err)
+			return false, false, fmt.Errorf("failed to extract managed fields for kind %s obj %s: %w", existing.GetKind(), namespacedNameExisting, err)
 		}
 		if managedFieldsObj == nil {
 			// No managed fields for our field manager, we should update.
 			log.Debug(logger, "No managed fields found for our field manager, will apply desired state", "kind", existing.GetKind(), "obj", namespacedNameExisting)
 			if err := cl.Apply(ctx, client.ApplyConfigurationFromUnstructured(&desired), client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
-				if errors.IsConflict(err) {
-					return false, fmt.Errorf("conflict during create of object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
+				if apierrors.IsConflict(err) {
+					return false, false, fmt.Errorf("conflict during create of object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 				}
-				return false, fmt.Errorf("failed to create object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
+				return false, false, fmt.Errorf("failed to create object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 			}
 			objectsUpdated++
 			log.Debug(logger, "Successfully applied desired state (no managed fields)", "kind", existing.GetKind(), "obj", namespacedNameExisting)
@@ -153,13 +271,13 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 		// Convert desired resource to unstructured.
 		desiredU, err := utils.ToUnstructured(&desired, cl.Scheme())
 		if err != nil {
-			return false, fmt.Errorf("failed to convert to unstructured desired obj for kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
+			return false, false, fmt.Errorf("failed to convert to unstructured desired obj for kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 		}
 
 		// Compare the two states.
 		compare, err := managedfields.Compare(managedFieldsObj, pruneDesiredObj(desiredU))
 		if err != nil {
-			return false, fmt.Errorf("failed to compare managed fields for kind %s obj %s: %w", existing.GetKind(), namespacedNameExisting, err)
+			return false, false, fmt.Errorf("failed to compare managed fields for kind %s obj %s: %w", existing.GetKind(), namespacedNameExisting, err)
 		}
 
 		if compare.IsSame() {
@@ -168,10 +286,10 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 			log.Info(logger, "Changes detected for obj, applying desired state", "kind", existing.GetKind(), "obj", namespacedNameExisting, "changes", compare.String())
 			// Changes detected, apply the desired state using server-side apply.
 			if err := cl.Apply(ctx, client.ApplyConfigurationFromUnstructured(&desired), client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
-				if errors.IsConflict(err) {
-					return false, fmt.Errorf("conflict during create of object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
+				if apierrors.IsConflict(err) {
+					return false, false, fmt.Errorf("conflict during create of object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 				}
-				return false, fmt.Errorf("failed to update object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
+				return false, false, fmt.Errorf("failed to update object kind %s obj %s: %w", desired.GetKind(), namespacedNameDesired, err)
 			}
 			objectsUpdated++
 			log.Debug(logger, "Successfully applied changes to object", "kind", existing.GetKind(), "obj", namespacedNameExisting)
@@ -188,7 +306,32 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 	stateChanged := (objectsCreated + objectsUpdated) > 0
 	// Return true also if any resources were skipped to ensure requeue for proper ordering
 	waitingForSkipped := objectsSkipped > 0
-	return stateChanged && waitingForSkipped, nil
+	return stateChanged, waitingForSkipped, nil
+}
+
+// desiredHasUpstreamNamed reports whether the pre-built upstream name set contains the given name.
+func desiredHasUpstreamNamed(desiredUpstreamNames map[string]struct{}, name string) bool {
+	_, ok := desiredUpstreamNames[name]
+	return ok
+}
+
+// upstreamTargetsProgrammed reports whether every KongTarget in the pre-filtered targets slice is present
+// in the cluster and Programmed.
+func upstreamTargetsProgrammed(ctx context.Context, cl client.Client, targets []unstructured.Unstructured) (bool, error) {
+	for i := range targets {
+		d := &targets[i]
+		var tgt configurationv1alpha1.KongTarget
+		if err := cl.Get(ctx, client.ObjectKey{Namespace: d.GetNamespace(), Name: d.GetName()}, &tgt); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to get KongTarget %s/%s: %w", d.GetNamespace(), d.GetName(), err)
+		}
+		if !k8sutils.HasConditionTrue(konnectv1alpha1.KonnectEntityProgrammedConditionType, &tgt) {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // enforceStatus updates the status of the root object managed by the provided APIConverter.
@@ -325,7 +468,7 @@ func cleanOrphanedResources[t converter.RootObject, tPtr converter.RootObjectPtr
 			}
 
 			log.Info(logger, "Deleting orphaned resource", "kind", item.GetKind(), "obj", client.ObjectKeyFromObject(&item))
-			if err := cl.Delete(ctx, &item); err != nil && !errors.IsNotFound(err) {
+			if err := cl.Delete(ctx, &item); err != nil && !apierrors.IsNotFound(err) {
 				return false, fmt.Errorf("failed to delete orphaned resource kind %s obj %s: %w", item.GetKind(), client.ObjectKeyFromObject(&item), err)
 			}
 			orphansForGVK++
@@ -451,7 +594,7 @@ func removeFinalizerIfNotManaged[t converter.RootObject](ctx context.Context, cl
 
 	// Patch the object.
 	if err := cl.Patch(ctx, obj, patch); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// Object was already deleted, this is fine.
 			log.Trace(logger, "Object already deleted, finalizer removal not needed")
 			return false, nil

--- a/controller/hybridgateway/reconciler_utils_test.go
+++ b/controller/hybridgateway/reconciler_utils_test.go
@@ -20,6 +20,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	finalizerconst "github.com/kong/kong-operator/v2/controller/hybridgateway/const/finalizers"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
@@ -85,6 +86,326 @@ func TestPruneDesiredObj(t *testing.T) {
 				_, hasSpec := u.Object["spec"]
 				assert.False(t, hasSpec)
 			}
+		})
+	}
+}
+
+func TestEnforceState_DependencyGating(t *testing.T) {
+	ctx := t.Context()
+	logger := logr.Discard()
+
+	// Prepare Scheme with needed types.
+	s := scheme.Get()
+
+	ns := "ns"
+
+	// Case 1: Target waits for missing Upstream.
+	t.Run("target waits for missing upstream", func(t *testing.T) {
+		// Desired contains a KongTarget referencing upstream "u1".
+		targetGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongTarget"}
+		desired := newUnstructured(ns, "t1", targetGVK, map[string]string{})
+		_ = unstructured.SetNestedField(desired.Object, map[string]any{
+			"upstreamRef": map[string]any{"name": "u1"},
+		}, "spec")
+
+		fakeConv := &fakeHTTPRouteConverter{desired: []unstructured.Unstructured{desired}}
+		cl := fake.NewClientBuilder().WithScheme(s).Build()
+
+		applied, waiting, err := enforceState(ctx, cl, logger, fakeConv)
+		require.NoError(t, err)
+		assert.False(t, applied)
+		assert.True(t, waiting)
+	})
+
+	// Case 2: Route waits for not-Programmed Service.
+	t.Run("route waits for not programmed service", func(t *testing.T) {
+		routeGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongRoute"}
+		desired := newUnstructured(ns, "r1", routeGVK, nil)
+		_ = unstructured.SetNestedField(desired.Object, map[string]any{
+			"serviceRef": map[string]any{"namespacedRef": map[string]any{"name": "svc1"}},
+		}, "spec")
+
+		// Existing KongService with Programmed=False.
+		svc := &configurationv1alpha1.KongService{}
+		svc.SetName("svc1")
+		svc.SetNamespace(ns)
+		// Default conditions include Programmed Unknown; ensure it's not True.
+
+		fakeConv := &fakeHTTPRouteConverter{desired: []unstructured.Unstructured{desired}}
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(svc).Build()
+
+		applied, waiting, err := enforceState(ctx, cl, logger, fakeConv)
+		require.NoError(t, err)
+		assert.False(t, applied)
+		assert.True(t, waiting)
+	})
+
+	// Case 3: PluginBinding waits for not-Programmed Route.
+	t.Run("pluginbinding waits for not programmed route", func(t *testing.T) {
+		kpbGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongPluginBinding"}
+		desired := newUnstructured(ns, "b1", kpbGVK, nil)
+		_ = unstructured.SetNestedField(desired.Object, map[string]any{
+			"routeRef": map[string]any{"name": "route1"},
+		}, "spec", "targets")
+
+		route := &configurationv1alpha1.KongRoute{}
+		route.SetName("route1")
+		route.SetNamespace(ns)
+		// Programmed not True by default.
+
+		fakeConv := &fakeHTTPRouteConverter{desired: []unstructured.Unstructured{desired}}
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(route).Build()
+
+		applied, waiting, err := enforceState(ctx, cl, logger, fakeConv)
+		require.NoError(t, err)
+		assert.False(t, applied)
+		assert.True(t, waiting)
+	})
+
+}
+
+func TestTranslate(t *testing.T) {
+	tests := []struct {
+		name          string
+		translateRet  int
+		translateErr  error
+		expectedCount int
+		expectError   bool
+	}{
+		{
+			name:          "returns translated count",
+			translateRet:  3,
+			expectedCount: 3,
+		},
+		{
+			name:         "propagates translate error",
+			translateErr: assert.AnError,
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conv := &fakeHTTPRouteConverter{translateRet: tt.translateRet, translateErr: tt.translateErr}
+
+			count, err := translate[gwtypes.HTTPRoute](conv, t.Context(), logr.Discard())
+
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedCount, count)
+		})
+	}
+}
+
+func TestEnforceStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		statusUpdated  bool
+		statusStop     bool
+		statusErr      error
+		expectedUpdate bool
+		expectedStop   bool
+		expectError    bool
+	}{
+		{
+			name:           "returns converter status result",
+			statusUpdated:  true,
+			statusStop:     true,
+			expectedUpdate: true,
+			expectedStop:   true,
+		},
+		{
+			name:        "propagates status error",
+			statusErr:   assert.AnError,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conv := &fakeHTTPRouteConverter{statusUpdated: tt.statusUpdated, statusStop: tt.statusStop, statusErr: tt.statusErr}
+
+			updated, stop, err := enforceStatus[gwtypes.HTTPRoute](t.Context(), logr.Discard(), conv)
+
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedUpdate, updated)
+			assert.Equal(t, tt.expectedStop, stop)
+		})
+	}
+}
+
+func TestEnforceState_CoreAndErrorPaths(t *testing.T) {
+	ctx := t.Context()
+	logger := logr.Discard()
+	kongServiceGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongService"}
+
+	makeDesiredService := func(name string, host any) unstructured.Unstructured {
+		u := newUnstructured("default", name, kongServiceGVK, nil)
+		_ = unstructured.SetNestedField(u.Object, host, "spec", "host")
+		_ = unstructured.SetNestedField(u.Object, int64(80), "spec", "port")
+		_ = unstructured.SetNestedField(u.Object, "httproute", "spec", "protocol")
+		return u
+	}
+
+	tests := []struct {
+		name            string
+		scheme          *runtime.Scheme
+		desired         []unstructured.Unstructured
+		outputStoreErr  error
+		preexisting     []client.Object
+		setupClient     func(t *testing.T, cl client.Client)
+		interceptor     *interceptor.Funcs
+		wantApplied     bool
+		wantWaiting     bool
+		wantErrContains string
+	}{
+		{
+			name:            "returns error when output store retrieval fails",
+			scheme:          scheme.Get(),
+			desired:         nil,
+			outputStoreErr:  assert.AnError,
+			wantApplied:     false,
+			wantWaiting:     false,
+			wantErrContains: "failed to get desired objects from converter",
+		},
+		{
+			name:        "returns without changes for empty desired list",
+			scheme:      scheme.Get(),
+			desired:     nil,
+			wantApplied: false,
+			wantWaiting: false,
+		},
+		{
+			name:        "creates object when not found",
+			scheme:      scheme.Get(),
+			desired:     []unstructured.Unstructured{makeDesiredService("svc-create", "create.example")},
+			wantApplied: true,
+			wantWaiting: false,
+		},
+		{
+			name:    "returns get error for existing lookup failures",
+			scheme:  scheme.Get(),
+			desired: []unstructured.Unstructured{makeDesiredService("svc-get-err", "err.example")},
+			interceptor: &interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if key.Name == "svc-get-err" {
+						return assert.AnError
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+			wantApplied:     false,
+			wantWaiting:     false,
+			wantErrContains: "failed to get object kind KongService obj default/svc-get-err",
+		},
+		{
+			name:    "waits when existing object is marked for deletion",
+			scheme:  scheme.Get(),
+			desired: []unstructured.Unstructured{makeDesiredService("svc-deleting", "deleting.example")},
+			preexisting: []client.Object{func() client.Object {
+				u := makeDesiredService("svc-deleting", "old.example")
+				ts := metav1.Now()
+				u.SetDeletionTimestamp(&ts)
+				u.SetFinalizers([]string{"test-finalizer"})
+				return &u
+			}()},
+			wantApplied: false,
+			wantWaiting: true,
+		},
+		{
+			name:    "applies update when managed fields are missing for field manager",
+			scheme:  scheme.Get(),
+			desired: []unstructured.Unstructured{makeDesiredService("svc-no-managed", "new.example")},
+			preexisting: []client.Object{func() client.Object {
+				u := makeDesiredService("svc-no-managed", "old.example")
+				return &u
+			}()},
+			wantApplied: true,
+			wantWaiting: false,
+		},
+		{
+			name:    "returns extract managed fields error for unsupported group",
+			scheme:  scheme.Get(),
+			desired: []unstructured.Unstructured{newUnstructured("default", "bad-group", schema.GroupVersionKind{Group: "invalid.group", Version: "v1", Kind: "Bad"}, nil)},
+			preexisting: []client.Object{func() client.Object {
+				u := newUnstructured("default", "bad-group", schema.GroupVersionKind{Group: "invalid.group", Version: "v1", Kind: "Bad"}, nil)
+				return &u
+			}()},
+			wantApplied:     false,
+			wantWaiting:     false,
+			wantErrContains: "failed to extract managed fields",
+		},
+		{
+			name:   "returns conversion error for invalid desired payload",
+			scheme: scheme.Get(),
+			desired: []unstructured.Unstructured{func() unstructured.Unstructured {
+				u := makeDesiredService("svc-convert", "ok.example")
+				u.Object["spec"] = map[string]any{"host": make(chan int), "port": int64(80), "protocol": "httproute"}
+				return u
+			}()},
+			wantApplied:     false,
+			wantWaiting:     false,
+			wantErrContains: "failed to create object kind KongService obj default/svc-convert",
+		},
+		{
+			name:    "returns conflict error during create apply",
+			scheme:  scheme.Get(),
+			desired: []unstructured.Unstructured{makeDesiredService("svc-create-conflict", "conflict.example")},
+			interceptor: &interceptor.Funcs{
+				Apply: func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+					return k8serrors.NewConflict(schema.GroupResource{Group: "configuration.konghq.com", Resource: "kongservices"}, "svc-create-conflict", assert.AnError)
+				},
+			},
+			wantErrContains: "conflict during create of object kind KongService obj default/svc-create-conflict",
+		},
+		{
+			name:        "returns update error when apply fails on diff",
+			scheme:      scheme.Get(),
+			desired:     []unstructured.Unstructured{makeDesiredService("svc-update-err", "new.example")},
+			preexisting: []client.Object{func() client.Object { u := makeDesiredService("svc-update-err", "old.example"); return &u }()},
+			interceptor: &interceptor.Funcs{
+				Apply: func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+					return assert.AnError
+				},
+			},
+			wantErrContains: "failed to create object kind KongService obj default/svc-update-err",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(tt.scheme)
+			if len(tt.preexisting) > 0 {
+				builder = builder.WithObjects(tt.preexisting...)
+			}
+			if tt.interceptor != nil {
+				builder = builder.WithInterceptorFuncs(*tt.interceptor)
+			}
+			cl := builder.Build()
+
+			if tt.setupClient != nil {
+				tt.setupClient(t, cl)
+			}
+
+			conv := &fakeHTTPRouteConverter{desired: tt.desired, outputStoreErr: tt.outputStoreErr}
+			applied, waiting, err := enforceState(ctx, cl, logger, conv)
+
+			if tt.wantErrContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantApplied, applied)
+			assert.Equal(t, tt.wantWaiting, waiting)
 		})
 	}
 }
@@ -279,12 +600,21 @@ func TestCleanOrphanedResources(t *testing.T) {
 // Minimal fake converter for HTTPRoute
 
 type fakeHTTPRouteConverter struct {
-	desired []unstructured.Unstructured
-	gvks    []schema.GroupVersionKind
-	root    gwtypes.HTTPRoute
+	desired        []unstructured.Unstructured
+	gvks           []schema.GroupVersionKind
+	root           gwtypes.HTTPRoute
+	outputStoreErr error
+	translateRet   int
+	translateErr   error
+	statusUpdated  bool
+	statusStop     bool
+	statusErr      error
 }
 
 func (f *fakeHTTPRouteConverter) GetOutputStore(ctx context.Context, logger logr.Logger) ([]unstructured.Unstructured, error) {
+	if f.outputStoreErr != nil {
+		return nil, f.outputStoreErr
+	}
 	return f.desired, nil
 }
 func (f *fakeHTTPRouteConverter) GetOutputStoreLen(ctx context.Context, logger logr.Logger) int {
@@ -293,6 +623,12 @@ func (f *fakeHTTPRouteConverter) GetOutputStoreLen(ctx context.Context, logger l
 func (f *fakeHTTPRouteConverter) GetExpectedGVKs() []schema.GroupVersionKind { return f.gvks }
 func (f *fakeHTTPRouteConverter) GetRootObject() gwtypes.HTTPRoute           { return f.root }
 func (f *fakeHTTPRouteConverter) Translate(ctx context.Context, logger logr.Logger) (int, error) {
+	if f.translateErr != nil {
+		return 0, f.translateErr
+	}
+	if f.translateRet != 0 {
+		return f.translateRet, nil
+	}
 	return len(f.desired), nil
 }
 func (f *fakeHTTPRouteConverter) ListExistingObjects(ctx context.Context) ([]unstructured.Unstructured, error) {
@@ -303,7 +639,10 @@ func (f *fakeHTTPRouteConverter) UpdateSharedRouteStatus([]unstructured.Unstruct
 }
 
 func (f *fakeHTTPRouteConverter) UpdateRootObjectStatus(ctx context.Context, logger logr.Logger) (updated bool, stop bool, err error) {
-	return false, false, nil
+	if f.statusErr != nil {
+		return false, false, f.statusErr
+	}
+	return f.statusUpdated, f.statusStop, nil
 }
 
 func (f *fakeHTTPRouteConverter) HandleOrphanedResource(ctx context.Context, logger logr.Logger, resource *unstructured.Unstructured) (bool, error) {
@@ -1369,6 +1708,365 @@ func TestRemoveFinalizerIfNotManaged_Gateway(t *testing.T) {
 				assert.Equal(t, tt.expectedHasFinalizer, slices.Contains(updated.GetFinalizers(), finalizerconst.HybridGatewayFinalizer), "finalizer presence mismatch")
 
 			}
+		})
+	}
+}
+
+func TestDesiredHasUpstreamNamed(t *testing.T) {
+	upstream := func(name string) unstructured.Unstructured {
+		u := unstructured.Unstructured{}
+		u.SetName(name)
+		u.SetGroupVersionKind(schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongUpstream"})
+		return u
+	}
+	notUpstream := func(name string) unstructured.Unstructured {
+		u := unstructured.Unstructured{}
+		u.SetName(name)
+		u.SetGroupVersionKind(schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongService"})
+		return u
+	}
+
+	tests := []struct {
+		name    string
+		desired []unstructured.Unstructured
+		search  string
+		want    bool
+	}{
+		{
+			name:    "empty list returns false",
+			desired: nil,
+			search:  "u1",
+			want:    false,
+		},
+		{
+			name:    "matching upstream returns true",
+			desired: []unstructured.Unstructured{upstream("u1"), upstream("u2")},
+			search:  "u1",
+			want:    true,
+		},
+		{
+			name:    "name present under different kind returns false",
+			desired: []unstructured.Unstructured{notUpstream("u1")},
+			search:  "u1",
+			want:    false,
+		},
+		{
+			name:    "name not in list returns false",
+			desired: []unstructured.Unstructured{upstream("u2")},
+			search:  "u1",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			names := make(map[string]struct{}, len(tt.desired))
+			for _, obj := range tt.desired {
+				if obj.GetKind() == "KongUpstream" {
+					names[obj.GetName()] = struct{}{}
+				}
+			}
+			assert.Equal(t, tt.want, desiredHasUpstreamNamed(names, tt.search))
+		})
+	}
+}
+
+func TestUpstreamTargetsProgrammed(t *testing.T) {
+	ctx := t.Context()
+	s := scheme.Get()
+	ns := "ns"
+
+	programmedCondition := metav1.Condition{
+		Type:               "Programmed",
+		Status:             metav1.ConditionTrue,
+		Reason:             "Programmed",
+		LastTransitionTime: metav1.Now(),
+	}
+
+	makeDesiredTarget := func(name, upstreamName string) unstructured.Unstructured {
+		u := unstructured.Unstructured{}
+		u.SetName(name)
+		u.SetNamespace(ns)
+		u.SetGroupVersionKind(schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongTarget"})
+		_ = unstructured.SetNestedField(u.Object, map[string]any{"name": upstreamName}, "spec", "upstreamRef")
+		return u
+	}
+
+	makeTarget := func(name string, programmed bool) *configurationv1alpha1.KongTarget {
+		tgt := &configurationv1alpha1.KongTarget{}
+		tgt.SetName(name)
+		tgt.SetNamespace(ns)
+		if programmed {
+			tgt.Status.Conditions = []metav1.Condition{programmedCondition}
+		}
+		return tgt
+	}
+
+	tests := []struct {
+		name            string
+		targets         []unstructured.Unstructured // pre-filtered targets for the upstream under test
+		existing        []client.Object
+		wantReady       bool
+		wantErrContains string
+		interceptorFn   *interceptor.Funcs
+	}{
+		{
+			name:      "nil targets returns ready",
+			targets:   nil,
+			wantReady: true,
+		},
+		{
+			name:      "empty targets slice returns ready",
+			targets:   []unstructured.Unstructured{},
+			wantReady: true,
+		},
+		{
+			name:      "target not in cluster returns not ready",
+			targets:   []unstructured.Unstructured{makeDesiredTarget("t1", "my-upstream")},
+			existing:  nil,
+			wantReady: false,
+		},
+		{
+			name:      "target in cluster but not Programmed returns not ready",
+			targets:   []unstructured.Unstructured{makeDesiredTarget("t1", "my-upstream")},
+			existing:  []client.Object{makeTarget("t1", false)},
+			wantReady: false,
+		},
+		{
+			name:      "target in cluster and Programmed returns ready",
+			targets:   []unstructured.Unstructured{makeDesiredTarget("t1", "my-upstream")},
+			existing:  []client.Object{makeTarget("t1", true)},
+			wantReady: true,
+		},
+		{
+			name: "multiple targets all Programmed returns ready",
+			targets: []unstructured.Unstructured{
+				makeDesiredTarget("t1", "my-upstream"),
+				makeDesiredTarget("t2", "my-upstream"),
+			},
+			existing:  []client.Object{makeTarget("t1", true), makeTarget("t2", true)},
+			wantReady: true,
+		},
+		{
+			name: "multiple targets, one not Programmed returns not ready",
+			targets: []unstructured.Unstructured{
+				makeDesiredTarget("t1", "my-upstream"),
+				makeDesiredTarget("t2", "my-upstream"),
+			},
+			existing:  []client.Object{makeTarget("t1", true), makeTarget("t2", false)},
+			wantReady: false,
+		},
+		{
+			name:    "Get error for existing target is propagated",
+			targets: []unstructured.Unstructured{makeDesiredTarget("t1", "my-upstream")},
+			interceptorFn: &interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*configurationv1alpha1.KongTarget); ok {
+						return assert.AnError
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+			wantReady:       false,
+			wantErrContains: "failed to get KongTarget",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(s)
+			if len(tt.existing) > 0 {
+				builder = builder.WithObjects(tt.existing...)
+			}
+			if tt.interceptorFn != nil {
+				builder = builder.WithInterceptorFuncs(*tt.interceptorFn)
+			}
+			cl := builder.Build()
+
+			ready, err := upstreamTargetsProgrammed(ctx, cl, tt.targets)
+
+			if tt.wantErrContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantReady, ready)
+		})
+	}
+}
+
+func TestEnforceState_UpstreamGating(t *testing.T) {
+	ctx := t.Context()
+	logger := logr.Discard()
+	s := scheme.Get()
+	ns := "ns"
+
+	programmedCondition := metav1.Condition{
+		Type:               "Programmed",
+		Status:             metav1.ConditionTrue,
+		Reason:             "Programmed",
+		LastTransitionTime: metav1.Now(),
+	}
+
+	svcGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongService"}
+	tgtGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongTarget"}
+	upGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongUpstream"}
+	routeGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongRoute"}
+	kpbGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongPluginBinding"}
+
+	makeObj := func(name string, gvk schema.GroupVersionKind, spec map[string]any) unstructured.Unstructured {
+		u := newUnstructured(ns, name, gvk, nil)
+		if spec != nil {
+			_ = unstructured.SetNestedField(u.Object, spec, "spec")
+		}
+		return u
+	}
+
+	tests := []struct {
+		name        string
+		desired     []unstructured.Unstructured
+		existing    []client.Object
+		wantApplied bool
+		wantWaiting bool
+		wantErr     bool
+	}{
+		{
+			// The service is gated (waiting=true) but the upstream prerequisite itself is
+			// still created in the same pass (applied=true): the loop skips the service
+			// but processes the upstream object that follows it.
+			name: "KongService waits when its host upstream is missing from cluster",
+			desired: []unstructured.Unstructured{
+				makeObj("svc1", svcGVK, map[string]any{"host": "upstream1"}),
+				makeObj("upstream1", upGVK, nil),
+			},
+			existing:    nil,
+			wantApplied: true,
+			wantWaiting: true,
+		},
+		{
+			// Upstream exists but isn't Programmed yet. The service is gated; the
+			// upstream is updated (no managed-fields yet → apply), so applied=true.
+			name: "KongService waits when its host upstream is not Programmed",
+			desired: []unstructured.Unstructured{
+				makeObj("svc1", svcGVK, map[string]any{"host": "upstream1"}),
+				makeObj("upstream1", upGVK, nil),
+			},
+			existing: func() []client.Object {
+				up := &configurationv1alpha1.KongUpstream{}
+				up.SetName("upstream1")
+				up.SetNamespace(ns)
+				return []client.Object{up}
+			}(),
+			wantApplied: true,
+			wantWaiting: true,
+		},
+		{
+			// Upstream is Programmed but targets are not yet. The service is gated on
+			// targets; the target itself is still processed in the same pass (applied=true).
+			name: "KongService waits when upstream is Programmed but targets are not",
+			desired: []unstructured.Unstructured{
+				makeObj("svc1", svcGVK, map[string]any{"host": "upstream1"}),
+				makeObj("upstream1", upGVK, nil),
+				makeObj("tgt1", tgtGVK, map[string]any{"upstreamRef": map[string]any{"name": "upstream1"}}),
+			},
+			existing: func() []client.Object {
+				up := &configurationv1alpha1.KongUpstream{}
+				up.SetName("upstream1")
+				up.SetNamespace(ns)
+				up.Status.Conditions = []metav1.Condition{programmedCondition}
+				// KongTarget exists but is not Programmed.
+				tgt := &configurationv1alpha1.KongTarget{}
+				tgt.SetName("tgt1")
+				tgt.SetNamespace(ns)
+				return []client.Object{up, tgt}
+			}(),
+			wantApplied: true,
+			wantWaiting: true,
+		},
+		{
+			name: "KongService skips upstream gate when host is not a desired upstream (external)",
+			desired: []unstructured.Unstructured{
+				makeObj("svc1", svcGVK, map[string]any{"host": "external.example.com"}),
+			},
+			existing:    nil,
+			wantApplied: true, // proceeds immediately, no upstream to wait for
+			wantWaiting: false,
+		},
+		{
+			name: "KongTarget waits when upstream exists but is not Programmed",
+			desired: []unstructured.Unstructured{
+				makeObj("tgt1", tgtGVK, map[string]any{"upstreamRef": map[string]any{"name": "upstream1"}}),
+			},
+			existing: func() []client.Object {
+				up := &configurationv1alpha1.KongUpstream{}
+				up.SetName("upstream1")
+				up.SetNamespace(ns)
+				return []client.Object{up}
+			}(),
+			wantApplied: false,
+			wantWaiting: true,
+		},
+		{
+			name: "KongRoute waits when service is missing",
+			desired: []unstructured.Unstructured{
+				makeObj("r1", routeGVK, map[string]any{
+					"serviceRef": map[string]any{"namespacedRef": map[string]any{"name": "svc1"}},
+				}),
+			},
+			existing:    nil,
+			wantApplied: false,
+			wantWaiting: true,
+		},
+		{
+			name: "KongPluginBinding waits when route is missing",
+			desired: []unstructured.Unstructured{
+				makeObj("b1", kpbGVK, map[string]any{
+					"targets": map[string]any{"routeRef": map[string]any{"name": "r1"}},
+				}),
+			},
+			existing:    nil,
+			wantApplied: false,
+			wantWaiting: true,
+		},
+		{
+			name: "KongPluginBinding waits when referenced KongService is not Programmed",
+			desired: []unstructured.Unstructured{
+				makeObj("b1", kpbGVK, map[string]any{
+					"targets": map[string]any{
+						"serviceRef": map[string]any{"name": "svc1", "kind": "KongService"},
+					},
+				}),
+			},
+			existing: func() []client.Object {
+				svc := &configurationv1alpha1.KongService{}
+				svc.SetName("svc1")
+				svc.SetNamespace(ns)
+				return []client.Object{svc}
+			}(),
+			wantApplied: false,
+			wantWaiting: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(s)
+			if len(tt.existing) > 0 {
+				builder = builder.WithObjects(tt.existing...)
+			}
+			cl := builder.Build()
+
+			fakeConv := &fakeHTTPRouteConverter{desired: tt.desired}
+			applied, waiting, err := enforceState(ctx, cl, logger, fakeConv)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantApplied, applied)
+			assert.Equal(t, tt.wantWaiting, waiting)
 		})
 	}
 }


### PR DESCRIPTION


**What this PR does / why we need it**:

(cherry picked from commit ed7f7787d6f27fa3f44617aae3a73e18cd09e1ca)

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
