### PR TITLE
chore(ci): run make generate on release

### DIFF
--- a/.github/workflows/__release-workflow.yaml
+++ b/.github/workflows/__release-workflow.yaml
@@ -265,6 +265,17 @@ jobs:
         with:
           install: false
 
+      - name: Run make generate
+        if: ${{ inputs.regenerate-manifests }}
+        run: |
+          make \
+            generate.api \
+            generate.api-from-oas \
+            generate.crds \
+            generate.crd-kustomize \
+            generate.docs \
+            generate.cli-arguments-docs
+
       # Generated manifests are part of the release PR.
       - name: Generate manifests
         if: ${{ inputs.regenerate-manifests }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent needing to run `make generate` manually, e.g.: https://github.com/Kong/kong-operator/pull/4739/changes/dd7bddfaa7128b68fbad1a39739ebda8ceb302ec

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

This does not run the full `make generate` as we do not e.g. need to run `generate.lint-fix` as part of the release. Just make sure that CRDs and docs are as they should be.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
