### PR TITLE
chore: register index options for `KegDataPlane` only when controller enabled

### DIFF
--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -151,12 +151,17 @@ func SetupCacheIndexes(ctx context.Context, mgr manager.Manager, cfg Config) err
 			index.OptionsForKonnectGatewayControlPlane(),
 			index.OptionsForKonnectAPIAuthConfiguration(),
 			index.OptionsForKonnectCloudGatewayNetwork(),
-			index.OptionsForKegDataPlane(),
 			index.OptionsForKonnectExtension(),
 			index.OptionsForKonnectCloudGatewayDataPlaneGroupConfiguration(cl),
 		)
 
 		indexOptions = append(indexOptions, generatedIndexOptionsForKonnectEntities(cl)...)
+	}
+
+	if cfg.KEGDataPlaneControllerEnabled {
+		indexOptions = slices.Concat(indexOptions,
+			index.OptionsForKegDataPlane(),
+		)
 	}
 
 	if cfg.FeatureGates.Enabled(FeatureGateMCPServer) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Registration of index options for `KegDataPlane` only makes sense when the respective controller is enabled 
