### PR TITLE
test: add cross-namespace KonnectAPIAuthConfigurationRef e2e tests

### DIFF
--- a/test/e2e/chainsaw/konnect/konnectaigateway_cross-namespace/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/konnect/konnectaigateway_cross-namespace/chainsaw-test.yaml
@@ -1,0 +1,301 @@
+# KonnectAIGateway cross-namespace KonnectAPIAuthConfigurationRef test.
+#
+# KonnectAIGateway carries a direct KonnectAPIAuthConfigurationRef (via
+# spec.konnect, an embedded KonnectConfiguration), making it another
+# representative of the direct KonnectAPIAuthConfigurationRef path in
+# GetAPIAuthRefNN, alongside KonnectGatewayControlPlane.
+#
+# Scenario A: AI Gateway and AuthConfig in the same namespace — baseline, no grant needed.
+#
+# Scenario B: AI Gateway in ns-A, AuthConfig in ns-B.
+#   A single AIGateway->AuthConfig grant is required.
+#
+# Scenario D: starting from Scenario B (Programmed=True), deleting the
+#   KongReferenceGrant reverts the AI Gateway to APIAuthResolvedRef=False/RefNotPermitted.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: konnectaigateway-cross-namespace
+spec:
+  description: |
+    Scenario A: KonnectAIGateway and KonnectAPIAuthConfiguration in the same namespace.
+    No grant needed; baseline sanity check.
+
+    Scenario B: KonnectAIGateway (ns-A) -> KonnectAPIAuthConfiguration (ns-B).
+    A single AIGateway->AuthConfig grant in ns-B is required.
+    Includes a negative assertion that the AI Gateway fails before the grant is added.
+
+    Scenario D: starting from Scenario B (Programmed=True), deleting the
+    KongReferenceGrant reverts the AI Gateway to APIAuthResolvedRef=False/RefNotPermitted
+    immediately, validating that the KongReferenceGrant watch is in place.
+
+  bindings:
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    # Namespace bindings.
+    - name: auth_namespace
+      value: (join('-', [$namespace, 'auth']))
+    # Scenario A resource names (both in test namespace).
+    - name: aigw0_name
+      value: (join('-', [$namespace, 'aigw0']))
+    - name: auth0_name
+      value: (join('-', [$namespace, 'auth0-konnect-api-auth']))
+    # Scenario B resource names (AI Gateway in test namespace, AuthConfig in auth_namespace).
+    - name: aigw_name
+      value: (join('-', [$namespace, 'aigw']))
+    - name: auth_name
+      value: (join('-', [$namespace, 'konnect-api-auth']))
+
+  steps:
+    # =========================================================================
+    # Scenario A: AI Gateway and AuthConfig in the same namespace. No grant needed.
+    # =========================================================================
+
+    - name: 1-create-auth-config-same-ns
+      description: Create KonnectAPIAuthConfiguration in the test namespace.
+      bindings:
+        - name: test_name
+          value: (join('-', [$namespace, 'auth0']))
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    - name: 2-create-and-assert-aigateway-same-ns
+      description: Create KonnectAIGateway with same-namespace authRef; assert it becomes Programmed.
+      try:
+        - apply:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAIGateway
+              metadata:
+                name: ($aigw0_name)
+                namespace: ($namespace)
+              spec:
+                apiSpec:
+                  name: ($aigw0_name)
+                  displayName: ($aigw0_name)
+                konnect:
+                  authRef:
+                    name: ($auth0_name)
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAIGateway
+              metadata:
+                name: ($aigw0_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (id != null): true
+
+    - name: 3-cleanup-scenario-a
+      description: Delete AIGateway0. Auth config has no Konnect finalizer; chainsaw cleans it up at namespace teardown.
+      try:
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAIGateway
+              name: ($aigw0_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAIGateway
+              metadata:
+                name: ($aigw0_name)
+                namespace: ($namespace)
+
+    # =========================================================================
+    # Scenario B: AI Gateway in test namespace, AuthConfig in auth_namespace.
+    # A single AIGateway->AuthConfig grant is required.
+    # =========================================================================
+
+    - name: 4-create-auth-namespace
+      description: Create namespace for KonnectAPIAuthConfiguration.
+      bindings:
+        - name: namespace_name
+          value: ($auth_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-namespace.yaml
+
+    - name: 5-create-auth-config-cross-ns
+      description: Create KonnectAPIAuthConfiguration in auth_namespace.
+      bindings:
+        - name: test_name
+          value: ($namespace)
+        - name: namespace
+          value: ($auth_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    - name: 6-create-aigateway-no-grant
+      description: Create KonnectAIGateway with cross-namespace authRef (no grant yet).
+      try:
+        - apply:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAIGateway
+              metadata:
+                name: ($aigw_name)
+                namespace: ($namespace)
+              spec:
+                apiSpec:
+                  name: ($aigw_name)
+                  displayName: ($aigw_name)
+                konnect:
+                  authRef:
+                    name: ($auth_name)
+                    namespace: ($auth_namespace)
+
+    - name: 7-assert-aigateway-auth-grant-missing
+      description: Assert AI Gateway has APIAuthResolvedRef=False/RefNotPermitted because no grant exists.
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAIGateway
+              metadata:
+                name: ($aigw_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    - name: 8-create-aigateway-to-auth-grant
+      description: Create KongReferenceGrant in auth_namespace allowing AI Gateway from test namespace to reference the AuthConfig.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'aigw-to-auth']))
+        - name: kong_reference_grant_namespace
+          value: ($auth_namespace)
+        - name: from
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectAIGateway
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectAPIAuthConfiguration
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 9-assert-aigateway-programmed
+      description: Assert AI Gateway is Programmed after the AIGateway->AuthConfig grant is in place.
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAIGateway
+              metadata:
+                name: ($aigw_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (id != null): true
+
+    # =========================================================================
+    # Scenario D: deleting the grant reverts the AI Gateway to ResolvedRefs=False/RefNotPermitted.
+    # =========================================================================
+
+    - name: 10-delete-aigateway-to-auth-grant
+      description: Delete the KongReferenceGrant to verify the AI Gateway reverts to RefNotPermitted.
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'aigw-to-auth']))
+              namespace: ($auth_namespace)
+
+    - name: 11-assert-aigateway-reverts-to-not-permitted
+      description: Assert AI Gateway transitions back to APIAuthResolvedRef=False/RefNotPermitted after grant deletion.
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAIGateway
+              metadata:
+                name: ($aigw_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    - name: 12-recreate-aigateway-to-auth-grant
+      description: Recreate the grant so the AI Gateway can be deprovisioned cleanly during cleanup.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'aigw-to-auth']))
+        - name: kong_reference_grant_namespace
+          value: ($auth_namespace)
+        - name: from
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectAIGateway
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectAPIAuthConfiguration
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 13-cleanup-scenario-b
+      description: |
+        Delete AI Gateway in order; wait for it to be gone before deleting the grant.
+        The AI Gateway needs the AIGateway->AuthConfig grant during Konnect deprovisioning.
+      try:
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAIGateway
+              name: ($aigw_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectAIGateway
+              metadata:
+                name: ($aigw_name)
+                namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'aigw-to-auth']))
+              namespace: ($auth_namespace)
+
+  catch:
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: konnectaigateway-cross-namespace
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: ADDITIONAL_NAMESPACES
+            value: ($auth_namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/konnect/konnecteventgateway_cross-namespace/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/konnect/konnecteventgateway_cross-namespace/chainsaw-test.yaml
@@ -1,0 +1,299 @@
+# KonnectEventGateway cross-namespace KonnectAPIAuthConfigurationRef test.
+#
+# KonnectEventGateway carries a direct KonnectAPIAuthConfigurationRef (via
+# spec.konnect, an embedded KonnectConfiguration), making it another
+# representative of the direct KonnectAPIAuthConfigurationRef path in
+# GetAPIAuthRefNN, alongside KonnectGatewayControlPlane.
+#
+# Scenario A: Event Gateway and AuthConfig in the same namespace — baseline, no grant needed.
+#
+# Scenario B: Event Gateway in ns-A, AuthConfig in ns-B.
+#   A single EventGateway->AuthConfig grant is required.
+#
+# Scenario D: starting from Scenario B (Programmed=True), deleting the
+#   KongReferenceGrant reverts the Event Gateway to APIAuthResolvedRef=False/RefNotPermitted.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: konnecteventgateway-cross-namespace
+spec:
+  description: |
+    Scenario A: KonnectEventGateway and KonnectAPIAuthConfiguration in the same namespace.
+    No grant needed; baseline sanity check.
+
+    Scenario B: KonnectEventGateway (ns-A) -> KonnectAPIAuthConfiguration (ns-B).
+    A single EventGateway->AuthConfig grant in ns-B is required.
+    Includes a negative assertion that the Event Gateway fails before the grant is added.
+
+    Scenario D: starting from Scenario B (Programmed=True), deleting the
+    KongReferenceGrant reverts the Event Gateway to APIAuthResolvedRef=False/RefNotPermitted
+    immediately, validating that the KongReferenceGrant watch is in place.
+
+  bindings:
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    # Namespace bindings.
+    - name: auth_namespace
+      value: (join('-', [$namespace, 'auth']))
+    # Scenario A resource names (both in test namespace).
+    - name: keg0_name
+      value: (join('-', [$namespace, 'keg0']))
+    - name: auth0_name
+      value: (join('-', [$namespace, 'auth0-konnect-api-auth']))
+    # Scenario B resource names (Event Gateway in test namespace, AuthConfig in auth_namespace).
+    - name: keg_name
+      value: (join('-', [$namespace, 'keg']))
+    - name: auth_name
+      value: (join('-', [$namespace, 'konnect-api-auth']))
+
+  steps:
+    # =========================================================================
+    # Scenario A: Event Gateway and AuthConfig in the same namespace. No grant needed.
+    # =========================================================================
+
+    - name: 1-create-auth-config-same-ns
+      description: Create KonnectAPIAuthConfiguration in the test namespace.
+      bindings:
+        - name: test_name
+          value: (join('-', [$namespace, 'auth0']))
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    - name: 2-create-and-assert-eventgateway-same-ns
+      description: Create KonnectEventGateway with same-namespace authRef; assert it becomes Programmed.
+      try:
+        - apply:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectEventGateway
+              metadata:
+                name: ($keg0_name)
+                namespace: ($namespace)
+              spec:
+                apiSpec:
+                  name: ($keg0_name)
+                konnect:
+                  authRef:
+                    name: ($auth0_name)
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectEventGateway
+              metadata:
+                name: ($keg0_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (id != null): true
+
+    - name: 3-cleanup-scenario-a
+      description: Delete EventGateway0. Auth config has no Konnect finalizer; chainsaw cleans it up at namespace teardown.
+      try:
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectEventGateway
+              name: ($keg0_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectEventGateway
+              metadata:
+                name: ($keg0_name)
+                namespace: ($namespace)
+
+    # =========================================================================
+    # Scenario B: Event Gateway in test namespace, AuthConfig in auth_namespace.
+    # A single EventGateway->AuthConfig grant is required.
+    # =========================================================================
+
+    - name: 4-create-auth-namespace
+      description: Create namespace for KonnectAPIAuthConfiguration.
+      bindings:
+        - name: namespace_name
+          value: ($auth_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-namespace.yaml
+
+    - name: 5-create-auth-config-cross-ns
+      description: Create KonnectAPIAuthConfiguration in auth_namespace.
+      bindings:
+        - name: test_name
+          value: ($namespace)
+        - name: namespace
+          value: ($auth_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    - name: 6-create-eventgateway-no-grant
+      description: Create KonnectEventGateway with cross-namespace authRef (no grant yet).
+      try:
+        - apply:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectEventGateway
+              metadata:
+                name: ($keg_name)
+                namespace: ($namespace)
+              spec:
+                apiSpec:
+                  name: ($keg_name)
+                konnect:
+                  authRef:
+                    name: ($auth_name)
+                    namespace: ($auth_namespace)
+
+    - name: 7-assert-eventgateway-auth-grant-missing
+      description: Assert Event Gateway has APIAuthResolvedRef=False/RefNotPermitted because no grant exists.
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectEventGateway
+              metadata:
+                name: ($keg_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    - name: 8-create-eventgateway-to-auth-grant
+      description: Create KongReferenceGrant in auth_namespace allowing Event Gateway from test namespace to reference the AuthConfig.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'keg-to-auth']))
+        - name: kong_reference_grant_namespace
+          value: ($auth_namespace)
+        - name: from
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectEventGateway
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectAPIAuthConfiguration
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 9-assert-eventgateway-programmed
+      description: Assert Event Gateway is Programmed after the EventGateway->AuthConfig grant is in place.
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectEventGateway
+              metadata:
+                name: ($keg_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (id != null): true
+
+    # =========================================================================
+    # Scenario D: deleting the grant reverts the Event Gateway to ResolvedRefs=False/RefNotPermitted.
+    # =========================================================================
+
+    - name: 10-delete-eventgateway-to-auth-grant
+      description: Delete the KongReferenceGrant to verify the Event Gateway reverts to RefNotPermitted.
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'keg-to-auth']))
+              namespace: ($auth_namespace)
+
+    - name: 11-assert-eventgateway-reverts-to-not-permitted
+      description: Assert Event Gateway transitions back to APIAuthResolvedRef=False/RefNotPermitted after grant deletion.
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectEventGateway
+              metadata:
+                name: ($keg_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    - name: 12-recreate-eventgateway-to-auth-grant
+      description: Recreate the grant so the Event Gateway can be deprovisioned cleanly during cleanup.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'keg-to-auth']))
+        - name: kong_reference_grant_namespace
+          value: ($auth_namespace)
+        - name: from
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectEventGateway
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectAPIAuthConfiguration
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 13-cleanup-scenario-b
+      description: |
+        Delete Event Gateway in order; wait for it to be gone before deleting the grant.
+        The Event Gateway needs the EventGateway->AuthConfig grant during Konnect deprovisioning.
+      try:
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectEventGateway
+              name: ($keg_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: KonnectEventGateway
+              metadata:
+                name: ($keg_name)
+                namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'keg-to-auth']))
+              namespace: ($auth_namespace)
+
+  catch:
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: konnecteventgateway-cross-namespace
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: ADDITIONAL_NAMESPACES
+            value: ($auth_namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/konnect/portal_cross-namespace/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/konnect/portal_cross-namespace/chainsaw-test.yaml
@@ -1,0 +1,299 @@
+# Portal cross-namespace KonnectAPIAuthConfigurationRef test.
+#
+# Portal carries a direct KonnectAPIAuthConfigurationRef (via spec.konnect, an
+# embedded KonnectConfiguration), making it another representative of the direct
+# KonnectAPIAuthConfigurationRef path in GetAPIAuthRefNN, alongside
+# KonnectGatewayControlPlane.
+#
+# Scenario A: Portal and AuthConfig in the same namespace — baseline, no grant needed.
+#
+# Scenario B: Portal in ns-A, AuthConfig in ns-B.
+#   A single Portal->AuthConfig grant is required.
+#
+# Scenario D: starting from Scenario B (Programmed=True), deleting the
+#   KongReferenceGrant reverts the Portal to APIAuthResolvedRef=False/RefNotPermitted.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: portal-cross-namespace
+spec:
+  description: |
+    Scenario A: Portal and KonnectAPIAuthConfiguration in the same namespace.
+    No grant needed; baseline sanity check.
+
+    Scenario B: Portal (ns-A) -> KonnectAPIAuthConfiguration (ns-B).
+    A single Portal->AuthConfig grant in ns-B is required.
+    Includes a negative assertion that the Portal fails before the grant is added.
+
+    Scenario D: starting from Scenario B (Programmed=True), deleting the
+    KongReferenceGrant reverts the Portal to APIAuthResolvedRef=False/RefNotPermitted
+    immediately, validating that the KongReferenceGrant watch is in place.
+
+  bindings:
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    # Namespace bindings.
+    - name: auth_namespace
+      value: (join('-', [$namespace, 'auth']))
+    # Scenario A resource names (both in test namespace).
+    - name: portal0_name
+      value: (join('-', [$namespace, 'portal0']))
+    - name: auth0_name
+      value: (join('-', [$namespace, 'auth0-konnect-api-auth']))
+    # Scenario B resource names (Portal in test namespace, AuthConfig in auth_namespace).
+    - name: portal_name
+      value: (join('-', [$namespace, 'portal']))
+    - name: auth_name
+      value: (join('-', [$namespace, 'konnect-api-auth']))
+
+  steps:
+    # =========================================================================
+    # Scenario A: Portal and AuthConfig in the same namespace. No grant needed.
+    # =========================================================================
+
+    - name: 1-create-auth-config-same-ns
+      description: Create KonnectAPIAuthConfiguration in the test namespace.
+      bindings:
+        - name: test_name
+          value: (join('-', [$namespace, 'auth0']))
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    - name: 2-create-and-assert-portal-same-ns
+      description: Create Portal with same-namespace authRef; assert it becomes Programmed.
+      try:
+        - apply:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: Portal
+              metadata:
+                name: ($portal0_name)
+                namespace: ($namespace)
+              spec:
+                apiSpec:
+                  name: ($portal0_name)
+                konnect:
+                  authRef:
+                    name: ($auth0_name)
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: Portal
+              metadata:
+                name: ($portal0_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (id != null): true
+
+    - name: 3-cleanup-scenario-a
+      description: Delete Portal0. Auth config has no Konnect finalizer; chainsaw cleans it up at namespace teardown.
+      try:
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: Portal
+              name: ($portal0_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: Portal
+              metadata:
+                name: ($portal0_name)
+                namespace: ($namespace)
+
+    # =========================================================================
+    # Scenario B: Portal in test namespace, AuthConfig in auth_namespace.
+    # A single Portal->AuthConfig grant is required.
+    # =========================================================================
+
+    - name: 4-create-auth-namespace
+      description: Create namespace for KonnectAPIAuthConfiguration.
+      bindings:
+        - name: namespace_name
+          value: ($auth_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-namespace.yaml
+
+    - name: 5-create-auth-config-cross-ns
+      description: Create KonnectAPIAuthConfiguration in auth_namespace.
+      bindings:
+        - name: test_name
+          value: ($namespace)
+        - name: namespace
+          value: ($auth_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration.yaml
+
+    - name: 6-create-portal-no-grant
+      description: Create Portal with cross-namespace authRef (no grant yet).
+      try:
+        - apply:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: Portal
+              metadata:
+                name: ($portal_name)
+                namespace: ($namespace)
+              spec:
+                apiSpec:
+                  name: ($portal_name)
+                konnect:
+                  authRef:
+                    name: ($auth_name)
+                    namespace: ($auth_namespace)
+
+    - name: 7-assert-portal-auth-grant-missing
+      description: Assert Portal has APIAuthResolvedRef=False/RefNotPermitted because no grant exists.
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: Portal
+              metadata:
+                name: ($portal_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    - name: 8-create-portal-to-auth-grant
+      description: Create KongReferenceGrant in auth_namespace allowing Portal from test namespace to reference the AuthConfig.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'portal-to-auth']))
+        - name: kong_reference_grant_namespace
+          value: ($auth_namespace)
+        - name: from
+          value:
+            - group: konnect.konghq.com
+              kind: Portal
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectAPIAuthConfiguration
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 9-assert-portal-programmed
+      description: Assert Portal is Programmed after the Portal->AuthConfig grant is in place.
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: Portal
+              metadata:
+                name: ($portal_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'True'
+                    reason: ResolvedRef
+                (conditions[?type == 'APIAuthValid']):
+                  - status: 'True'
+                    reason: Valid
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (id != null): true
+
+    # =========================================================================
+    # Scenario D: deleting the grant reverts the Portal to ResolvedRefs=False/RefNotPermitted.
+    # =========================================================================
+
+    - name: 10-delete-portal-to-auth-grant
+      description: Delete the KongReferenceGrant to verify the Portal reverts to RefNotPermitted.
+      try:
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'portal-to-auth']))
+              namespace: ($auth_namespace)
+
+    - name: 11-assert-portal-reverts-to-not-permitted
+      description: Assert Portal transitions back to APIAuthResolvedRef=False/RefNotPermitted after grant deletion.
+      try:
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: Portal
+              metadata:
+                name: ($portal_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'APIAuthResolvedRef']):
+                  - status: 'False'
+                    reason: RefNotPermitted
+
+    - name: 12-recreate-portal-to-auth-grant
+      description: Recreate the grant so the Portal can be deprovisioned cleanly during cleanup.
+      bindings:
+        - name: kong_reference_grant_name
+          value: (join('-', [$namespace, 'portal-to-auth']))
+        - name: kong_reference_grant_namespace
+          value: ($auth_namespace)
+        - name: from
+          value:
+            - group: konnect.konghq.com
+              kind: Portal
+              namespace: ($namespace)
+        - name: to
+          value:
+            - group: konnect.konghq.com
+              kind: KonnectAPIAuthConfiguration
+      use:
+        template: ../../common/_step_templates/apply-assert-kongreferencegrant.yaml
+
+    - name: 13-cleanup-scenario-b
+      description: |
+        Delete Portal in order; wait for it to be gone before deleting the grant.
+        The Portal needs the Portal->AuthConfig grant during Konnect deprovisioning.
+      try:
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: Portal
+              name: ($portal_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: Portal
+              metadata:
+                name: ($portal_name)
+                namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: configuration.konghq.com/v1alpha1
+              kind: KongReferenceGrant
+              name: (join('-', [$namespace, 'portal-to-auth']))
+              namespace: ($auth_namespace)
+
+  catch:
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: portal-cross-namespace
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: ADDITIONAL_NAMESPACES
+            value: ($auth_namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh


### PR DESCRIPTION


**What this PR does / why we need it**:

Kong/kong-operator#4839 added a Namespace field to KonnectAPIAuthConfigurationRef/ControlPlaneKonnectAPIAuthConfigurationRef, enabling cross-namespace references gated by KongReferenceGrant. This adds chainsaw e2e coverage for the remaining CRDs that embed those refs directly (Portal, KonnectAIGateway, KonnectEventGateway), mirroring the existing konnectgatewaycontrolplane_cross-namespace test: same-namespace baseline, cross-namespace resolution via a KongReferenceGrant, and reverting to RefNotPermitted when the grant is revoked.

KonnectCloudGatewayNetwork was considered but dropped: it always talks to Konnect's global API endpoint regardless of the configured region, which a region-scoped token can't authenticate against, and a failed delete-time Konnect ID lookup leaves the resource stuck with its finalizer forever rather than just failing the test.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
