### PR TITLE
feat: add aiGatewayRefAccessor in reconciler_apiauthref_get and AIGatewayControlPlane into _generatedHandlers

### DIFF
--- a/controller/konnect/reconciler_apiauthref_get.go
+++ b/controller/konnect/reconciler_apiauthref_get.go
@@ -42,6 +42,11 @@ type portalRefAccessor interface {
 	GetPortalRef() commonv1alpha1.ObjectRef
 }
 
+type aiGatewayRefAccessor interface {
+	objectWithParentRef
+	GetAiGatewayRef() commonv1alpha1.ObjectRef
+}
+
 func getAPIAuthRef[
 	T constraints.SupportedKonnectEntityType,
 	TEnt constraints.EntityType[T],
@@ -52,6 +57,9 @@ func getAPIAuthRef[
 ) (types.NamespacedName, error) {
 	// TODO: make this generic for all root dependent entities.
 
+	if obj, ok := any(ent).(aiGatewayRefAccessor); ok {
+		return getAPIAuthConfigurationRefFromParent[konnectv1alpha1.AIGatewayControlPlane](ctx, cl, obj, obj.GetParentRef())
+	}
 	if obj, ok := any(ent).(portalRefAccessor); ok {
 		return getAPIAuthConfigurationRefFromParent[konnectv1alpha1.Portal](ctx, cl, obj, obj.GetParentRef())
 	}

--- a/controller/konnect/reconciler_generic_handle_generated_refs.go
+++ b/controller/konnect/reconciler_generic_handle_generated_refs.go
@@ -76,6 +76,10 @@ func init() {
 			gvk:     konnectv1alpha1.GroupVersion.WithKind("Portal"),
 			handler: parentRefHandler[konnectv1alpha1.Portal, *konnectv1alpha1.Portal]{},
 		},
+		{
+			gvk:     konnectv1alpha1.GroupVersion.WithKind("AIGatewayControlPlane"),
+			handler: parentRefHandler[konnectv1alpha1.AIGatewayControlPlane, *konnectv1alpha1.AIGatewayControlPlane]{},
+		},
 	}
 	_generatedHandlersPerGVK = make(map[schema.GroupVersionKind]generatedParentRefHandler, len(_generatedHandlers))
 	for _, entry := range _generatedHandlers {


### PR DESCRIPTION
**What this PR does / why we need it**:

reconciler_apiauthref_get & _generatedHandlers are needed for child resources of AIGatewayControlPlane.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
