### PR TITLE
chore: update release issue template with charts sync instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/---release.md
+++ b/.github/ISSUE_TEMPLATE/---release.md
@@ -35,6 +35,7 @@ If the troubleshooting section does not contain the answer to the problem you en
 - [ ] Major/Minor only:
   - [ ] Update `renovate.json` config which targets the latest release branch (e.g. `release/2.1.x`) to update the `matchBaseBranches` field to the new release branch (e.g. `release/2.2.x`).
   - [ ] Update `.github/workflows/charts-sync.yaml` workflow by replacing the old release branch (e.g. `release/2.1.x`) with the new one (e.g. `release/2.2.x`) in the `branches` section.
+  - [ ] Remove `.github/workflows/charts-sync.yaml` from the old release branch (e.g. `release/2.1.x`) if it exists.
   - [ ] Update `.github/workflows/govulncheck-cron.yaml` workflow by adding the new release branch (e.g. `release/2.2.x`) to the `branches` section.
 
 ## Conformance tests report


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove the charts sync from old major/minor release branch to prevent updating charts with old templates, e.g.: https://github.com/Kong/charts/pull/1532/changes.

Related 2.1 change: https://github.com/Kong/kong-operator/pull/4731

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
