### PR TITLE
chore(deps): bump kong-gateway from 3.12 to 3.14

### DIFF
--- a/config/samples/gateway-hybrid-static-naming-with-kongconsumer.yaml
+++ b/config/samples/gateway-hybrid-static-naming-with-kongconsumer.yaml
@@ -22,7 +22,7 @@ spec:
         spec:
           containers:
           - name: proxy
-            image: kong/kong-gateway:3.12
+            image: kong/kong-gateway:3.14
 ---
 kind: GatewayClass
 apiVersion: gateway.networking.k8s.io/v1

--- a/config/samples/gateway-hybrid-static-naming-with-kongconsumer.yaml
+++ b/config/samples/gateway-hybrid-static-naming-with-kongconsumer.yaml
@@ -22,6 +22,7 @@ spec:
         spec:
           containers:
           - name: proxy
+            # renovate: datasource=docker versioning=docker
             image: kong/kong-gateway:3.14
 ---
 kind: GatewayClass

--- a/config/samples/gateway-hybrid-tls.yaml
+++ b/config/samples/gateway-hybrid-tls.yaml
@@ -31,6 +31,7 @@ spec:
       podTemplateSpec:
         spec:
           containers:
+            # renovate: datasource=docker versioning=docker
             - image: kong/kong-gateway:3.14
               name: proxy
   konnect:

--- a/config/samples/gateway-hybrid-tls.yaml
+++ b/config/samples/gateway-hybrid-tls.yaml
@@ -31,7 +31,7 @@ spec:
       podTemplateSpec:
         spec:
           containers:
-            - image: kong/kong-gateway:3.12
+            - image: kong/kong-gateway:3.14
               name: proxy
   konnect:
     authRef:

--- a/config/samples/gateway-hybrid-xns-konnectapiauth.yaml
+++ b/config/samples/gateway-hybrid-xns-konnectapiauth.yaml
@@ -35,6 +35,7 @@ spec:
         spec:
           containers:
           - name: proxy
+            # renovate: datasource=docker versioning=docker
             image: kong/kong-gateway:3.14
 ---
 kind: GatewayClass

--- a/config/samples/gateway-hybrid-xns-konnectapiauth.yaml
+++ b/config/samples/gateway-hybrid-xns-konnectapiauth.yaml
@@ -35,7 +35,7 @@ spec:
         spec:
           containers:
           - name: proxy
-            image: kong/kong-gateway:3.12
+            image: kong/kong-gateway:3.14
 ---
 kind: GatewayClass
 apiVersion: gateway.networking.k8s.io/v1

--- a/internal/versions/validation_test.go
+++ b/internal/versions/validation_test.go
@@ -80,17 +80,17 @@ func Test_versionFromImage(t *testing.T) {
 			ExpectedError: kgoerrors.ErrInvalidSemverVersion,
 		},
 		{
-			Tag: "kong/kong-gateway:3.12",
+			Tag: "kong/kong-gateway:3.14",
 			Expected: func(t *testing.T) semver.Version {
-				v, err := semver.Parse("3.12.0")
+				v, err := semver.Parse("3.14.0")
 				require.NoError(t, err)
 				return v
 			},
 		},
 		{
-			Tag: "kong/kong-gateway:3.12@sha256:8f0089833902c555bf02dee1a59d3fe1f9fed11745eb7dd75e9bf844755147c9",
+			Tag: "kong/kong-gateway:3.14@sha256:8f0089833902c555bf02dee1a59d3fe1f9fed11745eb7dd75e9bf844755147c9",
 			Expected: func(t *testing.T) semver.Version {
-				v, err := semver.Parse("3.12.0")
+				v, err := semver.Parse("3.14.0")
 				require.NoError(t, err)
 				return v
 			},

--- a/test/e2e/chainsaw/common/_step_templates/apply-assert-gatewayConfiguration.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/apply-assert-gatewayConfiguration.yaml
@@ -4,7 +4,7 @@
 #   - test_name: Test name used to compose the configuration name.
 #   - namespace: Namespace where the configuration will be created.
 #   - konnect_api_auth_namespace: Namespace where the referenced KonnectAPIAuthConfiguration is in.
-#   - gateway_image: Kong Gateway image to use (e.g., "kong/kong-gateway:3.12").
+#   - gateway_image: Kong Gateway image to use (e.g., "kong/kong-gateway:3.14").
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: StepTemplate
 metadata:

--- a/test/e2e/chainsaw/common/_step_templates/apply-assert-kongTarget.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/apply-assert-kongTarget.yaml
@@ -8,6 +8,12 @@
 #   - pod_namespace: Namespace where the pod is located.
 #   - target_port: The target address (host:port) for the KongTarget.
 #   - target_weight: The weight for the KongTarget (e.g., 100).
+#
+# Optional bindings:
+#   - target_address: Pre-computed "host:port" string. When non-empty, used directly
+#     as the KongTarget target instead of the resolved pod IP. Use this when the
+#     upstream requires SSL hostname verification (e.g. mTLS cert-ref tests) and the
+#     target must match the server certificate's CN/SAN.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: StepTemplate
 metadata:
@@ -37,7 +43,7 @@ spec:
           spec:
             upstreamRef:
               name: ($kong_upstream_name)
-            target: (join(':', [($upstream_pod_ip), (to_string($target_port))]))
+            target: ($target_address || join(':', [($upstream_pod_ip), (to_string($target_port))]))
             weight: ($target_weight)
     - assert:
         resource:

--- a/test/e2e/chainsaw/gateway/grpcroute-onprem/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/gateway/grpcroute-onprem/chainsaw-test.yaml
@@ -23,7 +23,7 @@ spec:
     - name: cert_secret_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: grpcbin_image
       value: 'kong/grpcbin:latest'
     - name: grpc_route_name

--- a/test/e2e/chainsaw/hybridgateway/basic-httproute/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-httproute/chainsaw-test.yaml
@@ -39,7 +39,7 @@ spec:
     - name: konnect_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_name
       value: (join('-', [($test_name), 'gateway']))
     - name: gateway_namespace

--- a/test/e2e/chainsaw/hybridgateway/basic-tlsroute/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-tlsroute/chainsaw-test.yaml
@@ -37,7 +37,7 @@ spec:
     - name: konnect_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_name
       value: (join('-', [($test_name), 'gateway']))
     - name: gateway_namespace

--- a/test/e2e/chainsaw/hybridgateway/gateway-infrastructure-labels/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/gateway-infrastructure-labels/chainsaw-test.yaml
@@ -38,7 +38,7 @@ spec:
     - name: konnect_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_name
       value: (join('-', [($test_name), 'gateway']))
     - name: gateway_namespace

--- a/test/e2e/chainsaw/hybridgateway/gateway-tls-certificates/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/gateway-tls-certificates/chainsaw-test.yaml
@@ -40,7 +40,7 @@ spec:
     - name: konnect_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_name
       value: (join('-', [($test_name), 'gateway']))
     - name: gateway_namespace

--- a/test/e2e/chainsaw/hybridgateway/gateway-tls-secret-cross-namespace/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/gateway-tls-secret-cross-namespace/chainsaw-test.yaml
@@ -43,7 +43,7 @@ spec:
     - name: konnect_api_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_name
       value: (join('-', [($test_name), 'gateway']))
     - name: gateway_namespace

--- a/test/e2e/chainsaw/hybridgateway/gatewayconfiguration-konnectapiauthconfiguration-cross-namespace/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/gatewayconfiguration-konnectapiauthconfiguration-cross-namespace/chainsaw-test.yaml
@@ -30,7 +30,7 @@ spec:
     - name: konnect_auth_namespace
       value: ($konnect_api_auth_namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_name
       value: (join('-', [($test_name), 'gateway']))
     - name: gateway_namespace

--- a/test/e2e/chainsaw/hybridgateway/httproute-annotations/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-annotations/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
     - name: konnect_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_name
       value: (join('-', [($namespace), 'gateway']))
     - name: gateway_namespace

--- a/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-backendref-cross-namespace-reference/chainsaw-test.yaml
@@ -39,7 +39,7 @@ spec:
     - name: konnect_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_name
       value: (join('-', [($test_name), 'gateway']))
     - name: gateway_namespace

--- a/test/e2e/chainsaw/hybridgateway/httproute-complex-multiple-rules/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-complex-multiple-rules/chainsaw-test.yaml
@@ -34,7 +34,7 @@ spec:
     - name: konnect_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_class_name
       value: (join('-', [($test_name), 'gateway-class']))
     - name: gateway_configuration_name

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/chainsaw-test.yaml
@@ -46,7 +46,7 @@ spec:
 
     # Gateway configuration.
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_name
       value: (join('-', [($test_name), 'gateway']))
     - name: gateway_namespace

--- a/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-filters/chainsaw-test.yaml
@@ -48,7 +48,7 @@ spec:
     - name: konnect_api_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_name
       value: (join('-', [($test_name), 'gateway']))
     - name: gateway_namespace

--- a/test/e2e/chainsaw/hybridgateway/httproute-header-match/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-header-match/chainsaw-test.yaml
@@ -39,7 +39,7 @@ spec:
     - name: gateway_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: http_route_name
       value: echo-header-match
     - name: http_route_namespace

--- a/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-listener-hostname-match/chainsaw-test.yaml
@@ -33,7 +33,7 @@ spec:
     - name: konnect_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_class_name
       value: (join('-', [($test_name), 'gateway-class']))
     - name: gateway_configuration_name

--- a/test/e2e/chainsaw/hybridgateway/httproute-method-matching/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-method-matching/chainsaw-test.yaml
@@ -40,7 +40,7 @@ spec:
     - name: gateway_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: httproute_name_get
       value: method-matching-get
     - name: httproute_name_post

--- a/test/e2e/chainsaw/hybridgateway/httproute-multiple-backends/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-multiple-backends/chainsaw-test.yaml
@@ -38,7 +38,7 @@ spec:
     - name: konnect_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_class_name
       value: (join('-', [($test_name), 'gateway-class']))
     - name: gateway_configuration_name

--- a/test/e2e/chainsaw/hybridgateway/httproute-multiple-parentrefs/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-multiple-parentrefs/chainsaw-test.yaml
@@ -26,7 +26,7 @@ spec:
     - name: konnect_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: konnect_api_auth_namespace
       value: ($namespace)
     

--- a/test/e2e/chainsaw/hybridgateway/httproute-overlapping-backends/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-overlapping-backends/chainsaw-test.yaml
@@ -52,7 +52,7 @@ spec:
     - name: konnect_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_class_name
       value: (join('-', [($test_name), 'gateway-class']))
     - name: gateway_configuration_name

--- a/test/e2e/chainsaw/hybridgateway/httproute-path-matching/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-path-matching/chainsaw-test.yaml
@@ -30,7 +30,7 @@ spec:
     - name: konnect_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_class_name
       value: (join('-', [($test_name), 'gateway-class']))
     - name: gateway_configuration_name

--- a/test/e2e/chainsaw/hybridgateway/httproute-service-annotations/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-service-annotations/chainsaw-test.yaml
@@ -58,7 +58,7 @@ spec:
     - name: konnect_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_name
       value: (join('-', [($namespace), 'gateway']))
     - name: gateway_namespace

--- a/test/e2e/chainsaw/hybridgateway/httproute-shared-backendrefs/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-shared-backendrefs/chainsaw-test.yaml
@@ -29,7 +29,7 @@ spec:
     - name: konnect_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: konnect_api_auth_namespace
       value: ($namespace)
 

--- a/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-status-resolved-refs/chainsaw-test.yaml
@@ -49,7 +49,7 @@ spec:
   - name: konnect_auth_namespace
     value: ($namespace)
   - name: gateway_image
-    value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+    value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
   - name: gateway_name
     value: (join('-', [($test_name), 'gateway']))
   - name: gateway_namespace

--- a/test/e2e/chainsaw/hybridgateway/httproute-upstream-policy/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-upstream-policy/chainsaw-test.yaml
@@ -43,7 +43,7 @@ spec:
     - name: konnect_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_name
       value: (join('-', [($namespace), 'gateway']))
     - name: gateway_namespace

--- a/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/tlsroute-backendref-cross-namespace-reference/chainsaw-test.yaml
@@ -43,7 +43,7 @@ spec:
     - name: konnect_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_name
       value: (join('-', [($test_name), 'gateway']))
     - name: gateway_namespace

--- a/test/e2e/chainsaw/hybridgateway/tlsroute-overlapping-backends/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/tlsroute-overlapping-backends/chainsaw-test.yaml
@@ -51,7 +51,7 @@ spec:
     - name: konnect_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_class_name
       value: (join('-', [($test_name), 'gateway-class']))
     - name: gateway_configuration_name

--- a/test/e2e/chainsaw/hybridgateway/tlsroute-terminate-listener/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/tlsroute-terminate-listener/chainsaw-test.yaml
@@ -39,7 +39,7 @@ spec:
     - name: konnect_auth_namespace
       value: ($namespace)
     - name: gateway_image
-      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+      value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
     - name: gateway_name
       value: (join('-', [($test_name), 'gateway']))
     - name: gateway_namespace

--- a/test/e2e/chainsaw/konnect/kongservice-cert-refs/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/konnect/kongservice-cert-refs/chainsaw-test.yaml
@@ -132,7 +132,7 @@ spec:
             - name: dataplane_namespace
               value: ($namespace)
             - name: dataplane_image
-              value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+              value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
             - name: extension_name
               value: ($extension_name)
 
@@ -216,7 +216,7 @@ spec:
             - name: upstream_port
               value: ($upstream_port)
             - name: kong_sidecar_image
-              value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+              value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
             - name: server_secret_name
               value: ($server_secret_name)
             - name: client_ca_secret_name

--- a/test/e2e/chainsaw/konnect/kongupstream-cert-refs/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/konnect/kongupstream-cert-refs/chainsaw-test.yaml
@@ -348,6 +348,10 @@ spec:
               value: ($upstream_port)
             - name: target_weight
               value: 100
+            # Use the service hostname so Kong's upstream SSL certificate hostname
+            # verification matches the server cert's CN (pod IP would not match).
+            - name: target_address
+              value: (join(':', [($upstream_host), (to_string($upstream_port))]))
 
     # Step 9: Verify HTTPS proxy call FAILS (4xx) because DataPlane has no client cert.
     - name: Verify-https-fails-without-cert-refs

--- a/test/e2e/chainsaw/konnect/kongupstream-cert-refs/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/konnect/kongupstream-cert-refs/chainsaw-test.yaml
@@ -139,7 +139,7 @@ spec:
             - name: dataplane_namespace
               value: ($namespace)
             - name: dataplane_image
-              value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+              value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
             - name: extension_name
               value: ($extension_name)
 
@@ -223,7 +223,7 @@ spec:
             - name: upstream_port
               value: ($upstream_port)
             - name: kong_sidecar_image
-              value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.12')
+              value: (env('GATEWAY_IMAGE') || 'kong/kong-gateway:3.14')
             - name: server_secret_name
               value: ($server_secret_name)
             - name: client_ca_secret_name

--- a/test/envtest/configerrorevent_envtest_test.go
+++ b/test/envtest/configerrorevent_envtest_test.go
@@ -11,6 +11,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/kong/kong-operator/v2/ingress-controller/test/testenv"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -104,10 +105,13 @@ func TestConfigErrorEventGenerationInMemoryMode(t *testing.T) {
 	t.Logf("deploying ingress %s", ingress.Name)
 	require.NoError(t, ctrlClient.Create(ctx, ingress))
 
+	kongVersion, err := testenv.GetDependencyVersion("envtests.kong-ee")
+	require.NoError(t, err)
+
 	RunManager(ctx, t, restConfig,
 		AdminAPIOptFns(
 			mocks.WithConfigPostError(formatErrBody(t, ns.Name, ingress, service)),
-			mocks.WithVersion("3.14.0"),
+			mocks.WithVersion(kongVersion),
 		),
 		WithPublishService(ns.Name),
 		WithIngressClass(ingressClassName),

--- a/test/envtest/configerrorevent_envtest_test.go
+++ b/test/envtest/configerrorevent_envtest_test.go
@@ -11,7 +11,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/kong/kong-operator/v2/ingress-controller/test/testenv"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -29,6 +28,7 @@ import (
 	"github.com/kong/kong-operator/v2/ingress-controller/test/dataplane"
 	"github.com/kong/kong-operator/v2/ingress-controller/test/manager/consts"
 	"github.com/kong/kong-operator/v2/ingress-controller/test/mocks"
+	"github.com/kong/kong-operator/v2/ingress-controller/test/testenv"
 )
 
 func TestConfigErrorEventGenerationInMemoryMode(t *testing.T) {

--- a/test/envtest/configerrorevent_envtest_test.go
+++ b/test/envtest/configerrorevent_envtest_test.go
@@ -107,7 +107,7 @@ func TestConfigErrorEventGenerationInMemoryMode(t *testing.T) {
 	RunManager(ctx, t, restConfig,
 		AdminAPIOptFns(
 			mocks.WithConfigPostError(formatErrBody(t, ns.Name, ingress, service)),
-			mocks.WithVersion("3.12.0"),
+			mocks.WithVersion("3.14.0"),
 		),
 		WithPublishService(ns.Name),
 		WithIngressClass(ingressClassName),


### PR DESCRIPTION
**What this PR does / why we need it**:

dataplane 3.12 is approaching end-of-life, bump it to 3.14

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
