### PR TITLE
test: increate waitTime for integration-konnect

### DIFF
--- a/test/integration/konnect/consts.go
+++ b/test/integration/konnect/consts.go
@@ -3,6 +3,6 @@ package konnect
 import "time"
 
 const (
-	waitTime = 60 * time.Second
+	waitTime = 120 * time.Second
 	tickTime = 1 * time.Second
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Integration test konnect failed frequently, might related to the slow cert generation and upload, try to increase the waitTime to see if it can be resolved

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
