### PR TITLE
fix(versions): tag parser accepts registry references with a port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,13 @@
 
 ### Fixes
 
+- Version parser: accept DataPlane image references whose registry host contains
+  a port (e.g. `registry.example.com:5000/kong/kong-gateway:3.10`). The tag is
+  now split at the last `:` instead of every `:`, so a host-port colon is no
+  longer misread as the tag separator. Without this fix, DataPlane Deployment
+  provisioning silently failed with
+  `expected "<image>:<tag>" format, got: <full-ref>`.
+  [#XXXX](https://github.com/Kong/kong-operator/pull/XXXX)
 - Konnect: prevent orphaned and duplicate Konnect entities when reconciliation
   races with the cached client. The cleanup finalizer is now added before the entity
   is created in Konnect, and the freshly created Konnect ID is kept in an in-memory

--- a/internal/versions/validation.go
+++ b/internal/versions/validation.go
@@ -42,12 +42,25 @@ func FromImage(image string) (semver.Version, error) {
 		image = image[:idx]
 	}
 
-	splitImage := strings.Split(image, ":")
-	if len(splitImage) != 2 {
+	// Use the last ':' as the tag separator. Splitting on every ':' breaks
+	// references whose registry host carries a port, e.g.
+	//   registry.example.com:5000/foo/bar:3.10
+	// where the first ':' is part of the host ("<host>:<port>") rather than
+	// a tag separator. The tag, if present, always follows the LAST ':'
+	// (any digest was already stripped above).
+	idx := strings.LastIndex(image, ":")
+	if idx == -1 {
+		return semver.Version{}, fmt.Errorf(`%w, got: %s`, ErrExpectedSemverVersion, image)
+	}
+	tag := image[idx+1:]
+	// If what looks like a tag actually contains '/', we split on a port
+	// separator in the registry host and the reference has no tag at all
+	// (e.g. "registry:5000/foo/bar" — LastIndex found ':' inside the host).
+	if tag == "" || strings.Contains(tag, "/") {
 		return semver.Version{}, fmt.Errorf(`%w, got: %s`, ErrExpectedSemverVersion, image)
 	}
 
-	rawVersion := strings.TrimPrefix(splitImage[1], "v")
+	rawVersion := strings.TrimPrefix(tag, "v")
 
 	// If we matched a semver without patch version with suffix e.g. 3.3-ubuntu
 	// then append ".0" before the flavour suffix for successful semver parsing.

--- a/internal/versions/validation_test.go
+++ b/internal/versions/validation_test.go
@@ -111,6 +111,49 @@ func Test_versionFromImage(t *testing.T) {
 				return v
 			},
 		},
+		// Regression: image references whose registry host carries a port
+		// number contain more than one ':', but the tag is always after the
+		// last one. See https://github.com/Kong/kong-operator/issues/... .
+		{
+			Tag: "registry.example.com:5000/kong/kong-gateway:3.3.0",
+			Expected: func(t *testing.T) semver.Version {
+				v, err := semver.Parse("3.3.0")
+				require.NoError(t, err)
+				return v
+			},
+		},
+		{
+			Tag: "registry.example.com:5000/kong/kong-gateway:3.10",
+			Expected: func(t *testing.T) semver.Version {
+				v, err := semver.Parse("3.10.0")
+				require.NoError(t, err)
+				return v
+			},
+		},
+		{
+			Tag: "registry.example.com:5000/kong/kong-gateway:3.3-alpine@sha256:abc123def456",
+			Expected: func(t *testing.T) semver.Version {
+				v, err := semver.Parse("3.3.0")
+				require.NoError(t, err)
+				return v
+			},
+		},
+		{
+			// Registry with port but no tag: the last ':' is inside the host,
+			// what follows it contains '/'. Must be rejected as "no tag".
+			Tag:           "registry.example.com:5000/kong/kong-gateway",
+			ExpectedError: ErrExpectedSemverVersion,
+		},
+		{
+			// No colon at all — no tag can exist.
+			Tag:           "kong/kong-gateway",
+			ExpectedError: ErrExpectedSemverVersion,
+		},
+		{
+			// Trailing colon with empty tag — invalid.
+			Tag:           "kong/kong-gateway:",
+			ExpectedError: ErrExpectedSemverVersion,
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
Fixes #4724

## Current behavior

`internal/versions.FromImage` splits image references on every `:` and requires the result to have exactly two segments. That check fails for any reference whose registry host carries a port, e.g.

```
registry.example.com:5000/kong/kong-gateway:3.10
```

The split returns three segments (`["registry.example.com", "5000/kong/kong-gateway", "3.10"]`), and the caller [`IsDataPlaneImageVersionSupported`](https://github.com/Kong/kong-operator/blob/main/controller/dataplane/owned_deployment.go#L197) surfaces this as `expected "<image>:<tag>" format, got: <full-ref>`.

The DataPlane controller then fails to build a Deployment, silently: the DataPlane CR sits at `Ready=False reason=DependenciesNotReady` with `.status.replicas: 0`, no Deployment is created, and the Gateway never reaches `Programmed=True`. The only pointer to the actual cause is a single manager log line — nothing surfaces on the CR conditions.

The same reference works fine as an OLM operator image (kubelet + containerd pull it correctly), so this is purely a KGO-side parser limitation.

## Fix

Use `strings.LastIndex(image, ":")` — the tag, when present, always follows the last `:` (any digest was already stripped earlier via the `@sha256:` handling). If what follows the last `:` contains `/`, the last `:` was the host-port separator and the reference has no tag; treat that as the existing "no tag" error.

## Tests

New cases in `internal/versions/validation_test.go`:

- host with port + tag (`registry.example.com:5000/kong/kong-gateway:3.3.0`)
- host with port + tag containing dots (`...:5000/...:3.10`)
- host with port + tag + digest (digest stripped first, then last-`:` split)
- host with port + no tag (must error)
- no colon at all (must error, unchanged)
- trailing colon with empty tag (must error, unchanged)

Existing cases (semver-with-flavour, enterprise 4-segment, digest-only) unchanged.

## Operator version

kong-operator 2.2.0 (`main` at 28fb8febd shows the same code path).
