### PR TITLE
fix: skip update in reconcilers for entities not supporting it (`AIGatewayDataPlaneCertificate`, `AIGatewayConsumerCredential`)

### DIFF
--- a/controller/konnect/ops/zz_generated_ops_update.go
+++ b/controller/konnect/ops/zz_generated_ops_update.go
@@ -31,8 +31,12 @@ func UpdateGeneratedOps[
 		return updateAIGatewayAgent(ctx, sdk.GetAIGatewayAgentsSDK(), ent)
 	case *konnectv1alpha1.AIGatewayConsumer:
 		return updateAIGatewayConsumer(ctx, sdk.GetAIGatewayConsumersSDK(), ent)
+	case *konnectv1alpha1.AIGatewayConsumerCredential:
+		return nil // Entity does not support update.
 	case *konnectv1alpha1.AIGatewayControlPlane:
 		return updateAIGatewayControlPlane(ctx, sdk.GetAIGatewaysSDK(), ent)
+	case *configurationv1alpha1.AIGatewayDataPlaneCertificate:
+		return nil // Entity does not support update.
 	case *konnectv1alpha1.AIGatewayModel:
 		return updateAIGatewayModel(ctx, sdk.GetAIGatewayModelsSDK(), ent)
 	case *konnectv1alpha1.AIGatewayModelProvider:

--- a/crd-from-oas/pkg/generator/generator_test.go
+++ b/crd-from-oas/pkg/generator/generator_test.go
@@ -5225,10 +5225,11 @@ func TestGenerateOpsUpdate_NoUpdateOp_Skipped(t *testing.T) {
 
 	file, info, err := g.generateOpsUpdate("Portal", schema, opsConfig)
 	require.NoError(t, err)
-	require.NotNil(t, file) // file emitted for create
-	require.Nil(t, info)    // no update info → not in dispatcher
+	require.NotNil(t, file)
+	require.NotNil(t, info)          // Update info present -> emits nil case in dispatcher
+	require.True(t, info.SkipUpdate) // No update stanza -> no-op dispatcher case.
 
-	// File contains create but no update.
+	// File contains create but no update function.
 	assert.Contains(t, file.Content, "func createPortal(")
 	assert.NotContains(t, file.Content, "func updatePortal(")
 }

--- a/crd-from-oas/pkg/generator/ops.go
+++ b/crd-from-oas/pkg/generator/ops.go
@@ -184,6 +184,15 @@ func (g *Generator) generateEntityOpsFile(
 			SDKGetter:      sdkGetter,
 			NeedsClient:    updateData.NeedsClient,
 		}
+	} else {
+		// No update stanza in config: emit a no-op case in the dispatcher so
+		// the entity is handled gracefully without returning an error.
+		updateInfo = &OpsUpdateFileInfo{
+			Entity:         entityName,
+			APIAlias:       g.config.APIGroupPackageAlias,
+			APIPackagePath: g.config.APIGroupPackagePath,
+			SkipUpdate:     true,
+		}
 	}
 
 	var deleteInfo *OpsDeleteFileInfo
@@ -287,6 +296,7 @@ func buildDispatcherFile(
 		APIAlias    string
 		SDKGetter   string
 		NeedsClient bool
+		SkipUpdate  bool
 	}
 
 	importSet := map[string]string{}
@@ -298,6 +308,7 @@ func buildDispatcherFile(
 			APIAlias:    info.APIAlias,
 			SDKGetter:   info.SDKGetter,
 			NeedsClient: info.NeedsClient,
+			SkipUpdate:  info.SkipUpdate,
 		})
 	}
 

--- a/crd-from-oas/pkg/generator/ops_create.go
+++ b/crd-from-oas/pkg/generator/ops_create.go
@@ -165,6 +165,7 @@ type flatInfo struct {
 	APIPackagePath string
 	SDKGetter      string
 	NeedsClient    bool
+	SkipUpdate     bool
 }
 
 // GenerateOpsCreateDispatcher emits zz_generated_ops_create.go with

--- a/crd-from-oas/pkg/generator/ops_update.go
+++ b/crd-from-oas/pkg/generator/ops_update.go
@@ -16,6 +16,9 @@ type OpsUpdateFileInfo struct {
 	APIPackagePath string
 	SDKGetter      string
 	NeedsClient    bool
+	// SkipUpdate indicates the entity does not support update. The dispatcher
+	// emits a nil return for this entity instead of calling an update function.
+	SkipUpdate bool
 }
 
 type updateOpCallShape struct {
@@ -206,6 +209,7 @@ func GenerateOpsUpdateDispatcher(infos []*OpsUpdateFileInfo) (*GeneratedFile, er
 			APIPackagePath: info.APIPackagePath,
 			SDKGetter:      info.SDKGetter,
 			NeedsClient:    info.NeedsClient,
+			SkipUpdate:     info.SkipUpdate,
 		})
 	}
 	return buildDispatcherFile("zz_generated_ops_update.go", opsUpdateDispatcherTemplate, "controller/konnect/ops", flat)

--- a/crd-from-oas/pkg/generator/templates.go
+++ b/crd-from-oas/pkg/generator/templates.go
@@ -2189,8 +2189,13 @@ func UpdateGeneratedOps[
 ) error {
 	switch ent := any(e).(type) {
 {{- range .Cases}}
+{{- if .SkipUpdate}}
+	case *{{.APIAlias}}.{{.Entity}}:
+		return nil // Entity does not support update.
+{{- else}}
 	case *{{.APIAlias}}.{{.Entity}}:
 		return update{{.Entity}}(ctx, {{if .NeedsClient}}cl, {{end}}sdk.{{.SDKGetter}}(), ent)
+{{- end}}
 {{- end}}
 	default:
 		return fmt.Errorf("unsupported entity type %T", ent)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adjusts the `crd-from-oas` generator so that, for a particular entity stanza, `update:` is skipped unsupported updating as part of reconciliation is also skipped, see `controller/konnect/ops/zz_generated_ops_update.go`.

Currently, it is applied to 
- `AIGatewayDataPlaneCertificate`
- `AIGatewayConsumerCredential`


For `AIGatewayDataPlaneCertificate` before

```yml
  status:
    conditions:
    - lastTransitionTime: "2026-07-08T11:06:27Z"
      message: Referenced AIGatewayControlPlane default/ai-gw-cp-1 is programmed
      observedGeneration: 1
      reason: Valid
      status: "True"
      type: AIGatewayControlPlaneRefValid
    - lastTransitionTime: "2026-07-08T11:07:27Z"
      message: unsupported entity type *v1alpha1.AIGatewayDataPlaneCertificate
      observedGeneration: 1
      reason: FailedToUpdate
      status: "False"
      type: Programmed
    - lastTransitionTime: "2026-07-08T11:06:27Z"
      message: KonnectAPIAuthConfiguration reference default/konnect-api-auth is resolved
      observedGeneration: 1
      reason: ResolvedRef
      status: "True"
      type: APIAuthResolvedRef
    - lastTransitionTime: "2026-07-08T11:06:27Z"
      message: referenced KonnectAPIAuthConfiguration default/konnect-api-auth is
        valid
      observedGeneration: 1
      reason: Valid
      status: "True"
      type: APIAuthValid
    gatewayID:
      id: 04784600-bb74-48d6-9d06-f36262614fc3
    id: 3d542485-d048-4af2-954e-f3367b35dca4
    organizationID: aba16dbf-0d4a-497f-bc3f-7fcfd7a3d1fc
    serverURL: https://us.api.konghq.tech
```

and in the logs

```log
[manager] 2026-07-08T11:07:27.014Z       DEBUG   AIGatewayControlPlane   reconciling     {"controller": "AIGatewayControlPlane", "controllerGroup": "konnect.konghq.com", "controllerKind": "AIGatewayControlPlane", "AIGatewayControlPlane": {"name":"ai-gw-cp-1","namespace":"default"}, "namespace": "default", "name": "ai-gw-cp-1", "reconcileID": "7578670d-1d2a-4ca8-9ab9-36bacb3e15a4", "konnect_id": "04784600-bb74-48d6-9d06-f36262614fc3"}
[manager] 2026-07-08T11:07:27.015Z       ERROR   AIGatewayDataPlaneCertificate   operation in Konnect API failed {"controller": "AIGatewayDataPlaneCertificate", "controllerGroup": "configuration.konghq.com", "controllerKind": "AIGatewayDataPlaneCertificate", "AIGatewayDataPlaneCertificate": {"name":"ai-gw-cp-1-dataplane-cert","namespace":"default"}, "namespace": "default", "name": "ai-gw-cp-1-dataplane-cert", "reconcileID": "0c295d81-5841-4080-975d-c68ad626e34a", "konnect_id": "3d542485-d048-4af2-954e-f3367b35dca4", "op": "update", "namespacedName": "default/ai-gw-cp-1-dataplane-cert", "duration": "518.872µs", "error": "unsupported entity type *v1alpha1.AIGatewayDataPlaneCertificate"}
[manager] 2026-07-08T11:07:27.031Z       ERROR   AIGatewayDataPlaneCertificate   failed to update        {"controller": "AIGatewayDataPlaneCertificate", "controllerGroup": "configuration.konghq.com", "controllerKind": "AIGatewayDataPlaneCertificate", "AIGatewayDataPlaneCertificate": {"name":"ai-gw-cp-1-dataplane-cert","namespace":"default"}, "namespace": "default", "name": "ai-gw-cp-1-dataplane-cert", "reconcileID": "0c295d81-5841-4080-975d-c68ad626e34a", "konnect_id": "3d542485-d048-4af2-954e-f3367b35dca4", "error": "unsupported entity type *v1alpha1.AIGatewayDataPlaneCertificate"}
[manager] github.com/kong/kong-operator/v2/controller/konnect.(*KonnectEntityReconciler[...]).Reconcile
[manager]        /workspace/controller/konnect/reconciler_generic.go:760
[manager] sigs.k8s.io/controller-runtime/pkg/reconcile.(*objectReconcilerAdapter[...]).Reconcile
[manager]        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/reconcile/reconcile.go:169
[manager] sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile
[manager]        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:221
[manager] sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
[manager]        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:478
[manager] sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
[manager]        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:437
[manager] sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
[manager]        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:312
[manager] 2026-07-08T11:07:27.032Z       DEBUG   AIGatewayDataPlaneCertificate   reconciling     {"controller": "AIGatewayDataPlaneCertificate", "controllerGroup": "configuration.konghq.com", "controllerKind": "AIGatewayDataPlaneCertificate", "AIGatewayDataPlaneCertificate": {"name":"ai-gw-cp-1-dataplane-cert","namespace":"default"}, "namespace": "default", "name": "ai-gw-cp-1-dataplane-cert", "reconcileID": "4b0b4f92-f8af-4200-bb46-185c43bc285d", "konnect_id": "3d542485-d048-4af2-954e-f3367b35dca4"}
```

after the change logs are clean and

```yml
  status:
    conditions:
    - lastTransitionTime: "2026-07-08T11:14:02Z"
      message: Referenced AIGatewayControlPlane default/ai-gw-cp-1 is programmed
      observedGeneration: 1
      reason: Valid
      status: "True"
      type: AIGatewayControlPlaneRefValid
    - lastTransitionTime: "2026-07-08T11:14:02Z"
      message: ""
      observedGeneration: 1
      reason: Programmed
      status: "True"
      type: Programmed
    - lastTransitionTime: "2026-07-08T11:14:02Z"
      message: KonnectAPIAuthConfiguration reference default/konnect-api-auth is resolved
      observedGeneration: 1
      reason: ResolvedRef
      status: "True"
      type: APIAuthResolvedRef
    - lastTransitionTime: "2026-07-08T11:14:02Z"
      message: referenced KonnectAPIAuthConfiguration default/konnect-api-auth is
        valid
      observedGeneration: 1
      reason: Valid
      status: "True"
      type: APIAuthValid
    gatewayID:
      id: 8cf4c4ee-9d95-458c-ae27-9c4720d4c093
    id: 2dd46e59-ff1b-4bad-9e73-6f6d006b91cb
    organizationID: aba16dbf-0d4a-497f-bc3f-7fcfd7a3d1fc
    serverURL: https://us.api.konghq.tech
```

**Which issue this PR fixes**

Follow-up for #4772

