### PR TITLE
chore: re-enable `TestControlPlanesClientUserAgent`

### DIFF
--- a/ingress-controller/internal/konnect/controlplanes/client_test.go
+++ b/ingress-controller/internal/konnect/controlplanes/client_test.go
@@ -35,7 +35,6 @@ func (m *mockControlPlanesServer) ServeHTTP(w http.ResponseWriter, r *http.Reque
 }
 
 func TestControlPlanesClientUserAgent(t *testing.T) {
-	t.Skip("skipping test until we have a better way to mock the Konnect API")
 	ts := httptest.NewServer(newMockControlPlanesServer(t))
 	t.Cleanup(ts.Close)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It's fixed by https://github.com/Kong/kong-operator/pull/4830