### PR TITLE
test(konnect): re-enable flaky automatic secret provisioning test and increasing readiness probe interval

### DIFF
--- a/test/integration/konnect/konnect_extension_test.go
+++ b/test/integration/konnect/konnect_extension_test.go
@@ -485,8 +485,8 @@ func konnectExtensionTestBody(t *testing.T, cl client.Client, p KonnectExtension
 							},
 						},
 						ReadinessProbe: &corev1.Probe{
-							InitialDelaySeconds: 1,
-							PeriodSeconds:       1,
+							InitialDelaySeconds: 3,
+							PeriodSeconds:       3,
 						},
 					},
 				},

--- a/test/integration/konnect/konnect_extension_test.go
+++ b/test/integration/konnect/konnect_extension_test.go
@@ -22,6 +22,7 @@ import (
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	"github.com/kong/kong-operator/v2/controller/pkg/builder"
 	"github.com/kong/kong-operator/v2/pkg/consts"
+	resourceutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes/resources"
 	testutils "github.com/kong/kong-operator/v2/pkg/utils/test"
 	"github.com/kong/kong-operator/v2/test"
 	"github.com/kong/kong-operator/v2/test/helpers"
@@ -479,15 +480,8 @@ func konnectExtensionTestBody(t *testing.T, cl client.Client, p KonnectExtension
 								Name:  "KONG_LOG_LEVEL",
 								Value: "debug",
 							},
-							{
-								Name:  "KONG_INCREMENTAL_SYNC",
-								Value: "off",
-							},
 						},
-						ReadinessProbe: &corev1.Probe{
-							InitialDelaySeconds: 3,
-							PeriodSeconds:       3,
-						},
+						ReadinessProbe: resourceutils.GenerateDataPlaneReadinessProbe(consts.DataPlaneStatusEndpoint),
 					},
 				},
 			},

--- a/test/integration/konnect/konnect_extension_test.go
+++ b/test/integration/konnect/konnect_extension_test.go
@@ -224,8 +224,6 @@ func TestKonnectExtension(t *testing.T) {
 		})
 
 		t.Run("Mirror ControlPlane", func(t *testing.T) {
-			t.Skipf("Skip until flakiness is resolved, TODO: https://github.com/Kong/kong-operator/issues/4807")
-
 			// Create a Mirror Konnect control plane for the KonnectExtension to attach to.
 			mirrorCP := deploy.KonnectGatewayControlPlane(t, ctx, clientNamespaced, authCfg,
 				deploy.WithTestIDLabel(testID),
@@ -480,6 +478,10 @@ func konnectExtensionTestBody(t *testing.T, cl client.Client, p KonnectExtension
 							{
 								Name:  "KONG_LOG_LEVEL",
 								Value: "debug",
+							},
+							{
+								Name:  "KONG_INCREMENTAL_SYNC",
+								Value: "off",
 							},
 						},
 						ReadinessProbe: &corev1.Probe{

--- a/test/integration/konnect/konnect_extension_test.go
+++ b/test/integration/konnect/konnect_extension_test.go
@@ -481,7 +481,7 @@ func konnectExtensionTestBody(t *testing.T, cl client.Client, p KonnectExtension
 								Value: "debug",
 							},
 						},
-						ReadinessProbe: resourceutils.GenerateDataPlaneReadinessProbe(consts.DataPlaneStatusEndpoint),
+						ReadinessProbe: resourceutils.GenerateDataPlaneReadinessProbe(consts.DataPlaneStatusReadyEndpoint),
 					},
 				},
 			},


### PR DESCRIPTION
… 

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
