### PR TITLE
feat(konnect): require KongReferenceGrant for cross-namespace KonnectAPIAuthConfiguration secret refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@
 
 ### Breaking changes
 
+- A cross-namespace reference from a `KonnectAPIAuthConfiguration` to a `Secret`
+  (via `spec.secretRef.namespace`) now requires a `KongReferenceGrant` in the
+  Secret's namespace permitting it. Without the grant the configuration reports
+  `ResolvedRefs=False` with reason `RefNotPermitted` and is marked invalid.
+  Previously such references were allowed with a warning only.
+  [#2908](https://github.com/Kong/kong-operator/issues/2908)
 - EventGateway CRDs (Tech Preview) which allow referencing a `Secret` through
   `secretRef`, now require the key name to be provided.
 

--- a/controller/konnect/reconciler_konnectapiauth.go
+++ b/controller/konnect/reconciler_konnectapiauth.go
@@ -146,6 +146,30 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 
 	token, err := GetTokenFromKonnectAPIAuthConfiguration(ctx, r.client, apiAuth)
 	if err != nil {
+		if crossnamespace.IsReferenceNotGranted(err) {
+			// The cross-namespace reference to the Secret is not permitted by a
+			// KongReferenceGrant. Surface it via ResolvedRefs and mark the auth
+			// configuration invalid. The KongReferenceGrant watch requeues the
+			// object once a permitting grant is created, so no error is returned.
+			if res, _, errStatus := patch.StatusWithConditions(
+				ctx, r.client, apiAuth,
+				metav1.Condition{
+					Type:    configurationv1alpha1.KongReferenceGrantConditionTypeResolvedRefs,
+					Status:  metav1.ConditionFalse,
+					Reason:  configurationv1alpha1.KongReferenceGrantReasonRefNotPermitted,
+					Message: err.Error(),
+				},
+				metav1.Condition{
+					Type:    konnectv1alpha1.KonnectEntityAPIAuthConfigurationValidConditionType,
+					Status:  metav1.ConditionFalse,
+					Reason:  konnectv1alpha1.KonnectEntityAPIAuthConfigurationReasonInvalid,
+					Message: err.Error(),
+				},
+			); errStatus != nil || !res.IsZero() {
+				return res, errStatus
+			}
+			return ctrl.Result{}, nil
+		}
 		if res, errStatus := patch.StatusWithCondition(
 			ctx, r.client, apiAuth,
 			konnectv1alpha1.KonnectEntityAPIAuthConfigurationValidConditionType,
@@ -156,6 +180,13 @@ func (r *KonnectAPIAuthConfigurationReconciler) Reconcile(
 			return res, errStatus
 		}
 		return ctrl.Result{}, err
+	}
+
+	// Manage the ResolvedRefs condition for the resolved Secret reference. It is
+	// present only for cross-namespace secretRefs, mirroring the other Konnect
+	// cross-namespace reference reconcilers.
+	if res, errStatus := r.reconcileSecretRefResolvedRefs(ctx, apiAuth); errStatus != nil || !res.IsZero() {
+		return res, errStatus
 	}
 
 	server, err := server.NewServer[konnectv1alpha1.KonnectAPIAuthConfiguration](apiAuth.Spec.ServerURL)
@@ -288,18 +319,11 @@ func GetTokenFromKonnectAPIAuthConfiguration(
 		if nn.Namespace != apiAuth.Namespace {
 			gvkAPIAuth := metav1.GroupVersionKind(apiAuth.GetObjectKind().GroupVersionKind())
 			gvkSecret := metav1.GroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
-			// TODO: Require a KongReferenceGrant for cross-namespace references in KO 2.3 and later:
+			// Cross-namespace references from a KonnectAPIAuthConfiguration to a Secret
+			// require a KongReferenceGrant in the Secret's namespace.
 			// https://github.com/Kong/kong-operator/issues/2908
-			err := crossnamespace.CheckKongReferenceGrantForResource(ctx, cl, apiAuth.Namespace, nn.Namespace, nn.Name, gvkAPIAuth, gvkSecret)
-			if err != nil {
-				ctrllog.FromContext(ctx).
-					Error(
-						fmt.Errorf("missing KongReferenceGrant from KonnectAPIAuthConfiguration %s to Secret %s",
-							client.ObjectKeyFromObject(apiAuth), nn,
-						),
-						"WARNING: referencing Secret in a different namespace. "+
-							"This will require a KongReferenceGrant in Secret's namespace in KO 2.3 and later.",
-					)
+			if err := crossnamespace.CheckKongReferenceGrantForResource(ctx, cl, apiAuth.Namespace, nn.Namespace, nn.Name, gvkAPIAuth, gvkSecret); err != nil {
+				return "", err
 			}
 		}
 
@@ -320,6 +344,34 @@ func GetTokenFromKonnectAPIAuthConfiguration(
 	}
 
 	return "", fmt.Errorf("unknown KonnectAPIAuthType: %s", apiAuth.Spec.Type)
+}
+
+// apiAuthHasCrossNamespaceSecretRef reports whether the KonnectAPIAuthConfiguration
+// references a Secret in a different namespace than its own.
+func apiAuthHasCrossNamespaceSecretRef(apiAuth *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
+	if apiAuth.Spec.Type != konnectv1alpha1.KonnectAPIAuthTypeSecretRef || apiAuth.Spec.SecretRef == nil {
+		return false
+	}
+	ns := apiAuth.Spec.SecretRef.Namespace
+	return ns != "" && ns != apiAuth.Namespace
+}
+
+// reconcileSecretRefResolvedRefs sets the ResolvedRefs condition to True for a
+// cross-namespace secretRef whose KongReferenceGrant has been verified, or
+// removes it for same-namespace (or non-secretRef) configurations.
+func (r *KonnectAPIAuthConfigurationReconciler) reconcileSecretRefResolvedRefs(
+	ctx context.Context, apiAuth *konnectv1alpha1.KonnectAPIAuthConfiguration,
+) (ctrl.Result, error) {
+	if apiAuthHasCrossNamespaceSecretRef(apiAuth) {
+		return patch.StatusWithCondition(
+			ctx, r.client, apiAuth,
+			configurationv1alpha1.KongReferenceGrantConditionTypeResolvedRefs,
+			metav1.ConditionTrue,
+			configurationv1alpha1.KongReferenceGrantReasonResolvedRefs,
+			"KongReferenceGrant allows access to the referenced Secret",
+		)
+	}
+	return patch.StatusWithoutCondition(ctx, r.client, apiAuth, configurationv1alpha1.KongReferenceGrantConditionTypeResolvedRefs)
 }
 
 // EnsureFinalizerOnKonnectAPIAuthConfiguration ensures that the KonnectAPIAuthConfiguration

--- a/controller/konnect/reconciler_konnectapiauth_test.go
+++ b/controller/konnect/reconciler_konnectapiauth_test.go
@@ -12,10 +12,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
 	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	"github.com/kong/kong-operator/v2/internal/utils/index"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
 )
 
 func TestGetTokenFromKonnectAPIAuthConfiguration(t *testing.T) {
@@ -513,6 +515,192 @@ func TestEnsureFinalizerOnKonnectAPIAuthConfiguration(t *testing.T) {
 			hasFinalizer := slices.Contains(updatedAuth.Finalizers, APIAuthInUseFinalizer)
 
 			assert.Equal(t, tt.expectedFinalizerAdded, hasFinalizer, "finalizer presence mismatch")
+		})
+	}
+}
+
+func TestApiAuthHasCrossNamespaceSecretRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiAuth  *konnectv1alpha1.KonnectAPIAuthConfiguration
+		expected bool
+	}{
+		{
+			name: "token type",
+			apiAuth: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns-a"},
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type: konnectv1alpha1.KonnectAPIAuthTypeToken,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "secretRef with nil SecretRef",
+			apiAuth: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns-a"},
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type: konnectv1alpha1.KonnectAPIAuthTypeSecretRef,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "secretRef with empty namespace defaults to same namespace",
+			apiAuth: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns-a"},
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type:      konnectv1alpha1.KonnectAPIAuthTypeSecretRef,
+					SecretRef: &corev1.SecretReference{Name: "secret", Namespace: ""},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "secretRef with same namespace",
+			apiAuth: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns-a"},
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type:      konnectv1alpha1.KonnectAPIAuthTypeSecretRef,
+					SecretRef: &corev1.SecretReference{Name: "secret", Namespace: "ns-a"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "secretRef with different namespace",
+			apiAuth: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns-a"},
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type:      konnectv1alpha1.KonnectAPIAuthTypeSecretRef,
+					SecretRef: &corev1.SecretReference{Name: "secret", Namespace: "ns-b"},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, apiAuthHasCrossNamespaceSecretRef(tt.apiAuth))
+		})
+	}
+}
+
+func TestReconcileSecretRefResolvedRefs(t *testing.T) {
+	tests := []struct {
+		name                string
+		apiAuth             *konnectv1alpha1.KonnectAPIAuthConfiguration
+		expectConditionSet  bool
+		expectConditionTrue bool
+	}{
+		{
+			name: "token type: no ResolvedRefs condition",
+			apiAuth: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "auth", Namespace: "ns-a"},
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type: konnectv1alpha1.KonnectAPIAuthTypeToken,
+				},
+			},
+			expectConditionSet: false,
+		},
+		{
+			name: "same-namespace secretRef: no ResolvedRefs condition",
+			apiAuth: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "auth", Namespace: "ns-a"},
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type:      konnectv1alpha1.KonnectAPIAuthTypeSecretRef,
+					SecretRef: &corev1.SecretReference{Name: "secret", Namespace: "ns-a"},
+				},
+			},
+			expectConditionSet: false,
+		},
+		{
+			name: "cross-namespace secretRef: ResolvedRefs=True",
+			apiAuth: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "auth", Namespace: "ns-a"},
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type:      konnectv1alpha1.KonnectAPIAuthTypeSecretRef,
+					SecretRef: &corev1.SecretReference{Name: "secret", Namespace: "ns-b"},
+				},
+			},
+			expectConditionSet:  true,
+			expectConditionTrue: true,
+		},
+		{
+			name: "cross-namespace secretRef with a stale ResolvedRefs=False is flipped to True",
+			apiAuth: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "auth", Namespace: "ns-a"},
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type:      konnectv1alpha1.KonnectAPIAuthTypeSecretRef,
+					SecretRef: &corev1.SecretReference{Name: "secret", Namespace: "ns-b"},
+				},
+				Status: konnectv1alpha1.KonnectAPIAuthConfigurationStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               configurationv1alpha1.KongReferenceGrantConditionTypeResolvedRefs,
+							Status:             metav1.ConditionFalse,
+							Reason:             configurationv1alpha1.KongReferenceGrantReasonRefNotPermitted,
+							ObservedGeneration: 1,
+						},
+					},
+				},
+			},
+			expectConditionSet:  true,
+			expectConditionTrue: true,
+		},
+		{
+			name: "same-namespace secretRef removes a stale ResolvedRefs condition",
+			apiAuth: &konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "auth", Namespace: "ns-a"},
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type:      konnectv1alpha1.KonnectAPIAuthTypeSecretRef,
+					SecretRef: &corev1.SecretReference{Name: "secret", Namespace: "ns-a"},
+				},
+				Status: konnectv1alpha1.KonnectAPIAuthConfigurationStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               configurationv1alpha1.KongReferenceGrantConditionTypeResolvedRefs,
+							Status:             metav1.ConditionTrue,
+							Reason:             configurationv1alpha1.KongReferenceGrantReasonResolvedRefs,
+							ObservedGeneration: 1,
+						},
+					},
+				},
+			},
+			expectConditionSet: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := scheme.Get()
+			cl := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(tt.apiAuth).
+				WithStatusSubresource(tt.apiAuth).
+				Build()
+
+			r := &KonnectAPIAuthConfigurationReconciler{client: cl}
+
+			_, err := r.reconcileSecretRefResolvedRefs(t.Context(), tt.apiAuth)
+			require.NoError(t, err)
+
+			var updated konnectv1alpha1.KonnectAPIAuthConfiguration
+			require.NoError(t, cl.Get(t.Context(), client.ObjectKeyFromObject(tt.apiAuth), &updated))
+
+			cond, ok := k8sutils.GetCondition(configurationv1alpha1.KongReferenceGrantConditionTypeResolvedRefs, &updated)
+			if !tt.expectConditionSet {
+				assert.False(t, ok, "expected no ResolvedRefs condition, got: %+v", cond)
+				return
+			}
+			require.True(t, ok, "expected a ResolvedRefs condition to be set")
+			if tt.expectConditionTrue {
+				assert.Equal(t, metav1.ConditionTrue, cond.Status)
+				assert.Equal(t, configurationv1alpha1.KongReferenceGrantReasonResolvedRefs, cond.Reason)
+			} else {
+				assert.Equal(t, metav1.ConditionFalse, cond.Status)
+			}
 		})
 	}
 }

--- a/test/e2e/chainsaw/konnect/apiAuth_referencegrant/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/konnect/apiAuth_referencegrant/chainsaw-test.yaml
@@ -1,19 +1,37 @@
-# KonnectAPIAuthConfiguration Cross-Namespace Reference Grant test scenario
+# KonnectAPIAuthConfiguration cross-namespace secretRef KongReferenceGrant test.
+#
+# The cross-namespace axis under test is spec.secretRef.namespace: the Secret holding the
+# Konnect token lives in a different namespace from the KonnectAPIAuthConfiguration.
+#
+# Scenario A: Secret and KonnectAPIAuthConfiguration in the same namespace — baseline, no
+#   grant needed. The ResolvedRefs condition is absent for same-namespace secretRefs.
+#
+# Scenario B: Secret in secret_namespace, KonnectAPIAuthConfiguration in the test namespace.
+#   The reference is denied (ResolvedRefs=False/RefNotPermitted, APIAuthValid=False) until a
+#   KongReferenceGrant in secret_namespace permits it.
+#
+# Scenario D: starting from Scenario B (APIAuthValid=True), deleting the KongReferenceGrant
+#   reverts the KonnectAPIAuthConfiguration to ResolvedRefs=False/RefNotPermitted, validating
+#   that the KongReferenceGrant watch is wired correctly.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
   name: konnectapiauthconfiguration-referencegrant
 spec:
   description: |
-    This test validates backward compatibility for cross-namespace secret references in KonnectAPIAuthConfiguration.
-    Currently, the operator still allows cross-namespace references (with warnings about missing KongReferenceGrant)
-    to ensure we don't break existing users. The test ensures that:
-    1. Cross-namespace secret references continue to work but show KongReferenceGrant warning messages
-    2. Existing user configurations remain functional during the deprecation period
-    
-    NOTE: This is a temporary backward compatibility test. In future versions when cross-namespace 
-    references without KongReferenceGrant are no longer supported, this test will fail and must be 
-    updated to properly test the ReferenceGrant mechanism with both Secret and KonnectAPIAuthConfiguration.
+    Tests that a cross-namespace reference from a KonnectAPIAuthConfiguration to a Secret
+    requires a KongReferenceGrant in the Secret's namespace.
+
+    Scenario A: Secret and KonnectAPIAuthConfiguration in the same namespace. No grant needed;
+    APIAuthValid=True and the ResolvedRefs condition is absent.
+
+    Scenario B: Secret in secret_namespace, KonnectAPIAuthConfiguration in the test namespace.
+    Without a grant the configuration reports ResolvedRefs=False/RefNotPermitted and
+    APIAuthValid=False. Creating a KongReferenceGrant in secret_namespace makes it valid.
+
+    Scenario D: starting from Scenario B (APIAuthValid=True), deleting the KongReferenceGrant
+    reverts the KonnectAPIAuthConfiguration to ResolvedRefs=False/RefNotPermitted, validating
+    that the KongReferenceGrant watch is wired correctly.
 
   bindings:
     # Common bindings.
@@ -21,59 +39,237 @@ spec:
       value: (env('KONNECT_TOKEN'))
     - name: konnect_url
       value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
-    # Namespace bindings - use chainsaw $namespace as base
-    - name: auth_namespace  
-      value: ($namespace)
+    # Namespace bindings.
     - name: secret_namespace
-      value: (join('-', [($namespace), 'secret']))
-    # Resource bindings
-    - name: auth_secret_name
-      value: (join('-', [($namespace), 'cross-ns-secret']))
-    - name: konnect_auth_name
-      value: (join('-', [($namespace), 'cross-ns-auth']))
+      value: (join('-', [$namespace, 'secret']))
+    # Scenario A resource names (all in the test namespace).
+    - name: auth0_name
+      value: (join('-', [$namespace, 'auth0']))
+    - name: secret0_name
+      value: (join('-', [$namespace, 'secret0']))
+    # Scenario B resource names (Secret in secret_namespace, auth config in the test namespace).
+    - name: auth_name
+      value: (join('-', [$namespace, 'auth']))
+    - name: secret_name
+      value: (join('-', [$namespace, 'secret']))
+    - name: grant_name
+      value: (join('-', [$namespace, 'auth-to-secret']))
 
   steps:
-    # Step 1: Create the secret namespace.
-    - name: Create-secret-namespace
-      description: Create namespace for the secret.
-      use:
-        template: ../../common/_step_templates/apply-assert-namespace.yaml
-        with:
-          bindings:
-            - name: namespace_name
-              value: ($secret_namespace)
+    # =========================================================================
+    # Scenario A: Secret and KonnectAPIAuthConfiguration in the same namespace.
+    # No grant needed; ResolvedRefs condition is absent.
+    # =========================================================================
 
-    # Step 2: Create secret in the secret namespace.
-    - name: Create-cross-ns-secret
-      description: Create secret in the secret namespace.
+    - name: 1-create-secret-same-ns
+      description: Create the Konnect token Secret in the test namespace.
+      bindings:
+        - name: auth_secret_name
+          value: ($secret0_name)
+        - name: auth_secret_namespace
+          value: ($namespace)
       use:
         template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
-        with:
-          bindings:
-            - name: auth_secret_name
-              value: ($auth_secret_name)
-            - name: auth_secret_namespace
-              value: ($secret_namespace)
-            - name: konnect_token
-              value: ($konnect_token)
 
-    # Step 3: Create KonnectAPIAuthConfiguration in default namespace (should fail).
-    - name: Create-cross-ns-auth-config
-      description: Create KonnectAPIAuthConfiguration that references secret from different namespace.
+    - name: 2-create-auth-config-same-ns
+      description: Create KonnectAPIAuthConfiguration with a same-namespace secretRef. No grant needed.
+      try:
+        - apply:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAPIAuthConfiguration
+              metadata:
+                name: ($auth0_name)
+                namespace: ($namespace)
+              spec:
+                type: secretRef
+                secretRef:
+                  name: ($secret0_name)
+                serverURL: ($konnect_url)
+
+    - name: 3-assert-auth-config-valid-same-ns
+      description: Assert APIAuthValid=True and that no ResolvedRefs condition is set for the same-namespace secretRef.
+      timeouts:
+        assert: 90s
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAPIAuthConfiguration
+              metadata:
+                name: ($auth0_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (length(conditions[?type == 'ResolvedRefs'])): 0
+
+    - name: 4-cleanup-scenario-a
+      description: Delete the same-namespace auth config; wait for it to be gone before proceeding.
+      timeouts:
+        delete: 120s
+        error: 120s
+      try:
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAPIAuthConfiguration
+              name: ($auth0_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAPIAuthConfiguration
+              metadata:
+                name: ($auth0_name)
+                namespace: ($namespace)
+
+    # =========================================================================
+    # Scenario B: Secret in secret_namespace, KonnectAPIAuthConfiguration in the
+    # test namespace. A KongReferenceGrant in secret_namespace is needed.
+    # =========================================================================
+
+    - name: 5-create-secret-namespace
+      description: Create the separate namespace for the Secret.
+      bindings:
+        - name: namespace_name
+          value: ($secret_namespace)
       use:
-        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
-        with:
-          bindings:
-            - name: konnect_auth_name
-              value: ($konnect_auth_name)
-            - name: konnect_auth_namespace
-              value: ($auth_namespace)
-            - name: auth_secret_name
-              value: ($auth_secret_name)
-            - name: auth_secret_namespace
-              value: ($secret_namespace)
-            - name: konnect_url
-              value: ($konnect_url)
+        template: ../../common/_step_templates/apply-assert-namespace.yaml
+
+    - name: 6-create-secret-cross-ns
+      description: Create the Konnect token Secret in secret_namespace.
+      bindings:
+        - name: auth_secret_name
+          value: ($secret_name)
+        - name: auth_secret_namespace
+          value: ($secret_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    - name: 7-create-auth-config-no-grant
+      description: Create KonnectAPIAuthConfiguration referencing the Secret in secret_namespace (no grant yet).
+      try:
+        - apply:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAPIAuthConfiguration
+              metadata:
+                name: ($auth_name)
+                namespace: ($namespace)
+              spec:
+                type: secretRef
+                secretRef:
+                  name: ($secret_name)
+                  namespace: ($secret_namespace)
+                serverURL: ($konnect_url)
+
+    - name: 8-assert-auth-config-grant-missing
+      description: Assert ResolvedRefs=False/RefNotPermitted and APIAuthValid=False because no grant exists.
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAPIAuthConfiguration
+              metadata:
+                name: ($auth_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'False'
+
+    - name: 9-create-auth-to-secret-grant
+      description: Create KongReferenceGrant in secret_namespace allowing KonnectAPIAuthConfiguration from the test namespace to reference the Secret.
+      bindings:
+        - name: kong_reference_grant_name
+          value: ($grant_name)
+        - name: kong_reference_grant_namespace
+          value: ($secret_namespace)
+        - name: from
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectAPIAuthConfiguration
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: core
+              kind: Secret
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 10-assert-auth-config-valid
+      description: Assert ResolvedRefs=True and APIAuthValid=True after the grant is in place.
+      timeouts:
+        assert: 90s
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAPIAuthConfiguration
+              metadata:
+                name: ($auth_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'True'
+                    reason: ResolvedRefs
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+
+    # =========================================================================
+    # Scenario D: delete the grant and verify the KonnectAPIAuthConfiguration
+    # reverts to ResolvedRefs=False/RefNotPermitted (validates grant watch).
+    # =========================================================================
+
+    - name: 11-delete-auth-to-secret-grant
+      description: Delete the grant to verify the auth config reverts to RefNotPermitted.
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: ($grant_name)
+              namespace: ($secret_namespace)
+
+    - name: 12-assert-auth-config-reverts-to-not-permitted
+      description: Assert the auth config transitions back to ResolvedRefs=False/RefNotPermitted after grant deletion.
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAPIAuthConfiguration
+              metadata:
+                name: ($auth_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'ResolvedRefs']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    - name: 13-cleanup-scenario-b
+      description: Delete the cross-namespace auth config; wait for it to be gone.
+      timeouts:
+        delete: 120s
+        error: 120s
+      try:
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAPIAuthConfiguration
+              name: ($auth_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAPIAuthConfiguration
+              metadata:
+                name: ($auth_name)
+                namespace: ($namespace)
 
   catch:
     # Capture debug snapshot on test failure for CI debugging.

--- a/test/e2e/chainsaw/konnect/apiAuth_referencegrant/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/konnect/apiAuth_referencegrant/chainsaw-test.yaml
@@ -89,8 +89,6 @@ spec:
 
     - name: 3-assert-auth-config-valid-same-ns
       description: Assert APIAuthValid=True and that no ResolvedRefs condition is set for the same-namespace secretRef.
-      timeouts:
-        assert: 90s
       try:
         - assert:
             resource:
@@ -107,9 +105,6 @@ spec:
 
     - name: 4-cleanup-scenario-a
       description: Delete the same-namespace auth config; wait for it to be gone before proceeding.
-      timeouts:
-        delete: 120s
-        error: 120s
       try:
         - delete:
             ref:
@@ -203,8 +198,6 @@ spec:
 
     - name: 10-assert-auth-config-valid
       description: Assert ResolvedRefs=True and APIAuthValid=True after the grant is in place.
-      timeouts:
-        assert: 90s
       try:
         - assert:
             resource:
@@ -253,9 +246,6 @@ spec:
 
     - name: 13-cleanup-scenario-b
       description: Delete the cross-namespace auth config; wait for it to be gone.
-      timeouts:
-        delete: 120s
-        error: 120s
       try:
         - delete:
             ref:

--- a/test/envtest/konnect_entities_konnectapiauthconfiguration_referencegrant_test.go
+++ b/test/envtest/konnect_entities_konnectapiauthconfiguration_referencegrant_test.go
@@ -1,0 +1,148 @@
+package envtest
+
+import (
+	"context"
+	"testing"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	"github.com/kong/kong-operator/v2/controller/konnect"
+	"github.com/kong/kong-operator/v2/modules/manager/logging"
+	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+	"github.com/kong/kong-operator/v2/test/helpers/deploy"
+	"github.com/kong/kong-operator/v2/test/mocks/sdkmocks"
+)
+
+// TestKonnectAPIAuthConfigurationReferenceGrant verifies that a cross-namespace
+// reference from a KonnectAPIAuthConfiguration to a Secret requires a
+// KongReferenceGrant in the Secret's namespace.
+func TestKonnectAPIAuthConfigurationReferenceGrant(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := Context(t, t.Context())
+	defer cancel()
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
+
+	t.Log("Setting up the manager with reconcilers")
+	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+	factory := sdkmocks.NewMockSDKFactory(t)
+	sdk := factory.SDK
+	StartReconcilers(ctx, t, mgr, logs,
+		konnect.NewKonnectAPIAuthConfigurationReconciler(controller.Options{}, factory, logging.DevelopmentMode, mgr.GetClient()),
+	)
+
+	t.Log("Setting up clients")
+	cl, err := client.NewWithWatch(mgr.GetConfig(), client.Options{
+		Scheme: scheme.Get(),
+	})
+	require.NoError(t, err)
+	clientNamespaced := client.NewNamespacedClient(mgr.GetClient(), ns.Name)
+
+	// The Konnect API is only reached once the cross-namespace reference is
+	// permitted; return a valid organization so APIAuthValid can become True.
+	sdk.MeSDK.EXPECT().
+		GetOrganizationsMe(mock.Anything, mock.Anything).
+		Return(
+			&sdkkonnectops.GetOrganizationsMeResponse{
+				MeOrganization: &sdkkonnectcomp.MeOrganization{
+					ID:   new("12345"),
+					Name: new("org-12345"),
+				},
+			},
+			nil,
+		)
+
+	t.Log("Creating a Secret holding a Konnect token in a different namespace")
+	secretNS := deploy.Namespace(t, ctx, cl)
+	secret := deploy.Secret(t, ctx, cl,
+		map[string][]byte{
+			konnect.SecretTokenKey: []byte("kpat_xxxxxx"),
+		},
+		func(obj client.Object) {
+			obj.SetNamespace(secretNS.Name)
+			obj.SetLabels(map[string]string{
+				konnect.SecretCredentialLabel: konnect.SecretCredentialLabelValueKonnect,
+			})
+		},
+	)
+
+	w := setupWatch[konnectv1alpha1.KonnectAPIAuthConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
+
+	t.Log("Creating a KonnectAPIAuthConfiguration referencing the Secret cross-namespace (no grant yet)")
+	apiAuth := &konnectv1alpha1.KonnectAPIAuthConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "api-auth-xns-",
+			Namespace:    ns.Name,
+		},
+		Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+			Type: konnectv1alpha1.KonnectAPIAuthTypeSecretRef,
+			SecretRef: &corev1.SecretReference{
+				Name:      secret.Name,
+				Namespace: secretNS.Name,
+			},
+			ServerURL: sdkmocks.SDKServerURL,
+		},
+	}
+	require.NoError(t, clientNamespaced.Create(ctx, apiAuth))
+
+	t.Log("Waiting for KonnectAPIAuthConfiguration to have ResolvedRefs=False/RefNotPermitted (no grant)")
+	watchFor(t, ctx, w, apiwatch.Modified, func(a *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
+		if a.GetName() != apiAuth.GetName() {
+			return false
+		}
+		return lo.ContainsBy(a.Status.Conditions, func(condition metav1.Condition) bool {
+			return condition.Type == configurationv1alpha1.KongReferenceGrantConditionTypeResolvedRefs &&
+				condition.Status == metav1.ConditionFalse &&
+				condition.Reason == configurationv1alpha1.KongReferenceGrantReasonRefNotPermitted
+		})
+	}, "KonnectAPIAuthConfiguration should have ResolvedRefs=False/RefNotPermitted without a KongReferenceGrant")
+
+	t.Log("Creating a KongReferenceGrant to allow the cross-namespace reference")
+	deploy.KongReferenceGrant(t, ctx, cl,
+		func(obj client.Object) {
+			obj.SetNamespace(secretNS.Name)
+		},
+		deploy.KongReferenceGrantFroms(configurationv1alpha1.ReferenceGrantFrom{
+			Group:     configurationv1alpha1.Group(konnectv1alpha1.GroupVersion.Group),
+			Kind:      "KonnectAPIAuthConfiguration",
+			Namespace: configurationv1alpha1.Namespace(ns.Name),
+		}),
+		deploy.KongReferenceGrantTos(configurationv1alpha1.ReferenceGrantTo{
+			Group: "core",
+			Kind:  "Secret",
+			Name:  new(configurationv1alpha1.ObjectName(secret.Name)),
+		}),
+	)
+
+	t.Log("Waiting for KonnectAPIAuthConfiguration to become ResolvedRefs=True and APIAuthValid=True after the grant")
+	watchFor(t, ctx, w, apiwatch.Modified, func(a *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
+		if a.GetName() != apiAuth.GetName() {
+			return false
+		}
+		hasResolvedRefs := lo.ContainsBy(a.Status.Conditions, func(condition metav1.Condition) bool {
+			return condition.Type == configurationv1alpha1.KongReferenceGrantConditionTypeResolvedRefs &&
+				condition.Status == metav1.ConditionTrue &&
+				condition.Reason == configurationv1alpha1.KongReferenceGrantReasonResolvedRefs
+		})
+		hasValid := lo.ContainsBy(a.Status.Conditions, func(condition metav1.Condition) bool {
+			return condition.Type == konnectv1alpha1.KonnectEntityAPIAuthConfigurationValidConditionType &&
+				condition.Status == metav1.ConditionTrue
+		})
+		return hasResolvedRefs && hasValid
+	}, "KonnectAPIAuthConfiguration should have ResolvedRefs=True and APIAuthValid=True after the KongReferenceGrant is created")
+
+	// Use a fresh context for cleanup: t.Context() is canceled before top-level
+	// cleanup functions run.
+	t.Cleanup(func() { assert.NoError(t, client.IgnoreNotFound(cl.Delete(context.Background(), apiAuth))) })
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Cross-namespace references from a `KonnectAPIAuthConfiguration` to a `Secret`
were allowed with a warning only. Enforce them via `KongReferenceGrant`, like
every other cross-namespace reference. Without a grant the configuration
reports `ResolvedRefs=False/RefNotPermitted` and `APIAuthValid=False`.

**Which issue this PR fixes**

Fixes #2908

**Special notes for your reviewer**:

- Reuses the existing `crossnamespace` helper and the `handleSecretRef` pattern.
- Envtest covers deny-without-grant and allow-with-grant; grant revocation is
  covered by the chainsaw Scenario D (informer-cache races make it flaky in envtest).

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
