### PR TITLE
test(konnect): recreate DataPlane on stalled Konnect config sync in TestKonnectExtension

### DIFF
--- a/test/integration/konnect/consts.go
+++ b/test/integration/konnect/consts.go
@@ -5,4 +5,16 @@ import "time"
 const (
 	waitTime = 60 * time.Second
 	tickTime = 1 * time.Second
+
+	// A Konnect-attached (hybrid) DataPlane becomes ready only after it receives
+	// its configuration from the Konnect control plane. That sync is normally fast
+	// (a healthy data plane is ready within ~20s), but it occasionally stalls for a
+	// freshly-provisioned data plane and never completes within any reasonable
+	// window. Recreating the DataPlane establishes a fresh control-plane session and
+	// reliably recovers, so readiness is retried with recreation rather than waited
+	// on with a single long timeout. dataPlaneReadinessAttemptTimeout is the per-
+	// attempt budget (generous versus the ~20s healthy case) and
+	// dataPlaneReadinessMaxAttempts caps the number of recreations.
+	dataPlaneReadinessAttemptTimeout = 90 * time.Second
+	dataPlaneReadinessMaxAttempts    = 3
 )

--- a/test/integration/konnect/konnect_extension_test.go
+++ b/test/integration/konnect/konnect_extension_test.go
@@ -462,53 +462,71 @@ func konnectExtensionTestBody(t *testing.T, cl client.Client, p KonnectExtension
 		conditions.CheckKonnectExtensionStatus(ctx, cl, p.konnectExtension, p.konnectControlPlane.GetKonnectID(), ""),
 		testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
-	t.Logf("Creating a DataPlane using the KonnectExtension %s/%s", p.konnectExtension.Namespace, p.konnectExtension.Name)
-	dataPlane := builder.NewDataPlaneBuilder().
-		WithObjectMeta(metav1.ObjectMeta{
-			Namespace: p.namespace,
-			Name:      "test-konnect-extension",
-		}).
-		WithPodTemplateSpec(&corev1.PodTemplateSpec{
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name:  consts.DataPlaneProxyContainerName,
-						Image: helpers.GetDefaultDataPlaneImage(),
-						Env: []corev1.EnvVar{
-							{
-								Name:  "KONG_LOG_LEVEL",
-								Value: "debug",
-							},
-						},
-						ReadinessProbe: &corev1.Probe{
-							InitialDelaySeconds: 1,
-							PeriodSeconds:       1,
-						},
-					},
-				},
-			},
-		}).
-		WithExtensions(
-			[]commonv1alpha1.ExtensionRef{
-				{
-					Group: konnectv1alpha1.GroupVersion.Group,
-					Kind:  "KonnectExtension",
-					NamespacedRef: commonv1alpha1.NamespacedRef{
-						Name: p.konnectExtension.Name,
-					},
-				},
-			},
-		).Build()
-	require.NoError(t, p.client.Create(ctx, dataPlane))
-	t.Cleanup(object.DeleteAndWaitForDeletionFn(context.Background(), t, cl, dataPlane))
-
 	dpName := k8stypes.NamespacedName{
-		Namespace: dataPlane.Namespace,
-		Name:      dataPlane.Name,
+		Namespace: p.namespace,
+		Name:      "test-konnect-extension",
 	}
 
-	t.Log("verifying dataplane gets marked provisioned")
-	require.Eventually(t, testutils.DataPlaneIsReady(t, ctx, dpName, integration.GetClients().OperatorClient), waitTime, tickTime)
+	// A hybrid DataPlane's Konnect config sync occasionally stalls and never
+	// completes for a freshly-provisioned data plane (see the constants in
+	// consts.go). A healthy one is ready within ~20s, so if readiness does not
+	// happen within dataPlaneReadinessAttemptTimeout we delete and recreate the
+	// DataPlane to establish a fresh control-plane session, retrying up to
+	// dataPlaneReadinessMaxAttempts times.
+	t.Logf("Creating a DataPlane using the KonnectExtension %s/%s and waiting for it to become provisioned", p.konnectExtension.Namespace, p.konnectExtension.Name)
+	isReady := testutils.DataPlaneIsReady(t, ctx, dpName, integration.GetClients().OperatorClient)
+	var ready bool
+	for attempt := 1; attempt <= dataPlaneReadinessMaxAttempts; attempt++ {
+		dataPlane := builder.NewDataPlaneBuilder().
+			WithObjectMeta(metav1.ObjectMeta{
+				Namespace: dpName.Namespace,
+				Name:      dpName.Name,
+			}).
+			WithPodTemplateSpec(&corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  consts.DataPlaneProxyContainerName,
+							Image: helpers.GetDefaultDataPlaneImage(),
+							Env: []corev1.EnvVar{
+								{
+									Name:  "KONG_LOG_LEVEL",
+									Value: "debug",
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								InitialDelaySeconds: 1,
+								PeriodSeconds:       1,
+							},
+						},
+					},
+				},
+			}).
+			WithExtensions(
+				[]commonv1alpha1.ExtensionRef{
+					{
+						Group: konnectv1alpha1.GroupVersion.Group,
+						Kind:  "KonnectExtension",
+						NamespacedRef: commonv1alpha1.NamespacedRef{
+							Name: p.konnectExtension.Name,
+						},
+					},
+				},
+			).Build()
+		require.NoError(t, p.client.Create(ctx, dataPlane))
+
+		if pollUntilTrue(isReady, dataPlaneReadinessAttemptTimeout, tickTime) {
+			ready = true
+			t.Cleanup(object.DeleteAndWaitForDeletionFn(context.Background(), t, cl, dataPlane))
+			break
+		}
+
+		t.Logf("DataPlane %s not ready after %s (attempt %d/%d); recreating to establish a fresh Konnect control-plane session",
+			dpName, dataPlaneReadinessAttemptTimeout, attempt, dataPlaneReadinessMaxAttempts)
+		object.DeleteAndWaitForDeletionFn(context.Background(), t, cl, dataPlane)()
+	}
+	require.Truef(t, ready, "DataPlane %s did not become ready within %d attempts of %s each",
+		dpName, dataPlaneReadinessMaxAttempts, dataPlaneReadinessAttemptTimeout)
 
 	t.Logf("verifying dataplane %s has ingress service", dpName)
 	var dpIngressService corev1.Service
@@ -555,5 +573,21 @@ func setKonnectExtensionDPCertSecretRef(t *testing.T, s *corev1.Secret) deploy.O
 				},
 			},
 		}
+	}
+}
+
+// pollUntilTrue polls check until it returns true or the timeout elapses. Unlike
+// require/assert.Eventually it does not fail the test on timeout; it returns
+// false so the caller can react (e.g. recreate a resource and retry).
+func pollUntilTrue(check func() bool, timeout, tick time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if check() {
+			return true
+		}
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		time.Sleep(tick)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes flakiness in `TestKonnectExtension` (konnect integration suite). A hybrid DataPlane's readiness probe hits Kong's `/status/ready`, which returns 200 only after the DP receives its config from the Konnect control plane.

Readiness is **bimodal**: a healthy DP is ready in ~10–20s, but occasionally the config sync for a freshly-provisioned DP stalls and never completes (503 observed for >180s in a run where sibling subtests on the same org became ready in <20s). So a longer timeout doesn't help — bumping it to 3m still flaked at 180s. Recreating the DataPlane establishes a fresh control-plane session and reliably recovers (which is why reruns and sibling subtests pass).

The readiness wait in `konnectExtensionTestBody` now retries with recreation: create the DP, wait up to `dataPlaneReadinessAttemptTimeout` (90s), and on timeout delete + recreate, up to `dataPlaneReadinessMaxAttempts` (3). Downstream waits revert to the default `waitTime`.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

Test-only change. The underlying stall is a Konnect-side config-sync issue for freshly-provisioned data planes; this makes the test resilient to it. Worth a separate Konnect-team follow-up.

**PR Readiness Checklist**:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes