### PR TITLE
tests: fix TestConfigErrorEventGenerationInMemoryMode

### DIFF
--- a/test/envtest/configerrorevent_envtest_test.go
+++ b/test/envtest/configerrorevent_envtest_test.go
@@ -117,8 +117,10 @@ func TestConfigErrorEventGenerationInMemoryMode(t *testing.T) {
 		WithIngressClass(ingressClassName),
 		WithKongUpstreamPolicyEnabled(),
 		WithProxySyncInterval(100*time.Millisecond),
-		// Add the init cache sync duration to prevent:
-		// Warning | KongConfigurationTranslationFailed | Service | httpbin | failed fetching KongUpstreamPolicy: KongUpstreamPolicy 800363bc-a654-497a-8467-061e56e22a8f/echo-drain-policy not found
+		// The init cache sync duration reduces the likelihood of:
+		// Warning | KongConfigurationTranslationFailed | Service | httpbin | failed fetching KongUpstreamPolicy: KongUpstreamPolicy <ns>/echo-drain-policy not found
+		// but it's a best-effort wait, not a barrier, so it cannot eliminate it under CI load.
+		// The event is tolerated as optional below (see optionalPredicates).
 		WithInitCacheSyncDuration(2*time.Second),
 	)
 
@@ -144,6 +146,11 @@ func TestConfigErrorEventGenerationInMemoryMode(t *testing.T) {
 		warningPredicate(dataplane.KongConfigurationTranslationFailedEventReason, "Service", service.Name, `^referenced KongPlugin or KongClusterPlugin "foo" does not exist$`),
 		warningPredicate(dataplane.KongConfigurationTranslationFailedEventReason, "Service", service.Name, `^referenced KongPlugin or KongClusterPlugin "bar" does not exist$`),
 		warningPredicate(dataplane.KongConfigurationTranslationFailedEventReason, "Service", service.Name, `^no grant found to referenced "n1:p1" plugin in the requested remote KongPlugin bind$`),
+		// KongUpstreamPolicy cache-population race: on a slow runner the first config
+		// translation can fire before the KongUpstreamPolicy is loaded into the controller
+		// cache, producing a transient "not found" translation failure. WithInitCacheSyncDuration
+		// reduces its frequency but cannot eliminate it (best-effort wait, not a barrier).
+		warningPredicate(dataplane.KongConfigurationTranslationFailedEventReason, "Service", service.Name, `^failed fetching KongUpstreamPolicy: KongUpstreamPolicy [^/]+/echo-drain-policy not found$`),
 	}
 
 	assertExpectedEvents(ctx, t, ctrlClient, ns, t.Name(), predicatesToCheck, optionalPredicates)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix flakingess in `TestConfigErrorEventGenerationInMemoryMode`:

```
2026-07-10T06:44:29.0034955Z     configerrorevent_envtest_test.go:149: 
2026-07-10T06:44:29.0037338Z         	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/envtest/configerrorevent_envtest_test.go:370
2026-07-10T06:44:29.0041054Z         	            				/opt/hostedtoolcache/go/1.26.5/x64/src/runtime/asm_amd64.s:1771
2026-07-10T06:44:29.0042895Z         	Error:      	Should be empty, but was [0]
2026-07-10T06:44:29.0044450Z         	Messages:   	observed unexpected events:
2026-07-10T06:44:29.0049679Z         	            	- Warning | KongConfigurationTranslationFailed | Service | httpbin | failed fetching KongUpstreamPolicy: KongUpstreamPolicy ns-vhtj6/echo-drain-policy not found
2026-07-10T06:44:29.0053590Z         	            	- Warning | KongConfigurationTranslationFailed | Service | httpbin | no grant found to referenced "n1:p1" plugin in the requested remote KongPlugin bind
2026-07-10T06:44:29.0056820Z         	            	- Warning | KongConfigurationTranslationFailed | Ingress | httpbin | referenced KongPlugin or KongClusterPlugin "baz" does not exist
2026-07-10T06:44:29.0060337Z         	            	- Warning | KongConfigurationTranslationFailed | Service | httpbin | referenced KongPlugin or KongClusterPlugin "foo" does not exist
2026-07-10T06:44:29.0064562Z         	            	- Warning | KongConfigurationTranslationFailed | Service | httpbin | referenced KongPlugin or KongClusterPlugin "bar" does not exist
2026-07-10T06:44:29.0068764Z         	            	- Warning | KongConfigurationApplyFailed | Ingress | httpbin | invalid methods: cannot set 'methods' when 'protocols' is 'grpc' or 'grpcs'
2026-07-10T06:44:29.0074647Z         	            	- Warning | KongConfigurationApplyFailed | Service | httpbin | invalid service:httpbin.httpbin.80: failed conditional validation given value of field 'protocol'
2026-07-10T06:44:29.0080114Z         	            	- Warning | FallbackKongConfigurationApplyFailed | Service | httpbin | invalid service:httpbin.httpbin.80: failed conditional validation given value of field 'protocol'
2026-07-10T06:44:29.0084082Z         	            	- Warning | KongConfigurationApplyFailed | Service | httpbin | invalid path: value must be null
2026-07-10T06:44:29.0087609Z         	            	- Warning | FallbackKongConfigurationApplyFailed | Ingress | httpbin | invalid methods: cannot set 'methods' when 'protocols' is 'grpc' or 'grpcs'
2026-07-10T06:44:29.0090165Z         	            	- Warning | FallbackKongConfigurationApplyFailed | Service | httpbin | invalid path: value must be null
2026-07-10T06:44:29.0093922Z         	            	- Warning | KongConfigurationApplyFailed | Pod | kong-ingress-controller-tyjh1 | failed to apply Kong configuration to http://127.0.0.1:43735: HTTP status 400 (message: "failed posting new config to /config")
2026-07-10T06:44:29.0097654Z         	            	- Warning | FallbackKongConfigurationApplyFailed | Pod | kong-ingress-controller-tyjh1 | failed to apply fallback Kong configuration to http://127.0.0.1:43735: HTTP status 400 (message: "failed posting new config to /config")
2026-07-10T06:44:29.0099078Z     configerrorevent_envtest_test.go:149: 
2026-07-10T06:44:29.0100670Z         	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/envtest/configerrorevent_envtest_test.go:343
2026-07-10T06:44:29.0102621Z         	            				/home/runner/work/kong-operator/kong-operator/test/envtest/configerrorevent_envtest_test.go:149
2026-07-10T06:44:29.0103484Z         	Error:      	Condition never satisfied
2026-07-10T06:44:29.0104181Z         	Test:       	TestConfigErrorEventGenerationInMemoryMode
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
