### PR TITLE
tests: fix kongintegration server url env

### DIFF
--- a/ingress-controller/test/consts.go
+++ b/ingress-controller/test/consts.go
@@ -36,8 +36,3 @@ const (
 	// RequestTimeout is the amount of time that will be given to any request to complete.
 	RequestTimeout = 10 * time.Second
 )
-
-const (
-	// konnectDefaultDevServerURL is the default Konnect API server URL used for development.
-	konnectDefaultDevServerURL = "https://us.api.konghq.tech"
-)

--- a/ingress-controller/test/helpers/konnect/access.go
+++ b/ingress-controller/test/helpers/konnect/access.go
@@ -1,9 +1,11 @@
 package konnect
 
 import (
+	"strings"
+
 	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
 
-	"github.com/kong/kong-operator/v2/ingress-controller/test"
+	"github.com/kong/kong-operator/v2/test"
 )
 
 // konnectControlPlaneAdminAPIBaseURL returns the base URL for Konnect Control Plane Admin API.
@@ -11,13 +13,12 @@ import (
 func konnectControlPlaneAdminAPIBaseURL() string {
 	const konnectDefaultControlPlaneAdminAPIBaseURL = "https://us.kic.api.konghq.tech"
 
-	serverURL := test.KonnectServerURL()
-	switch serverURL {
-	case "https://eu.api.konghq.tech":
+	switch serverURL() {
+	case "http://eu.api.konghq.tech":
 		return "https://eu.kic.api.konghq.tech"
-	case "https://ap.api.konghq.tech":
+	case "http://ap.api.konghq.tech":
 		return "https://ap.kic.api.konghq.tech"
-	case "https://us.api.konghq.tech":
+	case "http://us.api.konghq.tech":
 		return konnectDefaultControlPlaneAdminAPIBaseURL
 	default:
 		return konnectDefaultControlPlaneAdminAPIBaseURL
@@ -25,5 +26,13 @@ func konnectControlPlaneAdminAPIBaseURL() string {
 }
 
 func serverURLOpt() sdkkonnectgo.SDKOption {
-	return sdkkonnectgo.WithServerURL(test.KonnectServerURL())
+	return sdkkonnectgo.WithServerURL(serverURL())
+}
+
+func serverURL() string {
+	serverURL := test.KonnectServerURL()
+	serverURL = strings.TrimPrefix(serverURL, "http://")
+	serverURL = strings.TrimPrefix(serverURL, "https://")
+	serverURL = "https://" + serverURL
+	return serverURL
 }

--- a/ingress-controller/test/konnect.go
+++ b/ingress-controller/test/konnect.go
@@ -1,20 +1,10 @@
 package test
 
-import "os"
+import "github.com/kong/kong-operator/v2/test"
 
-// KonnectServerURL returns the Konnect server URL to be used for Konnect API
-// requests in tests and CI.
-// It is driven by the TEST_KONG_KONNECT_SERVER_URL environment variable.
-func KonnectServerURL() string {
-	serverURL := os.Getenv("TEST_KONG_KONNECT_SERVER_URL")
-	if serverURL != "" {
-		return serverURL
-	}
-	return konnectDefaultDevServerURL
-}
-
+// KonnectServerRegion returns the region of the Konnect server based on the server URL.
 func KonnectServerRegion() string {
-	serverURL := KonnectServerURL()
+	serverURL := test.KonnectServerURL()
 	switch serverURL {
 	case "https://eu.api.konghq.tech", "https://eu.kic.api.konghq.tech":
 		return "eu"


### PR DESCRIPTION
**What this PR does / why we need it**:

Get rid of `TEST_KONG_KONNECT_SERVER_URL` which is not used anywhere.

Use `KONG_TEST_KONNECT_SERVER_URL` which is uniformly used everywhere.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
