### PR TITLE
test: skip flaky automatic_secret_provisioning in konnect integration tests

### DIFF
--- a/test/integration/konnect/konnect_extension_test.go
+++ b/test/integration/konnect/konnect_extension_test.go
@@ -363,8 +363,8 @@ func konnectExtensionTestCases(t *testing.T, cl client.Client, params KonnectExt
 			konnectExtensionTestBody(t, cl, params)
 		})
 
-		/* skip until flakiness resolved https://github.com/Kong/kong-operator/issues/4807
 		t.Run("automatic secret provisioning", func(t *testing.T) {
+			t.Skipf("Skip until flakiness is resolved, TODO: https://github.com/Kong/kong-operator/issues/4807")
 			konnectExtension := deploy.KonnectExtension(
 				t, ctx, params.client,
 				deploy.WithKonnectExtensionKonnectNamespacedRefControlPlaneRef(params.konnectControlPlane),
@@ -380,7 +380,6 @@ func konnectExtensionTestCases(t *testing.T, cl client.Client, params KonnectExt
 			}
 			konnectExtensionTestBody(t, cl, params)
 		})
-		*/
 	})
 }
 

--- a/test/integration/konnect/konnect_extension_test.go
+++ b/test/integration/konnect/konnect_extension_test.go
@@ -363,6 +363,7 @@ func konnectExtensionTestCases(t *testing.T, cl client.Client, params KonnectExt
 			konnectExtensionTestBody(t, cl, params)
 		})
 
+		/* skip until flakiness resolved https://github.com/Kong/kong-operator/issues/4807
 		t.Run("automatic secret provisioning", func(t *testing.T) {
 			konnectExtension := deploy.KonnectExtension(
 				t, ctx, params.client,
@@ -379,6 +380,7 @@ func konnectExtensionTestCases(t *testing.T, cl client.Client, params KonnectExt
 			}
 			konnectExtensionTestBody(t, cl, params)
 		})
+		*/
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

we are experiencing some flakiness (roughly 50% failure) on KO integration tests: after creating a brand new CP, requesting certificates and provisioning a new DP, the data plane gets stuck because it can't receive any config.

skip it temporarily until #4807 resolved.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
